### PR TITLE
feat(#90): PlatformOps + ProcessHandle + ProcessRegistry (ADR-017/019)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 
 - [#90] Phase 5.2a: PlatformOps + ProcessHandle + ProcessRegistry — ADR-017/019 cross-platform process lifecycle, PosixOps/WindowsOps, spawn_block_process factory, 29 tests (@claude, 2026-04-04, branch: feat/issue-90/platform-process-handle, session: 20260404-042159-phase-5-2a-platformops-processhandle-pro)
+- [#91] Phase 5.3: ResourceManager with psutil watermark — ADR-022 OS-level memory monitoring, ADR-018 EventBus auto-release, GPU/CPU slot counting, 32 tests (@claude, 2026-04-04, branch: feat/issue-91/resource-management, session: 20260404-042212-phase-5-3-resource-management-adr-022)
 - [#85] Phase 5.5: EventBus publish/subscribe dispatcher — ADR-018 runtime backbone with sync/async callback support, error isolation, 12 tests (@claude, 2026-04-04, branch: feat/issue-85/event-bus, session: 20260404-041317-phase-5-5-event-bus-implementation-adr-0)
 - [#83] Phase 5.0a: Collection class + Block base utilities — ADR-020 Collection transport, pack/unpack/map_items/parallel_map, ProcessBlock Tier 1 process_item, port Collection transparency (@claude, 2026-04-04, branch: feat/issue-83/collection-block-utilities, session: 20260404-040318-phase-5-0a-collection-class-block-base-u)
 - [#74] ADR-017-022 backbone scaffolding — TODO-annotated code stubs for subprocess isolation, event-driven scheduler, ProcessHandle, Collection transport, Collection operation blocks, psutil memory monitoring (@claude, 2026-04-04, branch: refactor/issue-74/adr-017-022-backbone, session: 20260404-024138-adr-017-022-backbone-scaffolding)
@@ -79,6 +80,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- [#31] Deduplicate records in ProvenanceGraph descendants/ancestors traversals (@claude, 2026-04-04, branch: fix/issue-31/provenance-dedup, session: 20260404-034230-fix-provenancegraph-dedup-in-descendants)
 - [#28] Make CompositeStore.slice() and iter_chunks() lazy -- load only requested slots (@claude, 2026-04-04, branch: fix/issue-28/composite-store-lazy, session: 20260404-034336-fix-compositestore-slice-and-iter-chunks)
 - [#26] Persist axis metadata in ZarrBackend write/read for round-trip fidelity (@claude, 2026-04-04, branch: fix/issue-26/zarr-axes-metadata, session: 20260404-034314-fix-zarrbackend-to-persist-axis-metadata)
 - [#27] Default LineageStore to persistent file path instead of in-memory (@claude, 2026-04-04, branch: fix/issue-27/lineage-default-path, session: 20260404-034315-fix-lineagestore-default-to-persistent-f)

--- a/src/scieasy/core/lineage/graph.py
+++ b/src/scieasy/core/lineage/graph.py
@@ -36,6 +36,7 @@ class ProvenanceGraph:
     def ancestors(self, output_hash: str) -> list[LineageRecord]:
         """Return all ancestor records of *output_hash*."""
         visited: set[str] = set()
+        visited_records: set[int] = set()
         result: list[LineageRecord] = []
         queue = [output_hash]
 
@@ -45,7 +46,8 @@ class ProvenanceGraph:
                 continue
             visited.add(current)
             record = self._output_to_record.get(current)
-            if record is not None:
+            if record is not None and id(record) not in visited_records:
+                visited_records.add(id(record))
                 result.append(record)
                 for inp in record.input_hashes:
                     if inp not in visited:
@@ -56,6 +58,7 @@ class ProvenanceGraph:
     def descendants(self, input_hash: str) -> list[LineageRecord]:
         """Return all descendant records of *input_hash*."""
         visited: set[str] = set()
+        visited_records: set[int] = set()
         result: list[LineageRecord] = []
         queue = [input_hash]
 
@@ -66,7 +69,9 @@ class ProvenanceGraph:
             visited.add(current)
             consumers = self._input_to_records.get(current, [])
             for record in consumers:
-                result.append(record)
+                if id(record) not in visited_records:
+                    visited_records.add(id(record))
+                    result.append(record)
                 for out_hash in record.output_hashes:
                     if out_hash not in visited:
                         queue.append(out_hash)

--- a/src/scieasy/core/lineage/store.py
+++ b/src/scieasy/core/lineage/store.py
@@ -148,6 +148,7 @@ class LineageStore:
         then recursively finds records that produced each of its inputs.
         """
         visited: set[str] = set()
+        visited_records: set[tuple[str, str]] = set()
         result: list[LineageRecord] = []
         queue = [output_hash]
 
@@ -166,9 +167,12 @@ class LineageStore:
             )
             for row in cursor.fetchall():
                 record = self._row_to_record(row)
-                result.append(record)
-                for inp in record.input_hashes:
-                    if inp not in visited:
-                        queue.append(inp)
+                record_key = (record.block_id, record.timestamp)
+                if record_key not in visited_records:
+                    visited_records.add(record_key)
+                    result.append(record)
+                    for inp in record.input_hashes:
+                        if inp not in visited:
+                            queue.append(inp)
 
         return result

--- a/src/scieasy/engine/resources.py
+++ b/src/scieasy/engine/resources.py
@@ -42,9 +42,7 @@ class ResourceSnapshot:
 class ResourceManager:
     """Track and allocate compute resources for block execution.
 
-    TODO(ADR-022): Implement three-layer defence.
-
-    Layer 1 (this class): Dispatch gating.
+    Layer 1 (this class): Dispatch gating (ADR-022).
         - GPU: discrete slot counting (declaration-based)
         - CPU: discrete core counting (declaration-based)
         - Memory: OS-level check via psutil.virtual_memory().percent
@@ -52,20 +50,13 @@ class ResourceManager:
         - memory_critical=0.95: never dispatch above 95%
 
     Layer 2 (block-internal): _auto_flush, LazyList, parallel_map(max_workers)
-        — operates independently, not managed here.
+        -- operates independently, not managed here.
 
     Layer 3 (OS + ProcessMonitor): OS kills subprocess on OOM.
         ProcessMonitor detects, emits PROCESS_EXITED. Scheduler marks ERROR.
 
-    TODO(ADR-018): EventBus integration for automatic resource release.
-        __init__ accepts event_bus: EventBus | None. If provided, subscribe to
-        BLOCK_DONE, BLOCK_ERROR, BLOCK_CANCELLED, PROCESS_EXITED with
-        _on_block_terminal callback.
-
-        _on_block_terminal(event): look up allocation by event.block_id,
-        call self.release(allocation).
-
-        _allocations: dict[str, ResourceRequest] — maps block_id to allocated.
+    EventBus integration (ADR-018): automatic resource release on terminal
+    block states via _on_block_terminal callback.
     """
 
     def __init__(
@@ -76,41 +67,96 @@ class ResourceManager:
         memory_critical: float = 0.95,
         event_bus: Any | None = None,
     ) -> None:
-        # TODO(ADR-022): Store limits and watermarks.
-        # TODO(ADR-018): If event_bus provided, subscribe to terminal events.
-        # TODO(ADR-018): Initialize _allocations dict.
-        raise NotImplementedError
+        self.gpu_slots = gpu_slots
+        self.max_cpu_workers = cpu_workers
+        self.memory_high_watermark = memory_high_watermark
+        self.memory_critical = memory_critical
+        self._gpu_in_use: int = 0
+        self._cpu_in_use: int = 0
+        self._allocations: dict[str, ResourceRequest] = {}
+
+        if event_bus is not None:
+            from scieasy.engine.events import (
+                BLOCK_CANCELLED,
+                BLOCK_DONE,
+                BLOCK_ERROR,
+                PROCESS_EXITED,
+            )
+
+            event_bus.subscribe(BLOCK_DONE, self._on_block_terminal)
+            event_bus.subscribe(BLOCK_ERROR, self._on_block_terminal)
+            event_bus.subscribe(BLOCK_CANCELLED, self._on_block_terminal)
+            event_bus.subscribe(PROCESS_EXITED, self._on_block_terminal)
 
     def can_dispatch(self, request: ResourceRequest) -> bool:
         """Check if resources are available AND system memory is below watermark.
 
-        TODO(ADR-022): Check discrete GPU/CPU slots AND
-        psutil.virtual_memory().percent < memory_high_watermark.
-        Never dispatch if percent >= memory_critical.
+        Returns False if:
+        - GPU is required but all GPU slots are in use
+        - Requested CPU cores would exceed the pool
+        - System memory percent >= memory_critical (always blocked)
+        - System memory percent > memory_high_watermark (paused)
         """
-        raise NotImplementedError
+        import psutil
 
-    async def acquire(self, request: ResourceRequest) -> bool:
+        # GPU check
+        if request.requires_gpu and self._gpu_in_use >= self.gpu_slots:
+            return False
+        # CPU check
+        if self._cpu_in_use + request.cpu_cores > self.max_cpu_workers:
+            return False
+        # Memory check via psutil (ADR-022)
+        mem_percent = psutil.virtual_memory().percent / 100.0
+        if mem_percent >= self.memory_critical:
+            return False
+        return not mem_percent > self.memory_high_watermark
+
+    async def acquire(self, request: ResourceRequest, block_id: str = "") -> bool:
         """Reserve GPU slots and CPU cores.
 
-        TODO(ADR-022): Reserve discrete resources only. Memory is not reserved —
-        it drops naturally when subprocess exits.
-        TODO(ADR-018): Store allocation in _allocations[block_id].
-        """
-        raise NotImplementedError
+        Memory is not reserved -- it drops naturally when subprocess exits
+        (ADR-022). Allocation is tracked by block_id for auto-release
+        (ADR-018).
 
-    def release(self, request: ResourceRequest) -> None:
+        Returns True if resources were successfully acquired, False otherwise.
+        """
+        if not self.can_dispatch(request):
+            return False
+        if request.requires_gpu:
+            self._gpu_in_use += 1
+        self._cpu_in_use += request.cpu_cores
+        if block_id:
+            self._allocations[block_id] = request
+        return True
+
+    def release(self, request: ResourceRequest, block_id: str = "") -> None:
         """Return previously acquired GPU/CPU resources to the pool.
 
-        TODO(ADR-022): Release discrete resources only.
-        TODO(ADR-018): Remove from _allocations.
+        Uses max(0, ...) to prevent negative counters in edge cases.
         """
-        raise NotImplementedError
+        if request.requires_gpu:
+            self._gpu_in_use = max(0, self._gpu_in_use - 1)
+        self._cpu_in_use = max(0, self._cpu_in_use - request.cpu_cores)
+        if block_id and block_id in self._allocations:
+            del self._allocations[block_id]
+
+    def _on_block_terminal(self, event: Any) -> None:
+        """Auto-release resources when a block reaches a terminal state.
+
+        Called by EventBus for BLOCK_DONE, BLOCK_ERROR, BLOCK_CANCELLED,
+        and PROCESS_EXITED events (ADR-018).
+        """
+        block_id = event.block_id
+        if block_id and block_id in self._allocations:
+            self.release(self._allocations[block_id], block_id)
 
     @property
     def available(self) -> ResourceSnapshot:
-        """Return a snapshot including live system_memory_percent.
+        """Return a snapshot including live system_memory_percent from psutil."""
+        import psutil
 
-        TODO(ADR-022): Include psutil.virtual_memory().percent / 100.
-        """
-        raise NotImplementedError
+        return ResourceSnapshot(
+            available_gpu_slots=max(0, self.gpu_slots - self._gpu_in_use),
+            available_cpu_workers=max(0, self.max_cpu_workers - self._cpu_in_use),
+            system_memory_percent=psutil.virtual_memory().percent / 100.0,
+        )

--- a/tests/core/test_lineage.py
+++ b/tests/core/test_lineage.py
@@ -117,6 +117,15 @@ class TestLineageStore:
         ancestors = store.ancestors("nonexistent")
         assert ancestors == []
 
+    def test_store_ancestors_diamond_no_duplicates(self) -> None:
+        """LineageStore ancestors should deduplicate in diamond patterns."""
+        store = LineageStore(":memory:")
+        store.write(_make_record("A", ["raw"], ["h1", "h2"], timestamp="2026-01-01T00:00:00"))
+        store.write(_make_record("B", ["h1", "h2"], ["h3"], timestamp="2026-01-01T00:01:00"))
+        ancestors = store.ancestors("h3")
+        block_ids = [r.block_id for r in ancestors]
+        assert block_ids.count("A") == 1
+
     def test_default_path_persists(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """LineageStore with default path persists records to disk."""
         monkeypatch.chdir(tmp_path)
@@ -174,6 +183,34 @@ class TestProvenanceGraph:
         trail = graph.audit_trail("h3")
         block_ids = [r.block_id for r in trail]
         assert block_ids == ["A", "B", "C"]
+
+    def test_descendants_diamond_no_duplicates(self) -> None:
+        """Diamond DAG: D should appear exactly once in descendants."""
+        records = [
+            _make_record("A", ["raw"], ["h1"], timestamp="2026-01-01T00:00:00"),
+            _make_record("B", ["h1"], ["h2"], timestamp="2026-01-01T00:01:00"),
+            _make_record("C", ["h1"], ["h3"], timestamp="2026-01-01T00:01:00"),
+            _make_record("D", ["h2", "h3"], ["h4"], timestamp="2026-01-01T00:02:00"),
+        ]
+        graph = ProvenanceGraph()
+        graph.build(records)
+        descendants = graph.descendants("h1")
+        block_ids = [r.block_id for r in descendants]
+        assert block_ids.count("D") == 1
+        assert set(block_ids) == {"B", "C", "D"}
+
+    def test_ancestors_multi_output_no_duplicates(self) -> None:
+        """Record with multiple outputs should appear once in ancestors."""
+        records = [
+            _make_record("A", ["raw"], ["h1", "h2"], timestamp="2026-01-01T00:00:00"),
+            _make_record("B", ["h1", "h2"], ["h3"], timestamp="2026-01-01T00:01:00"),
+        ]
+        graph = ProvenanceGraph()
+        graph.build(records)
+        ancestors = graph.ancestors("h3")
+        block_ids = [r.block_id for r in ancestors]
+        assert block_ids.count("A") == 1
+        assert set(block_ids) == {"A", "B"}
 
     def test_diff(self) -> None:
         """Build a diamond: A -> B, A -> C, B+C -> D."""

--- a/tests/engine/test_resources.py
+++ b/tests/engine/test_resources.py
@@ -1,8 +1,357 @@
-"""Tests for ResourceManager — ADR-022."""
+"""Tests for ResourceManager -- ADR-022 / ADR-018."""
 
-# TODO(ADR-022): Test psutil-based memory checking (system_memory_percent).
-# TODO(ADR-022): Test memory_high_watermark threshold blocks dispatch.
-# TODO(ADR-022): Test memory_critical threshold always blocks dispatch.
-# TODO(ADR-022): Test GPU/CPU discrete slot counting.
-# TODO(ADR-018): Test auto-release via EventBus on BLOCK_DONE/ERROR/CANCELLED.
-# TODO(ADR-022): Test ResourceRequest has no estimated_memory_gb field.
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from scieasy.engine.resources import ResourceManager, ResourceRequest, ResourceSnapshot
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _mock_vm(percent: float) -> MagicMock:
+    """Create a mock psutil.virtual_memory() return value."""
+    vm = MagicMock()
+    vm.percent = percent
+    return vm
+
+
+def _run(coro):
+    """Run a coroutine synchronously for testing."""
+    return asyncio.run(coro)
+
+
+# ---------------------------------------------------------------------------
+# ResourceRequest dataclass
+# ---------------------------------------------------------------------------
+
+
+class TestResourceRequest:
+    def test_defaults(self):
+        req = ResourceRequest()
+        assert req.requires_gpu is False
+        assert req.gpu_memory_gb == 0.0
+        assert req.cpu_cores == 1
+
+    def test_no_estimated_memory_gb(self):
+        """ADR-022: estimated_memory_gb was removed."""
+        assert not hasattr(ResourceRequest(), "estimated_memory_gb")
+
+
+# ---------------------------------------------------------------------------
+# ResourceSnapshot dataclass
+# ---------------------------------------------------------------------------
+
+
+class TestResourceSnapshot:
+    def test_defaults(self):
+        snap = ResourceSnapshot()
+        assert snap.available_gpu_slots == 0
+        assert snap.available_cpu_workers == 4
+        assert snap.system_memory_percent == 0.0
+
+
+# ---------------------------------------------------------------------------
+# ResourceManager -- construction
+# ---------------------------------------------------------------------------
+
+
+class TestResourceManagerInit:
+    def test_default_construction(self):
+        rm = ResourceManager()
+        assert rm.gpu_slots == 0
+        assert rm.max_cpu_workers == 4
+        assert rm.memory_high_watermark == 0.80
+        assert rm.memory_critical == 0.95
+        assert rm._gpu_in_use == 0
+        assert rm._cpu_in_use == 0
+        assert rm._allocations == {}
+
+    def test_custom_parameters(self):
+        rm = ResourceManager(gpu_slots=2, cpu_workers=8, memory_high_watermark=0.70, memory_critical=0.90)
+        assert rm.gpu_slots == 2
+        assert rm.max_cpu_workers == 8
+        assert rm.memory_high_watermark == 0.70
+        assert rm.memory_critical == 0.90
+
+
+# ---------------------------------------------------------------------------
+# can_dispatch -- CPU slot limit
+# ---------------------------------------------------------------------------
+
+
+class TestCanDispatchCPU:
+    @patch("psutil.virtual_memory", return_value=_mock_vm(50.0))
+    def test_cpu_under_limit(self, _mock):
+        rm = ResourceManager(cpu_workers=4)
+        assert rm.can_dispatch(ResourceRequest(cpu_cores=2))
+
+    @patch("psutil.virtual_memory", return_value=_mock_vm(50.0))
+    def test_cpu_at_limit(self, _mock):
+        rm = ResourceManager(cpu_workers=2)
+        rm._cpu_in_use = 2
+        assert not rm.can_dispatch(ResourceRequest(cpu_cores=1))
+
+    @patch("psutil.virtual_memory", return_value=_mock_vm(50.0))
+    def test_cpu_exact_fit(self, _mock):
+        rm = ResourceManager(cpu_workers=4)
+        rm._cpu_in_use = 3
+        assert rm.can_dispatch(ResourceRequest(cpu_cores=1))
+
+    @patch("psutil.virtual_memory", return_value=_mock_vm(50.0))
+    def test_cpu_overflow(self, _mock):
+        rm = ResourceManager(cpu_workers=4)
+        rm._cpu_in_use = 3
+        assert not rm.can_dispatch(ResourceRequest(cpu_cores=2))
+
+
+# ---------------------------------------------------------------------------
+# can_dispatch -- GPU slot exhaustion
+# ---------------------------------------------------------------------------
+
+
+class TestCanDispatchGPU:
+    @patch("psutil.virtual_memory", return_value=_mock_vm(50.0))
+    def test_gpu_available(self, _mock):
+        rm = ResourceManager(gpu_slots=2)
+        assert rm.can_dispatch(ResourceRequest(requires_gpu=True, gpu_memory_gb=4.0))
+
+    @patch("psutil.virtual_memory", return_value=_mock_vm(50.0))
+    def test_gpu_exhausted(self, _mock):
+        rm = ResourceManager(gpu_slots=1)
+        rm._gpu_in_use = 1
+        assert not rm.can_dispatch(ResourceRequest(requires_gpu=True, gpu_memory_gb=4.0))
+
+    @patch("psutil.virtual_memory", return_value=_mock_vm(50.0))
+    def test_no_gpu_required_with_zero_slots(self, _mock):
+        """Non-GPU request should pass even with zero GPU slots."""
+        rm = ResourceManager(gpu_slots=0)
+        assert rm.can_dispatch(ResourceRequest(requires_gpu=False))
+
+
+# ---------------------------------------------------------------------------
+# can_dispatch -- memory watermarks
+# ---------------------------------------------------------------------------
+
+
+class TestCanDispatchMemory:
+    def test_below_watermark(self):
+        rm = ResourceManager(memory_high_watermark=0.80)
+        with patch("psutil.virtual_memory", return_value=_mock_vm(50.0)):
+            assert rm.can_dispatch(ResourceRequest())
+
+    def test_above_high_watermark(self):
+        rm = ResourceManager(memory_high_watermark=0.80)
+        with patch("psutil.virtual_memory", return_value=_mock_vm(85.0)):
+            assert not rm.can_dispatch(ResourceRequest())
+
+    def test_at_high_watermark_boundary(self):
+        """Exactly at watermark should still dispatch (> not >=)."""
+        rm = ResourceManager(memory_high_watermark=0.80)
+        with patch("psutil.virtual_memory", return_value=_mock_vm(80.0)):
+            assert rm.can_dispatch(ResourceRequest())
+
+    def test_above_critical(self):
+        rm = ResourceManager(memory_critical=0.95)
+        with patch("psutil.virtual_memory", return_value=_mock_vm(96.0)):
+            assert not rm.can_dispatch(ResourceRequest())
+
+    def test_at_critical_boundary(self):
+        """At exactly critical should block (>= check)."""
+        rm = ResourceManager(memory_critical=0.95)
+        with patch("psutil.virtual_memory", return_value=_mock_vm(95.0)):
+            assert not rm.can_dispatch(ResourceRequest())
+
+
+# ---------------------------------------------------------------------------
+# acquire / release round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestAcquireRelease:
+    @patch("psutil.virtual_memory", return_value=_mock_vm(50.0))
+    def test_acquire_cpu(self, _mock):
+        rm = ResourceManager(cpu_workers=4)
+        result = _run(rm.acquire(ResourceRequest(cpu_cores=2), block_id="b1"))
+        assert result is True
+        assert rm._cpu_in_use == 2
+        assert "b1" in rm._allocations
+
+    @patch("psutil.virtual_memory", return_value=_mock_vm(50.0))
+    def test_acquire_gpu(self, _mock):
+        rm = ResourceManager(gpu_slots=2)
+        result = _run(rm.acquire(ResourceRequest(requires_gpu=True), block_id="g1"))
+        assert result is True
+        assert rm._gpu_in_use == 1
+
+    @patch("psutil.virtual_memory", return_value=_mock_vm(50.0))
+    def test_acquire_fails_when_full(self, _mock):
+        rm = ResourceManager(cpu_workers=2)
+        rm._cpu_in_use = 2
+        result = _run(rm.acquire(ResourceRequest(cpu_cores=1), block_id="x"))
+        assert result is False
+        assert "x" not in rm._allocations
+
+    @patch("psutil.virtual_memory", return_value=_mock_vm(50.0))
+    def test_release_cpu(self, _mock):
+        rm = ResourceManager(cpu_workers=4)
+        req = ResourceRequest(cpu_cores=2)
+        _run(rm.acquire(req, block_id="b1"))
+        rm.release(req, block_id="b1")
+        assert rm._cpu_in_use == 0
+        assert "b1" not in rm._allocations
+
+    @patch("psutil.virtual_memory", return_value=_mock_vm(50.0))
+    def test_release_gpu(self, _mock):
+        rm = ResourceManager(gpu_slots=2)
+        req = ResourceRequest(requires_gpu=True)
+        _run(rm.acquire(req, block_id="g1"))
+        rm.release(req, block_id="g1")
+        assert rm._gpu_in_use == 0
+
+    def test_release_prevents_negative_counters(self):
+        rm = ResourceManager(cpu_workers=4, gpu_slots=2)
+        rm.release(ResourceRequest(cpu_cores=3, requires_gpu=True))
+        assert rm._cpu_in_use == 0
+        assert rm._gpu_in_use == 0
+
+    @patch("psutil.virtual_memory", return_value=_mock_vm(50.0))
+    def test_acquire_without_block_id(self, _mock):
+        """Acquire without block_id should still work but not track allocation."""
+        rm = ResourceManager(cpu_workers=4)
+        result = _run(rm.acquire(ResourceRequest(cpu_cores=1)))
+        assert result is True
+        assert rm._cpu_in_use == 1
+        assert rm._allocations == {}
+
+
+# ---------------------------------------------------------------------------
+# available property
+# ---------------------------------------------------------------------------
+
+
+class TestAvailableProperty:
+    @patch("psutil.virtual_memory", return_value=_mock_vm(42.0))
+    def test_snapshot_values(self, _mock):
+        rm = ResourceManager(gpu_slots=4, cpu_workers=8)
+        rm._gpu_in_use = 1
+        rm._cpu_in_use = 3
+        snap = rm.available
+        assert isinstance(snap, ResourceSnapshot)
+        assert snap.available_gpu_slots == 3
+        assert snap.available_cpu_workers == 5
+        assert snap.system_memory_percent == pytest.approx(0.42)
+
+    @patch("psutil.virtual_memory", return_value=_mock_vm(0.0))
+    def test_snapshot_zero_memory(self, _mock):
+        rm = ResourceManager()
+        snap = rm.available
+        assert snap.system_memory_percent == 0.0
+
+
+# ---------------------------------------------------------------------------
+# EventBus auto-release (ADR-018)
+# ---------------------------------------------------------------------------
+
+
+class TestEventBusAutoRelease:
+    @patch("psutil.virtual_memory", return_value=_mock_vm(50.0))
+    def test_auto_release_on_block_done(self, _mock):
+        from scieasy.engine.events import BLOCK_DONE, EngineEvent, EventBus
+
+        bus = EventBus()
+        rm = ResourceManager(cpu_workers=4, gpu_slots=2, event_bus=bus)
+
+        # Acquire resources
+        req = ResourceRequest(cpu_cores=2, requires_gpu=True)
+        _run(rm.acquire(req, block_id="block-1"))
+        assert rm._cpu_in_use == 2
+        assert rm._gpu_in_use == 1
+        assert "block-1" in rm._allocations
+
+        # Emit terminal event
+        event = EngineEvent(event_type=BLOCK_DONE, block_id="block-1")
+        _run(bus.emit(event))
+
+        # Resources should be released
+        assert rm._cpu_in_use == 0
+        assert rm._gpu_in_use == 0
+        assert "block-1" not in rm._allocations
+
+    @patch("psutil.virtual_memory", return_value=_mock_vm(50.0))
+    def test_auto_release_on_block_error(self, _mock):
+        from scieasy.engine.events import BLOCK_ERROR, EngineEvent, EventBus
+
+        bus = EventBus()
+        rm = ResourceManager(cpu_workers=4, event_bus=bus)
+
+        req = ResourceRequest(cpu_cores=3)
+        _run(rm.acquire(req, block_id="block-err"))
+        assert rm._cpu_in_use == 3
+
+        event = EngineEvent(event_type=BLOCK_ERROR, block_id="block-err")
+        _run(bus.emit(event))
+
+        assert rm._cpu_in_use == 0
+        assert "block-err" not in rm._allocations
+
+    @patch("psutil.virtual_memory", return_value=_mock_vm(50.0))
+    def test_auto_release_on_block_cancelled(self, _mock):
+        from scieasy.engine.events import BLOCK_CANCELLED, EngineEvent, EventBus
+
+        bus = EventBus()
+        rm = ResourceManager(cpu_workers=4, event_bus=bus)
+
+        req = ResourceRequest(cpu_cores=1)
+        _run(rm.acquire(req, block_id="block-cancel"))
+
+        event = EngineEvent(event_type=BLOCK_CANCELLED, block_id="block-cancel")
+        _run(bus.emit(event))
+
+        assert rm._cpu_in_use == 0
+        assert "block-cancel" not in rm._allocations
+
+    @patch("psutil.virtual_memory", return_value=_mock_vm(50.0))
+    def test_auto_release_on_process_exited(self, _mock):
+        from scieasy.engine.events import PROCESS_EXITED, EngineEvent, EventBus
+
+        bus = EventBus()
+        rm = ResourceManager(cpu_workers=4, event_bus=bus)
+
+        req = ResourceRequest(cpu_cores=2)
+        _run(rm.acquire(req, block_id="block-proc"))
+
+        event = EngineEvent(event_type=PROCESS_EXITED, block_id="block-proc")
+        _run(bus.emit(event))
+
+        assert rm._cpu_in_use == 0
+        assert "block-proc" not in rm._allocations
+
+    @patch("psutil.virtual_memory", return_value=_mock_vm(50.0))
+    def test_event_for_unknown_block_id_is_ignored(self, _mock):
+        from scieasy.engine.events import BLOCK_DONE, EngineEvent, EventBus
+
+        bus = EventBus()
+        rm = ResourceManager(cpu_workers=4, event_bus=bus)
+
+        req = ResourceRequest(cpu_cores=1)
+        _run(rm.acquire(req, block_id="known"))
+
+        # Emit event for a block_id not tracked
+        event = EngineEvent(event_type=BLOCK_DONE, block_id="unknown")
+        _run(bus.emit(event))  # Should not raise
+
+        # Original allocation still present
+        assert rm._cpu_in_use == 1
+        assert "known" in rm._allocations
+
+    def test_no_event_bus_no_subscriptions(self):
+        """ResourceManager without event_bus should work fine."""
+        rm = ResourceManager(cpu_workers=4)
+        assert rm._allocations == {}
+        # No error, just no auto-release capability


### PR DESCRIPTION
## Summary

- Implement `PosixOps` and `WindowsOps` — full PlatformOps protocol for cross-platform process group management
- Implement `ProcessHandle` — per-process lifecycle wrapper delegating to PlatformOps
- Implement `ProcessRegistry` — dict-based registry with `terminate_all` for engine shutdown
- Implement `spawn_block_process()` — single entry point for subprocess creation, emitting `PROCESS_SPAWNED` via EventBus
- Add 29 tests covering registry CRUD, handle delegation, platform ops conformance, and spawn factory with mocked subprocess

## Related Issues

Closes #90

## ADR References

- ADR-017: Subprocess isolation — `spawn_block_process()` is the single entry point
- ADR-019: PlatformOps protocol — PosixOps and WindowsOps implementations

## Dependencies

- Based on `feat/issue-85/event-bus` (PR #89) for EventBus and PROCESS_SPAWNED event

## Test plan

- [x] ProcessExitInfo defaults and custom fields
- [x] PosixOps and WindowsOps conform to PlatformOps protocol
- [x] `create_process_group` sets correct platform-specific kwargs
- [x] `is_alive` works for current process and nonexistent PIDs
- [x] ProcessHandle construction stores all fields
- [x] ProcessHandle delegates is_alive/exit_info/terminate/kill to PlatformOps
- [x] ProcessRegistry register/deregister/get_handle/active_handles
- [x] ProcessRegistry terminate_all iterates all handles
- [x] ProcessRegistry terminate_all continues on individual handle failure
- [x] spawn_block_process creates subprocess, registers handle, emits event
- [x] spawn_block_process handles class objects and string paths
- [x] spawn_block_process uses platform-specific process group kwargs
- [x] Full test suite passes (29 new tests, 0 regressions)
- [x] ruff check + ruff format clean

:robot: Generated with [Claude Code](https://claude.com/claude-code)