### PR TITLE
fix(gui): replace FolderBrowserDialog with modern IFileOpenDialog (#600)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- [#600] Replace FolderBrowserDialog with modern IFileOpenDialog COM folder picker on Windows (@claude, 2026-04-11, branch: fix/issue-600/modern-folder-dialog, session: 20260411-104043-replace-windows-folderbrowserdialog-with)
 - [#612] Wire ADR-029 F1 variadic port [+]/[-] buttons via onUpdateConfig + useReactFlow, fix F2 PortEditorTable key (@claude, 2026-04-11, branch: fix/issue-612/variadic-port-f1f2-wiring, session: 20260411-095429-fix-adr-029-f1-f2-wire-variadic-port-but)
 - [#581] Remove redundant fiji_path/napari_path fields, inject ClassVar defaults into config_schema, remove auto-open file manager, add copy button feedback (@claude, 2026-04-11, branch: fix/issue-581/path-cleanup-copy-feedback)
 - [#580] Add WORKFLOW_STARTED to WebSocket outbound events so frontend Run button spinner activates (@claude, 2026-04-11, branch: fix/issue-580/workflow-started-ws, session: 20260411-032524-fix-580-add-workflow-started-to-websocke)

--- a/src/scieasy/api/routes/filesystem.py
+++ b/src/scieasy/api/routes/filesystem.py
@@ -256,17 +256,79 @@ def _native_dialog_windows(mode: str, initial_dir: str | None) -> list[str]:
     For file mode the list may contain multiple files.
     """
     if mode == "directory":
-        # Bug 3 fix: EnableVisualStyles() forces the modern Vista-style dialog
-        # instead of the legacy Win2000 FolderBrowserDialog appearance.
-        # Bug 1 fix: braces in non-f-string fragments must be single `{ }`,
-        # not `{{ }}` (double braces are only needed inside f-strings).
+        # Use modern IFileOpenDialog COM with FOS_PICKFOLDERS for Vista+ style
+        # instead of the legacy Win2000-era FolderBrowserDialog.
+        # The C# source is compiled once per session by PowerShell Add-Type;
+        # the static FolderPicker.Pick() method shows the dialog and returns
+        # the selected path (or null on cancel).
+        # NOTE: COM interface method stubs follow vtable order — do NOT
+        # reorder or remove entries.
+        cs_source = r"""
+using System;
+using System.Runtime.InteropServices;
+
+[ComImport, Guid("DC1C5A9C-E88A-4DDE-A5A1-60F82A20AEF7"), ClassInterface(ClassInterfaceType.None)]
+public class FileOpenDialogClass { }
+
+[ComImport, Guid("42F85136-DB7E-439C-85F1-E4075D135FC8"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+public interface IFileDialog {
+    [PreserveSig] int Show(IntPtr hwnd);
+    void SetFileTypes();
+    void SetFileTypeIndex();
+    void GetFileTypeIndex();
+    void Advise();
+    void Unadvise();
+    void SetOptions(uint fos);
+    void GetOptions(out uint pfos);
+    void SetDefaultFolder();
+    void SetFolder(IShellItem psi);
+    void GetFolder();
+    void GetCurrentSelection();
+    void SetFileName();
+    void GetFileName();
+    void SetTitle([MarshalAs(UnmanagedType.LPWStr)] string pszTitle);
+    void SetOkButtonLabel([MarshalAs(UnmanagedType.LPWStr)] string pszText);
+    void SetFileNameLabel();
+    void GetResult(out IShellItem ppsi);
+    void AddPlace();
+    void SetDefaultExtension();
+    void Close();
+    void SetClientGuid();
+    void ClearClientData();
+    void SetFilter();
+}
+
+[ComImport, Guid("43826D1E-E718-42EE-BC55-A1E261C37BFE"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+public interface IShellItem {
+    void BindToHandler();
+    void GetParent();
+    void GetDisplayName(uint sigdnName, [MarshalAs(UnmanagedType.LPWStr)] out string ppszName);
+    void GetAttributes();
+    void Compare();
+}
+
+public static class FolderPicker {
+    public static string Pick(string title) {
+        var dlg = (IFileDialog)new FileOpenDialogClass();
+        uint opts;
+        dlg.GetOptions(out opts);
+        dlg.SetOptions(opts | 0x20 | 0x40);
+        if (title != null) dlg.SetTitle(title);
+        int hr = dlg.Show(IntPtr.Zero);
+        if (hr != 0) return null;
+        IShellItem item;
+        dlg.GetResult(out item);
+        string path;
+        item.GetDisplayName(0x80058000, out path);
+        return path;
+    }
+}
+"""
+        # Pass C# source in a PowerShell single-quoted string (escape ' as '').
         ps_script = (
-            "Add-Type -AssemblyName System.Windows.Forms;"
-            "[System.Windows.Forms.Application]::EnableVisualStyles();"
-            "$d = New-Object System.Windows.Forms.FolderBrowserDialog;"
-            "$d.ShowNewFolderButton = $true;"
-            f"$d.SelectedPath = '{initial_dir or ''}';"
-            "if ($d.ShowDialog() -eq 'OK') { $d.SelectedPath } else { '' }"
+            "Add-Type -TypeDefinition '" + cs_source.replace("'", "''") + "';"
+            "$result = [FolderPicker]::Pick('Select Folder');"
+            "if ($result) { $result } else { '' }"
         )
     else:
         # Bug 1 fix: single braces for non-f-string lines.

--- a/tests/api/test_native_dialog.py
+++ b/tests/api/test_native_dialog.py
@@ -1,4 +1,4 @@
-"""Tests for _native_dialog_windows directory picker (IFileOpenDialog COM)."""
+"""Tests for _native_dialog_windows: modern IFileOpenDialog COM folder picker."""
 
 from __future__ import annotations
 

--- a/tests/api/test_native_dialog.py
+++ b/tests/api/test_native_dialog.py
@@ -1,0 +1,70 @@
+"""Tests for _native_dialog_windows directory picker (IFileOpenDialog COM)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.mark.skipif(
+    __import__("sys").platform != "win32",
+    reason="Windows-only dialog",
+)
+class TestNativeDialogWindowsDirectory:
+    """Verify that the directory branch uses the modern IFileOpenDialog COM dialog."""
+
+    def test_directory_mode_uses_ifileopendialog(self) -> None:
+        """The PowerShell script should compile a C# FolderPicker via Add-Type,
+        NOT use the legacy FolderBrowserDialog."""
+        from scieasy.api.routes.filesystem import _native_dialog_windows
+
+        mock_result = MagicMock()
+        mock_result.stdout = r"C:\Users\test\Documents"
+        mock_result.returncode = 0
+
+        with patch("scieasy.api.routes.filesystem.subprocess.run", return_value=mock_result) as mock_run:
+            result = _native_dialog_windows("directory", None)
+
+        mock_run.assert_called_once()
+        ps_command = mock_run.call_args[0][0]
+        ps_script = ps_command[-1]  # last arg is the -Command value
+
+        # Must use IFileOpenDialog COM approach, not FolderBrowserDialog
+        assert "FolderPicker" in ps_script
+        assert "IFileDialog" in ps_script
+        assert "Add-Type -TypeDefinition" in ps_script
+        assert "FolderBrowserDialog" not in ps_script
+
+        assert result == [r"C:\Users\test\Documents"]
+
+    def test_directory_mode_cancel_returns_empty(self) -> None:
+        """When the user cancels, the function should return an empty list."""
+        from scieasy.api.routes.filesystem import _native_dialog_windows
+
+        mock_result = MagicMock()
+        mock_result.stdout = ""
+        mock_result.returncode = 0
+
+        with patch("scieasy.api.routes.filesystem.subprocess.run", return_value=mock_result):
+            result = _native_dialog_windows("directory", None)
+
+        assert result == []
+
+    def test_file_mode_uses_openfiledialog(self) -> None:
+        """The file branch should still use OpenFileDialog (not IFileOpenDialog)."""
+        from scieasy.api.routes.filesystem import _native_dialog_windows
+
+        mock_result = MagicMock()
+        mock_result.stdout = r"C:\file1.txt|C:\file2.txt"
+        mock_result.returncode = 0
+
+        with patch("scieasy.api.routes.filesystem.subprocess.run", return_value=mock_result) as mock_run:
+            result = _native_dialog_windows("file", None)
+
+        ps_command = mock_run.call_args[0][0]
+        ps_script = ps_command[-1]
+
+        assert "OpenFileDialog" in ps_script
+        assert "FolderPicker" not in ps_script
+        assert result == [r"C:\file1.txt", r"C:\file2.txt"]


### PR DESCRIPTION
## Summary
- Replace the legacy Win2000-era `FolderBrowserDialog` in `_native_dialog_windows()` directory mode with the modern `IFileOpenDialog` COM dialog using `FOS_PICKFOLDERS` flag
- Uses PowerShell `Add-Type` to compile a small C# shim that invokes the COM interface directly, producing the Vista+ style folder picker
- File picker (`mode == "file"`) is unchanged

Closes #600

## Test plan
- [ ] Open the app on Windows, trigger a directory picker (e.g. browse for output folder) and verify the modern Vista+ style dialog appears
- [ ] Verify cancel returns empty result
- [ ] Verify file picker still works unchanged