### PR TITLE
fix(lcms): switch load blocks to file_browser with multi-file support (#525)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- [#525] Switch LCMS load blocks from directory_browser/glob to file_browser with multi-file support (@claude, 2026-04-09, branch: fix/issue-525/load-blocks-file-browser, session: N/A)
 - [#520] Fix block error messages truncated — add expandable error display with tooltip, Problems tab, and copy button (@claude, 2026-04-09, branch: fix/issue-507/expandable-block-errors, session: 20260409-192041-block-error-messages-truncated-need-expa)
 - [#517] Fix TabBar invisible on startup — always render tab bar, use openTab for new projects (@claude, 2026-04-09, branch: fix/issue-503/tabbar-startup, session: 20260409-191833-fix-tabbar-invisible-on-startup-no-initi)
 - [#510] Fix ElMAVEN block to pass raw file paths as CLI arguments so data is pre-loaded (@claude, 2026-04-09, branch: fix/issue-510/elmaven-data-injection, session: 20260409-192253-elmaven-block-opens-without-input-data-5)

--- a/packages/scieasy-blocks-lcms/src/scieasy_blocks_lcms/io/load_mid_table.py
+++ b/packages/scieasy-blocks-lcms/src/scieasy_blocks_lcms/io/load_mid_table.py
@@ -93,8 +93,9 @@ class LoadMIDTable(_LCMSBlockMixin, IOBlock):
         "type": "object",
         "properties": {
             "path": {
-                "type": "string",
-                "title": "MID table file",
+                "type": ["string", "array"],
+                "items": {"type": "string"},
+                "title": "MID table file(s)",
                 "ui_priority": 0,
                 "ui_widget": "file_browser",
             },
@@ -122,52 +123,53 @@ class LoadMIDTable(_LCMSBlockMixin, IOBlock):
     }
 
     def load(self, config: BlockConfig) -> DataObject | Collection:
-        """Read the MID table and return a :class:`MIDTable`.
+        """Read MID table file(s) and return a :class:`Collection[MIDTable]`.
 
-        Implementation must:
+        Accepts ``config["path"]`` as a single string or a list of strings
+        (matching the :class:`LoadImage` multi-file pattern).
 
-        * raise :class:`FileNotFoundError` on missing file
-        * raise :class:`ValueError` on missing ``Compound`` column
-        * raise :class:`ValueError` on empty sample-column detection
-        * apply the regex override when ``sample_column_pattern`` is set
-        * fall back to the default heuristic
-          (``columns - _KNOWN_IDENTITY_COLUMNS - _KNOWN_ATOM_COLUMNS -
-          tracer_atoms``)
-        * preserve ``corrected=True`` and
-          ``correction_tool="AccuCor"`` defaults on the resulting
-          :class:`MIDTable.Meta`
+        Raises:
+            FileNotFoundError: If any path does not exist.
+            ValueError: If a required column is missing or path config is invalid.
         """
-        path = Path(config.get("path"))
-        if not path.exists():
-            raise FileNotFoundError(f"LoadMIDTable: source file not found: {path}")
-
-        frame = _read_table(path, sheet_name=config.get("sheet_name"))
-        compound_column = _find_compound_column(frame.columns)
-        if compound_column is None:
-            raise ValueError("LoadMIDTable requires a 'Compound' or 'compound' column")
+        raw_path = config.get("path")
+        if isinstance(raw_path, list):
+            paths = [Path(p) for p in raw_path if isinstance(p, str) and p]
+        elif isinstance(raw_path, str) and raw_path:
+            paths = [Path(raw_path)]
+        else:
+            raise ValueError("LoadMIDTable: config['path'] must be a non-empty string or list of strings")
 
         tracer_atoms = [str(atom) for atom in config.get("tracer_atoms", ["C13"])]
-        sample_columns = _detect_sample_columns(
-            frame.columns,
-            tracer_atoms=tracer_atoms,
-            pattern=config.get("sample_column_pattern"),
-        )
-        if not sample_columns:
-            raise ValueError("LoadMIDTable could not detect any sample columns")
-
-        table = MIDTable(
-            columns=[str(col) for col in frame.columns],
-            row_count=len(frame),
-            schema={str(col): str(dtype) for col, dtype in frame.dtypes.items()},
-            meta=MIDTable.Meta(
+        tables: list[MIDTable] = []
+        for path in paths:
+            if not path.exists():
+                raise FileNotFoundError(f"LoadMIDTable: source file not found: {path}")
+            frame = _read_table(path, sheet_name=config.get("sheet_name"))
+            compound_column = _find_compound_column(frame.columns)
+            if compound_column is None:
+                raise ValueError("LoadMIDTable requires a 'Compound' or 'compound' column")
+            sample_columns = _detect_sample_columns(
+                frame.columns,
                 tracer_atoms=tracer_atoms,
-                sample_columns=sample_columns,
-                corrected=True,
-                correction_tool="AccuCor",
-            ),
-        )
-        table.user["pandas_df"] = frame.copy()
-        return Collection(items=[table], item_type=MIDTable)
+                pattern=config.get("sample_column_pattern"),
+            )
+            if not sample_columns:
+                raise ValueError("LoadMIDTable could not detect any sample columns")
+            table = MIDTable(
+                columns=[str(col) for col in frame.columns],
+                row_count=len(frame),
+                schema={str(col): str(dtype) for col, dtype in frame.dtypes.items()},
+                meta=MIDTable.Meta(
+                    tracer_atoms=tracer_atoms,
+                    sample_columns=sample_columns,
+                    corrected=True,
+                    correction_tool="AccuCor",
+                ),
+            )
+            table.user["pandas_df"] = frame.copy()
+            tables.append(table)
+        return Collection(items=tables, item_type=MIDTable)
 
     def save(self, obj: DataObject | Collection, config: BlockConfig) -> None:
         """Not supported — use :class:`SaveTable` for output."""

--- a/packages/scieasy-blocks-lcms/src/scieasy_blocks_lcms/io/load_ms_raw_files.py
+++ b/packages/scieasy-blocks-lcms/src/scieasy_blocks_lcms/io/load_ms_raw_files.py
@@ -62,60 +62,46 @@ class LoadMSRawFiles(_LCMSBlockMixin, IOBlock):
         "type": "object",
         "properties": {
             "path": {
-                "type": "string",
-                "title": "Directory path",
+                "type": ["string", "array"],
+                "items": {"type": "string"},
+                "title": "Raw file path(s)",
                 "ui_priority": 0,
-                "ui_widget": "directory_browser",
-            },
-            "pattern": {
-                "type": "string",
-                "title": "Glob pattern",
-                "default": "*.mzML",
-                "ui_priority": 1,
-            },
-            "recursive": {
-                "type": "boolean",
-                "title": "Recursive",
-                "default": False,
-                "ui_priority": 2,
-            },
-            "format_hint": {
-                "type": ["string", "null"],
-                "enum": [None, "mzML", "mzXML", "raw", "d"],
-                "default": None,
-                "title": "Format hint",
-                "ui_priority": 3,
+                "ui_widget": "file_browser",
             },
         },
         "required": ["path"],
     }
 
     def load(self, config: BlockConfig) -> DataObject | Collection:
-        """Glob the configured path and return ``Collection[MSRawFile]``.
+        """Load file path(s) and return ``Collection[MSRawFile]``.
 
-        Implementation must:
+        Accepts ``config["path"]`` as a single string or a list of strings
+        (matching the :class:`LoadImage` multi-file pattern).
 
-        * raise :class:`FileNotFoundError` on missing directory
-        * respect ``recursive`` (``glob`` vs ``rglob``)
-        * call ``_probe_header`` to populate ``MSRawFile.Meta`` for
-          mzML/mzXML and skip header parsing for ``.raw``/``.d``
-        * fall back to ``path.stem`` for ``sample_id``
+        Each path is probed for lightweight header metadata via
+        :func:`_probe_header`.
 
         Returns:
             ``Collection[MSRawFile]`` (possibly empty).
+
+        Raises:
+            FileNotFoundError: If any specified path does not exist.
+            ValueError: If ``path`` is neither a string nor a list of strings.
         """
-        root = Path(config.get("path"))
-        if not root.exists():
-            raise FileNotFoundError(f"LoadMSRawFiles: path does not exist: {root}")
+        raw_path = config.get("path")
 
-        pattern = str(config.get("pattern", "*.mzML"))
-        recursive = bool(config.get("recursive", False))
-        format_hint = config.get("format_hint")
+        if isinstance(raw_path, list):
+            paths = [Path(p) for p in raw_path if isinstance(p, str) and p]
+        elif isinstance(raw_path, str) and raw_path:
+            paths = [Path(raw_path)]
+        else:
+            raise ValueError("LoadMSRawFiles: config['path'] must be a non-empty string or list of strings")
 
-        candidates = sorted(root.rglob(pattern) if recursive else root.glob(pattern))
         items: list[MSRawFile] = []
-        for path in candidates:
-            meta = _probe_header(path, format_hint=format_hint)
+        for path in paths:
+            if not path.exists():
+                raise FileNotFoundError(f"LoadMSRawFiles: path does not exist: {path}")
+            meta = _probe_header(path)
             items.append(
                 MSRawFile(
                     file_path=path,

--- a/packages/scieasy-blocks-lcms/src/scieasy_blocks_lcms/io/load_peak_table.py
+++ b/packages/scieasy-blocks-lcms/src/scieasy_blocks_lcms/io/load_peak_table.py
@@ -64,8 +64,9 @@ class LoadPeakTable(_LCMSBlockMixin, IOBlock):
         "type": "object",
         "properties": {
             "path": {
-                "type": "string",
-                "title": "Peak table file",
+                "type": ["string", "array"],
+                "items": {"type": "string"},
+                "title": "Peak table file(s)",
                 "ui_priority": 0,
                 "ui_widget": "file_browser",
             },
@@ -94,39 +95,44 @@ class LoadPeakTable(_LCMSBlockMixin, IOBlock):
     }
 
     def load(self, config: BlockConfig) -> DataObject | Collection:
-        """Read the peak table file and return a :class:`PeakTable`.
+        """Read peak table file(s) and return a :class:`Collection[PeakTable]`.
 
-        Implementation must:
+        Accepts ``config["path"]`` as a single string or a list of strings
+        (matching the :class:`LoadImage` multi-file pattern).
 
-        * raise :class:`FileNotFoundError` on missing file
-        * raise :class:`ValueError` on empty table
-        * detect ``.csv`` / ``.tsv`` / ``.xlsx`` / ``.xls`` by suffix
-        * resolve ``source="auto"`` via the heuristics in the module
-          docstring
-        * cache the pandas DataFrame under
-          ``peak_table.user["pandas_df"]`` for downstream reuse
+        Raises:
+            FileNotFoundError: If any path does not exist.
+            ValueError: If the table is empty or path config is invalid.
         """
-        path = Path(config.get("path"))
-        if not path.exists():
-            raise FileNotFoundError(f"LoadPeakTable: source file not found: {path}")
-
-        frame = _read_table(path, sheet_name=config.get("sheet_name"))
-        if frame.empty:
-            raise ValueError(f"LoadPeakTable: table is empty: {path}")
+        raw_path = config.get("path")
+        if isinstance(raw_path, list):
+            paths = [Path(p) for p in raw_path if isinstance(p, str) and p]
+        elif isinstance(raw_path, str) and raw_path:
+            paths = [Path(raw_path)]
+        else:
+            raise ValueError("LoadPeakTable: config['path'] must be a non-empty string or list of strings")
 
         source = str(config.get("source", "auto"))
-        resolved_source = _detect_source(frame.columns) if source == "auto" else source
-        table = PeakTable(
-            columns=[str(col) for col in frame.columns],
-            row_count=len(frame),
-            schema={str(col): str(dtype) for col, dtype in frame.dtypes.items()},
-            meta=PeakTable.Meta(
-                source=resolved_source,
-                polarity=config.get("polarity"),
-            ),
-        )
-        table.user["pandas_df"] = frame.copy()
-        return Collection(items=[table], item_type=PeakTable)
+        tables: list[PeakTable] = []
+        for path in paths:
+            if not path.exists():
+                raise FileNotFoundError(f"LoadPeakTable: source file not found: {path}")
+            frame = _read_table(path, sheet_name=config.get("sheet_name"))
+            if frame.empty:
+                raise ValueError(f"LoadPeakTable: table is empty: {path}")
+            resolved_source = _detect_source(frame.columns) if source == "auto" else source
+            table = PeakTable(
+                columns=[str(col) for col in frame.columns],
+                row_count=len(frame),
+                schema={str(col): str(dtype) for col, dtype in frame.dtypes.items()},
+                meta=PeakTable.Meta(
+                    source=resolved_source,
+                    polarity=config.get("polarity"),
+                ),
+            )
+            table.user["pandas_df"] = frame.copy()
+            tables.append(table)
+        return Collection(items=tables, item_type=PeakTable)
 
     def save(self, obj: DataObject | Collection, config: BlockConfig) -> None:
         """Not supported — use :class:`SaveTable` for output."""

--- a/packages/scieasy-blocks-lcms/src/scieasy_blocks_lcms/io/load_sample_metadata.py
+++ b/packages/scieasy-blocks-lcms/src/scieasy_blocks_lcms/io/load_sample_metadata.py
@@ -52,8 +52,9 @@ class LoadSampleMetadata(_LCMSBlockMixin, IOBlock):
         "type": "object",
         "properties": {
             "path": {
-                "type": "string",
-                "title": "Sample metadata file",
+                "type": ["string", "array"],
+                "items": {"type": "string"},
+                "title": "Sample metadata file(s)",
                 "ui_priority": 0,
                 "ui_widget": "file_browser",
             },
@@ -74,32 +75,40 @@ class LoadSampleMetadata(_LCMSBlockMixin, IOBlock):
     }
 
     def load(self, config: BlockConfig) -> DataObject | Collection:
-        """Read the metadata file and return :class:`SampleMetadata`.
+        """Read metadata file(s) and return :class:`Collection[SampleMetadata]`.
 
-        Implementation must:
+        Accepts ``config["path"]`` as a single string or a list of strings
+        (matching the :class:`LoadImage` multi-file pattern).
 
-        * raise :class:`FileNotFoundError` on missing file
-        * raise :class:`ValueError` if the configured
-          ``sample_id_column`` is not present in the loaded DataFrame
-        * preserve column order
+        Raises:
+            FileNotFoundError: If any path does not exist.
+            ValueError: If the sample ID column is missing or path config is invalid.
         """
-        path = Path(config.get("path"))
-        if not path.exists():
-            raise FileNotFoundError(f"LoadSampleMetadata: source file not found: {path}")
+        raw_path = config.get("path")
+        if isinstance(raw_path, list):
+            paths = [Path(p) for p in raw_path if isinstance(p, str) and p]
+        elif isinstance(raw_path, str) and raw_path:
+            paths = [Path(raw_path)]
+        else:
+            raise ValueError("LoadSampleMetadata: config['path'] must be a non-empty string or list of strings")
 
-        frame = _read_table(path, sheet_name=config.get("sheet_name"))
         sample_id_column = str(config.get("sample_id_column", "sample_id"))
-        if sample_id_column not in frame.columns:
-            raise ValueError(f"LoadSampleMetadata requires column '{sample_id_column}'")
-
-        metadata = SampleMetadata(
-            columns=[str(col) for col in frame.columns],
-            row_count=len(frame),
-            schema={str(col): str(dtype) for col, dtype in frame.dtypes.items()},
-            meta=SampleMetadata.Meta(sample_id_column=sample_id_column),
-        )
-        metadata.user["pandas_df"] = frame.copy()
-        return Collection(items=[metadata], item_type=SampleMetadata)
+        items: list[SampleMetadata] = []
+        for path in paths:
+            if not path.exists():
+                raise FileNotFoundError(f"LoadSampleMetadata: source file not found: {path}")
+            frame = _read_table(path, sheet_name=config.get("sheet_name"))
+            if sample_id_column not in frame.columns:
+                raise ValueError(f"LoadSampleMetadata requires column '{sample_id_column}'")
+            metadata = SampleMetadata(
+                columns=[str(col) for col in frame.columns],
+                row_count=len(frame),
+                schema={str(col): str(dtype) for col, dtype in frame.dtypes.items()},
+                meta=SampleMetadata.Meta(sample_id_column=sample_id_column),
+            )
+            metadata.user["pandas_df"] = frame.copy()
+            items.append(metadata)
+        return Collection(items=items, item_type=SampleMetadata)
 
     def save(self, obj: DataObject | Collection, config: BlockConfig) -> None:
         """Not supported — use :class:`SaveTable` for output."""

--- a/packages/scieasy-blocks-lcms/tests/test_io/test_load_ms_raw_files.py
+++ b/packages/scieasy-blocks-lcms/tests/test_io/test_load_ms_raw_files.py
@@ -29,7 +29,7 @@ def test_load_single_mzml_file(tmp_path: Path) -> None:
     path = tmp_path / "sample.mzML"
     _write_mzml(path)
 
-    result = LoadMSRawFiles().load(BlockConfig(params={"path": str(tmp_path), "pattern": "*.mzML"}))
+    result = LoadMSRawFiles().load(BlockConfig(params={"path": str(path)}))
     assert isinstance(result, Collection)
     assert len(result) == 1
     item = result[0]
@@ -40,39 +40,29 @@ def test_load_single_mzml_file(tmp_path: Path) -> None:
     assert item.meta.sample_id == "sample"
 
 
-def test_load_recursive_flag_controls_subdirs(tmp_path: Path) -> None:
-    nested = tmp_path / "nested"
-    nested.mkdir()
-    _write_mzml(nested / "deep.mzML", positive=False)
+def test_load_multiple_mzml_files(tmp_path: Path) -> None:
+    path_a = tmp_path / "a.mzML"
+    path_b = tmp_path / "b.mzML"
+    _write_mzml(path_a, positive=True)
+    _write_mzml(path_b, positive=False)
 
-    non_recursive = LoadMSRawFiles().load(
-        BlockConfig(params={"path": str(tmp_path), "pattern": "*.mzML", "recursive": False})
-    )
-    recursive = LoadMSRawFiles().load(
-        BlockConfig(params={"path": str(tmp_path), "pattern": "*.mzML", "recursive": True})
-    )
-
-    assert len(non_recursive) == 0
-    assert len(recursive) == 1
-    assert recursive[0].meta.polarity == "-"
-
-
-def test_load_raises_on_missing_directory(tmp_path: Path) -> None:
-    with pytest.raises(FileNotFoundError):
-        LoadMSRawFiles().load(BlockConfig(params={"path": str(tmp_path / "missing")}))
-
-
-def test_load_empty_glob_returns_empty_collection(tmp_path: Path) -> None:
-    result = LoadMSRawFiles().load(BlockConfig(params={"path": str(tmp_path), "pattern": "*.mzML"}))
+    result = LoadMSRawFiles().load(BlockConfig(params={"path": [str(path_a), str(path_b)]}))
     assert isinstance(result, Collection)
-    assert len(result) == 0
+    assert len(result) == 2
+    assert result[0].meta.polarity == "+"
+    assert result[1].meta.polarity == "-"
+
+
+def test_load_raises_on_missing_file(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError):
+        LoadMSRawFiles().load(BlockConfig(params={"path": str(tmp_path / "missing.mzML")}))
 
 
 def test_load_raw_file_records_path_only(tmp_path: Path) -> None:
     raw_path = tmp_path / "sample.raw"
     raw_path.write_bytes(b"RAW")
 
-    result = LoadMSRawFiles().load(BlockConfig(params={"path": str(tmp_path), "pattern": "*.raw"}))
+    result = LoadMSRawFiles().load(BlockConfig(params={"path": str(raw_path)}))
     assert result[0].file_path == raw_path
     assert result[0].meta.format == "raw"
     assert result[0].meta.instrument is None
@@ -82,16 +72,19 @@ def test_load_d_folder_records_path_only(tmp_path: Path) -> None:
     d_path = tmp_path / "sample.d"
     d_path.mkdir()
 
-    result = LoadMSRawFiles().load(BlockConfig(params={"path": str(tmp_path), "pattern": "*.d"}))
+    result = LoadMSRawFiles().load(BlockConfig(params={"path": str(d_path)}))
     assert result[0].file_path == d_path
     assert result[0].meta.format == "d"
 
 
-def test_format_hint_override(tmp_path: Path) -> None:
-    path = tmp_path / "sample.mzML"
-    _write_mzml(path)
+def test_load_invalid_path_raises_value_error() -> None:
+    with pytest.raises(ValueError, match="non-empty string"):
+        LoadMSRawFiles().load(BlockConfig(params={"path": ""}))
 
-    result = LoadMSRawFiles().load(
-        BlockConfig(params={"path": str(tmp_path), "pattern": "*.mzML", "format_hint": "mzXML"})
-    )
-    assert result[0].meta.format == "mzXML"
+
+def test_config_schema_uses_file_browser() -> None:
+    schema = LoadMSRawFiles.config_schema
+    path_prop = schema["properties"]["path"]
+    assert path_prop["ui_widget"] == "file_browser"
+    assert path_prop["type"] == ["string", "array"]
+    assert path_prop["items"] == {"type": "string"}

--- a/tests/plugins/test_lcms_loader_schemas.py
+++ b/tests/plugins/test_lcms_loader_schemas.py
@@ -8,19 +8,38 @@ config, matching the LoadImage pattern.
 from __future__ import annotations
 
 import pytest
-from scieasy_blocks_lcms.io.load_mid_table import LoadMIDTable
-from scieasy_blocks_lcms.io.load_ms_raw_files import LoadMSRawFiles
-from scieasy_blocks_lcms.io.load_peak_table import LoadPeakTable
-from scieasy_blocks_lcms.io.load_sample_metadata import LoadSampleMetadata
+
+try:
+    from scieasy_blocks_lcms.io.load_mid_table import LoadMIDTable
+    from scieasy_blocks_lcms.io.load_ms_raw_files import LoadMSRawFiles
+    from scieasy_blocks_lcms.io.load_peak_table import LoadPeakTable
+    from scieasy_blocks_lcms.io.load_sample_metadata import LoadSampleMetadata
+
+    HAS_LCMS = True
+except ImportError:
+    HAS_LCMS = False
+
+pytestmark = pytest.mark.skipif(not HAS_LCMS, reason="scieasy_blocks_lcms not installed")
 
 
 @pytest.mark.parametrize(
     "block_cls",
-    [LoadMSRawFiles, LoadPeakTable, LoadMIDTable, LoadSampleMetadata],
-    ids=lambda c: c.__name__,
+    [
+        pytest.param("LoadMSRawFiles", id="LoadMSRawFiles"),
+        pytest.param("LoadPeakTable", id="LoadPeakTable"),
+        pytest.param("LoadMIDTable", id="LoadMIDTable"),
+        pytest.param("LoadSampleMetadata", id="LoadSampleMetadata"),
+    ],
 )
-def test_path_config_uses_file_browser(block_cls: type) -> None:
-    path_prop = block_cls.config_schema["properties"]["path"]
-    assert path_prop["ui_widget"] == "file_browser", f"{block_cls.__name__} should use file_browser"
-    assert path_prop["type"] == ["string", "array"], f"{block_cls.__name__} should accept string or array"
-    assert path_prop["items"] == {"type": "string"}, f"{block_cls.__name__} items should be string"
+def test_path_config_uses_file_browser(block_cls: str) -> None:
+    cls_map = {
+        "LoadMSRawFiles": LoadMSRawFiles,
+        "LoadPeakTable": LoadPeakTable,
+        "LoadMIDTable": LoadMIDTable,
+        "LoadSampleMetadata": LoadSampleMetadata,
+    }
+    cls = cls_map[block_cls]
+    path_prop = cls.config_schema["properties"]["path"]
+    assert path_prop["ui_widget"] == "file_browser", f"{block_cls} should use file_browser"
+    assert path_prop["type"] == ["string", "array"], f"{block_cls} should accept string or array"
+    assert path_prop["items"] == {"type": "string"}, f"{block_cls} items should be string"

--- a/tests/plugins/test_lcms_loader_schemas.py
+++ b/tests/plugins/test_lcms_loader_schemas.py
@@ -1,0 +1,26 @@
+"""Verify LCMS loader blocks use file_browser with multi-file path schema.
+
+Regression test for issue #525: all LCMS load blocks should use
+``ui_widget: file_browser`` with ``type: ["string", "array"]`` path
+config, matching the LoadImage pattern.
+"""
+
+from __future__ import annotations
+
+import pytest
+from scieasy_blocks_lcms.io.load_mid_table import LoadMIDTable
+from scieasy_blocks_lcms.io.load_ms_raw_files import LoadMSRawFiles
+from scieasy_blocks_lcms.io.load_peak_table import LoadPeakTable
+from scieasy_blocks_lcms.io.load_sample_metadata import LoadSampleMetadata
+
+
+@pytest.mark.parametrize(
+    "block_cls",
+    [LoadMSRawFiles, LoadPeakTable, LoadMIDTable, LoadSampleMetadata],
+    ids=lambda c: c.__name__,
+)
+def test_path_config_uses_file_browser(block_cls: type) -> None:
+    path_prop = block_cls.config_schema["properties"]["path"]
+    assert path_prop["ui_widget"] == "file_browser", f"{block_cls.__name__} should use file_browser"
+    assert path_prop["type"] == ["string", "array"], f"{block_cls.__name__} should accept string or array"
+    assert path_prop["items"] == {"type": "string"}, f"{block_cls.__name__} items should be string"


### PR DESCRIPTION
## Summary
- Switch `LoadMSRawFiles` from `directory_browser` + glob to `file_browser` with `["string", "array"]` path type, matching the `LoadImage` pattern
- Remove `pattern`, `recursive`, `format_hint` config properties from `LoadMSRawFiles` (no longer needed with direct file selection)
- Add multi-file support to `LoadPeakTable`, `LoadMIDTable`, `LoadSampleMetadata` with the same `["string", "array"]` path schema
- Update tests to pass file paths instead of directory paths

Closes #525

## Test plan
- [x] All 7 tests in `test_load_ms_raw_files.py` pass (updated for new API)
- [ ] Verify file_browser widget renders correctly in the GUI for all 4 loader blocks
- [ ] Verify multi-file selection works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)