### PR TITLE
fix(#520): expandable block error display with multi-level UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- [#520] Fix block error messages truncated — add expandable error display with tooltip, Problems tab, and copy button (@claude, 2026-04-09, branch: fix/issue-507/expandable-block-errors, session: 20260409-192041-block-error-messages-truncated-need-expa)
 - [#488] Fix block palette: group core blocks under SciEasy Core, register LCMS/SRS plugins with entry-points (@claude, 2026-04-09, branch: fix/issue-488/palette-categorization, session: 20260409-180931-fix-block-palette-core-blocks-scattered)
 - [#495] Fix ResourceManager memory watermark deadlock on macOS and PosixOps pid=-1 alive check bug (@claude, 2026-04-09, branch: fix/issue-495/memory-watermark-deadlock, session: 20260409-180231-fix-resourcemanager-memory-watermark-dea)
 - [#461] Fix palette categorization: add type_name prefixes to LCMS/SRS blocks, refine subcategories, populate source/package_name for Custom group (@claude, 2026-04-09, branch: fix/issue-461/palette-categorization, session: 20260409-124810-fix-block-palette-categorization-461)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -417,7 +417,7 @@ export default function App() {
   const handleErrorClick = useCallback(
     (blockId: string) => {
       setSelectedNodeId(blockId);
-      setActiveBottomTab("logs");
+      setActiveBottomTab("problems");
     },
     [setSelectedNodeId, setActiveBottomTab],
   );
@@ -773,6 +773,7 @@ export default function App() {
                       activeTab={activeBottomTab}
                       aiError={aiError}
                       aiLoading={aiLoading}
+                      blockErrors={blockErrors}
                       chatMessages={chatMessages}
                       logEntries={logEntries}
                       onSendChat={onSendChat}

--- a/frontend/src/components/BottomPanel.test.tsx
+++ b/frontend/src/components/BottomPanel.test.tsx
@@ -21,6 +21,7 @@ describe("BottomPanel", () => {
         activeTab="config"
         aiError={null}
         aiLoading={false}
+        blockErrors={{}}
         chatMessages={[]}
         logEntries={[]}
         onSendChat={() => {}}
@@ -65,6 +66,7 @@ describe("BottomPanel", () => {
         activeTab="config"
         aiError={null}
         aiLoading={false}
+        blockErrors={{}}
         chatMessages={[]}
         logEntries={[]}
         onSendChat={() => {}}

--- a/frontend/src/components/BottomPanel.tsx
+++ b/frontend/src/components/BottomPanel.tsx
@@ -8,6 +8,7 @@ interface BottomPanelProps {
   activeTab: BottomTab;
   selectedNode: WorkflowNode | null;
   selectedSchema?: BlockSchemaResponse;
+  blockErrors: Record<string, string>;
   chatMessages: ChatMessage[];
   logEntries: LogEntry[];
   aiLoading: boolean;
@@ -131,6 +132,51 @@ function LogViewer({ entries }: { entries: LogEntry[] }) {
   );
 }
 
+function ProblemsPanel({ blockErrors }: { blockErrors: Record<string, string> }) {
+  const [copiedId, setCopiedId] = useState<string | null>(null);
+  const entries = Object.entries(blockErrors);
+
+  const copyToClipboard = (blockId: string, text: string) => {
+    void navigator.clipboard.writeText(text).then(() => {
+      setCopiedId(blockId);
+      setTimeout(() => setCopiedId(null), 2000);
+    });
+  };
+
+  if (entries.length === 0) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <p className="text-sm text-stone-400">No errors.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full flex-col gap-3 overflow-y-auto">
+      {entries.map(([blockId, errorText]) => (
+        <div key={blockId} className="rounded-xl border border-red-200 bg-red-50/50 p-3">
+          <div className="mb-2 flex items-center justify-between">
+            <span className="text-xs font-semibold text-red-700">
+              Block: {blockId}
+            </span>
+            <button
+              type="button"
+              className="rounded px-2 py-1 text-xs text-red-600 transition-colors hover:bg-red-100"
+              onClick={() => copyToClipboard(blockId, errorText)}
+              title="Copy full error to clipboard"
+            >
+              {copiedId === blockId ? "Copied!" : "Copy"}
+            </button>
+          </div>
+          <pre className="whitespace-pre-wrap break-words text-xs leading-relaxed text-red-900">
+            {errorText}
+          </pre>
+        </div>
+      ))}
+    </div>
+  );
+}
+
 function PlaceholderTab() {
   return (
     <div className="flex h-full items-center justify-center">
@@ -143,6 +189,7 @@ export function BottomPanel({
   activeTab,
   selectedNode,
   selectedSchema,
+  blockErrors,
   chatMessages,
   logEntries,
   aiLoading,
@@ -183,6 +230,8 @@ export function BottomPanel({
             <ConfigPanel onUpdateConfig={onUpdateConfig} schema={selectedSchema} selectedNode={selectedNode} />
           ) : activeTab === "logs" ? (
             <LogViewer entries={logEntries} />
+          ) : activeTab === "problems" ? (
+            <ProblemsPanel blockErrors={blockErrors} />
           ) : (
             <PlaceholderTab />
           )}

--- a/frontend/src/components/nodes/BlockNode.tsx
+++ b/frontend/src/components/nodes/BlockNode.tsx
@@ -496,16 +496,25 @@ function InlineConfigField({
 // Error message inline display
 // ---------------------------------------------------------------------------
 const MAX_INLINE_ERROR_LEN = 80;
+const MAX_TOOLTIP_LINES = 10;
 
 function ErrorMessage({ message }: { message: string }) {
   const truncated =
     message.length > MAX_INLINE_ERROR_LEN
       ? `${message.slice(0, MAX_INLINE_ERROR_LEN)}…`
       : message;
+
+  // Build a tooltip that shows up to MAX_TOOLTIP_LINES lines of the error
+  const lines = message.split("\n");
+  const tooltipText =
+    lines.length > MAX_TOOLTIP_LINES
+      ? lines.slice(0, MAX_TOOLTIP_LINES).join("\n") + "\n…(click for full trace)"
+      : message;
+
   return (
     <span
       className="ml-2 min-w-0 flex-1 truncate text-[10px] leading-tight text-red-500"
-      title={message}
+      title={tooltipText}
     >
       {truncated}
     </span>


### PR DESCRIPTION
## Summary
- **Node tooltip:** ErrorMessage on BlockNode now shows up to 10 lines on hover (was single-line title)
- **Problems tab:** New ProblemsPanel in BottomPanel shows full error text per block with copy-to-clipboard button
- **Click flow:** Clicking the error badge on a node now opens the Problems tab (was Logs) to show the full stack trace
- **Copy button:** Each error entry in the Problems tab has a "Copy" button for clipboard

## Related Issues
Closes #520

## Checklist
- [x] Multi-level error display: inline -> tooltip -> full panel
- [x] Copy-to-clipboard for full error text
- [x] Error click navigates to Problems tab
- [ ] CHANGELOG updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)