### PR TITLE
fix(gui): truncate long project path on Welcome Screen (#620)

### DIFF
--- a/frontend/src/components/WelcomeScreen.tsx
+++ b/frontend/src/components/WelcomeScreen.tsx
@@ -65,7 +65,7 @@ export function WelcomeScreen({
                   >
                     <span className="min-w-0 flex-1">
                       <span className="block truncate font-medium text-ink">{project.name}</span>
-                      <span className="mt-1 block truncate text-xs text-stone-500">{project.path}</span>
+                      <span className="mt-1 block max-w-[300px] truncate text-xs text-stone-500">{project.path}</span>
                     </span>
                     {onDeleteProject ? (
                       <span


### PR DESCRIPTION
## Summary

Add `max-w-[300px]` to project path span on the Welcome Screen to prevent layout overflow when a project has a deeply nested path.

Closes #620

## Test plan

- [ ] Open Welcome Screen with a project that has a very long path
- [ ] Verify path is truncated with ellipsis, layout not broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)