### PR TITLE
feat(#595): ADR-029 Addendum 1 — variadic port count min/max limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- [#595] Implement variadic port count min/max limits (ADR-029 Addendum 1) (@claude, 2026-04-11, branch: feat/issue-595/variadic-port-min-max-limits, session: 20260411-101739-implement-adr-029-addendum-1-variadic-po)
+
 ### Changed
 
 - [#606] ADR-029 B3: extend introspect_script() with input_ports auto-inference from run() parameter type annotations; add _params_to_port_dicts() and _annotation_to_type_name() helpers (@claude, 2026-04-11, branch: feat/issue-606/codeblock-signature-auto-inference, session: 20260411-105722-b3-codeblock-python-signature-auto-infer)

--- a/docs/adr/ADR.md
+++ b/docs/adr/ADR.md
@@ -7511,7 +7511,7 @@ resolutions" section.
 
 ## ADR-029 Addendum 1: Variadic port count limits
 
-**Status**: proposed
+**Status**: accepted
 **Date**: 2026-04-11
 **Parent**: ADR-029
 

--- a/frontend/src/components/BottomPanel.tsx
+++ b/frontend/src/components/BottomPanel.tsx
@@ -73,6 +73,8 @@ function ConfigPanel({
         <PortEditorTable
           allowedTypes={allowedInputTypes}
           direction="input"
+          maxPorts={schema.max_input_ports}
+          minPorts={schema.min_input_ports}
           onChange={(ports) => onUpdateConfig({ input_ports: ports })}
           ports={inputPorts}
           typeHierarchy={typeHierarchy}
@@ -82,6 +84,8 @@ function ConfigPanel({
         <PortEditorTable
           allowedTypes={allowedOutputTypes}
           direction="output"
+          maxPorts={schema.max_output_ports}
+          minPorts={schema.min_output_ports}
           onChange={(ports) => onUpdateConfig({ output_ports: ports })}
           ports={outputPorts}
           typeHierarchy={typeHierarchy}

--- a/frontend/src/components/PortEditorTable.tsx
+++ b/frontend/src/components/PortEditorTable.tsx
@@ -12,15 +12,23 @@ interface PortEditorTableProps {
   allowedTypes: string[];
   typeHierarchy: TypeHierarchyEntry[];
   onChange: (ports: PortRow[]) => void;
+  /** ADR-029 Addendum 1: minimum number of ports. null/undefined = no minimum. */
+  minPorts?: number | null;
+  /** ADR-029 Addendum 1: maximum number of ports. null/undefined = no maximum. */
+  maxPorts?: number | null;
 }
 
-export function PortEditorTable({ direction, ports, allowedTypes, typeHierarchy, onChange }: PortEditorTableProps) {
+export function PortEditorTable({ direction, ports, allowedTypes, typeHierarchy, onChange, minPorts, maxPorts }: PortEditorTableProps) {
   const availableTypes =
     allowedTypes.length > 0
       ? typeHierarchy.filter((t) => allowedTypes.includes(t.name))
       : typeHierarchy;
 
   const defaultType = availableTypes[0]?.name ?? "DataObject";
+
+  // ADR-029 Addendum 1: disable add/remove at min/max limits.
+  const canAdd = maxPorts == null || ports.length < maxPorts;
+  const canRemove = minPorts == null || ports.length > minPorts;
 
   function handleNameChange(index: number, name: string) {
     onChange(ports.map((p, i) => (i === index ? { ...p, name } : p)));
@@ -68,9 +76,10 @@ export function PortEditorTable({ direction, ports, allowedTypes, typeHierarchy,
               )}
             </select>
             <button
-              className="rounded-lg px-2 py-1 text-xs text-stone-500 hover:bg-red-100 hover:text-red-700"
+              className={`rounded-lg px-2 py-1 text-xs ${canRemove ? "text-stone-500 hover:bg-red-100 hover:text-red-700" : "cursor-not-allowed text-stone-300"}`}
+              disabled={!canRemove}
               onClick={() => handleRemove(index)}
-              title="Remove port"
+              title={canRemove ? "Remove port" : `Minimum ${minPorts} port(s) required`}
               type="button"
             >
               −
@@ -82,8 +91,10 @@ export function PortEditorTable({ direction, ports, allowedTypes, typeHierarchy,
         )}
       </div>
       <button
-        className="mt-2 rounded-xl border border-stone-300 bg-white px-3 py-1.5 text-sm text-stone-600 hover:bg-stone-50"
+        className={`mt-2 rounded-xl border px-3 py-1.5 text-sm ${canAdd ? "border-stone-300 bg-white text-stone-600 hover:bg-stone-50" : "cursor-not-allowed border-stone-200 bg-stone-50 text-stone-400"}`}
+        disabled={!canAdd}
         onClick={handleAdd}
+        title={canAdd ? undefined : `Maximum ${maxPorts} port(s) allowed`}
         type="button"
       >
         + Add Port

--- a/frontend/src/components/nodes/BlockNode.tsx
+++ b/frontend/src/components/nodes/BlockNode.tsx
@@ -662,6 +662,16 @@ export function BlockNode({ id: nodeId, data, selected }: NodeProps<Node<BlockNo
   const isVariadicInputs = data.schema?.variadic_inputs === true;
   const isVariadicOutputs = data.schema?.variadic_outputs === true;
 
+  // ADR-029 Addendum 1: min/max port count limits.
+  const minInputPorts = data.schema?.min_input_ports ?? null;
+  const maxInputPorts = data.schema?.max_input_ports ?? null;
+  const minOutputPorts = data.schema?.min_output_ports ?? null;
+  const maxOutputPorts = data.schema?.max_output_ports ?? null;
+  const canAddInput = maxInputPorts == null || effectiveInputPorts.length < maxInputPorts;
+  const canRemoveInput = minInputPorts == null || effectiveInputPorts.length > minInputPorts;
+  const canAddOutput = maxOutputPorts == null || effectiveOutputPorts.length < maxOutputPorts;
+  const canRemoveOutput = minOutputPorts == null || effectiveOutputPorts.length > minOutputPorts;
+
   const { deleteElements } = useReactFlow();
 
   const handleAddPort = (direction: "input" | "output") => {
@@ -792,7 +802,7 @@ export function BlockNode({ id: nodeId, data, selected }: NodeProps<Node<BlockNo
                 top: portTop,
               }}
             />
-            {isVariadicInputs && (
+            {isVariadicInputs && canRemoveInput && (
               <button
                 type="button"
                 className="nodrag absolute flex h-3.5 w-3.5 items-center justify-center rounded-full bg-red-100 text-[9px] text-red-500 opacity-0 transition-opacity hover:bg-red-200 group-hover:opacity-100"
@@ -806,7 +816,7 @@ export function BlockNode({ id: nodeId, data, selected }: NodeProps<Node<BlockNo
           </span>
         );
       })}
-      {isVariadicInputs && (
+      {isVariadicInputs && canAddInput && (
         <button
           type="button"
           className="nodrag absolute flex h-3.5 w-3.5 items-center justify-center rounded-full bg-stone-100 text-[9px] text-stone-500 transition-colors hover:bg-ember hover:text-white"
@@ -840,7 +850,7 @@ export function BlockNode({ id: nodeId, data, selected }: NodeProps<Node<BlockNo
                 top: portTop,
               }}
             />
-            {isVariadicOutputs && (
+            {isVariadicOutputs && canRemoveOutput && (
               <button
                 type="button"
                 className="nodrag absolute flex h-3.5 w-3.5 items-center justify-center rounded-full bg-red-100 text-[9px] text-red-500 opacity-0 transition-opacity hover:bg-red-200 group-hover:opacity-100"
@@ -854,7 +864,7 @@ export function BlockNode({ id: nodeId, data, selected }: NodeProps<Node<BlockNo
           </span>
         );
       })}
-      {isVariadicOutputs && (
+      {isVariadicOutputs && canAddOutput && (
         <button
           type="button"
           className="nodrag absolute flex h-3.5 w-3.5 items-center justify-center rounded-full bg-stone-100 text-[9px] text-stone-500 transition-colors hover:bg-ember hover:text-white"

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -145,6 +145,26 @@ export interface BlockSchemaResponse extends BlockSummary {
    * Empty array means "any DataObject subclass".
    */
   allowed_output_types?: string[];
+  /**
+   * ADR-029 Addendum 1: minimum number of variadic input ports.
+   * null/undefined means no minimum.
+   */
+  min_input_ports?: number | null;
+  /**
+   * ADR-029 Addendum 1: maximum number of variadic input ports.
+   * null/undefined means no maximum.
+   */
+  max_input_ports?: number | null;
+  /**
+   * ADR-029 Addendum 1: minimum number of variadic output ports.
+   * null/undefined means no minimum.
+   */
+  min_output_ports?: number | null;
+  /**
+   * ADR-029 Addendum 1: maximum number of variadic output ports.
+   * null/undefined means no maximum.
+   */
+  max_output_ports?: number | null;
 }
 
 export interface BlockListResponse {

--- a/src/scieasy/api/routes/blocks.py
+++ b/src/scieasy/api/routes/blocks.py
@@ -126,6 +126,11 @@ async def get_block_schema(
         # ADR-029 D11: variadic port type constraints for frontend port editor.
         allowed_input_types=list(getattr(spec, "allowed_input_types", []) or []),
         allowed_output_types=list(getattr(spec, "allowed_output_types", []) or []),
+        # ADR-029 Addendum 1: port count limits for variadic blocks.
+        min_input_ports=getattr(spec, "min_input_ports", None),
+        max_input_ports=getattr(spec, "max_input_ports", None),
+        min_output_ports=getattr(spec, "min_output_ports", None),
+        max_output_ports=getattr(spec, "max_output_ports", None),
     )
 
 

--- a/src/scieasy/api/schemas.py
+++ b/src/scieasy/api/schemas.py
@@ -128,6 +128,12 @@ class BlockSchemaResponse(BlockSummary):
     # a new port. Empty list means "any DataObject subclass".
     allowed_input_types: list[str] = Field(default_factory=list)
     allowed_output_types: list[str] = Field(default_factory=list)
+    # ADR-029 Addendum 1: optional min/max constraints on variadic port count.
+    # Frontend uses these to disable [+]/[-] buttons at limits.
+    min_input_ports: int | None = None
+    max_input_ports: int | None = None
+    min_output_ports: int | None = None
+    max_output_ports: int | None = None
 
 
 class BlockConnectionValidation(BaseModel):

--- a/src/scieasy/blocks/base/block.py
+++ b/src/scieasy/blocks/base/block.py
@@ -78,6 +78,14 @@ class Block(ABC):
     allowed_input_types: ClassVar[list[type]] = []
     allowed_output_types: ClassVar[list[type]] = []
 
+    # ADR-029 Addendum 1: optional min/max constraints on variadic port count.
+    # ``None`` means "no limit". Only meaningful when the corresponding
+    # ``variadic_inputs`` / ``variadic_outputs`` flag is ``True``.
+    min_input_ports: ClassVar[int | None] = None
+    max_input_ports: ClassVar[int | None] = None
+    min_output_ports: ClassVar[int | None] = None
+    max_output_ports: ClassVar[int | None] = None
+
     # ADR-028 Addendum 1 D1: declarative dynamic-port override mechanism.
     # When non-None, must be a dict of the shape::
     #
@@ -225,6 +233,26 @@ class Block(ABC):
             ok, desc = validate_port_constraint(port, value)
             if not ok:
                 raise ValueError(f"Port '{port.name}' constraint failed: {desc}")
+
+        # ADR-029 Addendum 1: validate variadic port count limits.
+        if type(self).variadic_inputs:
+            n_in = len(effective_input_ports)
+            min_in = type(self).min_input_ports
+            max_in = type(self).max_input_ports
+            if min_in is not None and n_in < min_in:
+                raise ValueError(f"Variadic input port count {n_in} is below minimum {min_in}.")
+            if max_in is not None and n_in > max_in:
+                raise ValueError(f"Variadic input port count {n_in} exceeds maximum {max_in}.")
+
+        if type(self).variadic_outputs:
+            effective_output_ports = self.get_effective_output_ports()
+            n_out = len(effective_output_ports)
+            min_out = type(self).min_output_ports
+            max_out = type(self).max_output_ports
+            if min_out is not None and n_out < min_out:
+                raise ValueError(f"Variadic output port count {n_out} is below minimum {min_out}.")
+            if max_out is not None and n_out > max_out:
+                raise ValueError(f"Variadic output port count {n_out} exceeds maximum {max_out}.")
 
         return True
 

--- a/src/scieasy/blocks/registry.py
+++ b/src/scieasy/blocks/registry.py
@@ -61,6 +61,11 @@ class BlockSpec:
     # Empty list means "any DataObject subclass".
     allowed_input_types: list[str] = field(default_factory=list)
     allowed_output_types: list[str] = field(default_factory=list)
+    # ADR-029 Addendum 1: optional min/max constraints on variadic port count.
+    min_input_ports: int | None = None
+    max_input_ports: int | None = None
+    min_output_ports: int | None = None
+    max_output_ports: int | None = None
 
 
 class BlockRegistry:
@@ -649,6 +654,11 @@ def _spec_from_class(cls: type, source: str = "") -> BlockSpec:
         variadic_outputs=bool(getattr(cls, "variadic_outputs", False)),
         allowed_input_types=allowed_in,
         allowed_output_types=allowed_out,
+        # ADR-029 Addendum 1: port count limits.
+        min_input_ports=getattr(cls, "min_input_ports", None),
+        max_input_ports=getattr(cls, "max_input_ports", None),
+        min_output_ports=getattr(cls, "min_output_ports", None),
+        max_output_ports=getattr(cls, "max_output_ports", None),
     )
 
 

--- a/tests/blocks/test_block_base.py
+++ b/tests/blocks/test_block_base.py
@@ -562,3 +562,149 @@ class TestVariadicPorts:
         """Block.allowed_input_types defaults to empty list."""
         assert _DummyBlock.allowed_input_types == []
         assert _DummyBlock.allowed_output_types == []
+
+    def test_port_count_limits_default_none(self) -> None:
+        """min/max port count limits default to None."""
+        assert _DummyBlock.min_input_ports is None
+        assert _DummyBlock.max_input_ports is None
+        assert _DummyBlock.min_output_ports is None
+        assert _DummyBlock.max_output_ports is None
+
+
+class TestVariadicPortCountLimits:
+    """ADR-029 Addendum 1: validate() enforces min/max port count limits."""
+
+    def test_validate_rejects_below_min_input_ports(self) -> None:
+        """Validation fails when input port count is below min_input_ports."""
+        from scieasy.core.types.base import DataObject
+
+        class _MinInputBlock(Block):
+            name: ClassVar[str] = "MinInput"
+            variadic_inputs: ClassVar[bool] = True
+            min_input_ports: ClassVar[int | None] = 2
+            input_ports: ClassVar[list[InputPort]] = []
+            output_ports: ClassVar[list[OutputPort]] = []
+
+            def run(self, inputs: dict[str, Any], config: BlockConfig) -> dict[str, Any]:
+                return {}
+
+        # Only 1 port configured, min is 2 — provide the required input value
+        block = _MinInputBlock(config={"input_ports": [{"name": "a", "types": ["DataObject"]}]})
+        with pytest.raises(ValueError, match="below minimum 2"):
+            block.validate({"a": DataObject()})
+
+    def test_validate_rejects_above_max_input_ports(self) -> None:
+        """Validation fails when input port count exceeds max_input_ports."""
+        from scieasy.core.types.base import DataObject
+
+        class _MaxInputBlock(Block):
+            name: ClassVar[str] = "MaxInput"
+            variadic_inputs: ClassVar[bool] = True
+            max_input_ports: ClassVar[int | None] = 2
+            input_ports: ClassVar[list[InputPort]] = []
+            output_ports: ClassVar[list[OutputPort]] = []
+
+            def run(self, inputs: dict[str, Any], config: BlockConfig) -> dict[str, Any]:
+                return {}
+
+        # 3 ports configured, max is 2
+        block = _MaxInputBlock(
+            config={
+                "input_ports": [
+                    {"name": "a", "types": ["DataObject"]},
+                    {"name": "b", "types": ["DataObject"]},
+                    {"name": "c", "types": ["DataObject"]},
+                ]
+            }
+        )
+        with pytest.raises(ValueError, match="exceeds maximum 2"):
+            block.validate({"a": DataObject(), "b": DataObject(), "c": DataObject()})
+
+    def test_validate_accepts_within_input_port_limits(self) -> None:
+        """Validation passes when input port count is within min/max range."""
+        from scieasy.core.types.base import DataObject
+
+        class _BoundedInputBlock(Block):
+            name: ClassVar[str] = "BoundedInput"
+            variadic_inputs: ClassVar[bool] = True
+            min_input_ports: ClassVar[int | None] = 1
+            max_input_ports: ClassVar[int | None] = 3
+            input_ports: ClassVar[list[InputPort]] = []
+            output_ports: ClassVar[list[OutputPort]] = []
+
+            def run(self, inputs: dict[str, Any], config: BlockConfig) -> dict[str, Any]:
+                return {}
+
+        block = _BoundedInputBlock(
+            config={
+                "input_ports": [
+                    {"name": "a", "types": ["DataObject"]},
+                    {"name": "b", "types": ["DataObject"]},
+                ]
+            }
+        )
+        assert block.validate({"a": DataObject(), "b": DataObject()}) is True
+
+    def test_validate_rejects_below_min_output_ports(self) -> None:
+        """Validation fails when output port count is below min_output_ports."""
+
+        class _MinOutputBlock(Block):
+            name: ClassVar[str] = "MinOutput"
+            variadic_outputs: ClassVar[bool] = True
+            min_output_ports: ClassVar[int | None] = 2
+            input_ports: ClassVar[list[InputPort]] = []
+            output_ports: ClassVar[list[OutputPort]] = []
+
+            def run(self, inputs: dict[str, Any], config: BlockConfig) -> dict[str, Any]:
+                return {}
+
+        block = _MinOutputBlock(config={"output_ports": [{"name": "a", "types": ["DataObject"]}]})
+        with pytest.raises(ValueError, match="below minimum 2"):
+            block.validate({})
+
+    def test_validate_rejects_above_max_output_ports(self) -> None:
+        """Validation fails when output port count exceeds max_output_ports."""
+
+        class _MaxOutputBlock(Block):
+            name: ClassVar[str] = "MaxOutput"
+            variadic_outputs: ClassVar[bool] = True
+            max_output_ports: ClassVar[int | None] = 1
+            input_ports: ClassVar[list[InputPort]] = []
+            output_ports: ClassVar[list[OutputPort]] = []
+
+            def run(self, inputs: dict[str, Any], config: BlockConfig) -> dict[str, Any]:
+                return {}
+
+        block = _MaxOutputBlock(
+            config={
+                "output_ports": [
+                    {"name": "a", "types": ["DataObject"]},
+                    {"name": "b", "types": ["DataObject"]},
+                ]
+            }
+        )
+        with pytest.raises(ValueError, match="exceeds maximum 1"):
+            block.validate({})
+
+    def test_validate_no_limits_allows_any_count(self) -> None:
+        """Without min/max limits, any port count is valid."""
+        from scieasy.core.types.base import DataObject
+
+        class _UnlimitedBlock(Block):
+            name: ClassVar[str] = "Unlimited"
+            variadic_inputs: ClassVar[bool] = True
+            variadic_outputs: ClassVar[bool] = True
+            input_ports: ClassVar[list[InputPort]] = []
+            output_ports: ClassVar[list[OutputPort]] = []
+
+            def run(self, inputs: dict[str, Any], config: BlockConfig) -> dict[str, Any]:
+                return {}
+
+        inputs = {f"p{i}": DataObject() for i in range(5)}
+        block = _UnlimitedBlock(
+            config={
+                "input_ports": [{"name": f"p{i}", "types": ["DataObject"]} for i in range(5)],
+                "output_ports": [{"name": f"o{i}", "types": ["DataObject"]} for i in range(5)],
+            }
+        )
+        assert block.validate(inputs) is True

--- a/tests/blocks/test_registry.py
+++ b/tests/blocks/test_registry.py
@@ -972,3 +972,53 @@ class TestVariadicPortsSpec:
         spec = _spec_from_class(_DefaultAllowedBlock)
         assert spec.allowed_input_types == []
         assert spec.allowed_output_types == []
+
+
+class TestPortCountLimitsSpec:
+    """ADR-029 Addendum 1: _spec_from_class() populates min/max port count limits."""
+
+    def test_default_limits_are_none(self) -> None:
+        """Block without explicit limits yields None for all 4 fields."""
+        from typing import Any, ClassVar
+
+        from scieasy.blocks.base.block import Block
+        from scieasy.blocks.base.config import BlockConfig
+        from scieasy.blocks.registry import _spec_from_class
+
+        class _NoLimitsBlock(Block):
+            name: ClassVar[str] = "NoLimitsBlock"
+
+            def run(self, inputs: dict[str, Any], config: BlockConfig) -> dict[str, Any]:
+                return {}
+
+        spec = _spec_from_class(_NoLimitsBlock)
+        assert spec.min_input_ports is None
+        assert spec.max_input_ports is None
+        assert spec.min_output_ports is None
+        assert spec.max_output_ports is None
+
+    def test_explicit_limits_captured(self) -> None:
+        """Block with explicit min/max ClassVars yields correct spec values."""
+        from typing import Any, ClassVar
+
+        from scieasy.blocks.base.block import Block
+        from scieasy.blocks.base.config import BlockConfig
+        from scieasy.blocks.registry import _spec_from_class
+
+        class _LimitedBlock(Block):
+            name: ClassVar[str] = "LimitedBlock"
+            variadic_inputs: ClassVar[bool] = True
+            variadic_outputs: ClassVar[bool] = True
+            min_input_ports: ClassVar[int | None] = 1
+            max_input_ports: ClassVar[int | None] = 5
+            min_output_ports: ClassVar[int | None] = 2
+            max_output_ports: ClassVar[int | None] = 4
+
+            def run(self, inputs: dict[str, Any], config: BlockConfig) -> dict[str, Any]:
+                return {}
+
+        spec = _spec_from_class(_LimitedBlock)
+        assert spec.min_input_ports == 1
+        assert spec.max_input_ports == 5
+        assert spec.min_output_ports == 2
+        assert spec.max_output_ports == 4


### PR DESCRIPTION
## Summary

- Add 4 optional ClassVars to Block: `min_input_ports`, `max_input_ports`, `min_output_ports`, `max_output_ports` (default `None` = no limit)
- Validate port count in `Block.validate()` for variadic blocks
- Expose limits in `BlockSpec`, `BlockSchemaResponse`, and frontend TypeScript types
- Frontend: disable [+] button at max, disable [-] button at min (BlockNode.tsx + PortEditorTable.tsx)
- Promote ADR-029 Addendum 1 to accepted status in ADR.md
- 8 tests (6 validate + 2 registry)

Closes #595

## Test plan

- [x] `pytest` — all tests pass
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npx vitest run` — all frontend tests pass
- [x] `ruff check . && ruff format --check .` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>