### PR TITLE
fix(#622): P0 serialize DataObject inputs before worker subprocess transport + welcome screen overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- [#621] Serialize DataObject inputs before worker subprocess transport to restore storage_ref (@claude, 2026-04-11, branch: fix/issue-622/storage-ref-input-serialization, session: 20260411-110544-fix-p0-storage-ref-regression-welcome-sc)
+- [#620] Truncate long project paths on Welcome Screen to prevent layout overflow (@claude, 2026-04-11, branch: fix/issue-622/storage-ref-input-serialization, session: 20260411-110544-fix-p0-storage-ref-regression-welcome-sc)
 - [#598] Enforce max 50 open tabs (@claude, 2026-04-11, branch: fix/issue-614/batch-small-fixes, session: 20260411-102935-fix-5-small-issues-max-tabs-bidirectiona)
 - [#601] Allow bidirectional subclass port connections (@claude, 2026-04-11, branch: fix/issue-614/batch-small-fixes, session: 20260411-102935-fix-5-small-issues-max-tabs-bidirectiona)
 - [#590] Return HTTP 422 for workflow cycle validation errors (@claude, 2026-04-11, branch: fix/issue-614/batch-small-fixes, session: 20260411-102935-fix-5-small-issues-max-tabs-bidirectiona)

--- a/frontend/src/components/WelcomeScreen.tsx
+++ b/frontend/src/components/WelcomeScreen.tsx
@@ -65,7 +65,7 @@ export function WelcomeScreen({
                   >
                     <span className="min-w-0 flex-1">
                       <span className="block truncate font-medium text-ink">{project.name}</span>
-                      <span className="mt-1 block truncate text-xs text-stone-500">{project.path}</span>
+                      <span className="mt-1 block max-w-[300px] truncate text-xs text-stone-500">{project.path}</span>
                     </span>
                     {onDeleteProject ? (
                       <span

--- a/src/scieasy/engine/runners/local.py
+++ b/src/scieasy/engine/runners/local.py
@@ -20,6 +20,63 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def serialise_inputs(inputs: dict[str, Any], output_dir: str) -> dict[str, Any]:
+    """Serialize DataObject inputs to wire format before subprocess transport.
+
+    Mirrors :func:`worker.serialise_outputs` for the input direction.
+    In-memory :class:`DataObject` instances without a
+    :class:`StorageReference` are auto-flushed to *output_dir* (persisted
+    to zarr) and then converted to wire-format dicts that
+    :func:`worker.reconstruct_inputs` can round-trip.
+
+    Scalars, lists, dicts, and other non-DataObject values pass through
+    unchanged.  :class:`Collection` instances are handled recursively
+    (each item is auto-flushed and serialised).
+    """
+    from scieasy.blocks.base.block import Block
+    from scieasy.core.storage.flush_context import clear, get_output_dir, set_output_dir
+    from scieasy.core.types.base import DataObject
+    from scieasy.core.types.collection import Collection
+    from scieasy.core.types.serialization import _serialise_one
+
+    previous_output_dir = get_output_dir()
+    if output_dir:
+        set_output_dir(output_dir)
+    try:
+        result: dict[str, Any] = {}
+        for key, value in inputs.items():
+            if isinstance(value, Collection):
+                item_payloads: list[Any] = []
+                for item in value:
+                    flushed = Block._auto_flush(item)
+                    if isinstance(flushed, DataObject):
+                        item_payloads.append(_serialise_one(flushed))
+                    else:
+                        item_payloads.append({"_value": str(flushed)})
+                result[key] = {
+                    "_collection": True,
+                    "items": item_payloads,
+                    "item_type": value.item_type.__name__ if value.item_type is not None else "DataObject",
+                }
+            elif isinstance(value, DataObject):
+                flushed_obj = Block._auto_flush(value)
+                if isinstance(flushed_obj, DataObject):
+                    result[key] = _serialise_one(flushed_obj)
+                else:
+                    result[key] = str(flushed_obj)
+            elif isinstance(value, dict) and "backend" in value and "path" in value:
+                # Already in wire format (e.g. from a previous subprocess).
+                result[key] = value
+            else:
+                result[key] = value
+        return result
+    finally:
+        if previous_output_dir is None:
+            clear()
+        else:
+            set_output_dir(previous_output_dir)
+
+
 def _derive_output_dir(block: Any, config: dict[str, Any]) -> str:
     """Return a persistence directory for worker auto-flush outputs."""
     explicit_output_dir = config.get("output_dir")
@@ -99,10 +156,17 @@ class LocalRunner:
         block_id = getattr(block, "id", block_class_path)
         output_dir = _derive_output_dir(block, config)
 
+        # Serialize DataObject inputs to wire format before crossing the
+        # subprocess boundary (issue #621).  This mirrors what
+        # worker.serialise_outputs() does for outputs: auto-flush in-memory
+        # DataObjects to zarr and convert to wire-format dicts that
+        # reconstruct_inputs() can round-trip.
+        wire_inputs = serialise_inputs(inputs, output_dir)
+
         # Build the serialized payload for the worker subprocess.
         payload_bytes = build_worker_payload(
             block_class=block_class_path,
-            inputs_refs=inputs,
+            inputs_refs=wire_inputs,
             config=config,
             output_dir=output_dir,
         )

--- a/tests/engine/test_input_serialization.py
+++ b/tests/engine/test_input_serialization.py
@@ -1,0 +1,127 @@
+"""Tests for input serialization before subprocess transport (issue #621).
+
+Verifies that ``serialise_inputs()`` in ``local.py`` correctly auto-flushes
+in-memory DataObject instances and converts them to wire-format dicts that
+``worker.reconstruct_inputs()`` can round-trip.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+
+from scieasy.core.types.array import Array
+
+
+def _make_array(data: np.ndarray, axes: list[str] | None = None) -> Array:
+    """Create an in-memory Array with _data set (no storage_ref)."""
+
+    arr = Array(axes=axes or ["y", "x"])
+    arr._data = data  # type: ignore[attr-defined]
+    return arr
+
+
+class TestSerialiseInputs:
+    """Test serialise_inputs() for the input serialization path."""
+
+    def test_in_memory_array_becomes_wire_format(self, tmp_path: Path) -> None:
+        """An in-memory Array (no storage_ref) should be auto-flushed and
+        converted to wire format with backend/path/metadata keys."""
+        from scieasy.engine.runners.local import serialise_inputs
+
+        arr = _make_array(np.zeros((10, 10), dtype=np.uint8))
+        assert arr.storage_ref is None
+
+        result = serialise_inputs({"image": arr}, str(tmp_path))
+
+        wire = result["image"]
+        assert isinstance(wire, dict)
+        assert "backend" in wire
+        assert "path" in wire
+        assert "metadata" in wire
+        assert wire["backend"] is not None
+        assert wire["path"] is not None
+        # type_chain should include Array
+        assert "Array" in wire["metadata"]["type_chain"]
+
+    def test_wire_format_round_trips_through_reconstruct(self, tmp_path: Path) -> None:
+        """Wire format from serialise_inputs should reconstruct via worker."""
+        from scieasy.core.types.array import Array
+        from scieasy.engine.runners.local import serialise_inputs
+        from scieasy.engine.runners.worker import reconstruct_inputs
+
+        arr = _make_array(np.zeros((5, 5), dtype=np.float32))
+        wire_inputs = serialise_inputs({"image": arr}, str(tmp_path))
+
+        # Wrap in payload envelope as worker expects
+        payload = {"inputs": wire_inputs}
+        reconstructed = reconstruct_inputs(payload)
+
+        assert "image" in reconstructed
+        recon_arr = reconstructed["image"]
+        assert isinstance(recon_arr, Array)
+        assert recon_arr.storage_ref is not None
+
+    def test_scalar_inputs_pass_through(self, tmp_path: Path) -> None:
+        """Scalars (str, int, float, bool, None, list, dict) pass through."""
+        from scieasy.engine.runners.local import serialise_inputs
+
+        inputs = {
+            "threshold": 0.5,
+            "name": "test",
+            "count": 42,
+            "flag": True,
+            "items": [1, 2, 3],
+            "options": {"a": 1},
+            "empty": None,
+        }
+        result = serialise_inputs(inputs, str(tmp_path))
+        assert result == inputs
+
+    def test_already_wire_format_passes_through(self, tmp_path: Path) -> None:
+        """Dicts already in wire format (with backend/path) pass through."""
+        from scieasy.engine.runners.local import serialise_inputs
+
+        wire = {
+            "backend": "zarr",
+            "path": "/data/existing.zarr",
+            "metadata": {"type_chain": ["DataObject", "Array"]},
+        }
+        result = serialise_inputs({"image": wire}, str(tmp_path))
+        assert result["image"] is wire
+
+    def test_collection_of_arrays(self, tmp_path: Path) -> None:
+        """A Collection of in-memory Arrays should be serialized recursively."""
+        from scieasy.core.types.array import Array
+        from scieasy.core.types.collection import Collection
+        from scieasy.engine.runners.local import serialise_inputs
+
+        arrays = [
+            _make_array(np.zeros((3, 3), dtype=np.uint8)),
+            _make_array(np.ones((3, 3), dtype=np.uint8)),
+        ]
+        coll = Collection(arrays, item_type=Array)
+
+        result = serialise_inputs({"images": coll}, str(tmp_path))
+
+        wire = result["images"]
+        assert wire["_collection"] is True
+        assert wire["item_type"] == "Array"
+        assert len(wire["items"]) == 2
+        for item in wire["items"]:
+            assert "backend" in item
+            assert "path" in item
+
+    def test_flush_context_restored_after_call(self, tmp_path: Path) -> None:
+        """The flush context output_dir should be restored after the call."""
+        from scieasy.core.storage.flush_context import clear, get_output_dir, set_output_dir
+        from scieasy.engine.runners.local import serialise_inputs
+
+        # Set a prior context
+        set_output_dir("/previous/dir")
+        serialise_inputs({}, str(tmp_path))
+        assert get_output_dir() == "/previous/dir"
+
+        # Clean up
+        clear()


### PR DESCRIPTION
## Summary

- **#621 (P0)**: Add `serialise_inputs()` helper in `LocalRunner` that auto-flushes in-memory DataObject instances to zarr and converts them to wire-format dicts before crossing the subprocess boundary. This mirrors the existing `serialise_outputs()` pattern from `worker.py` and fixes the regression where `LoadImage` outputs (in-memory, `storage_ref=None`) failed with "Cannot create ViewProxy without a storage reference" in downstream worker subprocesses.
- **#620**: Add `max-w-[300px]` constraint to project path display on the Welcome Screen to prevent long paths from overflowing the layout.

## Changes

- `src/scieasy/engine/runners/local.py`: Added `serialise_inputs()` function and call it in `LocalRunner.run()` before `build_worker_payload()`
- `frontend/src/components/WelcomeScreen.tsx`: Added `max-w-[300px]` to path span
- `tests/engine/test_input_serialization.py`: 6 new tests covering wire-format conversion, round-trip reconstruction, scalar passthrough, collection handling, and flush context restoration

## Test plan

- [x] 6 new unit tests for `serialise_inputs()` all pass
- [x] Full engine test suite passes (290 tests)
- [x] Frontend TypeScript check passes
- [x] Frontend vitest passes (82 tests)
- [x] ruff check + format passes

Closes #621, Closes #620