### PR TITLE
fix(#561): fix Windows browse dialog bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- [#561] Fix Windows browse dialog bugs: PowerShell double-brace syntax, add multi-file select, modernize folder dialog, update frontend to paths array (@claude, 2026-04-11, branch: fix/issue-561/browse-dialog-bugs, session: 20260411-020115-fix-browse-dialog-bugs-on-windows-561)
 - [#569] Add ADR-029 variadic ports implementation roadmap with 8 detailed tickets (@claude, 2026-04-11, branch: docs/issue-569/adr-029-variadic-ports-roadmap, session: 20260411-013533-docs-adr-029-variadic-ports-implementati)
 - [#555] Rewrite ElMAVEN block to follow standard AppBlock pattern -- fixes rerun deadlock (@claude, 2026-04-10, branch: refactor/issue-555/elmaven-standard-pattern, session: 20260410-005711-rewrite-elmaven-block-to-follow-standard)
 - [#541] LCMS process block audit: remove 9 premature/skeleton blocks, fix config labels, improve flux estimate with linregress (@claude, 2026-04-10, branch: refactor/issue-541/lcms-process-audit, session: 20260410-002151-refactor-lcms-lcms-process-block-audit-r)

--- a/frontend/src/components/nodes/BlockNode.tsx
+++ b/frontend/src/components/nodes/BlockNode.tsx
@@ -447,10 +447,13 @@ function InlineConfigField({
     }
     try {
       const result = await api.openNativeDialog(nativeMode, initialDir);
-      if (result.path) {
-        onChange(key, result.path);
+      if (result.paths.length > 0) {
+        // For file_browser, use the first selected file (multi-select may
+        // be supported in future via a dedicated list widget).
+        // For directory_browser, there is always at most one path.
+        onChange(key, result.paths[0]);
       }
-      // If result.path is null, user cancelled — do nothing
+      // If paths is empty, user cancelled — do nothing
     } catch {
       // Native dialog failed — fall back to in-app FileBrowserModal
       setBrowseOpen(true);

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -175,7 +175,7 @@ export const api = {
       body: JSON.stringify({ path }),
     }),
   openNativeDialog: (mode: "file" | "directory", initialDir?: string) =>
-    apiFetch<{ path: string | null }>("/api/filesystem/native-dialog", {
+    apiFetch<{ paths: string[] }>("/api/filesystem/native-dialog", {
       method: "POST",
       headers: JSON_HEADERS,
       body: JSON.stringify({ mode, initial_dir: initialDir }),

--- a/src/scieasy/api/routes/filesystem.py
+++ b/src/scieasy/api/routes/filesystem.py
@@ -241,28 +241,43 @@ class NativeDialogRequest(BaseModel):
 class NativeDialogResponse(BaseModel):
     """Response from the native dialog endpoint."""
 
-    path: str | None = Field(None, description="Selected path, or null if cancelled")
+    paths: list[str] = Field(default_factory=list, description="Selected paths (empty if cancelled)")
 
 
 # Per-session last-used directory (in-memory, resets on restart).
 _last_used_directory: str | None = None
 
 
-def _native_dialog_windows(mode: str, initial_dir: str | None) -> str | None:
-    """Open a native Windows file/directory dialog via PowerShell."""
+def _native_dialog_windows(mode: str, initial_dir: str | None) -> list[str]:
+    """Open a native Windows file/directory dialog via PowerShell.
+
+    Returns a list of selected paths (empty list if cancelled).
+    For directory mode the list contains at most one element.
+    For file mode the list may contain multiple files.
+    """
     if mode == "directory":
+        # Bug 3 fix: EnableVisualStyles() forces the modern Vista-style dialog
+        # instead of the legacy Win2000 FolderBrowserDialog appearance.
+        # Bug 1 fix: braces in non-f-string fragments must be single `{ }`,
+        # not `{{ }}` (double braces are only needed inside f-strings).
         ps_script = (
             "Add-Type -AssemblyName System.Windows.Forms;"
+            "[System.Windows.Forms.Application]::EnableVisualStyles();"
             "$d = New-Object System.Windows.Forms.FolderBrowserDialog;"
+            "$d.ShowNewFolderButton = $true;"
             f"$d.SelectedPath = '{initial_dir or ''}';"
-            "if ($d.ShowDialog() -eq 'OK') {{ $d.SelectedPath }} else {{ '' }}"
+            "if ($d.ShowDialog() -eq 'OK') { $d.SelectedPath } else { '' }"
         )
     else:
+        # Bug 1 fix: single braces for non-f-string lines.
+        # Bug 2 fix: enable Multiselect and return pipe-separated FileNames.
         ps_script = (
             "Add-Type -AssemblyName System.Windows.Forms;"
+            "[System.Windows.Forms.Application]::EnableVisualStyles();"
             "$d = New-Object System.Windows.Forms.OpenFileDialog;"
+            "$d.Multiselect = $true;"
             f"$d.InitialDirectory = '{initial_dir or ''}';"
-            "if ($d.ShowDialog() -eq 'OK') {{ $d.FileName }} else {{ '' }}"
+            "if ($d.ShowDialog() -eq 'OK') { ($d.FileNames -join '|') } else { '' }"
         )
     result = subprocess.run(
         ["powershell", "-NoProfile", "-NonInteractive", "-Command", ps_script],
@@ -271,11 +286,17 @@ def _native_dialog_windows(mode: str, initial_dir: str | None) -> str | None:
         timeout=120,
     )
     selected = result.stdout.strip()
-    return selected if selected else None
+    if not selected:
+        return []
+    # File mode returns pipe-separated paths; directory mode returns a single path.
+    return [p for p in selected.split("|") if p]
 
 
-def _native_dialog_macos(mode: str, initial_dir: str | None) -> str | None:
-    """Open a native macOS file/directory dialog via osascript."""
+def _native_dialog_macos(mode: str, initial_dir: str | None) -> list[str]:
+    """Open a native macOS file/directory dialog via osascript.
+
+    Returns a list of selected paths (empty list if cancelled).
+    """
     if mode == "directory":
         if initial_dir:
             script = f'choose folder with prompt "Select Directory" default location POSIX file "{initial_dir}"'
@@ -283,9 +304,12 @@ def _native_dialog_macos(mode: str, initial_dir: str | None) -> str | None:
             script = 'choose folder with prompt "Select Directory"'
     else:
         if initial_dir:
-            script = f'choose file with prompt "Select File" default location POSIX file "{initial_dir}"'
+            script = (
+                f'choose file with prompt "Select File" default location POSIX file "{initial_dir}"'
+                " with multiple selections allowed"
+            )
         else:
-            script = 'choose file with prompt "Select File"'
+            script = 'choose file with prompt "Select File" with multiple selections allowed'
     result = subprocess.run(
         ["osascript", "-e", script],
         capture_output=True,
@@ -294,28 +318,45 @@ def _native_dialog_macos(mode: str, initial_dir: str | None) -> str | None:
     )
     selected = result.stdout.strip()
     if not selected:
-        return None
-    # osascript returns "alias Macintosh HD:Users:foo:..." — convert to POSIX
-    if selected.startswith("alias "):
-        # Convert colon-separated HFS path to POSIX
-        parts = selected[len("alias ") :].split(":")
-        # First part is the volume name — on default installs, map to /
+        return []
+
+    def _hfs_to_posix(hfs: str) -> str:
+        """Convert an HFS alias string to a POSIX path."""
+        text = hfs.strip()
+        if text.startswith("alias "):
+            text = text[len("alias ") :]
+        parts = text.split(":")
         posix = "/" + "/".join(parts[1:])
-        # Remove trailing slash if present
         return posix.rstrip("/") or "/"
-    return selected
+
+    # osascript may return comma-separated aliases for multi-select
+    if ", alias " in selected:
+        aliases = selected.split(", alias ")
+        # First item already has 'alias ' prefix; subsequent ones don't after split
+        return [_hfs_to_posix(aliases[0])] + [_hfs_to_posix("alias " + a) for a in aliases[1:]]
+    if selected.startswith("alias "):
+        return [_hfs_to_posix(selected)]
+    return [selected]
 
 
-def _native_dialog_linux(mode: str, initial_dir: str | None) -> str | None:
-    """Open a native Linux file/directory dialog via zenity."""
+def _native_dialog_linux(mode: str, initial_dir: str | None) -> list[str]:
+    """Open a native Linux file/directory dialog via zenity.
+
+    Returns a list of selected paths (empty list if cancelled).
+    """
     cmd = ["zenity", "--file-selection"]
     if mode == "directory":
         cmd.append("--directory")
+    else:
+        cmd.append("--multiple")
+        cmd.extend(["--separator", "|"])
     if initial_dir:
         cmd.extend(["--filename", initial_dir + "/"])
     result = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
     selected = result.stdout.strip()
-    return selected if selected else None
+    if not selected:
+        return []
+    return [p for p in selected.split("|") if p]
 
 
 @router.post("/api/filesystem/native-dialog", response_model=NativeDialogResponse)
@@ -337,11 +378,11 @@ async def native_file_dialog(body: NativeDialogRequest) -> NativeDialogResponse:
     system = platform.system()
     try:
         if system == "Windows":
-            selected = _native_dialog_windows(body.mode, initial_dir)
+            selected_paths = _native_dialog_windows(body.mode, initial_dir)
         elif system == "Darwin":
-            selected = _native_dialog_macos(body.mode, initial_dir)
+            selected_paths = _native_dialog_macos(body.mode, initial_dir)
         else:
-            selected = _native_dialog_linux(body.mode, initial_dir)
+            selected_paths = _native_dialog_linux(body.mode, initial_dir)
     except FileNotFoundError as exc:
         raise HTTPException(
             status_code=500,
@@ -354,8 +395,9 @@ async def native_file_dialog(body: NativeDialogRequest) -> NativeDialogResponse:
         ) from exc
 
     # Track last-used directory for the session
-    if selected:
-        parent = str(Path(selected).parent) if Path(selected).is_file() else selected
+    if selected_paths:
+        first = selected_paths[0]
+        parent = str(Path(first).parent) if Path(first).is_file() else first
         _last_used_directory = parent
 
-    return NativeDialogResponse(path=selected)
+    return NativeDialogResponse(paths=selected_paths)

--- a/tests/api/test_filesystem.py
+++ b/tests/api/test_filesystem.py
@@ -109,8 +109,10 @@ class TestNativeDialog:
         )
         assert resp.status_code == 422
 
-    def test_directory_dialog_returns_path(self, client: TestClient, opened_project: Path, monkeypatch: object) -> None:
-        """Successful directory dialog returns the selected path."""
+    def test_directory_dialog_returns_paths(
+        self, client: TestClient, opened_project: Path, monkeypatch: object
+    ) -> None:
+        """Successful directory dialog returns the selected path in a list."""
         import subprocess
 
         import scieasy.api.routes.filesystem as fs_mod
@@ -130,12 +132,12 @@ class TestNativeDialog:
                 json={"mode": "directory", "initial_dir": str(opened_project)},
             )
             assert resp.status_code == 200
-            assert resp.json()["path"] == fake_dir
+            assert resp.json()["paths"] == [fake_dir]
         finally:
             fs_mod.subprocess.run = original_run  # type: ignore[assignment]
 
-    def test_file_dialog_returns_path(self, client: TestClient, opened_project: Path, monkeypatch: object) -> None:
-        """Successful file dialog returns the selected file path."""
+    def test_file_dialog_returns_paths(self, client: TestClient, opened_project: Path, monkeypatch: object) -> None:
+        """Successful file dialog returns the selected file path in a list."""
         import subprocess
 
         import scieasy.api.routes.filesystem as fs_mod
@@ -155,12 +157,38 @@ class TestNativeDialog:
                 json={"mode": "file"},
             )
             assert resp.status_code == 200
-            assert resp.json()["path"] == fake_file
+            assert resp.json()["paths"] == [fake_file]
         finally:
             fs_mod.subprocess.run = original_run  # type: ignore[assignment]
 
-    def test_cancelled_dialog_returns_null(self, client: TestClient, monkeypatch: object) -> None:
-        """Cancelled dialog returns path=null."""
+    def test_file_dialog_multi_select(self, client: TestClient, opened_project: Path, monkeypatch: object) -> None:
+        """File dialog with multiple selections returns pipe-separated paths."""
+        import subprocess
+
+        import scieasy.api.routes.filesystem as fs_mod
+
+        fake_a = str(opened_project / "data" / "a.csv")
+        fake_b = str(opened_project / "data" / "b.csv")
+
+        class FakeCompletedProcess:
+            stdout = f"{fake_a}|{fake_b}\n"
+            stderr = ""
+            returncode = 0
+
+        original_run = subprocess.run
+        fs_mod.subprocess.run = lambda *_args, **_kwargs: FakeCompletedProcess()  # type: ignore[assignment]
+        try:
+            resp = client.post(
+                "/api/filesystem/native-dialog",
+                json={"mode": "file"},
+            )
+            assert resp.status_code == 200
+            assert resp.json()["paths"] == [fake_a, fake_b]
+        finally:
+            fs_mod.subprocess.run = original_run  # type: ignore[assignment]
+
+    def test_cancelled_dialog_returns_empty_list(self, client: TestClient, monkeypatch: object) -> None:
+        """Cancelled dialog returns empty paths list."""
         import subprocess
 
         import scieasy.api.routes.filesystem as fs_mod
@@ -178,7 +206,7 @@ class TestNativeDialog:
                 json={"mode": "directory"},
             )
             assert resp.status_code == 200
-            assert resp.json()["path"] is None
+            assert resp.json()["paths"] == []
         finally:
             fs_mod.subprocess.run = original_run  # type: ignore[assignment]
 


### PR DESCRIPTION
## Summary
Closes #561

Fix 4 browse dialog bugs on Windows:

- **Bug 1 (CRITICAL):** `{{ }}` double braces in non-f-string PowerShell lines caused all dialogs to output literal `$d.FileName` / `$d.SelectedPath` instead of actual paths. Fixed by using single `{ }`.
- **Bug 2:** `OpenFileDialog` now enables `Multiselect` and returns pipe-separated `FileNames`. Backend response model changed from `path: str | None` to `paths: list[str]`.
- **Bug 3:** Added `[System.Windows.Forms.Application]::EnableVisualStyles()` before `FolderBrowserDialog` creation to force modern Vista-style appearance.
- **Bug 4:** Updated frontend `api.ts` and `BlockNode.tsx` to handle the new `paths: string[]` response.

## Changes
- `src/scieasy/api/routes/filesystem.py` — All 3 platform dialog helpers now return `list[str]`; `NativeDialogResponse.paths` replaces `.path`; PowerShell scripts fixed
- `frontend/src/lib/api.ts` — `openNativeDialog` return type updated
- `frontend/src/components/nodes/BlockNode.tsx` — `handleBrowseClick` uses `result.paths[0]`
- `tests/api/test_filesystem.py` — Updated to assert `paths` list; added multi-select test

## Checklist
- [x] Tests added covering the fix
- [x] Lint/format clean
- [x] No ADR needed (simple bug fix)

Generated with [Claude Code](https://claude.com/claude-code)