### PR TITLE
fix(#565): BlockConfig.get() ignores enriched runtime keys (block_id, project_dir)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- [#565] Fix BlockConfig.get() to find enriched runtime keys (block_id, project_dir); add data/exchange to create_project (@claude, 2026-04-10, branch: fix/issue-565/blockconfig-get-extra-fields, session: 20260410-045525-fix-blockconfig-get-not-finding-enriched)
 - [#563] Pass raw file paths as CLI arguments to ElMAVEN so files are pre-loaded on launch (@claude, 2026-04-10, branch: fix/issue-563/elmaven-file-args, session: 20260410-040343-fix-563-elmaven-block-does-not-pass-inpu)
 - [#534] Remove is_collection double-ring from port rendering (@claude, 2026-04-10, branch: fix/issue-534/remove-collection-double-ring, session: 20260410-000721-fix-gui-remove-is-collection-double-ring)
 - [#525] Switch LCMS load blocks from directory_browser/glob to file_browser with multi-file support (@claude, 2026-04-09, branch: fix/issue-525/load-blocks-file-browser, session: N/A)

--- a/src/scieasy/api/runtime.py
+++ b/src/scieasy/api/runtime.py
@@ -324,6 +324,7 @@ class ApiRuntime:
             "data/zarr",
             "data/parquet",
             "data/artifacts",
+            "data/exchange",
             "blocks",
             "types",
             "checkpoints",

--- a/src/scieasy/blocks/base/config.py
+++ b/src/scieasy/blocks/base/config.py
@@ -19,5 +19,15 @@ class BlockConfig(BaseModel):
     params: dict[str, Any] = {}
 
     def get(self, key: str, default: Any = None) -> Any:
-        """Return a parameter value by *key*, falling back to *default*."""
-        return self.params.get(key, default)
+        """Return a parameter value by *key*, falling back to *default*.
+
+        Checks ``params`` first, then Pydantic extra fields so that
+        runtime-enriched keys (``block_id``, ``project_dir``, …) injected
+        by the scheduler are discoverable via the same accessor (#565).
+        """
+        if key in self.params:
+            return self.params[key]
+        extras = self.__pydantic_extra__ or {}
+        if key in extras:
+            return extras[key]
+        return default

--- a/tests/api/test_projects.py
+++ b/tests/api/test_projects.py
@@ -49,6 +49,10 @@ def test_project_crud_and_path_opening(client: TestClient, project_parent: Path)
     assert by_path.status_code == 200
     assert by_path.json()["id"] == second_payload["id"]
 
+    # Verify data/exchange is created alongside other data subdirs (#565).
+    project_path = Path(second_payload["path"])
+    assert (project_path / "data" / "exchange").is_dir()
+
     deleted = client.delete(f"/api/projects/{first_payload['id']}")
     assert deleted.status_code == 204
     assert not Path(first_payload["path"]).exists()

--- a/tests/blocks/test_block_config.py
+++ b/tests/blocks/test_block_config.py
@@ -30,6 +30,22 @@ class TestBlockConfig:
         config = BlockConfig(params={"a": 1}, custom_field="hello")
         assert config.custom_field == "hello"  # type: ignore[attr-defined]
 
+    def test_get_finds_extra_fields(self) -> None:
+        """Enriched runtime keys (block_id, project_dir) are accessible via get() (#565)."""
+        config = BlockConfig(params={"a": 1}, block_id="blk-42", project_dir="/proj")
+        assert config.get("block_id") == "blk-42"
+        assert config.get("project_dir") == "/proj"
+
+    def test_get_params_takes_priority_over_extra(self) -> None:
+        """If a key exists in both params and extra fields, params wins."""
+        config = BlockConfig(params={"key": "from_params"}, key="from_extra")
+        assert config.get("key") == "from_params"
+
+    def test_get_extra_field_default(self) -> None:
+        """Default is returned when key is in neither params nor extra fields."""
+        config = BlockConfig(params={}, block_id="blk-1")
+        assert config.get("missing", "fallback") == "fallback"
+
 
 class TestBlockResult:
     """BlockResult — single block execution outcome."""


### PR DESCRIPTION
## Summary

- `BlockConfig.get()` only searched `self.params`, but the scheduler injects `block_id`/`project_dir` as top-level dict keys which Pydantic stores as extra fields. This caused `_resolve_exchange_dir()` to always fall back to `tempfile.mkdtemp()`, so AppBlock exchange directories were created in the system temp dir instead of `{project_dir}/data/exchange/{block_id}/`.
- Also adds `data/exchange` to the `create_project()` subdirectory list so it exists from project creation.

## Root Cause

Scheduler enriches config as a flat dict → worker calls `BlockConfig(**config)` → Pydantic puts non-`params` keys into extra fields → `get()` only checks `params` → returns `None` for `block_id`, `project_dir`, and also `output_dir` (PR #562).

## Changes

| File | Change |
|------|--------|
| `src/scieasy/blocks/base/config.py` | `get()` falls back to `__pydantic_extra__` |
| `src/scieasy/api/runtime.py` | Add `data/exchange` to `create_project()` |
| `tests/blocks/test_block_config.py` | 3 new tests for extra field lookup |
| `tests/api/test_projects.py` | Assert `data/exchange` exists after project creation |

## Related Issues
Closes #565

## Test plan
- [x] `test_get_finds_extra_fields` — verifies `block_id`/`project_dir` accessible via `get()`
- [x] `test_get_params_takes_priority_over_extra` — params wins on conflict
- [x] `test_get_extra_field_default` — missing key returns default
- [x] `test_project_crud_and_path_opening` — verifies `data/exchange` dir exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)