### PR TITLE
feat(#494): native OS file dialog for browse button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- [#494] Add native OS file/directory dialog for browse button with platform-specific subprocess calls (@claude, 2026-04-09, branch: feat/issue-494/native-file-dialog, session: 20260409-165203-native-os-file-dialog-for-browse-button)
 - [#484] Add universal filesystem browse button for all path config fields via ui_widget schema annotation (@claude, 2026-04-09, branch: feat/issue-484/universal-browse, session: 20260409-154209-universal-filesystem-browse-button-484)
 - [#465] Add project tree tab in left sidebar with lazy-loading file browser, right-click menu, and reveal-in-explorer (@claude, 2026-04-09, branch: feat/issue-465/project-tree, session: 20260409-150547-project-tree-tab-in-left-sidebar-465)
 - [#452] Implement AIBlock MVP: functional `run()` with LLM provider integration, input serialization, prompt templating, and Text output (@claude, 2026-04-08, branch: feat/issue-452/ai-block-mvp, session: 20260408-224820-feat-ai-aiblock-mvp-implementation)

--- a/frontend/src/components/nodes/BlockNode.tsx
+++ b/frontend/src/components/nodes/BlockNode.tsx
@@ -407,6 +407,38 @@ function InlineConfigField({
     uiWidget === "file_browser" || uiWidget === "directory_browser";
   const [browseOpen, setBrowseOpen] = useState(false);
 
+  const handleBrowseClick = async () => {
+    // Try native OS dialog first, fall back to in-app FileBrowserModal
+    const nativeMode = uiWidget === "directory_browser" ? "directory" : "file";
+    const currentVal = String(value ?? schema.default ?? "");
+    // Extract parent directory from current value for initial_dir
+    let initialDir: string | undefined;
+    if (currentVal) {
+      const sep = currentVal.includes("\\") ? "\\" : "/";
+      const parts = currentVal.split(sep);
+      if (parts.length > 1 && uiWidget === "file_browser") {
+        const last = parts[parts.length - 1];
+        if (last.includes(".")) {
+          initialDir = parts.slice(0, -1).join(sep);
+        } else {
+          initialDir = currentVal;
+        }
+      } else {
+        initialDir = currentVal;
+      }
+    }
+    try {
+      const result = await api.openNativeDialog(nativeMode, initialDir);
+      if (result.path) {
+        onChange(key, result.path);
+      }
+      // If result.path is null, user cancelled — do nothing
+    } catch {
+      // Native dialog failed — fall back to in-app FileBrowserModal
+      setBrowseOpen(true);
+    }
+  };
+
   return (
     <label className="flex items-center justify-between gap-2 text-xs">
       <span className="shrink-0 text-stone-500">{label}</span>
@@ -424,7 +456,7 @@ function InlineConfigField({
             type="button"
             className="nodrag shrink-0 rounded border border-stone-200 bg-white px-1.5 py-1 text-xs text-stone-600 hover:bg-stone-50"
             title="Browse filesystem"
-            onClick={() => setBrowseOpen(true)}
+            onClick={() => void handleBrowseClick()}
           >
             ...
           </button>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -174,4 +174,10 @@ export const api = {
       headers: JSON_HEADERS,
       body: JSON.stringify({ path }),
     }),
+  openNativeDialog: (mode: "file" | "directory", initialDir?: string) =>
+    apiFetch<{ path: string | null }>("/api/filesystem/native-dialog", {
+      method: "POST",
+      headers: JSON_HEADERS,
+      body: JSON.stringify({ mode, initial_dir: initialDir }),
+    }),
 };

--- a/src/scieasy/api/routes/filesystem.py
+++ b/src/scieasy/api/routes/filesystem.py
@@ -224,3 +224,138 @@ async def reveal_in_explorer(body: RevealRequest) -> dict[str, str]:
         ) from exc
 
     return {"status": "ok"}
+
+
+# ---------------------------------------------------------------------------
+# Native OS file/directory dialog
+# ---------------------------------------------------------------------------
+
+
+class NativeDialogRequest(BaseModel):
+    """Request body for the native file/directory dialog."""
+
+    mode: str = Field(..., pattern="^(file|directory)$", description="Dialog type: 'file' or 'directory'")
+    initial_dir: str | None = Field(None, description="Optional starting directory for the dialog")
+
+
+class NativeDialogResponse(BaseModel):
+    """Response from the native dialog endpoint."""
+
+    path: str | None = Field(None, description="Selected path, or null if cancelled")
+
+
+# Per-session last-used directory (in-memory, resets on restart).
+_last_used_directory: str | None = None
+
+
+def _native_dialog_windows(mode: str, initial_dir: str | None) -> str | None:
+    """Open a native Windows file/directory dialog via PowerShell."""
+    if mode == "directory":
+        ps_script = (
+            "Add-Type -AssemblyName System.Windows.Forms;"
+            "$d = New-Object System.Windows.Forms.FolderBrowserDialog;"
+            f"$d.SelectedPath = '{initial_dir or ''}';"
+            "if ($d.ShowDialog() -eq 'OK') {{ $d.SelectedPath }} else {{ '' }}"
+        )
+    else:
+        ps_script = (
+            "Add-Type -AssemblyName System.Windows.Forms;"
+            "$d = New-Object System.Windows.Forms.OpenFileDialog;"
+            f"$d.InitialDirectory = '{initial_dir or ''}';"
+            "if ($d.ShowDialog() -eq 'OK') {{ $d.FileName }} else {{ '' }}"
+        )
+    result = subprocess.run(
+        ["powershell", "-NoProfile", "-NonInteractive", "-Command", ps_script],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    selected = result.stdout.strip()
+    return selected if selected else None
+
+
+def _native_dialog_macos(mode: str, initial_dir: str | None) -> str | None:
+    """Open a native macOS file/directory dialog via osascript."""
+    if mode == "directory":
+        if initial_dir:
+            script = f'choose folder with prompt "Select Directory" default location POSIX file "{initial_dir}"'
+        else:
+            script = 'choose folder with prompt "Select Directory"'
+    else:
+        if initial_dir:
+            script = f'choose file with prompt "Select File" default location POSIX file "{initial_dir}"'
+        else:
+            script = 'choose file with prompt "Select File"'
+    result = subprocess.run(
+        ["osascript", "-e", script],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    selected = result.stdout.strip()
+    if not selected:
+        return None
+    # osascript returns "alias Macintosh HD:Users:foo:..." — convert to POSIX
+    if selected.startswith("alias "):
+        # Convert colon-separated HFS path to POSIX
+        parts = selected[len("alias ") :].split(":")
+        # First part is the volume name — on default installs, map to /
+        posix = "/" + "/".join(parts[1:])
+        # Remove trailing slash if present
+        return posix.rstrip("/") or "/"
+    return selected
+
+
+def _native_dialog_linux(mode: str, initial_dir: str | None) -> str | None:
+    """Open a native Linux file/directory dialog via zenity."""
+    cmd = ["zenity", "--file-selection"]
+    if mode == "directory":
+        cmd.append("--directory")
+    if initial_dir:
+        cmd.extend(["--filename", initial_dir + "/"])
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
+    selected = result.stdout.strip()
+    return selected if selected else None
+
+
+@router.post("/api/filesystem/native-dialog", response_model=NativeDialogResponse)
+async def native_file_dialog(body: NativeDialogRequest) -> NativeDialogResponse:
+    """Open a native OS file or directory dialog and return the selected path.
+
+    Uses platform-specific subprocess calls (PowerShell on Windows, osascript
+    on macOS, zenity on Linux). Returns ``{"path": null}`` if the user cancels.
+    """
+    global _last_used_directory
+
+    # Determine starting directory: request param > last-used > home
+    initial_dir = body.initial_dir
+    if not initial_dir or not Path(initial_dir).is_dir():
+        initial_dir = _last_used_directory
+    if not initial_dir or not Path(initial_dir).is_dir():
+        initial_dir = str(Path.home())
+
+    system = platform.system()
+    try:
+        if system == "Windows":
+            selected = _native_dialog_windows(body.mode, initial_dir)
+        elif system == "Darwin":
+            selected = _native_dialog_macos(body.mode, initial_dir)
+        else:
+            selected = _native_dialog_linux(body.mode, initial_dir)
+    except FileNotFoundError as exc:
+        raise HTTPException(
+            status_code=500,
+            detail=f"Native dialog command not available on this platform ({system})",
+        ) from exc
+    except subprocess.TimeoutExpired as exc:
+        raise HTTPException(
+            status_code=504,
+            detail="Dialog timed out (user may have left the dialog open)",
+        ) from exc
+
+    # Track last-used directory for the session
+    if selected:
+        parent = str(Path(selected).parent) if Path(selected).is_file() else selected
+        _last_used_directory = parent
+
+    return NativeDialogResponse(path=selected)

--- a/tests/api/test_filesystem.py
+++ b/tests/api/test_filesystem.py
@@ -98,6 +98,133 @@ class TestProjectTree:
         assert ".hidden_file" not in names
 
 
+class TestNativeDialog:
+    """Tests for POST /api/filesystem/native-dialog."""
+
+    def test_invalid_mode(self, client: TestClient) -> None:
+        """Mode must be 'file' or 'directory'."""
+        resp = client.post(
+            "/api/filesystem/native-dialog",
+            json={"mode": "invalid"},
+        )
+        assert resp.status_code == 422
+
+    def test_directory_dialog_returns_path(self, client: TestClient, opened_project: Path, monkeypatch: object) -> None:
+        """Successful directory dialog returns the selected path."""
+        import subprocess
+
+        import scieasy.api.routes.filesystem as fs_mod
+
+        fake_dir = str(opened_project / "data")
+
+        class FakeCompletedProcess:
+            stdout = fake_dir + "\n"
+            stderr = ""
+            returncode = 0
+
+        original_run = subprocess.run
+        fs_mod.subprocess.run = lambda *_args, **_kwargs: FakeCompletedProcess()  # type: ignore[assignment]
+        try:
+            resp = client.post(
+                "/api/filesystem/native-dialog",
+                json={"mode": "directory", "initial_dir": str(opened_project)},
+            )
+            assert resp.status_code == 200
+            assert resp.json()["path"] == fake_dir
+        finally:
+            fs_mod.subprocess.run = original_run  # type: ignore[assignment]
+
+    def test_file_dialog_returns_path(self, client: TestClient, opened_project: Path, monkeypatch: object) -> None:
+        """Successful file dialog returns the selected file path."""
+        import subprocess
+
+        import scieasy.api.routes.filesystem as fs_mod
+
+        fake_file = str(opened_project / "data" / "sample.csv")
+
+        class FakeCompletedProcess:
+            stdout = fake_file + "\n"
+            stderr = ""
+            returncode = 0
+
+        original_run = subprocess.run
+        fs_mod.subprocess.run = lambda *_args, **_kwargs: FakeCompletedProcess()  # type: ignore[assignment]
+        try:
+            resp = client.post(
+                "/api/filesystem/native-dialog",
+                json={"mode": "file"},
+            )
+            assert resp.status_code == 200
+            assert resp.json()["path"] == fake_file
+        finally:
+            fs_mod.subprocess.run = original_run  # type: ignore[assignment]
+
+    def test_cancelled_dialog_returns_null(self, client: TestClient, monkeypatch: object) -> None:
+        """Cancelled dialog returns path=null."""
+        import subprocess
+
+        import scieasy.api.routes.filesystem as fs_mod
+
+        class FakeCompletedProcess:
+            stdout = "\n"
+            stderr = ""
+            returncode = 1
+
+        original_run = subprocess.run
+        fs_mod.subprocess.run = lambda *_args, **_kwargs: FakeCompletedProcess()  # type: ignore[assignment]
+        try:
+            resp = client.post(
+                "/api/filesystem/native-dialog",
+                json={"mode": "directory"},
+            )
+            assert resp.status_code == 200
+            assert resp.json()["path"] is None
+        finally:
+            fs_mod.subprocess.run = original_run  # type: ignore[assignment]
+
+    def test_timeout_returns_504(self, client: TestClient, monkeypatch: object) -> None:
+        """Dialog timeout returns 504."""
+        import subprocess
+
+        import scieasy.api.routes.filesystem as fs_mod
+
+        original_run = subprocess.run
+
+        def timeout_run(*_args: object, **_kwargs: object) -> None:
+            raise subprocess.TimeoutExpired(cmd="dialog", timeout=120)
+
+        fs_mod.subprocess.run = timeout_run  # type: ignore[assignment]
+        try:
+            resp = client.post(
+                "/api/filesystem/native-dialog",
+                json={"mode": "file"},
+            )
+            assert resp.status_code == 504
+        finally:
+            fs_mod.subprocess.run = original_run  # type: ignore[assignment]
+
+    def test_missing_command_returns_500(self, client: TestClient, monkeypatch: object) -> None:
+        """Missing native command returns 500."""
+        import subprocess
+
+        import scieasy.api.routes.filesystem as fs_mod
+
+        original_run = subprocess.run
+
+        def not_found_run(*_args: object, **_kwargs: object) -> None:
+            raise FileNotFoundError("zenity not found")
+
+        fs_mod.subprocess.run = not_found_run  # type: ignore[assignment]
+        try:
+            resp = client.post(
+                "/api/filesystem/native-dialog",
+                json={"mode": "directory"},
+            )
+            assert resp.status_code == 500
+        finally:
+            fs_mod.subprocess.run = original_run  # type: ignore[assignment]
+
+
 class TestRevealInExplorer:
     """Tests for POST /api/filesystem/reveal."""
 


### PR DESCRIPTION
## Summary
- Add `POST /api/filesystem/native-dialog` endpoint for native OS file/directory picker
- Frontend browse button tries native dialog first, falls back to in-app FileBrowserModal
- Platform support: Windows (PowerShell), macOS (osascript), Linux (zenity)

## Related Issues
Closes #494

## Test plan
- [x] 6 backend tests: valid mode, file/directory selection, cancellation, timeout, missing command
- [x] Fallback logic preserves existing FileBrowserModal behavior