### PR TITLE
fix(app): ElMAVEN PIPE deadlock and wrong CLI invocation (#526)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- [#526] Fix ElMAVEN block freeze — remove unused argv_override CLI args, fix PIPE deadlock with DEVNULL, add proc.wait (@claude, 2026-04-09, branch: fix/issue-526/elmaven-cli-pipe-deadlock, session: N/A)
 - [#520] Fix block error messages truncated — add expandable error display with tooltip, Problems tab, and copy button (@claude, 2026-04-09, branch: fix/issue-507/expandable-block-errors, session: 20260409-192041-block-error-messages-truncated-need-expa)
 - [#517] Fix TabBar invisible on startup — always render tab bar, use openTab for new projects (@claude, 2026-04-09, branch: fix/issue-503/tabbar-startup, session: 20260409-191833-fix-tabbar-invisible-on-startup-no-initi)
 - [#510] Fix ElMAVEN block to pass raw file paths as CLI arguments so data is pre-loaded (@claude, 2026-04-09, branch: fix/issue-510/elmaven-data-injection, session: 20260409-192253-elmaven-block-opens-without-input-data-5)

--- a/packages/scieasy-blocks-lcms/src/scieasy_blocks_lcms/external/elmaven_block.py
+++ b/packages/scieasy-blocks-lcms/src/scieasy_blocks_lcms/external/elmaven_block.py
@@ -7,15 +7,19 @@ Per spec §8 Q-2 the block does **not** script ElMAVEN's UI — the user
 opens files, runs peak detection, and exports manually;
 :class:`FileWatcher` collects the exports.
 
-Issue #510: Refactored to pass raw file paths as CLI arguments so
-ElMAVEN opens with data pre-loaded (same pattern as FijiBlock #420).
+Issue #526: ElMAVEN does not accept positional file CLI args (unlike
+Fiji). Raw file paths are staged as symlinks in the exchange directory
+and recorded in the manifest. The PIPE deadlock from bridge.py is fixed
+by switching to DEVNULL.
 """
 
 from __future__ import annotations
 
 import json
 import logging
+import subprocess
 import tempfile
+from contextlib import suppress
 from pathlib import Path
 from typing import Any, ClassVar, cast
 
@@ -113,13 +117,12 @@ class ElMAVENBlock(_LCMSBlockMixin, AppBlock):
         inputs: dict[str, Collection],
         config: BlockConfig,
     ) -> dict[str, Collection]:
-        """Stage raw files and launch ElMAVEN with file paths as CLI args.
+        """Stage raw files and launch ElMAVEN for interactive peak picking.
 
-        Issue #510: Instead of delegating to ``AppBlock.run()`` (which
-        passes the exchange directory to the app), we follow the
-        FijiBlock pattern (#420): resolve the raw file paths and pass
-        them directly as ``launch_args`` so ElMAVEN opens with data
-        pre-loaded.
+        Issue #526: ElMAVEN's CLI does not accept positional file args
+        (unlike Fiji), so we stage the raw file paths as symlinks in the
+        exchange directory and write them to the manifest. The user opens
+        files manually from the exchange dir.
 
         After the user runs peak detection and exports results,
         :func:`_classify_export` routes each output file to either
@@ -166,13 +169,23 @@ class ElMAVENBlock(_LCMSBlockMixin, AppBlock):
             self.transition(BlockState.RUNNING)
         self.transition(BlockState.PAUSED)
 
-        # Launch ElMAVEN with raw file paths as CLI arguments (#510).
+        # Stage raw file paths into the exchange directory so the user
+        # can easily locate them.  ElMAVEN's CLI does not accept positional
+        # file arguments (unlike Fiji), so we do NOT pass argv_override.
+        # See issue #526.
+        for rp in raw_paths:
+            src = Path(rp)
+            if src.exists():
+                link = exchange_dir / "inputs" / src.name
+                if not link.exists():
+                    with suppress(OSError):
+                        link.symlink_to(src)
+
         bridge = FileExchangeBridge()
         timeout = int(config.get("watch_timeout", self.watch_timeout))
-        proc = bridge.launch(command, exchange_dir, argv_override=raw_paths)
+        proc = bridge.launch(command, exchange_dir)
         logger.info(
-            "ElMAVEN launched with %d raw files. Save exports to: %s",
-            len(raw_paths),
+            "ElMAVEN launched. Raw files staged in exchange dir. Save exports to: %s",
             output_dir,
         )
 
@@ -198,6 +211,8 @@ class ElMAVENBlock(_LCMSBlockMixin, AppBlock):
             }
         finally:
             watcher.stop()
+            with suppress(subprocess.TimeoutExpired):
+                proc.wait(timeout=5)
 
         if self.state == BlockState.PAUSED:
             self.transition(BlockState.RUNNING)

--- a/src/scieasy/blocks/app/bridge.py
+++ b/src/scieasy/blocks/app/bridge.py
@@ -106,8 +106,8 @@ class FileExchangeBridge:
         return subprocess.Popen(
             cmd,
             cwd=str(exchange_dir),
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
             shell=False,
         )
 

--- a/tests/plugins/test_elmaven_block.py
+++ b/tests/plugins/test_elmaven_block.py
@@ -1,7 +1,9 @@
-"""Tests for ElMAVEN block data injection fix (#510).
+"""Tests for ElMAVEN block fixes (#510, #526).
 
-These tests verify the staging and CLI-arg-passing logic without
+These tests verify the staging logic and bridge configuration without
 actually launching ElMAVEN (which requires a GUI application).
+
+Issue #526: verify PIPE→DEVNULL fix and removal of argv_override.
 """
 
 from __future__ import annotations
@@ -91,3 +93,17 @@ class TestElMAVENBlockManifest:
         assert len(raw_paths) == 2
         assert str(raw1) in raw_paths
         assert str(raw2) in raw_paths
+
+
+class TestBridgeDevNull:
+    """Test that FileExchangeBridge uses DEVNULL, not PIPE (#526)."""
+
+    def test_bridge_launch_uses_devnull(self) -> None:
+        """Verify the bridge source code uses DEVNULL to prevent PIPE deadlock."""
+        import inspect
+
+        from scieasy.blocks.app.bridge import FileExchangeBridge
+
+        source = inspect.getsource(FileExchangeBridge.launch)
+        assert "subprocess.DEVNULL" in source, "bridge.launch should use DEVNULL, not PIPE"
+        assert "subprocess.PIPE" not in source, "bridge.launch should NOT use PIPE (causes deadlock)"


### PR DESCRIPTION
## Summary
- Fix subprocess PIPE deadlock in `bridge.py`: change `stdout=PIPE, stderr=PIPE` to `DEVNULL` — no code reads from these pipes, and PIPE without a reader causes OS buffer fill and process deadlock. This affects all AppBlocks (Fiji, Napari, CellProfiler, QuPath, ElMAVEN) but is safe because FileWatcher monitors file output, not process stdout.
- Fix ElMAVEN CLI invocation: remove `argv_override=raw_paths` since ElMAVEN GUI does not accept positional file arguments (unlike Fiji). Instead, stage raw file symlinks in the exchange directory for user discoverability.
- Add `proc.wait(timeout=5)` in the finally block matching the imaging interactive block pattern.

Closes #526

## Test plan
- [ ] Verify ElMAVEN block launches without freezing
- [ ] Verify Fiji/Napari blocks still work correctly with DEVNULL change
- [ ] Verify raw file symlinks appear in exchange/inputs/ directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)