### PR TITLE
fix: auto-flush worker outputs before serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- [#416] Activate worker auto-flush context during output serialization so in-memory imaging outputs persist to storage before crossing subprocess boundaries, preventing downstream `Image.to_memory()` failures in interactive blocks like Fiji (@Codex, 2026-04-08, branch: codex/fix-416-worker-autoflush, session: 20260408-181444-fix-416-worker-serialise-outputs-activat)
 - [#408] Deprecate `deserialize_intermediate_refs()` and `_deserialize_value()` in `checkpoint.py` with detailed docstrings explaining the execute-from wire-format pass-through contract; add explanatory comment in `execute_from()` in `scheduler.py` (@claude, 2026-04-08, branch: fix/issue-408/deprecate-dead-deserialize, session: 20260408-154723-chore-deprecate-dead-deserialize-interme)
 - [#405] Fix `preview_data()` to use `TypeRegistry.resolve()` + `issubclass()` for plugin type dispatch, replacing hardcoded class name comparisons and the "Spectrum" substring hack; add `DataRecord.type_chain` field (@claude, 2026-04-08, branch: fix/issue-405/preview-type-identity, session: 20260408-154724-fix-405-preview-runtime-drops-plugin-typ)
 - [#404] Fix `_deserialize_value()` in `checkpoint.py` to read `metadata.type_chain` when building `TypeSignature` for `ViewProxy`, preserving plugin type identity for both single-object and collection-item wire-format dicts; add regression tests (@claude, 2026-04-08, branch: fix/issue-404/checkpoint-wire-format, session: 20260408-154723-fix-404-execute-from-checkpoint-typed-pa)

--- a/src/scieasy/engine/runners/worker.py
+++ b/src/scieasy/engine/runners/worker.py
@@ -118,52 +118,62 @@ def serialise_outputs(outputs: dict[str, Any], output_dir: str) -> dict[str, Any
         Directory for writing output artifacts when auto-flushing.
     """
     from scieasy.blocks.base.block import Block
+    from scieasy.core.storage.flush_context import clear, get_output_dir, set_output_dir
     from scieasy.core.types.base import DataObject
     from scieasy.core.types.collection import Collection
     from scieasy.core.types.serialization import _serialise_one
 
-    result: dict[str, Any] = {}
-    for key, value in outputs.items():
-        # Handle Collection: serialise each item via _serialise_one.
-        if isinstance(value, Collection):
-            item_payloads: list[Any] = []
-            for item in value:
-                flushed = Block._auto_flush(item)
-                if isinstance(flushed, DataObject):
-                    item_payloads.append(_serialise_one(flushed))
+    previous_output_dir = get_output_dir()
+    if output_dir:
+        set_output_dir(output_dir)
+    try:
+        result: dict[str, Any] = {}
+        for key, value in outputs.items():
+            # Handle Collection: serialise each item via _serialise_one.
+            if isinstance(value, Collection):
+                item_payloads: list[Any] = []
+                for item in value:
+                    flushed = Block._auto_flush(item)
+                    if isinstance(flushed, DataObject):
+                        item_payloads.append(_serialise_one(flushed))
+                    else:
+                        item_payloads.append({"_value": str(flushed)})
+                if value.item_type is None:
+                    logger.warning(
+                        "Collection output on port '%s' has item_type=None; defaulting to 'DataObject'",
+                        key,
+                    )
+                result[key] = {
+                    "_collection": True,
+                    "items": item_payloads,
+                    "item_type": value.item_type.__name__ if value.item_type is not None else "DataObject",
+                }
+                continue
+
+            # Typed DataObject: auto-flush then delegate to _serialise_one.
+            if isinstance(value, DataObject):
+                flushed_obj = Block._auto_flush(value)
+                if isinstance(flushed_obj, DataObject):
+                    result[key] = _serialise_one(flushed_obj)
                 else:
-                    item_payloads.append({"_value": str(flushed)})
-            if value.item_type is None:
-                logger.warning(
-                    "Collection output on port '%s' has item_type=None; defaulting to 'DataObject'",
-                    key,
-                )
-            result[key] = {
-                "_collection": True,
-                "items": item_payloads,
-                "item_type": value.item_type.__name__ if value.item_type is not None else "DataObject",
-            }
-            continue
+                    # _auto_flush only ever returns the same obj or a
+                    # passed-through non-DataObject; this branch is
+                    # defensive only.
+                    result[key] = str(flushed_obj)
+                continue
 
-        # Typed DataObject: auto-flush then delegate to _serialise_one.
-        if isinstance(value, DataObject):
-            flushed_obj = Block._auto_flush(value)
-            if isinstance(flushed_obj, DataObject):
-                result[key] = _serialise_one(flushed_obj)
+            # Scalar / list / dict / None: native JSON pass-through.
+            if isinstance(value, (str, int, float, bool, type(None), list, dict)):
+                result[key] = value
             else:
-                # _auto_flush only ever returns the same obj or a
-                # passed-through non-DataObject; this branch is
-                # defensive only.
-                result[key] = str(flushed_obj)
-            continue
+                result[key] = str(value)
 
-        # Scalar / list / dict / None: native JSON pass-through.
-        if isinstance(value, (str, int, float, bool, type(None), list, dict)):
-            result[key] = value
+        return result
+    finally:
+        if previous_output_dir is None:
+            clear()
         else:
-            result[key] = str(value)
-
-    return result
+            set_output_dir(previous_output_dir)
 
 
 def main() -> None:

--- a/tests/engine/test_worker.py
+++ b/tests/engine/test_worker.py
@@ -10,6 +10,8 @@ writes the full typed metadata sidecar via
 
 from __future__ import annotations
 
+from pathlib import Path
+
 from scieasy.engine.runners.worker import (
     main,
     reconstruct_inputs,
@@ -137,6 +139,24 @@ class TestSerialiseOutputs:
         assert result["data"]["path"] is None
         assert result["data"]["metadata"]["type_chain"] == ["DataObject", "Array"]
         assert result["data"]["metadata"]["axes"] == ["y", "x"]
+
+    def test_serialises_dataobject_without_storage_ref_auto_flushes_when_output_dir_present(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """An output_dir should activate auto-flush and produce a persisted ref."""
+        from scieasy.core.types.array import Array
+
+        arr = Array(axes=["y", "x"], shape=(2, 2), dtype="uint8")
+        arr._data = [[1, 2], [3, 4]]  # type: ignore[attr-defined]
+
+        result = serialise_outputs({"data": arr}, str(tmp_path))
+
+        assert result["data"]["backend"] == "zarr"
+        assert result["data"]["path"] is not None
+        assert result["data"]["metadata"]["axes"] == ["y", "x"]
+        assert str(result["data"]["path"]).endswith(".zarr")
+        assert Path(result["data"]["path"]).exists()
 
     def test_serialise_collection_with_none_item_type(self) -> None:
         """Collection with item_type=None should not crash the worker (#168)."""


### PR DESCRIPTION
## Summary
- activate the worker flush context while serializing outputs so in-memory DataObjects persist into the runner output directory before leaving the subprocess
- add regression coverage for serializing an in-memory Array with an output_dir to ensure a storage-backed ref is emitted
- record the fix in the changelog

## Testing
- pytest --no-cov tests/engine/test_worker.py tests/engine/test_worker_typed_reconstruction.py tests/engine/test_local_runner.py -q
- ruff check src/scieasy/engine/runners/worker.py tests/engine/test_worker.py
- mypy src/scieasy/engine/runners/worker.py tests/engine/test_worker.py --ignore-missing-imports

Closes #416