### PR TITLE
feat(#644): implement DataRouter + PairEditor interactive variadic blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- [#644] Implement DataRouter + PairEditor interactive variadic blocks — first consumers of ADR-029 variadic ports, with interactive PAUSED execution mode, drag-and-drop routing modal, sortable pairing modal, and scheduler interactive flow (@claude, 2026-04-11, branch: feat/issue-644/data-router-pair-editor, session: 20260411-225938-implement-datarouter-paireditor-interact)
 - [#595] Implement variadic port count min/max limits (ADR-029 Addendum 1) (@claude, 2026-04-11, branch: feat/issue-595/variadic-port-min-max-limits, session: 20260411-101739-implement-adr-029-addendum-1-variadic-po)
 
 ### Changed

--- a/docs/guides/block-sdk.md
+++ b/docs/guides/block-sdk.md
@@ -1598,12 +1598,63 @@ IDLE -> SKIPPED -> IDLE (upstream input unavailable)
 | Mode | Meaning |
 |------|---------|
 | `AUTO` | Engine schedules and runs the block automatically (default). |
-| `INTERACTIVE` | Block requires user interaction (manual review blocks). |
+| `INTERACTIVE` | Block pauses and presents a UI for user interaction (#591/#594). |
 | `EXTERNAL` | Block delegates to an external application (AppBlock). |
 
 ---
 
-## Appendix B: Execution Environment
+## Appendix B: Interactive Blocks (#591, #594)
+
+Interactive blocks use `execution_mode = ExecutionMode.INTERACTIVE` and run
+**in-process** (not in a subprocess) because they need bidirectional WebSocket
+communication with the frontend. The execution flow is:
+
+1. Scheduler detects `INTERACTIVE` mode on the block.
+2. Block transitions to `PAUSED` and emits `BLOCK_PAUSED`.
+3. Scheduler calls `block.prepare_prompt(inputs, config)` to build UI data.
+4. Scheduler emits `INTERACTIVE_PROMPT` event with the prepared data.
+5. Frontend receives the prompt and opens a modal dialog.
+6. User interacts (e.g. drag-and-drop routing, reordering) and clicks Confirm.
+7. Frontend sends `interactive_complete` WebSocket message.
+8. Scheduler receives the response, merges it into config as
+   `config["interactive_response"]`, and calls `block.run(inputs, config)`.
+9. Block produces outputs and transitions to `DONE`.
+
+### Authoring an interactive block
+
+```python
+class MyInteractiveBlock(ProcessBlock):
+    execution_mode = ExecutionMode.INTERACTIVE
+    variadic_inputs = True
+    variadic_outputs = True
+
+    def prepare_prompt(self, inputs, config):
+        """Return data for the frontend modal.
+
+        This data is sent as the INTERACTIVE_PROMPT event payload.
+        """
+        return {"items": [...], "options": [...]}
+
+    def run(self, inputs, config):
+        """Process the user's response.
+
+        The user's response is available in config["interactive_response"].
+        """
+        response = config.get("interactive_response", {})
+        # ... use response to produce outputs
+        return {"output_port": collection}
+```
+
+### Built-in interactive blocks
+
+| Block | Purpose |
+|-------|---------|
+| `DataRouter` | N-input to M-output item routing via drag-and-drop |
+| `PairEditor` | Reorder items within Collections for index-based pairing |
+
+---
+
+## Appendix C: Execution Environment
 
 Blocks run in **isolated subprocesses**, not in the main engine process. This
 means:
@@ -1632,7 +1683,7 @@ produce corrupt files.
 
 ---
 
-## Appendix C: Custom Data Types
+## Appendix D: Custom Data Types
 
 External developers define domain-specific types by subclassing **core** types
 (`Array`, `Series`, `DataFrame`, `Text`, `Artifact`, `CompositeData`). **Core
@@ -1741,7 +1792,7 @@ inputs from serialised `type_chain` metadata.
 
 ---
 
-## Appendix D: Quick Reference
+## Appendix E: Quick Reference
 
 ### Minimal ProcessBlock (Tier 1)
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,9 +3,11 @@ import { startTransition, useCallback, useEffect, useMemo, useRef, useState } fr
 
 import { api } from "./lib/api";
 import { useLogStream } from "./hooks/useSSE";
-import { useWorkflowWebSocket } from "./hooks/useWebSocket";
+import { useWorkflowWebSocket, sendWebSocketMessage } from "./hooks/useWebSocket";
 import { useAppStore } from "./store";
 import type { ChatMessage, ProjectResponse, WorkflowResponse } from "./types/api";
+import { DataRouterModal } from "./components/DataRouterModal";
+import { PairEditorModal } from "./components/PairEditorModal";
 import { BlockPalette } from "./components/BlockPalette";
 import { BottomPanel } from "./components/BottomPanel";
 import { DataPreview } from "./components/DataPreview";
@@ -69,6 +71,8 @@ export default function App() {
   const logEntries = useAppStore((state) => state.logEntries);
   const isRunning = useAppStore((state) => state.isRunning);
   const resetExecution = useAppStore((state) => state.resetExecution);
+  const interactivePrompt = useAppStore((state) => state.interactivePrompt);
+  const setInteractivePrompt = useAppStore((state) => state.setInteractivePrompt);
 
   const selectedNodeId = useAppStore((state) => state.selectedNodeId);
   const activeBottomTab = useAppStore((state) => state.activeBottomTab);
@@ -869,6 +873,66 @@ export default function App() {
             path={projectDialog.path}
             recentProjects={recentProjects}
           />
+
+          {/* #591/#594: Interactive block modals */}
+          {interactivePrompt?.blockType === "DataRouter" && (
+            <DataRouterModal
+              blockId={interactivePrompt.blockId}
+              inputPorts={(interactivePrompt.data.input_ports as string[]) ?? []}
+              outputPorts={(interactivePrompt.data.output_ports as string[]) ?? []}
+              itemsPerPort={
+                (interactivePrompt.data.items_per_port as Record<
+                  string,
+                  Array<{ index: number; port: string; ref: string; name: string; type: string }>
+                >) ?? {}
+              }
+              onConfirm={(assignments) => {
+                sendWebSocketMessage({
+                  type: "interactive_complete",
+                  block_id: interactivePrompt.blockId,
+                  data: { assignments },
+                });
+                setInteractivePrompt(null);
+              }}
+              onCancel={() => {
+                sendWebSocketMessage({
+                  type: "cancel_block",
+                  block_id: interactivePrompt.blockId,
+                  workflow_id: workflowId,
+                });
+                setInteractivePrompt(null);
+              }}
+            />
+          )}
+          {interactivePrompt?.blockType === "PairEditor" && (
+            <PairEditorModal
+              blockId={interactivePrompt.blockId}
+              ports={(interactivePrompt.data.ports as string[]) ?? []}
+              itemsPerPort={
+                (interactivePrompt.data.items_per_port as Record<
+                  string,
+                  Array<{ index: number; name: string; type: string }>
+                >) ?? {}
+              }
+              collectionLength={(interactivePrompt.data.collection_length as number) ?? 0}
+              onConfirm={(reorder) => {
+                sendWebSocketMessage({
+                  type: "interactive_complete",
+                  block_id: interactivePrompt.blockId,
+                  data: { reorder },
+                });
+                setInteractivePrompt(null);
+              }}
+              onCancel={() => {
+                sendWebSocketMessage({
+                  type: "cancel_block",
+                  block_id: interactivePrompt.blockId,
+                  workflow_id: workflowId,
+                });
+                setInteractivePrompt(null);
+              }}
+            />
+          )}
 
           {busy ? (
             <div className="fixed bottom-4 right-4 rounded-full bg-ink px-4 py-2 text-sm text-white">Working…</div>

--- a/frontend/src/components/DataRouterModal.tsx
+++ b/frontend/src/components/DataRouterModal.tsx
@@ -1,0 +1,287 @@
+/**
+ * DataRouterModal -- drag-and-drop routing modal for the DataRouter block (#591).
+ *
+ * Displays N input panels (left) and M output panels (right). Users drag items
+ * from input panels to output panels. All items must be assigned before Confirm.
+ *
+ * Uses the HTML5 Drag and Drop API (no external dependencies).
+ */
+
+import { useState, useCallback } from "react";
+
+interface ItemDescriptor {
+  index: number;
+  port: string;
+  ref: string;
+  name: string;
+  type: string;
+}
+
+interface DataRouterModalProps {
+  blockId: string;
+  inputPorts: string[];
+  outputPorts: string[];
+  itemsPerPort: Record<string, ItemDescriptor[]>;
+  onConfirm: (assignments: Record<string, string[]>) => void;
+  onCancel: () => void;
+}
+
+// Row colors for visual grouping.
+const ROW_COLORS = [
+  "bg-blue-50 border-blue-200",
+  "bg-green-50 border-green-200",
+  "bg-purple-50 border-purple-200",
+  "bg-amber-50 border-amber-200",
+  "bg-rose-50 border-rose-200",
+  "bg-cyan-50 border-cyan-200",
+  "bg-indigo-50 border-indigo-200",
+  "bg-lime-50 border-lime-200",
+];
+
+function ItemCard({
+  item,
+  draggable,
+  onDragStart,
+  colorIndex,
+}: {
+  item: ItemDescriptor;
+  draggable: boolean;
+  onDragStart?: (e: React.DragEvent, ref: string) => void;
+  colorIndex?: number;
+}) {
+  const colorClass = colorIndex != null ? ROW_COLORS[colorIndex % ROW_COLORS.length] : "bg-white border-stone-200";
+  return (
+    <div
+      className={`flex items-center gap-2 rounded border px-2 py-1.5 text-xs ${colorClass} ${draggable ? "cursor-grab" : "cursor-default opacity-50"}`}
+      draggable={draggable}
+      onDragStart={(e) => onDragStart?.(e, item.ref)}
+    >
+      <span className="truncate font-medium text-ink">{item.name}</span>
+      <span className="shrink-0 text-[10px] text-stone-400">{item.type}</span>
+    </div>
+  );
+}
+
+export function DataRouterModal({
+  blockId,
+  inputPorts,
+  outputPorts,
+  itemsPerPort,
+  onConfirm,
+  onCancel,
+}: DataRouterModalProps) {
+  // Track which items have been assigned to which output port.
+  // Key: output port name, Value: list of item refs.
+  const [assignments, setAssignments] = useState<Record<string, string[]>>(
+    () => Object.fromEntries(outputPorts.map((p) => [p, []]))
+  );
+
+  // Track which items are still unassigned.
+  const allItems = inputPorts.flatMap((p) => itemsPerPort[p] ?? []);
+  const assignedRefs = new Set(Object.values(assignments).flat());
+  const unassignedItems = allItems.filter((item) => !assignedRefs.has(item.ref));
+  const allAssigned = unassignedItems.length === 0;
+
+  // Lookup for item by ref.
+  const itemByRef: Record<string, ItemDescriptor> = {};
+  for (const item of allItems) {
+    itemByRef[item.ref] = item;
+  }
+
+  const handleDragStart = useCallback((e: React.DragEvent, ref: string) => {
+    e.dataTransfer.setData("text/plain", ref);
+    e.dataTransfer.effectAllowed = "move";
+  }, []);
+
+  const handleDropOnOutput = useCallback(
+    (e: React.DragEvent, outputPort: string) => {
+      e.preventDefault();
+      const ref = e.dataTransfer.getData("text/plain");
+      if (!ref) return;
+
+      setAssignments((prev) => {
+        // Remove from any other output port first.
+        const next: Record<string, string[]> = {};
+        for (const [port, refs] of Object.entries(prev)) {
+          next[port] = refs.filter((r) => r !== ref);
+        }
+        // Add to target port.
+        next[outputPort] = [...(next[outputPort] ?? []), ref];
+        return next;
+      });
+    },
+    []
+  );
+
+  const handleDropOnInput = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    const ref = e.dataTransfer.getData("text/plain");
+    if (!ref) return;
+
+    // Remove from all output ports (move back to unassigned).
+    setAssignments((prev) => {
+      const next: Record<string, string[]> = {};
+      for (const [port, refs] of Object.entries(prev)) {
+        next[port] = refs.filter((r) => r !== ref);
+      }
+      return next;
+    });
+  }, []);
+
+  const handleDragOver = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    e.dataTransfer.dropEffect = "move";
+  }, []);
+
+  const handleConfirm = () => {
+    onConfirm(assignments);
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/40"
+      onClick={onCancel}
+    >
+      <div
+        className="flex max-h-[85vh] w-[900px] flex-col rounded-xl border border-stone-200 bg-white shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="border-b border-stone-100 px-5 py-3">
+          <div className="text-sm font-semibold text-ink">Data Router</div>
+          <div className="mt-0.5 text-xs text-stone-500">
+            Drag items from input panels to output panels. All items must be assigned.
+          </div>
+        </div>
+
+        {/* Body */}
+        <div className="flex flex-1 gap-4 overflow-y-auto p-5">
+          {/* Input panels */}
+          <div
+            className="flex flex-1 flex-col gap-3"
+            onDrop={handleDropOnInput}
+            onDragOver={handleDragOver}
+          >
+            <div className="text-xs font-medium uppercase tracking-wide text-stone-400">
+              Inputs
+            </div>
+            {inputPorts.map((portName) => {
+              const portItems = itemsPerPort[portName] ?? [];
+              const unassignedPortItems = portItems.filter(
+                (item) => !assignedRefs.has(item.ref)
+              );
+              return (
+                <div
+                  key={portName}
+                  className="rounded-lg border border-stone-200 bg-stone-50 p-3"
+                >
+                  <div className="mb-2 text-xs font-medium text-stone-600">
+                    {portName}{" "}
+                    <span className="text-stone-400">
+                      ({unassignedPortItems.length}/{portItems.length})
+                    </span>
+                  </div>
+                  <div className="flex flex-wrap gap-1.5">
+                    {unassignedPortItems.map((item) => (
+                      <ItemCard
+                        key={item.ref}
+                        item={item}
+                        draggable
+                        onDragStart={handleDragStart}
+                      />
+                    ))}
+                    {unassignedPortItems.length === 0 && (
+                      <span className="text-[10px] italic text-stone-400">
+                        All items assigned
+                      </span>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+
+          {/* Arrow divider */}
+          <div className="flex items-center text-stone-300">
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <path d="M5 12h14M13 5l6 7-6 7" />
+            </svg>
+          </div>
+
+          {/* Output panels */}
+          <div className="flex flex-1 flex-col gap-3">
+            <div className="text-xs font-medium uppercase tracking-wide text-stone-400">
+              Outputs
+            </div>
+            {outputPorts.map((portName, portIndex) => {
+              const portRefs = assignments[portName] ?? [];
+              return (
+                <div
+                  key={portName}
+                  className="min-h-[60px] rounded-lg border-2 border-dashed border-stone-200 bg-stone-50 p-3 transition-colors hover:border-blue-300"
+                  onDrop={(e) => handleDropOnOutput(e, portName)}
+                  onDragOver={handleDragOver}
+                >
+                  <div className="mb-2 text-xs font-medium text-stone-600">
+                    {portName}{" "}
+                    <span className="text-stone-400">({portRefs.length})</span>
+                  </div>
+                  <div className="flex flex-wrap gap-1.5">
+                    {portRefs.map((ref) => {
+                      const item = itemByRef[ref];
+                      if (!item) return null;
+                      return (
+                        <ItemCard
+                          key={ref}
+                          item={item}
+                          draggable
+                          onDragStart={handleDragStart}
+                          colorIndex={portIndex}
+                        />
+                      );
+                    })}
+                    {portRefs.length === 0 && (
+                      <span className="text-[10px] italic text-stone-400">
+                        Drop items here
+                      </span>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div className="flex items-center justify-between border-t border-stone-100 px-5 py-3">
+          <div className="text-xs text-stone-500">
+            {allAssigned ? (
+              <span className="text-green-600">All items assigned</span>
+            ) : (
+              <span className="text-amber-600">
+                {unassignedItems.length} item(s) not yet assigned
+              </span>
+            )}
+          </div>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              className="rounded border border-stone-200 px-4 py-1.5 text-xs text-stone-600 hover:bg-stone-50"
+              onClick={onCancel}
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              className="rounded bg-blue-500 px-4 py-1.5 text-xs text-white hover:bg-blue-600 disabled:opacity-40"
+              disabled={!allAssigned}
+              onClick={handleConfirm}
+            >
+              Confirm
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/PairEditorModal.tsx
+++ b/frontend/src/components/PairEditorModal.tsx
@@ -1,0 +1,207 @@
+/**
+ * PairEditorModal -- sortable reordering modal for the PairEditor block (#594).
+ *
+ * Displays N side-by-side panels (one per input port). Each panel shows items
+ * as a vertically sortable list. Same-row items across panels are "paired"
+ * (highlighted with matching colors). Users drag to reorder within each panel.
+ *
+ * Uses the HTML5 Drag and Drop API (no external dependencies).
+ */
+
+import { useState, useCallback, useRef } from "react";
+
+interface ItemDescriptor {
+  index: number;
+  name: string;
+  type: string;
+}
+
+interface PairEditorModalProps {
+  blockId: string;
+  ports: string[];
+  itemsPerPort: Record<string, ItemDescriptor[]>;
+  collectionLength: number;
+  onConfirm: (reorder: Record<string, number[]>) => void;
+  onCancel: () => void;
+}
+
+// Row pairing colors.
+const PAIR_COLORS = [
+  { bg: "bg-blue-50", border: "border-blue-300", text: "text-blue-700" },
+  { bg: "bg-green-50", border: "border-green-300", text: "text-green-700" },
+  { bg: "bg-purple-50", border: "border-purple-300", text: "text-purple-700" },
+  { bg: "bg-amber-50", border: "border-amber-300", text: "text-amber-700" },
+  { bg: "bg-rose-50", border: "border-rose-300", text: "text-rose-700" },
+  { bg: "bg-cyan-50", border: "border-cyan-300", text: "text-cyan-700" },
+  { bg: "bg-indigo-50", border: "border-indigo-300", text: "text-indigo-700" },
+  { bg: "bg-lime-50", border: "border-lime-300", text: "text-lime-700" },
+  { bg: "bg-teal-50", border: "border-teal-300", text: "text-teal-700" },
+  { bg: "bg-orange-50", border: "border-orange-300", text: "text-orange-700" },
+];
+
+export function PairEditorModal({
+  blockId,
+  ports,
+  itemsPerPort,
+  collectionLength,
+  onConfirm,
+  onCancel,
+}: PairEditorModalProps) {
+  // State: per-port ordered list of original indices.
+  // Initially [0, 1, 2, ...collectionLength-1] for each port.
+  const [orders, setOrders] = useState<Record<string, number[]>>(() => {
+    const initial: Record<string, number[]> = {};
+    for (const port of ports) {
+      const items = itemsPerPort[port] ?? [];
+      initial[port] = items.map((item) => item.index);
+    }
+    return initial;
+  });
+
+  // Track drag state within a single panel.
+  const dragPortRef = useRef<string | null>(null);
+  const dragIndexRef = useRef<number>(-1);
+
+  const handleDragStart = useCallback(
+    (port: string, positionIndex: number) => (e: React.DragEvent) => {
+      dragPortRef.current = port;
+      dragIndexRef.current = positionIndex;
+      e.dataTransfer.effectAllowed = "move";
+      e.dataTransfer.setData("text/plain", `${port}:${positionIndex}`);
+    },
+    []
+  );
+
+  const handleDragOver = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    e.dataTransfer.dropEffect = "move";
+  }, []);
+
+  const handleDrop = useCallback(
+    (targetPort: string, targetPositionIndex: number) => (e: React.DragEvent) => {
+      e.preventDefault();
+      const sourcePort = dragPortRef.current;
+      const sourceIndex = dragIndexRef.current;
+
+      // Only allow drops within the same panel.
+      if (sourcePort !== targetPort || sourceIndex === targetPositionIndex) return;
+
+      setOrders((prev) => {
+        const portOrder = [...prev[targetPort]];
+        // Remove the dragged item and insert at the target position.
+        const [moved] = portOrder.splice(sourceIndex, 1);
+        portOrder.splice(targetPositionIndex, 0, moved);
+        return { ...prev, [targetPort]: portOrder };
+      });
+    },
+    []
+  );
+
+  const handleConfirm = () => {
+    onConfirm(orders);
+  };
+
+  // Build item lookup by port and original index.
+  const itemLookup: Record<string, Record<number, ItemDescriptor>> = {};
+  for (const port of ports) {
+    itemLookup[port] = {};
+    for (const item of itemsPerPort[port] ?? []) {
+      itemLookup[port][item.index] = item;
+    }
+  }
+
+  // Determine grid columns based on port count.
+  const gridCols =
+    ports.length <= 2
+      ? "grid-cols-2"
+      : ports.length <= 3
+        ? "grid-cols-3"
+        : ports.length <= 4
+          ? "grid-cols-4"
+          : "grid-cols-4";
+
+  return (
+    <div
+      className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/40"
+      onClick={onCancel}
+    >
+      <div
+        className="flex max-h-[85vh] w-[900px] flex-col rounded-xl border border-stone-200 bg-white shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="border-b border-stone-100 px-5 py-3">
+          <div className="text-sm font-semibold text-ink">Pair Editor</div>
+          <div className="mt-0.5 text-xs text-stone-500">
+            Reorder items within each panel so that same-row items are correctly paired.
+            Items in the same row (same color) are paired by index.
+          </div>
+        </div>
+
+        {/* Body */}
+        <div className="flex-1 overflow-y-auto p-5">
+          {/* Row number header */}
+          <div className={`grid gap-3 ${gridCols}`}>
+            {ports.map((portName) => (
+              <div key={portName} className="text-xs font-medium text-stone-600">
+                {portName}
+                <span className="ml-1 text-stone-400">({collectionLength})</span>
+              </div>
+            ))}
+          </div>
+
+          {/* Items grid — one row per index across all ports */}
+          {Array.from({ length: collectionLength }, (_, rowIdx) => {
+            const pairColor = PAIR_COLORS[rowIdx % PAIR_COLORS.length];
+            return (
+              <div key={rowIdx} className={`mt-1 grid gap-3 ${gridCols}`}>
+                {ports.map((portName) => {
+                  const originalIndex = orders[portName]?.[rowIdx];
+                  const item =
+                    originalIndex != null ? itemLookup[portName]?.[originalIndex] : null;
+                  if (!item) return <div key={portName} />;
+                  return (
+                    <div
+                      key={portName}
+                      className={`flex cursor-grab items-center gap-2 rounded border px-2 py-1.5 text-xs ${pairColor.bg} ${pairColor.border}`}
+                      draggable
+                      onDragStart={handleDragStart(portName, rowIdx)}
+                      onDragOver={handleDragOver}
+                      onDrop={handleDrop(portName, rowIdx)}
+                    >
+                      <span className={`shrink-0 text-[10px] font-medium ${pairColor.text}`}>
+                        {rowIdx + 1}
+                      </span>
+                      <span className="min-w-0 flex-1 truncate font-medium text-ink">
+                        {item.name}
+                      </span>
+                      <span className="shrink-0 text-[10px] text-stone-400">{item.type}</span>
+                    </div>
+                  );
+                })}
+              </div>
+            );
+          })}
+        </div>
+
+        {/* Footer */}
+        <div className="flex items-center justify-end gap-2 border-t border-stone-100 px-5 py-3">
+          <button
+            type="button"
+            className="rounded border border-stone-200 px-4 py-1.5 text-xs text-stone-600 hover:bg-stone-50"
+            onClick={onCancel}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            className="rounded bg-blue-500 px-4 py-1.5 text-xs text-white hover:bg-blue-600"
+            onClick={handleConfirm}
+          >
+            Confirm
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/nodes/BlockNode.tsx
+++ b/frontend/src/components/nodes/BlockNode.tsx
@@ -889,6 +889,11 @@ export function BlockNode({ id: nodeId, data, selected }: NodeProps<Node<BlockNo
         {data.status === "paused" && data.category === "app" && (
           <PausedToast outputDir={String(data.config?.output_dir ?? "")} />
         )}
+        {data.status === "paused" && data.category !== "app" && (
+          <div className="mt-1 flex items-center gap-1 rounded border border-blue-200 bg-blue-50 px-2 py-1 text-[10px] text-blue-700">
+            Waiting for user input...
+          </div>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -1,12 +1,26 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState, useCallback } from "react";
 
 import type { WorkflowEventMessage } from "../types/api";
 import { useAppStore } from "../store";
+
+/** Ref-holder for the active WebSocket so components can send messages. */
+let _activeSocket: WebSocket | null = null;
+
+/** Send a JSON message over the active WebSocket connection.
+ *  Returns false if the socket is not connected. */
+export function sendWebSocketMessage(message: Record<string, unknown>): boolean {
+  if (_activeSocket && _activeSocket.readyState === WebSocket.OPEN) {
+    _activeSocket.send(JSON.stringify(message));
+    return true;
+  }
+  return false;
+}
 
 export function useWorkflowWebSocket(enabled: boolean): { connected: boolean } {
   const consumeEvent = useAppStore((state) => state.consumeEvent);
   const appendLog = useAppStore((state) => state.appendLog);
   const setActiveBottomTab = useAppStore((state) => state.setActiveBottomTab);
+  const setInteractivePrompt = useAppStore((state) => state.setInteractivePrompt);
   const [connected, setConnected] = useState(false);
 
   useEffect(() => {
@@ -16,12 +30,30 @@ export function useWorkflowWebSocket(enabled: boolean): { connected: boolean } {
 
     const protocol = window.location.protocol === "https:" ? "wss" : "ws";
     const socket = new WebSocket(`${protocol}://${window.location.host}/ws`);
+    _activeSocket = socket;
 
     socket.onopen = () => setConnected(true);
-    socket.onclose = () => setConnected(false);
-    socket.onerror = () => setConnected(false);
+    socket.onclose = () => {
+      setConnected(false);
+      _activeSocket = null;
+    };
+    socket.onerror = () => {
+      setConnected(false);
+      _activeSocket = null;
+    };
     socket.onmessage = (event) => {
       const payload = JSON.parse(event.data) as WorkflowEventMessage;
+
+      // #591/#594: Handle interactive_prompt events from backend.
+      if (payload.type === "interactive_prompt") {
+        setInteractivePrompt({
+          blockId: payload.block_id ?? "",
+          blockType: (payload.data.block_type as string) ?? "",
+          data: payload.data,
+        });
+        return;
+      }
+
       consumeEvent(payload);
       if (payload.type.startsWith("block_") || payload.type.startsWith("workflow_")) {
         setActiveBottomTab("logs");
@@ -41,8 +73,9 @@ export function useWorkflowWebSocket(enabled: boolean): { connected: boolean } {
 
     return () => {
       socket.close();
+      _activeSocket = null;
     };
-  }, [appendLog, consumeEvent, enabled, setActiveBottomTab]);
+  }, [appendLog, consumeEvent, enabled, setActiveBottomTab, setInteractivePrompt]);
 
   return { connected };
 }

--- a/frontend/src/store/executionSlice.ts
+++ b/frontend/src/store/executionSlice.ts
@@ -10,6 +10,7 @@ export const createExecutionSlice: StateCreator<AppStore, [], [], ExecutionSlice
   executionMessages: [],
   logEntries: [],
   isRunning: false,
+  interactivePrompt: null,
   consumeEvent: (event) =>
     set((state) => {
       const nextStates = event.block_id
@@ -81,5 +82,6 @@ export const createExecutionSlice: StateCreator<AppStore, [], [], ExecutionSlice
     set((state) => ({
       logEntries: [...state.logEntries, entry].slice(-400),
     })),
-  resetExecution: () => set({ blockStates: {}, blockOutputs: {}, blockErrors: {}, blockErrorSummaries: {}, executionMessages: [], logEntries: [], isRunning: false }),
+  resetExecution: () => set({ blockStates: {}, blockOutputs: {}, blockErrors: {}, blockErrorSummaries: {}, executionMessages: [], logEntries: [], isRunning: false, interactivePrompt: null }),
+  setInteractivePrompt: (prompt) => set({ interactivePrompt: prompt }),
 });

--- a/frontend/src/store/types.ts
+++ b/frontend/src/store/types.ts
@@ -53,6 +53,13 @@ export interface WorkflowSlice {
   redoWorkflow: () => void;
 }
 
+/** #591/#594: Data for an interactive block prompt (DataRouter, PairEditor). */
+export interface InteractivePrompt {
+  blockId: string;
+  blockType: string;
+  data: Record<string, unknown>;
+}
+
 export interface ExecutionSlice {
   blockStates: Record<string, string>;
   blockOutputs: Record<string, Record<string, unknown>>;
@@ -62,9 +69,12 @@ export interface ExecutionSlice {
   logEntries: LogEntry[];
   /** True while a workflow execution is in progress. */
   isRunning: boolean;
+  /** #591/#594: Active interactive prompt from a PAUSED block (DataRouter/PairEditor). */
+  interactivePrompt: InteractivePrompt | null;
   consumeEvent: (event: WorkflowEventMessage) => void;
   appendLog: (entry: LogEntry) => void;
   resetExecution: () => void;
+  setInteractivePrompt: (prompt: InteractivePrompt | null) => void;
 }
 
 export interface UISlice {

--- a/src/scieasy/api/ws.py
+++ b/src/scieasy/api/ws.py
@@ -23,6 +23,8 @@ from scieasy.engine.events import (
     BLOCK_SKIPPED,
     CANCEL_BLOCK_REQUEST,
     CANCEL_WORKFLOW_REQUEST,
+    INTERACTIVE_COMPLETE,
+    INTERACTIVE_PROMPT,
     WORKFLOW_COMPLETED,
     WORKFLOW_STARTED,
     EngineEvent,
@@ -43,6 +45,7 @@ _OUTBOUND_EVENTS = frozenset(
         BLOCK_SKIPPED,
         WORKFLOW_COMPLETED,
         WORKFLOW_STARTED,
+        INTERACTIVE_PROMPT,
     }
 )
 
@@ -112,7 +115,7 @@ async def websocket_handler(websocket: WebSocket, event_bus: EventBus) -> None:
                 elif msg_type == "interactive_complete":
                     await event_bus.emit(
                         EngineEvent(
-                            event_type=BLOCK_DONE,
+                            event_type=INTERACTIVE_COMPLETE,
                             block_id=data.get("block_id"),
                             data=data.get("data", {}),
                         )

--- a/src/scieasy/blocks/process/builtins/__init__.py
+++ b/src/scieasy/blocks/process/builtins/__init__.py
@@ -1,16 +1,20 @@
 """Built-in process blocks shipped with the framework."""
 
+from scieasy.blocks.process.builtins.data_router import DataRouter
 from scieasy.blocks.process.builtins.filter_collection import FilterCollection
 from scieasy.blocks.process.builtins.merge import MergeBlock
 from scieasy.blocks.process.builtins.merge_collection import MergeCollection
+from scieasy.blocks.process.builtins.pair_editor import PairEditor
 from scieasy.blocks.process.builtins.slice_collection import SliceCollection
 from scieasy.blocks.process.builtins.split import SplitBlock
 from scieasy.blocks.process.builtins.split_collection import SplitCollection
 
 __all__ = [
+    "DataRouter",
     "FilterCollection",
     "MergeBlock",
     "MergeCollection",
+    "PairEditor",
     "SliceCollection",
     "SplitBlock",
     "SplitCollection",

--- a/src/scieasy/blocks/process/builtins/data_router.py
+++ b/src/scieasy/blocks/process/builtins/data_router.py
@@ -125,6 +125,9 @@ class DataRouter(ProcessBlock):
                 item_lookup[f"{port_name}:0"] = value
 
         # Route items to output ports per the user's assignments.
+        # Derive item_type per output batch: if all items share the same
+        # type use it; otherwise widen to DataObject so mixed-type routing
+        # (items from different input ports) doesn't fail.
         outputs: dict[str, Any] = {}
         for output_port, item_refs in assignments.items():
             routed_items = []
@@ -133,7 +136,11 @@ class DataRouter(ProcessBlock):
                     logger.warning("DataRouter: unknown item ref '%s', skipping", ref)
                     continue
                 routed_items.append(item_lookup[ref])
-            resolved_type = item_type or DataObject
-            outputs[output_port] = Collection(routed_items, item_type=resolved_type)
+            if routed_items:
+                types_seen = {type(item) for item in routed_items}
+                batch_type = types_seen.pop() if len(types_seen) == 1 else DataObject
+            else:
+                batch_type = DataObject
+            outputs[output_port] = Collection(routed_items, item_type=batch_type)
 
         return outputs

--- a/src/scieasy/blocks/process/builtins/data_router.py
+++ b/src/scieasy/blocks/process/builtins/data_router.py
@@ -1,0 +1,139 @@
+"""DataRouter -- interactive N-input to M-output item routing.
+
+#591: Replaces separate Merge Selection / Slice Collection / Split Collection
+blocks with a single interactive block that lets users drag items from
+any input port to any output port.
+
+First consumer of ADR-029 variadic port system.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, ClassVar
+
+from scieasy.blocks.base.config import BlockConfig
+from scieasy.blocks.base.state import ExecutionMode
+from scieasy.blocks.process.process_block import ProcessBlock
+from scieasy.core.types.base import DataObject
+
+logger = logging.getLogger(__name__)
+
+
+class DataRouter(ProcessBlock):
+    """Interactive N-to-M data routing block.
+
+    Users configure variadic input/output ports (ADR-029). At runtime the
+    block pauses with a drag-and-drop UI for manually routing items from
+    inputs to outputs.
+
+    Runtime flow:
+        1. User configures N input ports + M output ports via variadic editor
+        2. Workflow reaches DataRouter -> PAUSED
+        3. Frontend opens DataRouter modal (drag items from inputs to outputs)
+        4. Confirm -> assignments sent to backend -> block routes items -> DONE
+    """
+
+    name: ClassVar[str] = "Data Router"
+    description: ClassVar[str] = "Interactive drag-and-drop routing of items from N inputs to M outputs"
+    algorithm: ClassVar[str] = "data_router"
+    subcategory: ClassVar[str] = "routing"
+
+    execution_mode: ClassVar[ExecutionMode] = ExecutionMode.INTERACTIVE
+
+    variadic_inputs: ClassVar[bool] = True
+    variadic_outputs: ClassVar[bool] = True
+    allowed_input_types: ClassVar[list[type]] = [DataObject]
+    allowed_output_types: ClassVar[list[type]] = [DataObject]
+    min_input_ports: ClassVar[int | None] = 1
+    min_output_ports: ClassVar[int | None] = 1
+
+    def prepare_prompt(self, inputs: dict[str, Any], config: BlockConfig) -> dict[str, Any]:
+        """Prepare data for the frontend interactive prompt.
+
+        Returns a dict with:
+            input_ports: list of port name strings
+            items_per_port: dict mapping port name to list of item descriptors
+            output_ports: list of output port name strings
+        """
+        from scieasy.core.types.collection import Collection
+
+        input_ports = list(inputs.keys())
+        items_per_port: dict[str, list[dict[str, Any]]] = {}
+
+        for port_name, value in inputs.items():
+            items: list[dict[str, Any]] = []
+            if isinstance(value, Collection):
+                for i, item in enumerate(value):
+                    item_desc: dict[str, Any] = {
+                        "index": i,
+                        "port": port_name,
+                        "ref": f"{port_name}:{i}",
+                        "name": getattr(item, "name", None) or f"item_{i}",
+                        "type": type(item).__name__,
+                    }
+                    items.append(item_desc)
+            else:
+                items.append(
+                    {
+                        "index": 0,
+                        "port": port_name,
+                        "ref": f"{port_name}:0",
+                        "name": getattr(value, "name", None) or "item_0",
+                        "type": type(value).__name__,
+                    }
+                )
+            items_per_port[port_name] = items
+
+        # Read output port names from config.
+        effective_output_ports = self.get_effective_output_ports()
+        output_port_names = [p.name for p in effective_output_ports]
+
+        return {
+            "input_ports": input_ports,
+            "items_per_port": items_per_port,
+            "output_ports": output_port_names,
+        }
+
+    def run(self, inputs: dict[str, Any], config: BlockConfig) -> dict[str, Any]:
+        """Route items from inputs to outputs based on user assignments.
+
+        The ``interactive_response`` in config contains:
+            assignments: dict mapping output port name to list of item refs
+                (each ref is "input_port:index")
+        """
+        from scieasy.core.types.collection import Collection
+
+        response = config.get("interactive_response", {})
+        assignments = response.get("assignments", {})
+
+        if not assignments:
+            raise ValueError("DataRouter received no assignments from interactive response")
+
+        # Build a lookup of all input items by ref.
+        item_lookup: dict[str, Any] = {}
+        item_type: type | None = None
+        for port_name, value in inputs.items():
+            if isinstance(value, Collection):
+                if item_type is None and value.item_type is not None:
+                    item_type = value.item_type
+                for i, item in enumerate(value):
+                    item_lookup[f"{port_name}:{i}"] = item
+            else:
+                if item_type is None:
+                    item_type = type(value)
+                item_lookup[f"{port_name}:0"] = value
+
+        # Route items to output ports per the user's assignments.
+        outputs: dict[str, Any] = {}
+        for output_port, item_refs in assignments.items():
+            routed_items = []
+            for ref in item_refs:
+                if ref not in item_lookup:
+                    logger.warning("DataRouter: unknown item ref '%s', skipping", ref)
+                    continue
+                routed_items.append(item_lookup[ref])
+            resolved_type = item_type or DataObject
+            outputs[output_port] = Collection(routed_items, item_type=resolved_type)
+
+        return outputs

--- a/src/scieasy/blocks/process/builtins/pair_editor.py
+++ b/src/scieasy/blocks/process/builtins/pair_editor.py
@@ -1,0 +1,145 @@
+"""PairEditor -- interactive reordering to fix index-based pairing.
+
+#594: When a multi-input block (e.g. ExtractSpectrum) receives N Collections
+from N parallel branches, it zips by index. If the Collections arrive in
+different orders, the pairing is wrong. PairEditor lets users visually
+reorder items within each Collection so same-index items are paired.
+
+First consumer of ADR-029 variadic port system alongside DataRouter (#591).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, ClassVar
+
+from scieasy.blocks.base.config import BlockConfig
+from scieasy.blocks.base.state import ExecutionMode
+from scieasy.blocks.process.process_block import ProcessBlock
+from scieasy.core.types.base import DataObject
+
+logger = logging.getLogger(__name__)
+
+
+class PairEditor(ProcessBlock):
+    """Interactive item reordering block for fixing index-based pairing.
+
+    Users configure N variadic input ports (2-8). Output ports are
+    auto-mirrored from inputs (same count, same types). At runtime the
+    block pauses with side-by-side sortable panels. Same-row items across
+    panels are "paired" (highlighted with same color). Users drag to
+    reorder within each panel.
+
+    Runtime flow:
+        1. User configures N input ports (2-8), output ports auto-mirror
+        2. Workflow reaches PairEditor -> PAUSED
+        3. Frontend opens PairEditor modal (N side-by-side sortable panels)
+        4. Confirm -> reordered indices sent to backend -> reordered Collections -> DONE
+
+    Validation: All input Collections must have equal length.
+    """
+
+    name: ClassVar[str] = "Pair Editor"
+    description: ClassVar[str] = "Interactive reordering of items within Collections for correct index-based pairing"
+    algorithm: ClassVar[str] = "pair_editor"
+    subcategory: ClassVar[str] = "routing"
+
+    execution_mode: ClassVar[ExecutionMode] = ExecutionMode.INTERACTIVE
+
+    variadic_inputs: ClassVar[bool] = True
+    variadic_outputs: ClassVar[bool] = True
+    allowed_input_types: ClassVar[list[type]] = [DataObject]
+    allowed_output_types: ClassVar[list[type]] = [DataObject]
+    min_input_ports: ClassVar[int | None] = 2
+    max_input_ports: ClassVar[int | None] = 8
+
+    def prepare_prompt(self, inputs: dict[str, Any], config: BlockConfig) -> dict[str, Any]:
+        """Prepare data for the frontend interactive prompt.
+
+        Validates equal-length Collections and returns item descriptors
+        for each port.
+
+        Returns a dict with:
+            ports: list of port name strings
+            items_per_port: dict mapping port name to list of item descriptors
+            collection_length: int (common length of all Collections)
+        """
+        from scieasy.core.types.collection import Collection
+
+        ports = list(inputs.keys())
+        items_per_port: dict[str, list[dict[str, Any]]] = {}
+        lengths: dict[str, int] = {}
+
+        for port_name, value in inputs.items():
+            items: list[dict[str, Any]] = []
+            if isinstance(value, Collection):
+                lengths[port_name] = len(value)
+                for i, item in enumerate(value):
+                    item_desc: dict[str, Any] = {
+                        "index": i,
+                        "name": getattr(item, "name", None) or f"item_{i}",
+                        "type": type(item).__name__,
+                    }
+                    items.append(item_desc)
+            else:
+                lengths[port_name] = 1
+                items.append(
+                    {
+                        "index": 0,
+                        "name": getattr(value, "name", None) or "item_0",
+                        "type": type(value).__name__,
+                    }
+                )
+            items_per_port[port_name] = items
+
+        # Validate equal length.
+        unique_lengths = set(lengths.values())
+        if len(unique_lengths) > 1:
+            detail = ", ".join(f"{k}={v}" for k, v in lengths.items())
+            raise ValueError(f"PairEditor requires all input Collections to have equal length. Got: {detail}")
+
+        collection_length = unique_lengths.pop() if unique_lengths else 0
+
+        return {
+            "ports": ports,
+            "items_per_port": items_per_port,
+            "collection_length": collection_length,
+        }
+
+    def run(self, inputs: dict[str, Any], config: BlockConfig) -> dict[str, Any]:
+        """Reorder items in each Collection based on user-specified indices.
+
+        The ``interactive_response`` in config contains:
+            reorder: dict mapping port name to list of indices (new order)
+                e.g. {"A": [2, 0, 4, 1, 3], "B": [2, 0, 4, 1, 3]}
+        """
+        from scieasy.core.types.collection import Collection
+
+        response = config.get("interactive_response", {})
+        reorder = response.get("reorder", {})
+
+        if not reorder:
+            raise ValueError("PairEditor received no reorder data from interactive response")
+
+        outputs: dict[str, Any] = {}
+        for port_name, value in inputs.items():
+            indices = reorder.get(port_name)
+            if indices is None:
+                # If no reorder specified for this port, pass through unchanged.
+                outputs[port_name] = value
+                continue
+
+            if isinstance(value, Collection):
+                items = list(value)
+                if len(indices) != len(items):
+                    raise ValueError(
+                        f"PairEditor: reorder indices length ({len(indices)}) does not match "
+                        f"Collection length ({len(items)}) for port '{port_name}'"
+                    )
+                reordered = [items[i] for i in indices]
+                outputs[port_name] = Collection(reordered, item_type=value.item_type)
+            else:
+                # Single item — pass through.
+                outputs[port_name] = value
+
+        return outputs

--- a/src/scieasy/engine/events.py
+++ b/src/scieasy/engine/events.py
@@ -34,6 +34,8 @@ PROCESS_EXITED = "process_exited"  # ADR-017/019
 WORKFLOW_STARTED = "workflow_started"  # ADR-018
 WORKFLOW_COMPLETED = "workflow_completed"  # ADR-018
 CHECKPOINT_SAVED = "checkpoint_saved"  # ADR-018
+INTERACTIVE_PROMPT = "interactive_prompt"  # #591/#594: backend -> frontend interactive data
+INTERACTIVE_COMPLETE = "interactive_complete"  # #591/#594: frontend -> backend interactive response
 
 
 @dataclass

--- a/src/scieasy/engine/scheduler.py
+++ b/src/scieasy/engine/scheduler.py
@@ -625,9 +625,14 @@ class DAGScheduler:
         the cancel request is transitioned to SKIPPED with reason
         "workflow cancelled".
         """
-        running_blocks = [bid for bid, state in self._block_states.items() if state == BlockState.RUNNING]
+        # Include both RUNNING and PAUSED blocks — interactive blocks
+        # (DataRouter, PairEditor) sit in PAUSED while waiting for user
+        # input via an asyncio.Future. They must also be cancelled.
+        cancelable_blocks = [
+            bid for bid, state in self._block_states.items() if state in (BlockState.RUNNING, BlockState.PAUSED)
+        ]
 
-        for block_id in running_blocks:
+        for block_id in cancelable_blocks:
             handle = None
             if self._process_registry is not None:
                 handle = self._process_registry.get_handle(block_id)
@@ -648,6 +653,12 @@ class DAGScheduler:
                 task = self._active_tasks.get(block_id)
                 if task is not None and not task.done():
                     task.cancel()
+
+            # Cancel interactive future if the block is PAUSED waiting
+            # for user input (DataRouter/PairEditor).
+            interactive_future = self._interactive_futures.pop(block_id, None)
+            if interactive_future is not None and not interactive_future.done():
+                interactive_future.cancel()
 
             if hasattr(self._runner, "cancel"):
                 try:

--- a/src/scieasy/engine/scheduler.py
+++ b/src/scieasy/engine/scheduler.py
@@ -8,16 +8,19 @@ import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
-from scieasy.blocks.base.state import BlockState
+from scieasy.blocks.base.state import BlockState, ExecutionMode
 from scieasy.engine.dag import build_dag, get_downstream_blocks, topological_sort
 from scieasy.engine.events import (
     BLOCK_CANCELLED,
     BLOCK_DONE,
     BLOCK_ERROR,
+    BLOCK_PAUSED,
     BLOCK_RUNNING,
     BLOCK_SKIPPED,
     CANCEL_BLOCK_REQUEST,
     CANCEL_WORKFLOW_REQUEST,
+    INTERACTIVE_COMPLETE,
+    INTERACTIVE_PROMPT,
     PROCESS_EXITED,
     WORKFLOW_COMPLETED,
     WORKFLOW_STARTED,
@@ -125,11 +128,17 @@ class DAGScheduler:
         self._paused = False
         self._reset_lock = asyncio.Lock()
 
+        # #591/#594: Pending interactive responses. Maps block_id to an
+        # asyncio.Future that is resolved when the frontend sends an
+        # interactive_complete message for that block.
+        self._interactive_futures: dict[str, asyncio.Future[dict[str, Any]]] = {}
+
         self._event_bus.subscribe(BLOCK_DONE, self._on_block_done)
         self._event_bus.subscribe(BLOCK_ERROR, self._on_block_error)
         self._event_bus.subscribe(CANCEL_BLOCK_REQUEST, self._on_cancel_block)
         self._event_bus.subscribe(CANCEL_WORKFLOW_REQUEST, self._on_cancel_workflow)
         self._event_bus.subscribe(PROCESS_EXITED, self._on_process_exited)
+        self._event_bus.subscribe(INTERACTIVE_COMPLETE, self._on_interactive_complete)
 
     async def execute(self) -> None:
         """Begin executing the workflow from its current state.
@@ -239,10 +248,22 @@ class DAGScheduler:
         if self._project_dir:
             enriched_config["project_dir"] = self._project_dir
 
-        task = asyncio.create_task(
-            self._run_and_finalize(node_id, block, inputs, enriched_config),
-            name=f"dispatch:{node_id}",
-        )
+        # #591/#594: Interactive blocks run in-process (no subprocess) because
+        # they need bidirectional communication with the frontend. The block
+        # pauses, sends data to the frontend, waits for user response, then
+        # produces outputs.
+        is_interactive = getattr(block, "execution_mode", None) == ExecutionMode.INTERACTIVE
+
+        if is_interactive:
+            task = asyncio.create_task(
+                self._run_interactive(node_id, block, inputs, enriched_config),
+                name=f"dispatch-interactive:{node_id}",
+            )
+        else:
+            task = asyncio.create_task(
+                self._run_and_finalize(node_id, block, inputs, enriched_config),
+                name=f"dispatch:{node_id}",
+            )
         self._active_tasks[node_id] = task
 
     async def _run_and_finalize(
@@ -304,6 +325,146 @@ class DAGScheduler:
             # "no active tasks" once the final block finalises.
             self._active_tasks.pop(node_id, None)
             self._check_completion()
+
+    async def _run_interactive(
+        self,
+        node_id: str,
+        block: Any,
+        inputs: dict[str, Any],
+        config: dict[str, Any],
+    ) -> None:
+        """Execute an interactive block: PAUSE, prompt frontend, await response, run.
+
+        #591/#594: Interactive blocks (DataRouter, PairEditor) run in-process
+        because they need bidirectional WebSocket communication. The flow is:
+
+        1. Transition to PAUSED, emit BLOCK_PAUSED
+        2. Call ``block.prepare_prompt(inputs, config)`` to get data for the UI
+        3. Emit INTERACTIVE_PROMPT with the prepared data
+        4. Await the user's response via an asyncio.Future
+        5. Call ``block.run(inputs, config)`` with the response merged into config
+        6. Transition to DONE, emit BLOCK_DONE with outputs
+        """
+        try:
+            try:
+                # Step 1: Transition to PAUSED.
+                self._block_states[node_id] = BlockState.PAUSED
+                await self._event_bus.emit(
+                    EngineEvent(
+                        event_type=BLOCK_PAUSED,
+                        block_id=node_id,
+                        data={"workflow_id": self._workflow.id},
+                    )
+                )
+
+                # Step 2: Prepare the interactive prompt data.
+                prompt_data = {}
+                if hasattr(block, "prepare_prompt"):
+                    from scieasy.blocks.base.config import BlockConfig
+
+                    prompt_data = block.prepare_prompt(inputs, BlockConfig(**config))
+
+                # Step 3: Emit INTERACTIVE_PROMPT for the frontend.
+                await self._event_bus.emit(
+                    EngineEvent(
+                        event_type=INTERACTIVE_PROMPT,
+                        block_id=node_id,
+                        data={
+                            "workflow_id": self._workflow.id,
+                            "block_type": config.get("block_type", type(block).__name__),
+                            **prompt_data,
+                        },
+                    )
+                )
+
+                # Step 4: Create a future and wait for interactive_complete.
+                loop = asyncio.get_running_loop()
+                future: asyncio.Future[dict[str, Any]] = loop.create_future()
+                self._interactive_futures[node_id] = future
+
+                response_data = await future
+
+                # Step 5: Run the block with the user's response.
+                # Check for cancellation before running.
+                if self._block_states.get(node_id) == BlockState.CANCELLED:
+                    logger.info("Interactive block %s was cancelled while paused", node_id)
+                    return
+
+                self._block_states[node_id] = BlockState.RUNNING
+                await self._event_bus.emit(
+                    EngineEvent(
+                        event_type=BLOCK_RUNNING,
+                        block_id=node_id,
+                        data={"workflow_id": self._workflow.id},
+                    )
+                )
+
+                # Merge the user response into config for the block's run().
+                enriched_config = dict(config)
+                enriched_config["interactive_response"] = response_data
+
+                from scieasy.blocks.base.config import BlockConfig
+
+                result = block.run(inputs, BlockConfig(**enriched_config))
+
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                if self._block_states.get(node_id) == BlockState.CANCELLED:
+                    logger.info("Interactive block %s exited after cancellation", node_id)
+                    self.save_checkpoint(self._checkpoint_manager)
+                    return
+                logger.exception("Interactive block %s failed with exception", node_id)
+                self._block_states[node_id] = BlockState.ERROR
+                error_str = str(exc)
+                await self._event_bus.emit(
+                    EngineEvent(
+                        event_type=BLOCK_ERROR,
+                        block_id=node_id,
+                        data={
+                            "workflow_id": self._workflow.id,
+                            "error": error_str,
+                            "error_summary": _extract_error_summary(error_str),
+                        },
+                    )
+                )
+                self.save_checkpoint(self._checkpoint_manager)
+                return
+
+            # Step 6: Transition to DONE.
+            self._block_outputs[node_id] = result
+            self._block_states[node_id] = BlockState.DONE
+            await self._event_bus.emit(
+                EngineEvent(
+                    event_type=BLOCK_DONE,
+                    block_id=node_id,
+                    data={"workflow_id": self._workflow.id, "outputs": result},
+                )
+            )
+            self.save_checkpoint(self._checkpoint_manager)
+        finally:
+            self._interactive_futures.pop(node_id, None)
+            self._active_tasks.pop(node_id, None)
+            self._check_completion()
+
+    async def _on_interactive_complete(self, event: EngineEvent) -> None:
+        """Handle an interactive_complete event from the frontend.
+
+        Resolves the pending future for the block so that
+        ``_run_interactive`` can proceed with the user's response.
+        """
+        block_id = event.block_id
+        if block_id is None:
+            return
+
+        future = self._interactive_futures.get(block_id)
+        if future is not None and not future.done():
+            future.set_result(event.data)
+        else:
+            logger.warning(
+                "Received interactive_complete for block %s but no pending future found",
+                block_id,
+            )
 
     def _instantiate_block(self, node_id: str) -> Any:
         """Instantiate the concrete block for a DAG node.
@@ -419,6 +580,12 @@ class DAGScheduler:
         # _run_and_finalize's exception path sees the CANCELLED state
         # and does not re-emit BLOCK_ERROR.
         self._block_states[block_id] = BlockState.CANCELLED
+
+        # #591/#594: Cancel pending interactive future so _run_interactive
+        # receives CancelledError and unwinds.
+        interactive_future = self._interactive_futures.pop(block_id, None)
+        if interactive_future is not None and not interactive_future.done():
+            interactive_future.cancel()
 
         if handle is not None:
             # Authoritative path per ADR-019 — SIGTERM/SIGKILL the worker.

--- a/tests/blocks/test_data_router.py
+++ b/tests/blocks/test_data_router.py
@@ -1,0 +1,198 @@
+"""Tests for DataRouter interactive variadic block (#591)."""
+
+from __future__ import annotations
+
+import pytest
+
+from scieasy.blocks.base.config import BlockConfig
+from scieasy.blocks.base.state import ExecutionMode
+from scieasy.blocks.process.builtins.data_router import DataRouter
+from scieasy.core.types.base import DataObject
+from scieasy.core.types.collection import Collection
+
+
+class StubItem(DataObject):
+    """Minimal DataObject stub for testing."""
+
+    def __init__(self, name: str = "item") -> None:
+        super().__init__()
+        self.name = name
+
+
+class TestDataRouterMetadata:
+    """Test DataRouter class-level metadata and variadic port declarations."""
+
+    def test_name(self) -> None:
+        assert DataRouter.name == "Data Router"
+
+    def test_subcategory(self) -> None:
+        assert DataRouter.subcategory == "routing"
+
+    def test_execution_mode_is_interactive(self) -> None:
+        assert DataRouter.execution_mode == ExecutionMode.INTERACTIVE
+
+    def test_variadic_flags(self) -> None:
+        assert DataRouter.variadic_inputs is True
+        assert DataRouter.variadic_outputs is True
+
+    def test_allowed_types(self) -> None:
+        assert DataRouter.allowed_input_types == [DataObject]
+        assert DataRouter.allowed_output_types == [DataObject]
+
+    def test_min_ports(self) -> None:
+        assert DataRouter.min_input_ports == 1
+        assert DataRouter.min_output_ports == 1
+
+
+class TestDataRouterPreparePrompt:
+    """Test prepare_prompt() generates correct data for the frontend."""
+
+    def test_single_input_port(self) -> None:
+        block = DataRouter(
+            config={
+                "input_ports": [{"name": "images", "types": ["DataObject"]}],
+                "output_ports": [{"name": "batch_1", "types": ["DataObject"]}],
+            }
+        )
+        col = Collection([StubItem("im1"), StubItem("im2")], item_type=StubItem)
+        inputs = {"images": col}
+        config = BlockConfig()
+
+        result = block.prepare_prompt(inputs, config)
+
+        assert result["input_ports"] == ["images"]
+        assert len(result["items_per_port"]["images"]) == 2
+        assert result["items_per_port"]["images"][0]["ref"] == "images:0"
+        assert result["items_per_port"]["images"][0]["name"] == "im1"
+        assert result["items_per_port"]["images"][1]["ref"] == "images:1"
+        assert result["output_ports"] == ["batch_1"]
+
+    def test_multiple_input_ports(self) -> None:
+        block = DataRouter(
+            config={
+                "input_ports": [
+                    {"name": "port_a", "types": ["DataObject"]},
+                    {"name": "port_b", "types": ["DataObject"]},
+                ],
+                "output_ports": [
+                    {"name": "out_x", "types": ["DataObject"]},
+                    {"name": "out_y", "types": ["DataObject"]},
+                ],
+            }
+        )
+        col_a = Collection([StubItem("a1")], item_type=StubItem)
+        col_b = Collection([StubItem("b1"), StubItem("b2")], item_type=StubItem)
+        inputs = {"port_a": col_a, "port_b": col_b}
+        config = BlockConfig()
+
+        result = block.prepare_prompt(inputs, config)
+
+        assert set(result["input_ports"]) == {"port_a", "port_b"}
+        assert len(result["items_per_port"]["port_a"]) == 1
+        assert len(result["items_per_port"]["port_b"]) == 2
+        assert set(result["output_ports"]) == {"out_x", "out_y"}
+
+
+class TestDataRouterRun:
+    """Test run() routes items based on user assignments."""
+
+    def test_basic_routing(self) -> None:
+        block = DataRouter(
+            config={
+                "input_ports": [{"name": "images", "types": ["DataObject"]}],
+                "output_ports": [
+                    {"name": "batch_1", "types": ["DataObject"]},
+                    {"name": "batch_2", "types": ["DataObject"]},
+                ],
+            }
+        )
+
+        items = [StubItem("im1"), StubItem("im2"), StubItem("im3")]
+        col = Collection(items, item_type=StubItem)
+        inputs = {"images": col}
+
+        config = BlockConfig(
+            **{
+                "interactive_response": {
+                    "assignments": {
+                        "batch_1": ["images:0", "images:2"],
+                        "batch_2": ["images:1"],
+                    }
+                }
+            }
+        )
+
+        result = block.run(inputs, config)
+
+        assert "batch_1" in result
+        assert "batch_2" in result
+        assert len(result["batch_1"]) == 2
+        assert len(result["batch_2"]) == 1
+        assert next(iter(result["batch_1"])).name == "im1"
+        assert list(result["batch_1"])[1].name == "im3"
+        assert next(iter(result["batch_2"])).name == "im2"
+
+    def test_cross_port_routing(self) -> None:
+        """Items from different input ports can be routed to the same output."""
+        block = DataRouter(
+            config={
+                "input_ports": [
+                    {"name": "a", "types": ["DataObject"]},
+                    {"name": "b", "types": ["DataObject"]},
+                ],
+                "output_ports": [{"name": "merged", "types": ["DataObject"]}],
+            }
+        )
+
+        col_a = Collection([StubItem("a1")], item_type=StubItem)
+        col_b = Collection([StubItem("b1")], item_type=StubItem)
+        inputs = {"a": col_a, "b": col_b}
+
+        config = BlockConfig(
+            **{
+                "interactive_response": {
+                    "assignments": {
+                        "merged": ["a:0", "b:0"],
+                    }
+                }
+            }
+        )
+
+        result = block.run(inputs, config)
+        assert len(result["merged"]) == 2
+
+    def test_no_assignments_raises(self) -> None:
+        block = DataRouter(
+            config={
+                "input_ports": [{"name": "input", "types": ["DataObject"]}],
+                "output_ports": [{"name": "output", "types": ["DataObject"]}],
+            }
+        )
+        col = Collection([StubItem("item")], item_type=StubItem)
+
+        with pytest.raises(ValueError, match="no assignments"):
+            block.run({"input": col}, BlockConfig(**{"interactive_response": {}}))
+
+    def test_unknown_ref_skipped(self) -> None:
+        """Unknown item refs are skipped with a warning, not an error."""
+        block = DataRouter(
+            config={
+                "input_ports": [{"name": "input", "types": ["DataObject"]}],
+                "output_ports": [{"name": "output", "types": ["DataObject"]}],
+            }
+        )
+        col = Collection([StubItem("item")], item_type=StubItem)
+
+        config = BlockConfig(
+            **{
+                "interactive_response": {
+                    "assignments": {
+                        "output": ["input:0", "nonexistent:99"],
+                    }
+                }
+            }
+        )
+
+        result = block.run({"input": col}, config)
+        # Only the valid ref should be routed.
+        assert len(result["output"]) == 1

--- a/tests/blocks/test_pair_editor.py
+++ b/tests/blocks/test_pair_editor.py
@@ -1,0 +1,296 @@
+"""Tests for PairEditor interactive variadic block (#594)."""
+
+from __future__ import annotations
+
+import pytest
+
+from scieasy.blocks.base.config import BlockConfig
+from scieasy.blocks.base.state import ExecutionMode
+from scieasy.blocks.process.builtins.pair_editor import PairEditor
+from scieasy.core.types.base import DataObject
+from scieasy.core.types.collection import Collection
+
+
+class StubItem(DataObject):
+    """Minimal DataObject stub for testing."""
+
+    def __init__(self, name: str = "item") -> None:
+        super().__init__()
+        self.name = name
+
+
+class TestPairEditorMetadata:
+    """Test PairEditor class-level metadata and variadic port declarations."""
+
+    def test_name(self) -> None:
+        assert PairEditor.name == "Pair Editor"
+
+    def test_subcategory(self) -> None:
+        assert PairEditor.subcategory == "routing"
+
+    def test_execution_mode_is_interactive(self) -> None:
+        assert PairEditor.execution_mode == ExecutionMode.INTERACTIVE
+
+    def test_variadic_flags(self) -> None:
+        assert PairEditor.variadic_inputs is True
+        assert PairEditor.variadic_outputs is True
+
+    def test_port_limits(self) -> None:
+        assert PairEditor.min_input_ports == 2
+        assert PairEditor.max_input_ports == 8
+
+    def test_allowed_types(self) -> None:
+        assert PairEditor.allowed_input_types == [DataObject]
+        assert PairEditor.allowed_output_types == [DataObject]
+
+
+class TestPairEditorPreparePrompt:
+    """Test prepare_prompt() generates correct data for the frontend."""
+
+    def test_two_equal_collections(self) -> None:
+        block = PairEditor(
+            config={
+                "input_ports": [
+                    {"name": "A", "types": ["DataObject"]},
+                    {"name": "B", "types": ["DataObject"]},
+                ],
+                "output_ports": [
+                    {"name": "A", "types": ["DataObject"]},
+                    {"name": "B", "types": ["DataObject"]},
+                ],
+            }
+        )
+        col_a = Collection([StubItem("a1"), StubItem("a2"), StubItem("a3")], item_type=StubItem)
+        col_b = Collection([StubItem("b1"), StubItem("b2"), StubItem("b3")], item_type=StubItem)
+        inputs = {"A": col_a, "B": col_b}
+        config = BlockConfig()
+
+        result = block.prepare_prompt(inputs, config)
+
+        assert set(result["ports"]) == {"A", "B"}
+        assert result["collection_length"] == 3
+        assert len(result["items_per_port"]["A"]) == 3
+        assert len(result["items_per_port"]["B"]) == 3
+        assert result["items_per_port"]["A"][0]["name"] == "a1"
+
+    def test_unequal_lengths_raises(self) -> None:
+        block = PairEditor(
+            config={
+                "input_ports": [
+                    {"name": "A", "types": ["DataObject"]},
+                    {"name": "B", "types": ["DataObject"]},
+                ],
+                "output_ports": [
+                    {"name": "A", "types": ["DataObject"]},
+                    {"name": "B", "types": ["DataObject"]},
+                ],
+            }
+        )
+        col_a = Collection([StubItem("a1"), StubItem("a2")], item_type=StubItem)
+        col_b = Collection([StubItem("b1"), StubItem("b2"), StubItem("b3")], item_type=StubItem)
+        inputs = {"A": col_a, "B": col_b}
+        config = BlockConfig()
+
+        with pytest.raises(ValueError, match="equal length"):
+            block.prepare_prompt(inputs, config)
+
+    def test_three_ports(self) -> None:
+        block = PairEditor(
+            config={
+                "input_ports": [
+                    {"name": "X", "types": ["DataObject"]},
+                    {"name": "Y", "types": ["DataObject"]},
+                    {"name": "Z", "types": ["DataObject"]},
+                ],
+                "output_ports": [
+                    {"name": "X", "types": ["DataObject"]},
+                    {"name": "Y", "types": ["DataObject"]},
+                    {"name": "Z", "types": ["DataObject"]},
+                ],
+            }
+        )
+        items = [StubItem(f"i{i}") for i in range(5)]
+        inputs = {
+            "X": Collection(items, item_type=StubItem),
+            "Y": Collection(items, item_type=StubItem),
+            "Z": Collection(items, item_type=StubItem),
+        }
+        config = BlockConfig()
+
+        result = block.prepare_prompt(inputs, config)
+
+        assert result["collection_length"] == 5
+        assert len(result["ports"]) == 3
+
+
+class TestPairEditorRun:
+    """Test run() reorders items based on user-specified indices."""
+
+    def test_basic_reorder(self) -> None:
+        block = PairEditor(
+            config={
+                "input_ports": [
+                    {"name": "A", "types": ["DataObject"]},
+                    {"name": "B", "types": ["DataObject"]},
+                ],
+                "output_ports": [
+                    {"name": "A", "types": ["DataObject"]},
+                    {"name": "B", "types": ["DataObject"]},
+                ],
+            }
+        )
+
+        col_a = Collection([StubItem("a0"), StubItem("a1"), StubItem("a2")], item_type=StubItem)
+        col_b = Collection([StubItem("b0"), StubItem("b1"), StubItem("b2")], item_type=StubItem)
+        inputs = {"A": col_a, "B": col_b}
+
+        config = BlockConfig(
+            **{
+                "interactive_response": {
+                    "reorder": {
+                        "A": [2, 0, 1],
+                        "B": [1, 2, 0],
+                    }
+                }
+            }
+        )
+
+        result = block.run(inputs, config)
+
+        assert next(iter(result["A"])).name == "a2"
+        assert list(result["A"])[1].name == "a0"
+        assert list(result["A"])[2].name == "a1"
+        assert next(iter(result["B"])).name == "b1"
+        assert list(result["B"])[1].name == "b2"
+        assert list(result["B"])[2].name == "b0"
+
+    def test_identity_reorder(self) -> None:
+        """Confirming without changes should produce same order."""
+        block = PairEditor(
+            config={
+                "input_ports": [
+                    {"name": "A", "types": ["DataObject"]},
+                    {"name": "B", "types": ["DataObject"]},
+                ],
+                "output_ports": [
+                    {"name": "A", "types": ["DataObject"]},
+                    {"name": "B", "types": ["DataObject"]},
+                ],
+            }
+        )
+
+        items_a = [StubItem("x"), StubItem("y")]
+        items_b = [StubItem("p"), StubItem("q")]
+        inputs = {
+            "A": Collection(items_a, item_type=StubItem),
+            "B": Collection(items_b, item_type=StubItem),
+        }
+
+        config = BlockConfig(
+            **{
+                "interactive_response": {
+                    "reorder": {
+                        "A": [0, 1],
+                        "B": [0, 1],
+                    }
+                }
+            }
+        )
+
+        result = block.run(inputs, config)
+
+        assert next(iter(result["A"])).name == "x"
+        assert list(result["A"])[1].name == "y"
+        assert next(iter(result["B"])).name == "p"
+        assert list(result["B"])[1].name == "q"
+
+    def test_no_reorder_raises(self) -> None:
+        block = PairEditor(
+            config={
+                "input_ports": [
+                    {"name": "A", "types": ["DataObject"]},
+                    {"name": "B", "types": ["DataObject"]},
+                ],
+                "output_ports": [
+                    {"name": "A", "types": ["DataObject"]},
+                    {"name": "B", "types": ["DataObject"]},
+                ],
+            }
+        )
+        col = Collection([StubItem("item")], item_type=StubItem)
+
+        with pytest.raises(ValueError, match="no reorder"):
+            block.run(
+                {"A": col, "B": col},
+                BlockConfig(**{"interactive_response": {}}),
+            )
+
+    def test_mismatched_indices_length_raises(self) -> None:
+        block = PairEditor(
+            config={
+                "input_ports": [
+                    {"name": "A", "types": ["DataObject"]},
+                    {"name": "B", "types": ["DataObject"]},
+                ],
+                "output_ports": [
+                    {"name": "A", "types": ["DataObject"]},
+                    {"name": "B", "types": ["DataObject"]},
+                ],
+            }
+        )
+        col = Collection([StubItem("a"), StubItem("b")], item_type=StubItem)
+
+        config = BlockConfig(
+            **{
+                "interactive_response": {
+                    "reorder": {
+                        "A": [0],  # Wrong length — should be 2
+                        "B": [0, 1],
+                    }
+                }
+            }
+        )
+
+        with pytest.raises(ValueError, match="does not match"):
+            block.run({"A": col, "B": col}, config)
+
+    def test_port_without_reorder_passes_through(self) -> None:
+        """If reorder dict omits a port, that port's Collection passes through."""
+        block = PairEditor(
+            config={
+                "input_ports": [
+                    {"name": "A", "types": ["DataObject"]},
+                    {"name": "B", "types": ["DataObject"]},
+                ],
+                "output_ports": [
+                    {"name": "A", "types": ["DataObject"]},
+                    {"name": "B", "types": ["DataObject"]},
+                ],
+            }
+        )
+
+        items_a = [StubItem("a0"), StubItem("a1")]
+        items_b = [StubItem("b0"), StubItem("b1")]
+        inputs = {
+            "A": Collection(items_a, item_type=StubItem),
+            "B": Collection(items_b, item_type=StubItem),
+        }
+
+        config = BlockConfig(
+            **{
+                "interactive_response": {
+                    "reorder": {
+                        "A": [1, 0],
+                        # "B" omitted — should pass through unchanged.
+                    }
+                }
+            }
+        )
+
+        result = block.run(inputs, config)
+
+        assert next(iter(result["A"])).name == "a1"
+        assert list(result["A"])[1].name == "a0"
+        # B passes through unchanged.
+        assert next(iter(result["B"])).name == "b0"
+        assert list(result["B"])[1].name == "b1"


### PR DESCRIPTION
## Summary

- Implement **DataRouter** (#591): interactive N-input to M-output item routing block with drag-and-drop modal
- Implement **PairEditor** (#594): interactive sortable reordering block for fixing index-based pairing
- Add **interactive block execution infrastructure**: new scheduler path for INTERACTIVE execution mode with PAUSED -> prompt -> response -> DONE flow
- Add **WebSocket send capability** to frontend for interactive_complete messages
- First consumers of ADR-029 variadic port system

## Changes

### Backend
- `src/scieasy/blocks/process/builtins/data_router.py` — DataRouter block with `prepare_prompt()` and `run()`
- `src/scieasy/blocks/process/builtins/pair_editor.py` — PairEditor block with equal-length validation
- `src/scieasy/engine/events.py` — New `INTERACTIVE_PROMPT` and `INTERACTIVE_COMPLETE` event types
- `src/scieasy/engine/scheduler.py` — `_run_interactive()` method for in-process interactive blocks, `_on_interactive_complete()` handler, interactive future cancellation
- `src/scieasy/api/ws.py` — Route `interactive_complete` to proper event type, add `INTERACTIVE_PROMPT` to outbound events

### Frontend
- `frontend/src/components/DataRouterModal.tsx` — Drag-and-drop routing modal (HTML5 DnD API, no external deps)
- `frontend/src/components/PairEditorModal.tsx` — Sortable reordering modal with row color pairing
- `frontend/src/hooks/useWebSocket.ts` — Expose `sendWebSocketMessage()`, handle `interactive_prompt` events
- `frontend/src/store/` — `InteractivePrompt` type, `interactivePrompt` state, `setInteractivePrompt` action
- `frontend/src/App.tsx` — Render DataRouterModal/PairEditorModal when interactive prompt is active
- `frontend/src/components/nodes/BlockNode.tsx` — "Waiting for user input" indicator for PAUSED non-app blocks

### Tests
- `tests/blocks/test_data_router.py` — 12 tests: metadata, prepare_prompt, routing logic, error handling
- `tests/blocks/test_pair_editor.py` — 14 tests: metadata, prepare_prompt, reordering logic, validation

### Docs
- `docs/guides/block-sdk.md` — New Appendix B documenting interactive block execution flow and authoring pattern

## Related Issues
Closes #591, Closes #594, Closes #644

## Test plan
- [x] All 26 new tests pass
- [x] All 110 block tests pass (no regressions)
- [x] All 297 engine tests pass (no regressions)
- [x] Frontend builds successfully (TypeScript + Vite)
- [x] Ruff lint clean
- [ ] Manual test: create workflow with DataRouter, verify drag-and-drop modal
- [ ] Manual test: create workflow with PairEditor, verify sortable reordering modal