### PR TITLE
feat(#604): ADR-029 B2 -- MRO injection of port editor config_schema fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- [#604] ADR-029 B2: inject input_ports/output_ports port editor fields into AIBlock, CodeBlock, AppBlock config_schema via ADR-030 MRO pattern (@claude, 2026-04-11, branch: feat/issue-604/mro-port-editor-config-schema, session: 20260411-105345-b2-mro-injection-port-editor-config-sche)
 - [#588] Split category into base_category + subcategory so AppBlock subclasses with custom palette labels retain correct base type detection (@claude, 2026-04-11, branch: refactor/issue-588/category-subcategory-split, session: 20260411-042819-split-category-into-base-category-subcat)
 
 ### Fixed

--- a/src/scieasy/blocks/ai/ai_block.py
+++ b/src/scieasy/blocks/ai/ai_block.py
@@ -101,6 +101,36 @@ class AIBlock(Block):
                 "default": None,
                 "title": "System prompt (optional)",
             },
+            # ADR-029 D12: port editor fields injected via MRO merge (ADR-030).
+            # Leaf subclasses inherit these automatically; no subclass changes needed.
+            "input_ports": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string"},
+                        "types": {"type": "array", "items": {"type": "string"}},
+                    },
+                },
+                "default": [],
+                "title": "Input Ports",
+                "ui_widget": "port_editor",
+                "ui_priority": 10,
+            },
+            "output_ports": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string"},
+                        "types": {"type": "array", "items": {"type": "string"}},
+                    },
+                },
+                "default": [],
+                "title": "Output Ports",
+                "ui_widget": "port_editor",
+                "ui_priority": 11,
+            },
         },
         "required": ["prompt"],
     }

--- a/src/scieasy/blocks/app/app_block.py
+++ b/src/scieasy/blocks/app/app_block.py
@@ -89,6 +89,37 @@ class AppBlock(Block):
                 "default": "*",
                 "ui_priority": 2,
             },
+            # ADR-029 D12: port editor fields injected via MRO merge (ADR-030).
+            # Leaf subclasses inherit these automatically; no subclass changes needed.
+            # ui_priority >= 10 ensures these appear after block-specific config.
+            "input_ports": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string"},
+                        "types": {"type": "array", "items": {"type": "string"}},
+                    },
+                },
+                "default": [],
+                "title": "Input Ports",
+                "ui_widget": "port_editor",
+                "ui_priority": 10,
+            },
+            "output_ports": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string"},
+                        "types": {"type": "array", "items": {"type": "string"}},
+                    },
+                },
+                "default": [],
+                "title": "Output Ports",
+                "ui_widget": "port_editor",
+                "ui_priority": 11,
+            },
         },
         "required": ["app_command"],
     }

--- a/src/scieasy/blocks/code/code_block.py
+++ b/src/scieasy/blocks/code/code_block.py
@@ -67,6 +67,36 @@ class CodeBlock(Block):
             },
             "code": {"type": "string", "title": "Inline Code", "ui_priority": 3},
             "script_path": {"type": "string", "title": "Script Path", "ui_priority": 4, "ui_widget": "file_browser"},
+            # ADR-029 D12: port editor fields injected via MRO merge (ADR-030).
+            # Leaf subclasses inherit these automatically; no subclass changes needed.
+            "input_ports": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string"},
+                        "types": {"type": "array", "items": {"type": "string"}},
+                    },
+                },
+                "default": [],
+                "title": "Input Ports",
+                "ui_widget": "port_editor",
+                "ui_priority": 10,
+            },
+            "output_ports": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string"},
+                        "types": {"type": "array", "items": {"type": "string"}},
+                    },
+                },
+                "default": [],
+                "title": "Output Ports",
+                "ui_widget": "port_editor",
+                "ui_priority": 11,
+            },
         },
     }
 

--- a/tests/blocks/test_block_config_schema.py
+++ b/tests/blocks/test_block_config_schema.py
@@ -77,3 +77,89 @@ class TestBlockConfigSchema:
         spec = _spec_from_class(PlainBlock, source="test")
         # ADR-030: _merge_config_schema always produces a ``required`` key.
         assert spec.config_schema == {"type": "object", "properties": {}, "required": []}
+
+
+class TestVariadicPortEditorSchemaInjection:
+    """ADR-029 D12: port editor config_schema fields injected into AIBlock,
+    CodeBlock, AppBlock and propagated to leaf subclasses via MRO merge."""
+
+    def _assert_port_editor_fields(self, props: dict) -> None:
+        """Assert input_ports and output_ports port-editor fields are present."""
+        assert "input_ports" in props, "input_ports port editor field missing"
+        assert "output_ports" in props, "output_ports port editor field missing"
+        assert props["input_ports"]["type"] == "array"
+        assert props["input_ports"]["ui_widget"] == "port_editor"
+        assert props["output_ports"]["type"] == "array"
+        assert props["output_ports"]["ui_widget"] == "port_editor"
+
+    def test_aiblock_own_schema_has_port_editor_fields(self) -> None:
+        from scieasy.blocks.ai.ai_block import AIBlock
+
+        props = AIBlock.config_schema["properties"]
+        self._assert_port_editor_fields(props)
+
+    def test_codeblock_own_schema_has_port_editor_fields(self) -> None:
+        from scieasy.blocks.code.code_block import CodeBlock
+
+        props = CodeBlock.config_schema["properties"]
+        self._assert_port_editor_fields(props)
+
+    def test_appblock_own_schema_has_port_editor_fields(self) -> None:
+        from scieasy.blocks.app.app_block import AppBlock
+
+        props = AppBlock.config_schema["properties"]
+        self._assert_port_editor_fields(props)
+
+    def test_aiblock_mro_merged_schema_has_port_editor_fields(self) -> None:
+        from scieasy.blocks.ai.ai_block import AIBlock
+        from scieasy.blocks.registry import _merge_config_schema
+
+        merged = _merge_config_schema(AIBlock)
+        self._assert_port_editor_fields(merged["properties"])
+
+    def test_codeblock_mro_merged_schema_has_port_editor_fields(self) -> None:
+        from scieasy.blocks.code.code_block import CodeBlock
+        from scieasy.blocks.registry import _merge_config_schema
+
+        merged = _merge_config_schema(CodeBlock)
+        self._assert_port_editor_fields(merged["properties"])
+
+    def test_appblock_mro_merged_schema_has_port_editor_fields(self) -> None:
+        from scieasy.blocks.app.app_block import AppBlock
+        from scieasy.blocks.registry import _merge_config_schema
+
+        merged = _merge_config_schema(AppBlock)
+        self._assert_port_editor_fields(merged["properties"])
+
+    def test_aiblock_subclass_inherits_port_editor_via_mro(self) -> None:
+        """A subclass of AIBlock that declares no port editor fields gets them via MRO."""
+        from scieasy.blocks.ai.ai_block import AIBlock
+        from scieasy.blocks.registry import _merge_config_schema
+
+        class _MyAIBlock(AIBlock):
+            name: ClassVar[str] = "My AI"
+            config_schema: ClassVar[dict[str, Any]] = {
+                "type": "object",
+                "properties": {
+                    "custom_param": {"type": "string"},
+                },
+            }
+
+            def run(self, inputs: dict, config: Any) -> dict:
+                return {}
+
+        merged = _merge_config_schema(_MyAIBlock)
+        props = merged["properties"]
+        assert "custom_param" in props
+        self._assert_port_editor_fields(props)
+
+    def test_port_editor_fields_have_correct_item_schema(self) -> None:
+        """Each port entry must have name (string) and types (array of strings)."""
+        from scieasy.blocks.ai.ai_block import AIBlock
+
+        props = AIBlock.config_schema["properties"]
+        item_props = props["input_ports"]["items"]["properties"]
+        assert "name" in item_props
+        assert item_props["name"]["type"] == "string"
+        assert "types" in item_props
+        assert item_props["types"]["type"] == "array"


### PR DESCRIPTION
## Summary

Implements **Ticket B2** of the ADR-029 variadic ports roadmap: inject `input_ports` and `output_ports` JSON Schema array properties (with `ui_widget: 'port_editor'`) into the `config_schema` of `AIBlock`, `CodeBlock`, and `AppBlock`. The ADR-030 MRO merge mechanism in `_merge_config_schema()` propagates these fields automatically to all leaf subclasses.

## Changes

- **`src/scieasy/blocks/ai/ai_block.py`**: Add `input_ports` and `output_ports` array properties to `config_schema["properties"]` with `ui_widget: 'port_editor'` and `ui_priority: 10/11`.

- **`src/scieasy/blocks/code/code_block.py`**: Same additions at `ui_priority: 10/11`.

- **`src/scieasy/blocks/app/app_block.py`**: Same additions at `ui_priority: 10/11` (well above the reserved 0/1/2 priorities for `app_command`/`output_dir`/others).

- **`tests/blocks/test_block_config_schema.py`**: Add `TestVariadicPortEditorSchemaInjection` class testing that all three base classes carry the port editor fields, that MRO-merged schemas include them, and that leaf subclasses inherit them without modification.

## Design

Port editor schema shape:
```json
{
  "type": "array",
  "items": {"type": "object", "properties": {"name": {"type": "string"}, "types": {"type": "array", "items": {"type": "string"}}}},
  "default": [],
  "title": "Input Ports",
  "ui_widget": "port_editor",
  "ui_priority": 10
}
```

No changes to `_merge_config_schema()` — it already handles MRO merge correctly per ADR-030.

## Related Issues

Closes #604

## ADR

- ADR-029 D12 (MRO injection via ADR-030 pattern)
- Depends on: #602 (B1 foundation for ClassVar declaration)
