### PR TITLE
fix: inject output_dir default for AppBlocks with custom categories

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -707,8 +707,12 @@ export default function App() {
                           } else if (block.type_name === "io_block") {
                             defaultParams.direction = block.name === "Load Block" ? "input" : "output";
                           }
-                          // Bug 7: Set default output_dir for AppBlocks when a project is open
-                          if (block.category === "app" && currentProject) {
+                          // Set default output_dir for AppBlocks when a project is open.
+                          // Check for output_dir in config_schema rather than category,
+                          // since AppBlock subclasses may use custom categories (e.g. "interactive").
+                          const blockSchema = schemas[block.type_name];
+                          const hasOutputDir = blockSchema?.config_schema?.properties?.output_dir != null;
+                          if (hasOutputDir && currentProject) {
                             defaultParams.output_dir = `${currentProject.path}/data/exchange/outputs`;
                           }
                           addNode(block, { x: 160, y: 160 }, Object.keys(defaultParams).length > 0 ? defaultParams : undefined);


### PR DESCRIPTION
## Summary
AppBlock subclasses (Fiji, Napari) use `category = "interactive"`, not `"app"`. The check in `onAddBlock` was `block.category === "app"` which never matched. Changed to check for `output_dir` in the block's config_schema instead.

Closes partially #579 (bug 7 follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)