### PR TITLE
feat(#465): add project tree tab in left sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- [#465] Add project tree tab in left sidebar with lazy-loading file browser, right-click menu, and reveal-in-explorer (@claude, 2026-04-09, branch: feat/issue-465/project-tree, session: 20260409-150547-project-tree-tab-in-left-sidebar-465)
 - [#452] Implement AIBlock MVP: functional `run()` with LLM provider integration, input serialization, prompt templating, and Text output (@claude, 2026-04-08, branch: feat/issue-452/ai-block-mvp, session: 20260408-224820-feat-ai-aiblock-mvp-implementation)
 - [#446] Add workflow management toolbar: New, Save, Save As, Import buttons replace Export; backend endpoints for YAML workflow import and file browsing (@claude, 2026-04-08, branch: feat/issue-446/workflow-management, session: 20260408-220724-feat-gui-workflow-management-save-new-im)
 - [#445] Visual polish: solid colored port handles by data type with subtype ring colors, solid edge lines, higher-contrast palette tags, collapsible type legend, updated landing tagline (@claude, 2026-04-08, branch: feat/visual-polish-445, session: 20260408-220708-feat-gui-visual-polish-445)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,6 +10,7 @@ import { BlockPalette } from "./components/BlockPalette";
 import { BottomPanel } from "./components/BottomPanel";
 import { DataPreview } from "./components/DataPreview";
 import { ProjectDialog } from "./components/ProjectDialog";
+import { ProjectTree } from "./components/ProjectTree";
 import { Toolbar } from "./components/Toolbar";
 import { WelcomeScreen } from "./components/WelcomeScreen";
 import { WorkflowCanvas } from "./components/WorkflowCanvas";
@@ -97,6 +98,7 @@ export default function App() {
   const [busy, setBusy] = useState(false);
   const [aiLoading, setAiLoading] = useState(false);
   const [aiError, setAiError] = useState<string | null>(null);
+  const [leftTab, setLeftTab] = useState<"blocks" | "project">("blocks");
   const bootedRef = useRef(false);
 
   const { connected: wsConnected } = useWorkflowWebSocket(Boolean(currentProject));
@@ -143,6 +145,17 @@ export default function App() {
       return;
     }
     startTransition(() => setWorkflow(emptyWorkflow("main")));
+  }
+
+  async function loadWorkflowById(workflowId: string) {
+    try {
+      const workflow = await api.getWorkflow(workflowId);
+      startTransition(() => setWorkflow(workflow));
+      resetExecution();
+      setLastError(null);
+    } catch (error) {
+      setLastError((error as Error).message);
+    }
   }
 
   async function openProject(projectIdOrPath: string) {
@@ -620,23 +633,56 @@ export default function App() {
                 if (sizes[2] != null && sizes[2] >= 4) setPanelSize("preview", sizes[2]);
               }}
             >
-              {/* Block Palette — full height left column */}
+              {/* Left Sidebar — tab switcher + content */}
               <ResizablePanel defaultSize="15%" minSize="4%" maxSize="28%" collapsible collapsedSize="0%">
-                <BlockPalette
-                  blocks={blocks}
-                  collapsed={false}
-                  onAddBlock={(block) => {
-                    const defaultParams: Record<string, unknown> | undefined = block.direction
-                      ? { direction: block.direction }
-                      : block.type_name === "io_block"
-                        ? { direction: block.name === "Load Block" ? "input" : "output" }
-                        : undefined;
-                    addNode(block, { x: 160, y: 160 }, defaultParams);
-                  }}
-                  onReload={() => void refreshBlocks()}
-                  onSearch={setPaletteSearch}
-                  search={paletteSearch}
-                />
+                <div className="flex h-full flex-col overflow-hidden">
+                  {/* Tab switcher */}
+                  <div className="flex shrink-0 border-b border-stone-200 bg-[linear-gradient(180deg,_rgba(255,255,255,0.95),_rgba(245,241,232,0.98))]">
+                    <button
+                      className={`flex-1 px-3 py-2 text-xs font-medium transition ${leftTab === "blocks" ? "border-b-2 border-ember text-ink" : "text-stone-400 hover:text-stone-600"}`}
+                      onClick={() => setLeftTab("blocks")}
+                      type="button"
+                    >
+                      Blocks
+                    </button>
+                    <button
+                      className={`flex-1 px-3 py-2 text-xs font-medium transition ${leftTab === "project" ? "border-b-2 border-ember text-ink" : "text-stone-400 hover:text-stone-600"}`}
+                      onClick={() => setLeftTab("project")}
+                      type="button"
+                    >
+                      Project
+                    </button>
+                  </div>
+                  {/* Tab content */}
+                  <div className="min-h-0 flex-1">
+                    {leftTab === "blocks" ? (
+                      <BlockPalette
+                        blocks={blocks}
+                        collapsed={false}
+                        onAddBlock={(block) => {
+                          const defaultParams: Record<string, unknown> | undefined = block.direction
+                            ? { direction: block.direction }
+                            : block.type_name === "io_block"
+                              ? { direction: block.name === "Load Block" ? "input" : "output" }
+                              : undefined;
+                          addNode(block, { x: 160, y: 160 }, defaultParams);
+                        }}
+                        onReload={() => void refreshBlocks()}
+                        onSearch={setPaletteSearch}
+                        search={paletteSearch}
+                      />
+                    ) : currentProject ? (
+                      <ProjectTree
+                        projectId={currentProject.id}
+                        projectPath={currentProject.path}
+                        onLoadWorkflow={(workflowId) => void loadWorkflowById(workflowId)}
+                        onReloadBlocks={() => void refreshBlocks()}
+                      />
+                    ) : (
+                      <div className="p-4 text-xs text-stone-400">No project open</div>
+                    )}
+                  </div>
+                </div>
               </ResizablePanel>
               <ResizableHandle withHandle />
 

--- a/frontend/src/components/ProjectTree.tsx
+++ b/frontend/src/components/ProjectTree.tsx
@@ -1,0 +1,293 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { api } from "../lib/api";
+import type { TreeEntry } from "../types/api";
+
+interface TreeNodeData extends TreeEntry {
+  path: string;
+  children?: TreeNodeData[];
+  loaded: boolean;
+  expanded: boolean;
+}
+
+interface ProjectTreeProps {
+  projectId: string;
+  projectPath: string;
+  onLoadWorkflow: (filePath: string) => void;
+  onReloadBlocks: () => void;
+}
+
+function fileIcon(entry: TreeEntry): string {
+  if (entry.type === "directory") return "\u{1F4C1}";
+  const ext = entry.name.split(".").pop()?.toLowerCase() ?? "";
+  if (ext === "yaml" || ext === "yml") return "\u{1F4C4}";
+  if (ext === "py") return "\u{1F40D}";
+  if (ext === "json") return "\u{1F4CB}";
+  if (ext === "csv" || ext === "parquet") return "\u{1F4CA}";
+  if (ext === "tif" || ext === "tiff" || ext === "png" || ext === "jpg" || ext === "jpeg")
+    return "\u{1F5BC}";
+  return "\u{1F4C3}";
+}
+
+function formatSize(size: number | null | undefined): string {
+  if (size == null) return "";
+  if (size < 1024) return `${size} B`;
+  if (size < 1024 * 1024) return `${(size / 1024).toFixed(1)} KB`;
+  return `${(size / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+interface ContextMenuState {
+  x: number;
+  y: number;
+  node: TreeNodeData;
+}
+
+function TreeNodeRow({
+  node,
+  depth,
+  onToggle,
+  onDoubleClick,
+  onContextMenu,
+}: {
+  node: TreeNodeData;
+  depth: number;
+  onToggle: (node: TreeNodeData) => void;
+  onDoubleClick: (node: TreeNodeData) => void;
+  onContextMenu: (event: React.MouseEvent, node: TreeNodeData) => void;
+}) {
+  return (
+    <button
+      className="flex w-full items-center gap-1 rounded px-1 py-0.5 text-left text-xs hover:bg-stone-100"
+      onClick={() => {
+        if (node.type === "directory") onToggle(node);
+      }}
+      onContextMenu={(e) => onContextMenu(e, node)}
+      onDoubleClick={() => onDoubleClick(node)}
+      style={{ paddingLeft: `${depth * 16 + 4}px` }}
+      type="button"
+    >
+      {node.type === "directory" ? (
+        <span className="w-3 text-[10px] text-stone-400">{node.expanded ? "\u25BC" : "\u25B6"}</span>
+      ) : (
+        <span className="w-3" />
+      )}
+      <span className="shrink-0 text-[11px]">{fileIcon(node)}</span>
+      <span className="min-w-0 flex-1 truncate text-stone-700">{node.name}</span>
+      {node.type === "file" && node.size != null ? (
+        <span className="shrink-0 text-[10px] text-stone-400">{formatSize(node.size)}</span>
+      ) : null}
+    </button>
+  );
+}
+
+export function ProjectTree({
+  projectId,
+  projectPath,
+  onLoadWorkflow,
+  onReloadBlocks,
+}: ProjectTreeProps) {
+  const [rootNodes, setRootNodes] = useState<TreeNodeData[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [contextMenu, setContextMenu] = useState<ContextMenuState | null>(null);
+  const contextMenuRef = useRef<HTMLDivElement>(null);
+
+  const loadChildren = useCallback(
+    async (parentPath: string): Promise<TreeNodeData[]> => {
+      const response = await api.getProjectTree(projectId, parentPath);
+      return response.entries.map((entry) => ({
+        ...entry,
+        path: parentPath ? `${parentPath}/${entry.name}` : entry.name,
+        children: entry.type === "directory" ? [] : undefined,
+        loaded: false,
+        expanded: false,
+      }));
+    },
+    [projectId],
+  );
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    try {
+      const children = await loadChildren("");
+      setRootNodes(children);
+    } catch {
+      // silently ignore -- project may not be ready
+    } finally {
+      setLoading(false);
+    }
+  }, [loadChildren]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  // Close context menu on outside click
+  useEffect(() => {
+    if (!contextMenu) return undefined;
+    const handler = (e: MouseEvent) => {
+      if (contextMenuRef.current && !contextMenuRef.current.contains(e.target as Node)) {
+        setContextMenu(null);
+      }
+    };
+    window.addEventListener("mousedown", handler);
+    return () => window.removeEventListener("mousedown", handler);
+  }, [contextMenu]);
+
+  const updateNode = useCallback(
+    (nodes: TreeNodeData[], targetPath: string, updater: (n: TreeNodeData) => TreeNodeData): TreeNodeData[] => {
+      return nodes.map((node) => {
+        if (node.path === targetPath) {
+          return updater(node);
+        }
+        if (node.children && targetPath.startsWith(node.path + "/")) {
+          return { ...node, children: updateNode(node.children, targetPath, updater) };
+        }
+        return node;
+      });
+    },
+    [],
+  );
+
+  const handleToggle = useCallback(
+    async (node: TreeNodeData) => {
+      if (node.type !== "directory") return;
+
+      if (node.expanded) {
+        // Collapse
+        setRootNodes((prev) =>
+          updateNode(prev, node.path, (n) => ({ ...n, expanded: false })),
+        );
+        return;
+      }
+
+      // Expand: load children if not loaded
+      if (!node.loaded) {
+        try {
+          const children = await loadChildren(node.path);
+          setRootNodes((prev) =>
+            updateNode(prev, node.path, (n) => ({
+              ...n,
+              expanded: true,
+              loaded: true,
+              children,
+            })),
+          );
+        } catch {
+          // ignore
+        }
+      } else {
+        setRootNodes((prev) =>
+          updateNode(prev, node.path, (n) => ({ ...n, expanded: true })),
+        );
+      }
+    },
+    [loadChildren, updateNode],
+  );
+
+  const handleDoubleClick = useCallback(
+    (node: TreeNodeData) => {
+      if (node.type === "directory") return;
+      const ext = node.name.split(".").pop()?.toLowerCase() ?? "";
+
+      // Double-click .yaml in workflows/ -> load workflow
+      if ((ext === "yaml" || ext === "yml") && node.path.startsWith("workflows/")) {
+        const workflowId = node.name.replace(/\.(yaml|yml)$/, "");
+        onLoadWorkflow(workflowId);
+        return;
+      }
+
+      // Double-click .py in blocks/ -> hot-reload blocks
+      if (ext === "py" && node.path.startsWith("blocks/")) {
+        onReloadBlocks();
+      }
+    },
+    [onLoadWorkflow, onReloadBlocks],
+  );
+
+  const handleContextMenu = useCallback((event: React.MouseEvent, node: TreeNodeData) => {
+    event.preventDefault();
+    setContextMenu({ x: event.clientX, y: event.clientY, node });
+  }, []);
+
+  const copyToClipboard = useCallback((text: string) => {
+    void navigator.clipboard.writeText(text);
+    setContextMenu(null);
+  }, []);
+
+  const handleReveal = useCallback(
+    (node: TreeNodeData) => {
+      const fullPath = `${projectPath}/${node.path}`.replace(/\//g, "/");
+      void api.revealInExplorer(fullPath);
+      setContextMenu(null);
+    },
+    [projectPath],
+  );
+
+  const renderNodes = (nodes: TreeNodeData[], depth: number): React.ReactNode => {
+    return nodes.map((node) => (
+      <div key={node.path}>
+        <TreeNodeRow
+          depth={depth}
+          node={node}
+          onContextMenu={handleContextMenu}
+          onDoubleClick={handleDoubleClick}
+          onToggle={handleToggle}
+        />
+        {node.expanded && node.children ? renderNodes(node.children, depth + 1) : null}
+      </div>
+    ));
+  };
+
+  return (
+    <aside className="flex h-full flex-col overflow-hidden border-r border-stone-200 bg-[linear-gradient(180deg,_rgba(255,255,255,0.95),_rgba(245,241,232,0.98))] p-4">
+      <div className="flex items-center justify-between gap-2">
+        <p className="font-display text-xl text-ink">Project</p>
+        <button
+          className="toolbar-button"
+          disabled={loading}
+          onClick={() => void refresh()}
+          type="button"
+        >
+          {loading ? "..." : "Refresh"}
+        </button>
+      </div>
+
+      <div className="mt-4 min-h-0 flex-1 overflow-y-auto pb-6 scrollbar-thin">
+        {rootNodes.length === 0 && !loading ? (
+          <p className="text-xs text-stone-400">No files found</p>
+        ) : null}
+        {renderNodes(rootNodes, 0)}
+      </div>
+
+      {contextMenu ? (
+        <div
+          ref={contextMenuRef}
+          className="fixed z-50 rounded-lg border border-stone-200 bg-white py-1 shadow-lg"
+          style={{ left: contextMenu.x, top: contextMenu.y }}
+        >
+          <button
+            className="w-full px-4 py-1.5 text-left text-xs text-stone-700 hover:bg-stone-100"
+            onClick={() => copyToClipboard(contextMenu.node.name)}
+            type="button"
+          >
+            Copy Name
+          </button>
+          <button
+            className="w-full px-4 py-1.5 text-left text-xs text-stone-700 hover:bg-stone-100"
+            onClick={() => copyToClipboard(contextMenu.node.path)}
+            type="button"
+          >
+            Copy Path
+          </button>
+          <button
+            className="w-full px-4 py-1.5 text-left text-xs text-stone-700 hover:bg-stone-100"
+            onClick={() => handleReveal(contextMenu.node)}
+            type="button"
+          >
+            Reveal in Explorer
+          </button>
+        </div>
+      ) : null}
+    </aside>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -11,6 +11,7 @@ import type {
   DataUploadResponse,
   ExecuteFromResponse,
   ProjectResponse,
+  TreeResponse,
   WorkflowExecutionResponse,
   WorkflowResponse,
 } from "../types/api";
@@ -157,5 +158,15 @@ export const api = {
       method: "POST",
       headers: JSON_HEADERS,
       body: JSON.stringify(body),
+    }),
+  getProjectTree: (projectId: string, path = "") =>
+    apiFetch<TreeResponse>(
+      `/api/projects/${encodeURIComponent(projectId)}/tree?path=${encodeURIComponent(path)}`,
+    ),
+  revealInExplorer: (path: string) =>
+    apiFetch<{ status: string }>("/api/filesystem/reveal", {
+      method: "POST",
+      headers: JSON_HEADERS,
+      body: JSON.stringify({ path }),
     }),
 };

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -220,3 +220,13 @@ export interface AIOptimizeParamsResponse {
   suggestions: Record<string, unknown>;
   explanation: string;
 }
+
+export interface TreeEntry {
+  name: string;
+  type: "file" | "directory";
+  size?: number | null;
+}
+
+export interface TreeResponse {
+  entries: TreeEntry[];
+}

--- a/src/scieasy/api/app.py
+++ b/src/scieasy/api/app.py
@@ -60,8 +60,11 @@ def create_app() -> FastAPI:
     app.include_router(workflows.router)
     app.include_router(blocks.router)
     app.include_router(data.router)
-    app.include_router(projects.router)
+    # filesystem router must be registered BEFORE projects router because
+    # the projects router uses {project_id:path} which would greedily
+    # match /api/projects/{id}/tree as a project-id lookup.
     app.include_router(filesystem.router)
+    app.include_router(projects.router)
     app.include_router(ai.router)
 
     @app.get("/api/logs/stream")

--- a/src/scieasy/api/app.py
+++ b/src/scieasy/api/app.py
@@ -11,7 +11,7 @@ from fastapi import FastAPI, Request, WebSocket
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import RedirectResponse
 
-from scieasy.api.routes import ai, blocks, data, projects, workflows
+from scieasy.api.routes import ai, blocks, data, filesystem, projects, workflows
 from scieasy.api.runtime import ApiRuntime
 from scieasy.api.spa import SPAStaticFiles
 from scieasy.api.sse import sse_handler
@@ -61,6 +61,7 @@ def create_app() -> FastAPI:
     app.include_router(blocks.router)
     app.include_router(data.router)
     app.include_router(projects.router)
+    app.include_router(filesystem.router)
     app.include_router(ai.router)
 
     @app.get("/api/logs/stream")

--- a/src/scieasy/api/routes/filesystem.py
+++ b/src/scieasy/api/routes/filesystem.py
@@ -1,0 +1,120 @@
+"""Filesystem browsing and reveal endpoints for the project tree."""
+
+from __future__ import annotations
+
+import platform
+import subprocess
+from pathlib import Path
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel, Field
+
+from scieasy.api.deps import get_runtime
+from scieasy.api.runtime import ApiRuntime
+
+router = APIRouter(tags=["filesystem"])
+RuntimeDep = Annotated[ApiRuntime, Depends(get_runtime)]
+
+
+class TreeEntry(BaseModel):
+    """A single file or directory entry in a project tree listing."""
+
+    name: str
+    type: str  # "file" or "directory"
+    size: int | None = None
+
+
+class TreeResponse(BaseModel):
+    """Response body for a single-level directory listing."""
+
+    entries: list[TreeEntry] = Field(default_factory=list)
+
+
+class RevealRequest(BaseModel):
+    """Request body for the filesystem reveal action."""
+
+    path: str
+
+
+@router.get(
+    "/api/projects/{project_id}/tree",
+    response_model=TreeResponse,
+)
+async def project_tree(
+    project_id: str,
+    runtime: RuntimeDep,
+    path: str = Query("", description="Relative path within the project root"),
+) -> TreeResponse:
+    """Return one level of directory listing for a project (lazy loading).
+
+    Directories are listed first, then files, both sorted alphabetically.
+    Path traversal via ``..`` is rejected.
+    """
+    # Resolve project root
+    project = runtime.known_projects.get(project_id)
+    if project is None:
+        raise HTTPException(status_code=404, detail=f"Project {project_id} not found")
+    project_root = Path(project.path).resolve()
+
+    # Security: reject path traversal
+    if ".." in path.split("/") or ".." in path.split("\\"):
+        raise HTTPException(status_code=400, detail="Path traversal is not allowed")
+
+    target = (project_root / path).resolve()
+    # Ensure target is within project root
+    try:
+        target.relative_to(project_root)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail="Path is outside project root") from exc
+
+    if not target.is_dir():
+        raise HTTPException(status_code=404, detail="Directory not found")
+
+    dirs: list[TreeEntry] = []
+    files: list[TreeEntry] = []
+    try:
+        for child in target.iterdir():
+            # Skip hidden files/directories
+            if child.name.startswith("."):
+                continue
+            if child.is_dir():
+                dirs.append(TreeEntry(name=child.name, type="directory"))
+            elif child.is_file():
+                try:
+                    size = child.stat().st_size
+                except OSError:
+                    size = None
+                files.append(TreeEntry(name=child.name, type="file", size=size))
+    except PermissionError as exc:
+        raise HTTPException(status_code=403, detail="Permission denied") from exc
+
+    dirs.sort(key=lambda e: e.name.lower())
+    files.sort(key=lambda e: e.name.lower())
+    return TreeResponse(entries=dirs + files)
+
+
+@router.post("/api/filesystem/reveal")
+async def reveal_in_explorer(body: RevealRequest) -> dict[str, str]:
+    """Open the native file explorer and select/reveal the given path."""
+    target = Path(body.path).resolve()
+    if not target.exists():
+        raise HTTPException(status_code=404, detail="Path does not exist")
+
+    system = platform.system()
+    try:
+        if system == "Windows":
+            subprocess.Popen(["explorer", "/select,", str(target)])
+        elif system == "Darwin":
+            subprocess.Popen(["open", "-R", str(target)])
+        else:
+            # Linux/other: open the parent directory
+            parent = str(target.parent) if target.is_file() else str(target)
+            subprocess.Popen(["xdg-open", parent])
+    except FileNotFoundError as exc:
+        raise HTTPException(
+            status_code=500,
+            detail="Could not find the file explorer command for this platform",
+        ) from exc
+
+    return {"status": "ok"}

--- a/tests/api/test_filesystem.py
+++ b/tests/api/test_filesystem.py
@@ -1,0 +1,136 @@
+"""Tests for the filesystem browsing and reveal API endpoints."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+
+class TestProjectTree:
+    """Tests for GET /api/projects/{project_id}/tree."""
+
+    def test_list_root(self, client: TestClient, opened_project: Path) -> None:
+        """Root listing returns project-standard directories."""
+        runtime = client.app.state.runtime
+        project_id = runtime.active_project.id
+
+        resp = client.get(f"/api/projects/{project_id}/tree")
+        assert resp.status_code == 200
+        data = resp.json()
+        names = [e["name"] for e in data["entries"]]
+        # Standard project directories created by create_project
+        assert "workflows" in names
+        assert "blocks" in names
+        assert "data" in names
+
+    def test_directories_before_files(self, client: TestClient, opened_project: Path) -> None:
+        """Directories are listed before files, both alphabetical."""
+        # Create a file in the project root
+        (opened_project / "readme.txt").write_text("hello")
+        runtime = client.app.state.runtime
+        project_id = runtime.active_project.id
+
+        resp = client.get(f"/api/projects/{project_id}/tree")
+        assert resp.status_code == 200
+        entries = resp.json()["entries"]
+        # All directories come before all files
+        dir_indices = [i for i, e in enumerate(entries) if e["type"] == "directory"]
+        file_indices = [i for i, e in enumerate(entries) if e["type"] == "file"]
+        if dir_indices and file_indices:
+            assert max(dir_indices) < min(file_indices)
+
+    def test_subdirectory_listing(self, client: TestClient, opened_project: Path) -> None:
+        """Listing a subdirectory returns its contents."""
+        (opened_project / "data" / "raw" / "sample.csv").write_text("a,b\n1,2")
+        runtime = client.app.state.runtime
+        project_id = runtime.active_project.id
+
+        resp = client.get(f"/api/projects/{project_id}/tree", params={"path": "data/raw"})
+        assert resp.status_code == 200
+        names = [e["name"] for e in resp.json()["entries"]]
+        assert "sample.csv" in names
+
+    def test_file_size_returned(self, client: TestClient, opened_project: Path) -> None:
+        """File entries include a size field."""
+        content = "test content"
+        (opened_project / "test.txt").write_text(content)
+        runtime = client.app.state.runtime
+        project_id = runtime.active_project.id
+
+        resp = client.get(f"/api/projects/{project_id}/tree")
+        entries = resp.json()["entries"]
+        txt = next(e for e in entries if e["name"] == "test.txt")
+        assert txt["size"] is not None
+        assert txt["size"] > 0
+
+    def test_reject_path_traversal(self, client: TestClient, opened_project: Path) -> None:
+        """Paths containing '..' are rejected."""
+        runtime = client.app.state.runtime
+        project_id = runtime.active_project.id
+
+        resp = client.get(f"/api/projects/{project_id}/tree", params={"path": "../"})
+        assert resp.status_code == 400
+
+    def test_nonexistent_directory(self, client: TestClient, opened_project: Path) -> None:
+        """Listing a path that does not exist returns 404."""
+        runtime = client.app.state.runtime
+        project_id = runtime.active_project.id
+
+        resp = client.get(f"/api/projects/{project_id}/tree", params={"path": "nonexistent"})
+        assert resp.status_code == 404
+
+    def test_unknown_project(self, client: TestClient) -> None:
+        """Unknown project ID returns 404."""
+        resp = client.get("/api/projects/no-such-project/tree")
+        assert resp.status_code == 404
+
+    def test_hidden_files_excluded(self, client: TestClient, opened_project: Path) -> None:
+        """Files and directories starting with '.' are not listed."""
+        (opened_project / ".hidden_dir").mkdir()
+        (opened_project / ".hidden_file").write_text("secret")
+        runtime = client.app.state.runtime
+        project_id = runtime.active_project.id
+
+        resp = client.get(f"/api/projects/{project_id}/tree")
+        names = [e["name"] for e in resp.json()["entries"]]
+        assert ".hidden_dir" not in names
+        assert ".hidden_file" not in names
+
+
+class TestRevealInExplorer:
+    """Tests for POST /api/filesystem/reveal."""
+
+    def test_nonexistent_path(self, client: TestClient) -> None:
+        """Reveal with a nonexistent path returns 404."""
+        resp = client.post(
+            "/api/filesystem/reveal",
+            json={"path": "/tmp/definitely-does-not-exist-xyz"},
+        )
+        assert resp.status_code == 404
+
+    def test_reveal_existing_path(self, client: TestClient, opened_project: Path, monkeypatch: object) -> None:
+        """Reveal with a valid path returns 200 (mocked subprocess)."""
+        import subprocess
+
+        calls: list[list[str]] = []
+
+        class FakePopen:
+            def __init__(self, args: list[str], **_kwargs: object) -> None:
+                calls.append(args)
+
+        import scieasy.api.routes.filesystem as fs_mod
+
+        # Monkeypatch subprocess.Popen in the filesystem module
+        original_popen = subprocess.Popen
+        fs_mod.subprocess.Popen = FakePopen  # type: ignore[assignment]
+        try:
+            resp = client.post(
+                "/api/filesystem/reveal",
+                json={"path": str(opened_project)},
+            )
+            assert resp.status_code == 200
+            assert resp.json()["status"] == "ok"
+            assert len(calls) == 1
+        finally:
+            fs_mod.subprocess.Popen = original_popen  # type: ignore[assignment]


### PR DESCRIPTION
## Summary
- Add two backend API endpoints: `GET /api/projects/{project_id}/tree` for lazy directory listing and `POST /api/filesystem/reveal` to open native file explorer
- Add `ProjectTree` component with expand/collapse directories, file icons, size display
- Add Blocks/Project tab switcher in left sidebar panel
- Double-click `.yaml` in `workflows/` loads workflow; double-click `.py` in `blocks/` hot-reloads blocks
- Right-click context menu: Copy Name, Copy Path, Reveal in Explorer
- Security: rejects `..` path traversal, validates paths stay within project root

## Related Issues
Closes #465

## Test plan
- [ ] Open a project, switch to Project tab, verify directory listing loads
- [ ] Expand/collapse directories and verify lazy loading
- [ ] Double-click a workflow .yaml file, verify it loads into canvas
- [ ] Right-click a file, verify context menu actions work
- [ ] Verify Blocks tab still works normally after switching back

🤖 Generated with [Claude Code](https://claude.com/claude-code)