### PR TITLE
fix(frontend): toolbar fixed-width name area and visibility dirty indicator (#524)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- [#524] Fix toolbar layout shift — use fixed-width name area and visibility-based dirty indicator (@claude, 2026-04-09, branch: fix/issue-524/toolbar-fixed-width, session: N/A)
 - [#520] Fix block error messages truncated — add expandable error display with tooltip, Problems tab, and copy button (@claude, 2026-04-09, branch: fix/issue-507/expandable-block-errors, session: 20260409-192041-block-error-messages-truncated-need-expa)
 - [#517] Fix TabBar invisible on startup — always render tab bar, use openTab for new projects (@claude, 2026-04-09, branch: fix/issue-503/tabbar-startup, session: 20260409-191833-fix-tabbar-invisible-on-startup-no-initi)
 - [#510] Fix ElMAVEN block to pass raw file paths as CLI arguments so data is pre-loaded (@claude, 2026-04-09, branch: fix/issue-510/elmaven-data-injection, session: 20260409-192253-elmaven-block-opens-without-input-data-5)

--- a/frontend/src/components/TabBar.tsx
+++ b/frontend/src/components/TabBar.tsx
@@ -34,11 +34,7 @@ export function TabBar({
             <span className="min-w-0 flex-1 truncate" title={tab.workflowName}>
               {tab.workflowName}
             </span>
-            {tab.workflowDirty && (
-              <span className="shrink-0 text-[10px] text-amber-500" title="Unsaved changes">
-                *
-              </span>
-            )}
+            <span style={{ visibility: tab.workflowDirty ? "visible" : "hidden" }} className="shrink-0 text-[10px] text-amber-500" title="Unsaved changes">{" *"}</span>
             <button
               type="button"
               className="ml-1 shrink-0 rounded p-0.5 text-stone-400 opacity-0 transition-opacity hover:bg-stone-200 hover:text-stone-600 group-hover:opacity-100"

--- a/frontend/src/components/Toolbar.tsx
+++ b/frontend/src/components/Toolbar.tsx
@@ -167,7 +167,7 @@ export function Toolbar(props: ToolbarProps) {
           <div className="rounded-[1.4rem] bg-ink px-4 py-2.5 text-stone-50">
             <p className="font-display text-lg leading-tight">SciEasy</p>
           </div>
-          <div className="min-w-0" style={{ maxWidth: 200 }}>
+          <div className="w-[200px] shrink-0">
             <p className="truncate font-display text-base leading-tight text-ink" title={currentProject?.name ?? undefined}>
               {currentProject?.name ?? "No project open"}
             </p>


### PR DESCRIPTION
## Summary
- Fix toolbar layout shift by replacing `min-w-0` + `maxWidth: 200` with `w-[200px] shrink-0` for the project/workflow name area
- Fix TabBar dirty indicator (`*`) using visibility pattern instead of conditional rendering, preventing layout shift when dirty state changes

Closes #524

## Test plan
- [ ] Verify toolbar name area maintains consistent width regardless of project/workflow name length
- [ ] Verify dirty indicator (*) in tab bar does not shift tab content when toggled

🤖 Generated with [Claude Code](https://claude.com/claude-code)