### PR TITLE
fix(#199): add scrollbars to Palette, Preview, and Bottom panels

### DIFF
--- a/frontend/src/components/BlockPalette.tsx
+++ b/frontend/src/components/BlockPalette.tsx
@@ -90,7 +90,7 @@ export function BlockPalette({
 
   return (
     <aside
-      className="h-full overflow-hidden border-r border-stone-200 bg-[linear-gradient(180deg,_rgba(255,255,255,0.95),_rgba(245,241,232,0.98))] p-4"
+      className="flex h-full flex-col overflow-hidden border-r border-stone-200 bg-[linear-gradient(180deg,_rgba(255,255,255,0.95),_rgba(245,241,232,0.98))] p-4"
     >
       {/* Drag ghost element (offscreen) */}
       <div
@@ -115,7 +115,7 @@ export function BlockPalette({
         />
       )}
 
-      <div className="mt-4 flex-1 space-y-4 overflow-auto pb-6">
+      <div className="mt-4 min-h-0 flex-1 space-y-4 overflow-y-auto pb-6 scrollbar-thin">
         {grouped.map((group) => (
           <section key={group.category}>
             {collapsed ? null : (

--- a/frontend/src/components/BottomPanel.tsx
+++ b/frontend/src/components/BottomPanel.tsx
@@ -198,7 +198,7 @@ export function BottomPanel({
         </div>
       </div>
 
-      <div className="min-h-0 flex-1 overflow-hidden px-4 py-4">
+      <div className="min-h-0 flex-1 overflow-y-auto px-4 py-4 scrollbar-thin">
         <div className="h-full rounded-[1.8rem] border border-stone-200 bg-white/80 p-4">
           {activeTab === "ai" ? (
             <AIChat messages={chatMessages} onSendChat={onSendChat} />

--- a/frontend/src/components/DataPreview.tsx
+++ b/frontend/src/components/DataPreview.tsx
@@ -143,7 +143,7 @@ export function DataPreview({
   const preview = activeRef ? previewCache[activeRef] : null;
 
   return (
-    <aside className="flex h-full flex-col border-l border-stone-200 bg-[linear-gradient(180deg,_rgba(255,255,255,0.94),_rgba(245,241,232,0.98))] p-4">
+    <aside className="flex h-full flex-col overflow-hidden border-l border-stone-200 bg-[linear-gradient(180deg,_rgba(255,255,255,0.94),_rgba(245,241,232,0.98))] p-4">
       <div className="flex items-start justify-between gap-3">
         <div>
           <p className="text-xs uppercase tracking-[0.35em] text-stone-500">Preview</p>
@@ -183,7 +183,7 @@ export function DataPreview({
               </button>
             ))}
           </div>
-          <div className="mt-4 flex-1 overflow-auto">
+          <div className="mt-4 min-h-0 flex-1 overflow-y-auto scrollbar-thin">
             {activeRef && previewLoading[activeRef] ? (
               <div className="rounded-[1.6rem] border border-stone-200 bg-white p-4 text-sm text-stone-500">Loading preview…</div>
             ) : preview ? (

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -89,6 +89,11 @@ select {
   color: #fffdf8;
 }
 
+.scrollbar-thin {
+  scrollbar-width: thin;
+  scrollbar-color: #d6d3d1 transparent;
+}
+
 .react-flow__attribution {
   display: none;
 }


### PR DESCRIPTION
## Summary
- Add overflow scrolling to BlockPalette, DataPreview, and BottomPanel content areas
- Panel headers, search bars, and tab bars remain fixed at top; only content scrolls
- Add thin scrollbar CSS utility for consistent narrow scrollbar styling

## Changes
- **BlockPalette.tsx**: outer `<aside>` gets `flex flex-col`; block list div gets `min-h-0 overflow-y-auto scrollbar-thin`
- **DataPreview.tsx**: outer `<aside>` gets `overflow-hidden`; preview content div gets `min-h-0 overflow-y-auto scrollbar-thin`
- **BottomPanel.tsx**: tab content wrapper changes from `overflow-hidden` to `overflow-y-auto scrollbar-thin`
- **index.css**: add `.scrollbar-thin` utility class (`scrollbar-width: thin; scrollbar-color: #d6d3d1 transparent`)

## Related Issues
Closes #199

## Test plan
- [ ] Verify BlockPalette scrolls when many blocks are loaded; header and search bar stay fixed
- [ ] Verify DataPreview scrolls when preview content overflows; header stays fixed
- [ ] Verify BottomPanel tabs remain fixed while tab content scrolls
- [ ] Verify mouse wheel works in all three panels
- [ ] Verify thin scrollbar appears on hover in supported browsers
- [ ] Run `npx tsc --noEmit` -- passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)