### PR TITLE
fix(#517): TabBar invisible on startup — always render tab bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- [#517] Fix TabBar invisible on startup — always render tab bar, use openTab for new projects (@claude, 2026-04-09, branch: fix/issue-503/tabbar-startup, session: 20260409-191833-fix-tabbar-invisible-on-startup-no-initi)
 - [#488] Fix block palette: group core blocks under SciEasy Core, register LCMS/SRS plugins with entry-points (@claude, 2026-04-09, branch: fix/issue-488/palette-categorization, session: 20260409-180931-fix-block-palette-core-blocks-scattered)
 - [#495] Fix ResourceManager memory watermark deadlock on macOS and PosixOps pid=-1 alive check bug (@claude, 2026-04-09, branch: fix/issue-495/memory-watermark-deadlock, session: 20260409-180231-fix-resourcemanager-memory-watermark-dea)
 - [#461] Fix palette categorization: add type_name prefixes to LCMS/SRS blocks, refine subcategories, populate source/package_name for Custom group (@claude, 2026-04-09, branch: fix/issue-461/palette-categorization, session: 20260409-124810-fix-block-palette-categorization-461)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -195,7 +195,7 @@ export default function App() {
           path: projectDialog.path,
         });
         setCurrentProject(project);
-        startTransition(() => setWorkflow(emptyWorkflow("main")));
+        openTab(emptyWorkflow("main"));
         await refreshProjects();
       } else {
         await openProject(projectDialog.path);

--- a/frontend/src/components/TabBar.tsx
+++ b/frontend/src/components/TabBar.tsx
@@ -15,8 +15,6 @@ export function TabBar({
   onCloseTab,
   onNewTab,
 }: TabBarProps) {
-  if (tabs.length === 0) return null;
-
   return (
     <div className="flex items-center gap-0 border-b border-stone-200 bg-[linear-gradient(180deg,_rgba(255,255,255,0.95),_rgba(245,241,232,0.98))] px-1">
       {tabs.map((tab) => {


### PR DESCRIPTION
## Summary
- Remove `if (tabs.length === 0) return null` guard in TabBar so the tab bar always renders (showing at minimum the "+" button)
- Fix `submitProjectDialog` to use `openTab()` instead of `setWorkflow()` for new projects, ensuring a tab is created immediately

## Related Issues
Closes #517

## Checklist
- [x] TabBar always visible (+ button accessible even with no tabs)
- [x] New project creation opens an initial tab
- [ ] CHANGELOG updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)