### PR TITLE
fix(#338,#339): AppBlock subprocess and temp exchange dir resource leaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- [#338,#339] Fix AppBlock subprocess leak (no proc.wait after run) and temp exchange directory leak (tempfile.mkdtemp never cleaned up) (@claude, 2026-04-11, branch: fix/issue-338-339/appblock-resource-leaks, session: 20260411-020206-fix-appblock-subprocess-leak-338-and-tem)
 - [#565] Fix BlockConfig.get() to find enriched runtime keys (block_id, project_dir); add data/exchange to create_project (@claude, 2026-04-10, branch: fix/issue-565/blockconfig-get-extra-fields, session: 20260410-045525-fix-blockconfig-get-not-finding-enriched)
 - [#563] Pass raw file paths as CLI arguments to ElMAVEN so files are pre-loaded on launch (@claude, 2026-04-10, branch: fix/issue-563/elmaven-file-args, session: 20260410-040343-fix-563-elmaven-block-does-not-pass-inpu)
 - [#534] Remove is_collection double-ring from port rendering (@claude, 2026-04-10, branch: fix/issue-534/remove-collection-double-ring, session: 20260410-000721-fix-gui-remove-is-collection-double-ring)

--- a/src/scieasy/blocks/app/app_block.py
+++ b/src/scieasy/blocks/app/app_block.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import shutil
 import subprocess
 import tempfile
 from pathlib import Path
@@ -55,6 +56,7 @@ class AppBlock(Block):
     app_command: ClassVar[str] = ""
     execution_mode: ClassVar[ExecutionMode] = ExecutionMode.EXTERNAL
     output_patterns: ClassVar[list[str]] = ["*"]
+    terminate_grace_sec: ClassVar[float] = 10.0
 
     name: ClassVar[str] = "App Block"
     description: ClassVar[str] = "Delegate work to an external GUI application"
@@ -92,6 +94,10 @@ class AppBlock(Block):
         ADR-018: Handles CANCELLED transitions when external process exits unexpectedly.
         ADR-019: Stores ProcessHandle from bridge for cancellation support.
         ADR-020: Accepts and returns Collection-wrapped data.
+
+        Resource cleanup (#338, #339):
+        - Subprocess is always waited on / terminated / killed in finally block.
+        - Temp exchange directories (not project-dir) are cleaned up in finally block.
         """
         bridge = FileExchangeBridge()
         command = config.get("app_command") or self.app_command
@@ -114,6 +120,10 @@ class AppBlock(Block):
                 exchange_dir = Path(tempfile.mkdtemp(prefix="scieasy_app_"))
         exchange_dir.mkdir(parents=True, exist_ok=True)
 
+        # #339: Determine whether exchange_dir is a temp directory that we own.
+        # Project-dir and explicit exchange dirs are intentionally persistent.
+        is_temp_dir = not explicit_dir and not (config.get("project_dir") and config.get("block_id"))
+
         # ADR-020: Unpack Collection inputs to raw values for serialization.
         unpacked_inputs: dict[str, Any] = {}
         for key, value in inputs.items():
@@ -132,49 +142,77 @@ class AppBlock(Block):
         except ValueError as exc:
             raise ValueError(f"AppBlock command validation failed: {exc}") from exc
 
-        # Step 2: Launch and pause (waiting for external interaction).
-        self.transition(BlockState.PAUSED)
-        proc = bridge.launch(command, exchange_dir)
-
-        # ADR-019: Wrap Popen in adapter for FileWatcher process monitoring.
-        process_adapter = _PopenProcessAdapter(proc)
-
-        # Step 3: Watch for outputs with process monitoring.
-        # ADR-030 D3: use user-selected output_dir if configured.
-        from scieasy.blocks.app.watcher import FileWatcher, ProcessExitedWithoutOutputError
-
-        custom_output_dir = config.get("output_dir")
-        output_dir = Path(custom_output_dir) if custom_output_dir else exchange_dir / "outputs"
-        output_dir.mkdir(parents=True, exist_ok=True)
-        stability_period = float(config.get("stability_period", 2.0))
-        done_marker = config.get("done_marker")
-        watcher = FileWatcher(
-            directory=output_dir,
-            patterns=patterns,
-            timeout=None,
-            process_handle=process_adapter,
-            stability_period=stability_period,
-            done_marker=done_marker,
-        )
-        watcher.start()
+        proc: subprocess.Popen[bytes] | None = None
         try:
-            output_files = watcher.wait_for_output()
-        except ProcessExitedWithoutOutputError:
-            # ADR-018: Process exited without producing output — cancel.
-            self.transition(BlockState.CANCELLED)
-            return {}
+            # Step 2: Launch and pause (waiting for external interaction).
+            self.transition(BlockState.PAUSED)
+            proc = bridge.launch(command, exchange_dir)
+
+            # ADR-019: Wrap Popen in adapter for FileWatcher process monitoring.
+            process_adapter = _PopenProcessAdapter(proc)
+
+            # Step 3: Watch for outputs with process monitoring.
+            # ADR-030 D3: use user-selected output_dir if configured.
+            from scieasy.blocks.app.watcher import FileWatcher, ProcessExitedWithoutOutputError
+
+            custom_output_dir = config.get("output_dir")
+            output_dir = Path(custom_output_dir) if custom_output_dir else exchange_dir / "outputs"
+            output_dir.mkdir(parents=True, exist_ok=True)
+            stability_period = float(config.get("stability_period", 2.0))
+            done_marker = config.get("done_marker")
+            watcher = FileWatcher(
+                directory=output_dir,
+                patterns=patterns,
+                timeout=None,
+                process_handle=process_adapter,
+                stability_period=stability_period,
+                done_marker=done_marker,
+            )
+            watcher.start()
+            try:
+                output_files = watcher.wait_for_output()
+            except ProcessExitedWithoutOutputError:
+                # ADR-018: Process exited without producing output — cancel.
+                self.transition(BlockState.CANCELLED)
+                return {}
+            finally:
+                watcher.stop()
+
+            # Step 4: Collect results.
+            results = bridge.collect(output_files)
+
+            # ADR-020: Wrap output artifacts in Collection.
+            collection_results: dict[str, Any] = {}
+            for key, value in results.items():
+                if isinstance(value, Artifact):
+                    collection_results[key] = Collection([value], item_type=Artifact)
+                else:
+                    collection_results[key] = value
+
+            return collection_results
         finally:
-            watcher.stop()
+            # #338: Reap subprocess to prevent zombie processes.
+            if proc is not None:
+                _cleanup_process(proc, self.terminate_grace_sec)
+            # #339: Remove temp exchange directory (not project-dir).
+            if is_temp_dir and exchange_dir.exists():
+                shutil.rmtree(exchange_dir, ignore_errors=True)
 
-        # Step 4: Collect results.
-        results = bridge.collect(output_files)
 
-        # ADR-020: Wrap output artifacts in Collection.
-        collection_results: dict[str, Any] = {}
-        for key, value in results.items():
-            if isinstance(value, Artifact):
-                collection_results[key] = Collection([value], item_type=Artifact)
-            else:
-                collection_results[key] = value
+def _cleanup_process(
+    proc: subprocess.Popen[bytes],
+    terminate_grace_sec: float = 10.0,
+) -> None:
+    """Wait for *proc* to exit; terminate/kill if it does not exit in time.
 
-        return collection_results
+    Sequence: wait(5s) -> terminate -> wait(grace) -> kill -> wait.
+    """
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.terminate()
+        try:
+            proc.wait(timeout=terminate_grace_sec)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait()

--- a/tests/blocks/test_app_block.py
+++ b/tests/blocks/test_app_block.py
@@ -529,3 +529,268 @@ class TestFileWatcherStability:
         assert len(files) == 1
         # Total elapsed should be at least 0.1 (delay) + stability_period.
         assert elapsed >= 0.1 + stability - 0.15  # tolerance
+
+
+# ---------------------------------------------------------------------------
+# #338: Subprocess leak — proc.wait() must be called after run()
+# #339: Tempfile exchange directory leak — temp dirs must be cleaned up
+# ---------------------------------------------------------------------------
+
+
+class TestAppBlockSubprocessCleanup:
+    """#338: Verify subprocess is properly waited on / terminated after run()."""
+
+    def _make_running_block(self):
+        """Create an AppBlock in RUNNING state."""
+        from scieasy.blocks.app.app_block import AppBlock
+        from scieasy.blocks.base.state import BlockState
+
+        block = AppBlock()
+        block.transition(BlockState.READY)
+        block.transition(BlockState.RUNNING)
+        return block
+
+    def test_proc_wait_called_on_normal_exit(self, tmp_path: Path) -> None:
+        """After successful run(), proc.wait() must be called to reap the process."""
+        from unittest.mock import MagicMock, patch
+
+        from scieasy.blocks.base.config import BlockConfig
+
+        block = self._make_running_block()
+        config = BlockConfig(params={"app_command": "echo hello"})
+
+        with (
+            patch("scieasy.blocks.app.app_block.FileExchangeBridge") as mock_bridge_cls,
+            patch("scieasy.blocks.app.app_block.validate_app_command", return_value=["echo", "hello"]),
+            patch(
+                "scieasy.blocks.app.app_block.tempfile.mkdtemp",
+                return_value=str(tmp_path / "temp_exchange"),
+            ),
+        ):
+            mock_bridge = MagicMock()
+            mock_bridge_cls.return_value = mock_bridge
+            mock_proc = MagicMock()
+            mock_proc.poll.return_value = None
+            mock_proc.pid = 12345
+            mock_proc.wait.return_value = 0
+            mock_bridge.launch.return_value = mock_proc
+
+            with patch("scieasy.blocks.app.watcher.FileWatcher") as mock_watcher_cls:
+                mock_watcher = MagicMock()
+                mock_watcher_cls.return_value = mock_watcher
+                fake_output = tmp_path / "result.csv"
+                fake_output.write_text("a,b\n1,2\n")
+                mock_watcher.wait_for_output.return_value = [fake_output]
+                mock_bridge.collect.return_value = {}
+
+                block.run(inputs={}, config=config)
+
+            # proc.wait() must have been called at least once (cleanup).
+            assert mock_proc.wait.called, "proc.wait() was never called — subprocess leak (#338)"
+
+    def test_proc_terminated_when_wait_times_out(self, tmp_path: Path) -> None:
+        """If proc.wait() times out, proc.terminate() must be called."""
+        import subprocess as _subprocess
+        from unittest.mock import MagicMock, patch
+
+        from scieasy.blocks.base.config import BlockConfig
+
+        block = self._make_running_block()
+        config = BlockConfig(params={"app_command": "echo hello"})
+
+        with (
+            patch("scieasy.blocks.app.app_block.FileExchangeBridge") as mock_bridge_cls,
+            patch("scieasy.blocks.app.app_block.validate_app_command", return_value=["echo", "hello"]),
+            patch(
+                "scieasy.blocks.app.app_block.tempfile.mkdtemp",
+                return_value=str(tmp_path / "temp_exchange"),
+            ),
+        ):
+            mock_bridge = MagicMock()
+            mock_bridge_cls.return_value = mock_bridge
+            mock_proc = MagicMock()
+            mock_proc.poll.return_value = None
+            mock_proc.pid = 12345
+            # First wait times out, second (after terminate) succeeds.
+            mock_proc.wait.side_effect = [
+                _subprocess.TimeoutExpired(cmd="echo", timeout=5),
+                0,  # after terminate
+            ]
+            mock_bridge.launch.return_value = mock_proc
+
+            with patch("scieasy.blocks.app.watcher.FileWatcher") as mock_watcher_cls:
+                mock_watcher = MagicMock()
+                mock_watcher_cls.return_value = mock_watcher
+                fake_output = tmp_path / "result.csv"
+                fake_output.write_text("a,b\n1,2\n")
+                mock_watcher.wait_for_output.return_value = [fake_output]
+                mock_bridge.collect.return_value = {}
+
+                block.run(inputs={}, config=config)
+
+            mock_proc.terminate.assert_called_once()
+
+    def test_proc_waited_on_process_exited_without_output(self, tmp_path: Path) -> None:
+        """On ProcessExitedWithoutOutputError, proc must still be waited on."""
+        from unittest.mock import MagicMock, patch
+
+        from scieasy.blocks.app.watcher import ProcessExitedWithoutOutputError
+        from scieasy.blocks.base.config import BlockConfig
+
+        block = self._make_running_block()
+        config = BlockConfig(params={"app_command": "echo hello"})
+
+        with (
+            patch("scieasy.blocks.app.app_block.FileExchangeBridge") as mock_bridge_cls,
+            patch("scieasy.blocks.app.app_block.validate_app_command", return_value=["echo", "hello"]),
+            patch(
+                "scieasy.blocks.app.app_block.tempfile.mkdtemp",
+                return_value=str(tmp_path / "temp_exchange"),
+            ),
+        ):
+            mock_bridge = MagicMock()
+            mock_bridge_cls.return_value = mock_bridge
+            mock_proc = MagicMock()
+            mock_proc.poll.return_value = None
+            mock_proc.pid = 12345
+            mock_proc.wait.return_value = 0
+            mock_bridge.launch.return_value = mock_proc
+
+            with patch("scieasy.blocks.app.watcher.FileWatcher") as mock_watcher_cls:
+                mock_watcher = MagicMock()
+                mock_watcher_cls.return_value = mock_watcher
+                mock_watcher.wait_for_output.side_effect = ProcessExitedWithoutOutputError("Process exited")
+                mock_bridge.collect.return_value = {}
+
+                result = block.run(inputs={}, config=config)
+
+            assert result == {}
+            assert mock_proc.wait.called, "proc.wait() not called on cancelled path (#338)"
+
+
+class TestAppBlockTempDirCleanup:
+    """#339: Verify temp exchange directories are cleaned up."""
+
+    def _make_running_block(self):
+        from scieasy.blocks.app.app_block import AppBlock
+        from scieasy.blocks.base.state import BlockState
+
+        block = AppBlock()
+        block.transition(BlockState.READY)
+        block.transition(BlockState.RUNNING)
+        return block
+
+    def test_temp_exchange_dir_cleaned_up(self, tmp_path: Path) -> None:
+        """Temp exchange dir (no project_dir) must be removed after run()."""
+        from unittest.mock import MagicMock, patch
+
+        from scieasy.blocks.base.config import BlockConfig
+
+        block = self._make_running_block()
+
+        temp_dir = tmp_path / "scieasy_app_temp"
+        config = BlockConfig(params={"app_command": "echo hello"})
+
+        with (
+            patch("scieasy.blocks.app.app_block.FileExchangeBridge") as mock_bridge_cls,
+            patch("scieasy.blocks.app.app_block.validate_app_command", return_value=["echo", "hello"]),
+            patch(
+                "scieasy.blocks.app.app_block.tempfile.mkdtemp",
+                return_value=str(temp_dir),
+            ),
+        ):
+            mock_bridge = MagicMock()
+            mock_bridge_cls.return_value = mock_bridge
+            mock_proc = MagicMock()
+            mock_proc.poll.return_value = None
+            mock_proc.pid = 12345
+            mock_proc.wait.return_value = 0
+            mock_bridge.launch.return_value = mock_proc
+
+            with patch("scieasy.blocks.app.watcher.FileWatcher") as mock_watcher_cls:
+                mock_watcher = MagicMock()
+                mock_watcher_cls.return_value = mock_watcher
+                fake_output = tmp_path / "result.csv"
+                fake_output.write_text("a,b\n1,2\n")
+                mock_watcher.wait_for_output.return_value = [fake_output]
+                mock_bridge.collect.return_value = {}
+
+                block.run(inputs={}, config=config)
+
+        # The temp dir should have been cleaned up.
+        assert not temp_dir.exists(), "Temp exchange dir was not cleaned up (#339)"
+
+    def test_project_exchange_dir_not_cleaned_up(self, tmp_path: Path) -> None:
+        """Project exchange dir (project_dir + block_id) must NOT be removed."""
+        from unittest.mock import MagicMock, patch
+
+        from scieasy.blocks.base.config import BlockConfig
+
+        block = self._make_running_block()
+
+        project_dir = tmp_path / "my_project"
+        project_dir.mkdir()
+        config = BlockConfig(
+            params={
+                "app_command": "echo hello",
+                "project_dir": str(project_dir),
+                "block_id": "block_123",
+            }
+        )
+
+        exchange_dir = project_dir / "data" / "exchange" / "block_123"
+
+        with (
+            patch("scieasy.blocks.app.app_block.FileExchangeBridge") as mock_bridge_cls,
+            patch("scieasy.blocks.app.app_block.validate_app_command", return_value=["echo", "hello"]),
+        ):
+            mock_bridge = MagicMock()
+            mock_bridge_cls.return_value = mock_bridge
+            mock_proc = MagicMock()
+            mock_proc.poll.return_value = None
+            mock_proc.pid = 12345
+            mock_proc.wait.return_value = 0
+            mock_bridge.launch.return_value = mock_proc
+
+            with patch("scieasy.blocks.app.watcher.FileWatcher") as mock_watcher_cls:
+                mock_watcher = MagicMock()
+                mock_watcher_cls.return_value = mock_watcher
+                fake_output = tmp_path / "result.csv"
+                fake_output.write_text("a,b\n1,2\n")
+                mock_watcher.wait_for_output.return_value = [fake_output]
+                mock_bridge.collect.return_value = {}
+
+                block.run(inputs={}, config=config)
+
+        # Project exchange dir must still exist.
+        assert exchange_dir.exists(), "Project exchange dir was incorrectly cleaned up (#339)"
+
+    def test_temp_dir_cleaned_up_on_error(self, tmp_path: Path) -> None:
+        """Temp exchange dir must be cleaned up even if run() raises."""
+        from unittest.mock import MagicMock, patch
+
+        from scieasy.blocks.base.config import BlockConfig
+
+        block = self._make_running_block()
+
+        temp_dir = tmp_path / "scieasy_app_error"
+        config = BlockConfig(params={"app_command": "echo hello"})
+
+        with (
+            patch("scieasy.blocks.app.app_block.FileExchangeBridge") as mock_bridge_cls,
+            patch("scieasy.blocks.app.app_block.validate_app_command", return_value=["echo", "hello"]),
+            patch(
+                "scieasy.blocks.app.app_block.tempfile.mkdtemp",
+                return_value=str(temp_dir),
+            ),
+        ):
+            mock_bridge = MagicMock()
+            mock_bridge_cls.return_value = mock_bridge
+            # bridge.launch raises an error.
+            mock_bridge.launch.side_effect = RuntimeError("launch failed")
+
+            with pytest.raises(RuntimeError, match="launch failed"):
+                block.run(inputs={}, config=config)
+
+        # Even on error, temp dir should be cleaned up.
+        assert not temp_dir.exists(), "Temp dir not cleaned up after error (#339)"


### PR DESCRIPTION
## Summary
- **#338**: Add subprocess cleanup (`wait`/`terminate`/`kill`) in `try/finally` to prevent zombie processes after `AppBlock.run()` completes
- **#339**: Clean up temp exchange directories (created via `tempfile.mkdtemp`) in `finally` block; project-dir exchange directories are intentionally preserved

## Changes
- `src/scieasy/blocks/app/app_block.py`: Wrap `run()` body in `try/finally`; add `_cleanup_process()` module-level helper; add `terminate_grace_sec` class variable; import `shutil`
- `tests/blocks/test_app_block.py`: Add `TestAppBlockSubprocessCleanup` (3 tests) and `TestAppBlockTempDirCleanup` (3 tests)

## Related Issues
Closes #338
Closes #339

## Checklist
- [x] Tests added covering both fixes (6 new tests)
- [x] Lint and format pass
- [x] No ADR needed (simple bug fix)
- [ ] CHANGELOG updated (next gate step)
- [ ] CI passes