### PR TITLE
feat(#214): API package_name + palette two-level grouping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- [#214] Add package_name to block palette API, /api/blocks/packages endpoint, and two-level palette grouping (package -> category -> block) in frontend (@claude, 2026-04-05, branch: feat/issue-214/palette-grouping, session: 20260405-222647-api-package-name-field-frontend-palette)
+
 ### Fixed
 
 - [#203] Handle asyncio.CancelledError in WebSocket handler for clean server shutdown (@claude, 2026-04-05, branch: fix/issue-203/ws-shutdown-hang, session: 20260405-212520-fix-websocket-shutdown-hang-by-handling)

--- a/frontend/src/components/BlockPalette.tsx
+++ b/frontend/src/components/BlockPalette.tsx
@@ -1,4 +1,4 @@
-import { useRef } from "react";
+import { useRef, useState, useCallback } from "react";
 
 import type { BlockSummary } from "../types/api";
 
@@ -13,6 +13,11 @@ interface BlockPaletteProps {
 
 const categoryOrder = ["io", "process", "code", "app", "ai", "subworkflow", "custom"];
 
+/** Display label for a package_name. Empty string becomes "Core". */
+function packageLabel(packageName: string): string {
+  return packageName || "Core";
+}
+
 /**
  * Expand io_block into separate Load Block / Save Block palette entries.
  * Both map to the same backend block type with different default direction.
@@ -26,8 +31,6 @@ function expandIOBlocks(blocks: BlockSummary[]): BlockSummary[] {
         name: "Load Block",
         description: "Load data from a file (input)",
         type_name: "io_block",
-        // We tag a virtual key so palette can distinguish them.
-        // The actual type_name stays io_block for the backend.
       });
       result.push({
         ...block,
@@ -42,6 +45,67 @@ function expandIOBlocks(blocks: BlockSummary[]): BlockSummary[] {
   return result;
 }
 
+interface CategoryGroup {
+  category: string;
+  blocks: BlockSummary[];
+}
+
+interface PackageGroup {
+  packageName: string;
+  label: string;
+  categories: CategoryGroup[];
+}
+
+/**
+ * Group filtered blocks into a two-level hierarchy: package -> category -> blocks.
+ * Packages are sorted with "Core" (empty package_name) first, then alphabetically.
+ * Categories within each package follow the standard categoryOrder.
+ */
+function groupByPackageAndCategory(blocks: BlockSummary[]): PackageGroup[] {
+  // Group by package_name first
+  const byPackage: Record<string, BlockSummary[]> = {};
+  for (const block of blocks) {
+    const pkg = block.package_name ?? "";
+    if (!byPackage[pkg]) byPackage[pkg] = [];
+    byPackage[pkg].push(block);
+  }
+
+  // Sort package names: "" (Core) first, then alphabetical
+  const packageNames = Object.keys(byPackage).sort((a, b) => {
+    if (a === "") return -1;
+    if (b === "") return 1;
+    return a.localeCompare(b);
+  });
+
+  return packageNames.map((packageName) => {
+    const pkgBlocks = byPackage[packageName];
+    const categories = categoryOrder
+      .map((category) => ({
+        category,
+        blocks: pkgBlocks.filter((block) => block.category === category),
+      }))
+      .filter((entry) => entry.blocks.length > 0);
+
+    // Also include blocks with categories not in categoryOrder
+    const knownCategories = new Set(categoryOrder);
+    const unknownCategories = new Set(
+      pkgBlocks.map((b) => b.category).filter((c) => !knownCategories.has(c)),
+    );
+    for (const cat of unknownCategories) {
+      categories.push({
+        category: cat,
+        blocks: pkgBlocks.filter((b) => b.category === cat),
+      });
+    }
+
+    return {
+      packageName,
+      label: packageLabel(packageName),
+      categories,
+    };
+  });
+}
+
 export function BlockPalette({
   blocks,
   search,
@@ -51,6 +115,8 @@ export function BlockPalette({
   onAddBlock,
 }: BlockPaletteProps) {
   const dragImageRef = useRef<HTMLDivElement | null>(null);
+  const [collapsedPackages, setCollapsedPackages] = useState<Record<string, boolean>>({});
+  const [collapsedCategories, setCollapsedCategories] = useState<Record<string, boolean>>({});
 
   const expanded = expandIOBlocks(blocks);
 
@@ -59,17 +125,27 @@ export function BlockPalette({
     return value.includes(search.toLowerCase());
   });
 
-  const grouped = categoryOrder
-    .map((category) => ({
-      category,
-      blocks: filtered.filter((block) => block.category === category),
-    }))
-    .filter((entry) => entry.blocks.length);
+  const packageGroups = groupByPackageAndCategory(filtered);
+
+  // When there is only one package, skip the outer package grouping layer
+  const singlePackage = packageGroups.length <= 1;
+
+  const togglePackage = useCallback((packageName: string) => {
+    setCollapsedPackages((prev) => ({
+      ...prev,
+      [packageName]: !prev[packageName],
+    }));
+  }, []);
+
+  const toggleCategory = useCallback((key: string) => {
+    setCollapsedCategories((prev) => ({
+      ...prev,
+      [key]: !prev[key],
+    }));
+  }, []);
 
   const handleDragStart = (event: React.DragEvent, block: BlockSummary) => {
-    // Set the block data for drop handling
     const payload = { ...block };
-    // Inject default direction for split IO blocks
     if (block.type_name === "io_block") {
       (payload as Record<string, unknown>)._default_direction =
         block.name === "Load Block" ? "input" : "output";
@@ -77,7 +153,6 @@ export function BlockPalette({
     event.dataTransfer.setData("application/scieasy-block", JSON.stringify(payload));
     event.dataTransfer.effectAllowed = "copy";
 
-    // Create a drag ghost image
     if (dragImageRef.current) {
       dragImageRef.current.textContent = block.name;
       dragImageRef.current.style.display = "block";
@@ -86,6 +161,62 @@ export function BlockPalette({
         if (dragImageRef.current) dragImageRef.current.style.display = "none";
       });
     }
+  };
+
+  const renderBlockCard = (block: BlockSummary, index: number) => (
+    <div
+      className="rounded-[1.4rem] border border-stone-200 bg-white p-3 shadow-sm transition hover:-translate-y-0.5 hover:border-ember"
+      draggable
+      key={`${block.type_name}-${block.name}-${index}`}
+      onDragStart={(event) => handleDragStart(event, block)}
+    >
+      <button
+        className="w-full text-left"
+        onClick={() => onAddBlock(block)}
+        type="button"
+      >
+        <p className="font-medium text-ink">{collapsed ? block.name.slice(0, 2) : block.name}</p>
+        {collapsed ? null : (
+          <>
+            <p className="mt-1 text-xs text-stone-500">{block.description}</p>
+            <p className="mt-2 text-[11px] uppercase tracking-[0.25em] text-stone-400">
+              {block.input_ports.length} in / {block.output_ports.length} out
+            </p>
+          </>
+        )}
+      </button>
+    </div>
+  );
+
+  const renderCategorySection = (
+    group: CategoryGroup,
+    packageName: string,
+  ) => {
+    const catKey = `${packageName}:${group.category}`;
+    const isCatCollapsed = collapsedCategories[catKey] ?? false;
+
+    return (
+      <section key={catKey}>
+        {collapsed ? null : (
+          <button
+            className="mb-2 flex w-full items-center gap-1 text-left"
+            onClick={() => toggleCategory(catKey)}
+            type="button"
+          >
+            <span className="text-[10px] text-stone-400">{isCatCollapsed ? "\u25B6" : "\u25BC"}</span>
+            <span className="text-[11px] uppercase tracking-[0.3em] text-stone-500">
+              {group.category}
+            </span>
+            <span className="text-[10px] text-stone-400">({group.blocks.length})</span>
+          </button>
+        )}
+        {isCatCollapsed ? null : (
+          <div className="space-y-2">
+            {group.blocks.map((block, index) => renderBlockCard(block, index))}
+          </div>
+        )}
+      </section>
+    );
   };
 
   return (
@@ -116,39 +247,45 @@ export function BlockPalette({
       )}
 
       <div className="mt-4 min-h-0 flex-1 space-y-4 overflow-y-auto pb-6 scrollbar-thin">
-        {grouped.map((group) => (
-          <section key={group.category}>
-            {collapsed ? null : (
-              <p className="mb-2 text-[11px] uppercase tracking-[0.3em] text-stone-500">{group.category}</p>
-            )}
-            <div className="space-y-2">
-              {group.blocks.map((block, index) => (
-                <div
-                  className="rounded-[1.4rem] border border-stone-200 bg-white p-3 shadow-sm transition hover:-translate-y-0.5 hover:border-ember"
-                  draggable
-                  key={`${block.type_name}-${block.name}-${index}`}
-                  onDragStart={(event) => handleDragStart(event, block)}
+        {packageGroups.map((pkg) => {
+          const isPkgCollapsed = collapsedPackages[pkg.packageName] ?? false;
+
+          if (singlePackage) {
+            // Skip the package-level wrapper when there is only one package
+            return pkg.categories.map((group) =>
+              renderCategorySection(group, pkg.packageName),
+            );
+          }
+
+          return (
+            <div key={pkg.packageName || "__core__"} className="space-y-2">
+              {collapsed ? null : (
+                <button
+                  className="flex w-full items-center gap-1.5 rounded-lg px-1 py-1 text-left transition hover:bg-stone-100"
+                  onClick={() => togglePackage(pkg.packageName)}
+                  type="button"
                 >
-                  <button
-                    className="w-full text-left"
-                    onClick={() => onAddBlock(block)}
-                    type="button"
-                  >
-                    <p className="font-medium text-ink">{collapsed ? block.name.slice(0, 2) : block.name}</p>
-                    {collapsed ? null : (
-                      <>
-                        <p className="mt-1 text-xs text-stone-500">{block.description}</p>
-                        <p className="mt-2 text-[11px] uppercase tracking-[0.25em] text-stone-400">
-                          {block.input_ports.length} in / {block.output_ports.length} out
-                        </p>
-                      </>
-                    )}
-                  </button>
+                  <span className="text-[11px] text-stone-400">
+                    {isPkgCollapsed ? "\u25B6" : "\u25BC"}
+                  </span>
+                  <span className="font-display text-sm font-semibold text-ink">
+                    {pkg.label}
+                  </span>
+                  <span className="text-[10px] text-stone-400">
+                    ({pkg.categories.reduce((sum, c) => sum + c.blocks.length, 0)})
+                  </span>
+                </button>
+              )}
+              {isPkgCollapsed ? null : (
+                <div className="space-y-3 pl-2">
+                  {pkg.categories.map((group) =>
+                    renderCategorySection(group, pkg.packageName),
+                  )}
                 </div>
-              ))}
+              )}
             </div>
-          </section>
-        ))}
+          );
+        })}
       </div>
     </aside>
   );

--- a/frontend/src/components/BottomPanel.test.tsx
+++ b/frontend/src/components/BottomPanel.test.tsx
@@ -26,6 +26,7 @@ describe("BottomPanel", () => {
           category: "process",
           description: "",
           version: "0.1.0",
+          package_name: "",
           input_ports: [],
           output_ports: [],
           config_schema: {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -7,6 +7,7 @@ import type {
   DataPreviewResponse,
   DataUploadResponse,
   ExecuteFromResponse,
+  PackageListResponse,
   ProjectResponse,
   WorkflowExecutionResponse,
   WorkflowResponse,
@@ -52,6 +53,7 @@ export const api = {
     }),
   browseDirectory: () => apiFetch<{ path: string | null }>("/api/projects/browse-directory", { method: "POST" }),
   listBlocks: () => apiFetch<BlockListResponse>("/api/blocks/"),
+  listPackages: () => apiFetch<PackageListResponse>("/api/blocks/packages"),
   getBlockSchema: (blockType: string) =>
     apiFetch<BlockSchemaResponse>(`/api/blocks/${encodeURIComponent(blockType)}/schema`),
   validateConnection: (body: {

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -63,6 +63,7 @@ export interface BlockSummary {
   category: string;
   description: string;
   version: string;
+  package_name: string;
   input_ports: BlockPortResponse[];
   output_ports: BlockPortResponse[];
 }
@@ -85,6 +86,17 @@ export interface BlockSchemaResponse extends BlockSummary {
 
 export interface BlockListResponse {
   blocks: BlockSummary[];
+}
+
+export interface PackageInfoResponse {
+  name: string;
+  description: string;
+  author: string;
+  version: string;
+}
+
+export interface PackageListResponse {
+  packages: PackageInfoResponse[];
 }
 
 export interface ConnectionValidationResponse {

--- a/src/scieasy/api/routes/blocks.py
+++ b/src/scieasy/api/routes/blocks.py
@@ -14,6 +14,8 @@ from scieasy.api.schemas import (
     BlockSchemaResponse,
     BlockSummary,
     ConnectionValidationResponse,
+    PackageInfoResponse,
+    PackageListResponse,
     TypeHierarchyEntry,
 )
 from scieasy.blocks.base.ports import InputPort, OutputPort, validate_connection
@@ -45,6 +47,7 @@ def _summary(spec: Any) -> BlockSummary:
         category=spec.category,
         description=spec.description,
         version=spec.version,
+        package_name=getattr(spec, "package_name", ""),
         input_ports=[_port_response(port, direction="input") for port in spec.input_ports],
         output_ports=[_port_response(port, direction="output") for port in spec.output_ports],
     )
@@ -56,6 +59,22 @@ async def list_blocks(registry: BlockRegistryDep) -> BlockListResponse:
     blocks = [_summary(spec) for spec in registry.all_specs().values()]
     blocks.sort(key=lambda item: (item.category, item.name))
     return BlockListResponse(blocks=blocks)
+
+
+@router.get("/packages", response_model=PackageListResponse)
+async def list_packages(registry: BlockRegistryDep) -> PackageListResponse:
+    """Return metadata for all registered block packages."""
+    packages = [
+        PackageInfoResponse(
+            name=info.name,
+            description=info.description,
+            author=info.author,
+            version=info.version,
+        )
+        for info in registry.packages().values()
+    ]
+    packages.sort(key=lambda p: p.name)
+    return PackageListResponse(packages=packages)
 
 
 @router.get("/{block_type}/schema", response_model=BlockSchemaResponse)

--- a/src/scieasy/api/schemas.py
+++ b/src/scieasy/api/schemas.py
@@ -89,6 +89,7 @@ class BlockSummary(BaseModel):
     category: str
     description: str = ""
     version: str = "0.1.0"
+    package_name: str = ""
     input_ports: list[BlockPortResponse] = Field(default_factory=list)
     output_ports: list[BlockPortResponse] = Field(default_factory=list)
 
@@ -219,6 +220,21 @@ class CancelPropagationResponse(BaseModel):
     cancelled_blocks: list[str] = Field(default_factory=list)
     skipped_blocks: list[str] = Field(default_factory=list)
     skip_reasons: dict[str, str] = Field(default_factory=dict)
+
+
+class PackageInfoResponse(BaseModel):
+    """Metadata for a registered block package."""
+
+    name: str
+    description: str = ""
+    author: str = ""
+    version: str = "0.1.0"
+
+
+class PackageListResponse(BaseModel):
+    """Response body for the block packages listing."""
+
+    packages: list[PackageInfoResponse] = Field(default_factory=list)
 
 
 class ErrorResponse(BaseModel):

--- a/tests/api/test_blocks.py
+++ b/tests/api/test_blocks.py
@@ -26,6 +26,40 @@ def test_list_blocks_and_schema_alias_endpoints(client: TestClient) -> None:
     assert alias.json() == schema_payload
 
 
+def test_list_blocks_includes_package_name_field(client: TestClient) -> None:
+    """Each block in the palette response should include a package_name field."""
+    response = client.get("/api/blocks/")
+    assert response.status_code == 200
+    payload = response.json()
+    for block in payload["blocks"]:
+        assert "package_name" in block, f"Block {block['name']} missing package_name"
+        # Built-in blocks should have empty package_name
+        assert isinstance(block["package_name"], str)
+
+
+def test_builtin_blocks_have_empty_package_name(client: TestClient) -> None:
+    """Built-in blocks should have an empty string package_name."""
+    response = client.get("/api/blocks/")
+    assert response.status_code == 200
+    payload = response.json()
+    # All built-in blocks should have package_name == ""
+    for block in payload["blocks"]:
+        assert block["package_name"] == "", (
+            f"Built-in block {block['name']} has non-empty package_name: {block['package_name']!r}"
+        )
+
+
+def test_list_packages_endpoint_returns_empty_for_builtins(client: TestClient) -> None:
+    """With no external packages installed, /api/blocks/packages returns an empty list."""
+    response = client.get("/api/blocks/packages")
+    assert response.status_code == 200
+    payload = response.json()
+    assert "packages" in payload
+    assert isinstance(payload["packages"], list)
+    # No external packages registered in test environment
+    assert payload["packages"] == []
+
+
 def test_validate_connection_endpoint_uses_registry_type_information(client: TestClient) -> None:
     """Connection validation should accept compatible ports and reject mismatches."""
     compatible = client.post(


### PR DESCRIPTION
## Summary
- Add `package_name` field to `GET /api/blocks` response (from `BlockSpec.package_name` via ADR-025)
- Add `GET /api/blocks/packages` endpoint returning `PackageInfo` metadata for registered external packages
- Rewrite `BlockPalette.tsx` with two-level grouping: package -> category -> block
- Each package and category section is independently collapsible
- When only one package exists (all built-in), the outer package nesting is skipped for clean UX
- Search functionality preserved across all grouping levels

## Related Issues
Closes #214
Depends on PR #221 (PackageInfo + BlockRegistry callable protocol)

## Changes
| File | Change |
|------|--------|
| `src/scieasy/api/schemas.py` | Add `package_name` to `BlockSummary`; add `PackageInfoResponse` + `PackageListResponse` |
| `src/scieasy/api/routes/blocks.py` | Include `package_name` in `_summary()`; add `/packages` endpoint |
| `frontend/src/types/api.ts` | Add `package_name` to `BlockSummary`; add package response types |
| `frontend/src/lib/api.ts` | Add `listPackages()` API call |
| `frontend/src/components/BlockPalette.tsx` | Two-level grouping with collapsible package + category sections |
| `frontend/src/components/BottomPanel.test.tsx` | Add `package_name` to test fixture |
| `tests/api/test_blocks.py` | 3 new tests: package_name field, builtin empty package_name, packages endpoint |
| `CHANGELOG.md` | Add entry |

## Test plan
- [x] All 1205 backend tests pass
- [x] All 4 frontend tests pass (Vitest)
- [x] TypeScript compilation clean (`tsc --noEmit`)
- [x] Backend lint + type check clean (`ruff check`, `mypy`)
- [x] New tests verify `package_name` appears in API response
- [x] New tests verify `/api/blocks/packages` returns empty list for builtins
- [x] Palette still works when no external packages installed (all blocks grouped as "Core" without unnecessary nesting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)