### PR TITLE
feat(#608): ADR-029 F1 -- canvas node [+]/[-] variadic port buttons with edge cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- [#608] ADR-029 F1: add variadic port [+]/[-] buttons to canvas BlockNode with edge cleanup confirmation dialog; add onAddPort/onRemovePort to BlockNodeData; add variadic_inputs/variadic_outputs to api.ts types (@claude, 2026-04-11, branch: feat/issue-608/canvas-variadic-port-buttons, session: 20260411-110037-f1-canvas-node-button-port-deletion-edge)
 - [#588] Split category into base_category + subcategory so AppBlock subclasses with custom palette labels retain correct base type detection (@claude, 2026-04-11, branch: refactor/issue-588/category-subcategory-split, session: 20260411-042819-split-category-into-base-category-subcat)
 
 ### Fixed

--- a/frontend/src/components/nodes/BlockNode.tsx
+++ b/frontend/src/components/nodes/BlockNode.tsx
@@ -1,4 +1,4 @@
-import { type Node, Handle, Position, type NodeProps } from "@xyflow/react";
+import { type Node, Handle, Position, type NodeProps, useEdges } from "@xyflow/react";
 import { useState, useEffect, useCallback, useRef } from "react";
 
 import { resolveTypeColor, resolveRingColor, isAnyType, primaryTypeName } from "../../config/typeColorMap";
@@ -612,7 +612,7 @@ function PausedToast({ outputDir }: { outputDir: string }) {
   );
 }
 
-export function BlockNode({ data, selected }: NodeProps<Node<BlockNodeData>>) {
+export function BlockNode({ id: nodeId, data, selected }: NodeProps<Node<BlockNodeData>>) {
   // ADR-028 Addendum 1 §B fix #2 / §C11: hide the ``direction`` config
   // field for any IO block (not just the legacy abstract-base type_name).
   // ``direction`` is a ClassVar on the IOBlock subclass — it is not a
@@ -655,6 +655,30 @@ export function BlockNode({ data, selected }: NodeProps<Node<BlockNodeData>>) {
 
   const handleConfigChange = (key: string, value: unknown) => {
     data.onUpdateConfig?.({ [key]: value });
+  };
+
+  // ADR-029 D2: variadic port UI — [+] and [-] controls.
+  const edges = useEdges();
+  const isVariadicInputs = data.schema?.variadic_inputs === true;
+  const isVariadicOutputs = data.schema?.variadic_outputs === true;
+
+  const handleAddPort = (direction: "input" | "output") => {
+    data.onAddPort?.(direction);
+  };
+
+  const handleRemovePort = (direction: "input" | "output", portName: string) => {
+    const connected = edges.filter(
+      (e) =>
+        (direction === "input" && e.target === nodeId && e.targetHandle === portName) ||
+        (direction === "output" && e.source === nodeId && e.sourceHandle === portName),
+    );
+    if (connected.length > 0) {
+      const confirmed = window.confirm(
+        `This port has ${connected.length} connection(s). Remove port and disconnect?`,
+      );
+      if (!confirmed) return;
+    }
+    data.onRemovePort?.(direction, portName);
   };
 
   return (
@@ -739,48 +763,96 @@ export function BlockNode({ data, selected }: NodeProps<Node<BlockNodeData>>) {
         const anyType = isAnyType(port.accepted_types);
         const typeName = primaryTypeName(port.accepted_types);
         const borderColor = ringColor ?? (anyType ? "#d1d5db" : fillColor);
+        const portTop = 80 + index * 20;
         return (
-          <Handle
-            key={port.name}
-            id={port.name}
-            type="target"
-            position={Position.Left}
-            className="!h-3.5 !w-3.5 !border-2"
-            title={`${typeName}${port.description ? " \u2014 " + port.description : ""}`}
-            style={{
-              backgroundColor: anyType ? "#ffffff" : fillColor,
-              borderColor,
-              borderStyle: anyType ? "dashed" : "solid",
-              left: -7,
-              top: 80 + index * 20,
-            }}
-          />
+          <span key={port.name} className="group">
+            <Handle
+              id={port.name}
+              type="target"
+              position={Position.Left}
+              className="!h-3.5 !w-3.5 !border-2"
+              title={`${typeName}${port.description ? " \u2014 " + port.description : ""}`}
+              style={{
+                backgroundColor: anyType ? "#ffffff" : fillColor,
+                borderColor,
+                borderStyle: anyType ? "dashed" : "solid",
+                left: -7,
+                top: portTop,
+              }}
+            />
+            {isVariadicInputs && (
+              <button
+                type="button"
+                className="nodrag absolute flex h-3.5 w-3.5 items-center justify-center rounded-full bg-red-100 text-[9px] text-red-500 opacity-0 transition-opacity hover:bg-red-200 group-hover:opacity-100"
+                title={`Remove port "${port.name}"`}
+                style={{ left: 6, top: portTop - 1 }}
+                onClick={() => handleRemovePort("input", port.name)}
+              >
+                ×
+              </button>
+            )}
+          </span>
         );
       })}
+      {isVariadicInputs && (
+        <button
+          type="button"
+          className="nodrag absolute flex h-3.5 w-3.5 items-center justify-center rounded-full bg-stone-100 text-[9px] text-stone-500 transition-colors hover:bg-ember hover:text-white"
+          title="Add input port"
+          style={{ left: 6, top: 80 + effectiveInputPorts.length * 20 - 1 }}
+          onClick={() => handleAddPort("input")}
+        >
+          +
+        </button>
+      )}
       {effectiveOutputPorts.map((port, index) => {
         const fillColor = resolveTypeColor(port.accepted_types, typeHierarchy);
         const ringColor = resolveRingColor(port.accepted_types, typeHierarchy);
         const anyType = isAnyType(port.accepted_types);
         const typeName = primaryTypeName(port.accepted_types);
         const borderColor = ringColor ?? (anyType ? "#d1d5db" : fillColor);
+        const portTop = 80 + index * 20;
         return (
-          <Handle
-            key={port.name}
-            id={port.name}
-            type="source"
-            position={Position.Right}
-            className="!h-3.5 !w-3.5 !border-2"
-            title={`${typeName}${port.description ? " \u2014 " + port.description : ""}`}
-            style={{
-              backgroundColor: anyType ? "#ffffff" : fillColor,
-              borderColor,
-              borderStyle: anyType ? "dashed" : "solid",
-              right: -7,
-              top: 80 + index * 20,
-            }}
-          />
+          <span key={port.name} className="group">
+            <Handle
+              id={port.name}
+              type="source"
+              position={Position.Right}
+              className="!h-3.5 !w-3.5 !border-2"
+              title={`${typeName}${port.description ? " \u2014 " + port.description : ""}`}
+              style={{
+                backgroundColor: anyType ? "#ffffff" : fillColor,
+                borderColor,
+                borderStyle: anyType ? "dashed" : "solid",
+                right: -7,
+                top: portTop,
+              }}
+            />
+            {isVariadicOutputs && (
+              <button
+                type="button"
+                className="nodrag absolute flex h-3.5 w-3.5 items-center justify-center rounded-full bg-red-100 text-[9px] text-red-500 opacity-0 transition-opacity hover:bg-red-200 group-hover:opacity-100"
+                title={`Remove port "${port.name}"`}
+                style={{ right: 6, top: portTop - 1 }}
+                onClick={() => handleRemovePort("output", port.name)}
+              >
+                ×
+              </button>
+            )}
+          </span>
         );
       })}
+      {isVariadicOutputs && (
+        <button
+          type="button"
+          className="nodrag absolute flex h-3.5 w-3.5 items-center justify-center rounded-full bg-stone-100 text-[9px] text-stone-500 transition-colors hover:bg-ember hover:text-white"
+          title="Add output port"
+          style={{ right: 6, top: 80 + effectiveOutputPorts.length * 20 - 1 }}
+          onClick={() => handleAddPort("output")}
+        >
+          +
+        </button>
+      )}
 
       {/* ----------------------------------------------------------------- */}
       {/* Footer                                                            */}

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -71,6 +71,10 @@ export interface BlockSummary {
   direction?: string | null;
   source?: string;
   package_name?: string;
+  /** ADR-029 D8: true when this block supports user-configurable input port count. */
+  variadic_inputs?: boolean;
+  /** ADR-029 D8: true when this block supports user-configurable output port count. */
+  variadic_outputs?: boolean;
 }
 
 export interface TypeHierarchyEntry {
@@ -130,6 +134,17 @@ export interface BlockSchemaResponse extends BlockSummary {
    * ``blockType === "io_block"`` checks.
    */
   direction?: string | null;
+  /**
+   * ADR-029 D11: type names accepted by variadic input ports.
+   * Frontend uses this to populate the type dropdown in the port editor.
+   * Empty array means "any DataObject subclass".
+   */
+  allowed_input_types?: string[];
+  /**
+   * ADR-029 D11: type names accepted by variadic output ports.
+   * Empty array means "any DataObject subclass".
+   */
+  allowed_output_types?: string[];
 }
 
 export interface BlockListResponse {

--- a/frontend/src/types/ui.ts
+++ b/frontend/src/types/ui.ts
@@ -24,6 +24,10 @@ export interface BlockNodeData extends Record<string, unknown> {
   onDelete?: () => void;
   onUpdateConfig?: (patch: Record<string, unknown>) => void;
   onErrorClick?: () => void;
+  /** ADR-029 D2: add a new variadic port (input or output side). */
+  onAddPort?: (direction: "input" | "output") => void;
+  /** ADR-029 D2: remove a variadic port by name. Caller handles edge cleanup. */
+  onRemovePort?: (direction: "input" | "output", portName: string) => void;
 }
 
 export type BlockCanvasNode = Node<BlockNodeData>;


### PR DESCRIPTION
## Summary

Implements **Ticket F1** of the ADR-029 variadic ports roadmap: adds `[+]` and `[-]` buttons to `BlockNode.tsx` for variadic blocks, with confirmation-guarded edge cleanup on port removal.

## Changes

### `frontend/src/components/nodes/BlockNode.tsx`
- Import `useEdges` from `@xyflow/react` for edge detection
- Destructure `id: nodeId` from NodeProps to identify the current node's edges
- Compute `isVariadicInputs` / `isVariadicOutputs` from `data.schema?.variadic_inputs/outputs`
- Wrap each port Handle in a `<span class="group">` so the `[-]` button can show on hover via `group-hover:opacity-100`
- Render `[-]` button on each variadic port (absolute positioned, inside node boundary, red on hover)
- Render `[+]` button below the last port handle on each variadic side (stone → ember color on hover)
- `handleRemovePort`: checks `useEdges()` for connected edges; if any exist, shows `window.confirm()` before calling `onRemovePort` callback
- `handleAddPort`: calls `onAddPort` callback directly

### `frontend/src/types/ui.ts`
- Add `onAddPort?: (direction: "input" | "output") => void` to `BlockNodeData`
- Add `onRemovePort?: (direction: "input" | "output", portName: string) => void` to `BlockNodeData`

### `frontend/src/types/api.ts`
- Add `variadic_inputs?: boolean` and `variadic_outputs?: boolean` to `BlockSummary`
- Add `allowed_input_types?: string[]` and `allowed_output_types?: string[]` to `BlockSchemaResponse`
(mirrors B1 backend additions; needed for F1 TypeScript compilation)

## Design

- Non-variadic blocks: zero visual change (all conditional on `schema.variadic_inputs/outputs`)
- TypeScript type check: passes cleanly (`npx tsc --noEmit`)
- The `onAddPort` / `onRemovePort` callbacks are wired by the parent canvas component; BlockNode only signals intent
- Edge cleanup logic in `handleRemovePort` uses `useEdges()` to find connected edges by node ID + handle name

## Related Issues

Closes #608

## ADR

- ADR-029 D2 (canvas [+]/[-] port editor controls)
- Depends on: #602 (B1 for variadic_inputs/variadic_outputs on BlockSchemaResponse)
