### PR TITLE
feat(#606): ADR-029 B3 -- CodeBlock Python signature auto-inference for variadic ports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- [#606] ADR-029 B3: extend introspect_script() with input_ports auto-inference from run() parameter type annotations; add _params_to_port_dicts() and _annotation_to_type_name() helpers (@claude, 2026-04-11, branch: feat/issue-606/codeblock-signature-auto-inference, session: 20260411-105722-b3-codeblock-python-signature-auto-infer)
 - [#588] Split category into base_category + subcategory so AppBlock subclasses with custom palette labels retain correct base type detection (@claude, 2026-04-11, branch: refactor/issue-588/category-subcategory-split, session: 20260411-042819-split-category-into-base-category-subcat)
 
 ### Fixed

--- a/src/scieasy/blocks/code/introspect.py
+++ b/src/scieasy/blocks/code/introspect.py
@@ -14,6 +14,7 @@ def introspect_script(script_path: str | Path) -> dict[str, Any]:
     - ``run()`` function signature (parameter names, annotations, defaults).
     - ``configure()`` return value (if present) — treated as a parameter schema.
     - Top-level docstring.
+    - Variadic port list derived from ``run()`` parameter annotations (ADR-029 D7).
 
     Returns a dictionary with keys:
         ``has_run``: bool
@@ -21,6 +22,9 @@ def introspect_script(script_path: str | Path) -> dict[str, Any]:
         ``has_configure``: bool
         ``configure_schema``: dict or None
         ``docstring``: str or None
+        ``input_ports``: list of ``{"name": str, "types": list[str]}`` dicts
+            derived from ``run()`` parameter annotations.  Unannotated
+            parameters default to ``["DataObject"]``.
     """
     path = Path(script_path)
     if not path.exists():
@@ -35,13 +39,16 @@ def introspect_script(script_path: str | Path) -> dict[str, Any]:
         "has_configure": False,
         "configure_schema": None,
         "docstring": ast.get_docstring(tree),
+        "input_ports": [],
     }
 
     for node in ast.iter_child_nodes(tree):
         if isinstance(node, ast.FunctionDef):
             if node.name == "run":
                 result["has_run"] = True
-                result["run_params"] = _extract_params(node)
+                params = _extract_params(node)
+                result["run_params"] = params
+                result["input_ports"] = _params_to_port_dicts(params)
             elif node.name == "configure":
                 result["has_configure"] = True
                 result["configure_schema"] = _extract_configure_return(node, source)
@@ -76,6 +83,60 @@ def _extract_params(func_node: ast.FunctionDef) -> list[dict[str, Any]]:
         params.append(param)
 
     return params
+
+
+def _params_to_port_dicts(params: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Convert ``_extract_params()`` output to variadic port dict list (ADR-029 D7).
+
+    Maps each parameter to a port dict ``{"name": str, "types": list[str]}``.
+    Annotation strings are the ``ast.dump()`` representation produced by
+    :func:`_extract_params`.  Only simple ``Name(id='...')`` annotations are
+    resolved; all other forms fall back to ``"DataObject"`` silently.
+
+    The ``self`` and ``config`` parameters (common in ``run()`` signatures)
+    are skipped: ``self`` because it is the instance reference, ``config``
+    because it represents the block configuration, not data input.
+
+    Examples::
+
+        run(self, image: Image, table: DataFrame) -> ...
+        # → [{"name": "image", "types": ["Image"]},
+        #    {"name": "table", "types": ["DataFrame"]}]
+
+        run(self, x, y) -> ...
+        # → [{"name": "x", "types": ["DataObject"]},
+        #    {"name": "y", "types": ["DataObject"]}]
+    """
+    _skip_params = {"self", "config"}
+    port_dicts: list[dict[str, Any]] = []
+    for param in params:
+        name: str = param.get("name", "")
+        if name in _skip_params:
+            continue
+        annotation_dump: str | None = param.get("annotation")
+        type_name = _annotation_to_type_name(annotation_dump)
+        port_dicts.append({"name": name, "types": [type_name]})
+    return port_dicts
+
+
+def _annotation_to_type_name(annotation_dump: str | None) -> str:
+    """Extract a clean type name from an ``ast.dump()`` annotation string.
+
+    Only handles simple ``Name(id='TypeName')`` nodes.  All other forms
+    (subscripts, attributes, unions) fall back to ``"DataObject"``.
+    """
+    if annotation_dump is None:
+        return "DataObject"
+    # Simple name: Name(id='Image') or Name(id='Image', ctx=Load())
+    if annotation_dump.startswith("Name(id='"):
+        try:
+            # ast.dump format: "Name(id='Image')" or "Name(id='Image', ctx=Load())"
+            start = annotation_dump.index("id='") + 4
+            end = annotation_dump.index("'", start)
+            return annotation_dump[start:end]
+        except (ValueError, IndexError):
+            pass
+    return "DataObject"
 
 
 def _extract_configure_return(func_node: ast.FunctionDef, source: str) -> dict[str, Any] | None:

--- a/tests/blocks/test_introspect.py
+++ b/tests/blocks/test_introspect.py
@@ -1,0 +1,188 @@
+"""Tests for introspect.py — script interface extraction and port auto-inference.
+
+ADR-029 D7: introspect_script() now includes ``input_ports`` derived from the
+``run()`` function's parameter annotations.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scieasy.blocks.code.introspect import (
+    _annotation_to_type_name,
+    _params_to_port_dicts,
+    introspect_script,
+)
+
+# ---------------------------------------------------------------------------
+# Helper: write a temporary Python script file for introspection tests.
+# ---------------------------------------------------------------------------
+
+
+def _write_script(tmp_path: Path, source: str) -> Path:
+    """Write *source* to a temp .py file and return the path."""
+    script = tmp_path / "test_script.py"
+    script.write_text(source, encoding="utf-8")
+    return script
+
+
+# ---------------------------------------------------------------------------
+# _annotation_to_type_name unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestAnnotationToTypeName:
+    """_annotation_to_type_name — map ast.dump annotation strings to type names."""
+
+    def test_simple_name_annotation(self) -> None:
+        assert _annotation_to_type_name("Name(id='Image')") == "Image"
+
+    def test_dataframe_annotation(self) -> None:
+        assert _annotation_to_type_name("Name(id='DataFrame')") == "DataFrame"
+
+    def test_dataobject_annotation(self) -> None:
+        assert _annotation_to_type_name("Name(id='DataObject')") == "DataObject"
+
+    def test_none_annotation_falls_back(self) -> None:
+        assert _annotation_to_type_name(None) == "DataObject"
+
+    def test_subscript_annotation_falls_back(self) -> None:
+        # e.g. Optional[Image] -> "Subscript(...)"
+        assert _annotation_to_type_name("Subscript(value=Name(id='Optional'), ...)") == "DataObject"
+
+    def test_attribute_annotation_falls_back(self) -> None:
+        assert _annotation_to_type_name("Attribute(value=Name(id='scieasy'), attr='Image')") == "DataObject"
+
+    def test_empty_string_falls_back(self) -> None:
+        assert _annotation_to_type_name("") == "DataObject"
+
+    def test_name_with_ctx(self) -> None:
+        """ast.dump in Python 3.9+ includes ctx=Load() by default."""
+        assert _annotation_to_type_name("Name(id='Array', ctx=Load())") == "Array"
+
+
+# ---------------------------------------------------------------------------
+# _params_to_port_dicts unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestParamsToPortDicts:
+    """_params_to_port_dicts — convert extracted params to port dict list."""
+
+    def test_annotated_params(self) -> None:
+        params = [
+            {"name": "self", "annotation": None, "default": None},
+            {"name": "image", "annotation": "Name(id='Image')", "default": None},
+            {"name": "table", "annotation": "Name(id='DataFrame')", "default": None},
+        ]
+        ports = _params_to_port_dicts(params)
+        assert len(ports) == 2
+        assert ports[0] == {"name": "image", "types": ["Image"]}
+        assert ports[1] == {"name": "table", "types": ["DataFrame"]}
+
+    def test_unannotated_params_default_to_dataobject(self) -> None:
+        params = [
+            {"name": "x", "annotation": None, "default": None},
+            {"name": "y", "annotation": None, "default": None},
+        ]
+        ports = _params_to_port_dicts(params)
+        assert len(ports) == 2
+        assert ports[0]["types"] == ["DataObject"]
+        assert ports[1]["types"] == ["DataObject"]
+
+    def test_self_skipped(self) -> None:
+        params = [{"name": "self", "annotation": None, "default": None}]
+        ports = _params_to_port_dicts(params)
+        assert ports == []
+
+    def test_config_skipped(self) -> None:
+        params = [
+            {"name": "data", "annotation": "Name(id='DataObject')", "default": None},
+            {"name": "config", "annotation": None, "default": None},
+        ]
+        ports = _params_to_port_dicts(params)
+        assert len(ports) == 1
+        assert ports[0]["name"] == "data"
+
+    def test_empty_params(self) -> None:
+        assert _params_to_port_dicts([]) == []
+
+
+# ---------------------------------------------------------------------------
+# introspect_script integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestIntrospectScriptInputPorts:
+    """introspect_script() now includes input_ports derived from run() annotations."""
+
+    def test_annotated_run_produces_input_ports(self, tmp_path: Path) -> None:
+        script = _write_script(
+            tmp_path,
+            "def run(image, table):\n    return {}\n",
+        )
+        result = introspect_script(script)
+        assert result["has_run"] is True
+        assert result["input_ports"] == [
+            {"name": "image", "types": ["DataObject"]},
+            {"name": "table", "types": ["DataObject"]},
+        ]
+
+    def test_type_annotated_run_produces_typed_ports(self, tmp_path: Path) -> None:
+        script = _write_script(
+            tmp_path,
+            "from __future__ import annotations\ndef run(image: Image, table: DataFrame):\n    return {}\n",
+        )
+        result = introspect_script(script)
+        assert result["input_ports"] == [
+            {"name": "image", "types": ["Image"]},
+            {"name": "table", "types": ["DataFrame"]},
+        ]
+
+    def test_mixed_annotated_run(self, tmp_path: Path) -> None:
+        script = _write_script(
+            tmp_path,
+            "def run(x: Array, y):\n    return {}\n",
+        )
+        result = introspect_script(script)
+        assert result["input_ports"] == [
+            {"name": "x", "types": ["Array"]},
+            {"name": "y", "types": ["DataObject"]},
+        ]
+
+    def test_no_run_function_produces_empty_ports(self, tmp_path: Path) -> None:
+        script = _write_script(tmp_path, "def configure():\n    return {}\n")
+        result = introspect_script(script)
+        assert result["has_run"] is False
+        assert result["input_ports"] == []
+
+    def test_run_with_self_and_config_skipped(self, tmp_path: Path) -> None:
+        script = _write_script(
+            tmp_path,
+            "def run(self, data: DataObject, config):\n    return {}\n",
+        )
+        result = introspect_script(script)
+        assert result["input_ports"] == [{"name": "data", "types": ["DataObject"]}]
+
+    def test_introspect_result_has_input_ports_key(self, tmp_path: Path) -> None:
+        """input_ports key must always be present even when run() is absent."""
+        script = _write_script(tmp_path, "x = 1\n")
+        result = introspect_script(script)
+        assert "input_ports" in result
+
+    def test_configure_schema_still_extracted(self, tmp_path: Path) -> None:
+        """Existing configure() extraction still works alongside port inference."""
+        script = _write_script(
+            tmp_path,
+            "def run(data: Array):\n    return {}\n\ndef configure():\n    return {'threshold': 0.5}\n",
+        )
+        result = introspect_script(script)
+        assert result["has_configure"] is True
+        assert result["configure_schema"] == {"threshold": 0.5}
+        assert result["input_ports"] == [{"name": "data", "types": ["Array"]}]
+
+    def test_file_not_found_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(FileNotFoundError):
+            introspect_script(tmp_path / "nonexistent.py")


### PR DESCRIPTION
## Summary

Implements **Ticket B3** of the ADR-029 variadic ports roadmap: extend `introspect_script()` to derive a variadic input port list from the `run()` function's parameter type annotations.

## Changes

- **`src/scieasy/blocks/code/introspect.py`**:
  - `introspect_script()` now returns an `"input_ports"` key: `list[{"name": str, "types": list[str]}]`
  - New `_params_to_port_dicts(params)` helper: converts `_extract_params()` output to port dicts, skipping `self` and `config`, defaulting unannotated params to `"DataObject"`
  - New `_annotation_to_type_name(annotation_dump)` helper: resolves simple `Name(id='...')` AST nodes to type name strings; all other annotation forms fall back to `"DataObject"` safely

- **`tests/blocks/test_introspect.py`** (new file): 21 tests covering:
  - `_annotation_to_type_name` unit tests (Name, None, subscript, attribute, ctx=Load())
  - `_params_to_port_dicts` unit tests (annotated, unannotated, self/config skip)
  - `introspect_script()` integration tests (annotated run, unannotated run, mixed, no run, configure still works)

## Design Notes

- Only input port inference for MVP (output inference from return annotations deferred — dict keys are runtime values)
- Only simple `Name(id='...')` annotations resolved; complex types fall back to `DataObject` silently
- Purely additive: existing callers that don't inspect `"input_ports"` are unaffected
- No CodeBlock changes: the consumer integration trigger (auto-populating ports when script path changes) is part of C2

## Related Issues

Closes #606

## ADR

- ADR-029 D7 (CodeBlock hybrid: Python auto-infer from signature)
- Depends on: #602 (B1 for port dict format convention)
