### PR TITLE
test(frontend): add Playwright E2E testing infrastructure (#184)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,3 +132,70 @@ jobs:
       - name: Build frontend
         working-directory: frontend
         run: npm run build
+
+  frontend-unit:
+    name: Frontend Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: "frontend/package-lock.json"
+      - run: cd frontend && npm ci
+      - run: cd frontend && npm run test
+
+  frontend-e2e:
+    name: Frontend E2E Tests
+    needs: [frontend-unit, test]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: "frontend/package-lock.json"
+      - uses: astral-sh/setup-uv@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+      - run: uv pip install --system -e ".[dev]"
+      - run: cd frontend && npm ci
+      - run: cd frontend && npx playwright install --with-deps chromium
+      - name: Run E2E tests
+        run: cd frontend && npx playwright test --config=e2e/playwright.config.ts
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: playwright-report
+          path: frontend/playwright-report/
+          retention-days: 7
+
+  frontend-visual:
+    name: Frontend Visual Regression
+    needs: [frontend-unit]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: "frontend/package-lock.json"
+      - uses: astral-sh/setup-uv@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+      - run: uv pip install --system -e ".[dev]"
+      - run: cd frontend && npm ci
+      - run: cd frontend && npx playwright install --with-deps chromium
+      - name: Run visual regression tests
+        run: cd frontend && npx playwright test --config=e2e/playwright.config.ts e2e/visual/
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: visual-diff
+          path: frontend/e2e/visual/*.png
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -57,5 +57,9 @@ node_modules/
 .next/
 
 
+# Playwright (frontend E2E)
+frontend/playwright-report/
+frontend/test-results/
+
 # Workflow gate state files (local per-developer)
 .workflow/active/

--- a/frontend/e2e/fixtures/spec-constants.ts
+++ b/frontend/e2e/fixtures/spec-constants.ts
@@ -1,0 +1,62 @@
+/**
+ * Spec constants derived from ARCHITECTURE.md Section 9.
+ * Update these when the spec changes.
+ */
+
+/** Section 9.6 — Port type colour system */
+export const SPEC_TYPE_COLORS: Record<string, string> = {
+  Array:         '#3B82F6',
+  Series:        '#22C55E',
+  DataFrame:     '#F97316',
+  Text:          '#A855F7',
+  Artifact:      '#6B7280',
+  CompositeData: '#EF4444',
+  DataObject:    '#E5E7EB',
+};
+
+/** Section 9.2 — Panel default/min/max dimensions in pixels */
+export const SPEC_PANEL_DEFAULTS = {
+  palette:  { default: 220, min: 160, max: 400 },
+  preview:  { default: 320, min: 240, max: 600 },
+  bottom:   { default: 200, min: 100 },
+};
+
+/** Section 9.3 — Keyboard shortcuts */
+export const SPEC_KEYBOARD_SHORTCUTS: Record<string, string> = {
+  'Control+o':       'Import workflow',
+  'Control+s':       'Save workflow',
+  'Control+Shift+s': 'Export workflow',
+  'Control+Enter':   'Run workflow',
+  'Control+.':       'Stop execution',
+  'Delete':          'Delete selected',
+  'Backspace':       'Delete selected',
+  'Control+z':       'Undo',
+  'Control+y':       'Redo',
+  'Control+a':       'Select all',
+  'Escape':          'Deselect all',
+  'Control+b':       'Toggle palette',
+  'Control+d':       'Toggle preview',
+  'Control+j':       'Toggle bottom panel',
+  'Control+m':       'Toggle minimap',
+};
+
+/** Section 9.8 — Bottom panel tab names */
+export const SPEC_BOTTOM_TABS = [
+  'AI Chat', 'Config', 'Logs', 'Lineage', 'Jobs', 'Problems',
+];
+
+/** Section 9.5 — Block node design */
+export const SPEC_BLOCK_NODE = {
+  width: 280,
+  headerElements: ['icon', 'name', 'run-button', 'restart-button'],
+  stateBadgeLocation: 'footer' as const,
+  inlineParamCount: 3,
+};
+
+/** Section 9.3 — Toolbar button groups */
+export const SPEC_TOOLBAR_BUTTONS = {
+  projectMenu: ['New', 'Open', 'Save', 'Recent Projects', 'Close Project'],
+  fileOps: ['Import', 'Save', 'Export'],
+  execution: ['Run', 'Pause', 'Stop', 'Reset'],
+  edit: ['Delete', 'Reload Blocks'],
+};

--- a/frontend/e2e/fixtures/test-helpers.ts
+++ b/frontend/e2e/fixtures/test-helpers.ts
@@ -1,0 +1,224 @@
+/**
+ * Shared Playwright test helpers for SciEasy E2E tests.
+ *
+ * These helpers use data-testid selectors where available.
+ * Where data-testid attributes are missing from components,
+ * fallback selectors are used with TODO comments.
+ */
+import { Page, Locator, expect } from '@playwright/test';
+
+/**
+ * Mock the block list API to provide deterministic test data.
+ * Call before navigating to avoid race conditions.
+ */
+export async function mockBlocksApi(page: Page) {
+  await page.route('**/api/blocks', async (route) => {
+    await route.fulfill({
+      json: [
+        {
+          name: 'io_block',
+          category: 'IO',
+          display_name: 'IO Block',
+          description: 'Load and save data',
+          inputs: [{ name: 'input', type: 'DataObject' }],
+          outputs: [{ name: 'output', type: 'Array' }],
+          params: {
+            path: { type: 'string', default: '', ui_priority: 1 },
+            format: { type: 'string', default: 'auto', ui_priority: 2 },
+          },
+        },
+        {
+          name: 'process_block',
+          category: 'Process',
+          display_name: 'Process Block',
+          description: 'Process data',
+          inputs: [{ name: 'data', type: 'Array' }],
+          outputs: [{ name: 'result', type: 'DataFrame' }],
+          params: {
+            method: { type: 'string', default: 'default', ui_priority: 1 },
+            threshold: { type: 'number', default: 0.5, ui_priority: 2 },
+            normalize: { type: 'boolean', default: true, ui_priority: 3 },
+          },
+        },
+        {
+          name: 'code_block',
+          category: 'Code',
+          display_name: 'Code Block',
+          description: 'Run custom code',
+          inputs: [{ name: 'input', type: 'DataObject' }],
+          outputs: [{ name: 'output', type: 'DataObject' }],
+          params: {
+            language: { type: 'string', default: 'python', ui_priority: 1 },
+          },
+        },
+      ],
+    });
+  });
+}
+
+/**
+ * Mock the projects API for deterministic test data.
+ */
+export async function mockProjectsApi(page: Page) {
+  await page.route('**/api/projects', async (route) => {
+    if (route.request().method() === 'GET') {
+      await route.fulfill({ json: [] });
+    } else if (route.request().method() === 'POST') {
+      const body = route.request().postDataJSON();
+      await route.fulfill({
+        json: {
+          id: 'test-project-1',
+          name: body?.name || 'E2E Test',
+          description: body?.description || '',
+          path: '/tmp/test-project',
+          created_at: new Date().toISOString(),
+        },
+      });
+    } else {
+      await route.continue();
+    }
+  });
+}
+
+/**
+ * Mock the workflow API.
+ */
+export async function mockWorkflowApi(page: Page) {
+  await page.route('**/api/projects/*/workflows', async (route) => {
+    await route.fulfill({
+      json: {
+        id: 'test-workflow-1',
+        name: 'Main Workflow',
+        nodes: [],
+        edges: [],
+      },
+    });
+  });
+
+  await page.route('**/api/workflows/*', async (route) => {
+    if (route.request().method() === 'PUT') {
+      await route.fulfill({ json: { success: true } });
+    } else {
+      await route.fulfill({
+        json: {
+          id: 'test-workflow-1',
+          nodes: [],
+          edges: [],
+        },
+      });
+    }
+  });
+}
+
+/**
+ * Set up all standard API mocks for a test.
+ */
+export async function setupMocks(page: Page) {
+  await mockBlocksApi(page);
+  await mockProjectsApi(page);
+  await mockWorkflowApi(page);
+}
+
+/**
+ * Create a new project via the UI.
+ * Clicks New, fills the name, clicks Create, waits for the editor canvas.
+ */
+export async function createProject(page: Page, name = 'E2E Test') {
+  // TODO: add data-testid="new-project-button" to WelcomeScreen/Toolbar
+  await page.click('text=New');
+  await page.fill('input[placeholder*="name" i]', name);
+  // TODO: add data-testid="create-project-button" to ProjectDialog
+  await page.click('text=Create');
+  // Wait for the workflow canvas to appear
+  await expect(page.locator('.react-flow')).toBeVisible({ timeout: 10000 });
+}
+
+/**
+ * Drag a block from the palette to the canvas at the given position.
+ */
+export async function dragBlockToCanvas(
+  page: Page,
+  blockName: string,
+  target: { x: number; y: number } = { x: 300, y: 200 },
+) {
+  // TODO: add data-testid="palette-block-{name}" to BlockPalette items
+  const block = page.locator(`[data-testid="palette-block-${blockName}"]`).or(
+    page.getByText(blockName, { exact: false }).first()
+  );
+  const canvas = page.locator('.react-flow');
+  const canvasBox = await canvas.boundingBox();
+  if (!canvasBox) throw new Error('Canvas not found');
+
+  await block.dragTo(canvas, {
+    targetPosition: { x: target.x, y: target.y },
+  });
+}
+
+/**
+ * Connect the output port of one node to the input port of another.
+ */
+export async function connectPorts(
+  page: Page,
+  sourceNodeIndex: number,
+  targetNodeIndex: number,
+) {
+  const sourceHandle = page.locator('.react-flow__handle.source').nth(sourceNodeIndex);
+  const targetHandle = page.locator('.react-flow__handle.target').nth(targetNodeIndex);
+  await sourceHandle.dragTo(targetHandle);
+}
+
+/**
+ * Get the nth block node on the canvas.
+ */
+export function getBlockNode(page: Page, index: number): Locator {
+  // TODO: add data-testid="block-node" to BlockNode component
+  return page.locator('.react-flow__node').nth(index);
+}
+
+/**
+ * Get the bottom panel locator.
+ */
+export function getBottomPanel(page: Page): Locator {
+  // TODO: add data-testid="bottom-panel" to BottomPanel component
+  return page.locator('[data-testid="bottom-panel"]').or(
+    page.locator('[class*="bottom-panel"]')
+  ).first();
+}
+
+/**
+ * Get the palette panel locator.
+ */
+export function getPalettePanel(page: Page): Locator {
+  // TODO: add data-testid="block-palette" to BlockPalette component
+  return page.locator('[data-testid="block-palette"]').or(
+    page.locator('[class*="palette"]')
+  ).first();
+}
+
+/**
+ * Get the preview panel locator.
+ */
+export function getPreviewPanel(page: Page): Locator {
+  // TODO: add data-testid="preview-panel" to DataPreview component
+  return page.locator('[data-testid="preview-panel"]').or(
+    page.locator('[class*="preview"]')
+  ).first();
+}
+
+/**
+ * Navigate to the app and wait for it to be ready.
+ */
+export async function gotoApp(page: Page) {
+  await page.goto('/');
+  await page.waitForLoadState('networkidle');
+}
+
+/**
+ * Navigate to the app with mocks set up and a project created.
+ * Returns after the editor canvas is visible.
+ */
+export async function setupEditorWithProject(page: Page, projectName = 'E2E Test') {
+  await setupMocks(page);
+  await gotoApp(page);
+  await createProject(page, projectName);
+}

--- a/frontend/e2e/interactions/block-config.spec.ts
+++ b/frontend/e2e/interactions/block-config.spec.ts
@@ -1,0 +1,61 @@
+// Interaction test: block selection and configuration
+import { test, expect } from '@playwright/test';
+import { setupMocks, gotoApp, createProject, dragBlockToCanvas, getBlockNode, getPreviewPanel, getBottomPanel } from '../fixtures/test-helpers';
+
+test.describe('Block Config', () => {
+  test.beforeEach(async ({ page }) => {
+    await setupMocks(page);
+    await gotoApp(page);
+    await createProject(page);
+    await dragBlockToCanvas(page, 'Process Block', { x: 300, y: 200 });
+  });
+
+  test.fixme('click a block selects it (visual indicator)', async ({ page }) => {
+    // Blocked by #184: block selection visual indicator may not be implemented
+    const node = getBlockNode(page, 0);
+    await node.click();
+
+    // Node should have selected state (class or attribute)
+    await expect(node).toHaveClass(/selected/);
+  });
+
+  test.fixme('preview panel shows block name when selected', async ({ page }) => {
+    // Blocked by #184: preview panel may not show block name on selection
+    const node = getBlockNode(page, 0);
+    await node.click();
+
+    const preview = getPreviewPanel(page);
+    await expect(preview.getByText(/Process Block/i)).toBeVisible();
+  });
+
+  test.fixme('inline params are editable', async ({ page }) => {
+    // Blocked by #184: inline param editing may not be functional
+    const node = getBlockNode(page, 0);
+
+    // Find an input field within the node (inline params)
+    const input = node.locator('input').first();
+    if (await input.count() > 0) {
+      await input.click();
+      await input.fill('test-value');
+
+      const value = await input.inputValue();
+      expect(value).toBe('test-value');
+    }
+  });
+
+  test.fixme('clicking block switches bottom panel to Config tab', async ({ page }) => {
+    // Blocked by #184: bottom panel Config tab auto-switch may not work
+    const node = getBlockNode(page, 0);
+    await node.click();
+
+    const bottom = getBottomPanel(page);
+    const configTab = bottom.getByRole('tab', { name: /config/i }).or(
+      bottom.getByText('Config', { exact: false })
+    ).first();
+
+    // Config tab should be active
+    await expect(configTab).toHaveAttribute('data-state', 'active').catch(() =>
+      expect(configTab).toHaveAttribute('aria-selected', 'true')
+    );
+  });
+});

--- a/frontend/e2e/interactions/block-connection.spec.ts
+++ b/frontend/e2e/interactions/block-connection.spec.ts
@@ -1,0 +1,60 @@
+// Interaction test: block connections
+import { test, expect } from '@playwright/test';
+import { setupMocks, gotoApp, createProject, dragBlockToCanvas, connectPorts } from '../fixtures/test-helpers';
+
+test.describe('Block Connection', () => {
+  test.beforeEach(async ({ page }) => {
+    await setupMocks(page);
+    await gotoApp(page);
+    await createProject(page);
+  });
+
+  test.fixme('drag two blocks and connect output to input', async ({ page }) => {
+    // Blocked by #184: connection flow may not be fully functional
+    await dragBlockToCanvas(page, 'IO Block', { x: 200, y: 200 });
+    await dragBlockToCanvas(page, 'Process Block', { x: 500, y: 200 });
+
+    // Connect IO Block output to Process Block input
+    await connectPorts(page, 0, 1);
+
+    // Edge should appear
+    const edges = page.locator('.react-flow__edge');
+    await expect(edges).toHaveCount(1);
+  });
+
+  test.fixme('edge appears between connected blocks', async ({ page }) => {
+    // Blocked by #184: edge rendering may have issues
+    await dragBlockToCanvas(page, 'IO Block', { x: 200, y: 200 });
+    await dragBlockToCanvas(page, 'Process Block', { x: 500, y: 200 });
+
+    await connectPorts(page, 0, 1);
+
+    const edge = page.locator('.react-flow__edge').first();
+    await expect(edge).toBeVisible();
+
+    // Edge path should exist and have non-zero dimensions
+    const edgePath = edge.locator('path').first();
+    await expect(edgePath).toBeVisible();
+  });
+
+  test.fixme('edge is visible (not zero-opacity or hidden)', async ({ page }) => {
+    // Blocked by #184: edge visibility may have issues
+    await dragBlockToCanvas(page, 'IO Block', { x: 200, y: 200 });
+    await dragBlockToCanvas(page, 'Process Block', { x: 500, y: 200 });
+
+    await connectPorts(page, 0, 1);
+
+    const edge = page.locator('.react-flow__edge').first();
+    const path = edge.locator('path').first();
+
+    const opacity = await path.evaluate((el) => {
+      return window.getComputedStyle(el).opacity;
+    });
+    expect(parseFloat(opacity)).toBeGreaterThan(0);
+
+    const visibility = await path.evaluate((el) => {
+      return window.getComputedStyle(el).visibility;
+    });
+    expect(visibility).not.toBe('hidden');
+  });
+});

--- a/frontend/e2e/interactions/block-drag-drop.spec.ts
+++ b/frontend/e2e/interactions/block-drag-drop.spec.ts
@@ -1,0 +1,64 @@
+// Interaction test: block drag and drop
+import { test, expect } from '@playwright/test';
+import { setupMocks, gotoApp, createProject, dragBlockToCanvas, getBlockNode } from '../fixtures/test-helpers';
+
+test.describe('Block Drag and Drop', () => {
+  test.beforeEach(async ({ page }) => {
+    await setupMocks(page);
+    await gotoApp(page);
+    await createProject(page);
+  });
+
+  test.fixme('drag IO Block from palette to canvas', async ({ page }) => {
+    // Blocked by #184: drag-drop from palette may not be fully functional
+    await dragBlockToCanvas(page, 'IO Block', { x: 300, y: 200 });
+
+    // Block should appear on canvas
+    const nodes = page.locator('.react-flow__node');
+    await expect(nodes).toHaveCount(1);
+  });
+
+  test.fixme('block appears on canvas after drop', async ({ page }) => {
+    // Blocked by #184: block rendering after drop may have issues
+    await dragBlockToCanvas(page, 'IO Block', { x: 300, y: 200 });
+
+    const node = getBlockNode(page, 0);
+    await expect(node).toBeVisible();
+
+    // Block should display its name
+    await expect(node.getByText(/IO Block/i)).toBeVisible();
+  });
+
+  test.fixme('drag Process Block, verify two blocks on canvas', async ({ page }) => {
+    // Blocked by #184: multiple blocks on canvas may not work correctly
+    await dragBlockToCanvas(page, 'IO Block', { x: 200, y: 200 });
+    await dragBlockToCanvas(page, 'Process Block', { x: 500, y: 200 });
+
+    const nodes = page.locator('.react-flow__node');
+    await expect(nodes).toHaveCount(2);
+  });
+
+  test.fixme('block position is near the drop point (within 100px tolerance)', async ({ page }) => {
+    // Blocked by #184: block positioning after drop may be off
+    const dropX = 350;
+    const dropY = 250;
+    await dragBlockToCanvas(page, 'IO Block', { x: dropX, y: dropY });
+
+    const node = getBlockNode(page, 0);
+    const box = await node.boundingBox();
+    expect(box).toBeTruthy();
+
+    if (box) {
+      const canvas = page.locator('.react-flow');
+      const canvasBox = await canvas.boundingBox();
+      if (canvasBox) {
+        // Position relative to canvas
+        const relativeX = box.x - canvasBox.x;
+        const relativeY = box.y - canvasBox.y;
+        // Allow 100px tolerance for position
+        expect(Math.abs(relativeX - dropX)).toBeLessThan(100);
+        expect(Math.abs(relativeY - dropY)).toBeLessThan(100);
+      }
+    }
+  });
+});

--- a/frontend/e2e/interactions/project-lifecycle.spec.ts
+++ b/frontend/e2e/interactions/project-lifecycle.spec.ts
@@ -1,0 +1,83 @@
+// Interaction test: project lifecycle
+import { test, expect } from '@playwright/test';
+import { setupMocks, gotoApp } from '../fixtures/test-helpers';
+
+test.describe('Project Lifecycle', () => {
+  test.beforeEach(async ({ page }) => {
+    await setupMocks(page);
+    await gotoApp(page);
+  });
+
+  test.fixme('create new project with name and description', async ({ page }) => {
+    // Blocked by #184: project creation flow may not be fully implemented
+    // TODO: add data-testid="new-project-button" to WelcomeScreen
+    await page.click('text=New');
+
+    // Fill project name
+    await page.fill('input[placeholder*="name" i]', 'Test Project');
+
+    // Fill description if input exists
+    const descInput = page.locator('textarea[placeholder*="description" i]').or(
+      page.locator('input[placeholder*="description" i]')
+    );
+    if (await descInput.count() > 0) {
+      await descInput.first().fill('A test project for E2E testing');
+    }
+
+    // Click Create
+    // TODO: add data-testid="create-project-button" to ProjectDialog
+    await page.click('text=Create');
+
+    // Editor canvas should appear
+    await expect(page.locator('.react-flow')).toBeVisible({ timeout: 10000 });
+  });
+
+  test.fixme('project name appears in toolbar after creation', async ({ page }) => {
+    // Blocked by #184: project name display in toolbar may not be implemented
+    await page.click('text=New');
+    await page.fill('input[placeholder*="name" i]', 'My Science Project');
+    await page.click('text=Create');
+    await expect(page.locator('.react-flow')).toBeVisible({ timeout: 10000 });
+
+    // Project name should be visible somewhere in the toolbar area
+    await expect(page.getByText('My Science Project')).toBeVisible();
+  });
+
+  test.fixme('save project via Save button', async ({ page }) => {
+    // Blocked by #184: save flow may not be fully implemented
+    await page.click('text=New');
+    await page.fill('input[placeholder*="name" i]', 'Save Test');
+    await page.click('text=Create');
+    await expect(page.locator('.react-flow')).toBeVisible({ timeout: 10000 });
+
+    let saveCalled = false;
+    await page.route('**/api/projects/*/save', async (route) => {
+      saveCalled = true;
+      await route.fulfill({ json: { success: true } });
+    });
+    await page.route('**/api/workflows/*', async (route) => {
+      if (route.request().method() === 'PUT') {
+        saveCalled = true;
+        await route.fulfill({ json: { success: true } });
+      } else {
+        await route.continue();
+      }
+    });
+
+    // Click Save button
+    const saveButton = page.getByRole('button', { name: /save/i }).first();
+    await saveButton.click();
+    await page.waitForTimeout(500);
+  });
+
+  test.fixme('save project via Ctrl+S', async ({ page }) => {
+    // Blocked by #184: Ctrl+S may not be wired
+    await page.click('text=New');
+    await page.fill('input[placeholder*="name" i]', 'Shortcut Test');
+    await page.click('text=Create');
+    await expect(page.locator('.react-flow')).toBeVisible({ timeout: 10000 });
+
+    await page.keyboard.press('Control+s');
+    await page.waitForTimeout(500);
+  });
+});

--- a/frontend/e2e/playwright.config.ts
+++ b/frontend/e2e/playwright.config.ts
@@ -1,0 +1,40 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: '.',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI ? 'github' : 'html',
+
+  use: {
+    baseURL: 'http://localhost:5173',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+
+  // Auto-start dev servers for local development
+  webServer: [
+    {
+      command: 'cd .. && python -m uvicorn scieasy.api.app:create_app --factory --port 8000',
+      port: 8000,
+      timeout: 30000,
+      reuseExistingServer: !process.env.CI,
+      cwd: '..',
+    },
+    {
+      command: 'npm run dev',
+      port: 5173,
+      timeout: 15000,
+      reuseExistingServer: !process.env.CI,
+    },
+  ],
+});

--- a/frontend/e2e/spec-compliance/block-node.spec.ts
+++ b/frontend/e2e/spec-compliance/block-node.spec.ts
@@ -1,0 +1,113 @@
+// Spec: ARCHITECTURE.md Section 9.5
+import { test, expect } from '@playwright/test';
+import { setupMocks, gotoApp, createProject, dragBlockToCanvas, getBlockNode } from '../fixtures/test-helpers';
+import { SPEC_BLOCK_NODE } from '../fixtures/spec-constants';
+
+test.describe('Section 9.5: Block Node Design', () => {
+  test.beforeEach(async ({ page }) => {
+    await setupMocks(page);
+    await gotoApp(page);
+    await createProject(page);
+    await dragBlockToCanvas(page, 'Process Block');
+  });
+
+  test.fixme('Section 9.5: block node width is 280px', async ({ page }) => {
+    // Blocked by #184: block node width may not match spec
+    const node = getBlockNode(page, 0);
+    const box = await node.boundingBox();
+    expect(box).toBeTruthy();
+    if (box) {
+      expect(box.width).toBeCloseTo(SPEC_BLOCK_NODE.width, -1);
+    }
+  });
+
+  test.fixme('Section 9.5: block has 3-part structure (header, inline config, footer)', async ({ page }) => {
+    // Blocked by #184: block structure may not have distinct header/config/footer
+    const node = getBlockNode(page, 0);
+
+    // Look for header section
+    const header = node.locator('[data-testid="block-header"]').or(
+      node.locator('[class*="header"]')
+    ).first();
+    await expect(header).toBeVisible();
+
+    // Look for inline config section (form controls)
+    const config = node.locator('[data-testid="block-inline-config"]').or(
+      node.locator('input, select, [class*="param"]')
+    ).first();
+    await expect(config).toBeVisible();
+
+    // Look for footer section with state badge
+    const footer = node.locator('[data-testid="block-footer"]').or(
+      node.locator('[class*="footer"]')
+    ).first();
+    await expect(footer).toBeVisible();
+  });
+
+  test.fixme('Section 9.5: header contains block name, run button, restart button', async ({ page }) => {
+    // Blocked by #184: header elements may not all be present
+    const node = getBlockNode(page, 0);
+
+    // Block name
+    await expect(node.getByText('Process Block')).toBeVisible();
+
+    // Per-node run button [▶]
+    const runButton = node.locator('[data-testid="block-run-button"]').or(
+      node.getByRole('button', { name: /run|▶/i })
+    ).first();
+    await expect(runButton).toBeVisible();
+
+    // Per-node restart/start-from-here button [↻]
+    const restartButton = node.locator('[data-testid="block-restart-button"]').or(
+      node.getByRole('button', { name: /restart|start from here|↻/i })
+    ).first();
+    await expect(restartButton).toBeVisible();
+  });
+
+  test.fixme('Section 9.5: inline config renders form controls (not placeholder text)', async ({ page }) => {
+    // Blocked by #184: inline config may render placeholder text instead of form controls
+    const node = getBlockNode(page, 0);
+
+    // Should have actual form controls, not just text
+    const formControls = node.locator('input, select, [role="combobox"], [role="checkbox"]');
+    const count = await formControls.count();
+    expect(count).toBeGreaterThanOrEqual(1);
+  });
+
+  test.fixme('Section 9.5: state badge is in footer (not header)', async ({ page }) => {
+    // Blocked by #184: state badge location may not be in footer
+    const node = getBlockNode(page, 0);
+
+    // State badge should contain state text like "Idle", "Ready", etc.
+    const stateBadge = node.locator('[data-testid="block-state-badge"]').or(
+      node.getByText(/idle|ready|running|done|error/i)
+    ).first();
+    await expect(stateBadge).toBeVisible();
+
+    // Verify it's in the lower portion of the node
+    const nodeBox = await node.boundingBox();
+    const badgeBox = await stateBadge.boundingBox();
+    if (nodeBox && badgeBox) {
+      const nodeMidY = nodeBox.y + nodeBox.height / 2;
+      expect(badgeBox.y).toBeGreaterThan(nodeMidY);
+    }
+  });
+
+  test.fixme('Section 9.5: per-node run button exists', async ({ page }) => {
+    // Blocked by #184: per-node run button may not exist
+    const node = getBlockNode(page, 0);
+    const runButton = node.locator('[data-testid="block-run-button"]').or(
+      node.getByRole('button', { name: /run|▶/i })
+    ).first();
+    await expect(runButton).toBeVisible();
+  });
+
+  test.fixme('Section 9.5: per-node start-from-here button exists', async ({ page }) => {
+    // Blocked by #184: start-from-here button may not exist
+    const node = getBlockNode(page, 0);
+    const restartButton = node.locator('[data-testid="block-restart-button"]').or(
+      node.getByRole('button', { name: /restart|start from here|↻/i })
+    ).first();
+    await expect(restartButton).toBeVisible();
+  });
+});

--- a/frontend/e2e/spec-compliance/bottom-panel.spec.ts
+++ b/frontend/e2e/spec-compliance/bottom-panel.spec.ts
@@ -1,0 +1,61 @@
+// Spec: ARCHITECTURE.md Section 9.8
+import { test, expect } from '@playwright/test';
+import { setupMocks, gotoApp, createProject, dragBlockToCanvas, getBlockNode, getBottomPanel } from '../fixtures/test-helpers';
+import { SPEC_BOTTOM_TABS } from '../fixtures/spec-constants';
+
+test.describe('Section 9.8: Bottom Panel', () => {
+  test.beforeEach(async ({ page }) => {
+    await setupMocks(page);
+    await gotoApp(page);
+    await createProject(page);
+  });
+
+  test.fixme('Section 9.8: all 6 tabs present', async ({ page }) => {
+    // Blocked by #184: not all tabs may be present
+    const bottom = getBottomPanel(page);
+    await expect(bottom).toBeVisible();
+
+    for (const tabName of SPEC_BOTTOM_TABS) {
+      const tab = bottom.getByRole('tab', { name: new RegExp(tabName, 'i') }).or(
+        bottom.getByText(tabName, { exact: false })
+      );
+      await expect(tab.first()).toBeVisible();
+    }
+  });
+
+  test.fixme('Section 9.8: clicking a block switches to Config tab', async ({ page }) => {
+    // Blocked by #184: auto-switch to Config tab may not work
+    await dragBlockToCanvas(page, 'Process Block');
+
+    const node = getBlockNode(page, 0);
+    await node.click();
+
+    const bottom = getBottomPanel(page);
+    // Config tab should become active
+    const configTab = bottom.getByRole('tab', { name: /config/i }).or(
+      bottom.getByText('Config', { exact: false })
+    ).first();
+
+    await expect(configTab).toHaveAttribute('data-state', 'active').or(
+      expect(configTab).toHaveAttribute('aria-selected', 'true')
+    ).catch(() => {
+      // Fallback: check if config tab content is visible
+      const configContent = bottom.locator('[data-testid="config-tab-content"]').or(
+        bottom.locator('[role="tabpanel"]')
+      ).first();
+      return expect(configContent).toBeVisible();
+    });
+  });
+
+  test.fixme('Section 9.8: panel is visible (not zero-height, not hidden)', async ({ page }) => {
+    // Blocked by #184: bottom panel may be zero-height or hidden
+    const bottom = getBottomPanel(page);
+    await expect(bottom).toBeVisible();
+
+    const box = await bottom.boundingBox();
+    expect(box).toBeTruthy();
+    if (box) {
+      expect(box.height).toBeGreaterThan(30); // More than just a tab bar
+    }
+  });
+});

--- a/frontend/e2e/spec-compliance/keyboard.spec.ts
+++ b/frontend/e2e/spec-compliance/keyboard.spec.ts
@@ -1,0 +1,169 @@
+// Spec: ARCHITECTURE.md Section 9.3
+import { test, expect } from '@playwright/test';
+import { setupMocks, gotoApp, createProject, getPalettePanel, getPreviewPanel, getBottomPanel, dragBlockToCanvas, getBlockNode } from '../fixtures/test-helpers';
+import { SPEC_KEYBOARD_SHORTCUTS } from '../fixtures/spec-constants';
+
+test.describe('Section 9.3: Keyboard Shortcuts', () => {
+  test.beforeEach(async ({ page }) => {
+    await setupMocks(page);
+    await gotoApp(page);
+    await createProject(page);
+  });
+
+  test.fixme('Section 9.3: Ctrl+O triggers import workflow', async ({ page }) => {
+    // Blocked by #184: shortcut may not be wired
+    await page.keyboard.press('Control+o');
+    // Should open a file dialog or import modal
+    // Since browser file dialogs can't be tested, check if any modal/dialog appears
+    const dialog = page.locator('[role="dialog"]').or(page.locator('[class*="modal"]'));
+    await expect(dialog.first()).toBeVisible({ timeout: 2000 }).catch(() => {
+      // Alternative: check for a file input being triggered
+    });
+  });
+
+  test.fixme('Section 9.3: Ctrl+S triggers save workflow', async ({ page }) => {
+    // Blocked by #184: shortcut may not be wired
+    // Mock the save API endpoint and verify it was called
+    let saveCalled = false;
+    await page.route('**/api/workflows/*', async (route) => {
+      if (route.request().method() === 'PUT') {
+        saveCalled = true;
+        await route.fulfill({ json: { success: true } });
+      } else {
+        await route.continue();
+      }
+    });
+
+    await page.keyboard.press('Control+s');
+    await page.waitForTimeout(500);
+    // Save should have been triggered (or a save indicator shown)
+  });
+
+  test.fixme('Section 9.3: Ctrl+Shift+S triggers export workflow', async ({ page }) => {
+    // Blocked by #184: shortcut may not be wired
+    await page.keyboard.press('Control+Shift+s');
+    await page.waitForTimeout(500);
+  });
+
+  test.fixme('Section 9.3: Ctrl+Enter triggers run workflow', async ({ page }) => {
+    // Blocked by #184: shortcut may not be wired
+    let runCalled = false;
+    await page.route('**/api/workflows/*/execute', async (route) => {
+      runCalled = true;
+      await route.fulfill({ json: { execution_id: 'test-exec-1' } });
+    });
+
+    await page.keyboard.press('Control+Enter');
+    await page.waitForTimeout(500);
+  });
+
+  test.fixme('Section 9.3: Ctrl+. triggers stop execution', async ({ page }) => {
+    // Blocked by #184: shortcut may not be wired
+    await page.keyboard.press('Control+.');
+    await page.waitForTimeout(500);
+  });
+
+  test.fixme('Section 9.3: Delete key deletes selected block', async ({ page }) => {
+    // Blocked by #184: shortcut may not be wired
+    await dragBlockToCanvas(page, 'IO Block');
+    const node = getBlockNode(page, 0);
+    await node.click();
+    await page.waitForTimeout(200);
+
+    await page.keyboard.press('Delete');
+    await page.waitForTimeout(300);
+
+    // Node should be removed from canvas
+    const nodes = page.locator('.react-flow__node');
+    await expect(nodes).toHaveCount(0);
+  });
+
+  test.fixme('Section 9.3: Backspace key deletes selected block', async ({ page }) => {
+    // Blocked by #184: shortcut may not be wired
+    await dragBlockToCanvas(page, 'IO Block');
+    const node = getBlockNode(page, 0);
+    await node.click();
+    await page.waitForTimeout(200);
+
+    await page.keyboard.press('Backspace');
+    await page.waitForTimeout(300);
+
+    const nodes = page.locator('.react-flow__node');
+    await expect(nodes).toHaveCount(0);
+  });
+
+  test.fixme('Section 9.3: Ctrl+Z triggers undo', async ({ page }) => {
+    // Blocked by #184: undo may not be implemented
+    await page.keyboard.press('Control+z');
+    await page.waitForTimeout(300);
+  });
+
+  test.fixme('Section 9.3: Ctrl+Y triggers redo', async ({ page }) => {
+    // Blocked by #184: redo may not be implemented
+    await page.keyboard.press('Control+y');
+    await page.waitForTimeout(300);
+  });
+
+  test.fixme('Section 9.3: Ctrl+A selects all nodes', async ({ page }) => {
+    // Blocked by #184: select-all may not be implemented
+    await dragBlockToCanvas(page, 'IO Block', { x: 200, y: 200 });
+    await dragBlockToCanvas(page, 'Process Block', { x: 500, y: 200 });
+
+    await page.keyboard.press('Control+a');
+    await page.waitForTimeout(300);
+
+    // All nodes should be selected
+    const selectedNodes = page.locator('.react-flow__node.selected');
+    await expect(selectedNodes).toHaveCount(2);
+  });
+
+  test.fixme('Section 9.3: Escape deselects all', async ({ page }) => {
+    // Blocked by #184: deselect may not be implemented
+    await dragBlockToCanvas(page, 'IO Block');
+    const node = getBlockNode(page, 0);
+    await node.click();
+
+    await page.keyboard.press('Escape');
+    await page.waitForTimeout(300);
+
+    const selectedNodes = page.locator('.react-flow__node.selected');
+    await expect(selectedNodes).toHaveCount(0);
+  });
+
+  test.fixme('Section 9.3: Ctrl+B toggles palette visibility', async ({ page }) => {
+    // Blocked by #184: shortcut may not be wired
+    const palette = getPalettePanel(page);
+    await expect(palette).toBeVisible();
+
+    await page.keyboard.press('Control+b');
+    await page.waitForTimeout(300);
+
+    // Palette should be collapsed
+    const box = await palette.boundingBox();
+    if (box) {
+      expect(box.width).toBeLessThan(100); // Icon-only mode ~48px
+    }
+  });
+
+  test.fixme('Section 9.3: Ctrl+D toggles preview visibility', async ({ page }) => {
+    // Blocked by #184: shortcut may not be wired
+    const preview = getPreviewPanel(page);
+
+    await page.keyboard.press('Control+d');
+    await page.waitForTimeout(300);
+  });
+
+  test.fixme('Section 9.3: Ctrl+J toggles bottom panel', async ({ page }) => {
+    // Blocked by #184: shortcut may not be wired
+    await page.keyboard.press('Control+j');
+    await page.waitForTimeout(300);
+  });
+
+  test.fixme('Section 9.3: Ctrl+M toggles minimap', async ({ page }) => {
+    // Blocked by #184: shortcut may not be wired
+    const minimap = page.locator('.react-flow__minimap');
+
+    await page.keyboard.press('Control+m');
+    await page.waitForTimeout(300);
+  });
+});

--- a/frontend/e2e/spec-compliance/layout.spec.ts
+++ b/frontend/e2e/spec-compliance/layout.spec.ts
@@ -1,0 +1,136 @@
+// Spec: ARCHITECTURE.md Section 9.2
+import { test, expect } from '@playwright/test';
+import { setupMocks, gotoApp, createProject, getPalettePanel, getPreviewPanel, getBottomPanel } from '../fixtures/test-helpers';
+import { SPEC_PANEL_DEFAULTS } from '../fixtures/spec-constants';
+
+test.describe('Section 9.2: Layout', () => {
+  test.beforeEach(async ({ page }) => {
+    await setupMocks(page);
+    await gotoApp(page);
+    await createProject(page);
+  });
+
+  test.fixme('Section 9.2: three panels visible simultaneously (palette, canvas, preview)', async ({ page }) => {
+    // Blocked by #184: requires project creation flow and full layout to be functional
+    const palette = getPalettePanel(page);
+    const canvas = page.locator('.react-flow');
+    const preview = getPreviewPanel(page);
+
+    await expect(palette).toBeVisible();
+    await expect(canvas).toBeVisible();
+    await expect(preview).toBeVisible();
+  });
+
+  test.fixme('Section 9.2: bottom panel visible alongside palette (not hidden behind it)', async ({ page }) => {
+    // Blocked by #184: bottom panel may overlap or be hidden behind palette
+    const palette = getPalettePanel(page);
+    const bottom = getBottomPanel(page);
+
+    await expect(palette).toBeVisible();
+    await expect(bottom).toBeVisible();
+
+    const paletteBox = await palette.boundingBox();
+    const bottomBox = await bottom.boundingBox();
+    expect(paletteBox).toBeTruthy();
+    expect(bottomBox).toBeTruthy();
+
+    // Bottom panel should NOT overlap with palette — it should be in the center column
+    if (paletteBox && bottomBox) {
+      expect(bottomBox.x).toBeGreaterThanOrEqual(paletteBox.x + paletteBox.width - 5);
+    }
+  });
+
+  test.fixme('Section 9.2: palette default width ~220px (within 20% tolerance)', async ({ page }) => {
+    // Blocked by #184: palette width may not match spec default
+    const palette = getPalettePanel(page);
+    const box = await palette.boundingBox();
+    expect(box).toBeTruthy();
+    if (box) {
+      const expected = SPEC_PANEL_DEFAULTS.palette.default;
+      const tolerance = expected * 0.2;
+      expect(box.width).toBeGreaterThan(expected - tolerance);
+      expect(box.width).toBeLessThan(expected + tolerance);
+    }
+  });
+
+  test.fixme('Section 9.2: preview default width ~320px (within 20% tolerance)', async ({ page }) => {
+    // Blocked by #184: preview width may not match spec default
+    const preview = getPreviewPanel(page);
+    const box = await preview.boundingBox();
+    expect(box).toBeTruthy();
+    if (box) {
+      const expected = SPEC_PANEL_DEFAULTS.preview.default;
+      const tolerance = expected * 0.2;
+      expect(box.width).toBeGreaterThan(expected - tolerance);
+      expect(box.width).toBeLessThan(expected + tolerance);
+    }
+  });
+
+  test.fixme('Section 9.2: panels have drag handles for resizing', async ({ page }) => {
+    // Blocked by #184: drag handles may not be present or identifiable
+    // Look for resize handles between panels
+    const handles = page.locator('[data-panel-group-direction] [data-resize-handle]').or(
+      page.locator('[class*="resize-handle"]')
+    );
+    const count = await handles.count();
+    // Should have at least 2 horizontal handles (palette|canvas, canvas|preview)
+    // and 1 vertical handle (canvas|bottom)
+    expect(count).toBeGreaterThanOrEqual(2);
+  });
+
+  test.fixme('Section 9.2: Ctrl+B toggles palette collapse', async ({ page }) => {
+    // Blocked by #184: keyboard shortcut may not be wired
+    const palette = getPalettePanel(page);
+    await expect(palette).toBeVisible();
+    const initialBox = await palette.boundingBox();
+
+    await page.keyboard.press('Control+b');
+    await page.waitForTimeout(300);
+
+    const collapsedBox = await palette.boundingBox();
+    if (initialBox && collapsedBox) {
+      // Collapsed palette should be significantly narrower (icon-only ~48px)
+      expect(collapsedBox.width).toBeLessThan(initialBox.width * 0.5);
+    }
+
+    // Toggle back
+    await page.keyboard.press('Control+b');
+    await page.waitForTimeout(300);
+
+    const restoredBox = await palette.boundingBox();
+    if (initialBox && restoredBox) {
+      expect(restoredBox.width).toBeCloseTo(initialBox.width, -1);
+    }
+  });
+
+  test.fixme('Section 9.2: Ctrl+D toggles preview collapse', async ({ page }) => {
+    // Blocked by #184: keyboard shortcut may not be wired
+    const preview = getPreviewPanel(page);
+    await expect(preview).toBeVisible();
+
+    await page.keyboard.press('Control+d');
+    await page.waitForTimeout(300);
+
+    // Preview should be hidden (0px width) when collapsed
+    const collapsedBox = await preview.boundingBox();
+    if (collapsedBox) {
+      expect(collapsedBox.width).toBeLessThanOrEqual(5);
+    }
+  });
+
+  test.fixme('Section 9.2: Ctrl+J toggles bottom panel collapse', async ({ page }) => {
+    // Blocked by #184: keyboard shortcut may not be wired
+    const bottom = getBottomPanel(page);
+    await expect(bottom).toBeVisible();
+    const initialBox = await bottom.boundingBox();
+
+    await page.keyboard.press('Control+j');
+    await page.waitForTimeout(300);
+
+    const collapsedBox = await bottom.boundingBox();
+    if (initialBox && collapsedBox) {
+      // Collapsed bottom panel should show only tab bar (~32px height)
+      expect(collapsedBox.height).toBeLessThan(initialBox.height * 0.5);
+    }
+  });
+});

--- a/frontend/e2e/spec-compliance/port-colors.spec.ts
+++ b/frontend/e2e/spec-compliance/port-colors.spec.ts
@@ -1,0 +1,99 @@
+// Spec: ARCHITECTURE.md Section 9.6
+import { test, expect } from '@playwright/test';
+import { setupMocks, gotoApp, createProject, dragBlockToCanvas } from '../fixtures/test-helpers';
+import { SPEC_TYPE_COLORS } from '../fixtures/spec-constants';
+
+test.describe('Section 9.6: Port Type Colour System', () => {
+  test.beforeEach(async ({ page }) => {
+    await setupMocks(page);
+    await gotoApp(page);
+    await createProject(page);
+    // Add blocks that have different port types
+    await dragBlockToCanvas(page, 'IO Block', { x: 200, y: 200 });
+    await dragBlockToCanvas(page, 'Process Block', { x: 500, y: 200 });
+  });
+
+  test.fixme('Section 9.6: each port coloured individually by data type', async ({ page }) => {
+    // Blocked by #184: ports may not be individually coloured
+    const handles = page.locator('.react-flow__handle');
+    const count = await handles.count();
+    expect(count).toBeGreaterThanOrEqual(2);
+
+    // Collect colors of all handles
+    const colors: string[] = [];
+    for (let i = 0; i < count; i++) {
+      const handle = handles.nth(i);
+      const bgColor = await handle.evaluate((el) => {
+        return window.getComputedStyle(el).backgroundColor;
+      });
+      colors.push(bgColor);
+    }
+
+    // Not all ports should share the same color
+    const uniqueColors = new Set(colors);
+    expect(uniqueColors.size).toBeGreaterThan(1);
+  });
+
+  test.fixme('Section 9.6: Array port colour matches spec (#3B82F6)', async ({ page }) => {
+    // Blocked by #184: port colours may not match spec hex values
+    // IO Block has output of type Array
+    const outputHandle = page.locator('.react-flow__handle.source').first();
+    const bgColor = await outputHandle.evaluate((el) => {
+      const style = window.getComputedStyle(el);
+      return style.backgroundColor;
+    });
+
+    // Convert hex #3B82F6 to rgb(59, 130, 246)
+    expect(bgColor).toBe('rgb(59, 130, 246)');
+  });
+
+  test.fixme('Section 9.6: DataFrame port colour matches spec (#F97316)', async ({ page }) => {
+    // Blocked by #184: port colours may not match spec hex values
+    // Process Block has output of type DataFrame
+    const processOutputHandle = page.locator('.react-flow__node').nth(1)
+      .locator('.react-flow__handle.source').first();
+    const bgColor = await processOutputHandle.evaluate((el) => {
+      const style = window.getComputedStyle(el);
+      return style.backgroundColor;
+    });
+
+    // Convert hex #F97316 to rgb(249, 115, 22)
+    expect(bgColor).toBe('rgb(249, 115, 22)');
+  });
+
+  test.fixme('Section 9.6: DataObject port colour matches spec (#E5E7EB)', async ({ page }) => {
+    // Blocked by #184: port colours may not match spec hex values
+    // IO Block has input of type DataObject (fallback light grey)
+    const inputHandle = page.locator('.react-flow__node').first()
+      .locator('.react-flow__handle.target').first();
+    const bgColor = await inputHandle.evaluate((el) => {
+      const style = window.getComputedStyle(el);
+      return style.backgroundColor;
+    });
+
+    // Convert hex #E5E7EB to rgb(229, 231, 235)
+    expect(bgColor).toBe('rgb(229, 231, 235)');
+  });
+
+  test.fixme('Section 9.6: ports NOT sharing a single colour per node', async ({ page }) => {
+    // Blocked by #184: ports may share the same colour per node
+    // A node with both input and output of different types should have different handle colours
+    const node = page.locator('.react-flow__node').first();
+    const handles = node.locator('.react-flow__handle');
+    const count = await handles.count();
+
+    if (count >= 2) {
+      const colors: string[] = [];
+      for (let i = 0; i < count; i++) {
+        const bgColor = await handles.nth(i).evaluate((el) => {
+          return window.getComputedStyle(el).backgroundColor;
+        });
+        colors.push(bgColor);
+      }
+
+      const uniqueColors = new Set(colors);
+      // If input and output have different types, colors should differ
+      expect(uniqueColors.size).toBeGreaterThan(1);
+    }
+  });
+});

--- a/frontend/e2e/spec-compliance/toolbar.spec.ts
+++ b/frontend/e2e/spec-compliance/toolbar.spec.ts
@@ -1,0 +1,73 @@
+// Spec: ARCHITECTURE.md Section 9.3
+import { test, expect } from '@playwright/test';
+import { setupMocks, gotoApp, createProject } from '../fixtures/test-helpers';
+import { SPEC_TOOLBAR_BUTTONS } from '../fixtures/spec-constants';
+
+test.describe('Section 9.3: Toolbar', () => {
+  test.beforeEach(async ({ page }) => {
+    await setupMocks(page);
+    await gotoApp(page);
+    await createProject(page);
+  });
+
+  test.fixme('Section 9.3: all file operation buttons present (Import, Save, Export)', async ({ page }) => {
+    // Blocked by #184: toolbar buttons may not all be present
+    // TODO: add data-testid="toolbar" to Toolbar component
+    const toolbar = page.locator('[data-testid="toolbar"]').or(
+      page.locator('header').or(page.locator('[class*="toolbar"]'))
+    ).first();
+    await expect(toolbar).toBeVisible();
+
+    for (const label of SPEC_TOOLBAR_BUTTONS.fileOps) {
+      const button = toolbar.getByRole('button', { name: new RegExp(label, 'i') }).or(
+        toolbar.getByText(label, { exact: false })
+      );
+      await expect(button.first()).toBeVisible();
+    }
+  });
+
+  test.fixme('Section 9.3: all execution control buttons present (Run, Pause, Stop, Reset)', async ({ page }) => {
+    // Blocked by #184: execution buttons may not all be present
+    const toolbar = page.locator('[data-testid="toolbar"]').or(
+      page.locator('header').or(page.locator('[class*="toolbar"]'))
+    ).first();
+
+    for (const label of SPEC_TOOLBAR_BUTTONS.execution) {
+      const button = toolbar.getByRole('button', { name: new RegExp(label, 'i') }).or(
+        toolbar.getByText(label, { exact: false })
+      );
+      await expect(button.first()).toBeVisible();
+    }
+  });
+
+  test.fixme('Section 9.3: Delete and Reload Blocks buttons present', async ({ page }) => {
+    // Blocked by #184: edit buttons may not all be present
+    const toolbar = page.locator('[data-testid="toolbar"]').or(
+      page.locator('header').or(page.locator('[class*="toolbar"]'))
+    ).first();
+
+    for (const label of SPEC_TOOLBAR_BUTTONS.edit) {
+      const button = toolbar.getByRole('button', { name: new RegExp(label, 'i') }).or(
+        toolbar.getByText(label, { exact: false })
+      );
+      await expect(button.first()).toBeVisible();
+    }
+  });
+
+  test.fixme('Section 9.3: visual grouping separators between button groups', async ({ page }) => {
+    // Blocked by #184: separators may not be present
+    const toolbar = page.locator('[data-testid="toolbar"]').or(
+      page.locator('header').or(page.locator('[class*="toolbar"]'))
+    ).first();
+
+    // Look for separator elements (radix-ui separators or custom dividers)
+    const separators = toolbar.locator('[data-orientation="vertical"]').or(
+      toolbar.locator('[role="separator"]').or(
+        toolbar.locator('[class*="separator"]')
+      )
+    );
+    // Expect at least 2 separators (between 3 groups: file ops, execution, edit)
+    const count = await separators.count();
+    expect(count).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,6 +17,7 @@
         "zustand": "^5.0.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.59.1",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^14.6.1",
@@ -1132,6 +1133,22 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@plotly/d3": {
@@ -5395,6 +5412,53 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/plotly.js": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,24 +8,28 @@
     "build": "tsc -b && vite build",
     "preview": "vite preview",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:e2e": "playwright test --config=e2e/playwright.config.ts",
+    "test:e2e:ui": "playwright test --config=e2e/playwright.config.ts --ui",
+    "test:e2e:report": "playwright show-report"
   },
   "dependencies": {
     "@xyflow/react": "^12.0.0",
     "clsx": "^2.1.1",
-    "zustand": "^5.0.0",
     "plotly.js": "^2.35.0",
     "react": "^18.3.0",
     "react-dom": "^18.3.0",
-    "react-plotly.js": "^2.6.0"
+    "react-plotly.js": "^2.6.0",
+    "zustand": "^5.0.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.59.1",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",
-    "@types/react-plotly.js": "^2.6.3",
     "@types/react": "^18.3.0",
     "@types/react-dom": "^18.3.0",
+    "@types/react-plotly.js": "^2.6.3",
     "@vitejs/plugin-react": "^4.3.0",
     "autoprefixer": "^10.4.0",
     "jsdom": "^26.1.0",

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -20,5 +20,6 @@ export default defineConfig({
     environment: "jsdom",
     setupFiles: "./vitest.setup.ts",
     css: true,
+    exclude: ["e2e/**", "node_modules/**"],
   },
 });


### PR DESCRIPTION
## Summary
- Set up Playwright for browser-based E2E testing of the SciEasy frontend
- Created 57 spec-compliance and interaction tests documenting the contract between ARCHITECTURE.md Section 9 and the current implementation
- All tests are marked `fixme` (blocked by #184) — they define **what should work**, not what currently works
- Added 3 new CI jobs: `frontend-unit`, `frontend-e2e`, `frontend-visual`

## Changes
| Category | Files | Description |
|----------|-------|-------------|
| Config | `frontend/e2e/playwright.config.ts` | Playwright config: chromium-only, dual webServer, CI-aware |
| Fixtures | `frontend/e2e/fixtures/spec-constants.ts` | All Section 9 spec values (colors, dimensions, shortcuts, tabs) |
| Fixtures | `frontend/e2e/fixtures/test-helpers.ts` | Reusable helpers: createProject, dragBlockToCanvas, connectPorts, etc. |
| Spec tests | `frontend/e2e/spec-compliance/` (6 files) | Layout, toolbar, block-node, port-colors, bottom-panel, keyboard |
| Interaction tests | `frontend/e2e/interactions/` (4 files) | Project lifecycle, drag-drop, connections, block config |
| CI | `.github/workflows/ci.yml` | 3 new jobs: frontend-unit, frontend-e2e, frontend-visual |
| Config | `frontend/vite.config.ts` | Exclude e2e/ from Vitest collection |
| Config | `frontend/package.json` | Add @playwright/test + e2e scripts |
| Config | `.gitignore` | Add playwright-report/ and test-results/ |

## Test plan
- [x] `npm run test` — 4 existing unit tests pass
- [x] `npx playwright test` — 57 tests found, all 57 skipped (fixme)
- [x] No existing source files modified (only test infra + config)
- [ ] CI passes on PR

## Related Issues
Blocked by #184 — as spec compliance issues are fixed, corresponding `test.fixme()` annotations should be removed to activate the tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)