### PR TITLE
fix(frontend): IO block browse button, load/save split, smooth drag

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -466,7 +466,13 @@ export default function App() {
                 <BlockPalette
                   blocks={blocks}
                   collapsed={false}
-                  onAddBlock={(block) => addNode(block, { x: 160, y: 160 })}
+                  onAddBlock={(block) => {
+                    const defaultParams: Record<string, unknown> | undefined =
+                      block.type_name === "io_block"
+                        ? { direction: block.name === "Load Block" ? "input" : "output" }
+                        : undefined;
+                    addNode(block, { x: 160, y: 160 }, defaultParams);
+                  }}
                   onReload={() => void refreshBlocks()}
                   onSearch={setPaletteSearch}
                   search={paletteSearch}

--- a/frontend/src/components/WorkflowCanvas.tsx
+++ b/frontend/src/components/WorkflowCanvas.tsx
@@ -6,10 +6,11 @@ import {
   type Connection,
   type Edge,
   type Node,
+  type NodeChange,
   useReactFlow,
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
-import { useCallback, useMemo } from "react";
+import { useCallback, useMemo, useState } from "react";
 
 import { resolveTypeColor } from "../config/typeColorMap";
 import type { BlockSchemaResponse, BlockSummary, WorkflowEdge, WorkflowNode } from "../types/api";
@@ -67,6 +68,11 @@ export function WorkflowCanvas(props: WorkflowCanvasProps) {
     selectedNodeId,
   } = props;
 
+  // Track positions locally during drag so nodes follow the cursor smoothly.
+  // ReactFlow is in controlled mode (nodes prop), so without this the node
+  // would only jump to its final position on drag-stop.
+  const [dragPositions, setDragPositions] = useState<Record<string, { x: number; y: number }>>({});
+
   const makeOnRun = useCallback((nodeId: string) => () => onRunBlock(nodeId), [onRunBlock]);
   const makeOnRestart = useCallback((nodeId: string) => () => onRestartBlock(nodeId), [onRestartBlock]);
   const makeOnDelete = useCallback((nodeId: string) => () => onDeleteNode(nodeId), [onDeleteNode]);
@@ -76,18 +82,34 @@ export function WorkflowCanvas(props: WorkflowCanvasProps) {
     [onUpdateNodeConfig],
   );
 
+  /** Derive canvas display label for a node. For io_block nodes the label
+   *  reflects the configured direction (Load Block / Save Block). */
+  const resolveLabel = useCallback(
+    (node: WorkflowNode, summary?: BlockSummary, schema?: BlockSchemaResponse) => {
+      if (node.block_type === "io_block") {
+        const params = (node.config.params as Record<string, unknown> | undefined) ?? {};
+        const direction = params.direction as string | undefined;
+        if (direction === "output") return "Save Block";
+        return "Load Block";
+      }
+      return summary?.name ?? schema?.name ?? node.block_type;
+    },
+    [],
+  );
+
   const flowNodes = useMemo<Array<Node<BlockNodeData>>>(() => {
     return nodes.map((node, index) => {
       const summary = blocks.find((block) => block.type_name === node.block_type);
       const schema = schemas[node.block_type];
       const params = ((node.config.params as Record<string, unknown> | undefined) ?? {}) as Record<string, unknown>;
+      const storePos = node.layout ?? { x: 120 + index * 80, y: 120 + index * 40 };
       return {
         id: node.id,
         type: "block",
         dragHandle: ".drag-handle",
-        position: node.layout ?? { x: 120 + index * 80, y: 120 + index * 40 },
+        position: dragPositions[node.id] ?? storePos,
         data: {
-          label: summary?.name ?? schema?.name ?? node.block_type,
+          label: resolveLabel(node, summary, schema),
           blockType: node.block_type,
           category: summary?.category ?? schema?.category ?? "custom",
           summary,
@@ -106,7 +128,7 @@ export function WorkflowCanvas(props: WorkflowCanvasProps) {
         selected: selectedNodeId === node.id,
       };
     });
-  }, [blocks, blockStates, makeOnDelete, makeOnErrorClick, makeOnRestart, makeOnRun, makeOnUpdateConfig, nodes, schemas, selectedNodeId]);
+  }, [blocks, blockStates, dragPositions, makeOnDelete, makeOnErrorClick, makeOnRestart, makeOnRun, makeOnUpdateConfig, nodes, resolveLabel, schemas, selectedNodeId]);
 
   const flowEdges = useMemo<Array<Edge>>(() => {
     return edges.map((edge) => {
@@ -154,6 +176,20 @@ export function WorkflowCanvas(props: WorkflowCanvasProps) {
         fitView
         nodeTypes={nodeTypes}
         nodes={flowNodes}
+        onNodesChange={(changes: NodeChange<Node<BlockNodeData>>[]) => {
+          // Apply position changes locally during drag so nodes follow the
+          // cursor in real time. Other change types (select, remove, etc.)
+          // are handled by dedicated callbacks below.
+          const positionUpdates: Record<string, { x: number; y: number }> = {};
+          for (const change of changes) {
+            if (change.type === "position" && change.position) {
+              positionUpdates[change.id] = change.position;
+            }
+          }
+          if (Object.keys(positionUpdates).length > 0) {
+            setDragPositions((prev) => ({ ...prev, ...positionUpdates }));
+          }
+        }}
         onConnect={async (connection: Connection) => {
           if (!connection.source || !connection.target || !connection.sourceHandle || !connection.targetHandle) {
             return;
@@ -178,7 +214,16 @@ export function WorkflowCanvas(props: WorkflowCanvasProps) {
           });
         }}
         onNodeClick={(_, node) => onSelectNode(node.id)}
-        onNodeDragStop={(_, node) => onUpdateNodePosition(node.id, node.position)}
+        onNodeDragStop={(_, node) => {
+          // Persist the final position to the store and clear the local
+          // drag override so subsequent renders use the store value.
+          onUpdateNodePosition(node.id, node.position);
+          setDragPositions((prev) => {
+            const next = { ...prev };
+            delete next[node.id];
+            return next;
+          });
+        }}
         onNodesDelete={(deleted) => deleted.forEach((node) => onDeleteNode(node.id))}
         onPaneClick={() => onSelectNode(null)}
         deleteKeyCode={["Backspace", "Delete"]}

--- a/frontend/src/components/nodes/BlockNode.tsx
+++ b/frontend/src/components/nodes/BlockNode.tsx
@@ -1,5 +1,6 @@
 import { type Node, Handle, Position, type NodeProps } from "@xyflow/react";
 
+import { api } from "../../lib/api";
 import { resolveTypeColor } from "../../config/typeColorMap";
 import type { BlockNodeData } from "../../types/ui";
 
@@ -107,10 +108,12 @@ function InlineConfigField({
   prop,
   value,
   onChange,
+  blockType,
 }: {
   prop: ConfigProperty;
   value: unknown;
   onChange: (key: string, val: unknown) => void;
+  blockType?: string;
 }) {
   const { key, schema } = prop;
   const label = (schema.title as string) ?? key;
@@ -169,16 +172,40 @@ function InlineConfigField({
     );
   }
 
+  // Show Browse button for the path field on io_block
+  const showBrowse = blockType === "io_block" && key === "path";
+
   // Default: text input
   return (
     <label className="flex items-center justify-between gap-2 text-xs">
       <span className="shrink-0 text-stone-500">{label}</span>
-      <input
-        type="text"
-        className="nodrag nowheel min-w-0 flex-1 rounded border border-stone-200 bg-white px-2 py-1 text-xs text-ink focus:border-sea focus:outline-none"
-        value={String(value ?? schema.default ?? "")}
-        onChange={(e) => onChange(key, e.target.value)}
-      />
+      <div className={`flex min-w-0 ${showBrowse ? "flex-1 gap-1" : "flex-1"}`}>
+        <input
+          type="text"
+          className="nodrag nowheel min-w-0 flex-1 rounded border border-stone-200 bg-white px-2 py-1 text-xs text-ink focus:border-sea focus:outline-none"
+          value={String(value ?? schema.default ?? "")}
+          onChange={(e) => onChange(key, e.target.value)}
+        />
+        {showBrowse && (
+          <button
+            type="button"
+            className="nodrag shrink-0 rounded border border-stone-200 bg-white px-1.5 py-1 text-[10px] font-medium text-stone-600 transition hover:border-pine hover:bg-pine/5"
+            title="Browse for file or directory"
+            onClick={async () => {
+              try {
+                const result = await api.browseDirectory();
+                if (result.path) {
+                  onChange(key, result.path);
+                }
+              } catch {
+                // User cancelled or backend unavailable
+              }
+            }}
+          >
+            Browse
+          </button>
+        )}
+      </div>
     </label>
   );
 }
@@ -187,7 +214,11 @@ function InlineConfigField({
 // BlockNode component
 // ---------------------------------------------------------------------------
 export function BlockNode({ data, selected }: NodeProps<Node<BlockNodeData>>) {
-  const configProps = getTopConfigProperties(data.schema?.config_schema);
+  // For io_block, hide the "direction" field — it is determined by whether
+  // the user dragged a Load Block or Save Block from the palette.
+  const configProps = getTopConfigProperties(data.schema?.config_schema).filter(
+    (prop) => !(data.blockType === "io_block" && prop.key === "direction"),
+  );
   const typeHierarchy = data.schema?.type_hierarchy;
   const categoryIcon = categoryIcons[data.category] ?? categoryIcons.custom;
 
@@ -256,6 +287,7 @@ export function BlockNode({ data, selected }: NodeProps<Node<BlockNodeData>>) {
               prop={prop}
               value={data.config?.[prop.key]}
               onChange={handleConfigChange}
+              blockType={data.blockType}
             />
           ))
         ) : (


### PR DESCRIPTION
## Summary

Fixes three frontend GUI issues in a single scoped PR:

- **#200 — Browse button for IO Block path field**: Adds a "Browse" button next to the File/Directory Path text input on IO Block nodes. Reuses the existing `api.browseDirectory()` endpoint (from PR #196). The button only appears for `io_block` path fields.

- **#201 — Split IO Block into Load Block / Save Block**: IO Block nodes on the canvas now display as "Load Block" or "Save Block" based on their configured direction, instead of the generic "IO Block" label. The Direction dropdown is hidden from the inline config since it is pre-determined by which block type was dragged from the palette. Both palette click and drag-drop correctly set the default direction.

- **#202 — Block drag follows cursor smoothly**: Blocks now follow the cursor during drag instead of teleporting on mouse-up. The root cause was ReactFlow's controlled mode requiring an `onNodesChange` handler to process position updates during drag. A local `dragPositions` state tracks in-flight positions, which are cleared on drag-stop when the final position is persisted to the store.

## Files Changed

| File | Change | Rationale |
|------|--------|-----------|
| `frontend/src/components/nodes/BlockNode.tsx` | Add Browse button, hide direction dropdown for io_block | #200, #201 |
| `frontend/src/components/WorkflowCanvas.tsx` | Add `onNodesChange` + `dragPositions`, add `resolveLabel` for io_block | #202, #201 |
| `frontend/src/App.tsx` | Pass default direction when clicking io_block from palette | #201 |

## Related Issues

Closes #200
Closes #201
Closes #202

## Test plan

- [ ] Drag a "Load Block" from palette to canvas — should display as "Load Block", not "IO Block"
- [ ] Drag a "Save Block" from palette to canvas — should display as "Save Block"
- [ ] Neither Load nor Save block should show Direction dropdown in inline config
- [ ] Click the "Browse" button on the IO Block path field — should open directory picker
- [ ] Type a path manually in the path field — should still work
- [ ] Drag any block on canvas — should follow cursor smoothly during drag
- [ ] Release drag — block should stay at final position (persisted to store)
- [ ] `npx tsc --noEmit` passes with zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)