### PR TITLE
fix(#579): fix 7 project management bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- [#579] Fix 7 project management bugs: browse button, sort by last_opened, prune deleted, rename Save Project, delete button, clear canvas on open, direct recent open, AppBlock output_dir default (@claude, 2026-04-11, branch: fix/issue-579/project-management-bugs, session: 20260411-032627-fix-7-project-management-bugs-579)
 - [#574] Remove CellProfiler/QuPath blocks, add subcategory labels to Imaging blocks, enable category override in registry (@claude, 2026-04-11, branch: refactor/issue-574/imaging-cleanup-subcategories, session: 20260411-021002-remove-cellprofiler-qupath-blocks-add-su)
 - [#571] Inject Executable Path (file_browser) + Save Outputs At with forced ui_priority ordering in AppBlock (@claude, 2026-04-11, branch: fix/issue-571/appblock-config-injection, session: 20260411-020155-fix-571-inject-executable-path-save-outp)
 - [#572] Clean up Fiji config after AppBlock MRO injection: remove redundant watch_timeout from config_schema (@claude, 2026-04-11, branch: fix/issue-572/fiji-elmaven-config-cleanup, session: 20260411-020318-clean-up-fiji-and-elmaven-config-after-a)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -173,10 +173,19 @@ export default function App() {
     setBusy(true);
     try {
       const project = await api.openProject(projectIdOrPath);
+      // Bug 5: Clear current canvas state before loading new project.
+      // Reset workflow and clear all tabs so old project state is gone.
+      setWorkflow(null);
+      resetExecution();
+      // Force-clear all tabs from the store (useAppStore.setState is
+      // available via the bound set, but the simplest approach is to
+      // leverage the fact that openTab will create a fresh tab after
+      // we clear the tabs array here).
+      useAppStore.setState({ tabs: [], activeTabId: null });
+
       setCurrentProject(project);
       await refreshProjects();
       await loadWorkflowForProject(project);
-      resetExecution();
       setLastError(null);
       closeProjectDialog();
     } catch (error) {
@@ -208,6 +217,21 @@ export default function App() {
       setLastError((error as Error).message);
     } finally {
       setBusy(false);
+    }
+  }
+
+  async function deleteProject(projectId: string) {
+    try {
+      await api.deleteProject(projectId);
+      // If the deleted project is the current one, close it
+      if (currentProject?.id === projectId) {
+        setCurrentProject(null);
+        setWorkflow(null);
+        resetExecution();
+      }
+      await refreshProjects();
+    } catch (error) {
+      setLastError((error as Error).message);
     }
   }
 
@@ -611,6 +635,7 @@ export default function App() {
             recentProjects={recentProjects}
             onNewProject={() => openProjectDialog("new", { path: projectDialog.path })}
             onOpenProject={() => openProjectDialog("open")}
+            onOpenRecent={(project) => void openProject(project.id)}
             onCloseProject={() => {
               setCurrentProject(null);
               setWorkflow(emptyWorkflow());
@@ -676,12 +701,17 @@ export default function App() {
                         blocks={blocks}
                         collapsed={false}
                         onAddBlock={(block) => {
-                          const defaultParams: Record<string, unknown> | undefined = block.direction
-                            ? { direction: block.direction }
-                            : block.type_name === "io_block"
-                              ? { direction: block.name === "Load Block" ? "input" : "output" }
-                              : undefined;
-                          addNode(block, { x: 160, y: 160 }, defaultParams);
+                          const defaultParams: Record<string, unknown> = {};
+                          if (block.direction) {
+                            defaultParams.direction = block.direction;
+                          } else if (block.type_name === "io_block") {
+                            defaultParams.direction = block.name === "Load Block" ? "input" : "output";
+                          }
+                          // Bug 7: Set default output_dir for AppBlocks when a project is open
+                          if (block.category === "app" && currentProject) {
+                            defaultParams.output_dir = `${currentProject.path}/data/exchange/outputs`;
+                          }
+                          addNode(block, { x: 160, y: 160 }, Object.keys(defaultParams).length > 0 ? defaultParams : undefined);
                         }}
                         onReload={() => void refreshBlocks()}
                         onSearch={setPaletteSearch}
@@ -811,6 +841,7 @@ export default function App() {
           ) : (
             <div className="min-h-0 flex-1">
               <WelcomeScreen
+                onDeleteProject={(projectId) => void deleteProject(projectId)}
                 onNewProject={() => openProjectDialog("new")}
                 onOpenProject={() => openProjectDialog("open")}
                 onOpenRecent={(projectId) => void openProject(projectId)}
@@ -825,6 +856,7 @@ export default function App() {
             name={projectDialog.name}
             onChange={updateProjectDialog}
             onClose={closeProjectDialog}
+            onDeleteProject={(projectId) => void deleteProject(projectId)}
             onOpenRecent={(projectId) => void openProject(projectId)}
             onSubmit={() => void submitProjectDialog()}
             open={projectDialogOpen}

--- a/frontend/src/components/ProjectDialog.tsx
+++ b/frontend/src/components/ProjectDialog.tsx
@@ -1,3 +1,6 @@
+import { useState } from "react";
+
+import { api } from "../lib/api";
 import type { ProjectResponse } from "../types/api";
 
 interface ProjectDialogProps {
@@ -11,6 +14,7 @@ interface ProjectDialogProps {
   onChange: (patch: Partial<{ name: string; description: string; path: string }>) => void;
   onSubmit: () => void;
   onOpenRecent: (projectIdOrPath: string) => void;
+  onDeleteProject?: (projectId: string) => void;
 }
 
 export function ProjectDialog({
@@ -24,9 +28,44 @@ export function ProjectDialog({
   onChange,
   onSubmit,
   onOpenRecent,
+  onDeleteProject,
 }: ProjectDialogProps) {
+  const [pathError, setPathError] = useState<string | null>(null);
+
   if (!open) {
     return null;
+  }
+
+  async function handleBrowse() {
+    try {
+      const result = await api.openNativeDialog("directory");
+      if (result.paths.length > 0) {
+        onChange({ path: result.paths[0] });
+        setPathError(null);
+      }
+    } catch {
+      // Dialog cancelled or error — ignore
+    }
+  }
+
+  function handleSubmit() {
+    if (mode === "new" && !path.trim()) {
+      setPathError("Parent directory is required");
+      return;
+    }
+    if (mode === "open" && !path.trim()) {
+      setPathError("Project path is required");
+      return;
+    }
+    setPathError(null);
+    onSubmit();
+  }
+
+  function handleDeleteProject(event: React.MouseEvent, projectId: string, projectName: string) {
+    event.stopPropagation();
+    if (onDeleteProject && window.confirm(`Delete project '${projectName}'? This cannot be undone.`)) {
+      onDeleteProject(projectId);
+    }
   }
 
   return (
@@ -48,12 +87,21 @@ export function ProjectDialog({
           <label className="grid gap-2 text-sm text-stone-700">
             <span className="font-medium">{mode === "new" ? "Project name" : "Project ID or path"}</span>
             {mode === "open" ? (
-              <input
-                className="min-w-0 flex-1 rounded-2xl border border-stone-300 bg-white px-4 py-3 outline-none transition focus:border-ember"
-                onChange={(event) => onChange({ path: event.target.value })}
-                placeholder="C:\\research\\atlas-project"
-                value={path}
-              />
+              <div className="flex gap-2">
+                <input
+                  className="min-w-0 flex-1 rounded-2xl border border-stone-300 bg-white px-4 py-3 outline-none transition focus:border-ember"
+                  onChange={(event) => { onChange({ path: event.target.value }); setPathError(null); }}
+                  placeholder="C:\\research\\atlas-project"
+                  value={path}
+                />
+                <button
+                  className="shrink-0 rounded-2xl border border-stone-300 bg-white px-4 py-3 text-sm font-medium text-stone-600 transition hover:border-ember hover:text-ember"
+                  onClick={() => void handleBrowse()}
+                  type="button"
+                >
+                  Browse
+                </button>
+              </div>
             ) : (
               <input
                 className="rounded-2xl border border-stone-300 bg-white px-4 py-3 outline-none transition focus:border-ember"
@@ -64,15 +112,24 @@ export function ProjectDialog({
             )}
           </label>
           {mode === "new" ? (
-            <label className="grid gap-2 text-sm text-stone-700">
+            <div className="grid gap-2 text-sm text-stone-700">
               <span className="font-medium">Parent directory</span>
-              <input
-                className="min-w-0 flex-1 rounded-2xl border border-stone-300 bg-white px-4 py-3 outline-none transition focus:border-ember"
-                onChange={(event) => onChange({ path: event.target.value })}
-                placeholder="C:\\projects"
-                value={path}
-              />
-            </label>
+              <div className="flex gap-2">
+                <input
+                  className="min-w-0 flex-1 rounded-2xl border border-stone-300 bg-white px-4 py-3 outline-none transition focus:border-ember"
+                  onChange={(event) => { onChange({ path: event.target.value }); setPathError(null); }}
+                  placeholder="C:\\projects"
+                  value={path}
+                />
+                <button
+                  className="shrink-0 rounded-2xl border border-stone-300 bg-white px-4 py-3 text-sm font-medium text-stone-600 transition hover:border-ember hover:text-ember"
+                  onClick={() => void handleBrowse()}
+                  type="button"
+                >
+                  Browse
+                </button>
+              </div>
+            </div>
           ) : null}
           {mode === "new" ? (
             <label className="grid gap-2 text-sm text-stone-700 md:col-span-2">
@@ -87,23 +144,43 @@ export function ProjectDialog({
           ) : null}
         </div>
 
+        {pathError ? (
+          <p className="mt-2 text-sm text-red-600">{pathError}</p>
+        ) : null}
+
         <div className="mt-6 rounded-[1.5rem] border border-stone-200 bg-white/80 p-4">
           <p className="text-xs uppercase tracking-[0.3em] text-stone-500">Recent projects</p>
-          <div className="mt-3 flex flex-col gap-2">
+          <div className="mt-3 flex max-h-64 flex-col gap-2 overflow-y-auto">
             {recentProjects.length ? (
-              recentProjects.slice(0, 5).map((project) => (
+              recentProjects.map((project) => (
                 <button
                   className="flex items-center justify-between rounded-2xl border border-stone-200 px-4 py-3 text-left transition hover:border-pine hover:bg-pine/5"
                   key={project.id}
                   onClick={() => onOpenRecent(project.id)}
                   type="button"
                 >
-                  <span>
-                    <span className="block font-medium text-ink">{project.name}</span>
-                    <span className="block text-xs text-stone-500">{project.path}</span>
+                  <span className="min-w-0 flex-1">
+                    <span className="block truncate font-medium text-ink">{project.name}</span>
+                    <span className="block truncate text-xs text-stone-500">{project.path}</span>
                   </span>
-                  <span className="rounded-full bg-sand px-3 py-1 text-xs text-stone-700">
-                    {project.workflow_count} workflow{project.workflow_count === 1 ? "" : "s"}
+                  <span className="flex shrink-0 items-center gap-2">
+                    <span className="rounded-full bg-sand px-3 py-1 text-xs text-stone-700">
+                      {project.workflow_count} workflow{project.workflow_count === 1 ? "" : "s"}
+                    </span>
+                    {onDeleteProject ? (
+                      <span
+                        className="rounded-full p-1 text-stone-400 transition hover:bg-red-50 hover:text-red-600"
+                        onClick={(event) => handleDeleteProject(event, project.id, project.name)}
+                        onKeyDown={() => {}}
+                        role="button"
+                        tabIndex={0}
+                        title="Delete project"
+                      >
+                        <svg className="size-4" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
+                          <path d="M3 6h18M8 6V4a2 2 0 012-2h4a2 2 0 012 2v2m3 0v14a2 2 0 01-2 2H7a2 2 0 01-2-2V6h14" strokeLinecap="round" strokeLinejoin="round" />
+                        </svg>
+                      </span>
+                    ) : null}
                   </span>
                 </button>
               ))
@@ -119,7 +196,7 @@ export function ProjectDialog({
           </button>
           <button
             className="rounded-full bg-ink px-5 py-2 text-sm font-medium text-stone-50 transition hover:bg-pine"
-            onClick={onSubmit}
+            onClick={handleSubmit}
             type="button"
           >
             {mode === "new" ? "Create project" : "Open project"}

--- a/frontend/src/components/Toolbar.tsx
+++ b/frontend/src/components/Toolbar.tsx
@@ -48,6 +48,7 @@ interface ToolbarProps {
   recentProjects: ProjectResponse[];
   onNewProject: () => void;
   onOpenProject: () => void;
+  onOpenRecent: (project: ProjectResponse) => void;
   onCloseProject: () => void;
   onNewWorkflow: () => void;
   onSave: () => void;
@@ -146,6 +147,7 @@ export function Toolbar(props: ToolbarProps) {
     recentProjects,
     onNewProject,
     onOpenProject,
+    onOpenRecent,
     onCloseProject,
     onNewWorkflow,
     onSave,
@@ -195,7 +197,7 @@ export function Toolbar(props: ToolbarProps) {
               <ChevronDown className="size-3" />
             </Button>
           </DropdownMenuTrigger>
-          <DropdownMenuContent align="start" className="w-56">
+          <DropdownMenuContent align="start" className="max-h-96 w-56 overflow-y-auto">
             <DropdownMenuItem onClick={onNewProject}>
               <Plus className="size-4" />
               New Project...
@@ -209,7 +211,7 @@ export function Toolbar(props: ToolbarProps) {
               onClick={onSave}
             >
               <Save className="size-4" />
-              Save Project
+              Save Workflow
             </DropdownMenuItem>
             <DropdownMenuSeparator />
             <DropdownMenuLabel>Recent Projects</DropdownMenuLabel>
@@ -217,7 +219,7 @@ export function Toolbar(props: ToolbarProps) {
               recentProjects.slice(0, 5).map((project) => (
                 <DropdownMenuItem
                   key={project.id}
-                  onClick={onOpenProject}
+                  onClick={() => onOpenRecent(project)}
                 >
                   <span className="truncate">{project.name}</span>
                 </DropdownMenuItem>

--- a/frontend/src/components/WelcomeScreen.tsx
+++ b/frontend/src/components/WelcomeScreen.tsx
@@ -5,6 +5,7 @@ interface WelcomeScreenProps {
   onNewProject: () => void;
   onOpenProject: () => void;
   onOpenRecent: (projectId: string) => void;
+  onDeleteProject?: (projectId: string) => void;
 }
 
 export function WelcomeScreen({
@@ -12,7 +13,14 @@ export function WelcomeScreen({
   onNewProject,
   onOpenProject,
   onOpenRecent,
+  onDeleteProject,
 }: WelcomeScreenProps) {
+  function handleDeleteProject(event: React.MouseEvent, projectId: string, projectName: string) {
+    event.stopPropagation();
+    if (onDeleteProject && window.confirm(`Delete project '${projectName}'? This cannot be undone.`)) {
+      onDeleteProject(projectId);
+    }
+  }
   return (
     <div className="flex h-full items-center justify-center overflow-auto p-6">
       <div className="w-full max-w-4xl rounded-[2.5rem] border border-stone-200 bg-[radial-gradient(circle_at_top_left,_rgba(240,106,68,0.2),_transparent_35%),linear-gradient(135deg,_rgba(255,255,255,0.95),_rgba(245,241,232,0.98))] p-8 shadow-panel">
@@ -46,17 +54,33 @@ export function WelcomeScreen({
 
           <div className="rounded-[2rem] border border-stone-200 bg-white/80 p-5">
             <p className="text-xs uppercase tracking-[0.3em] text-stone-500">Recent Workspaces</p>
-            <div className="mt-4 flex flex-col gap-3">
+            <div className="mt-4 flex max-h-80 flex-col gap-3 overflow-y-auto">
               {recentProjects.length ? (
-                recentProjects.slice(0, 5).map((project) => (
+                recentProjects.map((project) => (
                   <button
-                    className="rounded-[1.5rem] border border-stone-200 px-4 py-4 text-left transition hover:border-pine hover:bg-pine/5"
+                    className="flex items-center justify-between rounded-[1.5rem] border border-stone-200 px-4 py-4 text-left transition hover:border-pine hover:bg-pine/5"
                     key={project.id}
                     onClick={() => onOpenRecent(project.id)}
                     type="button"
                   >
-                    <span className="block font-medium text-ink">{project.name}</span>
-                    <span className="mt-1 block text-xs text-stone-500">{project.path}</span>
+                    <span className="min-w-0 flex-1">
+                      <span className="block truncate font-medium text-ink">{project.name}</span>
+                      <span className="mt-1 block truncate text-xs text-stone-500">{project.path}</span>
+                    </span>
+                    {onDeleteProject ? (
+                      <span
+                        className="ml-2 shrink-0 rounded-full p-1 text-stone-400 transition hover:bg-red-50 hover:text-red-600"
+                        onClick={(event) => handleDeleteProject(event, project.id, project.name)}
+                        onKeyDown={() => {}}
+                        role="button"
+                        tabIndex={0}
+                        title="Delete project"
+                      >
+                        <svg className="size-4" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
+                          <path d="M3 6h18M8 6V4a2 2 0 012-2h4a2 2 0 012 2v2m3 0v14a2 2 0 01-2 2H7a2 2 0 01-2-2V6h14" strokeLinecap="round" strokeLinejoin="round" />
+                        </svg>
+                      </span>
+                    ) : null}
                   </button>
                 ))
               ) : (

--- a/src/scieasy/api/runtime.py
+++ b/src/scieasy/api/runtime.py
@@ -361,7 +361,18 @@ class ApiRuntime:
 
     def list_projects(self) -> list[KnownProject]:
         self._load_known_projects()
-        return sorted(self.known_projects.values(), key=lambda item: item.name.lower())
+        # Prune entries whose project directory no longer exists on disk
+        stale_ids = [pid for pid, entry in self.known_projects.items() if not Path(entry.path).is_dir()]
+        if stale_ids:
+            for pid in stale_ids:
+                self.known_projects.pop(pid, None)
+            self._save_known_projects()
+        # Sort by last_opened descending (most recently opened first)
+        return sorted(
+            self.known_projects.values(),
+            key=lambda item: item.last_opened or "",
+            reverse=True,
+        )
 
     def _load_project_from_path(self, project_path: Path) -> KnownProject:
         project_file = project_path / "project.yaml"

--- a/tests/api/test_projects.py
+++ b/tests/api/test_projects.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import shutil
+import time
 from pathlib import Path
 from urllib.parse import quote
 
@@ -56,3 +58,51 @@ def test_project_crud_and_path_opening(client: TestClient, project_parent: Path)
     deleted = client.delete(f"/api/projects/{first_payload['id']}")
     assert deleted.status_code == 204
     assert not Path(first_payload["path"]).exists()
+
+
+def test_list_projects_sorted_by_last_opened(client: TestClient, project_parent: Path) -> None:
+    """list_projects should return projects sorted by last_opened descending."""
+    # Create two projects
+    first = client.post(
+        "/api/projects/",
+        json={"name": "Older", "description": "first", "path": str(project_parent)},
+    )
+    assert first.status_code == 200
+
+    # Small delay so timestamps differ
+    time.sleep(0.05)
+
+    second = client.post(
+        "/api/projects/",
+        json={"name": "Newer", "description": "second", "path": str(project_parent)},
+    )
+    assert second.status_code == 200
+
+    listed = client.get("/api/projects/")
+    assert listed.status_code == 200
+    names = [entry["name"] for entry in listed.json()]
+    # "Newer" was created (and thus opened) more recently, so it comes first
+    assert names.index("Newer") < names.index("Older")
+
+
+def test_list_projects_prunes_deleted_directories(client: TestClient, project_parent: Path) -> None:
+    """list_projects should prune entries whose project directory no longer exists."""
+    resp = client.post(
+        "/api/projects/",
+        json={"name": "Ephemeral", "description": "will be deleted", "path": str(project_parent)},
+    )
+    assert resp.status_code == 200
+    project_path = Path(resp.json()["path"])
+
+    # Verify project appears in listing
+    listed = client.get("/api/projects/")
+    ids = [entry["id"] for entry in listed.json()]
+    assert resp.json()["id"] in ids
+
+    # Delete the project directory outside the API (simulate external deletion)
+    shutil.rmtree(project_path)
+
+    # Next listing should prune the stale entry
+    listed2 = client.get("/api/projects/")
+    ids2 = [entry["id"] for entry in listed2.json()]
+    assert resp.json()["id"] not in ids2


### PR DESCRIPTION
## Summary

Fixes 7 project management UI/UX bugs:

- **Bug 1**: Add Browse button for directory selection in New/Open Project dialogs with path validation
- **Bug 2**: Sort recent projects by `last_opened` descending, prune deleted projects from known list, scrollable project lists
- **Bug 3**: Rename misleading "Save Project" to "Save Workflow" in toolbar dropdown
- **Bug 4**: Add delete project button with confirmation dialog in ProjectDialog and WelcomeScreen
- **Bug 5**: Clear canvas (workflow state + tabs) when opening a different project
- **Bug 6**: Clicking recent project in toolbar dropdown directly opens it (no dialog)
- **Bug 7**: Auto-populate `output_dir` for AppBlock nodes dropped on canvas with project exchange path

## Related Issues
Closes #579

## Changes
- `frontend/src/components/ProjectDialog.tsx` -- Browse button, path validation, scrollable list, delete button
- `frontend/src/components/Toolbar.tsx` -- Rename Save Project, add onOpenRecent prop, scrollable dropdown
- `frontend/src/App.tsx` -- Clear tabs on project switch, wire onOpenRecent/onDeleteProject, AppBlock output_dir default
- `frontend/src/components/WelcomeScreen.tsx` -- Scrollable list, delete button
- `src/scieasy/api/runtime.py` -- Sort by last_opened, prune stale project entries

## Checklist
- [x] TypeScript compiles clean
- [x] Backend ruff check + format clean
- [ ] CI passes
- [x] CHANGELOG will be updated

## Test plan
- [ ] Create new project using Browse button
- [ ] Verify recent projects sorted by most recently opened
- [ ] Verify deleted project directories are pruned from list
- [ ] Verify delete button shows confirmation and removes project
- [ ] Open project A, add blocks, then open project B -- verify canvas is clean
- [ ] Click recent project in toolbar -- should open directly without dialog
- [ ] Drop AppBlock on canvas in a project -- verify output_dir is set