### PR TITLE
fix(gui): remove is_collection double-ring from port rendering (#534)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- [#534] Remove is_collection double-ring from port rendering (@claude, 2026-04-10, branch: fix/issue-534/remove-collection-double-ring, session: 20260410-000721-fix-gui-remove-is-collection-double-ring)
 - [#525] Switch LCMS load blocks from directory_browser/glob to file_browser with multi-file support (@claude, 2026-04-09, branch: fix/issue-525/load-blocks-file-browser, session: N/A)
 - [#526] Fix ElMAVEN block freeze — remove unused argv_override CLI args, fix PIPE deadlock with DEVNULL, add proc.wait (@claude, 2026-04-09, branch: fix/issue-526/elmaven-cli-pipe-deadlock, session: N/A)
 - [#524] Fix toolbar layout shift — use fixed-width name area and visibility-based dirty indicator (@claude, 2026-04-09, branch: fix/issue-524/toolbar-fixed-width, session: N/A)

--- a/frontend/src/components/WorkflowCanvas.tsx
+++ b/frontend/src/components/WorkflowCanvas.tsx
@@ -214,7 +214,7 @@ export function WorkflowCanvas(props: WorkflowCanvasProps) {
         type: "typed",
         data: {
           color: resolveTypeColor(sourcePort?.accepted_types ?? [], sourceSchema?.type_hierarchy),
-          dashed: sourcePort?.is_collection ?? false,
+          dashed: false,
         },
       };
     });

--- a/frontend/src/components/nodes/BlockNode.tsx
+++ b/frontend/src/components/nodes/BlockNode.tsx
@@ -651,10 +651,6 @@ export function BlockNode({ data, selected }: NodeProps<Node<BlockNodeData>>) {
         const anyType = isAnyType(port.accepted_types);
         const typeName = primaryTypeName(port.accepted_types);
         const borderColor = ringColor ?? (anyType ? "#d1d5db" : fillColor);
-        const shadows: string[] = [];
-        if (port.is_collection) {
-          shadows.push(`0 0 0 2px white`, `0 0 0 4px ${fillColor}`);
-        }
         return (
           <Handle
             key={port.name}
@@ -669,7 +665,6 @@ export function BlockNode({ data, selected }: NodeProps<Node<BlockNodeData>>) {
               borderStyle: anyType ? "dashed" : "solid",
               left: -7,
               top: 80 + index * 20,
-              boxShadow: shadows.length > 0 ? shadows.join(", ") : undefined,
             }}
           />
         );
@@ -680,10 +675,6 @@ export function BlockNode({ data, selected }: NodeProps<Node<BlockNodeData>>) {
         const anyType = isAnyType(port.accepted_types);
         const typeName = primaryTypeName(port.accepted_types);
         const borderColor = ringColor ?? (anyType ? "#d1d5db" : fillColor);
-        const shadows: string[] = [];
-        if (port.is_collection) {
-          shadows.push(`0 0 0 2px white`, `0 0 0 4px ${fillColor}`);
-        }
         return (
           <Handle
             key={port.name}
@@ -698,7 +689,6 @@ export function BlockNode({ data, selected }: NodeProps<Node<BlockNodeData>>) {
               borderStyle: anyType ? "dashed" : "solid",
               right: -7,
               top: 80 + index * 20,
-              boxShadow: shadows.length > 0 ? shadows.join(", ") : undefined,
             }}
           />
         );


### PR DESCRIPTION
## Summary
- Remove the `is_collection` double-ring (boxShadow) from input and output port rendering in `BlockNode.tsx`
- Remove the dashed edge style for collection connections in `WorkflowCanvas.tsx`
- ADR-020 unified Collections at the transport level, making this visual distinction misleading

Closes #534

## Test plan
- [ ] Verify ports render without double-ring shadow
- [ ] Verify edges render as solid lines (no dashed style)
- [ ] Verify existing port colors and ring colors still work correctly