### PR TITLE
fix(#571): inject Executable Path + Save Outputs At with forced ordering in AppBlock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- [#571] Inject Executable Path (file_browser) + Save Outputs At with forced ui_priority ordering in AppBlock (@claude, 2026-04-11, branch: fix/issue-571/appblock-config-injection, session: 20260411-020155-fix-571-inject-executable-path-save-outp)
 - [#569] Add ADR-029 variadic ports implementation roadmap with 8 detailed tickets (@claude, 2026-04-11, branch: docs/issue-569/adr-029-variadic-ports-roadmap, session: 20260411-013533-docs-adr-029-variadic-ports-implementati)
 - [#555] Rewrite ElMAVEN block to follow standard AppBlock pattern -- fixes rerun deadlock (@claude, 2026-04-10, branch: refactor/issue-555/elmaven-standard-pattern, session: 20260410-005711-rewrite-elmaven-block-to-follow-standard)
 - [#541] LCMS process block audit: remove 9 premature/skeleton blocks, fix config labels, improve flux estimate with linregress (@claude, 2026-04-10, branch: refactor/issue-541/lcms-process-audit, session: 20260410-002151-refactor-lcms-lcms-process-block-audit-r)

--- a/src/scieasy/blocks/app/app_block.py
+++ b/src/scieasy/blocks/app/app_block.py
@@ -99,16 +99,9 @@ class AppBlock(Block):
         ADR-020: Accepts and returns Collection-wrapped data.
         """
         bridge = FileExchangeBridge()
-        command: str | list[str] = config.get("app_command") or self.app_command
+        command = config.get("app_command") or self.app_command
         if not command:
             raise ValueError("AppBlock requires 'app_command' in config or as class variable")
-
-        # If the command is a bare filesystem path (e.g. selected via
-        # file_browser), wrap it as a single-element list so
-        # validate_app_command() does not shlex-split paths with spaces
-        # like "C:\Program Files\Fiji\fiji.exe".
-        if isinstance(command, str) and Path(command).is_file():
-            command = [command]
 
         patterns = config.get("output_patterns") or self.output_patterns
 

--- a/src/scieasy/blocks/app/app_block.py
+++ b/src/scieasy/blocks/app/app_block.py
@@ -68,14 +68,19 @@ class AppBlock(Block):
     config_schema: ClassVar[dict[str, Any]] = {
         "type": "object",
         "properties": {
+            "app_command": {
+                "type": "string",
+                "title": "Executable Path",
+                "ui_widget": "file_browser",
+                "ui_priority": 0,
+            },
             "output_dir": {
                 "type": ["string", "null"],
                 "default": None,
                 "title": "Save Outputs At",
                 "ui_widget": "directory_browser",
-                "ui_priority": 0,
+                "ui_priority": 1,
             },
-            "app_command": {"type": "string", "title": "Application Command", "ui_priority": 1},
             "output_patterns": {
                 "type": "string",
                 "title": "Output File Patterns",

--- a/src/scieasy/blocks/app/app_block.py
+++ b/src/scieasy/blocks/app/app_block.py
@@ -99,9 +99,16 @@ class AppBlock(Block):
         ADR-020: Accepts and returns Collection-wrapped data.
         """
         bridge = FileExchangeBridge()
-        command = config.get("app_command") or self.app_command
+        command: str | list[str] = config.get("app_command") or self.app_command
         if not command:
             raise ValueError("AppBlock requires 'app_command' in config or as class variable")
+
+        # If the command is a bare filesystem path (e.g. selected via
+        # file_browser), wrap it as a single-element list so
+        # validate_app_command() does not shlex-split paths with spaces
+        # like "C:\Program Files\Fiji\fiji.exe".
+        if isinstance(command, str) and Path(command).is_file():
+            command = [command]
 
         patterns = config.get("output_patterns") or self.output_patterns
 

--- a/src/scieasy/blocks/app/command_validator.py
+++ b/src/scieasy/blocks/app/command_validator.py
@@ -40,7 +40,11 @@ def validate_app_command(command: str | list[str]) -> list[str]:
         # Check for shell metacharacters before splitting.
         if _SHELL_META.search(command):
             raise ValueError(f"Command contains shell metacharacters and was rejected: {command!r}")
-        parts = shlex.split(command)
+        # If the string is a bare filesystem path (e.g. selected via
+        # file_browser widget), treat it as a single executable token
+        # so shlex.split does not break paths with spaces like
+        # "C:\Program Files\Fiji\fiji.exe".
+        parts = [command] if Path(command).is_file() else shlex.split(command)
 
     if not parts:
         raise ValueError("Empty command")

--- a/src/scieasy/blocks/registry.py
+++ b/src/scieasy/blocks/registry.py
@@ -565,6 +565,23 @@ def _merge_config_schema(cls: type) -> dict[str, Any]:
         path_prop["ui_widget"] = "directory_browser"
         path_prop.pop("items", None)
 
+    # Issue #571: enforce forced ordering for AppBlock subclasses.
+    # app_command must be ui_priority 0, output_dir must be ui_priority 1,
+    # and all other properties must have ui_priority >= 2.
+    from scieasy.blocks.app.app_block import AppBlock
+
+    if isinstance(cls, type) and issubclass(cls, AppBlock):
+        if "app_command" in merged_properties:
+            merged_properties["app_command"]["ui_priority"] = 0
+        if "output_dir" in merged_properties:
+            merged_properties["output_dir"]["ui_priority"] = 1
+        reserved_keys = {"app_command", "output_dir"}
+        for key, prop in merged_properties.items():
+            if key not in reserved_keys and isinstance(prop, dict):
+                current_priority = prop.get("ui_priority")
+                if isinstance(current_priority, (int, float)) and current_priority < 2:
+                    prop["ui_priority"] = 2
+
     return {
         "type": "object",
         "properties": merged_properties,

--- a/tests/blocks/test_block_config_schema.py
+++ b/tests/blocks/test_block_config_schema.py
@@ -51,6 +51,22 @@ class TestBlockConfigSchema:
         spec = _spec_from_class(MyBlock, source="test")
         assert spec.config_schema["properties"]["threshold"]["type"] == "number"
 
+    def test_appblock_schema_executable_path_and_output_dir(self) -> None:
+        """Issue #571: AppBlock config_schema has Executable Path (file_browser, priority 0)
+        and Save Outputs At (directory_browser, priority 1)."""
+        from scieasy.blocks.app.app_block import AppBlock
+
+        schema = AppBlock.config_schema
+        props = schema["properties"]
+        # app_command renamed to "Executable Path" with file_browser
+        assert props["app_command"]["title"] == "Executable Path"
+        assert props["app_command"]["ui_widget"] == "file_browser"
+        assert props["app_command"]["ui_priority"] == 0
+        # output_dir is "Save Outputs At" with directory_browser, priority 1
+        assert props["output_dir"]["title"] == "Save Outputs At"
+        assert props["output_dir"]["ui_widget"] == "directory_browser"
+        assert props["output_dir"]["ui_priority"] == 1
+
     def test_spec_from_class_default_when_no_schema(self) -> None:
         class PlainBlock(Block):
             name: ClassVar[str] = "Plain"

--- a/tests/blocks/test_registry.py
+++ b/tests/blocks/test_registry.py
@@ -677,6 +677,39 @@ class TestMergeConfigSchema:
         assert merged["properties"]["output_dir"]["ui_widget"] == "directory_browser"
         assert "custom_field" in merged["properties"]
         assert "app_command" in merged["properties"]
+        # Issue #571: verify forced ordering
+        assert merged["properties"]["app_command"]["ui_priority"] == 0
+        assert merged["properties"]["app_command"]["ui_widget"] == "file_browser"
+        assert merged["properties"]["app_command"]["title"] == "Executable Path"
+        assert merged["properties"]["output_dir"]["ui_priority"] == 1
+
+    def test_appblock_subclass_priority_enforcement(self) -> None:
+        """AppBlock subclass fields with ui_priority < 2 are bumped to 2."""
+        from typing import Any, ClassVar
+
+        from scieasy.blocks.app.app_block import AppBlock
+        from scieasy.blocks.registry import _merge_config_schema
+
+        class MyApp(AppBlock):
+            app_command: ClassVar[str] = "fiji"
+
+            config_schema: ClassVar[dict[str, Any]] = {
+                "type": "object",
+                "properties": {
+                    "sneaky_field": {"type": "string", "ui_priority": 0},
+                    "normal_field": {"type": "string", "ui_priority": 5},
+                },
+                "required": [],
+            }
+
+        merged = _merge_config_schema(MyApp)
+        # sneaky_field tried to claim priority 0 but must be bumped to 2
+        assert merged["properties"]["sneaky_field"]["ui_priority"] == 2
+        # normal_field already >= 2, should be untouched
+        assert merged["properties"]["normal_field"]["ui_priority"] == 5
+        # reserved fields keep their forced priorities
+        assert merged["properties"]["app_command"]["ui_priority"] == 0
+        assert merged["properties"]["output_dir"]["ui_priority"] == 1
 
     def test_subclass_path_override_wins(self) -> None:
         """When a leaf class explicitly declares path, its version wins."""


### PR DESCRIPTION
## Summary
- Rename `app_command` title to "Executable Path" with `file_browser` widget and `ui_priority: 0`
- Set `output_dir` to `ui_priority: 1` (was 0) so it renders second
- Add priority enforcement in `_merge_config_schema()`: for AppBlock subclasses, any field with `ui_priority < 2` (other than `app_command`/`output_dir`) is bumped to 2
- Add tests covering forced ordering and priority enforcement

Closes #571

## Test plan
- [x] `test_appblock_schema_executable_path_and_output_dir` — verifies base schema titles, widgets, priorities
- [x] `test_appblock_subclass_inherits_output_dir` — verifies MRO merge + forced priorities
- [x] `test_appblock_subclass_priority_enforcement` — verifies subclass fields with ui_priority < 2 are bumped

🤖 Generated with [Claude Code](https://claude.com/claude-code)