### PR TITLE
feat(#602): ADR-029 B1 -- variadic port foundation (Block ABC, BlockSpec, Registry, API schema)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- [#602] ADR-029 B1: add variadic_inputs/variadic_outputs ClassVars to Block ABC, ports_from_config_dicts() helper, BlockSpec variadic fields, BlockSchemaResponse allowed_input/output_types (@claude, 2026-04-11, branch: feat/issue-602/variadic-ports-block-abc-spec-registry, session: 20260411-104249-b1-block-abc-blockspec-registry-api-sche)
 - [#588] Split category into base_category + subcategory so AppBlock subclasses with custom palette labels retain correct base type detection (@claude, 2026-04-11, branch: refactor/issue-588/category-subcategory-split, session: 20260411-042819-split-category-into-base-category-subcat)
 
 ### Fixed

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -71,6 +71,10 @@ export interface BlockSummary {
   direction?: string | null;
   source?: string;
   package_name?: string;
+  /** ADR-029 D8: true when this block supports user-configurable input port count. */
+  variadic_inputs?: boolean;
+  /** ADR-029 D8: true when this block supports user-configurable output port count. */
+  variadic_outputs?: boolean;
 }
 
 export interface TypeHierarchyEntry {
@@ -130,6 +134,17 @@ export interface BlockSchemaResponse extends BlockSummary {
    * ``blockType === "io_block"`` checks.
    */
   direction?: string | null;
+  /**
+   * ADR-029 D11: type names accepted by variadic input ports.
+   * Frontend uses this to populate the type dropdown in the port editor.
+   * Empty array means "any DataObject subclass".
+   */
+  allowed_input_types?: string[];
+  /**
+   * ADR-029 D11: type names accepted by variadic output ports.
+   * Empty array means "any DataObject subclass".
+   */
+  allowed_output_types?: string[];
 }
 
 export interface BlockListResponse {

--- a/src/scieasy/api/routes/blocks.py
+++ b/src/scieasy/api/routes/blocks.py
@@ -84,6 +84,8 @@ def _summary(spec: Any) -> BlockSummary:
         direction=spec.direction or None,
         source=_map_source(getattr(spec, "source", "") or ""),
         package_name=package_name,
+        variadic_inputs=bool(getattr(spec, "variadic_inputs", False)),
+        variadic_outputs=bool(getattr(spec, "variadic_outputs", False)),
     )
 
 
@@ -121,6 +123,9 @@ async def get_block_schema(
         # direction to the frontend so BlockNode.tsx can render dynamic-port
         # UI and IO-specific controls without hardcoded type checks.
         dynamic_ports=spec.dynamic_ports,
+        # ADR-029 D11: variadic port type constraints for frontend port editor.
+        allowed_input_types=list(getattr(spec, "allowed_input_types", []) or []),
+        allowed_output_types=list(getattr(spec, "allowed_output_types", []) or []),
     )
 
 

--- a/src/scieasy/api/schemas.py
+++ b/src/scieasy/api/schemas.py
@@ -97,6 +97,10 @@ class BlockSummary(BaseModel):
     direction: str | None = None
     source: str = ""
     package_name: str = ""
+    # ADR-029 D8: variadic port flags so the frontend palette can show [+]
+    # affordances for variadic blocks even before the full schema is fetched.
+    variadic_inputs: bool = False
+    variadic_outputs: bool = False
 
 
 class BlockListResponse(BaseModel):
@@ -119,6 +123,11 @@ class BlockSchemaResponse(BlockSummary):
     # hardcoding ``blockType === "io_block"`` checks. ``None`` for
     # non-IO blocks.
     direction: str | None = None
+    # ADR-029 D11: type name lists for variadic port editor dropdown.
+    # Frontend uses these to populate the type selector when the user adds
+    # a new port. Empty list means "any DataObject subclass".
+    allowed_input_types: list[str] = Field(default_factory=list)
+    allowed_output_types: list[str] = Field(default_factory=list)
 
 
 class BlockConnectionValidation(BaseModel):

--- a/src/scieasy/blocks/base/block.py
+++ b/src/scieasy/blocks/base/block.py
@@ -9,7 +9,13 @@ if TYPE_CHECKING:
     from scieasy.core.types.collection import Collection
 
 from scieasy.blocks.base.config import BlockConfig
-from scieasy.blocks.base.ports import InputPort, OutputPort, port_accepts_type, validate_port_constraint
+from scieasy.blocks.base.ports import (
+    InputPort,
+    OutputPort,
+    port_accepts_type,
+    ports_from_config_dicts,
+    validate_port_constraint,
+)
 from scieasy.blocks.base.state import BlockState, ExecutionMode
 
 # Valid state transitions (ADR-018: added CANCELLED, SKIPPED).
@@ -54,6 +60,23 @@ class Block(ABC):
 
     input_ports: ClassVar[list[InputPort]] = []
     output_ports: ClassVar[list[OutputPort]] = []
+
+    # ADR-029 D8 / D11: variadic port flags and type constraints.
+    # When ``variadic_inputs`` / ``variadic_outputs`` is True the block's port
+    # list is determined per-instance from ``self.config["input_ports"]`` /
+    # ``self.config["output_ports"]`` (list of ``{"name": str, "types": [str]}``)
+    # rather than from the class-level ClassVar.  ``allowed_input_types`` /
+    # ``allowed_output_types`` constrain the type dropdown in the port editor UI.
+    variadic_inputs: ClassVar[bool] = False
+    variadic_outputs: ClassVar[bool] = False
+
+    # Block authors override these on variadic subclasses to restrict which
+    # types users may choose in the port editor dropdown (e.g.
+    # ``allowed_input_types = [Image, DataFrame]``).  An empty list means
+    # "accept any DataObject subclass" — consistent with the port system's
+    # own semantics (``accepted_types = []`` accepts anything).
+    allowed_input_types: ClassVar[list[type]] = []
+    allowed_output_types: ClassVar[list[type]] = []
 
     # ADR-028 Addendum 1 D1: declarative dynamic-port override mechanism.
     # When non-None, must be a dict of the shape::
@@ -104,27 +127,41 @@ class Block(ABC):
     def get_effective_input_ports(self) -> list[InputPort]:
         """Return effective input ports for this instance.
 
-        Default implementation returns a copy of the class-level
-        ``input_ports`` ClassVar. Dynamic blocks (e.g. ``LoadData`` /
-        ``SaveData``) override this method to return instance-specific ports
-        computed from ``self.config``.
+        For variadic blocks (``variadic_inputs = True``), reads the port list
+        from ``self.config["input_ports"]`` and converts it to
+        :class:`InputPort` instances via :func:`ports_from_config_dicts`.
+        Falls back to the class-level ``input_ports`` ClassVar when no
+        per-instance config is present.
+
+        For non-variadic blocks, returns a copy of the class-level
+        ``input_ports`` ClassVar unchanged (ADR-028 Addendum 1 D2 behaviour).
 
         Framework callsites that need per-instance port information (e.g.
         :meth:`Block.validate`, ``ProcessBlock.run``,
         ``workflow/validator.py``) MUST go through this method instead of
         reading the ClassVar directly.
         """
+        if type(self).variadic_inputs:
+            config_ports = self.config.get("input_ports")
+            if config_ports and isinstance(config_ports, list):
+                return ports_from_config_dicts(config_ports, "input")  # type: ignore[return-value]
         return list(type(self).input_ports)
 
     def get_effective_output_ports(self) -> list[OutputPort]:
         """Return effective output ports for this instance.
 
-        Default implementation returns a copy of the class-level
-        ``output_ports`` ClassVar. Dynamic blocks override this method to
-        return instance-specific ports computed from ``self.config``.
+        For variadic blocks (``variadic_outputs = True``), reads the port list
+        from ``self.config["output_ports"]`` and converts it to
+        :class:`OutputPort` instances via :func:`ports_from_config_dicts`.
+        Falls back to the class-level ``output_ports`` ClassVar when no
+        per-instance config is present.
 
         See :meth:`get_effective_input_ports` for the framework rationale.
         """
+        if type(self).variadic_outputs:
+            config_ports = self.config.get("output_ports")
+            if config_ports and isinstance(config_ports, list):
+                return ports_from_config_dicts(config_ports, "output")  # type: ignore[return-value]
         return list(type(self).output_ports)
 
     # -- hooks -----------------------------------------------------------------

--- a/src/scieasy/blocks/base/ports.py
+++ b/src/scieasy/blocks/base/ports.py
@@ -99,6 +99,47 @@ def validate_port_constraint(port: InputPort, value: Any) -> tuple[bool, str]:
     return True, ""
 
 
+def ports_from_config_dicts(
+    dicts: list[dict[str, Any]],
+    direction: str,
+) -> list[InputPort] | list[OutputPort]:
+    """Convert a list of port config dicts to InputPort or OutputPort instances.
+
+    Each dict must have the shape ``{"name": str, "types": list[str]}``.
+    Type name strings are resolved against the core type registry; unknown
+    names fall back to ``DataObject``.  Port names must be unique within
+    *dicts* — duplicates are silently de-duplicated (last wins).
+
+    ADR-029 D1: variadic port lists stored in block config use this format.
+    """
+    from scieasy.core.types.base import DataObject
+
+    def _resolve_type(name: str) -> type:
+        try:
+            from scieasy.core.types.serialization import _get_type_registry
+
+            reg = _get_type_registry()
+            return reg.load_class(name)
+        except Exception:
+            pass
+        return DataObject
+
+    seen: dict[str, None] = {}
+    result: list[Any] = []
+    for item in dicts:
+        port_name = str(item.get("name", "port"))
+        if port_name in seen:
+            continue
+        seen[port_name] = None
+        raw_types: list[str] = item.get("types", [])
+        accepted: list[type] = [_resolve_type(t) for t in raw_types] if raw_types else [DataObject]
+        if direction == "input":
+            result.append(InputPort(name=port_name, accepted_types=accepted))
+        else:
+            result.append(OutputPort(name=port_name, accepted_types=accepted))
+    return result  # type: ignore[return-value]
+
+
 def validate_connection(
     source_port: OutputPort,
     target_port: InputPort,

--- a/src/scieasy/blocks/registry.py
+++ b/src/scieasy/blocks/registry.py
@@ -54,6 +54,13 @@ class BlockSpec:
     # the class-level ``Block.dynamic_ports`` ClassVar. Validated at scan
     # time by :meth:`BlockRegistry._validate_dynamic_ports`.
     dynamic_ports: dict[str, Any] | None = None
+    # ADR-029 D8: variadic port flags — copied from Block ClassVars at scan time.
+    variadic_inputs: bool = False
+    variadic_outputs: bool = False
+    # ADR-029 D11: allowed type names for variadic port editor dropdown.
+    # Empty list means "any DataObject subclass".
+    allowed_input_types: list[str] = field(default_factory=list)
+    allowed_output_types: list[str] = field(default_factory=list)
 
 
 class BlockRegistry:
@@ -617,6 +624,12 @@ def _spec_from_class(cls: type, source: str = "") -> BlockSpec:
 
     base_cat = _infer_category(cls)
     sub_cat = getattr(cls, "subcategory", "") or ""
+
+    # ADR-029 D11: serialize allowed_input/output_types ClassVars to string
+    # lists for the API.  Empty list on the class means "any DataObject".
+    allowed_in: list[str] = [t.__name__ for t in (getattr(cls, "allowed_input_types", None) or [])]
+    allowed_out: list[str] = [t.__name__ for t in (getattr(cls, "allowed_output_types", None) or [])]
+
     return BlockSpec(
         name=getattr(cls, "name", cls.__name__),
         description=getattr(cls, "description", "") or (cls.__doc__ or "").split("\n")[0],
@@ -632,6 +645,10 @@ def _spec_from_class(cls: type, source: str = "") -> BlockSpec:
         type_name=_type_name_for_class(cls),
         direction=getattr(cls, "direction", "") or "",
         dynamic_ports=getattr(cls, "dynamic_ports", None),
+        variadic_inputs=bool(getattr(cls, "variadic_inputs", False)),
+        variadic_outputs=bool(getattr(cls, "variadic_outputs", False)),
+        allowed_input_types=allowed_in,
+        allowed_output_types=allowed_out,
     )
 
 

--- a/tests/blocks/test_block_base.py
+++ b/tests/blocks/test_block_base.py
@@ -469,3 +469,96 @@ class TestAutoFlush:
         assert result is img
         assert result.storage_ref is not None
         assert result.storage_ref.backend == "zarr"
+
+
+class TestVariadicPorts:
+    """ADR-029 D8: variadic_inputs / variadic_outputs ClassVars and
+    config-driven get_effective_*_ports() overrides."""
+
+    def test_static_block_defaults(self) -> None:
+        """Non-variadic blocks have both flags False by default."""
+        block = _DummyBlock()
+        assert type(block).variadic_inputs is False
+        assert type(block).variadic_outputs is False
+
+    def test_static_block_effective_ports_unchanged(self) -> None:
+        """Static block returns class-level port list unchanged."""
+        block = _DummyBlock()
+        assert block.get_effective_input_ports() == list(_DummyBlock.input_ports)
+        assert block.get_effective_output_ports() == list(_DummyBlock.output_ports)
+
+    def test_variadic_block_with_no_config_falls_back_to_classvars(self) -> None:
+        """Variadic block with no config port list falls back to class-level ports."""
+
+        class _VariadicBlock(Block):
+            name: ClassVar[str] = "Variadic"
+            variadic_inputs: ClassVar[bool] = True
+            variadic_outputs: ClassVar[bool] = True
+            input_ports: ClassVar[list[InputPort]] = [
+                InputPort(name="default_in", accepted_types=[Array]),
+            ]
+            output_ports: ClassVar[list[OutputPort]] = [
+                OutputPort(name="default_out", accepted_types=[Array]),
+            ]
+
+            def run(self, inputs: dict[str, Any], config: BlockConfig) -> dict[str, Any]:
+                return {}
+
+        block = _VariadicBlock()
+        assert block.get_effective_input_ports() == list(_VariadicBlock.input_ports)
+        assert block.get_effective_output_ports() == list(_VariadicBlock.output_ports)
+
+    def test_variadic_block_reads_input_ports_from_config(self) -> None:
+        """Variadic block reads input_ports from config when present."""
+
+        class _VariadicBlock(Block):
+            name: ClassVar[str] = "VariadicConfigIn"
+            variadic_inputs: ClassVar[bool] = True
+            variadic_outputs: ClassVar[bool] = False
+            input_ports: ClassVar[list[InputPort]] = []
+            output_ports: ClassVar[list[OutputPort]] = []
+
+            def run(self, inputs: dict[str, Any], config: BlockConfig) -> dict[str, Any]:
+                return {}
+
+        config = {
+            "input_ports": [
+                {"name": "img", "types": ["DataObject"]},
+                {"name": "mask", "types": ["DataObject"]},
+            ]
+        }
+        block = _VariadicBlock(config=config)
+        ports = block.get_effective_input_ports()
+        assert len(ports) == 2
+        assert ports[0].name == "img"
+        assert ports[1].name == "mask"
+
+    def test_variadic_block_reads_output_ports_from_config(self) -> None:
+        """Variadic block reads output_ports from config when present."""
+
+        class _VariadicBlock(Block):
+            name: ClassVar[str] = "VariadicConfigOut"
+            variadic_inputs: ClassVar[bool] = False
+            variadic_outputs: ClassVar[bool] = True
+            input_ports: ClassVar[list[InputPort]] = []
+            output_ports: ClassVar[list[OutputPort]] = []
+
+            def run(self, inputs: dict[str, Any], config: BlockConfig) -> dict[str, Any]:
+                return {}
+
+        config = {
+            "output_ports": [
+                {"name": "result", "types": ["DataObject"]},
+                {"name": "summary", "types": ["DataObject"]},
+            ]
+        }
+        block = _VariadicBlock(config=config)
+        ports = block.get_effective_output_ports()
+        assert len(ports) == 2
+        assert ports[0].name == "result"
+        assert ports[1].name == "summary"
+
+    def test_allowed_input_types_default_empty(self) -> None:
+        """Block.allowed_input_types defaults to empty list."""
+        assert _DummyBlock.allowed_input_types == []
+        assert _DummyBlock.allowed_output_types == []

--- a/tests/blocks/test_ports.py
+++ b/tests/blocks/test_ports.py
@@ -9,6 +9,7 @@ from scieasy.blocks.base.ports import (
     OutputPort,
     port_accepts_signature,
     port_accepts_type,
+    ports_from_config_dicts,
     validate_connection,
     validate_port_constraint,
 )
@@ -243,3 +244,65 @@ class TestCollectionTransparency:
         # type(c) is the Collection class, not a Collection instance
         # This should NOT match — Collection class is not a subclass of Image
         assert not port_accepts_type(port, type(c))
+
+
+class TestPortsFromConfigDicts:
+    """ADR-029 D1: ports_from_config_dicts — convert config dicts to port objects."""
+
+    def test_input_direction_creates_input_ports(self) -> None:
+        dicts = [{"name": "img", "types": ["DataObject"]}]
+        ports = ports_from_config_dicts(dicts, "input")
+        assert len(ports) == 1
+        assert isinstance(ports[0], InputPort)
+        assert ports[0].name == "img"
+
+    def test_output_direction_creates_output_ports(self) -> None:
+        dicts = [{"name": "result", "types": ["DataObject"]}]
+        ports = ports_from_config_dicts(dicts, "output")
+        assert len(ports) == 1
+        assert isinstance(ports[0], OutputPort)
+        assert ports[0].name == "result"
+
+    def test_empty_types_defaults_to_dataobject(self) -> None:
+        dicts = [{"name": "x", "types": []}]
+        ports = ports_from_config_dicts(dicts, "input")
+        assert ports[0].accepted_types == [DataObject]
+
+    def test_missing_types_key_defaults_to_dataobject(self) -> None:
+        dicts = [{"name": "x"}]
+        ports = ports_from_config_dicts(dicts, "input")
+        assert ports[0].accepted_types == [DataObject]
+
+    def test_unknown_type_name_falls_back_to_dataobject(self) -> None:
+        dicts = [{"name": "x", "types": ["NonExistentType99"]}]
+        ports = ports_from_config_dicts(dicts, "input")
+        assert ports[0].accepted_types == [DataObject]
+
+    def test_multiple_ports(self) -> None:
+        dicts = [
+            {"name": "a", "types": ["DataObject"]},
+            {"name": "b", "types": ["DataObject"]},
+        ]
+        ports = ports_from_config_dicts(dicts, "input")
+        assert len(ports) == 2
+        assert ports[0].name == "a"
+        assert ports[1].name == "b"
+
+    def test_duplicate_names_deduplicated(self) -> None:
+        dicts = [
+            {"name": "x", "types": ["DataObject"]},
+            {"name": "x", "types": ["DataObject"]},
+        ]
+        ports = ports_from_config_dicts(dicts, "input")
+        assert len(ports) == 1
+        assert ports[0].name == "x"
+
+    def test_empty_list_returns_empty(self) -> None:
+        ports = ports_from_config_dicts([], "input")
+        assert ports == []
+
+    def test_known_type_name_resolves_correctly(self) -> None:
+        """A registered type name like 'Array' or 'DataObject' resolves to the class."""
+        dicts = [{"name": "data", "types": ["DataObject"]}]
+        ports = ports_from_config_dicts(dicts, "input")
+        assert DataObject in ports[0].accepted_types

--- a/tests/blocks/test_registry.py
+++ b/tests/blocks/test_registry.py
@@ -884,3 +884,91 @@ class TestAppBlockSubclassConfigCleanup:
         merged = _merge_config_schema(ElMAVENBlock)
         props = merged.get("properties", {})
         assert "app_command" in props, "app_command should be inherited via MRO merge from AppBlock"
+
+
+class TestVariadicPortsSpec:
+    """ADR-029 D8: _spec_from_class() populates variadic_inputs/outputs on BlockSpec."""
+
+    def test_static_block_spec_has_variadic_false(self) -> None:
+        """Non-variadic block yields variadic_inputs=False, variadic_outputs=False."""
+        from typing import Any, ClassVar
+
+        from scieasy.blocks.base.block import Block
+        from scieasy.blocks.base.config import BlockConfig
+        from scieasy.blocks.registry import _spec_from_class
+
+        class _StaticBlock(Block):
+            name: ClassVar[str] = "StaticTestBlock"
+
+            def run(self, inputs: dict[str, Any], config: BlockConfig) -> dict[str, Any]:
+                return {}
+
+        spec = _spec_from_class(_StaticBlock)
+        assert spec.variadic_inputs is False
+        assert spec.variadic_outputs is False
+
+    def test_variadic_block_spec_has_variadic_true(self) -> None:
+        """Variadic block yields variadic_inputs=True, variadic_outputs=True."""
+        from typing import Any, ClassVar
+
+        from scieasy.blocks.base.block import Block
+        from scieasy.blocks.base.config import BlockConfig
+        from scieasy.blocks.registry import _spec_from_class
+
+        class _VariadicBlock(Block):
+            name: ClassVar[str] = "VariadicTestBlock"
+            variadic_inputs: ClassVar[bool] = True
+            variadic_outputs: ClassVar[bool] = True
+
+            def run(self, inputs: dict[str, Any], config: BlockConfig) -> dict[str, Any]:
+                return {}
+
+        spec = _spec_from_class(_VariadicBlock)
+        assert spec.variadic_inputs is True
+        assert spec.variadic_outputs is True
+
+    def test_allowed_types_serialized_as_string_list(self) -> None:
+        """allowed_input/output_types ClassVars are serialized to class name strings."""
+        from typing import Any, ClassVar
+
+        from scieasy.blocks.base.block import Block
+        from scieasy.blocks.base.config import BlockConfig
+        from scieasy.blocks.base.ports import InputPort, OutputPort
+        from scieasy.blocks.registry import _spec_from_class
+        from scieasy.core.types.array import Array
+        from scieasy.core.types.dataframe import DataFrame
+
+        class _TypedVariadicBlock(Block):
+            name: ClassVar[str] = "TypedVariadicBlock"
+            variadic_inputs: ClassVar[bool] = True
+            variadic_outputs: ClassVar[bool] = True
+            allowed_input_types: ClassVar[list[type]] = [Array, DataFrame]
+            allowed_output_types: ClassVar[list[type]] = [Array]
+            input_ports: ClassVar[list[InputPort]] = []
+            output_ports: ClassVar[list[OutputPort]] = []
+
+            def run(self, inputs: dict[str, Any], config: BlockConfig) -> dict[str, Any]:
+                return {}
+
+        spec = _spec_from_class(_TypedVariadicBlock)
+        assert spec.allowed_input_types == ["Array", "DataFrame"]
+        assert spec.allowed_output_types == ["Array"]
+
+    def test_empty_allowed_types_yields_empty_list(self) -> None:
+        """Block with no allowed_types ClassVar yields empty allowed_input/output_types."""
+        from typing import Any, ClassVar
+
+        from scieasy.blocks.base.block import Block
+        from scieasy.blocks.base.config import BlockConfig
+        from scieasy.blocks.registry import _spec_from_class
+
+        class _DefaultAllowedBlock(Block):
+            name: ClassVar[str] = "DefaultAllowedBlock"
+            variadic_inputs: ClassVar[bool] = True
+
+            def run(self, inputs: dict[str, Any], config: BlockConfig) -> dict[str, Any]:
+                return {}
+
+        spec = _spec_from_class(_DefaultAllowedBlock)
+        assert spec.allowed_input_types == []
+        assert spec.allowed_output_types == []


### PR DESCRIPTION
## Summary

Implements **Ticket B1** of the ADR-029 variadic ports roadmap: the foundational backend support that all other tickets (B2, B3, F1, F2) depend on.

All changes are **purely additive** — no existing behavior changes. Static blocks are unaffected.

## Changes

- **`Block` ABC** (`block.py`): Add 4 ClassVars: `variadic_inputs: ClassVar[bool] = False`, `variadic_outputs: ClassVar[bool] = False`, `allowed_input_types: ClassVar[list[type]] = []`, `allowed_output_types: ClassVar[list[type]] = []`. Update `get_effective_input_ports()` / `get_effective_output_ports()` to read from `self.config["input_ports"]` / `self.config["output_ports"]` when the variadic flag is True.

- **`ports.py`**: Add `ports_from_config_dicts()` helper that converts `[{"name": str, "types": [str]}]` config dicts to `InputPort`/`OutputPort` instances. Type names resolved via `_get_type_registry().load_class()`; unknown names fall back to `DataObject`.

- **`registry.py`** (`BlockSpec`): Add `variadic_inputs`, `variadic_outputs` (bool), `allowed_input_types`, `allowed_output_types` (list[str]). Update `_spec_from_class()` to populate from ClassVars.

- **`schemas.py`**: Add `variadic_inputs`/`variadic_outputs` to `BlockSummary`; add `allowed_input_types`/`allowed_output_types` to `BlockSchemaResponse`.

- **`routes/blocks.py`**: Wire new spec fields through `_summary()` and `get_block_schema()`.

- **`frontend/src/types/api.ts`**: Add TypeScript fields for `variadic_inputs`, `variadic_outputs`, `allowed_input_types`, `allowed_output_types`.

- **Tests**: Added `TestVariadicPorts` (test_block_base.py), `TestPortsFromConfigDicts` (test_ports.py), `TestVariadicPortsSpec` (test_registry.py).

## Related Issues

Closes #602

## ADR

- ADR-029 (proposed) — this is the foundation ticket
- Depends on: nothing
- Blocks: B2, B3, F1, F2
