### PR TITLE
fix(#572): clean up Fiji and ElMAVEN config after AppBlock MRO injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- [#572] Clean up Fiji config after AppBlock MRO injection: remove redundant watch_timeout from config_schema (@claude, 2026-04-11, branch: fix/issue-572/fiji-elmaven-config-cleanup, session: 20260411-020318-clean-up-fiji-and-elmaven-config-after-a)
 - [#569] Add ADR-029 variadic ports implementation roadmap with 8 detailed tickets (@claude, 2026-04-11, branch: docs/issue-569/adr-029-variadic-ports-roadmap, session: 20260411-013533-docs-adr-029-variadic-ports-implementati)
 - [#555] Rewrite ElMAVEN block to follow standard AppBlock pattern -- fixes rerun deadlock (@claude, 2026-04-10, branch: refactor/issue-555/elmaven-standard-pattern, session: 20260410-005711-rewrite-elmaven-block-to-follow-standard)
 - [#541] LCMS process block audit: remove 9 premature/skeleton blocks, fix config labels, improve flux estimate with linregress (@claude, 2026-04-10, branch: refactor/issue-541/lcms-process-audit, session: 20260410-002151-refactor-lcms-lcms-process-block-audit-r)

--- a/packages/scieasy-blocks-imaging/src/scieasy_blocks_imaging/interactive/fiji_block.py
+++ b/packages/scieasy-blocks-imaging/src/scieasy_blocks_imaging/interactive/fiji_block.py
@@ -65,7 +65,6 @@ class FijiBlock(AppBlock):
                 "title": "Optional Fiji macro path",
                 "ui_widget": "file_browser",
             },
-            "watch_timeout": {"type": "integer", "default": 1800},
         },
     }
 

--- a/tests/blocks/test_registry.py
+++ b/tests/blocks/test_registry.py
@@ -777,3 +777,77 @@ class TestMergeConfigSchema:
         merged = _merge_config_schema(Child)
         assert merged["required"].count("x") == 1
         assert merged["required"].count("y") == 1
+
+
+class TestAppBlockSubclassConfigCleanup:
+    """#572: FijiBlock and ElMAVENBlock must not redeclare AppBlock base fields."""
+
+    def test_fiji_own_config_schema_has_no_watch_timeout(self) -> None:
+        """FijiBlock's own config_schema must not include watch_timeout."""
+        from scieasy_blocks_imaging.interactive.fiji_block import FijiBlock
+
+        own_schema = FijiBlock.__dict__.get("config_schema", {})
+        props = own_schema.get("properties", {})
+        assert "watch_timeout" not in props, "watch_timeout should be removed from FijiBlock config_schema"
+
+    def test_fiji_own_config_schema_has_no_app_command(self) -> None:
+        """FijiBlock must not redeclare app_command in its own config_schema."""
+        from scieasy_blocks_imaging.interactive.fiji_block import FijiBlock
+
+        own_schema = FijiBlock.__dict__.get("config_schema", {})
+        props = own_schema.get("properties", {})
+        assert "app_command" not in props, "app_command should be inherited from AppBlock, not redeclared"
+
+    def test_fiji_own_config_schema_has_no_output_patterns(self) -> None:
+        """FijiBlock must not redeclare output_patterns in its own config_schema."""
+        from scieasy_blocks_imaging.interactive.fiji_block import FijiBlock
+
+        own_schema = FijiBlock.__dict__.get("config_schema", {})
+        props = own_schema.get("properties", {})
+        assert "output_patterns" not in props, "output_patterns should be inherited from AppBlock, not redeclared"
+
+    def test_fiji_mro_merged_includes_app_command(self) -> None:
+        """FijiBlock's MRO-merged config_schema includes app_command from AppBlock."""
+        from scieasy_blocks_imaging.interactive.fiji_block import FijiBlock
+
+        from scieasy.blocks.registry import _merge_config_schema
+
+        merged = _merge_config_schema(FijiBlock)
+        props = merged.get("properties", {})
+        assert "app_command" in props, "app_command should be inherited via MRO merge from AppBlock"
+
+    def test_fiji_mro_merged_includes_output_dir(self) -> None:
+        """FijiBlock's MRO-merged config_schema includes output_dir from AppBlock."""
+        from scieasy_blocks_imaging.interactive.fiji_block import FijiBlock
+
+        from scieasy.blocks.registry import _merge_config_schema
+
+        merged = _merge_config_schema(FijiBlock)
+        props = merged.get("properties", {})
+        assert "output_dir" in props, "output_dir should be inherited via MRO merge from AppBlock"
+
+    def test_elmaven_own_config_schema_has_no_app_command(self) -> None:
+        """ElMAVENBlock must not redeclare app_command in its own config_schema."""
+        from scieasy_blocks_lcms.external.elmaven_block import ElMAVENBlock
+
+        own_schema = ElMAVENBlock.__dict__.get("config_schema", {})
+        props = own_schema.get("properties", {})
+        assert "app_command" not in props, "app_command should be inherited from AppBlock, not redeclared"
+
+    def test_elmaven_own_config_schema_has_no_output_patterns(self) -> None:
+        """ElMAVENBlock must not redeclare output_patterns in its own config_schema."""
+        from scieasy_blocks_lcms.external.elmaven_block import ElMAVENBlock
+
+        own_schema = ElMAVENBlock.__dict__.get("config_schema", {})
+        props = own_schema.get("properties", {})
+        assert "output_patterns" not in props, "output_patterns should be inherited from AppBlock, not redeclared"
+
+    def test_elmaven_mro_merged_includes_app_command(self) -> None:
+        """ElMAVENBlock's MRO-merged config_schema includes app_command from AppBlock."""
+        from scieasy_blocks_lcms.external.elmaven_block import ElMAVENBlock
+
+        from scieasy.blocks.registry import _merge_config_schema
+
+        merged = _merge_config_schema(ElMAVENBlock)
+        props = merged.get("properties", {})
+        assert "app_command" in props, "app_command should be inherited via MRO merge from AppBlock"


### PR DESCRIPTION
## Summary

Closes #572

Remove redundant `watch_timeout` from FijiBlock's `config_schema`. After ADR-030 MRO merge (#557), AppBlock base config_schema fields (`app_command`, `output_dir`, `output_patterns`) are auto-inherited by all subclasses via `_merge_config_schema()`.

## Changes

- **FijiBlock**: Removed `watch_timeout` from `config_schema`. The `ClassVar[int] = 1800` default remains on the class. The config_schema entry was redundant (no UI widget, just a type + default that duplicated the ClassVar).
- **ElMAVENBlock**: No changes needed — its `config_schema` only declares `elmaven_path`, which is ElMAVEN-specific and not a duplicate of AppBlock base fields.

## Analysis

| Block | Field | In config_schema? | Action |
|-------|-------|--------------------|--------|
| FijiBlock | `fiji_path` | Yes (Fiji-specific) | KEEP |
| FijiBlock | `macro_path` | Yes (Fiji-specific) | KEEP |
| FijiBlock | `watch_timeout` | Yes (redundant) | REMOVED |
| ElMAVENBlock | `elmaven_path` | Yes (ElMAVEN-specific) | KEEP |

## Checklist
- [x] No ADR needed (simple cleanup)
- [x] Lint passes (`ruff check . && ruff format --check .`)
- [ ] CI passes
- [ ] CHANGELOG updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)