### PR TITLE
fix(gui): gate multi-file array on schema type support

### DIFF
--- a/frontend/src/components/nodes/BlockNode.tsx
+++ b/frontend/src/components/nodes/BlockNode.tsx
@@ -449,14 +449,18 @@ function InlineConfigField({
     try {
       const result = await api.openNativeDialog(nativeMode, initialDir);
       if (result.paths.length > 0) {
-        // For directory_browser, always a single path.
-        // For file_browser, pass the full array if multiple files selected,
-        // or a single string if only one file (matches config_schema type
-        // ["string", "array"] on IOBlock path fields).
-        if (nativeMode === "directory" || result.paths.length === 1) {
-          onChange(key, result.paths[0]);
-        } else {
+        // Only pass an array when the field schema explicitly supports it
+        // (type includes "array"). Fields like app_command and script_path
+        // are pure strings and must not receive an array.
+        const schemaType = schema.type;
+        const supportsArray =
+          Array.isArray(schemaType)
+            ? schemaType.includes("array")
+            : schemaType === "array";
+        if (supportsArray && result.paths.length > 1) {
           onChange(key, result.paths);
+        } else {
+          onChange(key, result.paths[0]);
         }
       }
       // If paths is empty, user cancelled — do nothing


### PR DESCRIPTION
## Summary
Follow-up to PR #597. The multi-file path fill was passing `string[]` to ALL `file_browser` fields, but fields like `app_command` and `script_path` are schema-typed as `"string"` only. Now checks `schema.type` for `"array"` support before passing an array.

- Schema type includes `"array"` (e.g. IOBlock `path`: `["string", "array"]`) → pass array when multi-select
- Schema type is `"string"` only (e.g. `app_command`, `script_path`) → always pass first path

🤖 Generated with [Claude Code](https://claude.com/claude-code)