### PR TITLE
feat(#497): multi-workflow tabs in frontend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- [#497] Add multi-workflow tabs: open multiple workflows as tabs with per-tab state, dirty indicators, and close confirmation (@claude, 2026-04-09, branch: feat/issue-497/multi-workflow-tabs, session: 20260409-165642-multi-workflow-tabs-in-frontend-462)
 - [#484] Add universal filesystem browse button for all path config fields via ui_widget schema annotation (@claude, 2026-04-09, branch: feat/issue-484/universal-browse, session: 20260409-154209-universal-filesystem-browse-button-484)
 - [#465] Add project tree tab in left sidebar with lazy-loading file browser, right-click menu, and reveal-in-explorer (@claude, 2026-04-09, branch: feat/issue-465/project-tree, session: 20260409-150547-project-tree-tab-in-left-sidebar-465)
 - [#452] Implement AIBlock MVP: functional `run()` with LLM provider integration, input serialization, prompt templating, and Text output (@claude, 2026-04-08, branch: feat/issue-452/ai-block-mvp, session: 20260408-224820-feat-ai-aiblock-mvp-implementation)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,6 +11,7 @@ import { BottomPanel } from "./components/BottomPanel";
 import { DataPreview } from "./components/DataPreview";
 import { ProjectDialog } from "./components/ProjectDialog";
 import { ProjectTree } from "./components/ProjectTree";
+import { TabBar } from "./components/TabBar";
 import { Toolbar } from "./components/Toolbar";
 import { WelcomeScreen } from "./components/WelcomeScreen";
 import { WorkflowCanvas } from "./components/WorkflowCanvas";
@@ -95,6 +96,13 @@ export default function App() {
   const chatMessages = useAppStore((state) => state.chatMessages);
   const pushChatMessage = useAppStore((state) => state.pushChatMessage);
 
+  const tabs = useAppStore((state) => state.tabs);
+  const activeTabId = useAppStore((state) => state.activeTabId);
+  const openTab = useAppStore((state) => state.openTab);
+  const switchTab = useAppStore((state) => state.switchTab);
+  const closeTab = useAppStore((state) => state.closeTab);
+  const syncActiveTab = useAppStore((state) => state.syncActiveTab);
+
   const [busy, setBusy] = useState(false);
   const [aiLoading, setAiLoading] = useState(false);
   const [aiError, setAiError] = useState<string | null>(null);
@@ -141,16 +149,18 @@ export default function App() {
   async function loadWorkflowForProject(project: ProjectResponse) {
     if (project.current_workflow_id) {
       const workflow = await api.getWorkflow(project.current_workflow_id);
-      startTransition(() => setWorkflow(workflow));
+      openTab(workflow);
       return;
     }
-    startTransition(() => setWorkflow(emptyWorkflow("main")));
+    const workflow = emptyWorkflow("main");
+    openTab(workflow);
   }
 
-  async function loadWorkflowById(workflowId: string) {
+  async function loadWorkflowById(wfId: string) {
     try {
-      const workflow = await api.getWorkflow(workflowId);
-      startTransition(() => setWorkflow(workflow));
+      const workflow = await api.getWorkflow(wfId);
+      // Open in a tab (or switch to existing tab for this workflow)
+      openTab(workflow);
       resetExecution();
       setLastError(null);
     } catch (error) {
@@ -226,14 +236,11 @@ export default function App() {
   }
 
   function newWorkflow() {
-    if (workflowDirty) {
-      const confirmed = window.confirm("You have unsaved changes. Discard them and create a new workflow?");
-      if (!confirmed) return;
-    }
     const name = window.prompt("Workflow name:", "Untitled");
     if (name === null) return; // cancelled
     const id = name.trim() || "Untitled";
-    setWorkflow(emptyWorkflow(id));
+    const workflow = emptyWorkflow(id);
+    openTab(workflow);
     resetExecution();
   }
 
@@ -248,7 +255,7 @@ export default function App() {
       if (!file) return;
       try {
         const workflow = await api.importWorkflowFile(file);
-        startTransition(() => setWorkflow(workflow));
+        openTab(workflow);
         resetExecution();
         setLastError(null);
 
@@ -281,7 +288,7 @@ export default function App() {
 
     try {
       const saved = await api.createWorkflow(payload);
-      startTransition(() => setWorkflow(saved));
+      openTab(saved);
       markWorkflowSaved();
       setCurrentProject({
         ...currentProject,
@@ -443,6 +450,13 @@ export default function App() {
     }, 800);
     return () => window.clearTimeout(timeout);
   }, [currentProject, workflowDirty, workflowPayload]);
+
+  // Sync active tab snapshot when workflow state changes
+  useEffect(() => {
+    if (activeTabId) {
+      syncActiveTab();
+    }
+  }, [workflowNodes, workflowEdges, workflowDirty, workflowDescription, selectedNodeId]);
 
   // Keyboard shortcuts
   useEffect(() => {
@@ -686,8 +700,16 @@ export default function App() {
               </ResizablePanel>
               <ResizableHandle withHandle />
 
-              {/* Center: Canvas + Bottom Panel vertical split */}
+              {/* Center: Tab Bar + Canvas + Bottom Panel vertical split */}
               <ResizablePanel defaultSize="63%">
+                <div className="flex h-full flex-col">
+                <TabBar
+                  tabs={tabs}
+                  activeTabId={activeTabId}
+                  onSwitchTab={switchTab}
+                  onCloseTab={closeTab}
+                  onNewTab={() => newWorkflow()}
+                />
                 <ResizablePanelGroup
                   orientation="vertical"
                   className="min-h-0 flex-1"
@@ -765,6 +787,7 @@ export default function App() {
                     />
                   </ResizablePanel>
                 </ResizablePanelGroup>
+                </div>
               </ResizablePanel>
               <ResizableHandle withHandle />
 

--- a/frontend/src/components/TabBar.tsx
+++ b/frontend/src/components/TabBar.tsx
@@ -1,0 +1,72 @@
+import type { TabState } from "../store/types";
+
+interface TabBarProps {
+  tabs: TabState[];
+  activeTabId: string | null;
+  onSwitchTab: (tabId: string) => void;
+  onCloseTab: (tabId: string) => void;
+  onNewTab: () => void;
+}
+
+export function TabBar({
+  tabs,
+  activeTabId,
+  onSwitchTab,
+  onCloseTab,
+  onNewTab,
+}: TabBarProps) {
+  if (tabs.length === 0) return null;
+
+  return (
+    <div className="flex items-center gap-0 border-b border-stone-200 bg-[linear-gradient(180deg,_rgba(255,255,255,0.95),_rgba(245,241,232,0.98))] px-1">
+      {tabs.map((tab) => {
+        const isActive = tab.id === activeTabId;
+        return (
+          <div
+            key={tab.id}
+            className={`group flex max-w-[180px] items-center gap-1 border-r border-stone-200 px-3 py-1.5 text-xs transition-colors ${
+              isActive
+                ? "border-b-2 border-b-ember bg-white/80 font-medium text-ink"
+                : "cursor-pointer text-stone-500 hover:bg-white/40 hover:text-stone-700"
+            }`}
+            onClick={() => onSwitchTab(tab.id)}
+            role="tab"
+            aria-selected={isActive}
+          >
+            <span className="min-w-0 flex-1 truncate" title={tab.workflowName}>
+              {tab.workflowName}
+            </span>
+            {tab.workflowDirty && (
+              <span className="shrink-0 text-[10px] text-amber-500" title="Unsaved changes">
+                *
+              </span>
+            )}
+            <button
+              type="button"
+              className="ml-1 shrink-0 rounded p-0.5 text-stone-400 opacity-0 transition-opacity hover:bg-stone-200 hover:text-stone-600 group-hover:opacity-100"
+              title="Close tab"
+              onClick={(e) => {
+                e.stopPropagation();
+                onCloseTab(tab.id);
+              }}
+            >
+              <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="1.5">
+                <path d="M2 2l6 6M8 2l-6 6" />
+              </svg>
+            </button>
+          </div>
+        );
+      })}
+      <button
+        type="button"
+        className="ml-1 rounded p-1.5 text-stone-400 transition-colors hover:bg-stone-100 hover:text-stone-600"
+        title="New workflow tab"
+        onClick={onNewTab}
+      >
+        <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.5">
+          <path d="M6 2v8M2 6h8" />
+        </svg>
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -6,6 +6,7 @@ import { createExecutionSlice } from "./executionSlice";
 import { createPaletteSlice } from "./paletteSlice";
 import { createPreviewSlice } from "./previewSlice";
 import { createProjectSlice } from "./projectSlice";
+import { createTabSlice } from "./tabSlice";
 import type { AppStore } from "./types";
 import { createUISlice } from "./uiSlice";
 import { createWorkflowSlice } from "./workflowSlice";
@@ -20,6 +21,7 @@ export const useAppStore = create<AppStore>()(
       ...createPreviewSlice(...args),
       ...createPaletteSlice(...args),
       ...createChatSlice(...args),
+      ...createTabSlice(...args),
     }),
     {
       name: "scieasy-studio-ui",

--- a/frontend/src/store/tabSlice.ts
+++ b/frontend/src/store/tabSlice.ts
@@ -1,0 +1,165 @@
+import type { StateCreator } from "zustand";
+
+import type { AppStore, TabSlice, TabState } from "./types";
+
+/**
+ * Capture the current workflow + UI state into a TabState snapshot.
+ */
+function captureTab(state: AppStore): TabState {
+  return {
+    id: state.activeTabId ?? state.workflowId ?? "main",
+    workflowId: state.workflowId ?? "main",
+    workflowName: state.workflowName,
+    workflowDescription: state.workflowDescription,
+    workflowVersion: state.workflowVersion,
+    workflowMetadata: state.workflowMetadata,
+    workflowNodes: state.workflowNodes,
+    workflowEdges: state.workflowEdges,
+    workflowDirty: state.workflowDirty,
+    workflowHistory: state.workflowHistory,
+    workflowFuture: state.workflowFuture,
+    selectedNodeId: state.selectedNodeId,
+  };
+}
+
+/**
+ * Restore a tab snapshot into the main workflow + UI state fields.
+ */
+function restoreTab(tab: TabState): Partial<AppStore> {
+  return {
+    workflowId: tab.workflowId,
+    workflowName: tab.workflowName,
+    workflowDescription: tab.workflowDescription,
+    workflowVersion: tab.workflowVersion,
+    workflowMetadata: tab.workflowMetadata,
+    workflowNodes: tab.workflowNodes,
+    workflowEdges: tab.workflowEdges,
+    workflowDirty: tab.workflowDirty,
+    workflowHistory: tab.workflowHistory,
+    workflowFuture: tab.workflowFuture,
+    selectedNodeId: tab.selectedNodeId,
+    activeTabId: tab.id,
+  };
+}
+
+export const createTabSlice: StateCreator<AppStore, [], [], TabSlice> = (set, get) => ({
+  tabs: [],
+  activeTabId: null,
+
+  openTab: (workflow) => {
+    const state = get();
+    // Check if this workflow is already open in a tab
+    const existing = state.tabs.find((t) => t.workflowId === workflow.id);
+    if (existing) {
+      // Switch to it instead of opening a duplicate
+      state.switchTab(existing.id);
+      return;
+    }
+
+    // Save current tab state before switching
+    const updatedTabs = state.activeTabId
+      ? state.tabs.map((t) => (t.id === state.activeTabId ? captureTab(state) : t))
+      : [...state.tabs];
+
+    // Create new tab
+    const tabId = `tab-${workflow.id}-${Date.now()}`;
+    const newTab: TabState = {
+      id: tabId,
+      workflowId: workflow.id,
+      workflowName: workflow.id,
+      workflowDescription: workflow.description,
+      workflowVersion: workflow.version,
+      workflowMetadata: workflow.metadata,
+      workflowNodes: workflow.nodes,
+      workflowEdges: workflow.edges,
+      workflowDirty: false,
+      workflowHistory: [],
+      workflowFuture: [],
+      selectedNodeId: null,
+    };
+
+    set({
+      tabs: [...updatedTabs, newTab],
+      ...restoreTab(newTab),
+    });
+  },
+
+  switchTab: (tabId) => {
+    const state = get();
+    if (tabId === state.activeTabId) return;
+
+    const target = state.tabs.find((t) => t.id === tabId);
+    if (!target) return;
+
+    // Save current tab state
+    const updatedTabs = state.activeTabId
+      ? state.tabs.map((t) => (t.id === state.activeTabId ? captureTab(state) : t))
+      : state.tabs;
+
+    set({
+      tabs: updatedTabs,
+      ...restoreTab(target),
+    });
+  },
+
+  closeTab: (tabId) => {
+    const state = get();
+    const tab = state.tabs.find((t) => t.id === tabId);
+    if (!tab) return true;
+
+    // If this is the active tab, check for the latest dirty state
+    const isDirty = tabId === state.activeTabId ? state.workflowDirty : tab.workflowDirty;
+
+    if (isDirty) {
+      const confirmed = window.confirm(
+        `"${tab.workflowName}" has unsaved changes. Close anyway?`,
+      );
+      if (!confirmed) return false;
+    }
+
+    const remaining = state.tabs.filter((t) => t.id !== tabId);
+
+    if (tabId === state.activeTabId) {
+      // Need to switch to another tab or clear
+      if (remaining.length > 0) {
+        // Switch to the tab that was next to this one
+        const closedIndex = state.tabs.findIndex((t) => t.id === tabId);
+        const nextTab = remaining[Math.min(closedIndex, remaining.length - 1)];
+        set({
+          tabs: remaining,
+          ...restoreTab(nextTab),
+        });
+      } else {
+        // No tabs left — reset to empty state
+        set({
+          tabs: [],
+          activeTabId: null,
+          workflowId: null,
+          workflowName: "Untitled",
+          workflowDescription: "",
+          workflowVersion: "1.0.0",
+          workflowMetadata: {},
+          workflowNodes: [],
+          workflowEdges: [],
+          workflowDirty: false,
+          workflowHistory: [],
+          workflowFuture: [],
+          selectedNodeId: null,
+        });
+      }
+    } else {
+      set({ tabs: remaining });
+    }
+    return true;
+  },
+
+  syncActiveTab: () => {
+    const state = get();
+    if (!state.activeTabId) return;
+    set({
+      tabs: state.tabs.map((t) =>
+        t.id === state.activeTabId ? captureTab(state) : t,
+      ),
+    });
+  },
+});

--- a/frontend/src/store/types.ts
+++ b/frontend/src/store/types.ts
@@ -105,10 +105,42 @@ export interface ChatSlice {
   clearChatMessages: () => void;
 }
 
+/** Per-tab snapshot of workflow + UI state. */
+export interface TabState {
+  id: string;
+  workflowId: string;
+  workflowName: string;
+  workflowDescription: string;
+  workflowVersion: string;
+  workflowMetadata: Record<string, unknown>;
+  workflowNodes: WorkflowNode[];
+  workflowEdges: WorkflowEdge[];
+  workflowDirty: boolean;
+  workflowHistory: WorkflowHistoryEntry[];
+  workflowFuture: WorkflowHistoryEntry[];
+  selectedNodeId: string | null;
+}
+
+export interface TabSlice {
+  /** All open tabs (order = display order). */
+  tabs: TabState[];
+  /** ID of the currently active tab. */
+  activeTabId: string | null;
+  /** Open (or switch to) a workflow in a tab. */
+  openTab: (workflow: WorkflowResponse) => void;
+  /** Switch to an existing tab. */
+  switchTab: (tabId: string) => void;
+  /** Close a tab by ID. Returns true if closed, false if cancelled. */
+  closeTab: (tabId: string) => boolean;
+  /** Sync the active tab's snapshot from current workflow state. */
+  syncActiveTab: () => void;
+}
+
 export type AppStore = ProjectSlice &
   WorkflowSlice &
   ExecutionSlice &
   UISlice &
   PreviewSlice &
   PaletteSlice &
-  ChatSlice;
+  ChatSlice &
+  TabSlice;


### PR DESCRIPTION
## Summary
- Add tab bar above the canvas for opening multiple workflows simultaneously
- Each tab preserves its own workflow graph state, selected node, and dirty flag
- New/Import/Save As/Project Tree all open workflows in tabs (or switch to existing)
- Close tab with unsaved changes prompts for confirmation

## Related Issues
Closes #497

## Test plan
- [x] Frontend type-checks and builds successfully
- [ ] Manual: open project, verify tab appears for initial workflow
- [ ] Manual: click "New" in toolbar, verify new tab opens
- [ ] Manual: open workflow from Project Tree, verify it opens in a tab (or switches)
- [ ] Manual: switch between tabs, verify state is preserved
- [ ] Manual: close tab with unsaved changes, verify confirmation dialog