### PR TITLE
fix(#563): pass raw file paths as CLI arguments to ElMAVEN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [#540] LCMS IO block audit: rename LoadMSRawFiles to LoadMzMLFiles, remove regex config from LoadMIDTable (@claude, 2026-04-10, branch: refactor/issue-540/lcms-io-audit, session: 20260410-001346-refactor-lcms-lcms-io-block-audit-rename)
 - [#545] Show spinning indicator on Run button during workflow execution (@claude, 2026-04-10, branch: feat/issue-545/run-button-spinner, session: 20260410-001118-show-spinning-indicator-on-run-button-du)
 - [#542] SRS block audit — remove Band Ratio and SRS Normalize, rename Denoise to Spectral Denoise with Savitzky-Golay, add Calibrate ui_priority, add Unmix mode selector (@claude, 2026-04-10, branch: refactor/issue-542/srs-block-audit, session: 20260410-000652-srs-block-audit-remove-band-ratio-and-sr)
-<<<<<<< fix/issue-530/palette-audit
 - [#530] Core block palette audit: remove base classes and placeholders from palette, rename Load Data/Save Data to Load/Save, add SubWorkflow config_schema (@claude, 2026-04-10, branch: fix/issue-530/palette-audit, session: 20260410-000636-refactor-gui-core-block-palette-audit-re)
-=======
 - [#538] LCMS app block audit: ElMAVEN cleanup, remove GraphPad skeleton, remove watch_timeout (@claude, 2026-04-10, branch: refactor/issue-538/lcms-app-audit, session: 20260410-000747-refactor-lcms-lcms-app-block-audit-elmav)
->>>>>>> main
 - [#464] Improve preview panel: dark-bg image viewer with pan/zoom/LUT, compact table viewer with formatting (@claude, 2026-04-09, branch: feat/issue-464/preview-viewer, session: 20260409-124853-improve-preview-image-table-viewers-464)
 - [#476] Cache Python site-packages in CI to reduce install overhead (@claude, 2026-04-09, branch: perf/issue-476/ci-pip-cache, session: 20260409-124905-optimize-ci-pip-install-caching)
 - [#468] Optimize CI: parallel jobs, single-version coverage, pytest-xdist (@claude, 2026-04-09, branch: perf/issue-468/ci-speedup, session: wave2-ci-perf)
@@ -38,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- [#563] Pass raw file paths as CLI arguments to ElMAVEN so files are pre-loaded on launch (@claude, 2026-04-10, branch: fix/issue-563/elmaven-file-args, session: 20260410-040343-fix-563-elmaven-block-does-not-pass-inpu)
 - [#534] Remove is_collection double-ring from port rendering (@claude, 2026-04-10, branch: fix/issue-534/remove-collection-double-ring, session: 20260410-000721-fix-gui-remove-is-collection-double-ring)
 - [#525] Switch LCMS load blocks from directory_browser/glob to file_browser with multi-file support (@claude, 2026-04-09, branch: fix/issue-525/load-blocks-file-browser, session: N/A)
 - [#526] Fix ElMAVEN block freeze — remove unused argv_override CLI args, fix PIPE deadlock with DEVNULL, add proc.wait (@claude, 2026-04-09, branch: fix/issue-526/elmaven-cli-pipe-deadlock, session: N/A)

--- a/packages/scieasy-blocks-lcms/src/scieasy_blocks_lcms/external/elmaven_block.py
+++ b/packages/scieasy-blocks-lcms/src/scieasy_blocks_lcms/external/elmaven_block.py
@@ -16,7 +16,7 @@ imaging package's shared infrastructure:
 ElMAVEN-specific logic preserved:
   - Output classification via ``_classify_export()`` (column-header heuristic)
   - Two typed output ports: peak_table (PeakTable) and mid_table (MIDTable)
-  - Raw file paths staged as symlinks (ElMAVEN CLI does not accept positional args)
+  - Raw file paths staged as symlinks and passed as positional CLI args
 """
 
 from __future__ import annotations
@@ -107,8 +107,9 @@ def _prepare_elmaven_exchange(
 ) -> None:
     """Stage raw file symlinks in the exchange dir and write the manifest.
 
-    ElMAVEN's CLI does not accept positional file arguments (unlike Fiji),
-    so files are staged as symlinks for the user to open manually.
+    Raw files are staged as symlinks in the exchange directory for reference.
+    The files are also passed as positional CLI arguments so ElMAVEN loads
+    them automatically on launch.
     """
     input_dir = exchange_dir / "inputs"
     for rp in raw_paths:
@@ -330,13 +331,14 @@ class ElMAVENBlock(_LCMSBlockMixin, AppBlock):
         command = _resolve_command(config, app_command=self.app_command, override_key="elmaven_path")
 
         # 5. Launch and wait (shared helper manages state transitions).
-        # ElMAVEN CLI does not accept positional file args -- no launch_args.
+        # Pass raw file paths as positional args so ElMAVEN loads them on launch.
         output_files = _run_external_app(
             self,
             command=command,
             exchange_dir=exchange_dir,
             patterns=self.output_patterns,
             config=config,
+            launch_args=raw_paths,
         )
 
         # 6. Classify and load outputs.

--- a/packages/scieasy-blocks-lcms/src/scieasy_blocks_lcms/external/elmaven_block.py
+++ b/packages/scieasy-blocks-lcms/src/scieasy_blocks_lcms/external/elmaven_block.py
@@ -319,7 +319,7 @@ class ElMAVENBlock(_LCMSBlockMixin, AppBlock):
         """
         # 1. Extract raw file paths from input.
         raw_items = list(inputs.get("raw_files", Collection(items=[], item_type=MSRawFile)))
-        raw_paths = [str(item.file_path) for item in raw_items if item.file_path is not None]
+        raw_paths = [str(Path(item.file_path).resolve()) for item in raw_items if item.file_path is not None]
 
         # 2. Resolve exchange directory.
         exchange_dir = _resolve_exchange_dir(config, prefix="scieasy_elmaven_")

--- a/packages/scieasy-blocks-lcms/tests/test_external/test_elmaven_block.py
+++ b/packages/scieasy-blocks-lcms/tests/test_external/test_elmaven_block.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import shutil
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 from scieasy_blocks_lcms.external.elmaven_block import (
@@ -93,6 +94,37 @@ def test_collect_elmaven_outputs_empty() -> None:
     result = _collect_elmaven_outputs([])
     assert len(result["peak_table"]) == 0
     assert len(result["mid_table"]) == 0
+
+
+def test_run_passes_raw_paths_as_launch_args(tmp_path: Path) -> None:
+    """run() must forward raw file paths as launch_args to _run_external_app."""
+    raw1 = tmp_path / "sample1.mzXML"
+    raw2 = tmp_path / "sample2.mzML"
+    raw1.write_text("<mzXML/>", encoding="utf-8")
+    raw2.write_text("<mzML/>", encoding="utf-8")
+
+    raw_files = Collection(
+        items=[
+            MSRawFile(file_path=raw1, meta=MSRawFile.Meta(format="mzXML")),
+            MSRawFile(file_path=raw2, meta=MSRawFile.Meta(format="mzML")),
+        ],
+        item_type=MSRawFile,
+    )
+
+    captured_kwargs: dict = {}
+
+    def fake_run_external_app(_block, **kwargs):  # type: ignore[no-untyped-def]
+        captured_kwargs.update(kwargs)
+        return []  # no output files
+
+    with patch(
+        "scieasy_blocks_lcms.external.elmaven_block._run_external_app",
+        side_effect=fake_run_external_app,
+    ):
+        ElMAVENBlock().run({"raw_files": raw_files}, BlockConfig(params={}))
+
+    assert "launch_args" in captured_kwargs, "launch_args not passed to _run_external_app"
+    assert captured_kwargs["launch_args"] == [str(raw1), str(raw2)]
 
 
 @pytest.mark.skipif(shutil.which("elmaven") is None, reason="ElMAVEN not installed")

--- a/packages/scieasy-blocks-lcms/tests/test_external/test_elmaven_block.py
+++ b/packages/scieasy-blocks-lcms/tests/test_external/test_elmaven_block.py
@@ -124,7 +124,42 @@ def test_run_passes_raw_paths_as_launch_args(tmp_path: Path) -> None:
         ElMAVENBlock().run({"raw_files": raw_files}, BlockConfig(params={}))
 
     assert "launch_args" in captured_kwargs, "launch_args not passed to _run_external_app"
-    assert captured_kwargs["launch_args"] == [str(raw1), str(raw2)]
+    # Paths must be resolved to absolute so they survive cwd changes in the bridge.
+    assert captured_kwargs["launch_args"] == [str(raw1.resolve()), str(raw2.resolve())]
+
+
+def test_run_resolves_relative_paths_to_absolute(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Relative file_path values must be resolved to absolute before launch."""
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    raw = data_dir / "sample.mzML"
+    raw.write_text("<mzML/>", encoding="utf-8")
+
+    # Store a *relative* path in the MSRawFile (simulates LoadMzMLFiles with relative config).
+    monkeypatch.chdir(tmp_path)
+    relative_path = Path("data/sample.mzML")
+
+    raw_files = Collection(
+        items=[MSRawFile(file_path=relative_path, meta=MSRawFile.Meta(format="mzML"))],
+        item_type=MSRawFile,
+    )
+
+    captured_kwargs: dict = {}
+
+    def fake_run_external_app(_block, **kwargs):  # type: ignore[no-untyped-def]
+        captured_kwargs.update(kwargs)
+        return []
+
+    with patch(
+        "scieasy_blocks_lcms.external.elmaven_block._run_external_app",
+        side_effect=fake_run_external_app,
+    ):
+        ElMAVENBlock().run({"raw_files": raw_files}, BlockConfig(params={}))
+
+    launch_args = captured_kwargs["launch_args"]
+    assert len(launch_args) == 1
+    assert Path(launch_args[0]).is_absolute(), f"Expected absolute path, got: {launch_args[0]}"
+    assert launch_args[0] == str(raw.resolve())
 
 
 @pytest.mark.skipif(shutil.which("elmaven") is None, reason="ElMAVEN not installed")

--- a/tests/blocks/test_bridge_extended.py
+++ b/tests/blocks/test_bridge_extended.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -31,6 +32,35 @@ class TestBridgeGuessMime:
 
     def test_unknown_extension(self) -> None:
         assert _guess_mime(Path("file.xyz")) == "application/octet-stream"
+
+
+class TestBridgeLaunchArgvOverride:
+    """FileExchangeBridge.launch — argv_override appends file paths instead of exchange_dir."""
+
+    def test_argv_override_appends_file_paths(self, tmp_path: Path) -> None:
+        """When argv_override is given, those paths replace the default exchange_dir trailing arg."""
+        bridge = FileExchangeBridge()
+        file_paths = ["/data/sample1.mzXML", "/data/sample2.mzML"]
+
+        with patch("scieasy.blocks.app.bridge.subprocess.Popen") as mock_popen:
+            mock_popen.return_value.pid = 12345
+            bridge.launch(["echo"], tmp_path, argv_override=file_paths)
+
+        cmd = mock_popen.call_args[0][0]
+        # The command should end with the file paths, not the exchange dir
+        assert cmd[-2:] == file_paths
+        assert str(tmp_path) not in cmd
+
+    def test_no_argv_override_uses_exchange_dir(self, tmp_path: Path) -> None:
+        """Without argv_override, the exchange_dir is appended as trailing arg."""
+        bridge = FileExchangeBridge()
+
+        with patch("scieasy.blocks.app.bridge.subprocess.Popen") as mock_popen:
+            mock_popen.return_value.pid = 12345
+            bridge.launch(["echo"], tmp_path)
+
+        cmd = mock_popen.call_args[0][0]
+        assert cmd[-1] == str(tmp_path)
 
 
 class TestBridgePrepareExtended:


### PR DESCRIPTION
## Summary
Closes #563

- Pass `raw_paths` as `launch_args` to `_run_external_app()` so ElMAVEN receives file paths as positional CLI arguments and loads them automatically on launch
- Fix incorrect docstrings/comments that claimed ElMAVEN CLI does not accept positional file arguments
- Add regression test verifying `launch_args` is forwarded with the correct file paths

## ADR
- [x] No ADR needed (simple fix)

## Checklist
- [x] Tests added covering the fix
- [ ] CHANGELOG updated
- [ ] CI passes