### PR TITLE
feat(#557): ADR-030 config_schema MRO merge, IOBlock path injection, AppBlock output_dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [#540] LCMS IO block audit: rename LoadMSRawFiles to LoadMzMLFiles, remove regex config from LoadMIDTable (@claude, 2026-04-10, branch: refactor/issue-540/lcms-io-audit, session: 20260410-001346-refactor-lcms-lcms-io-block-audit-rename)
 - [#545] Show spinning indicator on Run button during workflow execution (@claude, 2026-04-10, branch: feat/issue-545/run-button-spinner, session: 20260410-001118-show-spinning-indicator-on-run-button-du)
 - [#542] SRS block audit — remove Band Ratio and SRS Normalize, rename Denoise to Spectral Denoise with Savitzky-Golay, add Calibrate ui_priority, add Unmix mode selector (@claude, 2026-04-10, branch: refactor/issue-542/srs-block-audit, session: 20260410-000652-srs-block-audit-remove-band-ratio-and-sr)
-<<<<<<< fix/issue-530/palette-audit
 - [#530] Core block palette audit: remove base classes and placeholders from palette, rename Load Data/Save Data to Load/Save, add SubWorkflow config_schema (@claude, 2026-04-10, branch: fix/issue-530/palette-audit, session: 20260410-000636-refactor-gui-core-block-palette-audit-re)
-=======
 - [#538] LCMS app block audit: ElMAVEN cleanup, remove GraphPad skeleton, remove watch_timeout (@claude, 2026-04-10, branch: refactor/issue-538/lcms-app-audit, session: 20260410-000747-refactor-lcms-lcms-app-block-audit-elmav)
->>>>>>> main
 - [#464] Improve preview panel: dark-bg image viewer with pan/zoom/LUT, compact table viewer with formatting (@claude, 2026-04-09, branch: feat/issue-464/preview-viewer, session: 20260409-124853-improve-preview-image-table-viewers-464)
 - [#476] Cache Python site-packages in CI to reduce install overhead (@claude, 2026-04-09, branch: perf/issue-476/ci-pip-cache, session: 20260409-124905-optimize-ci-pip-install-caching)
 - [#468] Optimize CI: parallel jobs, single-version coverage, pytest-xdist (@claude, 2026-04-09, branch: perf/issue-468/ci-speedup, session: wave2-ci-perf)
@@ -26,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- [#557] ADR-030 config_schema MRO merge: auto-inherit base class config fields, IOBlock path injection, AppBlock output_dir, directory_browser copy button, PAUSED toast (@claude, 2026-04-10, branch: feat/issue-557/config-schema-mro-merge, session: 20260410-024235-adr-030-config-schema-mro-merge-ioblock)
 - [#543] Auto-assign port colors for plugin types via deterministic hashing (@claude, 2026-04-10, branch: feat/issue-543/port-color-hashing, session: 20260410-001558-feat-gui-auto-assign-port-colors-for-plu)
 - [#531] AI block: large prompt textarea widget + load prompt from file (.md/.txt) (@claude, 2026-04-10, branch: fix/issue-531/ai-block-textarea, session: 20260410-001127-feat-gui-ai-block-large-prompt-textarea)
 - [#494] Add native OS file/directory dialog for browse button with platform-specific subprocess calls (@claude, 2026-04-09, branch: feat/issue-494/native-file-dialog, session: 20260409-165203-native-os-file-dialog-for-browse-button)

--- a/docs/adr/ADR.md
+++ b/docs/adr/ADR.md
@@ -7269,7 +7269,7 @@ Reviewers may cite this ADR to reject any such PR.
 
 ## ADR-030: config_schema MRO merge and base-class field injection
 
-**Status**: proposed
+**Status**: accepted
 **Date**: 2026-04-10
 **Issue**: #558
 

--- a/frontend/src/components/nodes/BlockNode.tsx
+++ b/frontend/src/components/nodes/BlockNode.tsx
@@ -1,5 +1,5 @@
 import { type Node, Handle, Position, type NodeProps } from "@xyflow/react";
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 
 import { resolveTypeColor, resolveRingColor, isAnyType, primaryTypeName } from "../../config/typeColorMap";
 import { api } from "../../lib/api";
@@ -479,6 +479,22 @@ function InlineConfigField({
             ...
           </button>
         )}
+        {uiWidget === "directory_browser" && (
+          <button
+            type="button"
+            className="nodrag shrink-0 rounded border border-stone-200 bg-white px-1.5 py-1 text-xs text-stone-600 hover:bg-stone-50"
+            title="Copy path to clipboard"
+            onClick={() => {
+              const val = String(value ?? schema.default ?? "");
+              if (val) void navigator.clipboard.writeText(val);
+            }}
+          >
+            <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
+              <rect x="5" y="5" width="9" height="9" rx="1" />
+              <path d="M11 5V3a1 1 0 0 0-1-1H3a1 1 0 0 0-1 1v7a1 1 0 0 0 1 1h2" />
+            </svg>
+          </button>
+        )}
       </div>
       {browseOpen && hasBrowse && (
         <FileBrowserModal
@@ -542,6 +558,39 @@ function ErrorMessage({ message }: { message: string }) {
 // ---------------------------------------------------------------------------
 // BlockNode component
 // ---------------------------------------------------------------------------
+// ---------------------------------------------------------------------------
+// PausedToast — shown when an AppBlock enters PAUSED state
+// ---------------------------------------------------------------------------
+function PausedToast({ outputDir }: { outputDir: string }) {
+  const [copied, setCopied] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const handleCopy = () => {
+    if (outputDir) void navigator.clipboard.writeText(outputDir);
+    setCopied(true);
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => setCopied(false), 1500);
+  };
+
+  return (
+    <div className="mt-1 flex items-center gap-1 rounded border border-amber-200 bg-amber-50 px-2 py-1 text-[10px] text-amber-700">
+      <span className="min-w-0 flex-1 truncate" title={outputDir}>
+        Save outputs to: {outputDir || "(exchange dir)"}
+      </span>
+      {outputDir && (
+        <button
+          type="button"
+          className="nodrag shrink-0 rounded border border-amber-300 bg-white px-1 py-0.5 text-[10px] text-amber-700 hover:bg-amber-50"
+          title="Copy output path"
+          onClick={handleCopy}
+        >
+          {copied ? "Copied" : "Copy"}
+        </button>
+      )}
+    </div>
+  );
+}
+
 export function BlockNode({ data, selected }: NodeProps<Node<BlockNodeData>>) {
   // ADR-028 Addendum 1 §B fix #2 / §C11: hide the ``direction`` config
   // field for any IO block (not just the legacy abstract-base type_name).
@@ -715,11 +764,16 @@ export function BlockNode({ data, selected }: NodeProps<Node<BlockNodeData>>) {
       {/* ----------------------------------------------------------------- */}
       {/* Footer                                                            */}
       {/* ----------------------------------------------------------------- */}
-      <div className="flex min-w-0 items-center border-t border-stone-100 px-3 py-2">
-        <StatusBadge status={data.status} onErrorClick={data.onErrorClick} />
-        {data.status === "error" && data.errorMessage ? (
-          <ErrorMessage message={data.errorMessage} />
-        ) : null}
+      <div className="border-t border-stone-100 px-3 py-2">
+        <div className="flex min-w-0 items-center">
+          <StatusBadge status={data.status} onErrorClick={data.onErrorClick} />
+          {data.status === "error" && data.errorMessage ? (
+            <ErrorMessage message={data.errorMessage} />
+          ) : null}
+        </div>
+        {data.status === "paused" && data.category === "app" && (
+          <PausedToast outputDir={String(data.config?.output_dir ?? "")} />
+        )}
       </div>
     </div>
   );

--- a/packages/scieasy-blocks-imaging/src/scieasy_blocks_imaging/interactive/__init__.py
+++ b/packages/scieasy-blocks-imaging/src/scieasy_blocks_imaging/interactive/__init__.py
@@ -154,13 +154,16 @@ def _run_external_app(
     if block.state == BlockState.RUNNING:
         block.transition(BlockState.PAUSED)
 
-    output_dir = exchange_dir / "outputs"
+    # ADR-030 D3: use user-selected output_dir if configured.
+    custom_output_dir = config.get("output_dir")
+    output_dir = Path(str(custom_output_dir)) if custom_output_dir else exchange_dir / "outputs"
+    output_dir.mkdir(parents=True, exist_ok=True)
     logger.info("Waiting for external application output. Save files to: %s", output_dir)
     _open_file_manager(output_dir)
 
     proc = bridge.launch(command, exchange_dir, argv_override=launch_args)
     watcher = FileWatcher(
-        directory=exchange_dir / "outputs",
+        directory=output_dir,
         patterns=patterns,
         timeout=timeout,
         process_handle=_PopenProcessAdapter(proc),

--- a/packages/scieasy-blocks-imaging/src/scieasy_blocks_imaging/io/load_image.py
+++ b/packages/scieasy-blocks-imaging/src/scieasy_blocks_imaging/io/load_image.py
@@ -162,15 +162,10 @@ class LoadImage(IOBlock):
     config_schema: ClassVar[dict[str, Any]] = {
         "type": "object",
         "properties": {
-            "path": {
-                "type": ["string", "array"],
-                "items": {"type": "string"},
-                "ui_priority": 0,
-                "ui_widget": "file_browser",
-            },
+            # ADR-030: ``path`` is inherited from IOBlock base class via MRO merge.
             "axes": {"type": "string", "ui_priority": 1},
         },
-        "required": ["path"],
+        "required": [],
     }
 
     def load(self, config: BlockConfig) -> DataObject | Collection:

--- a/packages/scieasy-blocks-imaging/src/scieasy_blocks_imaging/io/save_image.py
+++ b/packages/scieasy-blocks-imaging/src/scieasy_blocks_imaging/io/save_image.py
@@ -137,22 +137,15 @@ class SaveImage(IOBlock):
     config_schema: ClassVar[dict[str, Any]] = {
         "type": "object",
         "properties": {
-            "path": {
-                "type": "string",
-                "description": (
-                    "Output file path for single images. "
-                    "For batch save (multi-item Collection), treated as a directory."
-                ),
-                "ui_priority": 0,
-                "ui_widget": "directory_browser",
-            },
+            # ADR-030: ``path`` is inherited from IOBlock base class via MRO merge.
+            # Direction-aware post-processing auto-switches to directory_browser.
             "format": {
                 "type": "string",
                 "enum": ["tiff", "zarr"],
                 "ui_priority": 1,
             },
         },
-        "required": ["path"],
+        "required": [],
     }
 
     def load(self, config: BlockConfig) -> DataObject | Collection:  # pragma: no cover - output block

--- a/packages/scieasy-blocks-lcms/src/scieasy_blocks_lcms/io/save_table.py
+++ b/packages/scieasy-blocks-lcms/src/scieasy_blocks_lcms/io/save_table.py
@@ -57,12 +57,9 @@ class SaveTable(_LCMSBlockMixin, IOBlock):
     config_schema: ClassVar[dict[str, Any]] = {
         "type": "object",
         "properties": {
-            "path": {
-                "type": "string",
-                "title": "Output file path",
-                "ui_priority": 0,
-                "ui_widget": "file_browser",
-            },
+            # ADR-030: ``path`` is inherited from IOBlock base class via MRO merge.
+            # Direction-aware post-processing auto-switches to directory_browser,
+            # fixing the incorrect file_browser that was declared here previously.
             "format": {
                 "type": "string",
                 "enum": ["csv", "tsv", "xlsx"],
@@ -77,7 +74,7 @@ class SaveTable(_LCMSBlockMixin, IOBlock):
                 "ui_priority": 2,
             },
         },
-        "required": ["path"],
+        "required": [],
     }
 
     def load(self, config: BlockConfig) -> DataObject | Collection:

--- a/src/scieasy/blocks/app/app_block.py
+++ b/src/scieasy/blocks/app/app_block.py
@@ -68,6 +68,13 @@ class AppBlock(Block):
     config_schema: ClassVar[dict[str, Any]] = {
         "type": "object",
         "properties": {
+            "output_dir": {
+                "type": ["string", "null"],
+                "default": None,
+                "title": "Save Outputs At",
+                "ui_widget": "directory_browser",
+                "ui_priority": 0,
+            },
             "app_command": {"type": "string", "title": "Application Command", "ui_priority": 1},
             "output_patterns": {
                 "type": "string",
@@ -133,10 +140,12 @@ class AppBlock(Block):
         process_adapter = _PopenProcessAdapter(proc)
 
         # Step 3: Watch for outputs with process monitoring.
+        # ADR-030 D3: use user-selected output_dir if configured.
         from scieasy.blocks.app.watcher import FileWatcher, ProcessExitedWithoutOutputError
 
-        output_dir = exchange_dir / "outputs"
-        output_dir.mkdir(exist_ok=True)
+        custom_output_dir = config.get("output_dir")
+        output_dir = Path(custom_output_dir) if custom_output_dir else exchange_dir / "outputs"
+        output_dir.mkdir(parents=True, exist_ok=True)
         stability_period = float(config.get("stability_period", 2.0))
         done_marker = config.get("done_marker")
         watcher = FileWatcher(

--- a/src/scieasy/blocks/io/io_block.py
+++ b/src/scieasy/blocks/io/io_block.py
@@ -55,7 +55,14 @@ class IOBlock(Block):
     ]
     config_schema: ClassVar[dict[str, Any]] = {
         "type": "object",
-        "properties": {"path": {"type": "string", "ui_priority": 1}},
+        "properties": {
+            "path": {
+                "type": ["string", "array"],
+                "items": {"type": "string"},
+                "ui_priority": 0,
+                "ui_widget": "file_browser",
+            },
+        },
         "required": ["path"],
     }
 

--- a/src/scieasy/blocks/io/loaders/load_data.py
+++ b/src/scieasy/blocks/io/loaders/load_data.py
@@ -98,19 +98,14 @@ class LoadData(IOBlock):
                 "default": "DataFrame",
                 "ui_priority": 0,
             },
-            "path": {
-                "type": ["string", "array"],
-                "items": {"type": "string"},
-                "ui_priority": 1,
-                "ui_widget": "file_browser",
-            },
+            # ADR-030: ``path`` is inherited from IOBlock base class via MRO merge.
             "allow_pickle": {
                 "type": "boolean",
                 "default": False,
                 "ui_priority": 2,
             },
         },
-        "required": ["core_type", "path"],
+        "required": ["core_type"],
     }
 
     def get_effective_output_ports(self) -> list[OutputPort]:

--- a/src/scieasy/blocks/io/savers/save_data.py
+++ b/src/scieasy/blocks/io/savers/save_data.py
@@ -166,14 +166,15 @@ class SaveData(IOBlock):
                 "default": "DataFrame",
                 "ui_priority": 0,
             },
-            "path": {"type": "string", "ui_priority": 1, "ui_widget": "directory_browser"},
+            # ADR-030: ``path`` is inherited from IOBlock base class via MRO merge.
+            # Direction-aware post-processing auto-switches to directory_browser.
             "allow_pickle": {
                 "type": "boolean",
                 "default": False,
                 "ui_priority": 2,
             },
         },
-        "required": ["core_type", "path"],
+        "required": ["core_type"],
     }
 
     def get_effective_input_ports(self) -> list[InputPort]:

--- a/src/scieasy/blocks/registry.py
+++ b/src/scieasy/blocks/registry.py
@@ -518,12 +518,69 @@ class BlockRegistry:
         return dict(self._registry)
 
 
+def _subclass_declares_field(cls: type, field_name: str) -> bool:
+    """Return True if the leaf class's own ``config_schema`` declares *field_name*.
+
+    Checks only ``cls.__dict__`` (the leaf class itself), not the MRO.
+    Used by direction-aware post-processing to decide whether to override
+    inherited path fields.
+    """
+    own_schema = cls.__dict__.get("config_schema")
+    if not isinstance(own_schema, dict):
+        return False
+    return field_name in own_schema.get("properties", {})
+
+
+def _merge_config_schema(cls: type) -> dict[str, Any]:
+    """Merge ``config_schema`` properties along the MRO (child wins on conflict).
+
+    ADR-030 D1: walks ``cls.__mro__`` in reverse (base first) and unions
+    all ``properties`` dicts.  Uses ``klass.__dict__`` (own attributes only),
+    not ``getattr``, so intermediate classes that do not declare their own
+    ``config_schema`` are skipped rather than inheriting the same dict
+    repeatedly.
+
+    After merging, applies direction-aware post-processing for IOBlock
+    subclasses (ADR-030 D2): if the block has ``direction == "output"``
+    and the ``path`` field was inherited (not declared in the leaf class),
+    the path field is converted to single-string ``directory_browser``.
+    """
+    import copy
+
+    merged_properties: dict[str, Any] = {}
+    merged_required: list[str] = []
+    for klass in reversed(cls.__mro__):
+        schema = klass.__dict__.get("config_schema")
+        if schema and isinstance(schema, dict):
+            # Deep-copy so post-processing mutations don't corrupt the
+            # class-level dict shared by all instances of the base class.
+            merged_properties.update(copy.deepcopy(schema.get("properties", {})))
+            merged_required.extend(schema.get("required", []))
+
+    # ADR-030 D2: direction-aware path adjustment for IOBlock output subclasses.
+    direction = getattr(cls, "direction", "")
+    if direction == "output" and "path" in merged_properties and not _subclass_declares_field(cls, "path"):
+        path_prop = merged_properties["path"]
+        path_prop["type"] = "string"
+        path_prop["ui_widget"] = "directory_browser"
+        path_prop.pop("items", None)
+
+    return {
+        "type": "object",
+        "properties": merged_properties,
+        "required": list(dict.fromkeys(merged_required)),
+    }
+
+
 def _spec_from_class(cls: type, source: str = "") -> BlockSpec:
     """Build a :class:`BlockSpec` from a Block subclass's class-level metadata.
 
     ADR-028 Addendum 1 D3: validates ``dynamic_ports`` shape at scan time and
     captures both ``direction`` (for IO blocks) and ``dynamic_ports`` (for
     enum-driven dynamic-port blocks) onto the spec.
+
+    ADR-030 D1: uses ``_merge_config_schema()`` instead of a simple
+    ``getattr`` to merge config_schema properties along the MRO.
     """
     # Fail loudly at scan time on malformed dynamic-port descriptors.
     BlockRegistry._validate_dynamic_ports(cls)
@@ -537,7 +594,7 @@ def _spec_from_class(cls: type, source: str = "") -> BlockSpec:
         category=_infer_category(cls),
         input_ports=list(getattr(cls, "input_ports", [])),
         output_ports=list(getattr(cls, "output_ports", [])),
-        config_schema=getattr(cls, "config_schema", {"type": "object", "properties": {}}),
+        config_schema=_merge_config_schema(cls),
         source=source,
         type_name=_type_name_for_class(cls),
         direction=getattr(cls, "direction", "") or "",

--- a/tests/blocks/io/test_io_block_abc.py
+++ b/tests/blocks/io/test_io_block_abc.py
@@ -73,7 +73,8 @@ class TestIOBlockConfigSchema:
         assert IOBlock.config_schema["required"] == ["path"]
 
     def test_path_has_ui_priority(self) -> None:
-        assert IOBlock.config_schema["properties"]["path"]["ui_priority"] == 1
+        # ADR-030: ui_priority changed from 1 to 0 for the base IOBlock path field.
+        assert IOBlock.config_schema["properties"]["path"]["ui_priority"] == 0
 
 
 class TestIOBlockSubclassDispatch:

--- a/tests/blocks/io/test_save_data.py
+++ b/tests/blocks/io/test_save_data.py
@@ -99,8 +99,10 @@ class TestSaveDataClassShape:
         assert _CORE_TYPE_MAP["CompositeData"] is CompositeData
 
     def test_config_schema_required_fields(self) -> None:
+        # ADR-030: ``path`` is now inherited from IOBlock via MRO merge,
+        # so ``required`` on the SaveData class-level schema only lists ``core_type``.
         schema = SaveData.config_schema
-        assert schema["required"] == ["core_type", "path"]
+        assert schema["required"] == ["core_type"]
         assert schema["properties"]["core_type"]["default"] == "DataFrame"
         assert schema["properties"]["allow_pickle"]["default"] is False
         # core_type enum exposes all six core types.

--- a/tests/blocks/test_block_config_schema.py
+++ b/tests/blocks/test_block_config_schema.py
@@ -59,4 +59,5 @@ class TestBlockConfigSchema:
                 return {}
 
         spec = _spec_from_class(PlainBlock, source="test")
-        assert spec.config_schema == {"type": "object", "properties": {}}
+        # ADR-030: _merge_config_schema always produces a ``required`` key.
+        assert spec.config_schema == {"type": "object", "properties": {}, "required": []}

--- a/tests/blocks/test_registry.py
+++ b/tests/blocks/test_registry.py
@@ -512,3 +512,268 @@ class TestStage101CategoryAndSource:
         After Agent B updates the comparison in ``hot_reload`` to
         ``spec.source == "custom"``, deleted drop-in files are still pruned.
         """
+
+
+# ----------------------------------------------------------------------------
+# ADR-030 — config_schema MRO merge tests
+# ----------------------------------------------------------------------------
+
+
+class TestMergeConfigSchema:
+    """ADR-030: _merge_config_schema() merges properties along the MRO."""
+
+    def test_child_properties_override_parent(self) -> None:
+        """When both parent and child declare the same field, child wins."""
+        from typing import Any, ClassVar
+
+        from scieasy.blocks.base.block import Block
+        from scieasy.blocks.registry import _merge_config_schema
+
+        class Parent(Block):
+            config_schema: ClassVar[dict[str, Any]] = {
+                "type": "object",
+                "properties": {
+                    "field_a": {"type": "string", "title": "Parent A"},
+                },
+                "required": ["field_a"],
+            }
+
+            def run(self, inputs, config):
+                return {}
+
+        class Child(Parent):
+            config_schema: ClassVar[dict[str, Any]] = {
+                "type": "object",
+                "properties": {
+                    "field_a": {"type": "string", "title": "Child A"},
+                },
+                "required": [],
+            }
+
+        merged = _merge_config_schema(Child)
+        assert merged["properties"]["field_a"]["title"] == "Child A"
+        assert "field_a" in merged["required"]
+
+    def test_parent_fields_appear_when_not_overridden(self) -> None:
+        """Fields declared only in parent appear in the merged schema."""
+        from typing import Any, ClassVar
+
+        from scieasy.blocks.base.block import Block
+        from scieasy.blocks.registry import _merge_config_schema
+
+        class Parent(Block):
+            config_schema: ClassVar[dict[str, Any]] = {
+                "type": "object",
+                "properties": {
+                    "parent_field": {"type": "string"},
+                },
+                "required": ["parent_field"],
+            }
+
+            def run(self, inputs, config):
+                return {}
+
+        class Child(Parent):
+            config_schema: ClassVar[dict[str, Any]] = {
+                "type": "object",
+                "properties": {
+                    "child_field": {"type": "number"},
+                },
+                "required": ["child_field"],
+            }
+
+        merged = _merge_config_schema(Child)
+        assert "parent_field" in merged["properties"]
+        assert "child_field" in merged["properties"]
+        assert "parent_field" in merged["required"]
+        assert "child_field" in merged["required"]
+
+    def test_direction_aware_path_for_output_ioblock(self) -> None:
+        """Output IOBlock subclass gets directory_browser + single-string path."""
+        from typing import Any, ClassVar
+
+        from scieasy.blocks.base.config import BlockConfig
+        from scieasy.blocks.io.io_block import IOBlock
+        from scieasy.blocks.registry import _merge_config_schema
+        from scieasy.core.types.base import DataObject
+        from scieasy.core.types.collection import Collection
+
+        class MySaver(IOBlock):
+            direction: ClassVar[str] = "output"
+
+            config_schema: ClassVar[dict[str, Any]] = {
+                "type": "object",
+                "properties": {
+                    "format": {"type": "string"},
+                },
+                "required": [],
+            }
+
+            def load(self, config: BlockConfig) -> DataObject | Collection:
+                raise NotImplementedError
+
+            def save(self, obj: DataObject | Collection, config: BlockConfig) -> None:
+                pass
+
+        merged = _merge_config_schema(MySaver)
+        path_prop = merged["properties"]["path"]
+        assert path_prop["type"] == "string"
+        assert path_prop["ui_widget"] == "directory_browser"
+        assert "items" not in path_prop
+
+    def test_input_ioblock_inherits_file_browser(self) -> None:
+        """Input IOBlock subclass inherits file_browser + array path from base."""
+        from typing import Any, ClassVar
+
+        from scieasy.blocks.base.config import BlockConfig
+        from scieasy.blocks.io.io_block import IOBlock
+        from scieasy.blocks.registry import _merge_config_schema
+        from scieasy.core.types.base import DataObject
+        from scieasy.core.types.collection import Collection
+
+        class MyLoader(IOBlock):
+            direction: ClassVar[str] = "input"
+
+            config_schema: ClassVar[dict[str, Any]] = {
+                "type": "object",
+                "properties": {
+                    "format": {"type": "string"},
+                },
+                "required": [],
+            }
+
+            def load(self, config: BlockConfig) -> DataObject | Collection:
+                raise NotImplementedError
+
+            def save(self, obj: DataObject | Collection, config: BlockConfig) -> None:
+                raise NotImplementedError
+
+        merged = _merge_config_schema(MyLoader)
+        path_prop = merged["properties"]["path"]
+        assert path_prop["type"] == ["string", "array"]
+        assert path_prop["ui_widget"] == "file_browser"
+        assert "items" in path_prop
+
+    def test_appblock_subclass_inherits_output_dir(self) -> None:
+        """AppBlock subclass inherits output_dir from the base class."""
+        from typing import Any, ClassVar
+
+        from scieasy.blocks.app.app_block import AppBlock
+        from scieasy.blocks.registry import _merge_config_schema
+
+        class MyApp(AppBlock):
+            app_command: ClassVar[str] = "fiji"
+
+            config_schema: ClassVar[dict[str, Any]] = {
+                "type": "object",
+                "properties": {
+                    "custom_field": {"type": "string"},
+                },
+                "required": [],
+            }
+
+        merged = _merge_config_schema(MyApp)
+        assert "output_dir" in merged["properties"]
+        assert merged["properties"]["output_dir"]["ui_widget"] == "directory_browser"
+        assert "custom_field" in merged["properties"]
+        assert "app_command" in merged["properties"]
+
+    def test_subclass_path_override_wins(self) -> None:
+        """When a leaf class explicitly declares path, its version wins."""
+        from typing import Any, ClassVar
+
+        from scieasy.blocks.base.config import BlockConfig
+        from scieasy.blocks.io.io_block import IOBlock
+        from scieasy.blocks.registry import _merge_config_schema
+        from scieasy.core.types.base import DataObject
+        from scieasy.core.types.collection import Collection
+
+        class CustomLoader(IOBlock):
+            direction: ClassVar[str] = "input"
+
+            config_schema: ClassVar[dict[str, Any]] = {
+                "type": "object",
+                "properties": {
+                    "path": {
+                        "type": ["string", "array"],
+                        "items": {"type": "string"},
+                        "title": "Custom Path Title",
+                        "ui_priority": 0,
+                        "ui_widget": "file_browser",
+                    },
+                },
+                "required": ["path"],
+            }
+
+            def load(self, config: BlockConfig) -> DataObject | Collection:
+                raise NotImplementedError
+
+            def save(self, obj: DataObject | Collection, config: BlockConfig) -> None:
+                raise NotImplementedError
+
+        merged = _merge_config_schema(CustomLoader)
+        assert merged["properties"]["path"]["title"] == "Custom Path Title"
+
+    def test_output_block_with_own_path_not_overridden(self) -> None:
+        """Output IOBlock that declares its own path keeps it as-is."""
+        from typing import Any, ClassVar
+
+        from scieasy.blocks.base.config import BlockConfig
+        from scieasy.blocks.io.io_block import IOBlock
+        from scieasy.blocks.registry import _merge_config_schema
+        from scieasy.core.types.base import DataObject
+        from scieasy.core.types.collection import Collection
+
+        class CustomSaver(IOBlock):
+            direction: ClassVar[str] = "output"
+
+            config_schema: ClassVar[dict[str, Any]] = {
+                "type": "object",
+                "properties": {
+                    "path": {
+                        "type": "string",
+                        "title": "My Output Path",
+                        "ui_widget": "file_browser",
+                    },
+                },
+                "required": ["path"],
+            }
+
+            def load(self, config: BlockConfig) -> DataObject | Collection:
+                raise NotImplementedError
+
+            def save(self, obj: DataObject | Collection, config: BlockConfig) -> None:
+                pass
+
+        merged = _merge_config_schema(CustomSaver)
+        # Subclass explicitly declared path, so direction-aware override is skipped.
+        assert merged["properties"]["path"]["ui_widget"] == "file_browser"
+        assert merged["properties"]["path"]["title"] == "My Output Path"
+
+    def test_required_deduplication(self) -> None:
+        """Duplicate required fields across MRO are deduplicated."""
+        from typing import Any, ClassVar
+
+        from scieasy.blocks.base.block import Block
+        from scieasy.blocks.registry import _merge_config_schema
+
+        class Parent(Block):
+            config_schema: ClassVar[dict[str, Any]] = {
+                "type": "object",
+                "properties": {"x": {"type": "string"}},
+                "required": ["x"],
+            }
+
+            def run(self, inputs, config):
+                return {}
+
+        class Child(Parent):
+            config_schema: ClassVar[dict[str, Any]] = {
+                "type": "object",
+                "properties": {"y": {"type": "string"}},
+                "required": ["x", "y"],
+            }
+
+        merged = _merge_config_schema(Child)
+        assert merged["required"].count("x") == 1
+        assert merged["required"].count("y") == 1


### PR DESCRIPTION
## Summary

Implements ADR-030: automatic `config_schema` property inheritance along the class MRO.

- **Registry MRO merge**: `_merge_config_schema()` walks `cls.__mro__` in reverse and unions all `properties` dicts (child wins on name conflict)
- **IOBlock path injection**: base class declares full `path` field with `ui_widget: file_browser`; direction-aware post-processing auto-switches output blocks to `directory_browser` + single string
- **AppBlock output_dir injection**: "Save Outputs At" field inherited by all AppBlock subclasses; FileWatcher uses user-selected directory when set
- **Frontend**: copy-to-clipboard button on `directory_browser` widgets; PAUSED toast for AppBlocks showing output path
- **Cleanup**: removed redundant `path` declarations from 5 IOBlock subclasses; fixes SaveTable's incorrect `file_browser` bug

## Changes

| File | Change |
|------|--------|
| `src/scieasy/blocks/registry.py` | Add `_merge_config_schema()`, `_subclass_declares_field()`, direction-aware post-processing |
| `src/scieasy/blocks/io/io_block.py` | Full `path` declaration with `ui_widget`, `type`, `items` |
| `src/scieasy/blocks/app/app_block.py` | Add `output_dir` field; update `run()` |
| `packages/.../interactive/__init__.py` | `_run_external_app()` reads `output_dir` |
| `frontend/.../BlockNode.tsx` | Copy button + PAUSED toast |
| `src/.../load_data.py` | Remove redundant `path` |
| `src/.../save_data.py` | Remove redundant `path` |
| `packages/.../load_image.py` | Remove redundant `path` |
| `packages/.../save_image.py` | Remove redundant `path` |
| `packages/.../save_table.py` | Remove redundant `path` (fixes file_browser bug) |
| `tests/blocks/test_registry.py` | 8 new tests for MRO merge |

## Related Issues
Closes #557

## ADR
- [x] ADR-030 (already written in PR #559)

## Checklist
- [x] Tests added covering the fix (8 new tests for `_merge_config_schema`)
- [x] Ruff check + format pass
- [x] Backward compatible (existing subclass overrides still win)