### PR TITLE
docs(adr): ADR-031 DataObject reference-only contract, ViewProxy elimination, lazy loading enforcement

### DIFF
--- a/docs/adr/ADR-031-draft.md
+++ b/docs/adr/ADR-031-draft.md
@@ -1,0 +1,671 @@
+## ADR-031: Data Object Reference-Only Contract, ViewProxy Elimination, and Lazy Loading Enforcement
+
+**Status**: draft
+**Date**: 2026-04-11
+**Supersedes**: ADR-027 Addendum 1 (~~proposed~~ → **deprecated**)
+**Amends**: ADR-007 (implementation alignment), ADR-017 (transport contract), ADR-028 (IOBlock contract)
+
+---
+
+### 1. Purpose
+
+This ADR addresses a **critical divergence between architectural design and implementation** across the data storage, transport, and access layers. An independent audit (ref: `docs/data-storage-transport-audit.en.md`, 2026-04-11) confirmed that the "lazy by default" principle from ADR-007 is systematically violated in practice.
+
+This ADR:
+
+1. Establishes **DataObject as the single, definitive data reference type** — no secondary accessor classes.
+2. **Eliminates `ViewProxy`** entirely — its methods are absorbed into DataObject/Array.
+3. **Prohibits the `_data` / `_arrow_table` in-memory backdoor** on DataObject instances that cross block boundaries.
+4. **Requires IOBlock loaders to persist data to storage and return reference-only objects.**
+5. **Exempts Artifact/file-handle types from auto-flush** — path-only transport.
+6. **Deprecates ADR-027 Addendum 1** in its entirety; correct decisions are restated here.
+7. **Aligns documentation** to a single coherent model.
+
+### 2. Context
+
+#### 2.1 Design intent (ADR-007, ADR-017, ADR-027)
+
+The architecture specifies:
+
+> DataObject instances are lightweight wrappers (~KB) holding a StorageReference. Blocks never receive raw data directly. — ADR-007
+
+> No scientific data crosses the process boundary. Only StorageReference pointers (~100 bytes each) and config dicts cross. — ADR-017
+
+> `worker.reconstruct_inputs` returns typed DataObject instances, not ViewProxy. Lazy loading is preserved at the method level. — ADR-027 Addendum 1
+
+#### 2.2 Actual implementation state (audit findings)
+
+The independent audit (`docs/data-storage-transport-audit.en.md`) found:
+
+1. **Almost all loaders are eager.** Only `LoadData(.zarr)` returns a storage-backed reference. All other paths (`LoadImage` TIFF/Zarr, `LoadData` .npy/.csv/.parquet/.json, plugin loaders) read full data into memory and attach it to an undeclared `_data` or `_arrow_table` attribute. Evidence: `load_data.py:233-427`, `load_image.py:76-141`.
+
+2. **`_data` is not part of the DataObject contract.** The `DataObject.__init__` constructor has four declared slots: `framework`, `meta`, `user`, `storage_ref`. The `_data` attribute appears nowhere in the base class. It is monkey-patched onto instances by loader code: `img._data = np.asarray(...)`. The base class's `get_in_memory_data()` legitimizes this via `hasattr(self, "_data")` — a contract violation that the framework itself endorses.
+
+3. **ViewProxy is vestigial.** ADR-027 Addendum 1 demoted ViewProxy from "engine-injected input type" to "opt-in helper via `item.view()`". In practice, **zero package-level blocks call `item.view()`**. ViewProxy's sole runtime role is as an unnecessary intermediary in `DataObject.to_memory()` → `self.view().to_memory()`. The class adds indirection without value.
+
+4. **The transport layer is reference-based, but load/process/export are not.** The scheduler→worker JSON wire protocol correctly transmits StorageReference pointers. But data enters the system as in-memory blobs (load), gets processed as in-memory blobs (process), and gets exported from in-memory blobs (save). The reference-based transport is sandwiched between eager endpoints.
+
+5. **SaveData cannot reliably export storage-backed objects.** `_save_array()` calls `obj.get_in_memory_data()`, which succeeds only if `_data` is set. A storage-backed Array (reconstructed in worker with only `storage_ref`) has no `_data`, causing `get_in_memory_data()` to raise. Evidence: `save_data.py:280-348`, `base.py:350-362`.
+
+6. **`LoadData(Series)` loses payload.** `_load_series()` returns a `Series()` with neither `_data`, `_arrow_table`, nor `storage_ref`. The data is silently discarded. Evidence: `load_data.py:456-468`.
+
+7. **`LoadPeakTable` stores pandas DataFrame in `user` metadata.** The `user` dict requires JSON-serializability per ADR-017. A pandas DataFrame is not JSON-serializable. This silently breaks cross-process transport. Evidence: `load_peak_table.py:123-134`.
+
+8. **Artifact file semantics are broken by auto-flush.** `MSRawFile` is designed as a path handle, but `_auto_flush()` calls `get_in_memory_data()` which reads the file's raw bytes, then writes them to managed storage. The original file semantics are lost. Evidence: `block.py:374-403`, `artifact.py:44-48`.
+
+9. **`Array.sel()` materializes full data before slicing.** The method that should enable lazy partial reads (`sel(z=5)`) starts by calling `self.to_memory()` to load the entire array. Evidence: `array.py:165-223`.
+
+10. **Documentation mixes two generations.** `ARCHITECTURE.md:331-362` describes the old ViewProxy-injection model. `ADR.md:4659-5135` (ADR-027 Addendum 1) describes typed DataObject reconstruction. The code matches the newer model, but the architectural docs still reference the old one.
+
+#### 2.3 Why ADR-027 Addendum 1 is deprecated
+
+ADR-027 Addendum 1 made several correct observations but stopped short of the necessary conclusion:
+
+- **Correct**: worker should return typed DataObject, not ViewProxy.
+- **Correct**: `_reconstruct_extra_kwargs` / `_serialise_extra_metadata` hooks are the right per-class reconstruction pattern.
+- **Correct**: Meta Pydantic constraints (frozen, JSON-round-trippable) are necessary.
+- **Incorrect**: ViewProxy should be "demoted to opt-in helper." It should be **deleted** — no block uses it, and its functionality belongs on DataObject directly.
+- **Incomplete**: Did not address the `_data` backdoor, loader eagerness, SaveData breakage, or Artifact semantics.
+- **Incomplete**: Did not establish DataObject as the single source of truth for data access methods.
+
+This ADR supersedes ADR-027 Addendum 1 in full. Decisions that remain correct are restated below with updated rationale.
+
+---
+
+### 3. Decisions
+
+#### D1. DataObject is the single data reference type (source of truth)
+
+**D1.1 Type hierarchy and per-class responsibilities**
+
+```
+DataObject (base)
+├── Array          — N-dimensional numeric data (images, spectra, tensors)
+│   ├── Image      — 2D/3D images (plugin)
+│   ├── Label      — segmentation masks (plugin, CompositeData subclass)
+│   └── ...
+├── DataFrame      — tabular data (columns + rows)
+├── Series         — single-column data
+├── Text           — string content
+├── Artifact       — opaque file handle (PDF, binary, raw instrument files)
+│   └── MSRawFile  — mass spec raw data (plugin)
+└── CompositeData  — named slots of DataObjects
+    └── Label      — raster + metadata slots (plugin)
+```
+
+**D1.2 DataObject base class contract**
+
+DataObject holds exactly four declared slots:
+- `_framework: FrameworkMeta` — identity and lineage
+- `_meta: BaseModel | None` — typed metadata
+- `_user: dict[str, Any]` — free-form metadata (JSON-serializable)
+- `_storage_ref: StorageReference | None` — pointer to persisted data
+
+**DataObject MUST NOT carry raw data payloads.** There is no `_data` attribute, no `_arrow_table` attribute, no in-memory data container of any kind on DataObject instances that cross block boundaries.
+
+**DataObject provides these data access methods** (all route through `storage_ref` → backend):
+
+| Method | Defined on | Behavior |
+|--------|-----------|----------|
+| `to_memory()` | **DataObject** | Materialize full data from storage. Emits 2GB size warning. |
+| `get_in_memory_data()` | **DataObject** | Alias for `to_memory()`. Subclasses may override (Text, Artifact). |
+| `slice(*args)` | **DataObject** | Backend-specific sub-selection (zarr indexing, arrow column filter, etc.) |
+| `iter_chunks(chunk_size)` | **DataObject** | Yield successive chunks from storage. |
+
+**D1.3 Array subclass contract**
+
+Array adds geometry metadata and array-specific access methods. These are **declared constructor parameters**, not monkey-patched attributes:
+
+| Attribute/Method | Defined on | Type | Notes |
+|-----------------|-----------|------|-------|
+| `axes` | **Array** (constructor) | `list[str]` | Named axes, e.g. `["z", "y", "x", "c"]` |
+| `shape` | **Array** (constructor) | `tuple[int, ...] \| None` | Data dimensions |
+| `dtype` | **Array** (constructor) | `str \| None` | Element type |
+| `chunk_shape` | **Array** (constructor) | `tuple[int, ...] \| None` | Storage chunk hint |
+| `sel(**kwargs)` | **Array** | `-> Array` | Partial read along named axes. Reads from storage, not `_data`. |
+| `iter_over(axis)` | **Array** | `-> Iterator[Array]` | Yield slices along one axis. Each slice has `storage_ref` set. |
+| `__array__(dtype)` | **Array** | `-> np.ndarray` | NumPy protocol. Calls `to_memory()`. |
+
+**Key change**: `sel()` and `iter_over()` no longer stash results in `_data`. Slice results are persisted to a temporary zarr store and returned with `storage_ref` set. This maintains the reference-only contract even for derived slices.
+
+**D1.4 DataFrame subclass contract**
+
+| Attribute/Method | Defined on | Notes |
+|-----------------|-----------|-------|
+| `to_memory()` | Inherited from **DataObject** | Returns `pyarrow.Table` from arrow backend |
+| `get_in_memory_data()` | Inherited from **DataObject** | Same as `to_memory()` |
+
+**Key change**: No `_arrow_table` attribute. All data access goes through `storage_ref` → ArrowBackend. The `_arrow_table` pattern is eliminated.
+
+**D1.5 Text subclass contract**
+
+| Attribute/Method | Defined on | Notes |
+|-----------------|-----------|-------|
+| `content` | **Text** (constructor) | String content. Small enough to hold in memory. |
+| `get_in_memory_data()` | **Text** (override) | Returns `self.content` directly. |
+
+Text is exempt from the "no in-memory data" rule because text content is inherently small (~KB) and is part of the object's identity (e.g., a prompt string). `storage_ref` is optional for Text.
+
+**D1.6 Artifact subclass contract**
+
+| Attribute/Method | Defined on | Notes |
+|-----------------|-----------|-------|
+| `file_path` | **Artifact** (constructor) | Path to the opaque file on disk. |
+| `mime_type` | **Artifact** (constructor) | MIME type string. |
+| `get_in_memory_data()` | **Artifact** (override) | Reads bytes from `file_path`. |
+
+Artifact uses **path-only transport** — `file_path` is the reference, not `storage_ref`. Artifact is exempt from auto-flush (D5). `_auto_flush()` skips Artifact instances with `file_path` set.
+
+**D1.7 CompositeData subclass contract**
+
+CompositeData holds named slots, each of which is a DataObject. Each slot independently follows the storage-ref contract. The CompositeStore backend handles recursive persistence.
+
+#### D2. ViewProxy is deleted
+
+The `ViewProxy` class (`src/scieasy/core/proxy.py`) is deleted entirely. Its functionality is absorbed into the type hierarchy as follows:
+
+| ViewProxy method | New location | Notes |
+|---|---|---|
+| `to_memory()` | **DataObject**.`to_memory()` | Direct backend read via `_get_backend(self._storage_ref).read(...)`. Includes 2GB size warning. |
+| `slice(*args)` | **DataObject**.`slice(*args)` | Direct backend call. |
+| `iter_chunks(chunk_size)` | **DataObject**.`iter_chunks(chunk_size)` | Direct backend call. |
+| `shape` property | **Array**.`shape` | Already a constructor parameter on Array. Not on DataObject. |
+| `axes` property | **Array**.`axes` | Already a constructor parameter on Array. Not on DataObject. |
+| `from_file(path)` | Removed | Use `Artifact(file_path=Path(path))` or construct DataObject with appropriate `storage_ref`. |
+| `_get_backend(ref)` | Module-level utility in `scieasy.core.storage.backend_router` | Shared backend resolution, used by DataObject methods internally. |
+
+**`DataObject.view()` is deleted.** There is no ViewProxy path. Block authors call methods directly on the typed instance:
+
+```python
+# OLD (via ViewProxy):
+data = image.view().to_memory()        # indirection through ViewProxy
+chunk = image.view().slice(0, 100)     # indirection through ViewProxy
+
+# NEW (direct on DataObject/Array):
+data = image.to_memory()               # DataObject method, direct backend call
+sub = image.sel(z=5)                   # Array method, direct backend call
+for chunk in image.iter_chunks(1024):  # DataObject method, direct backend call
+    ...
+```
+
+#### D3. `_data` and `_arrow_table` are prohibited on cross-boundary DataObjects
+
+**Rule**: Any DataObject returned from `Block.run()` (or `IOBlock.load()`) MUST have `storage_ref` set (or `file_path` for Artifact). The framework enforces this at the IOBlock level (D4) and at the worker auto-flush boundary.
+
+**Transient in-memory data within a single block's `run()` is allowed.** A block may compute results in memory (e.g., CellPose producing a mask ndarray). The framework's existing `_auto_flush()` mechanism persists these to storage before the data crosses the process boundary. This behavior is unchanged.
+
+**Per-class elimination of in-memory backdoors:**
+
+| Class | Attribute removed | Current usage | Migration |
+|-------|------------------|---------------|-----------|
+| **Array** | `_data` (monkey-patched, not declared) | Set by loaders: `img._data = np.asarray(...)`. Checked by `Array.to_memory()`, `Array.sel()`, `get_in_memory_data()`. | Remove all `_data` assignments and `hasattr` checks. All data access routes through `storage_ref` → ZarrBackend. |
+| **DataFrame** | `_arrow_table` (monkey-patched, not declared) | Set by loaders: `df._arrow_table = table`. Checked by `get_in_memory_data()`, `_dataframe_to_arrow_table()`. | Remove all `_arrow_table` assignments and checks. All data access routes through `storage_ref` → ArrowBackend. |
+| **Series** | `_arrow_table` (inherited pattern from DataFrame) | Set inconsistently. `_load_series()` currently loses payload entirely. | Fix payload loss first (write to arrow backend). Then same migration as DataFrame. |
+| **Text** | `content` (declared constructor parameter) | **Exempt.** Text content is small (~KB) and is part of the object's identity. `content` is a legitimate declared field, not a monkey-patched backdoor. | No change. |
+| **Artifact** | `file_path` (declared constructor parameter) | **Exempt.** File path is the transport mechanism. | No change. See D5. |
+| **CompositeData** | Per-slot `_data`/`_arrow_table` on slot objects | Each slot is independently a DataObject. | Recursive: each slot follows its own class's migration. |
+
+**What `_auto_flush()` handles after this ADR**: Only transient outputs from ProcessBlock/CodeBlock/AppBlock `run()` methods — block authors who compute results in memory and don't explicitly persist them. The framework flushes these to storage before serialization. IOBlock loaders are expected to handle their own persistence (D4).
+
+#### D4. IOBlock base class guarantees storage-ref; provides persistence helpers for loader authors
+
+The `load()` signature changes to accept an `output_dir` parameter. The IOBlock base class provides two guarantees:
+
+1. **Correctness guarantee**: After `load()` returns, the base class checks every DataObject. If `storage_ref` is missing, the base class auto-flushes to storage. **No DataObject without `storage_ref` ever crosses the block boundary.** This is a safety net — loader authors who return in-memory objects still produce correct results.
+
+2. **Helper API**: The base class provides `persist_array()` and `persist_table()` helpers for loader authors who want streaming writes (constant memory). **Loader authors who know their data is large SHOULD use these helpers.** Loader authors who don't care can return in-memory objects and let the base class handle persistence.
+
+**The framework guarantees correctness. The loader author controls optimality.** Loader authors know their data characteristics — a 1KB CSV doesn't need streaming; a 100G TIFF does.
+
+**New `IOBlock` contract:**
+
+```python
+class IOBlock(Block):
+    @abstractmethod
+    def load(self, config: BlockConfig, output_dir: str) -> DataObject | Collection:
+        """Load data from source.
+
+        Implementations may EITHER:
+
+        (a) Return an in-memory DataObject (simple path):
+            The base class auto-persists it to storage. Works for small/medium
+            files. Will OOM on very large files.
+
+            return Image(_data=np.array(...), axes=["y","x"], shape=shape, dtype=dtype)
+
+        (b) Write to storage directly and return a reference (streaming path):
+            Use self.persist_array() / self.persist_table() helpers for
+            constant-memory writes. Required for large files.
+
+            ref = self.persist_array(chunks_iter, shape, dtype, output_dir)
+            return Image(storage_ref=ref, axes=["y","x"], shape=shape, dtype=dtype)
+
+        Artifact subclasses are exempt — return with file_path, no storage write needed.
+        """
+        ...
+
+    # -- persistence helpers for loader authors ---
+
+    def persist_array(
+        self, data_or_iterator, shape, dtype, output_dir, chunks=None,
+    ) -> StorageReference:
+        """Write array data to zarr storage, return StorageReference.
+
+        data_or_iterator may be:
+        - numpy ndarray (written in one shot)
+        - iterator of (slice, chunk_array) tuples (streaming, constant memory)
+
+        Memory usage: O(one chunk) for iterator mode, O(full array) for ndarray mode.
+        """
+        ...
+
+    def persist_table(self, table, output_dir) -> StorageReference:
+        """Write Arrow table to storage, return StorageReference."""
+        ...
+
+    # -- run() with auto-flush safety net ---
+
+    def run(self, inputs, config):
+        if self.direction == "input":
+            output_dir = get_output_dir()
+            result = self.load(config, output_dir=output_dir)
+            if not isinstance(result, Collection):
+                result = Collection(items=[result], item_type=type(result))
+            # Safety net: auto-flush any item without storage_ref
+            for item in result:
+                if isinstance(item, DataObject) and item.storage_ref is None:
+                    if not (isinstance(item, Artifact) and item.file_path is not None):
+                        self._auto_flush(item)  # persist to zarr/arrow, set storage_ref
+            return {self._resolved_load_output_port_name(): result}
+```
+
+**Example: LoadImage TIFF — streaming path (large files, constant memory):**
+
+```python
+def load(self, config, output_dir=None):
+    path = Path(config.get("path"))
+
+    with tifffile.TiffFile(str(path)) as tf:
+        page0 = tf.pages[0]
+        shape = (len(tf.pages), *page0.shape) if len(tf.pages) > 1 else page0.shape
+        dtype = page0.dtype
+        axes = _infer_axes(tf)
+
+        # Stream page-by-page — memory = O(one page)
+        def page_chunks():
+            for i, page in enumerate(tf.pages):
+                yield (i, page.asarray())
+
+        ref = self.persist_array(page_chunks(), shape, dtype, output_dir)
+
+    return Image(axes=axes, shape=shape, dtype=dtype, storage_ref=ref)
+    # ← ~KB object. No _data, no in-memory payload.
+```
+
+**Example: LoadData CSV — simple path (small files, base class handles persistence):**
+
+```python
+def _load_dataframe(self, path, config, output_dir):
+    import pyarrow.csv as pcsv
+    table = pcsv.read_csv(str(path))
+    # Return in-memory — base class will auto-persist via _auto_flush
+    df = DataFrame()
+    df._arrow_table = table  # OK for simple path; base class flushes this
+    return df
+```
+
+**Example: LoadData CSV — streaming path (large files):**
+
+```python
+def _load_dataframe(self, path, config, output_dir):
+    import pyarrow.csv as pcsv
+    table = pcsv.read_csv(str(path))
+    ref = self.persist_table(table, output_dir)
+    return DataFrame(storage_ref=ref)
+    # ← Reference only. No _arrow_table.
+```
+
+**Loader author's choice matrix:**
+
+| Data size | Approach | Memory | Code complexity |
+|-----------|----------|--------|-----------------|
+| Small (< 1GB) | Return in-memory, base class auto-flushes | O(file size) | Minimal — same as today |
+| Large (> 1GB) | Use `persist_array()` / `persist_table()` streaming helpers | O(chunk size) | Slightly more — iterate chunks |
+
+**All 6 loader classes should be updated to use the new `load(config, output_dir)` signature.** Whether each individual loader function uses the simple path or streaming path is the loader author's decision based on expected data size:
+
+| Loader | Recommended path | Rationale |
+|--------|-----------------|-----------|
+| `LoadImage` TIFF | Streaming | Scientific images routinely exceed 1GB |
+| `LoadImage` Zarr | Reference | Zarr is already chunked storage — reference existing store |
+| `LoadData` Array .zarr | Reference | Already lazy (only correct loader today) |
+| `LoadData` Array .npy/.npz | Simple | Typically small; streaming .npy is not straightforward |
+| `LoadData` DataFrame csv/parquet | Simple or Streaming | Author's choice based on expected table size |
+| `LoadData` Text | Simple | Text files are small |
+| `LoadData` Artifact | Exempt | Path-only transport (D5) |
+| LCMS loaders | Simple | Domain-specific, typically small tables |
+
+#### D5. Artifact and file-handle types skip auto-flush
+
+`Artifact` and its subclasses (e.g., `MSRawFile`) use `file_path` as their transport mechanism, not `storage_ref`. They represent opaque files that should not be read into memory or copied into managed storage.
+
+**`_auto_flush()` is modified to skip Artifact instances that have `file_path` set:**
+
+```python
+@staticmethod
+def _auto_flush(obj: Any) -> Any:
+    if not isinstance(obj, DataObject):
+        return obj
+    # NEW: Artifact with file_path uses path-only transport
+    from scieasy.core.types.artifact import Artifact
+    if isinstance(obj, Artifact) and obj.file_path is not None:
+        return obj
+    # ... existing flush logic ...
+```
+
+**Serialization**: `_serialise_one()` already handles Artifact via `_serialise_extra_metadata()` which writes `file_path` to the metadata sidecar. `_reconstruct_one()` already handles it via `_reconstruct_extra_kwargs()` which restores `file_path`. No changes needed to the wire protocol.
+
+**SaveData for Artifact**: `_save_artifact()` copies the file via `shutil.copy2()`. This is correct behavior — it copies the file to the user-chosen path, not to managed storage.
+
+#### D6. `get_in_memory_data()` per-class behavior
+
+The current `get_in_memory_data()` on `DataObject` uses `hasattr` to check for undeclared attributes. This is replaced with a clean per-class dispatch:
+
+**DataObject (base class):**
+```python
+def get_in_memory_data(self) -> Any:
+    """Materialize data from storage for persistence/export."""
+    return self.to_memory()  # storage_ref → backend → read
+```
+
+**Per-class overrides:**
+
+| Class | `get_in_memory_data()` behavior | Rationale |
+|-------|-------------------------------|-----------|
+| **DataObject** (base) | `return self.to_memory()` | Default: read from storage via backend. |
+| **Array** | Inherited from DataObject | `to_memory()` → ZarrBackend.read() → `np.ndarray` |
+| **DataFrame** | Inherited from DataObject | `to_memory()` → ArrowBackend.read() → `pyarrow.Table` |
+| **Series** | Inherited from DataObject | `to_memory()` → ArrowBackend.read() → `pyarrow.Table` (single column) |
+| **Text** (override) | `return self.content` | Text content is in-memory by design (~KB). No storage round-trip needed. |
+| **Artifact** (override) | `return self.file_path.read_bytes()` | Reads from original file. Not from managed storage. |
+| **CompositeData** | Inherited from DataObject | `to_memory()` → CompositeStore.read() → reconstructs slot dict |
+
+**Removed**: The `hasattr(self, "_data")` and `hasattr(self, "_arrow_table")` checks in the base class. No monkey-patched attributes are consulted.
+
+This means SaveData's `_save_array()`, `_save_dataframe()`, etc. all work correctly with storage-backed objects — they call `get_in_memory_data()` → `to_memory()` → backend read.
+
+#### D7. Worker reconstruction contract (restated from ADR-027 Add1)
+
+`worker.reconstruct_inputs()` returns **typed DataObject instances** (e.g., `Image`, `DataFrame`), not `ViewProxy`. This decision from ADR-027 Addendum 1 is **correct and retained**.
+
+The reconstruction hooks remain:
+- `cls._reconstruct_extra_kwargs(metadata)` — per-base-class kwargs extraction
+- `cls._serialise_extra_metadata(obj)` — per-base-class metadata serialization
+
+The Meta Pydantic constraints remain:
+- Frozen, no `PrivateAttr`, all fields must round-trip through `model_dump_json` / `model_validate_json`
+
+#### D8. Checkpoint deserialization updated
+
+`checkpoint.py`'s `deserialize_intermediate_refs()` currently constructs `ViewProxy` instances. This function is rewritten to construct typed `DataObject` instances using the same `_reconstruct_one()` path as the worker.
+
+If type resolution fails (missing plugin), fall back to a base `DataObject(storage_ref=ref)` rather than a `ViewProxy`.
+
+#### D9. Documentation is unified
+
+All references to the old "engine injects ViewProxy" model are removed from:
+- `docs/architecture/ARCHITECTURE.md:331-362` (and line 618)
+- `docs/adr/ADR.md` ADR-007 discussion text
+- Block SDK guide
+
+The canonical documentation model is:
+- Blocks receive **typed DataObject instances** with `storage_ref` set
+- Data is lazy — `to_memory()` / `sel()` / `iter_chunks()` trigger reads on demand
+- ViewProxy does not exist
+
+---
+
+### 4. Impact Scope
+
+#### 4.1 Files deleted
+
+| File | Reason |
+|------|--------|
+| `src/scieasy/core/proxy.py` | ViewProxy class eliminated |
+| `tests/core/test_proxy.py` | Tests for deleted class |
+| `tests/core/test_proxy_multi_backend.py` | Tests for deleted class |
+
+#### 4.2 Core type system changes
+
+**DataObject base class** (`src/scieasy/core/types/base.py`):
+
+| Change | Detail |
+|--------|--------|
+| Delete `view()` method | Returns ViewProxy — ViewProxy no longer exists (D2) |
+| Rewrite `to_memory()` | Direct: `_get_backend(self._storage_ref).read(self._storage_ref)`. Add 2GB size warning from ViewProxy. |
+| Add `slice(*args)` | New method: `_get_backend(self._storage_ref).slice(self._storage_ref, *args)` |
+| Add `iter_chunks(chunk_size)` | New method: `yield from _get_backend(self._storage_ref).iter_chunks(self._storage_ref, chunk_size)` |
+| Rewrite `get_in_memory_data()` | Remove `hasattr(self, "_data")` and `hasattr(self, "_arrow_table")` checks. New body: `return self.to_memory()` (D6) |
+| Remove `TYPE_CHECKING` ViewProxy import | Line 34: `from scieasy.core.proxy import ViewProxy` |
+
+**Array subclass** (`src/scieasy/core/types/array.py`):
+
+| Change | Detail |
+|--------|--------|
+| Remove `to_memory()` override | Delete the `if self._storage_ref is None and hasattr(self, "_data")` backdoor. Inherit DataObject's `to_memory()`. |
+| Rewrite `sel(**kwargs)` | Remove `hasattr(self, "_data")` check (line 214). Always read from storage: `full_data = self.to_memory()`. Persist slice result to temp zarr with `storage_ref` instead of stashing in `_data`. |
+| Rewrite `iter_over(axis)` | Delegates to `sel()` per-index — inherits sel()'s storage-based behavior. |
+| `__array__()` | No change — already calls `self.to_memory()`. |
+| `shape`, `axes`, `dtype` | No change — already declared constructor parameters. |
+
+**DataFrame subclass** (`src/scieasy/core/types/dataframe.py`):
+
+| Change | Detail |
+|--------|--------|
+| No `_arrow_table` attribute | All data access through inherited `to_memory()` → ArrowBackend |
+
+**Text subclass** (`src/scieasy/core/types/text.py`):
+
+| Change | Detail |
+|--------|--------|
+| `get_in_memory_data()` override | Returns `self.content`. No storage round-trip. (Existing behavior, no change.) |
+
+**Artifact subclass** (`src/scieasy/core/types/artifact.py`):
+
+| Change | Detail |
+|--------|--------|
+| `get_in_memory_data()` override | Returns `self.file_path.read_bytes()`. (Existing behavior, no change.) |
+| Exempt from auto-flush | See D5. |
+
+**CompositeData** (`src/scieasy/core/types/composite.py`):
+
+| Change | Detail |
+|--------|--------|
+| Per-slot compliance | Each slot is an independent DataObject — follows its own class's contract. CompositeStore handles recursive persistence. |
+
+#### 4.3 IOBlock and loader changes
+
+| File | Changes |
+|------|---------|
+| `src/scieasy/blocks/io/io_block.py` | Change `load()` signature to `load(self, config, output_dir)`. Add `persist_array()` and `persist_table()` helper methods. Update `run()` to pass `output_dir` and auto-flush any item without `storage_ref` (D4 safety net). |
+| `src/scieasy/blocks/io/loaders/load_data.py` | Update `load()` to accept `output_dir`. Per-function changes: `_load_array .zarr` (already lazy, no change). `_load_array .npy/.npz/.parquet` (simple path — base class auto-flushes). `_load_dataframe` (simple or streaming — author's choice). `_load_series` (fix payload loss — must write to arrow). `_load_text` (simple path). `_load_artifact` (exempt, path-only D5). `_load_composite_data` (recursive, pass output_dir). |
+| `packages/scieasy-blocks-imaging/.../load_image.py` | Streaming path for `_load_tiff` (page-by-page via `persist_array()`). `_load_zarr` (reference existing zarr store, no copy). |
+| `packages/scieasy-blocks-lcms/.../load_mzml_files.py` | Update `load()` signature. MSRawFile is Artifact subclass — path-only, exempt. |
+| `packages/scieasy-blocks-lcms/.../load_peak_table.py` | Fix: write DataFrame to arrow via `persist_table()`, remove pandas from `user` dict. |
+| `packages/scieasy-blocks-lcms/.../load_mid_table.py` | Update `load()` signature, use simple or streaming path. |
+| `packages/scieasy-blocks-lcms/.../load_sample_metadata.py` | Update `load()` signature, use simple path. |
+| `src/scieasy/blocks/io/savers/save_data.py` | Remove `_arrow_table` check. Phase 3: add chunked export for Parquet/CSV/Zarr. |
+| `packages/scieasy-blocks-imaging/.../save_image.py` | No immediate change. Phase 3: add chunked TIFF write. |
+| `packages/scieasy-blocks-lcms/.../save_table.py` | Update `save()` to use `get_in_memory_data()` consistently. |
+
+#### 4.4 Block framework changes
+
+| File | Changes |
+|------|---------|
+| `src/scieasy/blocks/base/block.py` | Remove `_is_view_proxy()` helper. Update `validate()` to remove ViewProxy branch. Update `_auto_flush()` to skip Artifact (D5). |
+| `src/scieasy/blocks/process/process_block.py` | No change — already calls `_auto_flush()` on outputs. |
+| `src/scieasy/blocks/process/utils.py` | Remove ViewProxy isinstance check in `to_arrow()`. |
+| `src/scieasy/blocks/app/bridge.py` | Remove ViewProxy isinstance check. |
+| `src/scieasy/blocks/process/builtins/split.py` | Replace `_arrow_table` assignments with `get_in_memory_data()` + storage write. |
+| `src/scieasy/blocks/process/builtins/merge.py` | Same pattern. |
+
+#### 4.5 Engine changes
+
+| File | Changes |
+|------|---------|
+| `src/scieasy/engine/checkpoint.py` | Rewrite `deserialize_intermediate_refs()` to construct DataObject, not ViewProxy (D8). |
+| `src/scieasy/engine/runners/worker.py` | Remove ViewProxy references from docstrings. No structural changes — already returns typed DataObject. |
+| `src/scieasy/engine/runners/local.py` | `serialise_inputs()` added by PR #623 (P0 fix) remains as defense-in-depth. |
+| `src/scieasy/engine/scheduler.py` | Remove ViewProxy comments. |
+
+#### 4.6 SaveData and saver changes
+
+SaveData is a **sink block** — it reads data from storage and writes to a user-chosen file format.
+
+**Audit finding §2.2.5: SaveData currently cannot reliably export storage-backed objects.** `_save_array()` calls `obj.get_in_memory_data()`, which checks `hasattr(self, "_data")`. A storage-backed Array reconstructed in the worker has `storage_ref` set but no `_data`, so `get_in_memory_data()` raises `ValueError`. The same applies to `_dataframe_to_arrow_table()` which checks for `_arrow_table`.
+
+**This is resolved by D6**: `get_in_memory_data()` is rewritten to route through `to_memory()` → storage backend read. SaveData works correctly with storage-backed objects without SaveData-specific code changes in Phase 1/2.
+
+**Phase 3 optimization**: For large data, SaveData should read from storage chunk-by-chunk and write to the target format incrementally, avoiding full materialization. This is format-dependent — Parquet and Zarr support chunked writes; NPY and CSV do not.
+
+| File | Changes |
+|------|---------|
+| `src/scieasy/blocks/io/savers/save_data.py` | Phase 1/2: Remove `_arrow_table` check in `_dataframe_to_arrow_table()`. All paths work via `get_in_memory_data()` → `to_memory()` → storage read. Phase 3: Add chunked export paths for formats that support it (Parquet, Zarr). |
+| `packages/scieasy-blocks-imaging/.../save_image.py` | Phase 1/2: No change needed — SaveImage calls `to_memory()` which now routes through storage. Phase 3: Add chunked TIFF write (page-by-page from zarr). |
+
+**Per-format SaveData behavior after this ADR:**
+
+| Format | Phase 1/2 (correctness) | Phase 3 (streaming) |
+|--------|------------------------|---------------------|
+| `.zarr` | `get_in_memory_data()` → full read → zarr write | Direct zarr-to-zarr copy (zero materialization) |
+| `.npy` | `get_in_memory_data()` → full read → `np.save()` | Full read required (NPY format is not chunked) |
+| `.parquet` | `get_in_memory_data()` → full read → `pq.write_table()` | Chunked: read row groups from arrow → write row groups to parquet |
+| `.csv` | `get_in_memory_data()` → full read → `write_csv()` | Chunked: read batches from arrow → write batches to CSV |
+| TIFF | `get_in_memory_data()` → full read → `tifffile.imwrite()` | Chunked: read z-planes from zarr → write pages to TIFF |
+
+#### 4.7 Utility changes
+
+| File | Changes |
+|------|---------|
+| `src/scieasy/utils/axis_iter.py` | Replace `result._data = data` with persist-to-zarr + set storage_ref. |
+| `src/scieasy/utils/broadcast.py` | Update ViewProxy references in docstrings/warnings. |
+
+#### 4.8 Test changes
+
+| File | Changes |
+|------|---------|
+| `tests/core/test_proxy.py` | Delete entirely. |
+| `tests/core/test_proxy_multi_backend.py` | Delete entirely. |
+| `tests/core/test_dataobject_extended.py` | Update: assert `storage_ref is not None` instead of `_data` checks. |
+| `tests/core/test_storage.py` | Remove ViewProxy construction. |
+| `tests/engine/test_checkpoint.py` | Update: assert DataObject instead of ViewProxy from deserialization. |
+| `tests/engine/test_worker.py` | Remove ViewProxy assertion (already asserts `not isinstance(x, ViewProxy)`). |
+| `tests/engine/test_worker_typed_reconstruction.py` | Remove ViewProxy imports and negative assertions. |
+| `tests/blocks/test_block_base.py` | Remove ViewProxy validation tests. |
+| `tests/blocks/test_process_utils.py` | Remove ViewProxy mock. |
+| `tests/blocks/io/test_load_data.py` | Update: assert `storage_ref is not None` instead of `_data`/`_arrow_table` checks. |
+
+#### 4.9 Documentation changes
+
+| File | Changes |
+|------|---------|
+| `docs/architecture/ARCHITECTURE.md` | Remove ViewProxy-injection model (lines 331-362, 613-618). Update to DataObject-only model. |
+| `docs/adr/ADR.md` (ADR-007) | Add note: "ViewProxy eliminated in ADR-031. Methods absorbed into DataObject." |
+| `docs/adr/ADR.md` (ADR-027 Add1) | Mark as ~~deprecated~~ — superseded by ADR-031. |
+| `docs/guides/block-sdk.md` | Update data access examples: `item.to_memory()` not `item.view().to_memory()`. |
+
+---
+
+### 5. Implementation Plan
+
+#### Phase 1: Loader rewrite + core enforcement (all loaders write to storage directly)
+
+1. **Change `IOBlock.load()` signature** — add `output_dir: str` parameter. Update `IOBlock.run()` to pass `output_dir` and enforce `storage_ref` on returned objects (D4).
+2. **Rewrite all 6 loader classes (~12 functions)** to write directly to zarr/arrow storage and return reference-only DataObjects. Use streaming writes where the format supports it (TIFF page-by-page, CSV Arrow streaming, etc.).
+3. **Artifact auto-flush skip** (D5) — `_auto_flush()` skips Artifact with `file_path`.
+4. **Fix `_load_series()` payload loss** — write to arrow backend, return with `storage_ref`.
+5. **Fix `LoadPeakTable` user-dict violation** — write DataFrame to arrow storage, not `user` dict.
+6. **Update test fixtures** — mock loaders in `tests/` must comply with new `load()` signature.
+
+#### Phase 2: ViewProxy elimination and `_data` cleanup
+
+7. **Move `_get_backend()` and data access methods to DataObject** — `to_memory()`, `slice()`, `iter_chunks()`. Add 2GB size warning.
+8. **Delete `ViewProxy` class** (`src/scieasy/core/proxy.py`) and `DataObject.view()` method.
+9. **Rewrite `get_in_memory_data()`** — route through `to_memory()`, remove `hasattr(self, "_data")` / `_arrow_table` checks (D6).
+10. **Update `Array.to_memory()`** — remove `_data` backdoor, always read from storage.
+11. **Update `Array.sel()`** — remove `_data` check, read from storage. Persist slice result to temp zarr with storage_ref (no `_data` stashing).
+12. **Update `checkpoint.py`** — `deserialize_intermediate_refs()` constructs typed DataObject, not ViewProxy (D8).
+13. **Update `save_data.py`** — remove `_arrow_table` check in `_dataframe_to_arrow_table()`.
+14. **Remove all ViewProxy imports, isinstance checks, and helpers** — `block.py:_is_view_proxy()`, `process/utils.py`, `app/bridge.py`, all comments.
+15. **Update `split.py`, `merge.py`, `axis_iter.py`** �� replace `_arrow_table`/`_data` assignments with storage writes.
+16. **Delete test files** — `test_proxy.py`, `test_proxy_multi_backend.py`. Update all tests asserting `_data` to assert `storage_ref`.
+
+#### Phase 3: Process-side optimization (incremental)
+
+17. **Array.sel() Zarr partial-read** — leverage Zarr backend's native slicing instead of full materialization + numpy indexing.
+18. **SaveData streaming export** — for formats that support it, read from zarr chunk-by-chunk, write to target format chunk-by-chunk.
+19. **Block SDK guidance** — document `iter_chunks()` / `sel()` as preferred over `to_memory()` for large data. Add framework-level memory warning when `to_memory()` on large data.
+
+---
+
+### 6. Risks
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| **Performance regression from format conversion** — loaders convert source format (TIFF/CSV/etc.) to zarr/arrow; downstream reads from zarr/arrow, SaveData converts back to target format | Medium | This is inherent to using zarr as universal intermediate format. Streaming writes minimize memory. For workflows where source and target format match, a future "passthrough" optimization can skip intermediate storage. |
+| **Existing plugin blocks break** — blocks that set `_data` directly | Low | D4 enforcement is backward-compatible — it flushes `_data` objects to zarr automatically. Blocks don't need to change immediately. |
+| **`Array.sel()` becomes slower** — currently reads from `_data` (in-memory), will read from zarr | Medium | Zarr partial-read (Phase 4) mitigates this. For small arrays, the overhead is negligible. |
+| **Test breakage** — many tests assert `_data` presence | Low | Systematic update: assert `storage_ref is not None` instead. |
+| **Checkpoint backward compatibility** — old checkpoints may have ViewProxy-format entries | Low | `deserialize_intermediate_refs()` rewritten to produce DataObject. Old wire format still parseable. |
+
+---
+
+### 7. Alternatives Considered
+
+1. **Keep ViewProxy as opt-in helper (ADR-027 Add1 approach).** Rejected — no block uses it. Maintaining a class with zero consumers adds complexity without value.
+
+2. **Keep `_data` but enforce it's always backed by storage_ref too.** Rejected — two sources of truth for the same data. Which wins when they disagree? The `_data` pattern invites bypass of the storage contract.
+
+3. **Create per-format read-only backends (TiffBackend, NpyBackend, etc.) for true zero-copy lazy loading.** Deferred — not rejected, but not required for this ADR. Zarr as the universal intermediate format is sufficient. Per-format backends can be added incrementally when performance requires it.
+
+4. **Make DataObject.to_memory() check `_data` first as fast-path cache.** Rejected — this is the existing backdoor that caused the regression. A single code path (storage_ref → backend → read) is simpler, more predictable, and debuggable.
+
+---
+
+### 8. Consequences
+
+- **DataObject becomes the single, unambiguous data abstraction.** No ViewProxy, no `_data` backdoor, no dual code paths.
+- **All loaders become compliant immediately** via D4 (IOBlock enforcement), without individual loader code changes.
+- **SaveData works with storage-backed objects** because `get_in_memory_data()` routes through `to_memory()`.
+- **100G+ data support becomes architecturally possible** once Phase 3 (streaming loaders) is implemented. Phase 1 alone does not solve the OOM problem but removes the architectural barriers to solving it.
+- **The wire protocol is unchanged.** JSON payload format between scheduler and worker is not modified.
+- **56+ code locations require updates** across 19 source files. The changes are mechanical (remove ViewProxy imports, remove `_data` checks, update assertions) except for the IOBlock enforcement (D4) and the `to_memory()` rewrite.
+- **ADR-027 Addendum 1 is formally deprecated.** Its correct decisions (typed reconstruction, per-class hooks, Meta constraints) are restated in D7.
+
+---
+
+### Appendix A: Deprecated ADR-027 Addendum 1
+
+**Status**: ~~proposed~~ → **deprecated (superseded by ADR-031)**
+
+ADR-027 Addendum 1 ("Worker subprocess type reconstruction returns typed DataObject instances, not ViewProxy") is deprecated in its entirety. The following decisions from Addendum 1 are **restated in ADR-031** with updated scope:
+
+| Addendum 1 Decision | ADR-031 Status |
+|---|---|
+| D11': typed DataObject reconstruction in worker | **Retained** (ADR-031 D7) |
+| `_reconstruct_extra_kwargs` / `_serialise_extra_metadata` hooks | **Retained** (ADR-031 D7) |
+| Meta Pydantic constraints (frozen, JSON-round-trippable) | **Retained** (ADR-031 D7) |
+| ViewProxy "demoted to opt-in helper via `item.view()`" | **Rejected** — ViewProxy deleted entirely (ADR-031 D2) |
+| PhysicalQuantity Pydantic integration via `__get_pydantic_core_schema__` | **Retained** — unchanged, not in scope of ADR-031 |
+
+References to ADR-027 Addendum 1 in code comments should be updated to cite ADR-031 D7 for reconstruction contract and ADR-031 D2 for ViewProxy elimination.
+
+---
+
+### Appendix B: Audit Report Reference
+
+This ADR was motivated by the independent data storage and transport audit documented in `docs/data-storage-transport-audit.en.md` (2026-04-11). Key audit findings are cited in §2.2 with evidence references to specific source files and line numbers.
+
+The audit's summary:
+
+> SciEasy's transport layer is mostly reference-based now, but its load, processing, and export layers still contain widespread eager materialization, payload-loss edge cases, and multiple mismatches with the stated design philosophy.

--- a/docs/adr/ADR.md
+++ b/docs/adr/ADR.md
@@ -4656,9 +4656,9 @@ No outright deletions. Domain subclasses are moved (deleted from core, recreated
 
 ---
 
-## ADR-027 Addendum 1: Worker subprocess type reconstruction returns typed DataObject instances, not ViewProxy
+## ~~ADR-027 Addendum 1: Worker subprocess type reconstruction returns typed DataObject instances, not ViewProxy~~
 
-**Status**: proposed
+**Status**: ~~proposed~~ → **deprecated (superseded by ADR-031)**
 **Date**: 2026-04-06
 
 ### Purpose
@@ -7939,3 +7939,675 @@ redundant declarations is a separate follow-up, not a prerequisite.
 5. Frontend: add copy button to `directory_browser`, add PAUSED toast.
 6. Verify path portability (serializer, runtime).
 7. Follow-up PR: clean up redundant `path` declarations in subclasses.
+## ADR-031: Data Object Reference-Only Contract, ViewProxy Elimination, and Lazy Loading Enforcement
+
+**Status**: draft
+**Date**: 2026-04-11
+**Supersedes**: ADR-027 Addendum 1 (~~proposed~~ → **deprecated**)
+**Amends**: ADR-007 (implementation alignment), ADR-017 (transport contract), ADR-028 (IOBlock contract)
+
+---
+
+### 1. Purpose
+
+This ADR addresses a **critical divergence between architectural design and implementation** across the data storage, transport, and access layers. An independent audit (ref: `docs/data-storage-transport-audit.en.md`, 2026-04-11) confirmed that the "lazy by default" principle from ADR-007 is systematically violated in practice.
+
+This ADR:
+
+1. Establishes **DataObject as the single, definitive data reference type** — no secondary accessor classes.
+2. **Eliminates `ViewProxy`** entirely — its methods are absorbed into DataObject/Array.
+3. **Prohibits the `_data` / `_arrow_table` in-memory backdoor** on DataObject instances that cross block boundaries.
+4. **Requires IOBlock loaders to persist data to storage and return reference-only objects.**
+5. **Exempts Artifact/file-handle types from auto-flush** — path-only transport.
+6. **Deprecates ADR-027 Addendum 1** in its entirety; correct decisions are restated here.
+7. **Aligns documentation** to a single coherent model.
+
+### 2. Context
+
+#### 2.1 Design intent (ADR-007, ADR-017, ADR-027)
+
+The architecture specifies:
+
+> DataObject instances are lightweight wrappers (~KB) holding a StorageReference. Blocks never receive raw data directly. — ADR-007
+
+> No scientific data crosses the process boundary. Only StorageReference pointers (~100 bytes each) and config dicts cross. — ADR-017
+
+> `worker.reconstruct_inputs` returns typed DataObject instances, not ViewProxy. Lazy loading is preserved at the method level. — ADR-027 Addendum 1
+
+#### 2.2 Actual implementation state (audit findings)
+
+The independent audit (`docs/data-storage-transport-audit.en.md`) found:
+
+1. **Almost all loaders are eager.** Only `LoadData(.zarr)` returns a storage-backed reference. All other paths (`LoadImage` TIFF/Zarr, `LoadData` .npy/.csv/.parquet/.json, plugin loaders) read full data into memory and attach it to an undeclared `_data` or `_arrow_table` attribute. Evidence: `load_data.py:233-427`, `load_image.py:76-141`.
+
+2. **`_data` is not part of the DataObject contract.** The `DataObject.__init__` constructor has four declared slots: `framework`, `meta`, `user`, `storage_ref`. The `_data` attribute appears nowhere in the base class. It is monkey-patched onto instances by loader code: `img._data = np.asarray(...)`. The base class's `get_in_memory_data()` legitimizes this via `hasattr(self, "_data")` — a contract violation that the framework itself endorses.
+
+3. **ViewProxy is vestigial.** ADR-027 Addendum 1 demoted ViewProxy from "engine-injected input type" to "opt-in helper via `item.view()`". In practice, **zero package-level blocks call `item.view()`**. ViewProxy's sole runtime role is as an unnecessary intermediary in `DataObject.to_memory()` → `self.view().to_memory()`. The class adds indirection without value.
+
+4. **The transport layer is reference-based, but load/process/export are not.** The scheduler→worker JSON wire protocol correctly transmits StorageReference pointers. But data enters the system as in-memory blobs (load), gets processed as in-memory blobs (process), and gets exported from in-memory blobs (save). The reference-based transport is sandwiched between eager endpoints.
+
+5. **SaveData cannot reliably export storage-backed objects.** `_save_array()` calls `obj.get_in_memory_data()`, which succeeds only if `_data` is set. A storage-backed Array (reconstructed in worker with only `storage_ref`) has no `_data`, causing `get_in_memory_data()` to raise. Evidence: `save_data.py:280-348`, `base.py:350-362`.
+
+6. **`LoadData(Series)` loses payload.** `_load_series()` returns a `Series()` with neither `_data`, `_arrow_table`, nor `storage_ref`. The data is silently discarded. Evidence: `load_data.py:456-468`.
+
+7. **`LoadPeakTable` stores pandas DataFrame in `user` metadata.** The `user` dict requires JSON-serializability per ADR-017. A pandas DataFrame is not JSON-serializable. This silently breaks cross-process transport. Evidence: `load_peak_table.py:123-134`.
+
+8. **Artifact file semantics are broken by auto-flush.** `MSRawFile` is designed as a path handle, but `_auto_flush()` calls `get_in_memory_data()` which reads the file's raw bytes, then writes them to managed storage. The original file semantics are lost. Evidence: `block.py:374-403`, `artifact.py:44-48`.
+
+9. **`Array.sel()` materializes full data before slicing.** The method that should enable lazy partial reads (`sel(z=5)`) starts by calling `self.to_memory()` to load the entire array. Evidence: `array.py:165-223`.
+
+10. **Documentation mixes two generations.** `ARCHITECTURE.md:331-362` describes the old ViewProxy-injection model. `ADR.md:4659-5135` (ADR-027 Addendum 1) describes typed DataObject reconstruction. The code matches the newer model, but the architectural docs still reference the old one.
+
+#### 2.3 Why ADR-027 Addendum 1 is deprecated
+
+ADR-027 Addendum 1 made several correct observations but stopped short of the necessary conclusion:
+
+- **Correct**: worker should return typed DataObject, not ViewProxy.
+- **Correct**: `_reconstruct_extra_kwargs` / `_serialise_extra_metadata` hooks are the right per-class reconstruction pattern.
+- **Correct**: Meta Pydantic constraints (frozen, JSON-round-trippable) are necessary.
+- **Incorrect**: ViewProxy should be "demoted to opt-in helper." It should be **deleted** — no block uses it, and its functionality belongs on DataObject directly.
+- **Incomplete**: Did not address the `_data` backdoor, loader eagerness, SaveData breakage, or Artifact semantics.
+- **Incomplete**: Did not establish DataObject as the single source of truth for data access methods.
+
+This ADR supersedes ADR-027 Addendum 1 in full. Decisions that remain correct are restated below with updated rationale.
+
+---
+
+### 3. Decisions
+
+#### D1. DataObject is the single data reference type (source of truth)
+
+**D1.1 Type hierarchy and per-class responsibilities**
+
+```
+DataObject (base)
+├── Array          — N-dimensional numeric data (images, spectra, tensors)
+│   ├── Image      — 2D/3D images (plugin)
+│   ├── Label      — segmentation masks (plugin, CompositeData subclass)
+│   └── ...
+├── DataFrame      — tabular data (columns + rows)
+├── Series         — single-column data
+├── Text           — string content
+├── Artifact       — opaque file handle (PDF, binary, raw instrument files)
+│   └── MSRawFile  — mass spec raw data (plugin)
+└── CompositeData  — named slots of DataObjects
+    └── Label      — raster + metadata slots (plugin)
+```
+
+**D1.2 DataObject base class contract**
+
+DataObject holds exactly four declared slots:
+- `_framework: FrameworkMeta` — identity and lineage
+- `_meta: BaseModel | None` — typed metadata
+- `_user: dict[str, Any]` — free-form metadata (JSON-serializable)
+- `_storage_ref: StorageReference | None` — pointer to persisted data
+
+**DataObject MUST NOT carry raw data payloads.** There is no `_data` attribute, no `_arrow_table` attribute, no in-memory data container of any kind on DataObject instances that cross block boundaries.
+
+**DataObject provides these data access methods** (all route through `storage_ref` → backend):
+
+| Method | Defined on | Behavior |
+|--------|-----------|----------|
+| `to_memory()` | **DataObject** | Materialize full data from storage. Emits 2GB size warning. |
+| `get_in_memory_data()` | **DataObject** | Alias for `to_memory()`. Subclasses may override (Text, Artifact). |
+| `slice(*args)` | **DataObject** | Backend-specific sub-selection (zarr indexing, arrow column filter, etc.) |
+| `iter_chunks(chunk_size)` | **DataObject** | Yield successive chunks from storage. |
+
+**D1.3 Array subclass contract**
+
+Array adds geometry metadata and array-specific access methods. These are **declared constructor parameters**, not monkey-patched attributes:
+
+| Attribute/Method | Defined on | Type | Notes |
+|-----------------|-----------|------|-------|
+| `axes` | **Array** (constructor) | `list[str]` | Named axes, e.g. `["z", "y", "x", "c"]` |
+| `shape` | **Array** (constructor) | `tuple[int, ...] \| None` | Data dimensions |
+| `dtype` | **Array** (constructor) | `str \| None` | Element type |
+| `chunk_shape` | **Array** (constructor) | `tuple[int, ...] \| None` | Storage chunk hint |
+| `sel(**kwargs)` | **Array** | `-> Array` | Partial read along named axes. Reads from storage, not `_data`. |
+| `iter_over(axis)` | **Array** | `-> Iterator[Array]` | Yield slices along one axis. Each slice has `storage_ref` set. |
+| `__array__(dtype)` | **Array** | `-> np.ndarray` | NumPy protocol. Calls `to_memory()`. |
+
+**Key change**: `sel()` and `iter_over()` no longer stash results in `_data`. Slice results are persisted to a temporary zarr store and returned with `storage_ref` set. This maintains the reference-only contract even for derived slices.
+
+**D1.4 DataFrame subclass contract**
+
+| Attribute/Method | Defined on | Notes |
+|-----------------|-----------|-------|
+| `to_memory()` | Inherited from **DataObject** | Returns `pyarrow.Table` from arrow backend |
+| `get_in_memory_data()` | Inherited from **DataObject** | Same as `to_memory()` |
+
+**Key change**: No `_arrow_table` attribute. All data access goes through `storage_ref` → ArrowBackend. The `_arrow_table` pattern is eliminated.
+
+**D1.5 Text subclass contract**
+
+| Attribute/Method | Defined on | Notes |
+|-----------------|-----------|-------|
+| `content` | **Text** (constructor) | String content. Small enough to hold in memory. |
+| `get_in_memory_data()` | **Text** (override) | Returns `self.content` directly. |
+
+Text is exempt from the "no in-memory data" rule because text content is inherently small (~KB) and is part of the object's identity (e.g., a prompt string). `storage_ref` is optional for Text.
+
+**D1.6 Artifact subclass contract**
+
+| Attribute/Method | Defined on | Notes |
+|-----------------|-----------|-------|
+| `file_path` | **Artifact** (constructor) | Path to the opaque file on disk. |
+| `mime_type` | **Artifact** (constructor) | MIME type string. |
+| `get_in_memory_data()` | **Artifact** (override) | Reads bytes from `file_path`. |
+
+Artifact uses **path-only transport** — `file_path` is the reference, not `storage_ref`. Artifact is exempt from auto-flush (D5). `_auto_flush()` skips Artifact instances with `file_path` set.
+
+**D1.7 CompositeData subclass contract**
+
+CompositeData holds named slots, each of which is a DataObject. Each slot independently follows the storage-ref contract. The CompositeStore backend handles recursive persistence.
+
+#### D2. ViewProxy is deleted
+
+The `ViewProxy` class (`src/scieasy/core/proxy.py`) is deleted entirely. Its functionality is absorbed into the type hierarchy as follows:
+
+| ViewProxy method | New location | Notes |
+|---|---|---|
+| `to_memory()` | **DataObject**.`to_memory()` | Direct backend read via `_get_backend(self._storage_ref).read(...)`. Includes 2GB size warning. |
+| `slice(*args)` | **DataObject**.`slice(*args)` | Direct backend call. |
+| `iter_chunks(chunk_size)` | **DataObject**.`iter_chunks(chunk_size)` | Direct backend call. |
+| `shape` property | **Array**.`shape` | Already a constructor parameter on Array. Not on DataObject. |
+| `axes` property | **Array**.`axes` | Already a constructor parameter on Array. Not on DataObject. |
+| `from_file(path)` | Removed | Use `Artifact(file_path=Path(path))` or construct DataObject with appropriate `storage_ref`. |
+| `_get_backend(ref)` | Module-level utility in `scieasy.core.storage.backend_router` | Shared backend resolution, used by DataObject methods internally. |
+
+**`DataObject.view()` is deleted.** There is no ViewProxy path. Block authors call methods directly on the typed instance:
+
+```python
+# OLD (via ViewProxy):
+data = image.view().to_memory()        # indirection through ViewProxy
+chunk = image.view().slice(0, 100)     # indirection through ViewProxy
+
+# NEW (direct on DataObject/Array):
+data = image.to_memory()               # DataObject method, direct backend call
+sub = image.sel(z=5)                   # Array method, direct backend call
+for chunk in image.iter_chunks(1024):  # DataObject method, direct backend call
+    ...
+```
+
+#### D3. `_data` and `_arrow_table` are prohibited on cross-boundary DataObjects
+
+**Rule**: Any DataObject returned from `Block.run()` (or `IOBlock.load()`) MUST have `storage_ref` set (or `file_path` for Artifact). The framework enforces this at the IOBlock level (D4) and at the worker auto-flush boundary.
+
+**Transient in-memory data within a single block's `run()` is allowed.** A block may compute results in memory (e.g., CellPose producing a mask ndarray). The framework's existing `_auto_flush()` mechanism persists these to storage before the data crosses the process boundary. This behavior is unchanged.
+
+**Per-class elimination of in-memory backdoors:**
+
+| Class | Attribute removed | Current usage | Migration |
+|-------|------------------|---------------|-----------|
+| **Array** | `_data` (monkey-patched, not declared) | Set by loaders: `img._data = np.asarray(...)`. Checked by `Array.to_memory()`, `Array.sel()`, `get_in_memory_data()`. | Remove all `_data` assignments and `hasattr` checks. All data access routes through `storage_ref` → ZarrBackend. |
+| **DataFrame** | `_arrow_table` (monkey-patched, not declared) | Set by loaders: `df._arrow_table = table`. Checked by `get_in_memory_data()`, `_dataframe_to_arrow_table()`. | Remove all `_arrow_table` assignments and checks. All data access routes through `storage_ref` → ArrowBackend. |
+| **Series** | `_arrow_table` (inherited pattern from DataFrame) | Set inconsistently. `_load_series()` currently loses payload entirely. | Fix payload loss first (write to arrow backend). Then same migration as DataFrame. |
+| **Text** | `content` (declared constructor parameter) | **Exempt.** Text content is small (~KB) and is part of the object's identity. `content` is a legitimate declared field, not a monkey-patched backdoor. | No change. |
+| **Artifact** | `file_path` (declared constructor parameter) | **Exempt.** File path is the transport mechanism. | No change. See D5. |
+| **CompositeData** | Per-slot `_data`/`_arrow_table` on slot objects | Each slot is independently a DataObject. | Recursive: each slot follows its own class's migration. |
+
+**What `_auto_flush()` handles after this ADR**: Only transient outputs from ProcessBlock/CodeBlock/AppBlock `run()` methods — block authors who compute results in memory and don't explicitly persist them. The framework flushes these to storage before serialization. IOBlock loaders are expected to handle their own persistence (D4).
+
+#### D4. IOBlock base class guarantees storage-ref; provides persistence helpers for loader authors
+
+The `load()` signature changes to accept an `output_dir` parameter. The IOBlock base class provides two guarantees:
+
+1. **Correctness guarantee**: After `load()` returns, the base class checks every DataObject. If `storage_ref` is missing, the base class auto-flushes to storage. **No DataObject without `storage_ref` ever crosses the block boundary.** This is a safety net — loader authors who return in-memory objects still produce correct results.
+
+2. **Helper API**: The base class provides `persist_array()` and `persist_table()` helpers for loader authors who want streaming writes (constant memory). **Loader authors who know their data is large SHOULD use these helpers.** Loader authors who don't care can return in-memory objects and let the base class handle persistence.
+
+**The framework guarantees correctness. The loader author controls optimality.** Loader authors know their data characteristics — a 1KB CSV doesn't need streaming; a 100G TIFF does.
+
+**New `IOBlock` contract:**
+
+```python
+class IOBlock(Block):
+    @abstractmethod
+    def load(self, config: BlockConfig, output_dir: str) -> DataObject | Collection:
+        """Load data from source.
+
+        Implementations may EITHER:
+
+        (a) Return an in-memory DataObject (simple path):
+            The base class auto-persists it to storage. Works for small/medium
+            files. Will OOM on very large files.
+
+            return Image(_data=np.array(...), axes=["y","x"], shape=shape, dtype=dtype)
+
+        (b) Write to storage directly and return a reference (streaming path):
+            Use self.persist_array() / self.persist_table() helpers for
+            constant-memory writes. Required for large files.
+
+            ref = self.persist_array(chunks_iter, shape, dtype, output_dir)
+            return Image(storage_ref=ref, axes=["y","x"], shape=shape, dtype=dtype)
+
+        Artifact subclasses are exempt — return with file_path, no storage write needed.
+        """
+        ...
+
+    # -- persistence helpers for loader authors ---
+
+    def persist_array(
+        self, data_or_iterator, shape, dtype, output_dir, chunks=None,
+    ) -> StorageReference:
+        """Write array data to zarr storage, return StorageReference.
+
+        data_or_iterator may be:
+        - numpy ndarray (written in one shot)
+        - iterator of (slice, chunk_array) tuples (streaming, constant memory)
+
+        Memory usage: O(one chunk) for iterator mode, O(full array) for ndarray mode.
+        """
+        ...
+
+    def persist_table(self, table, output_dir) -> StorageReference:
+        """Write Arrow table to storage, return StorageReference."""
+        ...
+
+    # -- run() with auto-flush safety net ---
+
+    def run(self, inputs, config):
+        if self.direction == "input":
+            output_dir = get_output_dir()
+            result = self.load(config, output_dir=output_dir)
+            if not isinstance(result, Collection):
+                result = Collection(items=[result], item_type=type(result))
+            # Safety net: auto-flush any item without storage_ref
+            for item in result:
+                if isinstance(item, DataObject) and item.storage_ref is None:
+                    if not (isinstance(item, Artifact) and item.file_path is not None):
+                        self._auto_flush(item)  # persist to zarr/arrow, set storage_ref
+            return {self._resolved_load_output_port_name(): result}
+```
+
+**Example: LoadImage TIFF — streaming path (large files, constant memory):**
+
+```python
+def load(self, config, output_dir=None):
+    path = Path(config.get("path"))
+
+    with tifffile.TiffFile(str(path)) as tf:
+        page0 = tf.pages[0]
+        shape = (len(tf.pages), *page0.shape) if len(tf.pages) > 1 else page0.shape
+        dtype = page0.dtype
+        axes = _infer_axes(tf)
+
+        # Stream page-by-page — memory = O(one page)
+        def page_chunks():
+            for i, page in enumerate(tf.pages):
+                yield (i, page.asarray())
+
+        ref = self.persist_array(page_chunks(), shape, dtype, output_dir)
+
+    return Image(axes=axes, shape=shape, dtype=dtype, storage_ref=ref)
+    # ← ~KB object. No _data, no in-memory payload.
+```
+
+**Example: LoadData CSV — simple path (small files, base class handles persistence):**
+
+```python
+def _load_dataframe(self, path, config, output_dir):
+    import pyarrow.csv as pcsv
+    table = pcsv.read_csv(str(path))
+    # Return in-memory — base class will auto-persist via _auto_flush
+    df = DataFrame()
+    df._arrow_table = table  # OK for simple path; base class flushes this
+    return df
+```
+
+**Example: LoadData CSV — streaming path (large files):**
+
+```python
+def _load_dataframe(self, path, config, output_dir):
+    import pyarrow.csv as pcsv
+    table = pcsv.read_csv(str(path))
+    ref = self.persist_table(table, output_dir)
+    return DataFrame(storage_ref=ref)
+    # ← Reference only. No _arrow_table.
+```
+
+**Loader author's choice matrix:**
+
+| Data size | Approach | Memory | Code complexity |
+|-----------|----------|--------|-----------------|
+| Small (< 1GB) | Return in-memory, base class auto-flushes | O(file size) | Minimal — same as today |
+| Large (> 1GB) | Use `persist_array()` / `persist_table()` streaming helpers | O(chunk size) | Slightly more — iterate chunks |
+
+**All 6 loader classes should be updated to use the new `load(config, output_dir)` signature.** Whether each individual loader function uses the simple path or streaming path is the loader author's decision based on expected data size:
+
+| Loader | Recommended path | Rationale |
+|--------|-----------------|-----------|
+| `LoadImage` TIFF | Streaming | Scientific images routinely exceed 1GB |
+| `LoadImage` Zarr | Reference | Zarr is already chunked storage — reference existing store |
+| `LoadData` Array .zarr | Reference | Already lazy (only correct loader today) |
+| `LoadData` Array .npy/.npz | Simple | Typically small; streaming .npy is not straightforward |
+| `LoadData` DataFrame csv/parquet | Simple or Streaming | Author's choice based on expected table size |
+| `LoadData` Text | Simple | Text files are small |
+| `LoadData` Artifact | Exempt | Path-only transport (D5) |
+| LCMS loaders | Simple | Domain-specific, typically small tables |
+
+#### D5. Artifact and file-handle types skip auto-flush
+
+`Artifact` and its subclasses (e.g., `MSRawFile`) use `file_path` as their transport mechanism, not `storage_ref`. They represent opaque files that should not be read into memory or copied into managed storage.
+
+**`_auto_flush()` is modified to skip Artifact instances that have `file_path` set:**
+
+```python
+@staticmethod
+def _auto_flush(obj: Any) -> Any:
+    if not isinstance(obj, DataObject):
+        return obj
+    # NEW: Artifact with file_path uses path-only transport
+    from scieasy.core.types.artifact import Artifact
+    if isinstance(obj, Artifact) and obj.file_path is not None:
+        return obj
+    # ... existing flush logic ...
+```
+
+**Serialization**: `_serialise_one()` already handles Artifact via `_serialise_extra_metadata()` which writes `file_path` to the metadata sidecar. `_reconstruct_one()` already handles it via `_reconstruct_extra_kwargs()` which restores `file_path`. No changes needed to the wire protocol.
+
+**SaveData for Artifact**: `_save_artifact()` copies the file via `shutil.copy2()`. This is correct behavior — it copies the file to the user-chosen path, not to managed storage.
+
+#### D6. `get_in_memory_data()` per-class behavior
+
+The current `get_in_memory_data()` on `DataObject` uses `hasattr` to check for undeclared attributes. This is replaced with a clean per-class dispatch:
+
+**DataObject (base class):**
+```python
+def get_in_memory_data(self) -> Any:
+    """Materialize data from storage for persistence/export."""
+    return self.to_memory()  # storage_ref → backend → read
+```
+
+**Per-class overrides:**
+
+| Class | `get_in_memory_data()` behavior | Rationale |
+|-------|-------------------------------|-----------|
+| **DataObject** (base) | `return self.to_memory()` | Default: read from storage via backend. |
+| **Array** | Inherited from DataObject | `to_memory()` → ZarrBackend.read() → `np.ndarray` |
+| **DataFrame** | Inherited from DataObject | `to_memory()` → ArrowBackend.read() → `pyarrow.Table` |
+| **Series** | Inherited from DataObject | `to_memory()` → ArrowBackend.read() → `pyarrow.Table` (single column) |
+| **Text** (override) | `return self.content` | Text content is in-memory by design (~KB). No storage round-trip needed. |
+| **Artifact** (override) | `return self.file_path.read_bytes()` | Reads from original file. Not from managed storage. |
+| **CompositeData** | Inherited from DataObject | `to_memory()` → CompositeStore.read() → reconstructs slot dict |
+
+**Removed**: The `hasattr(self, "_data")` and `hasattr(self, "_arrow_table")` checks in the base class. No monkey-patched attributes are consulted.
+
+This means SaveData's `_save_array()`, `_save_dataframe()`, etc. all work correctly with storage-backed objects — they call `get_in_memory_data()` → `to_memory()` → backend read.
+
+#### D7. Worker reconstruction contract (restated from ADR-027 Add1)
+
+`worker.reconstruct_inputs()` returns **typed DataObject instances** (e.g., `Image`, `DataFrame`), not `ViewProxy`. This decision from ADR-027 Addendum 1 is **correct and retained**.
+
+The reconstruction hooks remain:
+- `cls._reconstruct_extra_kwargs(metadata)` — per-base-class kwargs extraction
+- `cls._serialise_extra_metadata(obj)` — per-base-class metadata serialization
+
+The Meta Pydantic constraints remain:
+- Frozen, no `PrivateAttr`, all fields must round-trip through `model_dump_json` / `model_validate_json`
+
+#### D8. Checkpoint deserialization updated
+
+`checkpoint.py`'s `deserialize_intermediate_refs()` currently constructs `ViewProxy` instances. This function is rewritten to construct typed `DataObject` instances using the same `_reconstruct_one()` path as the worker.
+
+If type resolution fails (missing plugin), fall back to a base `DataObject(storage_ref=ref)` rather than a `ViewProxy`.
+
+#### D9. Documentation is unified
+
+All references to the old "engine injects ViewProxy" model are removed from:
+- `docs/architecture/ARCHITECTURE.md:331-362` (and line 618)
+- `docs/adr/ADR.md` ADR-007 discussion text
+- Block SDK guide
+
+The canonical documentation model is:
+- Blocks receive **typed DataObject instances** with `storage_ref` set
+- Data is lazy — `to_memory()` / `sel()` / `iter_chunks()` trigger reads on demand
+- ViewProxy does not exist
+
+---
+
+### 4. Impact Scope
+
+#### 4.1 Files deleted
+
+| File | Reason |
+|------|--------|
+| `src/scieasy/core/proxy.py` | ViewProxy class eliminated |
+| `tests/core/test_proxy.py` | Tests for deleted class |
+| `tests/core/test_proxy_multi_backend.py` | Tests for deleted class |
+
+#### 4.2 Core type system changes
+
+**DataObject base class** (`src/scieasy/core/types/base.py`):
+
+| Change | Detail |
+|--------|--------|
+| Delete `view()` method | Returns ViewProxy — ViewProxy no longer exists (D2) |
+| Rewrite `to_memory()` | Direct: `_get_backend(self._storage_ref).read(self._storage_ref)`. Add 2GB size warning from ViewProxy. |
+| Add `slice(*args)` | New method: `_get_backend(self._storage_ref).slice(self._storage_ref, *args)` |
+| Add `iter_chunks(chunk_size)` | New method: `yield from _get_backend(self._storage_ref).iter_chunks(self._storage_ref, chunk_size)` |
+| Rewrite `get_in_memory_data()` | Remove `hasattr(self, "_data")` and `hasattr(self, "_arrow_table")` checks. New body: `return self.to_memory()` (D6) |
+| Remove `TYPE_CHECKING` ViewProxy import | Line 34: `from scieasy.core.proxy import ViewProxy` |
+
+**Array subclass** (`src/scieasy/core/types/array.py`):
+
+| Change | Detail |
+|--------|--------|
+| Remove `to_memory()` override | Delete the `if self._storage_ref is None and hasattr(self, "_data")` backdoor. Inherit DataObject's `to_memory()`. |
+| Rewrite `sel(**kwargs)` | Remove `hasattr(self, "_data")` check (line 214). Always read from storage: `full_data = self.to_memory()`. Persist slice result to temp zarr with `storage_ref` instead of stashing in `_data`. |
+| Rewrite `iter_over(axis)` | Delegates to `sel()` per-index — inherits sel()'s storage-based behavior. |
+| `__array__()` | No change — already calls `self.to_memory()`. |
+| `shape`, `axes`, `dtype` | No change — already declared constructor parameters. |
+
+**DataFrame subclass** (`src/scieasy/core/types/dataframe.py`):
+
+| Change | Detail |
+|--------|--------|
+| No `_arrow_table` attribute | All data access through inherited `to_memory()` → ArrowBackend |
+
+**Text subclass** (`src/scieasy/core/types/text.py`):
+
+| Change | Detail |
+|--------|--------|
+| `get_in_memory_data()` override | Returns `self.content`. No storage round-trip. (Existing behavior, no change.) |
+
+**Artifact subclass** (`src/scieasy/core/types/artifact.py`):
+
+| Change | Detail |
+|--------|--------|
+| `get_in_memory_data()` override | Returns `self.file_path.read_bytes()`. (Existing behavior, no change.) |
+| Exempt from auto-flush | See D5. |
+
+**CompositeData** (`src/scieasy/core/types/composite.py`):
+
+| Change | Detail |
+|--------|--------|
+| Per-slot compliance | Each slot is an independent DataObject — follows its own class's contract. CompositeStore handles recursive persistence. |
+
+#### 4.3 IOBlock and loader changes
+
+| File | Changes |
+|------|---------|
+| `src/scieasy/blocks/io/io_block.py` | Change `load()` signature to `load(self, config, output_dir)`. Add `persist_array()` and `persist_table()` helper methods. Update `run()` to pass `output_dir` and auto-flush any item without `storage_ref` (D4 safety net). |
+| `src/scieasy/blocks/io/loaders/load_data.py` | Update `load()` to accept `output_dir`. Per-function changes: `_load_array .zarr` (already lazy, no change). `_load_array .npy/.npz/.parquet` (simple path — base class auto-flushes). `_load_dataframe` (simple or streaming — author's choice). `_load_series` (fix payload loss — must write to arrow). `_load_text` (simple path). `_load_artifact` (exempt, path-only D5). `_load_composite_data` (recursive, pass output_dir). |
+| `packages/scieasy-blocks-imaging/.../load_image.py` | Streaming path for `_load_tiff` (page-by-page via `persist_array()`). `_load_zarr` (reference existing zarr store, no copy). |
+| `packages/scieasy-blocks-lcms/.../load_mzml_files.py` | Update `load()` signature. MSRawFile is Artifact subclass — path-only, exempt. |
+| `packages/scieasy-blocks-lcms/.../load_peak_table.py` | Fix: write DataFrame to arrow via `persist_table()`, remove pandas from `user` dict. |
+| `packages/scieasy-blocks-lcms/.../load_mid_table.py` | Update `load()` signature, use simple or streaming path. |
+| `packages/scieasy-blocks-lcms/.../load_sample_metadata.py` | Update `load()` signature, use simple path. |
+| `src/scieasy/blocks/io/savers/save_data.py` | Remove `_arrow_table` check. Phase 3: add chunked export for Parquet/CSV/Zarr. |
+| `packages/scieasy-blocks-imaging/.../save_image.py` | No immediate change. Phase 3: add chunked TIFF write. |
+| `packages/scieasy-blocks-lcms/.../save_table.py` | Update `save()` to use `get_in_memory_data()` consistently. |
+
+#### 4.4 Block framework changes
+
+| File | Changes |
+|------|---------|
+| `src/scieasy/blocks/base/block.py` | Remove `_is_view_proxy()` helper. Update `validate()` to remove ViewProxy branch. Update `_auto_flush()` to skip Artifact (D5). |
+| `src/scieasy/blocks/process/process_block.py` | No change — already calls `_auto_flush()` on outputs. |
+| `src/scieasy/blocks/process/utils.py` | Remove ViewProxy isinstance check in `to_arrow()`. |
+| `src/scieasy/blocks/app/bridge.py` | Remove ViewProxy isinstance check. |
+| `src/scieasy/blocks/process/builtins/split.py` | Replace `_arrow_table` assignments with `get_in_memory_data()` + storage write. |
+| `src/scieasy/blocks/process/builtins/merge.py` | Same pattern. |
+
+#### 4.5 Engine changes
+
+| File | Changes |
+|------|---------|
+| `src/scieasy/engine/checkpoint.py` | Rewrite `deserialize_intermediate_refs()` to construct DataObject, not ViewProxy (D8). |
+| `src/scieasy/engine/runners/worker.py` | Remove ViewProxy references from docstrings. No structural changes — already returns typed DataObject. |
+| `src/scieasy/engine/runners/local.py` | `serialise_inputs()` added by PR #623 (P0 fix) remains as defense-in-depth. |
+| `src/scieasy/engine/scheduler.py` | Remove ViewProxy comments. |
+
+#### 4.6 SaveData and saver changes
+
+SaveData is a **sink block** — it reads data from storage and writes to a user-chosen file format.
+
+**Audit finding §2.2.5: SaveData currently cannot reliably export storage-backed objects.** `_save_array()` calls `obj.get_in_memory_data()`, which checks `hasattr(self, "_data")`. A storage-backed Array reconstructed in the worker has `storage_ref` set but no `_data`, so `get_in_memory_data()` raises `ValueError`. The same applies to `_dataframe_to_arrow_table()` which checks for `_arrow_table`.
+
+**This is resolved by D6**: `get_in_memory_data()` is rewritten to route through `to_memory()` → storage backend read. SaveData works correctly with storage-backed objects without SaveData-specific code changes in Phase 1/2.
+
+**Phase 3 optimization**: For large data, SaveData should read from storage chunk-by-chunk and write to the target format incrementally, avoiding full materialization. This is format-dependent — Parquet and Zarr support chunked writes; NPY and CSV do not.
+
+| File | Changes |
+|------|---------|
+| `src/scieasy/blocks/io/savers/save_data.py` | Phase 1/2: Remove `_arrow_table` check in `_dataframe_to_arrow_table()`. All paths work via `get_in_memory_data()` → `to_memory()` → storage read. Phase 3: Add chunked export paths for formats that support it (Parquet, Zarr). |
+| `packages/scieasy-blocks-imaging/.../save_image.py` | Phase 1/2: No change needed — SaveImage calls `to_memory()` which now routes through storage. Phase 3: Add chunked TIFF write (page-by-page from zarr). |
+
+**Per-format SaveData behavior after this ADR:**
+
+| Format | Phase 1/2 (correctness) | Phase 3 (streaming) |
+|--------|------------------------|---------------------|
+| `.zarr` | `get_in_memory_data()` → full read → zarr write | Direct zarr-to-zarr copy (zero materialization) |
+| `.npy` | `get_in_memory_data()` → full read → `np.save()` | Full read required (NPY format is not chunked) |
+| `.parquet` | `get_in_memory_data()` → full read → `pq.write_table()` | Chunked: read row groups from arrow → write row groups to parquet |
+| `.csv` | `get_in_memory_data()` → full read → `write_csv()` | Chunked: read batches from arrow → write batches to CSV |
+| TIFF | `get_in_memory_data()` → full read → `tifffile.imwrite()` | Chunked: read z-planes from zarr → write pages to TIFF |
+
+#### 4.7 Utility changes
+
+| File | Changes |
+|------|---------|
+| `src/scieasy/utils/axis_iter.py` | Replace `result._data = data` with persist-to-zarr + set storage_ref. |
+| `src/scieasy/utils/broadcast.py` | Update ViewProxy references in docstrings/warnings. |
+
+#### 4.8 Test changes
+
+| File | Changes |
+|------|---------|
+| `tests/core/test_proxy.py` | Delete entirely. |
+| `tests/core/test_proxy_multi_backend.py` | Delete entirely. |
+| `tests/core/test_dataobject_extended.py` | Update: assert `storage_ref is not None` instead of `_data` checks. |
+| `tests/core/test_storage.py` | Remove ViewProxy construction. |
+| `tests/engine/test_checkpoint.py` | Update: assert DataObject instead of ViewProxy from deserialization. |
+| `tests/engine/test_worker.py` | Remove ViewProxy assertion (already asserts `not isinstance(x, ViewProxy)`). |
+| `tests/engine/test_worker_typed_reconstruction.py` | Remove ViewProxy imports and negative assertions. |
+| `tests/blocks/test_block_base.py` | Remove ViewProxy validation tests. |
+| `tests/blocks/test_process_utils.py` | Remove ViewProxy mock. |
+| `tests/blocks/io/test_load_data.py` | Update: assert `storage_ref is not None` instead of `_data`/`_arrow_table` checks. |
+
+#### 4.9 Documentation changes
+
+| File | Changes |
+|------|---------|
+| `docs/architecture/ARCHITECTURE.md` | Remove ViewProxy-injection model (lines 331-362, 613-618). Update to DataObject-only model. |
+| `docs/adr/ADR.md` (ADR-007) | Add note: "ViewProxy eliminated in ADR-031. Methods absorbed into DataObject." |
+| `docs/adr/ADR.md` (ADR-027 Add1) | Mark as ~~deprecated~~ — superseded by ADR-031. |
+| `docs/guides/block-sdk.md` | Update data access examples: `item.to_memory()` not `item.view().to_memory()`. |
+
+---
+
+### 5. Implementation Plan
+
+#### Phase 1: Loader rewrite + core enforcement (all loaders write to storage directly)
+
+1. **Change `IOBlock.load()` signature** — add `output_dir: str` parameter. Update `IOBlock.run()` to pass `output_dir` and enforce `storage_ref` on returned objects (D4).
+2. **Rewrite all 6 loader classes (~12 functions)** to write directly to zarr/arrow storage and return reference-only DataObjects. Use streaming writes where the format supports it (TIFF page-by-page, CSV Arrow streaming, etc.).
+3. **Artifact auto-flush skip** (D5) — `_auto_flush()` skips Artifact with `file_path`.
+4. **Fix `_load_series()` payload loss** — write to arrow backend, return with `storage_ref`.
+5. **Fix `LoadPeakTable` user-dict violation** — write DataFrame to arrow storage, not `user` dict.
+6. **Update test fixtures** — mock loaders in `tests/` must comply with new `load()` signature.
+
+#### Phase 2: ViewProxy elimination and `_data` cleanup
+
+7. **Move `_get_backend()` and data access methods to DataObject** — `to_memory()`, `slice()`, `iter_chunks()`. Add 2GB size warning.
+8. **Delete `ViewProxy` class** (`src/scieasy/core/proxy.py`) and `DataObject.view()` method.
+9. **Rewrite `get_in_memory_data()`** — route through `to_memory()`, remove `hasattr(self, "_data")` / `_arrow_table` checks (D6).
+10. **Update `Array.to_memory()`** — remove `_data` backdoor, always read from storage.
+11. **Update `Array.sel()`** — remove `_data` check, read from storage. Persist slice result to temp zarr with storage_ref (no `_data` stashing).
+12. **Update `checkpoint.py`** — `deserialize_intermediate_refs()` constructs typed DataObject, not ViewProxy (D8).
+13. **Update `save_data.py`** — remove `_arrow_table` check in `_dataframe_to_arrow_table()`.
+14. **Remove all ViewProxy imports, isinstance checks, and helpers** — `block.py:_is_view_proxy()`, `process/utils.py`, `app/bridge.py`, all comments.
+15. **Update `split.py`, `merge.py`, `axis_iter.py`** �� replace `_arrow_table`/`_data` assignments with storage writes.
+16. **Delete test files** — `test_proxy.py`, `test_proxy_multi_backend.py`. Update all tests asserting `_data` to assert `storage_ref`.
+
+#### Phase 3: Process-side optimization (incremental)
+
+17. **Array.sel() Zarr partial-read** — leverage Zarr backend's native slicing instead of full materialization + numpy indexing.
+18. **SaveData streaming export** — for formats that support it, read from zarr chunk-by-chunk, write to target format chunk-by-chunk.
+19. **Block SDK guidance** — document `iter_chunks()` / `sel()` as preferred over `to_memory()` for large data. Add framework-level memory warning when `to_memory()` on large data.
+
+---
+
+### 6. Risks
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| **Performance regression from format conversion** — loaders convert source format (TIFF/CSV/etc.) to zarr/arrow; downstream reads from zarr/arrow, SaveData converts back to target format | Medium | This is inherent to using zarr as universal intermediate format. Streaming writes minimize memory. For workflows where source and target format match, a future "passthrough" optimization can skip intermediate storage. |
+| **Existing plugin blocks break** — blocks that set `_data` directly | Low | D4 enforcement is backward-compatible — it flushes `_data` objects to zarr automatically. Blocks don't need to change immediately. |
+| **`Array.sel()` becomes slower** — currently reads from `_data` (in-memory), will read from zarr | Medium | Zarr partial-read (Phase 4) mitigates this. For small arrays, the overhead is negligible. |
+| **Test breakage** — many tests assert `_data` presence | Low | Systematic update: assert `storage_ref is not None` instead. |
+| **Checkpoint backward compatibility** — old checkpoints may have ViewProxy-format entries | Low | `deserialize_intermediate_refs()` rewritten to produce DataObject. Old wire format still parseable. |
+
+---
+
+### 7. Alternatives Considered
+
+1. **Keep ViewProxy as opt-in helper (ADR-027 Add1 approach).** Rejected — no block uses it. Maintaining a class with zero consumers adds complexity without value.
+
+2. **Keep `_data` but enforce it's always backed by storage_ref too.** Rejected — two sources of truth for the same data. Which wins when they disagree? The `_data` pattern invites bypass of the storage contract.
+
+3. **Create per-format read-only backends (TiffBackend, NpyBackend, etc.) for true zero-copy lazy loading.** Deferred — not rejected, but not required for this ADR. Zarr as the universal intermediate format is sufficient. Per-format backends can be added incrementally when performance requires it.
+
+4. **Make DataObject.to_memory() check `_data` first as fast-path cache.** Rejected — this is the existing backdoor that caused the regression. A single code path (storage_ref → backend → read) is simpler, more predictable, and debuggable.
+
+---
+
+### 8. Consequences
+
+- **DataObject becomes the single, unambiguous data abstraction.** No ViewProxy, no `_data` backdoor, no dual code paths.
+- **All loaders become compliant immediately** via D4 (IOBlock enforcement), without individual loader code changes.
+- **SaveData works with storage-backed objects** because `get_in_memory_data()` routes through `to_memory()`.
+- **100G+ data support becomes architecturally possible** once Phase 3 (streaming loaders) is implemented. Phase 1 alone does not solve the OOM problem but removes the architectural barriers to solving it.
+- **The wire protocol is unchanged.** JSON payload format between scheduler and worker is not modified.
+- **56+ code locations require updates** across 19 source files. The changes are mechanical (remove ViewProxy imports, remove `_data` checks, update assertions) except for the IOBlock enforcement (D4) and the `to_memory()` rewrite.
+- **ADR-027 Addendum 1 is formally deprecated.** Its correct decisions (typed reconstruction, per-class hooks, Meta constraints) are restated in D7.
+
+---
+
+### Appendix A: Deprecated ADR-027 Addendum 1
+
+**Status**: ~~proposed~~ → **deprecated (superseded by ADR-031)**
+
+ADR-027 Addendum 1 ("Worker subprocess type reconstruction returns typed DataObject instances, not ViewProxy") is deprecated in its entirety. The following decisions from Addendum 1 are **restated in ADR-031** with updated scope:
+
+| Addendum 1 Decision | ADR-031 Status |
+|---|---|
+| D11': typed DataObject reconstruction in worker | **Retained** (ADR-031 D7) |
+| `_reconstruct_extra_kwargs` / `_serialise_extra_metadata` hooks | **Retained** (ADR-031 D7) |
+| Meta Pydantic constraints (frozen, JSON-round-trippable) | **Retained** (ADR-031 D7) |
+| ViewProxy "demoted to opt-in helper via `item.view()`" | **Rejected** — ViewProxy deleted entirely (ADR-031 D2) |
+| PhysicalQuantity Pydantic integration via `__get_pydantic_core_schema__` | **Retained** — unchanged, not in scope of ADR-031 |
+
+References to ADR-027 Addendum 1 in code comments should be updated to cite ADR-031 D7 for reconstruction contract and ADR-031 D2 for ViewProxy elimination.
+
+---
+
+### Appendix B: Audit Report Reference
+
+This ADR was motivated by the independent data storage and transport audit documented in `docs/data-storage-transport-audit.en.md` (2026-04-11). Key audit findings are cited in §2.2 with evidence references to specific source files and line numbers.
+
+The audit's summary:
+
+> SciEasy's transport layer is mostly reference-based now, but its load, processing, and export layers still contain widespread eager materialization, payload-loss edge cases, and multiple mismatches with the stated design philosophy.
+

--- a/docs/data-storage-transport-audit.en.md
+++ b/docs/data-storage-transport-audit.en.md
@@ -1,0 +1,220 @@
+# SciEasy Data Storage and Transport Audit Report (English)
+
+Audit date: 2026-04-11  
+Scope: `docs/architecture/ARCHITECTURE.md`, `docs/adr/ADR.md`, `src/scieasy/**`, `packages/scieasy-blocks-*/**`  
+Method: read-only audit, no business-code changes
+
+## Executive Summary
+
+The main conclusions are:
+
+1. The real runtime boundary is no longer the older “engine injects `ViewProxy`” model that still appears in older docs. The current implementation sends JSON wire payloads across the process boundary, and the worker reconstructs typed `DataObject` / `Collection` instances with `storage_ref`. Payload data is only read when code later calls `to_memory()` or `view()`. Evidence: `src/scieasy/engine/runners/worker.py:43-91`, `src/scieasy/core/types/serialization.py:93-225`, aligned with newer ADR text in `docs/adr/ADR.md:4659-4705`, `4722-4726`, `5108-5113`.
+2. “Lazy by default” is only partially true. It is mostly true at the scheduler/worker transport boundary, but many loaders, utilities, process blocks, and plugin blocks still materialize full data eagerly inside the worker.
+3. Laziness is not enforced uniformly by the framework. In practice it depends on file format and block implementation.
+4. There are several implementation gaps that are more than documentation drift: `SaveData` cannot reliably export storage-backed core objects; `LoadData(core_type='Series')` drops payload; `LoadPeakTable` stores a `pandas.DataFrame` inside JSON-oriented `user` metadata; and raw-file / artifact “path handle” semantics are broken by auto-flush copying the actual file at block boundaries.
+
+## Design Intent and Documentation State
+
+### Core intent
+
+The architecture principles say:
+
+- `Lazy by default`: data objects should hold references, not payloads.  
+  `docs/architecture/ARCHITECTURE.md:28-35`
+
+This is clearly aimed at keeping very large datasets on disk until a block explicitly requests access.
+
+### Older documentation model
+
+Older docs still describe an injected-`ViewProxy` system:
+
+- `docs/architecture/ARCHITECTURE.md:331-362`
+- `docs/architecture/ARCHITECTURE.md:613-618`
+- `docs/adr/ADR.md:210-239`
+
+Those sections say blocks receive `ViewProxy`, and the worker reconstructs `ViewProxy`.
+
+### Newer documentation model
+
+Newer ADR addenda describe a different runtime:
+
+- worker reconstructs typed `DataObject`, not `ViewProxy`:  
+  `docs/adr/ADR.md:4659-4705`, `4722-4726`
+- `ViewProxy` is retained only as an opt-in helper via `item.view()`:  
+  `docs/adr/ADR.md:5108-5113`
+
+So the documentation set currently mixes two generations of architecture. The code matches the newer model.
+
+## Actual End-to-End Data Flow
+
+### 1. Loading stage
+
+`IOBlock.run()` wraps input-direction results into `Collection` and forwards output-direction blocks to `save()`:  
+`src/scieasy/blocks/io/io_block.py:105-145`
+
+#### Core `LoadData`
+
+The real behavior is format-dependent:
+
+| Type / Format | Real implementation | Full in-memory load? |
+|---|---|---|
+| `Array` + `.zarr` | metadata-only object with `storage_ref` | No |
+| `Array` + `.npy/.npz/.parquet` | reads full ndarray into `_data` | Yes |
+| `DataFrame` + csv/tsv/parquet/json | reads full `pyarrow.Table` into `_arrow_table` | Yes |
+| `Series` + tabular | returns metadata-only `Series(...)`, payload not preserved | Payload lost |
+| `Text` | `read_text()` | Yes |
+| `Artifact` | keeps `file_path`, no `storage_ref` | Not yet, but copied later |
+
+Evidence:
+
+- `src/scieasy/blocks/io/loaders/load_data.py:233-339`
+- `src/scieasy/blocks/io/loaders/load_data.py:342-427`
+- `src/scieasy/blocks/io/loaders/load_data.py:430-468`
+- `src/scieasy/blocks/io/loaders/load_data.py:488-562`
+
+#### Plugin loaders
+
+Representative cases:
+
+- Imaging `LoadImage` loads both TIFF and Zarr eagerly through `tf.asarray()` or `np.asarray(arr_node[...])`:  
+  `packages/scieasy-blocks-imaging/src/scieasy_blocks_imaging/io/load_image.py:76-141`
+- LCMS `LoadMzMLFiles` returns `MSRawFile(file_path=path, meta=...)`, which looks like a handle-only design:  
+  `packages/scieasy-blocks-lcms/src/scieasy_blocks_lcms/io/load_mzml_files.py:100-113`
+- LCMS `LoadPeakTable` stores a pandas frame copy in `table.user["pandas_df"]`:  
+  `packages/scieasy-blocks-lcms/src/scieasy_blocks_lcms/io/load_peak_table.py:123-134`
+
+### 2. How data moves between blocks
+
+The scheduler stores runner results directly in `_block_outputs`:  
+`src/scieasy/engine/scheduler.py:292-301`
+
+Downstream inputs are gathered by simply forwarding the stored output entry by port name:  
+`src/scieasy/engine/scheduler.py:322-346`
+
+`LocalRunner` sends worker input as pure JSON:  
+`src/scieasy/engine/runners/local.py:97-108`  
+`src/scieasy/engine/runners/process_handle.py:145-170`
+
+So the real path is:
+
+1. worker serializes outputs into wire-format dicts
+2. scheduler stores those dicts
+3. downstream execution sends those dicts to a new worker over stdin JSON
+4. the new worker reconstructs typed `DataObject` instances there
+
+This means the engine mostly stores lightweight wire payloads, not live typed objects.
+
+### 3. How data is processed inside blocks
+
+`ProcessBlock.run()` is per-item at the framework loop level and auto-flushes each result:  
+`src/scieasy/blocks/process/process_block.py:123-174`
+
+But many APIs still materialize eagerly:
+
+- `Array.__array__()` calls `to_memory()`: `src/scieasy/core/types/array.py:120-134`
+- `Array.sel()` materializes storage-backed arrays before slicing: `src/scieasy/core/types/array.py:165-172`, `211-223`
+- `iterate_over_axes()` starts with `source.to_memory()`: `src/scieasy/utils/axis_iter.py:151-188`
+- `broadcast_apply()` is explicitly in-memory-only: `src/scieasy/utils/broadcast.py:68-75`
+- SRS baseline explicitly does `np.asarray(item.to_memory(), dtype=np.float64)`: `packages/scieasy-blocks-srs/src/scieasy_blocks_srs/preprocess/srs_baseline.py:76-97`
+
+`CodeBlock` is even more explicit:
+
+- single-item `Collection` -> `view().to_memory()`
+- multi-item `Collection` -> `LazyList`
+
+Evidence:
+
+- `src/scieasy/blocks/code/code_block.py:24-37`
+- `src/scieasy/blocks/code/code_block.py:105-125`
+- `src/scieasy/blocks/code/lazy_list.py:33-35`
+
+Important nuance: `LazyList` is item-lazy, not chunk-lazy. Accessing an item still loads the full item through `to_memory()`.
+
+### 4. Saving, auto-flush, and checkpoints
+
+Intermediate persistence relies on `_auto_flush()`:  
+`src/scieasy/blocks/base/block.py:350-403`
+
+The worker calls `_auto_flush()` before serializing outputs:  
+`src/scieasy/engine/runners/worker.py:94-177`
+
+The default intermediate output directory comes from `LocalRunner._derive_output_dir()`:  
+`src/scieasy/engine/runners/local.py:23-39`
+
+Default path:
+
+`<project_dir>/data/zarr/<workflow_id>/<block_id>`
+
+But that directory can contain `.zarr`, `.parquet`, text files, binary artifacts, or composite directories. The name is misleading.
+
+Checkpoints also persist mostly wire-format references rather than live objects:  
+`src/scieasy/engine/checkpoint.py:26-83`
+
+On restore, the scheduler does not use the deprecated `ViewProxy` deserialization path. It injects wire-format dicts back into `_block_outputs` and lets the worker reconstruct typed objects later:  
+`src/scieasy/engine/checkpoint.py:86-122`  
+`src/scieasy/engine/scheduler.py:934-971`
+
+## Direct Answer: Is data fully loaded into memory?
+
+Not always, but often.
+
+The accurate statement is:
+
+- usually not in the scheduler/engine process
+- usually not across the process boundary
+- often yes inside worker-side loaders and algorithm blocks
+
+Most obviously eager paths include:
+
+- `LoadData(Array .npy/.npz/.parquet)`
+- `LoadData(DataFrame csv/tsv/parquet/json)`
+- `LoadImage(TIFF/Zarr)`
+- many algorithm blocks using `to_memory()` or `np.asarray(...)`
+
+## Key Gaps and Violations of the Design Philosophy
+
+### High priority
+
+1. **Core architecture docs still describe injected `ViewProxy`, but the runtime now uses typed `DataObject`.**  
+   Old docs: `docs/architecture/ARCHITECTURE.md:331-362`, `618`. Newer ADR + code: `docs/adr/ADR.md:4659-4705`, `4722-4726`, `5108-5113`, and `src/scieasy/engine/runners/worker.py:43-91`.
+
+2. **“Lazy by default” is not consistently realized.**  
+   Counterexamples include eager `LoadData` paths for `.npy/.npz/.csv/.parquet/.json`, eager imaging TIFF/Zarr loading, and `Array.sel()` materializing full arrays before slicing. Evidence: `src/scieasy/blocks/io/loaders/load_data.py:233-427`, `packages/scieasy-blocks-imaging/src/scieasy_blocks_imaging/io/load_image.py:76-141`, `src/scieasy/core/types/array.py:165-223`.
+
+3. **`SaveData` cannot reliably export storage-backed core objects.**  
+   It depends on `get_in_memory_data()` or `_arrow_table`, while downstream workers often only reconstruct storage-backed typed objects. Evidence: `src/scieasy/blocks/io/savers/save_data.py:271-425`, `597-625`; `src/scieasy/core/types/base.py:350-381`.
+
+4. **`LoadData(core_type='Series')` loses payload.**  
+   `_load_series()` reads the table indirectly, then returns a new `Series(...)` without `_data`, `_arrow_table`, or `storage_ref`. Evidence: `src/scieasy/blocks/io/loaders/load_data.py:456-468`.
+
+5. **Mutable `user` metadata bypasses validation, and `LoadPeakTable` already stores a non-JSON object there.**  
+   JSON requirement: `src/scieasy/core/types/base.py:193-206`; mutable dict exposure: `230-237`; plugin example: `packages/scieasy-blocks-lcms/src/scieasy_blocks_lcms/io/load_peak_table.py:123-134`; serialization assumes JSON-clean `user`: `src/scieasy/core/types/serialization.py:281-305`.
+
+6. **Raw-file / artifact handle semantics are broken at block boundaries.**  
+   `MSRawFile` is intended as path + header metadata only: `packages/scieasy-blocks-lcms/src/scieasy_blocks_lcms/types.py:24-35`. But `_auto_flush()` plus `Artifact.get_in_memory_data()` ends up reading bytes from the original file and copying them into managed intermediate storage. Evidence: `src/scieasy/blocks/base/block.py:374-403`, `src/scieasy/core/types/artifact.py:44-48`.
+
+### Medium priority
+
+1. **Imaging Zarr loading clearly violates the large-data lazy-loading goal.**  
+   Evidence: `packages/scieasy-blocks-imaging/src/scieasy_blocks_imaging/io/load_image.py:97-140`.
+
+2. **CodeBlock is asymmetric across languages.**  
+   Python sees real Python objects, but R/Julia runners reserialize with `default=str`, so complex objects can degrade into strings. Evidence: `src/scieasy/blocks/code/runners/python_runner.py:32-84`, `r_runner.py:36-38,91-92`, `julia_runner.py:35-36,92-93`.
+
+3. **Persistence atomicity is inconsistent.**  
+   `FilesystemBackend` and `ZarrBackend` use temp-then-rename: `src/scieasy/core/storage/filesystem.py:31-68`, `src/scieasy/core/storage/zarr_backend.py:25-60`. `ArrowBackend` does not provide the same level of atomic write, and `CompositeStore` explicitly documents non-atomic multi-slot writes: `src/scieasy/core/storage/arrow_backend.py:21-45`, `src/scieasy/core/storage/composite_store.py:58-76`.
+
+## Overall Judgment
+
+SciEasy has already built two important foundations well:
+
+- lightweight reference-style cross-process transport
+- typed `DataObject` reconstruction inside worker subprocesses
+
+Those parts are coherent and mostly aligned with the newer ADR addenda.
+
+The real weakness is that “lazy by default” has not become a stable end-to-end system property. It behaves more like a partial capability: strong at the transport boundary, inconsistent at ingestion, frequently abandoned inside algorithm blocks, and not fully supported by the generic export layer.
+
+If the whole audit is compressed into one sentence:
+
+> SciEasy’s transport layer is mostly reference-based now, but its load, processing, and export layers still contain widespread eager materialization, payload-loss edge cases, and multiple mismatches with the stated design philosophy.


### PR DESCRIPTION
## Summary

- ADR-031 (draft): Major architectural realignment addressing critical divergence between design and implementation
- Deprecates ADR-027 Addendum 1 (superseded)
- Includes independent data storage and transport audit report (`docs/data-storage-transport-audit.en.md`)

## Key Decisions

- **D1**: DataObject is the single data reference type — no `_data`/`_arrow_table` backdoors
- **D2**: ViewProxy deleted entirely — methods absorbed into DataObject/Array
- **D3**: `_data` prohibited on cross-boundary DataObjects
- **D4**: IOBlock base class guarantees storage-ref; provides persist helpers for loader authors
- **D5**: Artifact skips auto-flush (path-only transport)
- **D6**: `get_in_memory_data()` routes through `to_memory()` → storage read
- **D7**: Worker typed reconstruction retained from Add1
- **D8**: Checkpoint deserialization updated
- **D9**: Documentation unified

## Implementation Issues

- #625 Phase 1: IOBlock loader rewrite + core enforcement
- #626 Phase 2: ViewProxy elimination + `_data` cleanup
- #627 Phase 3: Process-side streaming optimization

## Test plan

- [ ] Review ADR decisions for architectural soundness
- [ ] Verify audit report findings against current code
- [ ] No code changes — documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)