### PR TITLE
refactor(#625): ADR-031 Phase 1 — IOBlock loader rewrite + core enforcement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- [#625] ADR-031 Phase 1: IOBlock loader rewrite — persist data to storage, return reference-only objects; fix Series payload loss; streaming TIFF load; reference-only Zarr; remove pandas from LCMS user dicts; Artifact auto-flush exemption (@claude, 2026-04-11, branch: refactor/issue-625/adr-031-phase1-loader-rewrite, session: 20260411-130407-adr-031-phase-1-ioblock-loader-rewrite-c)
 - [#606] ADR-029 B3: extend introspect_script() with input_ports auto-inference from run() parameter type annotations; add _params_to_port_dicts() and _annotation_to_type_name() helpers (@claude, 2026-04-11, branch: feat/issue-606/codeblock-signature-auto-inference, session: 20260411-105722-b3-codeblock-python-signature-auto-infer)
 - [#604] ADR-029 B2: inject input_ports/output_ports port editor fields into AIBlock, CodeBlock, AppBlock config_schema via ADR-030 MRO pattern (@claude, 2026-04-11, branch: feat/issue-604/mro-port-editor-config-schema, session: 20260411-105345-b2-mro-injection-port-editor-config-sche)
 - [#602] ADR-029 B1: add variadic_inputs/variadic_outputs ClassVars to Block ABC, ports_from_config_dicts() helper, BlockSpec variadic fields, BlockSchemaResponse allowed_input/output_types (@claude, 2026-04-11, branch: feat/issue-602/variadic-ports-block-abc-spec-registry, session: 20260411-104249-b1-block-abc-blockspec-registry-api-sche)

--- a/packages/scieasy-blocks-imaging/src/scieasy_blocks_imaging/io/load_image.py
+++ b/packages/scieasy-blocks-imaging/src/scieasy_blocks_imaging/io/load_image.py
@@ -183,9 +183,12 @@ def _load_zarr(path: Path, axes_override: list[str] | None) -> Image:
         raise ValueError(f"LoadImage: axes {axes!r} do not match array ndim={ndim} for {path}")
 
     # ADR-031: reference-only — point at existing zarr store, no copy.
+    # For group-backed stores with a "data" sub-array, point the ref at the
+    # actual array node so ZarrBackend.read() (zarr.open_array) succeeds.
+    arr_path = str(path) if isinstance(node, zarr.Array) else str(path / "data")
     ref = StorageReference(
         backend="zarr",
-        path=str(path),
+        path=arr_path,
         format="zarr",
         metadata={"shape": list(shape), "dtype": dtype_str},
     )

--- a/packages/scieasy-blocks-imaging/src/scieasy_blocks_imaging/io/load_image.py
+++ b/packages/scieasy-blocks-imaging/src/scieasy_blocks_imaging/io/load_image.py
@@ -73,35 +73,83 @@ def _normalise_tiff_axes(tiff_axes: str, ndim: int) -> list[str]:
     return _default_axes_for_ndim(ndim)
 
 
-def _load_tiff(path: Path, axes_override: list[str] | None) -> Image:
-    """Load a TIFF file eagerly into an :class:`Image`."""
+def _load_tiff(path: Path, axes_override: list[str] | None, block: Any = None, output_dir: str = "") -> Image:
+    """Load a TIFF file into an :class:`Image`.
+
+    ADR-031 D4: when ``block`` and ``output_dir`` are provided, uses
+    streaming page-by-page writes via :meth:`IOBlock.persist_array`
+    for constant-memory loading of large TIFFs. Falls back to eager
+    in-memory loading (with base-class auto-flush) when no block is
+    available.
+    """
     import tifffile
 
     with tifffile.TiffFile(str(path)) as tf:
-        data: np.ndarray = tf.asarray()
         series_axes = tf.series[0].axes if tf.series else ""
-    axes = axes_override if axes_override is not None else _normalise_tiff_axes(series_axes, data.ndim)
-    if len(axes) != data.ndim:
-        raise ValueError(f"LoadImage: axes override {axes!r} does not match array ndim={data.ndim} for {path}")
-    img = Image(
-        axes=axes,
-        shape=tuple(data.shape),
-        dtype=data.dtype,
-        framework=FrameworkMeta(source=str(path)),
-        meta=Image.Meta(source_file=str(path)),
-    )
-    img._data = data  # type: ignore[attr-defined]
-    return img
+        n_pages = len(tf.pages)
+
+        if n_pages == 0:
+            raise ValueError(f"LoadImage: TIFF file has no pages: {path}")
+
+        page0 = tf.pages[0]
+        page_shape = page0.shape
+        page_dtype = page0.dtype
+
+        # Determine overall shape: multi-page TIFFs get a leading page dimension.
+        if n_pages > 1:
+            shape: tuple[int, ...] = (n_pages, *page_shape)
+        else:
+            shape = page_shape
+
+        ndim = len(shape)
+        axes = axes_override if axes_override is not None else _normalise_tiff_axes(series_axes, ndim)
+        if len(axes) != ndim:
+            raise ValueError(f"LoadImage: axes override {axes!r} does not match array ndim={ndim} for {path}")
+
+        # ADR-031 D4: streaming path — write pages to zarr one at a time.
+        if block is not None and output_dir and n_pages > 1:
+
+            def page_chunks() -> Any:
+                for i, page in enumerate(tf.pages):
+                    yield (i, page.asarray())
+
+            ref = block.persist_array(page_chunks(), shape, page_dtype, output_dir)
+            return Image(
+                axes=axes,
+                shape=shape,
+                dtype=str(np.dtype(page_dtype)),
+                framework=FrameworkMeta(source=str(path)),
+                meta=Image.Meta(source_file=str(path)),
+                storage_ref=ref,
+            )
+        else:
+            # Single-page or no block: read into memory (simple path).
+            data: np.ndarray = tf.asarray()
+            img = Image(
+                axes=axes,
+                shape=tuple(data.shape),
+                dtype=str(data.dtype),
+                framework=FrameworkMeta(source=str(path)),
+                meta=Image.Meta(source_file=str(path)),
+            )
+            img._data = data  # type: ignore[attr-defined]
+            return img
 
 
 def _load_zarr(path: Path, axes_override: list[str] | None) -> Image:
-    """Load a ``.zarr`` store eagerly into an :class:`Image`.
+    """Load a ``.zarr`` store as a reference-only :class:`Image`.
+
+    ADR-031 D4: creates a :class:`StorageReference` pointing at the
+    existing zarr store. Does NOT copy or eagerly read data. The zarr
+    store is used in-place as the backing storage.
 
     Supports both a top-level array store and a group containing a
     single array named ``"data"``. Axis metadata is read from the group
     attribute ``"axes"`` when present.
     """
     import zarr
+
+    from scieasy.core.storage.ref import StorageReference
 
     node = zarr.open(str(path), mode="r")
     attrs_axes: list[str] | None = None
@@ -121,24 +169,34 @@ def _load_zarr(path: Path, axes_override: list[str] | None) -> Image:
         if not isinstance(data_node, zarr.Array):
             raise ValueError(f"LoadImage: zarr group at {path} 'data' entry is not an array")
         arr_node = data_node
-    data = np.asarray(arr_node[...])
+
+    shape = tuple(arr_node.shape)
+    dtype_str = str(arr_node.dtype)
+    ndim = len(shape)
     if axes_override is not None:
         axes = axes_override
     elif attrs_axes is not None:
         axes = attrs_axes
     else:
-        axes = _default_axes_for_ndim(data.ndim)
-    if len(axes) != data.ndim:
-        raise ValueError(f"LoadImage: axes {axes!r} do not match array ndim={data.ndim} for {path}")
-    img = Image(
+        axes = _default_axes_for_ndim(ndim)
+    if len(axes) != ndim:
+        raise ValueError(f"LoadImage: axes {axes!r} do not match array ndim={ndim} for {path}")
+
+    # ADR-031: reference-only — point at existing zarr store, no copy.
+    ref = StorageReference(
+        backend="zarr",
+        path=str(path),
+        format="zarr",
+        metadata={"shape": list(shape), "dtype": dtype_str},
+    )
+    return Image(
         axes=axes,
-        shape=tuple(data.shape),
-        dtype=data.dtype,
+        shape=shape,
+        dtype=dtype_str,
         framework=FrameworkMeta(source=str(path)),
         meta=Image.Meta(source_file=str(path)),
+        storage_ref=ref,
     )
-    img._data = data  # type: ignore[attr-defined]
-    return img
 
 
 class LoadImage(IOBlock):
@@ -168,14 +226,17 @@ class LoadImage(IOBlock):
         "required": [],
     }
 
-    def load(self, config: BlockConfig) -> DataObject | Collection:
+    def load(self, config: BlockConfig, output_dir: str = "") -> DataObject | Collection:
         """Load the configured file(s) into a ``Collection[Image]``.
+
+        ADR-031 D4: ``output_dir`` is used for streaming TIFF persistence.
 
         Args:
             config: BlockConfig with ``path`` (str or list[str]) and optional
                 ``axes`` (axis string override, e.g. ``"cyx"``). When
                 ``path`` is a list, each file is loaded and all images are
                 packed into a single :class:`Collection`.
+            output_dir: Directory for persisting loaded data to storage.
 
         Returns:
             A :class:`Collection` of :class:`Image`. Length-1 for a single
@@ -203,20 +264,21 @@ class LoadImage(IOBlock):
             for single_raw in raw_path:
                 if not isinstance(single_raw, str) or not single_raw:
                     raise ValueError("LoadImage: each entry in path list must be a non-empty string")
-                images.append(self._load_single(Path(single_raw), axes_override))
+                images.append(self._load_single(Path(single_raw), axes_override, output_dir))
             return Collection(items=images, item_type=Image)
 
         if not isinstance(raw_path, str) or not raw_path:
             raise ValueError("LoadImage: config['path'] must be a non-empty string or list of strings")
-        image = self._load_single(Path(raw_path), axes_override)
+        image = self._load_single(Path(raw_path), axes_override, output_dir)
         return Collection(items=[image], item_type=Image)
 
-    def _load_single(self, path: Path, axes_override: list[str] | None) -> Image:
+    def _load_single(self, path: Path, axes_override: list[str] | None, output_dir: str = "") -> Image:
         """Load a single image file into an :class:`Image`.
 
         Args:
             path: Absolute or relative path to a TIFF or Zarr file.
             axes_override: Optional per-axis label override list.
+            output_dir: Directory for persisting loaded data to storage.
 
         Returns:
             A loaded :class:`Image`.
@@ -232,7 +294,9 @@ class LoadImage(IOBlock):
             raise ValueError(
                 f"LoadImage: unsupported image format {ext!r}; supported extensions are {sorted(_SUPPORTED_EXTS)}"
             )
-        return _load_tiff(path, axes_override) if ext in _TIFF_EXTS else _load_zarr(path, axes_override)
+        if ext in _TIFF_EXTS:
+            return _load_tiff(path, axes_override, block=self, output_dir=output_dir)
+        return _load_zarr(path, axes_override)
 
     def save(
         self,

--- a/packages/scieasy-blocks-imaging/src/scieasy_blocks_imaging/io/save_image.py
+++ b/packages/scieasy-blocks-imaging/src/scieasy_blocks_imaging/io/save_image.py
@@ -148,7 +148,9 @@ class SaveImage(IOBlock):
         "required": [],
     }
 
-    def load(self, config: BlockConfig) -> DataObject | Collection:  # pragma: no cover - output block
+    def load(
+        self, config: BlockConfig, output_dir: str = ""
+    ) -> DataObject | Collection:  # pragma: no cover - output block
         """Direction is ``output``; ``load`` is unreachable via dispatch."""
         raise NotImplementedError("SaveImage is an output block; use save()")
 

--- a/packages/scieasy-blocks-lcms/src/scieasy_blocks_lcms/io/load_mid_table.py
+++ b/packages/scieasy-blocks-lcms/src/scieasy_blocks_lcms/io/load_mid_table.py
@@ -115,8 +115,12 @@ class LoadMIDTable(_LCMSBlockMixin, IOBlock):
         "required": ["path"],
     }
 
-    def load(self, config: BlockConfig) -> DataObject | Collection:
+    def load(self, config: BlockConfig, output_dir: str = "") -> DataObject | Collection:
         """Read MID table file(s) and return a :class:`Collection[MIDTable]`.
+
+        ADR-031 D4: uses :meth:`persist_table` to write the DataFrame
+        payload to arrow storage instead of storing a pandas DataFrame
+        in the ``user`` dict.
 
         Accepts ``config["path"]`` as a single string or a list of strings
         (matching the :class:`LoadImage` multi-file pattern).
@@ -148,6 +152,16 @@ class LoadMIDTable(_LCMSBlockMixin, IOBlock):
             )
             if not sample_columns:
                 raise ValueError("LoadMIDTable could not detect any sample columns")
+
+            # ADR-031 D4: persist to arrow storage instead of storing
+            # pandas DataFrame in user dict.
+            storage_ref = None
+            if output_dir:
+                import pyarrow as pa
+
+                arrow_table = pa.Table.from_pandas(frame)
+                storage_ref = self.persist_table(arrow_table, output_dir)
+
             table = MIDTable(
                 columns=[str(col) for col in frame.columns],
                 row_count=len(frame),
@@ -158,8 +172,9 @@ class LoadMIDTable(_LCMSBlockMixin, IOBlock):
                     corrected=True,
                     correction_tool="AccuCor",
                 ),
+                storage_ref=storage_ref,
             )
-            table.user["pandas_df"] = frame.copy()
+            # ADR-031: no longer store pandas_df in user dict.
             tables.append(table)
         return Collection(items=tables, item_type=MIDTable)
 

--- a/packages/scieasy-blocks-lcms/src/scieasy_blocks_lcms/io/load_mzml_files.py
+++ b/packages/scieasy-blocks-lcms/src/scieasy_blocks_lcms/io/load_mzml_files.py
@@ -72,8 +72,12 @@ class LoadMzMLFiles(_LCMSBlockMixin, IOBlock):
         "required": ["path"],
     }
 
-    def load(self, config: BlockConfig) -> DataObject | Collection:
+    def load(self, config: BlockConfig, output_dir: str = "") -> DataObject | Collection:
         """Load file path(s) and return ``Collection[MSRawFile]``.
+
+        ADR-031 D4: ``output_dir`` accepted for signature compatibility.
+        MSRawFile is an Artifact subclass — path-only transport, exempt
+        from storage writes.
 
         Accepts ``config["path"]`` as a single string or a list of strings
         (matching the :class:`LoadImage` multi-file pattern).

--- a/packages/scieasy-blocks-lcms/src/scieasy_blocks_lcms/io/load_peak_table.py
+++ b/packages/scieasy-blocks-lcms/src/scieasy_blocks_lcms/io/load_peak_table.py
@@ -94,8 +94,13 @@ class LoadPeakTable(_LCMSBlockMixin, IOBlock):
         "required": ["path"],
     }
 
-    def load(self, config: BlockConfig) -> DataObject | Collection:
+    def load(self, config: BlockConfig, output_dir: str = "") -> DataObject | Collection:
         """Read peak table file(s) and return a :class:`Collection[PeakTable]`.
+
+        ADR-031 D4: uses :meth:`persist_table` to write the DataFrame
+        payload to arrow storage instead of storing a pandas DataFrame
+        in the ``user`` dict (which violates JSON-serializability per
+        ADR-017).
 
         Accepts ``config["path"]`` as a single string or a list of strings
         (matching the :class:`LoadImage` multi-file pattern).
@@ -121,6 +126,16 @@ class LoadPeakTable(_LCMSBlockMixin, IOBlock):
             if frame.empty:
                 raise ValueError(f"LoadPeakTable: table is empty: {path}")
             resolved_source = _detect_source(frame.columns) if source == "auto" else source
+
+            # ADR-031 D4: persist to arrow storage instead of storing
+            # pandas DataFrame in user dict.
+            storage_ref = None
+            if output_dir:
+                import pyarrow as pa
+
+                arrow_table = pa.Table.from_pandas(frame)
+                storage_ref = self.persist_table(arrow_table, output_dir)
+
             table = PeakTable(
                 columns=[str(col) for col in frame.columns],
                 row_count=len(frame),
@@ -129,8 +144,10 @@ class LoadPeakTable(_LCMSBlockMixin, IOBlock):
                     source=resolved_source,
                     polarity=config.get("polarity"),
                 ),
+                storage_ref=storage_ref,
             )
-            table.user["pandas_df"] = frame.copy()
+            # ADR-031: no longer store pandas_df in user dict.
+            # The data is now in arrow storage via storage_ref.
             tables.append(table)
         return Collection(items=tables, item_type=PeakTable)
 

--- a/packages/scieasy-blocks-lcms/src/scieasy_blocks_lcms/io/load_sample_metadata.py
+++ b/packages/scieasy-blocks-lcms/src/scieasy_blocks_lcms/io/load_sample_metadata.py
@@ -74,8 +74,12 @@ class LoadSampleMetadata(_LCMSBlockMixin, IOBlock):
         "required": ["path"],
     }
 
-    def load(self, config: BlockConfig) -> DataObject | Collection:
+    def load(self, config: BlockConfig, output_dir: str = "") -> DataObject | Collection:
         """Read metadata file(s) and return :class:`Collection[SampleMetadata]`.
+
+        ADR-031 D4: uses :meth:`persist_table` to write the DataFrame
+        payload to arrow storage instead of storing a pandas DataFrame
+        in the ``user`` dict.
 
         Accepts ``config["path"]`` as a single string or a list of strings
         (matching the :class:`LoadImage` multi-file pattern).
@@ -100,14 +104,25 @@ class LoadSampleMetadata(_LCMSBlockMixin, IOBlock):
             frame = _read_table(path, sheet_name=config.get("sheet_name"))
             if sample_id_column not in frame.columns:
                 raise ValueError(f"LoadSampleMetadata requires column '{sample_id_column}'")
-            metadata = SampleMetadata(
+
+            # ADR-031 D4: persist to arrow storage instead of storing
+            # pandas DataFrame in user dict.
+            storage_ref = None
+            if output_dir:
+                import pyarrow as pa
+
+                arrow_table = pa.Table.from_pandas(frame)
+                storage_ref = self.persist_table(arrow_table, output_dir)
+
+            sm = SampleMetadata(
                 columns=[str(col) for col in frame.columns],
                 row_count=len(frame),
                 schema={str(col): str(dtype) for col, dtype in frame.dtypes.items()},
                 meta=SampleMetadata.Meta(sample_id_column=sample_id_column),
+                storage_ref=storage_ref,
             )
-            metadata.user["pandas_df"] = frame.copy()
-            items.append(metadata)
+            # ADR-031: no longer store pandas_df in user dict.
+            items.append(sm)
         return Collection(items=items, item_type=SampleMetadata)
 
     def save(self, obj: DataObject | Collection, config: BlockConfig) -> None:

--- a/packages/scieasy-blocks-lcms/src/scieasy_blocks_lcms/io/save_table.py
+++ b/packages/scieasy-blocks-lcms/src/scieasy_blocks_lcms/io/save_table.py
@@ -77,7 +77,7 @@ class SaveTable(_LCMSBlockMixin, IOBlock):
         "required": [],
     }
 
-    def load(self, config: BlockConfig) -> DataObject | Collection:
+    def load(self, config: BlockConfig, output_dir: str = "") -> DataObject | Collection:
         """Not supported — :class:`SaveTable` is output-only."""
         raise NotImplementedError("T-LCMS-006 SaveTable is direction='output'; load() is unreachable.")
 

--- a/src/scieasy/blocks/base/block.py
+++ b/src/scieasy/blocks/base/block.py
@@ -355,10 +355,20 @@ class Block(ABC):
         If no flush context output directory is configured, return as-is.
         Called internally by ``map_items``, ``parallel_map``, ``pack``, and
         the ``process_item`` default ``run()``.
+
+        ADR-031 D5: Artifact instances with ``file_path`` set use
+        path-only transport and are exempt from auto-flush. They should
+        NOT be read into memory and copied to managed storage.
         """
         from scieasy.core.types.base import DataObject
 
         if not isinstance(obj, DataObject):
+            return obj
+
+        # ADR-031 D5: Artifact with file_path uses path-only transport.
+        from scieasy.core.types.artifact import Artifact
+
+        if isinstance(obj, Artifact) and getattr(obj, "file_path", None) is not None:
             return obj
 
         # #436: Recursively flush CompositeData internal slots so that

--- a/src/scieasy/blocks/io/io_block.py
+++ b/src/scieasy/blocks/io/io_block.py
@@ -5,6 +5,14 @@ override :meth:`load` (for ``direction="input"``) or :meth:`save` (for
 ``direction="output"``); the default :meth:`run` dispatches based on
 the ``direction`` ClassVar.
 
+ADR-031 D4: ``load()`` now accepts an ``output_dir`` parameter so
+loader implementations can persist data to storage and return
+reference-only :class:`DataObject` instances. The base class provides
+:meth:`persist_array` and :meth:`persist_table` helper methods for
+streaming writes. The ``run()`` method enforces a safety net: any
+DataObject returned without ``storage_ref`` is auto-flushed before
+crossing the block boundary.
+
 The legacy ``adapter_registry`` / ``adapters/`` dispatch layer was
 removed in T-TRK-004. Concrete core loaders (``LoadData``, ``SaveData``)
 arrive in T-TRK-007 and T-TRK-008. Plugin-owned IO blocks (e.g.
@@ -14,15 +22,22 @@ directly and register via the ``scieasy.blocks`` entry-point group.
 
 from __future__ import annotations
 
+import logging
+import tempfile
+import uuid
 from abc import abstractmethod
+from pathlib import Path
 from typing import Any, ClassVar
 
 from scieasy.blocks.base.block import Block
 from scieasy.blocks.base.config import BlockConfig
 from scieasy.blocks.base.ports import InputPort, OutputPort
+from scieasy.core.storage.ref import StorageReference
 from scieasy.core.types.base import DataObject
 from scieasy.core.types.collection import Collection
 from scieasy.core.types.text import Text
+
+_logger = logging.getLogger(__name__)
 
 
 class IOBlock(Block):
@@ -67,8 +82,23 @@ class IOBlock(Block):
     }
 
     @abstractmethod
-    def load(self, config: BlockConfig) -> DataObject | Collection:
-        """Load and return a single :class:`DataObject` or :class:`Collection`."""
+    def load(self, config: BlockConfig, output_dir: str = "") -> DataObject | Collection:
+        """Load and return a single :class:`DataObject` or :class:`Collection`.
+
+        ADR-031 D4: ``output_dir`` is the directory where loaders should
+        persist data to storage. Implementations may EITHER:
+
+        (a) Return an in-memory DataObject (simple path):
+            The base class auto-persists it to storage via ``_auto_flush``.
+            Works for small/medium files. Will OOM on very large files.
+
+        (b) Write to storage directly using :meth:`persist_array` or
+            :meth:`persist_table` and return a reference-only object
+            (streaming path). Required for large files.
+
+        Artifact subclasses are exempt — return with ``file_path``, no
+        storage write needed.
+        """
         ...
 
     @abstractmethod
@@ -102,6 +132,79 @@ class IOBlock(Block):
             return "path"
         return ports[0].name
 
+    def persist_array(
+        self,
+        data_or_iterator: Any,
+        shape: tuple[int, ...],
+        dtype: Any,
+        output_dir: str,
+        chunks: tuple[int, ...] | None = None,
+    ) -> StorageReference:
+        """Write array data to zarr storage and return a :class:`StorageReference`.
+
+        ADR-031 D4: persistence helper for loader authors.
+
+        ``data_or_iterator`` may be:
+
+        - A numpy ndarray (written in one shot).
+        - An iterator/generator yielding ``(index, chunk_array)`` tuples
+          for streaming, constant-memory writes. For a 3-D array of shape
+          ``(N, H, W)``, yield ``(i, page_2d)`` where ``page_2d`` has
+          shape ``(H, W)`` for each ``i`` in ``range(N)``.
+
+        Returns a :class:`StorageReference` pointing at the created zarr
+        store.
+        """
+        import numpy as np
+        import zarr
+
+        store_name = f"{uuid.uuid4()}.zarr"
+        store_path = str(Path(output_dir) / store_name)
+        Path(store_path).parent.mkdir(parents=True, exist_ok=True)
+
+        np_dtype = np.dtype(dtype)
+        if chunks is None:
+            zarr_chunks: tuple[int, ...] | bool = True  # let zarr auto-chunk
+        else:
+            zarr_chunks = chunks
+
+        z = zarr.open_array(store_path, mode="w", shape=shape, dtype=np_dtype, chunks=zarr_chunks)
+
+        if isinstance(data_or_iterator, np.ndarray):
+            z[:] = data_or_iterator
+        else:
+            # Iterator of (index, chunk_array) tuples — streaming write.
+            for idx, chunk in data_or_iterator:
+                z[idx] = chunk
+
+        metadata = {"shape": list(shape), "dtype": str(np_dtype)}
+        return StorageReference(
+            backend="zarr",
+            path=store_path,
+            format="zarr",
+            metadata=metadata,
+        )
+
+    def persist_table(self, table: Any, output_dir: str) -> StorageReference:
+        """Write an Arrow table to parquet storage and return a :class:`StorageReference`.
+
+        ADR-031 D4: persistence helper for loader authors.
+
+        ``table`` should be a ``pyarrow.Table``. The table is written to
+        a parquet file in ``output_dir`` and the returned
+        :class:`StorageReference` points at the persisted file.
+        """
+        from scieasy.core.storage.arrow_backend import ArrowBackend
+
+        file_name = f"{uuid.uuid4()}.parquet"
+        file_path = str(Path(output_dir) / file_name)
+        Path(output_dir).mkdir(parents=True, exist_ok=True)
+
+        backend = ArrowBackend()
+        ref = StorageReference(backend="arrow", path=file_path, format="parquet")
+        result_ref = backend.write(table, ref)
+        return result_ref
+
     def run(
         self,
         inputs: dict[str, Collection],
@@ -119,9 +222,25 @@ class IOBlock(Block):
         backward compatibility.
         """
         if self.direction == "input":
-            result = self.load(config)
+            # ADR-031 D4: resolve output_dir for loader persistence.
+            from scieasy.core.storage.flush_context import get_output_dir
+
+            output_dir = get_output_dir() or tempfile.mkdtemp(prefix="scieasy-io-")
+            result = self.load(config, output_dir=output_dir)
             if not isinstance(result, Collection):
                 result = Collection(items=[result], item_type=type(result))
+            # ADR-031 D4 safety net: auto-flush any DataObject without
+            # storage_ref before it crosses the block boundary. Artifact
+            # instances with file_path are exempt (D5 path-only transport).
+            from scieasy.core.types.artifact import Artifact
+
+            for item in result:
+                if (
+                    isinstance(item, DataObject)
+                    and item.storage_ref is None
+                    and not (isinstance(item, Artifact) and item.file_path is not None)
+                ):
+                    self._auto_flush(item)
             return {self._resolved_load_output_port_name(): result}
         else:
             input_port_name = self._resolved_input_port_name()

--- a/src/scieasy/blocks/io/loaders/load_data.py
+++ b/src/scieasy/blocks/io/loaders/load_data.py
@@ -150,12 +150,16 @@ class LoadData(IOBlock):
         object return behavior is preserved.
         """
         type_name = config.get("core_type", "DataFrame")
+
+        # ADR-031: dispatch table. Functions that don't need output_dir
+        # are wrapped with lambdas to accept and ignore the parameter,
+        # keeping a uniform (config, output_dir) call signature.
         dispatch: dict[str, Any] = {
-            "Array": _load_array,
+            "Array": lambda cfg, od: _load_array(cfg),
             "DataFrame": self._load_dataframe_with_persist,
             "Series": self._load_series_with_persist,
-            "Text": _load_text,
-            "Artifact": _load_artifact,
+            "Text": lambda cfg, od: _load_text(cfg),
+            "Artifact": lambda cfg, od: _load_artifact(cfg),
             "CompositeData": self._load_composite_with_persist,
         }
         if type_name not in dispatch:

--- a/src/scieasy/blocks/io/loaders/load_data.py
+++ b/src/scieasy/blocks/io/loaders/load_data.py
@@ -127,8 +127,14 @@ class LoadData(IOBlock):
         is_multi = isinstance(self.config.get("path"), list)
         return [OutputPort(name="data", accepted_types=[cls], is_collection=is_multi)]
 
-    def load(self, config: BlockConfig) -> DataObject | Collection:
+    def load(self, config: BlockConfig, output_dir: str = "") -> DataObject | Collection:
         """Dispatch to one of the six private ``_load_*`` functions.
+
+        ADR-031 D4: ``output_dir`` is passed through from :meth:`IOBlock.run`.
+        Loaders that produce tabular data use :meth:`persist_table` to
+        write to arrow storage. Array/npy loaders use the simple path
+        (base class auto-flush handles persistence). Artifact and Text
+        loaders are exempt.
 
         The selected function is determined by ``config["core_type"]``;
         unknown values raise ``ValueError`` rather than silently picking
@@ -146,11 +152,11 @@ class LoadData(IOBlock):
         type_name = config.get("core_type", "DataFrame")
         dispatch: dict[str, Any] = {
             "Array": _load_array,
-            "DataFrame": _load_dataframe,
-            "Series": _load_series,
+            "DataFrame": self._load_dataframe_with_persist,
+            "Series": self._load_series_with_persist,
             "Text": _load_text,
             "Artifact": _load_artifact,
-            "CompositeData": _load_composite_data,
+            "CompositeData": self._load_composite_with_persist,
         }
         if type_name not in dispatch:
             raise ValueError(f"Unknown core_type: {type_name}")
@@ -167,11 +173,40 @@ class LoadData(IOBlock):
             items: list[DataObject] = []
             for single_path in raw_path:
                 single_config = BlockConfig(params={**shared_params, "path": str(single_path)})
-                items.append(loader(single_config))
+                items.append(loader(single_config, output_dir))
             return Collection(items=items, item_type=item_cls)
 
-        result: DataObject = dispatch[type_name](config)
+        result: DataObject = dispatch[type_name](config, output_dir)
         return result
+
+    def _load_dataframe_with_persist(self, config: BlockConfig, output_dir: str) -> DataFrame:
+        """Load DataFrame and persist to arrow storage.
+
+        ADR-031 D4: uses :meth:`persist_table` to write the arrow table
+        to storage and returns a reference-only DataFrame.
+        """
+        df = _load_dataframe(config)
+        # If the dataframe has an in-memory table, persist it.
+        table = getattr(df, "_arrow_table", None)
+        if table is not None and output_dir:
+            ref = self.persist_table(table, output_dir)
+            df._storage_ref = ref
+            # Clean up in-memory reference (the data is now in storage)
+            del df._arrow_table  # type: ignore[attr-defined]
+        return df
+
+    def _load_series_with_persist(self, config: BlockConfig, output_dir: str) -> Series:
+        """Load Series and persist to arrow storage.
+
+        ADR-031: fixes the payload-loss bug where ``_load_series`` returned
+        a Series with no data. Now writes the underlying arrow table to
+        storage via :meth:`persist_table`.
+        """
+        return _load_series(config, self, output_dir)
+
+    def _load_composite_with_persist(self, config: BlockConfig, output_dir: str) -> CompositeData:
+        """Load CompositeData, passing output_dir for slot persistence."""
+        return _load_composite_data(config, self, output_dir)
 
     def save(self, obj: DataObject | Any, config: BlockConfig) -> None:
         """``LoadData`` is input-only; ``save()`` always raises.
@@ -427,8 +462,12 @@ def _load_dataframe(config: BlockConfig) -> DataFrame:
     )
 
 
-def _load_series(config: BlockConfig) -> Series:
+def _load_series(config: BlockConfig, block: Any = None, output_dir: str = "") -> Series:
     """Load Series from .csv / .tsv (single column) / .parquet / .pkl.
+
+    ADR-031: fixes the payload-loss bug. The underlying arrow table is
+    now persisted to storage via ``block.persist_table()`` and the
+    resulting :class:`Series` carries a ``storage_ref``.
 
     Delegates the heavy lifting to :func:`_load_dataframe` for tabular
     formats and then asserts a single column. Pickle is gated via
@@ -461,10 +500,16 @@ def _load_series(config: BlockConfig) -> Series:
                 f"LoadData(core_type='Series') expects a single-column tabular file, "
                 f"got {len(df.columns) if df.columns else 0} columns in {path}"
             )
+        # ADR-031: persist the arrow table to storage to fix payload loss.
+        table = getattr(df, "_arrow_table", None)
+        storage_ref = None
+        if table is not None and block is not None and output_dir:
+            storage_ref = block.persist_table(table, output_dir)
         return Series(
             index_name=None,
             value_name=df.columns[0],
             length=df.row_count,
+            storage_ref=storage_ref,
         )
 
     raise ValueError(
@@ -562,8 +607,11 @@ def _load_artifact(config: BlockConfig) -> Artifact:
     return artifact
 
 
-def _load_composite_data(config: BlockConfig) -> CompositeData:
+def _load_composite_data(config: BlockConfig, block: Any = None, output_dir: str = "") -> CompositeData:
     """Load CompositeData from a JSON manifest pointing at sidecar files.
+
+    ADR-031: accepts ``block`` and ``output_dir`` so that slot loaders
+    for DataFrame/Series types can persist data to storage.
 
     The manifest schema is::
 
@@ -608,7 +656,7 @@ def _load_composite_data(config: BlockConfig) -> CompositeData:
     inner_dispatch: dict[str, Any] = {
         "Array": _load_array,
         "DataFrame": _load_dataframe,
-        "Series": _load_series,
+        "Series": lambda cfg: _load_series(cfg, block, output_dir),
         "Text": _load_text,
         "Artifact": _load_artifact,
     }
@@ -639,6 +687,14 @@ def _load_composite_data(config: BlockConfig) -> CompositeData:
                 "allow_pickle": bool(slot_decl.get("allow_pickle", False)),
             }
         )
-        loaded_slots[slot_name] = inner_dispatch[slot_type](slot_config)
+        slot_obj = inner_dispatch[slot_type](slot_config)
+        # ADR-031: persist DataFrame slots to arrow storage.
+        if slot_type == "DataFrame" and block is not None and output_dir:
+            table = getattr(slot_obj, "_arrow_table", None)
+            if table is not None:
+                ref = block.persist_table(table, output_dir)
+                slot_obj._storage_ref = ref
+                del slot_obj._arrow_table  # type: ignore[attr-defined]
+        loaded_slots[slot_name] = slot_obj
 
     return CompositeData(slots=loaded_slots)

--- a/src/scieasy/blocks/io/savers/save_data.py
+++ b/src/scieasy/blocks/io/savers/save_data.py
@@ -189,7 +189,7 @@ class SaveData(IOBlock):
         cls = _CORE_TYPE_MAP.get(type_name, DataFrame)
         return [InputPort(name="data", accepted_types=[cls], required=True)]
 
-    def load(self, config: BlockConfig) -> DataObject | Collection:
+    def load(self, config: BlockConfig, output_dir: str = "") -> DataObject | Collection:
         """SaveData is output-only — :meth:`load` raises.
 
         Use :class:`scieasy.blocks.io.loaders.LoadData` for the

--- a/src/scieasy/engine/runners/worker.py
+++ b/src/scieasy/engine/runners/worker.py
@@ -215,6 +215,14 @@ def main() -> None:
         module = importlib.import_module(module_path)
         block_cls = getattr(module, class_name)
 
+        # Set output_dir BEFORE block.run() so IOBlock.run() can resolve it
+        # via get_output_dir() for loader persistence (ADR-031 D4).
+        # serialise_outputs() also uses this context, so it stays set.
+        if output_dir:
+            from scieasy.core.storage.flush_context import set_output_dir
+
+            set_output_dir(output_dir)
+
         # Reconstruct inputs as typed DataObject instances (ADR-027 Addendum 1).
         inputs = reconstruct_inputs(payload)
 

--- a/tests/blocks/io/conftest.py
+++ b/tests/blocks/io/conftest.py
@@ -42,7 +42,7 @@ class InMemoryIOBlock(IOBlock):
         self.payload: DataObject = DataObject()
         self.last_saved: tuple[object, BlockConfig] | None = None
 
-    def load(self, config: BlockConfig) -> DataObject | Collection:
+    def load(self, config: BlockConfig, output_dir: str = "") -> DataObject | Collection:
         return self.payload
 
     def save(self, obj: DataObject | Collection, config: BlockConfig) -> None:

--- a/tests/blocks/io/test_io_block_abc.py
+++ b/tests/blocks/io/test_io_block_abc.py
@@ -48,7 +48,7 @@ class TestIOBlockIsAbstract:
         un-instantiable."""
 
         class HalfDone(IOBlock):
-            def load(self, config: BlockConfig) -> DataObject | Collection:
+            def load(self, config: BlockConfig, output_dir: str = "") -> DataObject | Collection:
                 return DataObject()
 
         with pytest.raises(TypeError, match="abstract"):
@@ -119,7 +119,7 @@ class TestIOBlockSubclassDispatch:
         existing = Collection(items=[DataObject(), DataObject()], item_type=DataObject)
 
         class CollectionLoader(InMemoryIOBlock):
-            def load(self, config: BlockConfig) -> DataObject | Collection:
+            def load(self, config: BlockConfig, output_dir: str = "") -> DataObject | Collection:
                 return existing
 
         block = CollectionLoader(config={"params": {"path": "/tmp/dir"}})

--- a/tests/blocks/test_registry.py
+++ b/tests/blocks/test_registry.py
@@ -609,7 +609,7 @@ class TestMergeConfigSchema:
                 "required": [],
             }
 
-            def load(self, config: BlockConfig) -> DataObject | Collection:
+            def load(self, config: BlockConfig, output_dir: str = "") -> DataObject | Collection:
                 raise NotImplementedError
 
             def save(self, obj: DataObject | Collection, config: BlockConfig) -> None:
@@ -642,7 +642,7 @@ class TestMergeConfigSchema:
                 "required": [],
             }
 
-            def load(self, config: BlockConfig) -> DataObject | Collection:
+            def load(self, config: BlockConfig, output_dir: str = "") -> DataObject | Collection:
                 raise NotImplementedError
 
             def save(self, obj: DataObject | Collection, config: BlockConfig) -> None:
@@ -738,7 +738,7 @@ class TestMergeConfigSchema:
                 "required": ["path"],
             }
 
-            def load(self, config: BlockConfig) -> DataObject | Collection:
+            def load(self, config: BlockConfig, output_dir: str = "") -> DataObject | Collection:
                 raise NotImplementedError
 
             def save(self, obj: DataObject | Collection, config: BlockConfig) -> None:
@@ -772,7 +772,7 @@ class TestMergeConfigSchema:
                 "required": ["path"],
             }
 
-            def load(self, config: BlockConfig) -> DataObject | Collection:
+            def load(self, config: BlockConfig, output_dir: str = "") -> DataObject | Collection:
                 raise NotImplementedError
 
             def save(self, obj: DataObject | Collection, config: BlockConfig) -> None:

--- a/tests/fixtures/noop_io_block.py
+++ b/tests/fixtures/noop_io_block.py
@@ -47,7 +47,7 @@ class NoopIOBlock(IOBlock):
     name: ClassVar[str] = "IO Block"
     description: ClassVar[str] = "Test-only concrete IOBlock that creates lazy StorageReferences."
 
-    def load(self, config: BlockConfig) -> DataObject | Collection:
+    def load(self, config: BlockConfig, output_dir: str = "") -> DataObject | Collection:
         """Build a single-item :class:`Collection` of one
         :class:`DataObject` referencing the configured path."""
         path_str = config.get("path") or config.params.get("path")


### PR DESCRIPTION
## Summary

Implements Phase 1 of ADR-031: make all IOBlock loaders persist data to storage and return reference-only DataObject instances.

- **IOBlock base class** (D4): `load()` now accepts `output_dir`; adds `persist_array()` and `persist_table()` helper methods for streaming writes to zarr/arrow storage; `run()` adds safety-net auto-flush for items without `storage_ref`
- **Artifact auto-flush skip** (D5): `_auto_flush()` skips Artifact instances with `file_path` set (path-only transport)
- **LoadData rewrite**: DataFrames persist to arrow via `persist_table()`; **fixes Series payload-loss bug** by writing to arrow storage and returning Series with `storage_ref` set
- **LoadImage rewrite**: TIFF uses streaming page-by-page writes via `persist_array()` for constant-memory loading; Zarr returns reference-only Image pointing at existing store (no copy, no eager read)
- **LCMS loaders** (LoadPeakTable, LoadMIDTable, LoadSampleMetadata): persist to arrow storage and no longer store pandas DataFrame in `user` dict (fixes JSON-serializability violation per ADR-017)
- **Test fixtures**: all mock `load()` signatures updated

## Related Issues
Closes #625

## Scope Boundary
Phase 1 ONLY. Does NOT touch: ViewProxy, `_data` elimination, Array.sel() rewrite, checkpoint.py, save_data.py `_arrow_table` checks.

## Test plan
- [x] All 125 IO block tests pass
- [x] All block/registry tests pass (176 tests, 5 skipped pre-existing)
- [x] ruff check clean
- [x] ruff format clean