### PR TITLE
fix(#506): store relative paths in workflow YAML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- [#506] Store relative paths in workflow YAML for cross-machine portability (@claude, 2026-04-09, branch: fix/issue-506/relative-paths, session: 20260409-191659-store-relative-paths-in-workflow-yaml-50)
 - [#499] Configure Python logging handlers so logger output is not silently discarded (@claude, 2026-04-09, branch: fix/issue-499/configure-logging, session: 20260409-180335-configure-logging-handlers-for-the-codeb)
 - [#488] Fix block palette: group core blocks under SciEasy Core, register LCMS/SRS plugins with entry-points (@claude, 2026-04-09, branch: fix/issue-488/palette-categorization, session: 20260409-180931-fix-block-palette-core-blocks-scattered)
 - [#495] Fix ResourceManager memory watermark deadlock on macOS and PosixOps pid=-1 alive check bug (@claude, 2026-04-09, branch: fix/issue-495/memory-watermark-deadlock, session: 20260409-180231-fix-resourcemanager-memory-watermark-dea)

--- a/src/scieasy/api/runtime.py
+++ b/src/scieasy/api/runtime.py
@@ -33,7 +33,7 @@ from scieasy.engine.runners.local import LocalRunner
 from scieasy.engine.runners.process_handle import ProcessRegistry
 from scieasy.engine.scheduler import DAGScheduler
 from scieasy.workflow.definition import EdgeDef, NodeDef, WorkflowDefinition
-from scieasy.workflow.serializer import load_yaml, save_yaml
+from scieasy.workflow.serializer import absolutify_paths, load_yaml, relativify_paths, save_yaml
 
 logger = logging.getLogger(__name__)
 
@@ -460,6 +460,9 @@ class ApiRuntime:
         return Path(project.path) / "workflows" / f"{workflow_id}.yaml"
 
     def save_workflow(self, payload: dict[str, Any]) -> WorkflowDefinition:
+        # #506: relativify paths in node configs before persisting YAML.
+        project_dir = self.active_project.path if self.active_project else None
+
         definition = WorkflowDefinition(
             id=payload["id"],
             version=payload.get("version", "1.0.0"),
@@ -469,7 +472,7 @@ class ApiRuntime:
                 NodeDef(
                     id=node["id"],
                     block_type=node["block_type"],
-                    config=node.get("config", {}),
+                    config=self._relativify_node_config(node.get("config", {}), node["block_type"], project_dir),
                     execution_mode=node.get("execution_mode"),
                     layout=node.get("layout"),
                 )
@@ -490,7 +493,40 @@ class ApiRuntime:
         path = self.workflow_path(workflow_id)
         if not path.exists():
             raise FileNotFoundError(f"Workflow not found: {workflow_id}")
-        return load_yaml(path)
+        definition = load_yaml(path)
+
+        # #506: resolve relative paths back to absolute using project dir.
+        project_dir = self.active_project.path if self.active_project else None
+        if project_dir:
+            for node in definition.nodes:
+                node.config = self._absolutify_node_config(node.config, node.block_type, project_dir)
+
+        return definition
+
+    def _config_schema_for_block(self, block_type: str) -> dict[str, Any]:
+        """Look up the config_schema for a block type from the registry."""
+        spec = self.block_registry.get_spec(block_type)
+        if spec is not None:
+            return spec.config_schema
+        return {"type": "object", "properties": {}}
+
+    def _relativify_node_config(
+        self, config: dict[str, Any], block_type: str, project_dir: str | None
+    ) -> dict[str, Any]:
+        """Convert absolute paths in node config to relative paths (#506)."""
+        if not project_dir:
+            return config
+        schema = self._config_schema_for_block(block_type)
+        return relativify_paths(config, project_dir, schema)
+
+    def _absolutify_node_config(
+        self, config: dict[str, Any], block_type: str, project_dir: str | None
+    ) -> dict[str, Any]:
+        """Resolve relative paths in node config to absolute paths (#506)."""
+        if not project_dir:
+            return config
+        schema = self._config_schema_for_block(block_type)
+        return absolutify_paths(config, project_dir, schema)
 
     def delete_workflow(self, workflow_id: str) -> None:
         path = self.workflow_path(workflow_id)

--- a/src/scieasy/workflow/serializer.py
+++ b/src/scieasy/workflow/serializer.py
@@ -2,12 +2,85 @@
 
 from __future__ import annotations
 
-from pathlib import Path
+from pathlib import Path, PurePosixPath
+from typing import Any
 
 import yaml
 
 from scieasy.workflow.definition import WorkflowDefinition
 from scieasy.workflow.schema import WorkflowFileModel, WorkflowModel
+
+# ---------------------------------------------------------------------------
+# Path portability helpers (#506)
+# ---------------------------------------------------------------------------
+
+
+def _path_config_keys(config_schema: dict[str, Any]) -> set[str]:
+    """Return config keys whose ``ui_widget`` indicates a path field."""
+    props = config_schema.get("properties", {})
+    keys: set[str] = set()
+    for key, schema in props.items():
+        widget = schema.get("ui_widget", "")
+        if widget in ("file_browser", "directory_browser"):
+            keys.add(key)
+    return keys
+
+
+def relativify_paths(
+    config: dict[str, Any],
+    project_dir: str | Path,
+    config_schema: dict[str, Any],
+) -> dict[str, Any]:
+    """Convert absolute paths under *project_dir* to forward-slash relative paths.
+
+    Only fields identified by ``ui_widget`` in *config_schema* are considered.
+    Paths outside *project_dir* are left unchanged.
+    """
+    path_keys = _path_config_keys(config_schema)
+    if not path_keys:
+        return config
+
+    project = Path(project_dir).resolve()
+    result = dict(config)
+    for key in path_keys:
+        value = result.get(key)
+        if not isinstance(value, str) or not value:
+            continue
+        try:
+            resolved = Path(value).resolve()
+            relative = resolved.relative_to(project)
+            # Always use forward slashes in YAML regardless of OS.
+            result[key] = str(PurePosixPath(relative))
+        except (ValueError, OSError):
+            # Path is not under project_dir -- keep as-is.
+            pass
+    return result
+
+
+def absolutify_paths(
+    config: dict[str, Any],
+    project_dir: str | Path,
+    config_schema: dict[str, Any],
+) -> dict[str, Any]:
+    """Resolve relative paths in *config* to absolute paths under *project_dir*.
+
+    Already-absolute paths are returned unchanged (backward compatible with
+    workflows saved before #506).
+    """
+    path_keys = _path_config_keys(config_schema)
+    if not path_keys:
+        return config
+
+    project = Path(project_dir).resolve()
+    result = dict(config)
+    for key in path_keys:
+        value = result.get(key)
+        if not isinstance(value, str) or not value:
+            continue
+        p = Path(value)
+        if not p.is_absolute():
+            result[key] = str((project / value).resolve())
+    return result
 
 
 def load_yaml(path: str | Path) -> WorkflowDefinition:

--- a/tests/workflow/test_path_portability.py
+++ b/tests/workflow/test_path_portability.py
@@ -1,0 +1,134 @@
+"""Tests for workflow path portability (#506).
+
+Verifies that absolute paths in block configs are relativized on save
+and absolutified on load, using forward slashes in YAML.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scieasy.workflow.serializer import absolutify_paths, relativify_paths
+
+# Sample config schema with file_browser and directory_browser widgets.
+SCHEMA = {
+    "type": "object",
+    "properties": {
+        "path": {"type": "string", "ui_widget": "file_browser"},
+        "output_dir": {"type": "string", "ui_widget": "directory_browser"},
+        "name": {"type": "string"},
+        "timeout": {"type": "integer"},
+    },
+}
+
+
+class TestRelativifyPaths:
+    """Test relativify_paths utility."""
+
+    def test_converts_path_under_project(self, tmp_path: Path) -> None:
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        data_file = project_dir / "data" / "raw" / "sample.tif"
+        data_file.parent.mkdir(parents=True)
+        data_file.touch()
+
+        config = {"path": str(data_file), "name": "test"}
+        result = relativify_paths(config, str(project_dir), SCHEMA)
+
+        assert result["path"] == "data/raw/sample.tif"
+        assert result["name"] == "test"  # non-path field unchanged
+
+    def test_keeps_path_outside_project(self, tmp_path: Path) -> None:
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        external_file = tmp_path / "external" / "data.csv"
+        external_file.parent.mkdir(parents=True)
+        external_file.touch()
+
+        config = {"path": str(external_file)}
+        result = relativify_paths(config, str(project_dir), SCHEMA)
+
+        # Path outside project dir should remain absolute.
+        assert Path(result["path"]).is_absolute()
+
+    def test_uses_forward_slashes(self, tmp_path: Path) -> None:
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        nested = project_dir / "sub" / "dir" / "file.csv"
+        nested.parent.mkdir(parents=True)
+        nested.touch()
+
+        config = {"path": str(nested)}
+        result = relativify_paths(config, str(project_dir), SCHEMA)
+
+        assert "\\" not in result["path"]
+        assert result["path"] == "sub/dir/file.csv"
+
+    def test_handles_directory_browser(self, tmp_path: Path) -> None:
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        output = project_dir / "results"
+        output.mkdir()
+
+        config = {"output_dir": str(output)}
+        result = relativify_paths(config, str(project_dir), SCHEMA)
+
+        assert result["output_dir"] == "results"
+
+    def test_ignores_empty_value(self, tmp_path: Path) -> None:
+        config = {"path": "", "name": "test"}
+        result = relativify_paths(config, str(tmp_path), SCHEMA)
+        assert result["path"] == ""
+
+    def test_ignores_none_value(self, tmp_path: Path) -> None:
+        config = {"path": None, "name": "test"}
+        result = relativify_paths(config, str(tmp_path), SCHEMA)
+        assert result["path"] is None
+
+    def test_no_path_keys_in_schema(self, tmp_path: Path) -> None:
+        schema = {"type": "object", "properties": {"name": {"type": "string"}}}
+        config = {"name": "test"}
+        result = relativify_paths(config, str(tmp_path), schema)
+        assert result == config
+
+
+class TestAbsolutifyPaths:
+    """Test absolutify_paths utility."""
+
+    def test_resolves_relative_path(self, tmp_path: Path) -> None:
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        (project_dir / "data").mkdir()
+
+        config = {"path": "data/sample.tif"}
+        result = absolutify_paths(config, str(project_dir), SCHEMA)
+
+        expected = str((project_dir / "data" / "sample.tif").resolve())
+        assert result["path"] == expected
+
+    def test_leaves_absolute_path_unchanged(self, tmp_path: Path) -> None:
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+
+        abs_path = str(tmp_path / "external" / "file.csv")
+        config = {"path": abs_path}
+        result = absolutify_paths(config, str(project_dir), SCHEMA)
+
+        assert result["path"] == abs_path
+
+    def test_round_trip(self, tmp_path: Path) -> None:
+        """relativify -> absolutify should return the original absolute path."""
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        data_file = project_dir / "data" / "raw" / "image.tif"
+        data_file.parent.mkdir(parents=True)
+        data_file.touch()
+
+        original = {"path": str(data_file.resolve()), "output_dir": str(project_dir / "results")}
+        (project_dir / "results").mkdir()
+
+        relative = relativify_paths(original, str(project_dir), SCHEMA)
+        restored = absolutify_paths(relative, str(project_dir), SCHEMA)
+
+        assert Path(restored["path"]).resolve() == data_file.resolve()
+        assert Path(restored["output_dir"]).resolve() == (project_dir / "results").resolve()


### PR DESCRIPTION
## Summary
- Add `relativify_paths` / `absolutify_paths` utilities to workflow serializer
- On save: convert absolute paths under project dir to forward-slash relative paths
- On load: resolve relative paths back to absolute using current project dir
- Identify path fields via block config_schema `ui_widget` annotations (`file_browser`, `directory_browser`)
- Paths outside project directory remain absolute (backward compatible)

Closes #515

## Test plan
- [x] 10 unit tests covering relativify/absolutify round-trip, edge cases
- [ ] Manual: save workflow with file paths, verify YAML has relative paths
- [ ] Manual: copy project to different location, load workflow, verify paths resolve