### PR TITLE
fix(engine): batch validator improvements — registry pass-through, variadic cardinality, config pre-check (#638)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- [#630] Pass block registry to validate_workflow() in API save path so type compatibility and dangling port checks run (@claude, 2026-04-11, branch: fix/issue-638/validator-batch-improvements, session: 20260411-224417-batch-validator-improvements-registry-pa)
+- [#631] Add variadic port cardinality validation (Check 7) to workflow validator (@claude, 2026-04-11, branch: fix/issue-638/validator-batch-improvements, session: 20260411-224417-batch-validator-improvements-registry-pa)
+- [#632] Validate block config required fields before dispatch to catch misconfiguration before subprocess creation (@claude, 2026-04-11, branch: fix/issue-638/validator-batch-improvements, session: 20260411-224417-batch-validator-improvements-registry-pa)
 - [#600] Replace FolderBrowserDialog with modern IFileOpenDialog COM folder picker on Windows (@claude, 2026-04-11, branch: fix/issue-600/modern-folder-dialog, session: 20260411-104043-replace-windows-folderbrowserdialog-with)
 - [#598] Enforce max 50 open tabs (@claude, 2026-04-11, branch: fix/issue-614/batch-small-fixes, session: 20260411-102935-fix-5-small-issues-max-tabs-bidirectiona)
 - [#601] Allow bidirectional subclass port connections (@claude, 2026-04-11, branch: fix/issue-614/batch-small-fixes, session: 20260411-102935-fix-5-small-issues-max-tabs-bidirectiona)

--- a/src/scieasy/api/runtime.py
+++ b/src/scieasy/api/runtime.py
@@ -506,7 +506,7 @@ class ApiRuntime:
         )
         from scieasy.workflow.validator import validate_workflow
 
-        errors = validate_workflow(definition)
+        errors = validate_workflow(definition, registry=self.block_registry)
         if errors:
             raise ValueError(f"Workflow validation failed: {'; '.join(str(e) for e in errors)}")
 

--- a/src/scieasy/engine/scheduler.py
+++ b/src/scieasy/engine/scheduler.py
@@ -232,6 +232,36 @@ class DAGScheduler:
             self.save_checkpoint(self._checkpoint_manager)
             return
 
+        # #632: Pre-dispatch config validation — check required fields
+        # from the block's config_schema before handing off to a subprocess.
+        # This catches the most common misconfiguration (missing required
+        # fields) with a clean error instead of a traceback in the worker.
+        # Note: config values live inside node.config["params"] (see
+        # BlockConfig.params), so we check that dict rather than the
+        # top-level node.config.
+        config_schema = getattr(block, "config_schema", None)
+        if isinstance(config_schema, dict) and config_schema.get("required"):
+            required_fields = config_schema["required"]
+            params = node.config.get("params", {}) if isinstance(node.config.get("params"), dict) else {}
+            missing = [f for f in required_fields if f not in params or params[f] is None]
+            if missing:
+                error_str = f"Block '{node_id}' config is missing required field(s): {', '.join(sorted(missing))}"
+                logger.error("Pre-dispatch config validation failed for %s: %s", node_id, error_str)
+                self._block_states[node_id] = BlockState.ERROR
+                await self._event_bus.emit(
+                    EngineEvent(
+                        event_type=BLOCK_ERROR,
+                        block_id=node_id,
+                        data={
+                            "workflow_id": self._workflow.id,
+                            "error": error_str,
+                            "error_summary": _extract_error_summary(error_str),
+                        },
+                    )
+                )
+                self.save_checkpoint(self._checkpoint_manager)
+                return
+
         # Enrich the block config with runtime context (#444).
         enriched_config = dict(node.config)
         enriched_config["block_id"] = node_id

--- a/src/scieasy/engine/scheduler.py
+++ b/src/scieasy/engine/scheduler.py
@@ -236,14 +236,15 @@ class DAGScheduler:
         # from the block's config_schema before handing off to a subprocess.
         # This catches the most common misconfiguration (missing required
         # fields) with a clean error instead of a traceback in the worker.
-        # Note: config values live inside node.config["params"] (see
-        # BlockConfig.params), so we check that dict rather than the
-        # top-level node.config.
+        # Config values may live in node.config["params"] (BlockConfig's
+        # params dict) OR at the top level of node.config (extras readable
+        # via BlockConfig(**config).get(key)).  Check both locations.
         config_schema = getattr(block, "config_schema", None)
         if isinstance(config_schema, dict) and config_schema.get("required"):
             required_fields = config_schema["required"]
             params = node.config.get("params", {}) if isinstance(node.config.get("params"), dict) else {}
-            missing = [f for f in required_fields if f not in params or params[f] is None]
+            top_level = node.config if isinstance(node.config, dict) else {}
+            missing = [f for f in required_fields if (params.get(f) is None and top_level.get(f) is None)]
             if missing:
                 error_str = f"Block '{node_id}' config is missing required field(s): {', '.join(sorted(missing))}"
                 logger.error("Pre-dispatch config validation failed for %s: %s", node_id, error_str)

--- a/src/scieasy/workflow/validator.py
+++ b/src/scieasy/workflow/validator.py
@@ -84,6 +84,10 @@ def validate_workflow(
        *registry* is provided).
     6. **Dangling required input ports** -- required ``InputPort`` instances
        without an incoming edge (only when *registry* is provided).
+    7. **Variadic port cardinality** -- effective port count within
+       ``min_input_ports`` / ``max_input_ports`` / ``min_output_ports`` /
+       ``max_output_ports`` limits declared on the ``BlockSpec`` (only when
+       *registry* is provided).
 
     Parameters
     ----------
@@ -247,5 +251,40 @@ def validate_workflow(
         for port in node_input_ports:
             if isinstance(port, InputPort) and port.required and port.name not in connected_inputs[node.id]:
                 errors.append(f"Node '{node.id}': required input port '{port.name}' has no incoming connection")
+
+    # ------------------------------------------------------------------
+    # Check 7: Variadic port cardinality limits (ADR-029 Addendum 1)
+    # ------------------------------------------------------------------
+    # For blocks with variadic_inputs or variadic_outputs, verify that
+    # the number of effective ports respects min/max ClassVar limits
+    # exposed on BlockSpec.
+    for node in workflow.nodes:
+        spec = registry.get_spec(node.block_type)
+        if spec is None:
+            continue
+
+        if spec.variadic_inputs:
+            input_ports, _ = _ports_for(node, spec)
+            n_in = len(input_ports)
+            if spec.min_input_ports is not None and n_in < spec.min_input_ports:
+                errors.append(
+                    f"Node '{node.id}': variadic input port count {n_in} is below minimum {spec.min_input_ports}"
+                )
+            if spec.max_input_ports is not None and n_in > spec.max_input_ports:
+                errors.append(
+                    f"Node '{node.id}': variadic input port count {n_in} exceeds maximum {spec.max_input_ports}"
+                )
+
+        if spec.variadic_outputs:
+            _, output_ports = _ports_for(node, spec)
+            n_out = len(output_ports)
+            if spec.min_output_ports is not None and n_out < spec.min_output_ports:
+                errors.append(
+                    f"Node '{node.id}': variadic output port count {n_out} is below minimum {spec.min_output_ports}"
+                )
+            if spec.max_output_ports is not None and n_out > spec.max_output_ports:
+                errors.append(
+                    f"Node '{node.id}': variadic output port count {n_out} exceeds maximum {spec.max_output_ports}"
+                )
 
     return errors

--- a/tests/engine/test_scheduler.py
+++ b/tests/engine/test_scheduler.py
@@ -873,3 +873,139 @@ class TestSchedulerCheckpoint:
 
         assert scheduler._block_states["A"] == BlockState.ERROR
         assert checkpoint_mgr.save.called
+
+
+# ---------------------------------------------------------------------------
+# Config pre-dispatch validation (#632)
+# ---------------------------------------------------------------------------
+
+
+class TestSchedulerConfigPreCheck:
+    """Test that missing required config fields are caught before dispatch."""
+
+    def test_missing_required_config_field_errors_before_dispatch(self) -> None:
+        """Block with required config field missing should ERROR without calling runner."""
+        wf = _wf(nodes=[("A", "myblock")])
+        wf.nodes[0].config = {"params": {}}  # missing 'path' which is required
+
+        # Mock registry that returns a block with a config_schema requiring 'path'
+        mock_block = MagicMock()
+        mock_block.config_schema = {
+            "type": "object",
+            "properties": {"path": {"type": "string"}},
+            "required": ["path"],
+        }
+
+        mock_registry = MagicMock()
+        mock_registry.instantiate.return_value = mock_block
+
+        event_bus = EventBus()
+        runner = AsyncMock()
+
+        scheduler = DAGScheduler(
+            workflow=wf,
+            event_bus=event_bus,
+            resource_manager=MagicMock(can_dispatch=MagicMock(return_value=True)),
+            process_registry=MagicMock(),
+            runner=runner,
+            registry=mock_registry,
+        )
+
+        asyncio.run(scheduler.execute())
+
+        assert scheduler._block_states["A"] == BlockState.ERROR
+        runner.run.assert_not_called()
+
+    def test_none_valued_required_config_field_errors(self) -> None:
+        """Required config field set to None should ERROR before dispatch."""
+        wf = _wf(nodes=[("A", "myblock")])
+        wf.nodes[0].config = {"params": {"path": None}}
+
+        mock_block = MagicMock()
+        mock_block.config_schema = {
+            "type": "object",
+            "properties": {"path": {"type": "string"}},
+            "required": ["path"],
+        }
+
+        mock_registry = MagicMock()
+        mock_registry.instantiate.return_value = mock_block
+
+        runner = AsyncMock()
+
+        scheduler = DAGScheduler(
+            workflow=wf,
+            event_bus=EventBus(),
+            resource_manager=MagicMock(can_dispatch=MagicMock(return_value=True)),
+            process_registry=MagicMock(),
+            runner=runner,
+            registry=mock_registry,
+        )
+
+        asyncio.run(scheduler.execute())
+
+        assert scheduler._block_states["A"] == BlockState.ERROR
+        runner.run.assert_not_called()
+
+    def test_all_required_config_fields_present_dispatches(self) -> None:
+        """Block with all required config fields present should dispatch normally."""
+        wf = _wf(nodes=[("A", "myblock")])
+        wf.nodes[0].config = {"params": {"path": "/data/input.csv"}}
+
+        mock_block = MagicMock()
+        mock_block.config_schema = {
+            "type": "object",
+            "properties": {"path": {"type": "string"}},
+            "required": ["path"],
+        }
+
+        mock_registry = MagicMock()
+        mock_registry.instantiate.return_value = mock_block
+
+        runner = AsyncMock()
+        runner.run.return_value = {"output": "ok"}
+
+        scheduler = DAGScheduler(
+            workflow=wf,
+            event_bus=EventBus(),
+            resource_manager=MagicMock(can_dispatch=MagicMock(return_value=True)),
+            process_registry=MagicMock(),
+            runner=runner,
+            registry=mock_registry,
+        )
+
+        asyncio.run(scheduler.execute())
+
+        assert scheduler._block_states["A"] == BlockState.DONE
+        runner.run.assert_called_once()
+
+    def test_no_required_fields_dispatches_normally(self) -> None:
+        """Block with no required fields in config_schema dispatches normally."""
+        wf = _wf(nodes=[("A", "myblock")])
+        wf.nodes[0].config = {}
+
+        mock_block = MagicMock()
+        mock_block.config_schema = {
+            "type": "object",
+            "properties": {"optional_param": {"type": "string"}},
+        }
+
+        mock_registry = MagicMock()
+        mock_registry.instantiate.return_value = mock_block
+
+        runner = AsyncMock()
+        runner.run.return_value = {"output": "ok"}
+
+        scheduler = DAGScheduler(
+            workflow=wf,
+            event_bus=EventBus(),
+            resource_manager=MagicMock(can_dispatch=MagicMock(return_value=True)),
+            process_registry=MagicMock(),
+            runner=runner,
+            registry=mock_registry,
+        )
+
+        asyncio.run(scheduler.execute())
+
+        assert scheduler._block_states["A"] == BlockState.DONE
+        runner.run.assert_called_once()

--- a/tests/workflow/test_validator.py
+++ b/tests/workflow/test_validator.py
@@ -395,3 +395,127 @@ class TestValidatorDanglingPorts:
         dangling = [e for e in errors if "required input port" in e]
         assert len(dangling) == 1
         assert "'right'" in dangling[0]
+
+
+# ---------------------------------------------------------------------------
+# Variadic port cardinality (Check 7)
+# ---------------------------------------------------------------------------
+
+
+class TestValidatorVariadicCardinality:
+    """Check 7: variadic port count within min/max limits."""
+
+    def test_variadic_input_below_min(self) -> None:
+        """Block with min_input_ports=2 but only 1 effective input port should error."""
+        spec = BlockSpec(
+            name="variadic_block",
+            variadic_inputs=True,
+            min_input_ports=2,
+            input_ports=[InputPort(name="in0", accepted_types=[Array])],
+            output_ports=[OutputPort(name="out", accepted_types=[Array])],
+        )
+        reg = _registry_from_specs(spec)
+
+        wf = WorkflowDefinition(
+            nodes=[NodeDef(id="V", block_type="variadic_block")],
+        )
+        errors = validate_workflow(wf, registry=reg)
+        assert any("variadic input port count 1" in e and "below minimum 2" in e for e in errors)
+
+    def test_variadic_input_above_max(self) -> None:
+        """Block with max_input_ports=1 but 2 effective input ports should error."""
+        spec = BlockSpec(
+            name="variadic_block",
+            variadic_inputs=True,
+            max_input_ports=1,
+            input_ports=[
+                InputPort(name="in0", accepted_types=[Array]),
+                InputPort(name="in1", accepted_types=[Array]),
+            ],
+            output_ports=[OutputPort(name="out", accepted_types=[Array])],
+        )
+        reg = _registry_from_specs(spec)
+
+        wf = WorkflowDefinition(
+            nodes=[NodeDef(id="V", block_type="variadic_block")],
+        )
+        errors = validate_workflow(wf, registry=reg)
+        assert any("variadic input port count 2" in e and "exceeds maximum 1" in e for e in errors)
+
+    def test_variadic_output_below_min(self) -> None:
+        """Block with min_output_ports=2 but only 1 effective output port should error."""
+        spec = BlockSpec(
+            name="variadic_block",
+            variadic_outputs=True,
+            min_output_ports=2,
+            input_ports=[InputPort(name="in", accepted_types=[Array])],
+            output_ports=[OutputPort(name="out0", accepted_types=[Array])],
+        )
+        reg = _registry_from_specs(spec)
+
+        wf = WorkflowDefinition(
+            nodes=[NodeDef(id="V", block_type="variadic_block")],
+        )
+        errors = validate_workflow(wf, registry=reg)
+        assert any("variadic output port count 1" in e and "below minimum 2" in e for e in errors)
+
+    def test_variadic_output_above_max(self) -> None:
+        """Block with max_output_ports=1 but 2 effective output ports should error."""
+        spec = BlockSpec(
+            name="variadic_block",
+            variadic_outputs=True,
+            max_output_ports=1,
+            input_ports=[InputPort(name="in", accepted_types=[Array])],
+            output_ports=[
+                OutputPort(name="out0", accepted_types=[Array]),
+                OutputPort(name="out1", accepted_types=[Array]),
+            ],
+        )
+        reg = _registry_from_specs(spec)
+
+        wf = WorkflowDefinition(
+            nodes=[NodeDef(id="V", block_type="variadic_block")],
+        )
+        errors = validate_workflow(wf, registry=reg)
+        assert any("variadic output port count 2" in e and "exceeds maximum 1" in e for e in errors)
+
+    def test_variadic_within_limits_no_error(self) -> None:
+        """Block with port count within min/max should produce no cardinality errors."""
+        spec = BlockSpec(
+            name="variadic_block",
+            variadic_inputs=True,
+            min_input_ports=1,
+            max_input_ports=3,
+            input_ports=[
+                InputPort(name="in0", accepted_types=[Array]),
+                InputPort(name="in1", accepted_types=[Array]),
+            ],
+            output_ports=[OutputPort(name="out", accepted_types=[Array])],
+        )
+        reg = _registry_from_specs(spec)
+
+        wf = WorkflowDefinition(
+            nodes=[NodeDef(id="V", block_type="variadic_block")],
+        )
+        errors = validate_workflow(wf, registry=reg)
+        cardinality_errors = [e for e in errors if "variadic" in e]
+        assert cardinality_errors == []
+
+    def test_non_variadic_skips_cardinality_check(self) -> None:
+        """Non-variadic blocks should never produce cardinality errors."""
+        spec = BlockSpec(
+            name="normal_block",
+            variadic_inputs=False,
+            variadic_outputs=False,
+            min_input_ports=5,  # would fail if checked
+            input_ports=[InputPort(name="in", accepted_types=[Array])],
+            output_ports=[OutputPort(name="out", accepted_types=[Array])],
+        )
+        reg = _registry_from_specs(spec)
+
+        wf = WorkflowDefinition(
+            nodes=[NodeDef(id="N", block_type="normal_block")],
+        )
+        errors = validate_workflow(wf, registry=reg)
+        cardinality_errors = [e for e in errors if "variadic" in e]
+        assert cardinality_errors == []


### PR DESCRIPTION
## Summary
- **#630**: Pass `registry=self.block_registry` to `validate_workflow()` in `save_workflow()` so type compatibility (Check 5) and dangling port (Check 6) checks actually run on save
- **#631**: Add Check 7 to workflow validator for variadic port cardinality limits — verifies effective port count against `min_input_ports`/`max_input_ports`/`min_output_ports`/`max_output_ports` from BlockSpec
- **#632**: Add config required-field pre-dispatch check in scheduler `_dispatch()` — validates `config_schema.required` fields are present in `node.config.params` before subprocess creation

## Changes
| File | Change |
|------|--------|
| `src/scieasy/api/runtime.py` | 1-line fix: pass `registry=self.block_registry` to `validate_workflow()` |
| `src/scieasy/workflow/validator.py` | Add Check 7: variadic port cardinality validation (~40 lines) |
| `src/scieasy/engine/scheduler.py` | Add config required-field pre-check before dispatch (~25 lines) |
| `tests/workflow/test_validator.py` | 6 new tests for Check 7 cardinality validation |
| `tests/engine/test_scheduler.py` | 4 new tests for config pre-dispatch validation |

## Test plan
- [x] Validator tests: variadic input below min, above max, output below min, above max, within limits, non-variadic skips check
- [x] Scheduler tests: missing required field errors, None-valued field errors, present fields dispatch, no required fields dispatch
- [x] Existing test_workflows.py integration tests still pass
- [x] Ruff lint + format clean

Closes #630, Closes #631, Closes #632, Closes #638

🤖 Generated with [Claude Code](https://claude.com/claude-code)