### PR TITLE
fix(#612): wire variadic port buttons and fix PortEditorTable key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- [#612] Wire ADR-029 F1 variadic port [+]/[-] buttons via onUpdateConfig + useReactFlow, fix F2 PortEditorTable key (@claude, 2026-04-11, branch: fix/issue-612/variadic-port-f1f2-wiring, session: 20260411-095429-fix-adr-029-f1-f2-wire-variadic-port-but)
 - [#581] Remove redundant fiji_path/napari_path fields, inject ClassVar defaults into config_schema, remove auto-open file manager, add copy button feedback (@claude, 2026-04-11, branch: fix/issue-581/path-cleanup-copy-feedback)
 - [#580] Add WORKFLOW_STARTED to WebSocket outbound events so frontend Run button spinner activates (@claude, 2026-04-11, branch: fix/issue-580/workflow-started-ws, session: 20260411-032524-fix-580-add-workflow-started-to-websocke)
 

--- a/frontend/src/components/BottomPanel.tsx
+++ b/frontend/src/components/BottomPanel.tsx
@@ -3,6 +3,7 @@ import { useMemo, useState } from "react";
 import type { BlockSchemaResponse, ChatMessage, LogEntry, WorkflowNode } from "../types/api";
 import type { BottomTab } from "../types/ui";
 import { AIChat } from "./AIChat";
+import { type PortRow, PortEditorTable } from "./PortEditorTable";
 
 interface BottomPanelProps {
   activeTab: BottomTab;
@@ -42,22 +43,51 @@ function ConfigPanel({
   const params = ((selectedNode?.config.params as Record<string, unknown> | undefined) ?? {}) as Record<string, unknown>;
   const properties = schema?.config_schema.properties ?? {};
   const ordered = Object.entries(properties)
-    .filter(([key]) => {
+    .filter(([key, value]) => {
       // For io_block, hide "direction" — it is already determined by whether
       // the user dragged a Load Block or Save Block from the palette.
       if ((schema?.direction || selectedNode?.block_type === "io_block") && key === "direction") return false;
+      // Skip port_editor fields — rendered separately as PortEditorTable below.
+      if ((value as Record<string, unknown>).ui_widget === "port_editor") return false;
       return true;
     })
     .sort(([, left], [, right]) => {
       return Number(left.ui_priority ?? 99) - Number(right.ui_priority ?? 99);
     });
 
+  const isVariadicInputs = schema?.variadic_inputs === true;
+  const isVariadicOutputs = schema?.variadic_outputs === true;
+  const inputPorts = Array.isArray(params["input_ports"]) ? (params["input_ports"] as PortRow[]) : [];
+  const outputPorts = Array.isArray(params["output_ports"]) ? (params["output_ports"] as PortRow[]) : [];
+  const typeHierarchy = schema?.type_hierarchy ?? [];
+  const allowedInputTypes = schema?.allowed_input_types ?? [];
+  const allowedOutputTypes = schema?.allowed_output_types ?? [];
+
   if (!selectedNode || !schema) {
     return <div className="text-sm text-stone-500">Select a node to edit its JSON-schema-driven configuration.</div>;
   }
 
   return (
-    <div className="grid gap-4 md:grid-cols-2">
+    <div>
+      {isVariadicInputs && (
+        <PortEditorTable
+          allowedTypes={allowedInputTypes}
+          direction="input"
+          onChange={(ports) => onUpdateConfig({ input_ports: ports })}
+          ports={inputPorts}
+          typeHierarchy={typeHierarchy}
+        />
+      )}
+      {isVariadicOutputs && (
+        <PortEditorTable
+          allowedTypes={allowedOutputTypes}
+          direction="output"
+          onChange={(ports) => onUpdateConfig({ output_ports: ports })}
+          ports={outputPorts}
+          typeHierarchy={typeHierarchy}
+        />
+      )}
+      <div className="grid gap-4 md:grid-cols-2">
       {ordered.map(([key, value]) => {
         const currentValue = params[key] ?? value.default ?? "";
         if (Array.isArray(value.enum)) {
@@ -95,6 +125,7 @@ function ConfigPanel({
           </label>
         );
       })}
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/PortEditorTable.tsx
+++ b/frontend/src/components/PortEditorTable.tsx
@@ -1,0 +1,93 @@
+import type { TypeHierarchyEntry } from "../types/api";
+
+export interface PortRow {
+  name: string;
+  types: string[];
+}
+
+interface PortEditorTableProps {
+  direction: "input" | "output";
+  ports: PortRow[];
+  /** Type names allowed for this direction. Empty = show all from typeHierarchy. */
+  allowedTypes: string[];
+  typeHierarchy: TypeHierarchyEntry[];
+  onChange: (ports: PortRow[]) => void;
+}
+
+export function PortEditorTable({ direction, ports, allowedTypes, typeHierarchy, onChange }: PortEditorTableProps) {
+  const availableTypes =
+    allowedTypes.length > 0
+      ? typeHierarchy.filter((t) => allowedTypes.includes(t.name))
+      : typeHierarchy;
+
+  const defaultType = availableTypes[0]?.name ?? "DataObject";
+
+  function handleNameChange(index: number, name: string) {
+    onChange(ports.map((p, i) => (i === index ? { ...p, name } : p)));
+  }
+
+  function handleTypeChange(index: number, typeName: string) {
+    onChange(ports.map((p, i) => (i === index ? { ...p, types: [typeName] } : p)));
+  }
+
+  function handleRemove(index: number) {
+    onChange(ports.filter((_, i) => i !== index));
+  }
+
+  function handleAdd() {
+    onChange([...ports, { name: `port_${ports.length + 1}`, types: [defaultType] }]);
+  }
+
+  return (
+    <div className="mb-4">
+      <h3 className="mb-2 text-sm font-semibold text-ink">
+        {direction === "input" ? "Input Ports" : "Output Ports"}
+      </h3>
+      <div className="flex flex-col gap-1.5">
+        {ports.map((port, index) => (
+          <div className="flex items-center gap-2" key={port.name + '-' + index}>
+            <input
+              className="w-32 rounded-xl border border-stone-300 bg-white px-3 py-1.5 text-sm"
+              onChange={(e) => handleNameChange(index, e.target.value)}
+              placeholder="port name"
+              value={port.name}
+            />
+            <select
+              className="min-w-0 flex-1 rounded-xl border border-stone-300 bg-white px-3 py-1.5 text-sm"
+              onChange={(e) => handleTypeChange(index, e.target.value)}
+              value={port.types[0] ?? defaultType}
+            >
+              {availableTypes.length > 0 ? (
+                availableTypes.map((t) => (
+                  <option key={t.name} value={t.name}>
+                    {t.name}
+                  </option>
+                ))
+              ) : (
+                <option value="DataObject">DataObject</option>
+              )}
+            </select>
+            <button
+              className="rounded-lg px-2 py-1 text-xs text-stone-500 hover:bg-red-100 hover:text-red-700"
+              onClick={() => handleRemove(index)}
+              title="Remove port"
+              type="button"
+            >
+              −
+            </button>
+          </div>
+        ))}
+        {ports.length === 0 && (
+          <p className="text-xs text-stone-400">No ports defined. Click &quot;+ Add Port&quot; to add one.</p>
+        )}
+      </div>
+      <button
+        className="mt-2 rounded-xl border border-stone-300 bg-white px-3 py-1.5 text-sm text-stone-600 hover:bg-stone-50"
+        onClick={handleAdd}
+        type="button"
+      >
+        + Add Port
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/components/nodes/BlockNode.tsx
+++ b/frontend/src/components/nodes/BlockNode.tsx
@@ -1,4 +1,4 @@
-import { type Node, Handle, Position, type NodeProps } from "@xyflow/react";
+import { type Node, Handle, Position, type NodeProps, useEdges, useReactFlow } from "@xyflow/react";
 import { useState, useEffect, useCallback, useRef } from "react";
 
 import { resolveTypeColor, resolveRingColor, isAnyType, primaryTypeName } from "../../config/typeColorMap";
@@ -612,7 +612,7 @@ function PausedToast({ outputDir }: { outputDir: string }) {
   );
 }
 
-export function BlockNode({ data, selected }: NodeProps<Node<BlockNodeData>>) {
+export function BlockNode({ id: nodeId, data, selected }: NodeProps<Node<BlockNodeData>>) {
   // ADR-028 Addendum 1 §B fix #2 / §C11: hide the ``direction`` config
   // field for any IO block (not just the legacy abstract-base type_name).
   // ``direction`` is a ClassVar on the IOBlock subclass — it is not a
@@ -655,6 +655,42 @@ export function BlockNode({ data, selected }: NodeProps<Node<BlockNodeData>>) {
 
   const handleConfigChange = (key: string, value: unknown) => {
     data.onUpdateConfig?.({ [key]: value });
+  };
+
+  // ADR-029 D2: variadic port UI — [+] and [-] controls.
+  const edges = useEdges();
+  const isVariadicInputs = data.schema?.variadic_inputs === true;
+  const isVariadicOutputs = data.schema?.variadic_outputs === true;
+
+  const { deleteElements } = useReactFlow();
+
+  const handleAddPort = (direction: "input" | "output") => {
+    const key = direction === "input" ? "input_ports" : "output_ports";
+    const current = Array.isArray(data.config?.[key]) ? (data.config[key] as Array<{name: string; types: string[]}>) : [];
+    const defaultType = direction === "input"
+      ? (data.schema?.allowed_input_types?.[0] ?? "DataObject")
+      : (data.schema?.allowed_output_types?.[0] ?? "DataObject");
+    data.onUpdateConfig?.({
+      [key]: [...current, { name: `port_${current.length + 1}`, types: [defaultType] }],
+    });
+  };
+
+  const handleRemovePort = (direction: "input" | "output", portName: string) => {
+    const connected = edges.filter(
+      (e) =>
+        (direction === "input" && e.target === nodeId && e.targetHandle === portName) ||
+        (direction === "output" && e.source === nodeId && e.sourceHandle === portName),
+    );
+    if (connected.length > 0) {
+      const confirmed = window.confirm(
+        `This port has ${connected.length} connection(s). Remove port and disconnect?`,
+      );
+      if (!confirmed) return;
+      deleteElements({ edges: connected });
+    }
+    const key = direction === "input" ? "input_ports" : "output_ports";
+    const current = Array.isArray(data.config?.[key]) ? (data.config[key] as Array<{name: string; types: string[]}>) : [];
+    data.onUpdateConfig?.({ [key]: current.filter((p) => p.name !== portName) });
   };
 
   return (
@@ -739,48 +775,96 @@ export function BlockNode({ data, selected }: NodeProps<Node<BlockNodeData>>) {
         const anyType = isAnyType(port.accepted_types);
         const typeName = primaryTypeName(port.accepted_types);
         const borderColor = ringColor ?? (anyType ? "#d1d5db" : fillColor);
+        const portTop = 80 + index * 20;
         return (
-          <Handle
-            key={port.name}
-            id={port.name}
-            type="target"
-            position={Position.Left}
-            className="!h-3.5 !w-3.5 !border-2"
-            title={`${typeName}${port.description ? " \u2014 " + port.description : ""}`}
-            style={{
-              backgroundColor: anyType ? "#ffffff" : fillColor,
-              borderColor,
-              borderStyle: anyType ? "dashed" : "solid",
-              left: -7,
-              top: 80 + index * 20,
-            }}
-          />
+          <span key={port.name} className="group">
+            <Handle
+              id={port.name}
+              type="target"
+              position={Position.Left}
+              className="!h-3.5 !w-3.5 !border-2"
+              title={`${typeName}${port.description ? " \u2014 " + port.description : ""}`}
+              style={{
+                backgroundColor: anyType ? "#ffffff" : fillColor,
+                borderColor,
+                borderStyle: anyType ? "dashed" : "solid",
+                left: -7,
+                top: portTop,
+              }}
+            />
+            {isVariadicInputs && (
+              <button
+                type="button"
+                className="nodrag absolute flex h-3.5 w-3.5 items-center justify-center rounded-full bg-red-100 text-[9px] text-red-500 opacity-0 transition-opacity hover:bg-red-200 group-hover:opacity-100"
+                title={`Remove port "${port.name}"`}
+                style={{ left: 6, top: portTop - 1 }}
+                onClick={() => handleRemovePort("input", port.name)}
+              >
+                ×
+              </button>
+            )}
+          </span>
         );
       })}
+      {isVariadicInputs && (
+        <button
+          type="button"
+          className="nodrag absolute flex h-3.5 w-3.5 items-center justify-center rounded-full bg-stone-100 text-[9px] text-stone-500 transition-colors hover:bg-ember hover:text-white"
+          title="Add input port"
+          style={{ left: 6, top: 80 + effectiveInputPorts.length * 20 - 1 }}
+          onClick={() => handleAddPort("input")}
+        >
+          +
+        </button>
+      )}
       {effectiveOutputPorts.map((port, index) => {
         const fillColor = resolveTypeColor(port.accepted_types, typeHierarchy);
         const ringColor = resolveRingColor(port.accepted_types, typeHierarchy);
         const anyType = isAnyType(port.accepted_types);
         const typeName = primaryTypeName(port.accepted_types);
         const borderColor = ringColor ?? (anyType ? "#d1d5db" : fillColor);
+        const portTop = 80 + index * 20;
         return (
-          <Handle
-            key={port.name}
-            id={port.name}
-            type="source"
-            position={Position.Right}
-            className="!h-3.5 !w-3.5 !border-2"
-            title={`${typeName}${port.description ? " \u2014 " + port.description : ""}`}
-            style={{
-              backgroundColor: anyType ? "#ffffff" : fillColor,
-              borderColor,
-              borderStyle: anyType ? "dashed" : "solid",
-              right: -7,
-              top: 80 + index * 20,
-            }}
-          />
+          <span key={port.name} className="group">
+            <Handle
+              id={port.name}
+              type="source"
+              position={Position.Right}
+              className="!h-3.5 !w-3.5 !border-2"
+              title={`${typeName}${port.description ? " \u2014 " + port.description : ""}`}
+              style={{
+                backgroundColor: anyType ? "#ffffff" : fillColor,
+                borderColor,
+                borderStyle: anyType ? "dashed" : "solid",
+                right: -7,
+                top: portTop,
+              }}
+            />
+            {isVariadicOutputs && (
+              <button
+                type="button"
+                className="nodrag absolute flex h-3.5 w-3.5 items-center justify-center rounded-full bg-red-100 text-[9px] text-red-500 opacity-0 transition-opacity hover:bg-red-200 group-hover:opacity-100"
+                title={`Remove port "${port.name}"`}
+                style={{ right: 6, top: portTop - 1 }}
+                onClick={() => handleRemovePort("output", port.name)}
+              >
+                ×
+              </button>
+            )}
+          </span>
         );
       })}
+      {isVariadicOutputs && (
+        <button
+          type="button"
+          className="nodrag absolute flex h-3.5 w-3.5 items-center justify-center rounded-full bg-stone-100 text-[9px] text-stone-500 transition-colors hover:bg-ember hover:text-white"
+          title="Add output port"
+          style={{ right: 6, top: 80 + effectiveOutputPorts.length * 20 - 1 }}
+          onClick={() => handleAddPort("output")}
+        >
+          +
+        </button>
+      )}
 
       {/* ----------------------------------------------------------------- */}
       {/* Footer                                                            */}


### PR DESCRIPTION
## Summary

- Wire ADR-029 F1 variadic port [+]/[-] buttons in BlockNode.tsx to use `data.onUpdateConfig` (already wired by WorkflowCanvas) instead of dead `onAddPort`/`onRemovePort` callbacks that nobody connected
- Use `useReactFlow().deleteElements()` for edge cleanup when removing a connected port -- no new props or WorkflowCanvas changes needed
- Add PortEditorTable component with stable `key={port.name + '-' + index}` (fixes F2 React key anti-pattern)
- Integrate PortEditorTable into BottomPanel ConfigPanel for variadic blocks
- No changes to ui.ts BlockNodeData -- onAddPort/onRemovePort were never needed

Closes #612
Supersedes #609 and #611

## Test plan

- [x] `npx tsc --noEmit` -- 0 errors
- [x] `npx vitest run` -- 82/82 tests pass
- [ ] Manual: open a variadic block, click [+] to add port, verify port appears
- [ ] Manual: click [-] on connected port, verify confirmation dialog and edge removal

🤖 Generated with [Claude Code](https://claude.com/claude-code)