### PR TITLE
fix(#195): use percentage strings for panel size props

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -462,7 +462,7 @@ export default function App() {
               }}
             >
               {/* Block Palette — full height left column */}
-              <ResizablePanel defaultSize={15} minSize={4} maxSize={28} collapsible collapsedSize={0}>
+              <ResizablePanel defaultSize="15%" minSize="4%" maxSize="28%" collapsible collapsedSize="0%">
                 <BlockPalette
                   blocks={blocks}
                   collapsed={false}
@@ -475,7 +475,7 @@ export default function App() {
               <ResizableHandle withHandle />
 
               {/* Center: Canvas + Bottom Panel vertical split */}
-              <ResizablePanel defaultSize={63}>
+              <ResizablePanel defaultSize="63%">
                 <ResizablePanelGroup
                   orientation="vertical"
                   className="min-h-0 flex-1"
@@ -484,7 +484,7 @@ export default function App() {
                     if (sizes[1] != null && sizes[1] >= 10) setPanelSize("bottom", sizes[1]);
                   }}
                 >
-                  <ResizablePanel defaultSize={70} minSize={20}>
+                  <ResizablePanel defaultSize="70%" minSize="20%">
                     <WorkflowCanvas
                       blockStates={blockStates}
                       blocks={blocks.filter((block) => {
@@ -533,7 +533,7 @@ export default function App() {
                     />
                   </ResizablePanel>
                   <ResizableHandle withHandle />
-                  <ResizablePanel defaultSize={30} minSize={5} collapsible collapsedSize={3}>
+                  <ResizablePanel defaultSize="30%" minSize="5%" collapsible collapsedSize="3%">
                     <BottomPanel
                       activeTab={activeBottomTab}
                       chatMessages={chatMessages}
@@ -564,7 +564,7 @@ export default function App() {
               <ResizableHandle withHandle />
 
               {/* Data Preview — full height right column */}
-              <ResizablePanel defaultSize={22} minSize={15} maxSize={42} collapsible collapsedSize={0}>
+              <ResizablePanel defaultSize="22%" minSize="15%" maxSize="42%" collapsible collapsedSize="0%">
                 <DataPreview
                   blockOutputs={blockOutputs}
                   onCancelSelected={() => void cancelSelectedBlock()}


### PR DESCRIPTION
## Summary

- **Root cause**: `react-resizable-panels` v4.9.0's internal parser (`ht()`) treats numeric values as **pixels**, not percentages. `defaultSize={15}` → 15px (~1% of viewport), not 15%.
- **Fix**: Changed all panel size props from numbers to percentage strings (e.g. `defaultSize="15%"`)
- Previous fix attempt (PR #197) added minimum guards and rehydration validation, but couldn't fix the fundamental unit mismatch

## Changes

5 lines changed in `frontend/src/App.tsx`:

| Panel | Before | After |
|-------|--------|-------|
| Palette | `defaultSize={15} minSize={4} maxSize={28} collapsedSize={0}` | `defaultSize="15%" minSize="4%" maxSize="28%" collapsedSize="0%"` |
| Center | `defaultSize={63}` | `defaultSize="63%"` |
| Canvas | `defaultSize={70} minSize={20}` | `defaultSize="70%" minSize="20%"` |
| Bottom | `defaultSize={30} minSize={5} collapsedSize={3}` | `defaultSize="30%" minSize="5%" collapsedSize="3%"` |
| Preview | `defaultSize={22} minSize={15} maxSize={42} collapsedSize={0}` | `defaultSize="22%" minSize="15%" maxSize="42%" collapsedSize="0%"` |

## Verification

Tested in Chrome: panels render at correct proportions, drag resize works in both directions, sizes persist correctly to localStorage after drag.

## Related Issues

Closes #195

## Test plan

- [ ] Clear localStorage, reload → panels at default sizes (~15%, ~63%, ~22%)
- [ ] Drag palette handle left/right → palette resizes correctly
- [ ] Drag bottom handle up/down → bottom panel resizes correctly
- [ ] Refresh page → dragged sizes preserved
- [ ] Collapse panel → re-expand → correct size restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)