### PR TITLE
fix(app): AppBlock default watch_timeout should be None (#539)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- [#539] AppBlock default watch_timeout changed to None for infinite wait (@claude, 2026-04-10, branch: fix/issue-539/appblock-timeout-none, session: 20260410-001020-fix-app-appblock-default-watch-timeout-s)
 - [#525] Switch LCMS load blocks from directory_browser/glob to file_browser with multi-file support (@claude, 2026-04-09, branch: fix/issue-525/load-blocks-file-browser, session: N/A)
 - [#526] Fix ElMAVEN block freeze — remove unused argv_override CLI args, fix PIPE deadlock with DEVNULL, add proc.wait (@claude, 2026-04-09, branch: fix/issue-526/elmaven-cli-pipe-deadlock, session: N/A)
 - [#524] Fix toolbar layout shift — use fixed-width name area and visibility-based dirty indicator (@claude, 2026-04-09, branch: fix/issue-524/toolbar-fixed-width, session: N/A)

--- a/src/scieasy/blocks/app/app_block.py
+++ b/src/scieasy/blocks/app/app_block.py
@@ -55,7 +55,7 @@ class AppBlock(Block):
     app_command: ClassVar[str] = ""
     execution_mode: ClassVar[ExecutionMode] = ExecutionMode.EXTERNAL
     output_patterns: ClassVar[list[str]] = ["*"]
-    watch_timeout: ClassVar[int] = 300
+    watch_timeout: ClassVar[int | None] = None
 
     name: ClassVar[str] = "App Block"
     description: ClassVar[str] = "Delegate work to an external GUI application"
@@ -76,7 +76,12 @@ class AppBlock(Block):
                 "default": "*",
                 "ui_priority": 2,
             },
-            "watch_timeout": {"type": "integer", "title": "Watch Timeout (s)", "default": 300, "ui_priority": 3},
+            "watch_timeout": {
+                "type": ["integer", "null"],
+                "title": "Watch Timeout (s)",
+                "default": None,
+                "ui_priority": 3,
+            },
         },
         "required": ["app_command"],
     }
@@ -94,7 +99,8 @@ class AppBlock(Block):
             raise ValueError("AppBlock requires 'app_command' in config or as class variable")
 
         patterns = config.get("output_patterns") or self.output_patterns
-        timeout = int(config.get("watch_timeout", self.watch_timeout))
+        raw_timeout = config.get("watch_timeout", self.watch_timeout)
+        timeout = int(raw_timeout) if raw_timeout is not None else None
 
         # Create exchange directory.
         # Prefer project workspace for reboot-survivable exchange dirs.

--- a/tests/blocks/test_app_block.py
+++ b/tests/blocks/test_app_block.py
@@ -238,6 +238,79 @@ class TestAppBlockExchangeDir:
             mock_mkdtemp.assert_called_once_with(prefix="scieasy_app_")
 
 
+class TestAppBlockWatchTimeout:
+    """#539: AppBlock.watch_timeout defaults to None (infinite wait)."""
+
+    def test_default_watch_timeout_is_none(self) -> None:
+        """AppBlock.watch_timeout ClassVar defaults to None."""
+        from scieasy.blocks.app.app_block import AppBlock
+
+        assert AppBlock.watch_timeout is None
+
+    def test_config_schema_watch_timeout_default_is_none(self) -> None:
+        """Config schema exposes watch_timeout with default None."""
+        from scieasy.blocks.app.app_block import AppBlock
+
+        schema_props = AppBlock.config_schema["properties"]
+        assert schema_props["watch_timeout"]["default"] is None
+
+    def test_subclass_can_override_watch_timeout(self) -> None:
+        """Subclasses can still set a finite watch_timeout."""
+        from scieasy.blocks.app.app_block import AppBlock
+
+        class CustomAppBlock(AppBlock):
+            watch_timeout = 600
+
+        assert CustomAppBlock.watch_timeout == 600
+        # Base class unchanged
+        assert AppBlock.watch_timeout is None
+
+    def test_run_passes_none_timeout_to_watcher(self, tmp_path: Path) -> None:
+        """When watch_timeout is None, FileWatcher receives timeout=None."""
+        from unittest.mock import MagicMock, patch
+
+        from scieasy.blocks.app.app_block import AppBlock
+        from scieasy.blocks.base.config import BlockConfig
+        from scieasy.blocks.base.state import BlockState
+
+        block = AppBlock()
+        block.transition(BlockState.READY)
+        block.transition(BlockState.RUNNING)
+
+        config = BlockConfig(
+            params={
+                "app_command": "echo hello",
+                "project_dir": str(tmp_path),
+                "block_id": "test_block",
+            }
+        )
+
+        with (
+            patch("scieasy.blocks.app.app_block.FileExchangeBridge") as mock_bridge_cls,
+            patch("scieasy.blocks.app.app_block.validate_app_command", return_value=["echo", "hello"]),
+        ):
+            mock_bridge = MagicMock()
+            mock_bridge_cls.return_value = mock_bridge
+            mock_proc = MagicMock()
+            mock_proc.poll.return_value = None
+            mock_proc.pid = 12345
+            mock_bridge.launch.return_value = mock_proc
+
+            with patch("scieasy.blocks.app.watcher.FileWatcher") as mock_watcher_cls:
+                mock_watcher = MagicMock()
+                mock_watcher_cls.return_value = mock_watcher
+                fake_output = tmp_path / "result.csv"
+                fake_output.write_text("a,b\n1,2\n")
+                mock_watcher.wait_for_output.return_value = [fake_output]
+                mock_bridge.collect.return_value = {}
+
+                block.run(inputs={}, config=config)
+
+                # Verify FileWatcher was called with timeout=None
+                watcher_call_kwargs = mock_watcher_cls.call_args[1]
+                assert watcher_call_kwargs["timeout"] is None
+
+
 class TestFileExchangeBridgeCollection:
     """ADR-020: Collection handling in bridge.prepare()."""
 


### PR DESCRIPTION
## Summary
- Change `AppBlock.watch_timeout` ClassVar from `300` to `None` (type: `int | None`)
- Update config schema default from `300` to `None`, type to `["integer", "null"]`
- Fix `run()` to handle `None` timeout without calling `int(None)`

Closes #539

## Test plan
- [ ] Verify AppBlock defaults to infinite wait (no timeout)
- [ ] Verify users can still set a finite timeout via block config
- [ ] Verify existing AppBlock subclasses that override watch_timeout still work
- [ ] Verify FileWatcher handles None timeout correctly (infinite wait)