### PR TITLE
fix: batch 1 — remove InputDelivery, postprocess types, constraint docs, JSON metadata (#59, #57, #58, #48)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Removed
+
+- [#59] Remove InputDelivery enum — MEMORY-only delivery via ADR-020 Collection auto-unpack (@claude, 2026-04-04, branch: fix/batch-1/issues-59-57-58-48, session: 20260404-192842-batch-1-remove-inputdelivery-postprocess)
+
+### Changed
+
+- [#57] Update Block.postprocess() type annotation to dict[str, Collection] (@claude, 2026-04-04, branch: fix/batch-1/issues-59-57-58-48, session: 20260404-192842-batch-1-remove-inputdelivery-postprocess)
+- [#58] Document that port constraint functions receive Collection objects (@claude, 2026-04-04, branch: fix/batch-1/issues-59-57-58-48, session: 20260404-192842-batch-1-remove-inputdelivery-postprocess)
+
 ### Added
+
+- [#48] Enforce JSON-serializable metadata on DataObject construction (@claude, 2026-04-04, branch: fix/batch-1/issues-59-57-58-48, session: 20260404-192842-batch-1-remove-inputdelivery-postprocess)
 
 - [#113] Implement all ADR-017–022 TODO stubs, raise coverage threshold to 85% — resolve 38 TODOs across 32 files, implement WebSocket handler, ProcessExitedWithoutOutputError, create_reference(), Collection unpack/pack, CheckpointManager integration, ViewProxy.from_file(), add 24 new tests (@claude, 2026-04-04, branch: feat/issue-113/implement-all-todos-raise-coverage, session: 20260404-170726-implement-all-todo-stubs-adr-017-to-adr)
 - [#109] Phase 6.2: Implement scieasy CLI commands — init, validate, run, blocks, serve with typer.testing smoke tests (@claude, 2026-04-04, branch: phase6/cli-commands)

--- a/docs/adr/ADR.md
+++ b/docs/adr/ADR.md
@@ -169,7 +169,7 @@ The framework introspects script files to auto-generate port declarations and co
 - Users can integrate existing scripts without modification beyond adding a `run()` wrapper function.
 - Script introspection (`introspect.py`) must handle Python, R, and Julia function signatures — a moderate implementation effort.
 - Inline mode executes code via `exec()`, which has security implications. Acceptable for single-user local deployment; requires sandboxing for any future multi-user scenario (see Appendix C.3 of ARCHITECTURE.md).
-- Data delivery to user scripts requires explicit handling — see ADR-016 for the per-port `InputDelivery` mechanism that resolves the tension between lazy loading and script compatibility.
+- Data delivery to user scripts requires explicit handling — see ADR-016 for the original per-port `InputDelivery` mechanism (now partially superseded by ADR-020 Collection auto-unpack).
 
 ---
 
@@ -498,8 +498,9 @@ The framework never reimplements functionality that existing tools do well. Inst
 
 ## ADR-016: Per-port InputDelivery for CodeBlock data handoff
 
-**Status**: accepted  
-**Date**: 2026-04-02
+**Status**: partially superseded by ADR-020  
+**Date**: 2026-04-02  
+**Supersession note**: ADR-020 introduces Collection-based transport with auto-unpack/repack for CodeBlock (ADR-020-Add4). MEMORY is now the only delivery mode; PROXY and CHUNKED are removed. Users who need lazy access should write a ProcessBlock instead. The `InputDelivery` enum has been deleted.
 
 ### Context
 

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -513,32 +513,41 @@ class OutputPort(Port):
 
 1. **Design-time (fast)**: when the user draws a connection in ReactFlow, the frontend checks whether the source port's output type is in the target port's `accepted_types`, accounting for inheritance. Invalid connections are visually rejected. This check is purely structural — it only considers the class hierarchy.
 
-2. **Pre-execution (precise)**: before a block runs, the engine calls the optional `constraint` function on each input, passing the actual `DataObject`. This catches semantic mismatches that type alone cannot express.
+2. **Pre-execution (precise)**: before a block runs, the engine calls the optional `constraint` function on each input, passing the **Collection** (ADR-020). Constraint functions that need per-item checks should iterate over the Collection. This catches semantic mismatches that type alone cannot express.
 
-Example constraints:
+Example constraints (ADR-020: constraints receive Collection):
 
 ```python
-# A 2D convolution block needs spatial axes (using named axes)
+# A 2D convolution block needs all images to have spatial axes
 InputPort(
-    name="image",
+    name="images",
     accepted_types=[Image],
-    constraint=lambda img: img.axes is not None and {"y", "x"}.issubset(set(img.axes)),
-    constraint_description="Image must have spatial axes (y, x)",
+    constraint=lambda col: all(
+        img.axes is not None and {"y", "x"}.issubset(set(img.axes))
+        for img in col
+    ),
+    constraint_description="All images must have spatial axes (y, x)",
 )
 
-# A broadcast block needs the mask axes to be a subset of the target axes
+# A broadcast block needs all masks to be 2D spatial
 InputPort(
-    name="mask",
+    name="masks",
     accepted_types=[Image],
-    constraint=lambda img: img.axes is not None and set(img.axes) == {"y", "x"},
-    constraint_description="Mask must be 2D spatial (y, x) for broadcasting over target channels",
+    constraint=lambda col: all(
+        img.axes is not None and set(img.axes) == {"y", "x"}
+        for img in col
+    ),
+    constraint_description="All masks must be 2D spatial (y, x) for broadcasting over target channels",
 )
 
 # A merge block needs two DataFrames with at least one shared column
 InputPort(
     name="right",
     accepted_types=[DataFrame],
-    constraint=lambda df: len(set(df.columns) & set(self._left_columns)) > 0,
+    constraint=lambda col: all(
+        len(set(df.columns) & set(self._left_columns)) > 0
+        for df in col
+    ),
     constraint_description="Must share at least one column with the left input",
 )
 
@@ -546,7 +555,10 @@ InputPort(
 InputPort(
     name="spatial_data",
     accepted_types=[CompositeData],
-    constraint=lambda cd: "images" in cd.slot_names and "table" in cd.slot_names,
+    constraint=lambda col: all(
+        "images" in cd.slot_names and "table" in cd.slot_names
+        for cd in col
+    ),
     constraint_description="Must contain 'images' (Array) and 'table' slots",
 )
 ```
@@ -635,7 +647,7 @@ Each `ProcessBlock` subclass declares its input/output ports with specific type 
 
 #### CodeBlock
 
-Enables zero-friction integration of existing scripts. Supports two execution modes (inline, script) and three data delivery modes per input port.
+Enables zero-friction integration of existing scripts. Supports two execution modes (inline, script) with automatic Collection unpack/repack (ADR-020-Add4).
 
 ##### Execution modes
 
@@ -704,75 +716,15 @@ run <- function(inputs, config) {
 }
 ```
 
-##### Input delivery modes
+##### Input handling (ADR-020)
 
-CodeBlock is the boundary between the framework (ViewProxy-based lazy loading) and user scripts (which expect native Python/R objects). The framework must decide **how** to deliver data from each input port to the user's code. This is controlled per-port via `InputDelivery`:
+CodeBlock inputs are handled via the Collection auto-unpack/repack layer (ADR-020-Add4). All inputs are delivered as native in-memory objects — equivalent to the former MEMORY delivery mode. The `InputDelivery` enum has been removed (see ADR-016, now partially superseded by ADR-020).
 
-```python
-class InputDelivery(Enum):
-    MEMORY = "memory"       # to_memory() — full load as native object (numpy, pandas, etc.)
-    PROXY = "proxy"         # pass ViewProxy directly — user controls slice/iter_chunks
-    CHUNKED = "chunked"     # framework iterates chunks, calls run() once per chunk
-```
+For each input port:
+- **Collection length=1**: the single item is materialised via `.view().to_memory()` (e.g., a numpy array).
+- **Collection length>1**: replaced with a `LazyList` that loads items on demand, keeping peak memory at O(1) per iteration step.
 
-**MEMORY (default)** — full load, maximum compatibility:
-
-The input is fully loaded into memory as a native object. Compatible with any script — numpy, pandas, scipy, R, all just work. This is the correct default because 90% of CodeBlock usage involves small-to-medium data.
-
-```python
-# Inline mode: input_0 is a numpy array, just use it normally
-result = savgol_filter(input_0, 11, 3)
-output_0 = result
-```
-
-If an input exceeds a configurable threshold (default: 2 GB), the framework displays a warning in the block's config panel: *"Input 'msi' is 47 GB. Consider switching to proxy or chunked delivery in script mode."*
-
-**PROXY** — lazy access for large data, user controls memory:
-
-The input is delivered as a `ViewProxy` object. The user script decides what to load and when. Only available in script mode (inline scripts are too short to justify proxy manipulation).
-
-```python
-# large_msi_analysis.py
-
-def configure():
-    return {
-        "input_delivery": {
-            "msi": "proxy",             # I'll manage memory myself
-            "cell_metadata": "memory",  # small table, load fully
-        },
-    }
-
-def run(inputs, config):
-    msi_proxy = inputs["msi"]               # ViewProxy, nothing loaded yet
-    metadata = inputs["cell_metadata"]       # pandas DataFrame, already in memory
-
-    # Only load one m/z channel at a time — memory stays bounded
-    ion_image = msi_proxy.slice({"mz": 885.5})      # ~50 MB, not 100 GB
-    cell_means = extract_per_cell(ion_image, metadata)
-    return {"output_0": cell_means}
-```
-
-**CHUNKED** — framework-driven iteration, user writes single-chunk logic:
-
-The user's `run()` function processes one chunk at a time. The framework handles iteration and result assembly. The user never sees the full dataset.
-
-```python
-# batch_spectral_smooth.py
-
-def configure():
-    return {
-        "input_delivery": {"spectra": "chunked"},
-        "chunk_size": 100,      # 100 spectra per chunk
-        "window": {"type": "int", "default": 11},
-    }
-
-def run(inputs, config):
-    # inputs["spectra"] is a small numpy array (100, n_wavelengths) — not the full dataset
-    batch = inputs["spectra"]
-    smoothed = savgol_filter(batch, config["window"], 3, axis=1)
-    return {"output_0": smoothed}
-    # Framework calls run() repeatedly for each chunk, concatenates results
-```
+Users who need fine-grained control over data loading (slicing, chunked iteration) should write a **ProcessBlock** instead of a CodeBlock. ProcessBlock authors receive `ViewProxy` directly and decide for themselves when to materialise.
 
 ##### Framework bridge implementation
 
@@ -785,82 +737,33 @@ class CodeBlock(Block):
 
         The engine serialises StorageReference pointers and config to the
         subprocess. The subprocess reconstructs ViewProxy instances from
-        storage, applies InputDelivery modes, and calls this method.
+        storage, unpacks Collection inputs, and calls this method.
         """
         language = config["language"]
         runner = CodeRunnerRegistry.get(language)
-        delivery_map = config.get("input_delivery", {})
+
+        # Unpack Collection inputs for user scripts (ADR-020-Add4)
+        unpacked = self._unpack_inputs(inputs)
 
         if config["mode"] == "inline":
-            # Inline mode: always MEMORY (simple mental model)
-            namespace = {name: proxy.to_memory() for name, proxy in inputs.items()}
-            result = runner.execute_inline(config["script"], namespace)
-
+            result = runner.execute_inline(config["script"], unpacked)
         else:
-            # Script mode: respect per-port delivery settings
-            chunked_ports = {
-                name: proxy for name, proxy in inputs.items()
-                if delivery_map.get(name) == "chunked"
-            }
+            result = runner.execute_script(
+                script_path=config["script_path"],
+                entry_function=config.get("entry_function", "run"),
+                inputs=unpacked,
+                config=config.get("script_config", {}),
+            )
 
-            if chunked_ports:
-                # CHUNKED path: framework drives iteration
-                result = self._run_chunked(runner, inputs, config, chunked_ports)
-            else:
-                # MEMORY / PROXY path: single invocation
-                input_data = {}
-                for name, proxy in inputs.items():
-                    delivery = delivery_map.get(name, "memory")
-                    if delivery == "proxy":
-                        input_data[name] = proxy           # pass ViewProxy as-is
-                    else:
-                        input_data[name] = proxy.to_memory()  # full load
-
-                result = runner.execute_script(
-                    script_path=config["script_path"],
-                    entry_function=config.get("entry_function", "run"),
-                    inputs=input_data,
-                    config=config.get("script_config", {}),
-                )
-
-        return {name: wrap_as_dataobject(v) for name, v in result.items()}
-
-    def _run_chunked(self, runner, inputs, config, chunked_ports):
-        chunk_size = config.get("chunk_size", 1000)
-        all_results = []
-
-        # Build non-chunked inputs once (MEMORY or PROXY)
-        static_inputs = {}
-        delivery_map = config.get("input_delivery", {})
-        for name, proxy in inputs.items():
-            if name not in chunked_ports:
-                delivery = delivery_map.get(name, "memory")
-                static_inputs[name] = proxy if delivery == "proxy" else proxy.to_memory()
-
-        # Iterate over chunks of the chunked port(s)
-        # (For simplicity, one chunked port at a time; multiple chunked ports
-        #  iterate in lockstep if they have the same length.)
-        for name, proxy in chunked_ports.items():
-            for chunk in proxy.iter_chunks(chunk_size):
-                chunk_inputs = {**static_inputs, name: chunk}
-                chunk_result = runner.execute_script(
-                    script_path=config["script_path"],
-                    entry_function=config.get("entry_function", "run"),
-                    inputs=chunk_inputs,
-                    config=config.get("script_config", {}),
-                )
-                all_results.append(chunk_result)
-
-        return concatenate_results(all_results)
+        # Repack outputs into Collections (ADR-020-Add4)
+        return self._repack_outputs(result)
 ```
 
-Note: `proxy.to_memory()` and `proxy.iter_chunks()` calls happen inside the subprocess, loading data into the subprocess's memory — not the engine's. This preserves the lazy-loading contract (ADR-007): the engine process never touches the actual data.
+Note: data materialisation calls happen inside the subprocess, loading data into the subprocess's memory — not the engine's. This preserves the lazy-loading contract (ADR-007): the engine process never touches the actual data.
 
 ##### Script discovery and UI integration
 
-The frontend provides a file picker for `.py` / `.R` / `.jl` files. When a script is selected, the framework introspects it — reads port names from the `run()` function signature, config schema and `input_delivery` declarations from `configure()` (if present) — and auto-populates the block's port declarations, config form, and per-port delivery dropdowns. The user's script does not need to be modified beyond adding the `run()` convention.
-
-In the config panel, each input port shows a delivery mode selector (defaulting to MEMORY). For inline mode, delivery is locked to MEMORY and the selector is hidden.
+The frontend provides a file picker for `.py` / `.R` / `.jl` files. When a script is selected, the framework introspects it — reads port names from the `run()` function signature and config schema from `configure()` (if present) — and auto-populates the block's port declarations and config form. The user's script does not need to be modified beyond adding the `run()` convention.
 
 **Code runners** are isolated subprocess execution environments (ADR-017):
 - **Python**: the subprocess worker calls `exec()` for inline mode or `importlib` for script mode — both inside the subprocess, never in the engine process.

--- a/src/scieasy/blocks/base/__init__.py
+++ b/src/scieasy/blocks/base/__init__.py
@@ -15,20 +15,18 @@ from scieasy.blocks.base.ports import (
 )
 from scieasy.blocks.base.result import BlockResult
 from scieasy.blocks.base.state import (
-    # ADR-020: BatchErrorStrategy, BatchMode REMOVED
+    # ADR-020: BatchErrorStrategy, BatchMode, InputDelivery REMOVED
     BlockState,
     ExecutionMode,
-    InputDelivery,
 )
 
 __all__ = [
-    # ADR-020: "BatchErrorStrategy", "BatchMode", "BatchResult" REMOVED
+    # ADR-020: "BatchErrorStrategy", "BatchMode", "BatchResult", "InputDelivery" REMOVED
     "Block",
     "BlockConfig",
     "BlockResult",
     "BlockState",
     "ExecutionMode",
-    "InputDelivery",
     "InputPort",
     "OutputPort",
     "Port",

--- a/src/scieasy/blocks/base/block.py
+++ b/src/scieasy/blocks/base/block.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Any, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar
+
+if TYPE_CHECKING:
+    from scieasy.core.types.collection import Collection
 
 from scieasy.blocks.base.config import BlockConfig
 from scieasy.blocks.base.ports import InputPort, OutputPort, port_accepts_type, validate_port_constraint
@@ -115,9 +118,11 @@ class Block(ABC):
         """Execute the block's main logic and return output mapping."""
         ...
 
-    def postprocess(self, outputs: dict[str, Any]) -> dict[str, Any]:
+    def postprocess(self, outputs: dict[str, Collection]) -> dict[str, Collection]:
         """Optional post-processing of *outputs* before downstream delivery.
 
+        ADR-020: Outputs are ``dict[str, Collection]`` — each value is a
+        Collection wrapping the block's output DataObjects for that port.
         Default implementation passes outputs through unchanged.
         """
         return outputs

--- a/src/scieasy/blocks/base/ports.py
+++ b/src/scieasy/blocks/base/ports.py
@@ -74,6 +74,15 @@ def port_accepts_signature(port: Port, signature: TypeSignature) -> bool:
 def validate_port_constraint(port: InputPort, value: Any) -> tuple[bool, str]:
     """Validate *value* against the input port's constraint function.
 
+    ADR-020: *value* is a :class:`Collection` (not an individual DataObject).
+    Constraint functions should iterate over the Collection if they need
+    per-item checks::
+
+        constraint=lambda col: all(
+            item.axes is not None and {"y", "x"}.issubset(set(item.axes))
+            for item in col
+        )
+
     Returns ``(True, "")`` if valid or no constraint is set.
     Returns ``(False, description)`` on constraint failure.
     """

--- a/src/scieasy/blocks/base/state.py
+++ b/src/scieasy/blocks/base/state.py
@@ -1,4 +1,4 @@
-"""BlockState, ExecutionMode, BatchMode, InputDelivery, BatchErrorStrategy enums."""
+"""BlockState, ExecutionMode enums."""
 
 from __future__ import annotations
 
@@ -30,13 +30,9 @@ class ExecutionMode(Enum):
 # Collection iteration is block-internal (see process_item(), map_items(), parallel_map()).
 
 
-class InputDelivery(Enum):
-    """How input data is delivered to the block."""
-
-    MEMORY = "memory"
-    PROXY = "proxy"
-    CHUNKED = "chunked"
-
+# ADR-020: InputDelivery enum REMOVED — CodeBlock uses Collection auto-unpack
+# only (LazyList for length>1, to_memory() for length=1). PROXY and CHUNKED
+# delivery modes superseded by ProcessBlock for framework-aware code.
 
 # ADR-020: BatchErrorStrategy enum REMOVED — block authors handle item-level
 # errors internally. Engine only sees DONE, ERROR, CANCELLED, SKIPPED.

--- a/src/scieasy/blocks/code/code_block.py
+++ b/src/scieasy/blocks/code/code_block.py
@@ -21,11 +21,6 @@ class CodeBlock(Block):
 
     *language* selects the runner; *mode* is ``"inline"`` or ``"script"``.
 
-    Delivery modes (per-port or block-level):
-        MEMORY  -- ``to_memory()`` is called, block receives raw data.
-        PROXY   -- block receives :class:`ViewProxy` instances directly.
-        CHUNKED -- ``iter_chunks()`` is called, results are concatenated.
-
     Auto-unpack/repack layer (ADR-020-Add4):
         Before user code runs, ``_unpack_inputs()`` converts Collection
         inputs so that user scripts never see Collection objects directly:
@@ -36,8 +31,9 @@ class CodeBlock(Block):
 
     Note (ADR-017): All execution is delegated to subprocess-based runner
         via spawn_block_process(). No in-process exec() or importlib.
-    Note (ADR-017): _prepare_inputs() moves to subprocess worker
-        (engine/runners/worker.py). Input preparation happens in child process.
+    Note (ADR-020): InputDelivery enum removed. PROXY and CHUNKED delivery
+        modes are superseded by ProcessBlock for framework-aware code.
+        CodeBlock always delivers data as native in-memory objects.
     """
 
     language: ClassVar[str] = "python"
@@ -109,9 +105,8 @@ class CodeBlock(Block):
         Steps:
             1. Resolve language runner from RunnerRegistry.
             2. Unpack Collection inputs for user scripts (ADR-020-Add4).
-            3. Apply delivery mode (MEMORY/PROXY/CHUNKED) to ViewProxy inputs.
-            4. Dispatch to runner (inline or script mode).
-            5. Repack outputs into Collections (ADR-020-Add4).
+            3. Dispatch to runner (inline or script mode).
+            4. Repack outputs into Collections (ADR-020-Add4).
         """
         from scieasy.blocks.base.state import BlockState
         from scieasy.blocks.code.runner_registry import RunnerRegistry
@@ -120,7 +115,6 @@ class CodeBlock(Block):
         try:
             language = config.get("language") or self.language
             mode = config.get("mode") or self.mode
-            delivery = config.get("delivery", "memory")
 
             # Step 1: Get runner
             registry = RunnerRegistry()
@@ -130,25 +124,22 @@ class CodeBlock(Block):
             # Step 2: Unpack Collection inputs
             unpacked = self._unpack_inputs(inputs)
 
-            # Step 3: Apply delivery mode to ViewProxy inputs
-            prepared = self._apply_delivery(unpacked, delivery, config)
-
-            # Step 4: Dispatch to runner
+            # Step 3: Dispatch to runner
             if mode == "inline":
                 script = config.get("script", "")
                 if not script:
                     raise ValueError("Inline mode requires 'script' in config")
-                raw_outputs = runner.execute_inline(script, prepared)
+                raw_outputs = runner.execute_inline(script, unpacked)
             elif mode == "script":
                 script_path = config.get("script_path", "")
                 if not script_path:
                     raise ValueError("Script mode requires 'script_path' in config")
                 entry = config.get("entry_function", "run")
-                raw_outputs = runner.execute_script(script_path, entry, prepared, dict(config.params))
+                raw_outputs = runner.execute_script(script_path, entry, unpacked, dict(config.params))
             else:
                 raise ValueError(f"Unknown CodeBlock mode: '{mode}'")
 
-            # Step 5: Repack outputs
+            # Step 4: Repack outputs
             result = self._repack_outputs(raw_outputs)
 
             self.transition(BlockState.DONE)
@@ -156,28 +147,3 @@ class CodeBlock(Block):
         except Exception:
             self.transition(BlockState.ERROR)
             raise
-
-    @staticmethod
-    def _apply_delivery(inputs: dict[str, Any], delivery: str, config: BlockConfig) -> dict[str, Any]:
-        """Apply delivery mode to ViewProxy inputs.
-
-        MEMORY:  call to_memory() -- block receives raw data.
-        PROXY:   pass through -- block receives ViewProxy directly.
-        CHUNKED: call iter_chunks() -- block receives list of chunks.
-        """
-        from scieasy.core.proxy import ViewProxy
-
-        prepared: dict[str, Any] = {}
-        for key, value in inputs.items():
-            if not isinstance(value, ViewProxy):
-                prepared[key] = value
-                continue
-
-            if delivery == "proxy":
-                prepared[key] = value
-            elif delivery == "chunked":
-                chunk_size = int(config.get("chunk_size", 1024))
-                prepared[key] = list(value.iter_chunks(chunk_size))
-            else:  # "memory" (default)
-                prepared[key] = value.to_memory()
-        return prepared

--- a/src/scieasy/core/types/base.py
+++ b/src/scieasy/core/types/base.py
@@ -75,6 +75,10 @@ class DataObject:
 
     Subclasses represent concrete scientific data kinds (arrays, series,
     dataframes, text, artifacts, composites).
+
+    ADR-017: ``metadata`` must be JSON-serializable for subprocess transport.
+    Non-serializable values (numpy arrays, custom objects, lambdas) raise
+    ``TypeError`` at construction time.
     """
 
     def __init__(
@@ -83,7 +87,18 @@ class DataObject:
         storage_ref: StorageReference | None = None,
     ) -> None:
         self._metadata: dict[str, Any] = metadata or {}
+        self._validate_metadata(self._metadata)
         self._storage_ref: StorageReference | None = storage_ref
+
+    @staticmethod
+    def _validate_metadata(metadata: dict[str, Any]) -> None:
+        """Validate that *metadata* is JSON-serializable (ADR-017)."""
+        import json
+
+        try:
+            json.dumps(metadata)
+        except (TypeError, ValueError) as exc:
+            raise TypeError(f"DataObject metadata must be JSON-serializable: {exc}") from exc
 
     # -- properties ----------------------------------------------------------
 

--- a/tests/blocks/test_code_block.py
+++ b/tests/blocks/test_code_block.py
@@ -1,18 +1,15 @@
-"""Tests for CodeBlock — inline Python, script Python, PROXY mode, CHUNKED mode."""
+"""Tests for CodeBlock — inline Python, script Python, Collection unpack/repack."""
 
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import MagicMock
 
-import numpy as np
 import pytest
 
 from scieasy.blocks.base.state import BlockState
 from scieasy.blocks.code.code_block import CodeBlock
 from scieasy.blocks.code.introspect import introspect_script
 from scieasy.blocks.code.runners.python_runner import PythonRunner
-from scieasy.core.proxy import ViewProxy
 
 
 class TestPythonRunnerInline:
@@ -60,16 +57,16 @@ class TestPythonRunnerScript:
 
 
 class TestCodeBlockInline:
-    """CodeBlock inline mode with MEMORY delivery."""
+    """CodeBlock inline mode."""
 
     def test_inline_execution(self) -> None:
-        block = CodeBlock(config={"params": {"script": "result = 42", "delivery": "memory"}})
+        block = CodeBlock(config={"params": {"script": "result = 42"}})
         block.transition(BlockState.READY)
         result = block.run({}, block.config)
         assert result["result"] == 42
 
     def test_inline_with_input(self) -> None:
-        block = CodeBlock(config={"params": {"script": "output = data * 2", "delivery": "memory"}})
+        block = CodeBlock(config={"params": {"script": "output = data * 2"}})
         block.transition(BlockState.READY)
         result = block.run({"data": 10}, block.config)
         assert result["output"] == 20
@@ -81,46 +78,16 @@ class TestCodeBlockScript:
     def test_script_execution(self, tmp_path: Path) -> None:
         script = tmp_path / "block_script.py"
         script.write_text("def run(inputs, config):\n    return {'result': sum(inputs.get('values', []))}\n")
-        block = CodeBlock(config={"params": {"script_path": str(script), "delivery": "memory"}})
+        block = CodeBlock(config={"params": {"script_path": str(script)}})
         block.mode = "script"
         block.transition(BlockState.READY)
         result = block.run({"values": [1, 2, 3]}, block.config)
         assert result["result"] == 6
 
 
-class TestCodeBlockProxyMode:
-    """CodeBlock PROXY delivery — passes ViewProxy directly."""
-
-    def test_proxy_passthrough(self) -> None:
-        """Verify that PROXY mode passes the ViewProxy without materialising."""
-        block = CodeBlock(config={"params": {"script": "result = type(data).__name__", "delivery": "proxy"}})
-        block.transition(BlockState.READY)
-
-        # Create a mock ViewProxy.
-        proxy = MagicMock(spec=ViewProxy)
-        proxy.to_memory = MagicMock(return_value="should not be called")
-
-        result = block.run({"data": proxy}, block.config)
-        assert result["result"] == "MagicMock"
-        # to_memory should NOT have been called.
-        proxy.to_memory.assert_not_called()
-
-
-class TestCodeBlockChunkedMode:
-    """CodeBlock CHUNKED delivery — iterates chunks."""
-
-    def test_chunked_delivery(self) -> None:
-        """Verify CHUNKED mode calls iter_chunks and delivers a list."""
-        block = CodeBlock(config={"params": {"script": "result = len(data)", "delivery": "chunked", "chunk_size": 2}})
-        block.transition(BlockState.READY)
-
-        proxy = MagicMock(spec=ViewProxy)
-        proxy.iter_chunks = MagicMock(return_value=iter([np.array([1, 2]), np.array([3, 4])]))
-
-        result = block.run({"data": proxy}, block.config)
-        # The input 'data' should be a list of chunks.
-        assert result["result"] == 2
-        proxy.iter_chunks.assert_called_once_with(2)
+# ADR-020: TestCodeBlockProxyMode and TestCodeBlockChunkedMode removed.
+# InputDelivery enum deleted — CodeBlock uses Collection auto-unpack only.
+# PROXY and CHUNKED delivery are superseded by ProcessBlock.
 
 
 class TestIntrospectScript:

--- a/tests/blocks/test_state_enums.py
+++ b/tests/blocks/test_state_enums.py
@@ -1,12 +1,11 @@
-"""Tests for state enums — BlockState, ExecutionMode, BatchMode, InputDelivery, BatchErrorStrategy."""
+"""Tests for state enums — BlockState, ExecutionMode."""
 
 from __future__ import annotations
 
 from scieasy.blocks.base.state import (
-    # ADR-020: BatchErrorStrategy and BatchMode removed
+    # ADR-020: BatchErrorStrategy, BatchMode, InputDelivery removed
     BlockState,
     ExecutionMode,
-    InputDelivery,
 )
 
 
@@ -43,18 +42,5 @@ class TestExecutionModeValues:
 
 
 # ADR-020: TestBatchModeValues removed — BatchMode enum deleted.
-
-
-class TestInputDeliveryValues:
-    """InputDelivery — how input data is delivered to the block."""
-
-    def test_all_values(self) -> None:
-        assert InputDelivery.MEMORY.value == "memory"
-        assert InputDelivery.PROXY.value == "proxy"
-        assert InputDelivery.CHUNKED.value == "chunked"
-
-    def test_member_count(self) -> None:
-        assert len(InputDelivery) == 3
-
-
+# ADR-020: TestInputDeliveryValues removed — InputDelivery enum deleted.
 # ADR-020: TestBatchErrorStrategyValues removed — BatchErrorStrategy enum deleted.

--- a/tests/core/test_dataobject_extended.py
+++ b/tests/core/test_dataobject_extended.py
@@ -17,6 +17,49 @@ from scieasy.core.types.series import Series
 from scieasy.core.types.text import Text
 
 
+class TestMetadataValidation:
+    """ADR-017: metadata must be JSON-serializable for subprocess transport."""
+
+    def test_valid_json_primitives(self) -> None:
+        obj = DataObject(metadata={"str": "hello", "int": 42, "float": 3.14, "bool": True, "none": None})
+        assert obj.metadata["str"] == "hello"
+
+    def test_valid_nested_structures(self) -> None:
+        obj = DataObject(metadata={"list": [1, 2, 3], "nested": {"a": {"b": [1]}}})
+        assert obj.metadata["list"] == [1, 2, 3]
+
+    def test_empty_metadata_passes(self) -> None:
+        obj = DataObject(metadata={})
+        assert obj.metadata == {}
+
+    def test_none_metadata_defaults_to_empty(self) -> None:
+        obj = DataObject(metadata=None)
+        assert obj.metadata == {}
+
+    def test_no_metadata_arg(self) -> None:
+        obj = DataObject()
+        assert obj.metadata == {}
+
+    def test_set_raises(self) -> None:
+        with pytest.raises(TypeError, match="JSON-serializable"):
+            DataObject(metadata={"bad": {1, 2, 3}})
+
+    def test_lambda_raises(self) -> None:
+        with pytest.raises(TypeError, match="JSON-serializable"):
+            DataObject(metadata={"fn": lambda x: x})
+
+    def test_custom_object_raises(self) -> None:
+        class Custom:
+            pass
+
+        with pytest.raises(TypeError, match="JSON-serializable"):
+            DataObject(metadata={"obj": Custom()})
+
+    def test_bytes_raises(self) -> None:
+        with pytest.raises(TypeError, match="JSON-serializable"):
+            DataObject(metadata={"data": b"\x00\x01"})
+
+
 class TestDataObjectStorageRef:
     """DataObject.storage_ref — getter and setter."""
 


### PR DESCRIPTION
## Summary

- **#59**: Remove `InputDelivery` enum — ADR-020 Collection auto-unpack supersedes MEMORY/PROXY/CHUNKED delivery modes. CodeBlock `_apply_delivery()` deleted, `run()` simplified.
- **#57**: Update `Block.postprocess()` type annotation from `dict[str, Any]` to `dict[str, Collection]` for ADR-020 consistency.
- **#58**: Document that port constraint functions receive `Collection` objects. Updated `validate_port_constraint()` docstring and ARCHITECTURE.md constraint examples.
- **#48**: Enforce JSON-serializable metadata on `DataObject` construction. `_validate_metadata()` uses `json.dumps()` and raises `TypeError` for non-serializable values.

## Related Issues
Closes #59, closes #57, closes #58, closes #48

## Changes
| File | Change |
|------|--------|
| `blocks/base/state.py` | Delete `InputDelivery` enum |
| `blocks/base/__init__.py` | Remove export |
| `blocks/code/code_block.py` | Remove `_apply_delivery()`, simplify `run()` |
| `blocks/base/block.py` | `postprocess()` → `dict[str, Collection]` |
| `blocks/base/ports.py` | Constraint docstring update |
| `core/types/base.py` | JSON metadata validation |
| `docs/adr/ADR.md` | ADR-016 status → partially superseded |
| `docs/architecture/ARCHITECTURE.md` | Delivery modes → ADR-020 note, constraint examples |

## Test plan
- [x] All existing tests pass (85.15% coverage)
- [x] New metadata validation tests (valid JSON, non-serializable raises TypeError)
- [x] Removed proxy/chunked test classes that tested deleted functionality
- [x] ruff check clean
- [x] ruff format clean
- [x] mypy: no new errors (pre-existing platform/yaml stub errors only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)