### PR TITLE
docs(adr): ADR-029 preliminary — variadic ports (scope pending) (#297)

### DIFF
--- a/src/scieasy/blocks/ai/ai_block.py
+++ b/src/scieasy/blocks/ai/ai_block.py
@@ -16,19 +16,6 @@ class AIBlock(Block):
 
     *model* identifies the LLM backend; *prompt_template* holds the
     template string that is rendered with block inputs before inference.
-
-    TODO(ADR-029): AIBlock is intended to support variadic input and
-    output ports — the user designs the workflow with N inputs and M
-    outputs by clicking "add port" / "remove port" controls in the GUI
-    and declaring each port's name and accepted_types. ADR-029 (status:
-    draft, scope pending discussion) reserves the namespace and lists
-    the open questions for how variadic ports are stored, edited,
-    validated, scheduled, and serialised through the worker subprocess.
-    Until ADR-029 is promoted from `draft, scope pending` to `proposed`,
-    AIBlock has empty class-level port lists and ``run()`` raises
-    NotImplementedError. No method on this class should be added or
-    modified to support variadic ports without an explicit ADR-029
-    decision; reviewers may cite ADR-029 to reject any such PR.
     """
 
     model: ClassVar[str] = ""

--- a/src/scieasy/blocks/code/code_block.py
+++ b/src/scieasy/blocks/code/code_block.py
@@ -34,21 +34,6 @@ class CodeBlock(Block):
     Note (ADR-020): InputDelivery enum removed. PROXY and CHUNKED delivery
         modes are superseded by ProcessBlock for framework-aware code.
         CodeBlock always delivers data as native in-memory objects.
-
-    TODO(ADR-029): CodeBlock is intended to support variadic input and
-    output ports — the user's script declares an arbitrary set of named
-    inputs and outputs (Python AST inference, R signature parsing, or
-    explicit per-instance port editor) instead of being constrained to
-    the current single ``data``-in / ``result``-out shape. ADR-029
-    (status: draft, scope pending discussion) reserves the namespace
-    and lists the open questions for how variadic ports are stored,
-    edited, validated, scheduled, and serialised through the worker
-    subprocess. Until ADR-029 is promoted from `draft, scope pending`
-    to `proposed`, CodeBlock keeps its single static input port and
-    single static output port and is constrained to 1-in / 1-out
-    workflows. No additional ports may be declared and no new methods
-    may be added to support variadic ports without an explicit ADR-029
-    decision; reviewers may cite ADR-029 to reject any such PR.
     """
 
     language: ClassVar[str] = "python"


### PR DESCRIPTION
## Summary

Reserve the **ADR-029** namespace and document the problem space for the *variadic port count* dimension that ADR-028 Addendum 1 explicitly deferred. This is a **preliminary draft** with status `draft — scope pending discussion` and **contains no architectural decisions** — every section that would normally hold a "Decision" / "Alternatives considered" / "Consequences" reads "Pending discussion".

The ADR documents the current state of `AIBlock` (30-line stub whose `run()` raises `NotImplementedError`) and `CodeBlock` (single static `data`-in / `result`-out shape both typed `DataObject`), explains why variadic ports are needed via concrete use cases (AI block taking N images and producing M tables, R-script ensemble averaging with variable fan-in, Python preprocessing fork with multiple typed outputs, future ensemble blocks), distinguishes the count dimension from Addendum 1's type dimension, and explains why the design discussion is being deferred until after the Phase 11 plugin cascade lands.

Lists ten open questions Q1–Q10 each with 2–4 candidate answer directions A/B/C/D, **none of which are endorsed**:

| Q   | Topic |
|-----|---|
| Q1  | Where is the variadic port list stored on a block instance? |
| Q2  | How does the GUI render add/remove port controls? |
| Q3  | How does validation handle variadic ports? |
| Q4  | How does the scheduler route through variadic ports at runtime? |
| Q5  | How does `_reconstruct_one` handle variadic ports given ADR-027 Addendum 1's typed reconstruction contract? |
| Q6  | Does AIBlock need a `port_template` for the palette preview? |
| Q7  | CodeBlock — auto-infer ports from script AST or user declares explicitly? |
| Q8  | How does `BlockSpec` represent a variadic block at scan time? |
| Q9  | Does variadic mode mix with Addendum 1's enum `dynamic_ports` mapping? |
| Q10 | What's the wire format for variadic ports in the engine→worker payload? |

## Files changed (4)

| File | Δ | Notes |
|---|---:|---|
| `docs/adr/ADR.md` | +739 | New ADR-029 section appended after ADR-028 Addendum 1 |
| `CHANGELOG.md` | +1 | New `[#297]` entry under `[Unreleased]` → `### Added` |
| `src/scieasy/blocks/ai/ai_block.py` | +13 | `TODO(ADR-029)` paragraph inside existing class docstring (no code changes, no new methods, no signature changes, no field additions) |
| `src/scieasy/blocks/code/code_block.py` | +15 | `TODO(ADR-029)` paragraph inside existing class docstring (no code changes, no new methods) |

## Scope discipline

- Status string is exactly `draft — scope pending discussion`. Not `proposed`, not `accepted`.
- Zero architectural decisions. Every "Decision" slot reads "Pending discussion".
- All ten open questions from master plan §2.3 (Q1–Q10) are listed.
- No new methods on `Block`, `AIBlock`, or `CodeBlock`. Only TODO comments inside existing docstrings.
- No tests, no source-file deletions, no frontend changes, no architecture-doc changes outside the ADR file itself.
- Branch is `docs/issue-297/adr-029-preliminary`, based on `origin/main` at commit `1406b2a`.

## Hard freeze (per the ADR body)

Until ADR-029 is promoted from `draft — scope pending` to `proposed` by a future decision-making round, **any implementation PR that touches `AIBlock` variadic behaviour, `CodeBlock` variadic behaviour, or "add port" / "remove port" GUI controls MUST reference this ADR explicitly** and note that it is acting on preliminary assumptions. Reviewers may cite this ADR to reject any such PR.

## Test plan

- [x] `docs/adr/ADR.md` parses as valid Markdown (visual verification).
- [x] `CHANGELOG.md` `[#297]` entry follows the standard `[#NNN] ... (@claude, 2026-04-07, branch: ..., session: ...)` attribution format.
- [x] `src/scieasy/blocks/ai/ai_block.py` and `src/scieasy/blocks/code/code_block.py` are byte-identical to `origin/main` outside the docstring TODO paragraphs (no method bodies changed).
- [x] No test files modified.
- [x] No frontend files modified.
- [x] No architecture docs modified.
- [x] Workflow gate completes all 6 stages.

## Related Issues

Closes #297

## Related ADRs

- ADR-028 + Addendum 1 (PR #294, PR #296) — provides the `get_effective_*_ports()` mechanism this ADR's future implementation will extend
- ADR-027 + Addendum 1 — the worker subprocess typed reconstruction contract that ADR-029 Q5 / Q10 will need to round-trip through

🤖 Generated with [Claude Code](https://claude.com/claude-code)