### PR TITLE
fix(api): prefer frontend/dist/ over stale static/ for SPA serving

### DIFF
--- a/src/scieasy/api/app.py
+++ b/src/scieasy/api/app.py
@@ -98,26 +98,23 @@ def create_app() -> FastAPI:
 
 
 def _resolve_spa_static_dir() -> Path | None:
-    """Locate the built SPA assets, preferring packaged over dev layout.
+    """Locate the built SPA assets.
 
-    Returns the first directory that contains an ``index.html``, or ``None``
-    if no built SPA is available. See ``create_app`` for the resolution
-    order and rationale.
+    For editable installs (development), ``frontend/dist/`` is preferred
+    because it reflects the latest ``npm run build``.  The packaged copy
+    at ``src/scieasy/api/static/`` is only used as a fallback — it is
+    written once during ``pip install`` and quickly becomes stale when
+    the developer rebuilds the frontend.
+
+    Returns the first directory that contains an ``index.html``, or
+    ``None`` if no built SPA is available.
     """
-    packaged = Path(__file__).parent / "static"
-    if (packaged / "index.html").is_file():
-        return packaged
-
-    # Walk up from ``src/scieasy/api/app.py`` to the repo root and look for
-    # ``frontend/dist/``. Only used for editable installs where ``__file__``
-    # is still inside the source tree.
+    # 1. Prefer frontend/dist/ (fresh dev build).
+    #    Walk up from ``src/scieasy/api/app.py`` to the repo root.
     for parent in Path(__file__).resolve().parents:
         candidate = parent / "frontend" / "dist"
         if (candidate / "index.html").is_file():
-            # #406: Warn developers when frontend/src has files newer than
-            # dist/index.html — the built SPA may be stale.  This check is
-            # best-effort (errors are silently swallowed) and emits a warning
-            # only; it never blocks startup.
+            # #406: Warn when frontend/src is newer than the build.
             src_dir = parent / "frontend" / "src"
             if src_dir.exists():
                 try:
@@ -139,4 +136,10 @@ def _resolve_spa_static_dir() -> Path | None:
         if (parent / "pyproject.toml").is_file():
             # Reached the repo root without finding frontend/dist/
             break
+
+    # 2. Fall back to packaged static/ (wheel installs).
+    packaged = Path(__file__).parent / "static"
+    if (packaged / "index.html").is_file():
+        return packaged
+
     return None

--- a/tests/api/test_spa_mount.py
+++ b/tests/api/test_spa_mount.py
@@ -30,22 +30,22 @@ def _make_spa_dir(root: Path) -> Path:
     return root
 
 
-def test_resolve_spa_prefers_packaged_over_dev(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """When both layouts exist, the packaged ``api/static/`` wins."""
+def test_resolve_spa_prefers_dev_over_packaged(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """When both layouts exist, ``frontend/dist/`` wins (fresher dev build)."""
     fake_api_dir = tmp_path / "pkg" / "scieasy" / "api"
     fake_api_dir.mkdir(parents=True)
     fake_app_py = fake_api_dir / "app.py"
     fake_app_py.write_text("", encoding="utf-8")
 
     packaged = _make_spa_dir(fake_api_dir / "static")
-    dev_fallback = _make_spa_dir(tmp_path / "frontend" / "dist")
+    dev_build = _make_spa_dir(tmp_path / "frontend" / "dist")
     (tmp_path / "pyproject.toml").write_text("", encoding="utf-8")
 
     monkeypatch.setattr(app_module, "__file__", str(fake_app_py))
 
     resolved = app_module._resolve_spa_static_dir()
-    assert resolved == packaged
-    assert resolved != dev_fallback
+    assert resolved == dev_build
+    assert resolved != packaged
 
 
 def test_resolve_spa_falls_back_to_frontend_dist(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
Closes #491

## Summary
- Reverse SPA static directory resolution priority: check `frontend/dist/` first, fall back to `src/scieasy/api/static/`
- During development (editable install), `static/` is stale from pip install time while `frontend/dist/` reflects the latest `npm run build`
- Wheel installs unaffected since `frontend/dist/` won't exist in that context

## Test plan
- [ ] Run `cd frontend && npm run build` then `scieasy gui` — should see latest frontend
- [ ] Verify wheel install still works (no `frontend/dist/` → falls back to `static/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)