### PR TITLE
fix(#580): add WORKFLOW_STARTED to WebSocket outbound events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- [#580] Add WORKFLOW_STARTED to WebSocket outbound events so frontend Run button spinner activates (@claude, 2026-04-11, branch: fix/issue-580/workflow-started-ws, session: 20260411-032524-fix-580-add-workflow-started-to-websocke)
+
 ### Changed
 
 - [#574] Remove CellProfiler/QuPath blocks, add subcategory labels to Imaging blocks, enable category override in registry (@claude, 2026-04-11, branch: refactor/issue-574/imaging-cleanup-subcategories, session: 20260411-021002-remove-cellprofiler-qupath-blocks-add-su)

--- a/src/scieasy/api/ws.py
+++ b/src/scieasy/api/ws.py
@@ -24,6 +24,7 @@ from scieasy.engine.events import (
     CANCEL_BLOCK_REQUEST,
     CANCEL_WORKFLOW_REQUEST,
     WORKFLOW_COMPLETED,
+    WORKFLOW_STARTED,
     EngineEvent,
     EventBus,
 )
@@ -41,6 +42,7 @@ _OUTBOUND_EVENTS = frozenset(
         BLOCK_CANCELLED,
         BLOCK_SKIPPED,
         WORKFLOW_COMPLETED,
+        WORKFLOW_STARTED,
     }
 )
 

--- a/tests/api/test_ws.py
+++ b/tests/api/test_ws.py
@@ -9,9 +9,21 @@ from unittest.mock import AsyncMock
 from fastapi.testclient import TestClient
 
 from scieasy.api.runtime import ApiRuntime
-from scieasy.api.ws import websocket_handler
-from scieasy.engine.events import BLOCK_DONE, CANCEL_BLOCK_REQUEST, CANCEL_WORKFLOW_REQUEST, EngineEvent, EventBus
+from scieasy.api.ws import _OUTBOUND_EVENTS, websocket_handler
+from scieasy.engine.events import (
+    BLOCK_DONE,
+    CANCEL_BLOCK_REQUEST,
+    CANCEL_WORKFLOW_REQUEST,
+    WORKFLOW_STARTED,
+    EngineEvent,
+    EventBus,
+)
 from tests.api.helpers import wait_for_condition
+
+
+def test_workflow_started_in_outbound_events() -> None:
+    """WORKFLOW_STARTED must be forwarded to WebSocket clients (#580)."""
+    assert WORKFLOW_STARTED in _OUTBOUND_EVENTS
 
 
 def test_websocket_receives_serialised_engine_events(client: TestClient, runtime: ApiRuntime) -> None:


### PR DESCRIPTION
Closes #580

## Summary
- Add `WORKFLOW_STARTED` to the import from `scieasy.engine.events` in `src/scieasy/api/ws.py`
- Add `WORKFLOW_STARTED` to the `_OUTBOUND_EVENTS` frozenset so it is forwarded to WebSocket clients

Without this, the frontend Run button spinner never activates because the `workflow_started` event is never pushed over the WebSocket.

## Checklist
- [x] Lint clean (`ruff check . && ruff format --check .`)
- [x] WS tests pass (`tests/api/test_ws.py`)
- [x] No ADR needed (simple bug fix)