### PR TITLE
feat(#651): implement ADR-032 MetadataStore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- [#651] Implement ADR-032 MetadataStore — SQLite persistent mirror of DataObject metadata with engine-side writes, checkpoint restore sync, and 30 unit tests (@claude, 2026-04-12, branch: feat/issue-651/adr-032-metadata-store, session: 20260412-003142-implement-adr-032-metadatastore-639-640)
 - [#644] Implement DataRouter + PairEditor interactive variadic blocks — first consumers of ADR-029 variadic ports, with interactive PAUSED execution mode, drag-and-drop routing modal, sortable pairing modal, and scheduler interactive flow (@claude, 2026-04-11, branch: feat/issue-644/data-router-pair-editor, session: 20260411-225938-implement-datarouter-paireditor-interact)
 - [#595] Implement variadic port count min/max limits (ADR-029 Addendum 1) (@claude, 2026-04-11, branch: feat/issue-595/variadic-port-min-max-limits, session: 20260411-101739-implement-adr-029-addendum-1-variadic-po)
 

--- a/docs/adr/ADR-032-draft.md
+++ b/docs/adr/ADR-032-draft.md
@@ -1,6 +1,6 @@
 ## ADR-032: Project-Level Metadata Store — SQLite Persistent Mirror of DataObject Metadata
 
-**Status**: draft
+**Status**: accepted
 **Date**: 2026-04-11
 **Related**: ADR-007 (lazy loading), ADR-017 (cross-process transport), ADR-027 D5 (three-slot metadata), ADR-031 (reference-only contract)
 

--- a/src/scieasy/api/runtime.py
+++ b/src/scieasy/api/runtime.py
@@ -312,6 +312,29 @@ class ApiRuntime:
         registry.scan(include_monorepo=os.environ.get("SCIEASY_DEV") == "1")
         self.block_registry = registry
 
+    def _init_metadata_store(self, project_path: Path) -> None:
+        """Initialize the project-level MetadataStore (ADR-032).
+
+        Creates or opens the SQLite database at ``<project>/metadata.db``
+        and sets the module-level singleton so that the engine scheduler
+        can persist DataObject metadata after block execution.
+
+        Non-fatal: if initialization fails the store is set to None and
+        the system degrades to pre-ADR-032 behaviour (no metadata persistence).
+        """
+        try:
+            from scieasy.core.metadata_store import MetadataStore, set_metadata_store
+
+            db_path = project_path / "metadata.db"
+            store = MetadataStore(db_path)
+            set_metadata_store(store)
+            logger.info("ADR-032: MetadataStore opened at %s", db_path)
+        except Exception:
+            logger.warning("ADR-032: Failed to initialize MetadataStore (non-fatal)", exc_info=True)
+            from scieasy.core.metadata_store import set_metadata_store
+
+            set_metadata_store(None)
+
     def create_project(self, name: str, description: str = "", parent_path: str | None = None) -> KnownProject:
         parent_dir = _safe_parent_dir(parent_path)
         project_path = parent_dir / _slugify(name)
@@ -406,6 +429,7 @@ class ApiRuntime:
         self.active_project = candidate
         self.data_catalog = {}
         self.refresh_block_registry()
+        self._init_metadata_store(Path(candidate.path))
         return candidate
 
     def update_project(

--- a/src/scieasy/core/metadata_store.py
+++ b/src/scieasy/core/metadata_store.py
@@ -1,0 +1,389 @@
+"""MetadataStore -- project-level SQLite persistent mirror of DataObject metadata.
+
+Implements ADR-032: a per-project SQLite database that stores the exact
+wire-format JSON produced by :func:`_serialise_one` for every DataObject
+that passes through the engine.  The database preserves framework
+identity, typed plugin metadata, and user annotations across project
+reopens, checkpoint restores, and cross-workflow data reuse.
+
+The store is **not** a replacement for storage backends (Zarr, Arrow,
+filesystem) -- those still store the data payloads.  This database
+stores only the DataObject identity and metadata envelope.
+
+Per ADR-032 Addendum 1, writes happen in the **engine process** (not
+worker subprocesses) after the engine receives wire-format output dicts.
+The singleton accessor (:func:`get_metadata_store`) follows the same
+pattern as :mod:`scieasy.core.storage.flush_context`.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from scieasy.core.types.base import DataObject
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Schema version -- bump when the table DDL changes.
+# ---------------------------------------------------------------------------
+_SCHEMA_VERSION = 1
+
+_CREATE_TABLE = """\
+CREATE TABLE IF NOT EXISTS data_objects (
+    object_id       TEXT PRIMARY KEY,
+    derived_from    TEXT,
+    type_name       TEXT NOT NULL,
+    backend         TEXT,
+    storage_path    TEXT,
+    created_at      TEXT NOT NULL,
+    wire_payload    TEXT NOT NULL,
+    workflow_id     TEXT,
+    block_id        TEXT,
+    port_name       TEXT
+);
+"""
+
+_CREATE_INDEXES = [
+    "CREATE INDEX IF NOT EXISTS idx_derived_from ON data_objects(derived_from);",
+    "CREATE INDEX IF NOT EXISTS idx_type_name ON data_objects(type_name);",
+    "CREATE INDEX IF NOT EXISTS idx_storage_path ON data_objects(storage_path);",
+    "CREATE INDEX IF NOT EXISTS idx_workflow_block ON data_objects(workflow_id, block_id);",
+]
+
+
+# ---------------------------------------------------------------------------
+# MetadataStore
+# ---------------------------------------------------------------------------
+
+
+class MetadataStore:
+    """Project-level SQLite metadata store for DataObject identity and metadata.
+
+    Each project directory contains one ``metadata.db`` file.  The database
+    mirrors the wire-format JSON produced by ``_serialise_one()``, with
+    extracted index columns for efficient queries.
+
+    Parameters
+    ----------
+    db_path:
+        Path to the SQLite database file.  Created if it does not exist.
+    """
+
+    def __init__(self, db_path: str | Path) -> None:
+        self._db_path = Path(db_path)
+        self._db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._conn = sqlite3.connect(str(self._db_path))
+        self._conn.execute("PRAGMA journal_mode=WAL;")
+        self._conn.execute("PRAGMA foreign_keys=ON;")
+        self._init_schema()
+
+    # -- Schema management --------------------------------------------------
+
+    def _init_schema(self) -> None:
+        """Create tables/indexes if absent and track schema version."""
+        current_version = self._conn.execute("PRAGMA user_version;").fetchone()[0]
+        if current_version < _SCHEMA_VERSION:
+            self._conn.execute(_CREATE_TABLE)
+            for idx_sql in _CREATE_INDEXES:
+                self._conn.execute(idx_sql)
+            self._conn.execute(f"PRAGMA user_version = {_SCHEMA_VERSION};")
+            self._conn.commit()
+
+    # -- Write methods ------------------------------------------------------
+
+    def put(
+        self,
+        obj: DataObject,
+        workflow_id: str | None = None,
+        block_id: str | None = None,
+        port_name: str | None = None,
+    ) -> None:
+        """Persist DataObject metadata.  Upsert by ``object_id``.
+
+        Serialises *obj* via ``_serialise_one()`` then delegates to
+        :meth:`put_wire`.
+        """
+        from scieasy.core.types.serialization import _serialise_one
+
+        wire_dict = _serialise_one(obj)
+        self.put_wire(wire_dict, workflow_id=workflow_id, block_id=block_id, port_name=port_name)
+
+    def put_wire(
+        self,
+        wire_dict: dict[str, Any],
+        workflow_id: str | None = None,
+        block_id: str | None = None,
+        port_name: str | None = None,
+    ) -> None:
+        """Persist a raw wire-format dict.  Upsert by ``object_id``.
+
+        Extracts index columns from the wire-format structure and performs
+        an ``INSERT OR REPLACE``.  If the dict has no ``object_id`` in its
+        ``metadata.framework`` sub-dict the call is silently ignored (cannot
+        store without identity).
+
+        Parameters
+        ----------
+        wire_dict:
+            The exact dict produced by ``_serialise_one()``.
+        workflow_id:
+            Optional workflow identifier for bookkeeping.
+        block_id:
+            Optional block identifier for bookkeeping.
+        port_name:
+            Optional output port name for bookkeeping.
+        """
+        md = wire_dict.get("metadata") or {}
+        if not isinstance(md, dict):
+            return
+        framework = md.get("framework") or {}
+        if not isinstance(framework, dict):
+            return
+        object_id = framework.get("object_id")
+        if not object_id:
+            return
+
+        type_chain = md.get("type_chain")
+        type_name = str(type_chain[-1]) if isinstance(type_chain, list) and type_chain else "DataObject"
+
+        self._conn.execute(
+            "INSERT OR REPLACE INTO data_objects "
+            "(object_id, derived_from, type_name, backend, storage_path, "
+            "created_at, wire_payload, workflow_id, block_id, port_name) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                object_id,
+                framework.get("derived_from"),
+                type_name,
+                wire_dict.get("backend"),
+                wire_dict.get("path"),
+                framework.get("created_at", ""),
+                json.dumps(wire_dict),
+                workflow_id,
+                block_id,
+                port_name,
+            ),
+        )
+        self._conn.commit()
+
+    def put_wire_if_missing(
+        self,
+        wire_dict: dict[str, Any],
+        workflow_id: str | None = None,
+        block_id: str | None = None,
+        port_name: str | None = None,
+    ) -> None:
+        """Insert wire-format dict only when the object_id is not already stored.
+
+        Used by checkpoint restore sync to avoid overwriting entries that
+        were written during a prior execution.
+        """
+        md = wire_dict.get("metadata") or {}
+        if not isinstance(md, dict):
+            return
+        framework = md.get("framework") or {}
+        if not isinstance(framework, dict):
+            return
+        object_id = framework.get("object_id")
+        if not object_id:
+            return
+
+        existing = self._conn.execute(
+            "SELECT 1 FROM data_objects WHERE object_id = ?",
+            (object_id,),
+        ).fetchone()
+        if existing is not None:
+            return
+
+        self.put_wire(wire_dict, workflow_id=workflow_id, block_id=block_id, port_name=port_name)
+
+    # -- Read methods -------------------------------------------------------
+
+    def get(self, object_id: str) -> DataObject | None:
+        """Reconstruct a full DataObject from stored metadata.
+
+        Uses the same ``_reconstruct_one()`` path as the worker subprocess.
+        Returns ``None`` when *object_id* is not found.
+        """
+        wire = self.get_wire(object_id)
+        if wire is None:
+            return None
+        from scieasy.core.types.serialization import _reconstruct_one
+
+        return _reconstruct_one(wire)
+
+    def get_wire(self, object_id: str) -> dict[str, Any] | None:
+        """Return the raw wire-format dict for *object_id*, or ``None``."""
+        row = self._conn.execute(
+            "SELECT wire_payload FROM data_objects WHERE object_id = ?",
+            (object_id,),
+        ).fetchone()
+        if row is None:
+            return None
+        return json.loads(row[0])
+
+    def get_by_storage_path(self, path: str) -> DataObject | None:
+        """Look up metadata for a data file on disk.
+
+        Returns the first matching DataObject, or ``None``.
+        """
+        row = self._conn.execute(
+            "SELECT wire_payload FROM data_objects WHERE storage_path = ? LIMIT 1",
+            (path,),
+        ).fetchone()
+        if row is None:
+            return None
+        from scieasy.core.types.serialization import _reconstruct_one
+
+        return _reconstruct_one(json.loads(row[0]))
+
+    # -- Lineage queries ----------------------------------------------------
+
+    def ancestors(self, object_id: str) -> list[dict[str, Any]]:
+        """Return the full provenance chain (derived_from traversal).
+
+        Returns a list of dicts with ``object_id``, ``derived_from``,
+        ``type_name``, ``block_id`` for each ancestor, starting from the
+        given object and walking up through ``derived_from`` links.
+        The first element is the queried object itself.
+        """
+        rows = self._conn.execute(
+            """
+            WITH RECURSIVE anc AS (
+                SELECT object_id, derived_from, type_name, block_id
+                FROM data_objects WHERE object_id = ?
+                UNION ALL
+                SELECT d.object_id, d.derived_from, d.type_name, d.block_id
+                FROM data_objects d
+                JOIN anc a ON d.object_id = a.derived_from
+            )
+            SELECT object_id, derived_from, type_name, block_id FROM anc;
+            """,
+            (object_id,),
+        ).fetchall()
+        return [{"object_id": r[0], "derived_from": r[1], "type_name": r[2], "block_id": r[3]} for r in rows]
+
+    def descendants(self, object_id: str) -> list[dict[str, Any]]:
+        """Return all objects derived from this one.
+
+        Returns a list of dicts with ``object_id``, ``derived_from``,
+        ``type_name``, ``block_id`` for each descendant.
+        The first element is the queried object itself.
+        """
+        rows = self._conn.execute(
+            """
+            WITH RECURSIVE desc AS (
+                SELECT object_id, derived_from, type_name, block_id
+                FROM data_objects WHERE object_id = ?
+                UNION ALL
+                SELECT d.object_id, d.derived_from, d.type_name, d.block_id
+                FROM data_objects d
+                JOIN desc a ON d.derived_from = a.object_id
+            )
+            SELECT object_id, derived_from, type_name, block_id FROM desc;
+            """,
+            (object_id,),
+        ).fetchall()
+        return [{"object_id": r[0], "derived_from": r[1], "type_name": r[2], "block_id": r[3]} for r in rows]
+
+    # -- Listing queries ----------------------------------------------------
+
+    def list_by_type(self, type_name: str) -> list[dict[str, Any]]:
+        """List all objects of a given type (e.g. all Images)."""
+        rows = self._conn.execute(
+            "SELECT object_id, type_name, storage_path, workflow_id, block_id FROM data_objects WHERE type_name = ?",
+            (type_name,),
+        ).fetchall()
+        return [
+            {
+                "object_id": r[0],
+                "type_name": r[1],
+                "storage_path": r[2],
+                "workflow_id": r[3],
+                "block_id": r[4],
+            }
+            for r in rows
+        ]
+
+    def list_by_workflow(self, workflow_id: str) -> list[dict[str, Any]]:
+        """List all objects produced by a workflow run."""
+        rows = self._conn.execute(
+            "SELECT object_id, type_name, storage_path, block_id, port_name FROM data_objects WHERE workflow_id = ?",
+            (workflow_id,),
+        ).fetchall()
+        return [
+            {
+                "object_id": r[0],
+                "type_name": r[1],
+                "storage_path": r[2],
+                "block_id": r[3],
+                "port_name": r[4],
+            }
+            for r in rows
+        ]
+
+    # -- Maintenance --------------------------------------------------------
+
+    def delete(self, object_id: str) -> None:
+        """Remove metadata entry (e.g. when data file is deleted)."""
+        self._conn.execute("DELETE FROM data_objects WHERE object_id = ?", (object_id,))
+        self._conn.commit()
+
+    def vacuum(self, existing_paths: set[str]) -> int:
+        """Remove entries whose ``storage_path`` no longer exists.
+
+        Parameters
+        ----------
+        existing_paths:
+            Set of storage paths that are known to exist on disk.
+
+        Returns
+        -------
+        int
+            Number of rows removed.
+        """
+        rows = self._conn.execute(
+            "SELECT object_id, storage_path FROM data_objects WHERE storage_path IS NOT NULL"
+        ).fetchall()
+        orphan_ids = [r[0] for r in rows if r[1] not in existing_paths]
+        if orphan_ids:
+            placeholders = ",".join("?" for _ in orphan_ids)
+            self._conn.execute(
+                f"DELETE FROM data_objects WHERE object_id IN ({placeholders})",
+                orphan_ids,
+            )
+            self._conn.commit()
+        return len(orphan_ids)
+
+    def close(self) -> None:
+        """Close the database connection."""
+        self._conn.close()
+
+    # -- Dunder -------------------------------------------------------------
+
+    def __repr__(self) -> str:
+        return f"MetadataStore(db_path={self._db_path!r})"
+
+
+# ---------------------------------------------------------------------------
+# Module-level singleton (same pattern as flush_context.py)
+# ---------------------------------------------------------------------------
+
+_store: MetadataStore | None = None
+
+
+def get_metadata_store() -> MetadataStore | None:
+    """Return the active MetadataStore, or ``None`` when no project context."""
+    return _store
+
+
+def set_metadata_store(store: MetadataStore | None) -> None:
+    """Set (or clear) the active MetadataStore singleton."""
+    global _store
+    _store = store

--- a/src/scieasy/core/metadata_store.py
+++ b/src/scieasy/core/metadata_store.py
@@ -226,7 +226,8 @@ class MetadataStore:
         ).fetchone()
         if row is None:
             return None
-        return json.loads(row[0])
+        result: dict[str, Any] = json.loads(row[0])
+        return result
 
     def get_by_storage_path(self, path: str) -> DataObject | None:
         """Look up metadata for a data file on disk.

--- a/src/scieasy/engine/scheduler.py
+++ b/src/scieasy/engine/scheduler.py
@@ -342,6 +342,8 @@ class DAGScheduler:
                 return
 
             self._block_outputs[node_id] = result
+            # ADR-032: persist DataObject metadata to project-level SQLite db.
+            self._persist_output_metadata(node_id, result, self._workflow.id)
             self._block_states[node_id] = BlockState.DONE
             await self._event_bus.emit(
                 EngineEvent(
@@ -464,6 +466,8 @@ class DAGScheduler:
 
             # Step 6: Transition to DONE.
             self._block_outputs[node_id] = result
+            # ADR-032: persist DataObject metadata to project-level SQLite db.
+            self._persist_output_metadata(node_id, result, self._workflow.id)
             self._block_states[node_id] = BlockState.DONE
             await self._event_bus.emit(
                 EngineEvent(
@@ -477,6 +481,129 @@ class DAGScheduler:
             self._interactive_futures.pop(node_id, None)
             self._active_tasks.pop(node_id, None)
             self._check_completion()
+
+    # -- ADR-032: Metadata persistence helpers --------------------------------
+
+    def _persist_output_metadata(
+        self,
+        node_id: str,
+        result: dict[str, Any] | Any,
+        workflow_id: str,
+    ) -> None:
+        """Persist DataObject wire-format metadata to the project MetadataStore.
+
+        Called in the engine process after receiving wire-format outputs from
+        a worker subprocess (ADR-032 Addendum 1).  Iterates the result dict
+        and calls ``put_wire()`` for each DataObject-shaped entry.
+
+        This method is **non-fatal**: any exception is logged as a warning
+        and does not crash the workflow.
+        """
+        try:
+            from scieasy.core.metadata_store import get_metadata_store
+
+            store = get_metadata_store()
+            if store is None:
+                return
+            if not isinstance(result, dict):
+                return
+            for port_name, value in result.items():
+                self._persist_single_output(store, value, workflow_id, node_id, port_name)
+        except Exception:
+            logger.warning(
+                "ADR-032: metadata persist failed for node %s (non-fatal)",
+                node_id,
+                exc_info=True,
+            )
+
+    def _persist_single_output(
+        self,
+        store: Any,
+        value: Any,
+        workflow_id: str,
+        node_id: str,
+        port_name: str,
+    ) -> None:
+        """Persist a single output value (scalar or collection) to the store."""
+        if not isinstance(value, dict):
+            return
+        # Collection: {"_collection": True, "items": [...], "item_type": "..."}
+        if value.get("_collection"):
+            for item in value.get("items", []):
+                if isinstance(item, dict) and "metadata" in item:
+                    try:
+                        store.put_wire(item, workflow_id=workflow_id, block_id=node_id, port_name=port_name)
+                    except Exception:
+                        logger.warning(
+                            "ADR-032: metadata persist failed for item in %s/%s (non-fatal)",
+                            node_id,
+                            port_name,
+                        )
+        elif "metadata" in value:
+            try:
+                store.put_wire(value, workflow_id=workflow_id, block_id=node_id, port_name=port_name)
+            except Exception:
+                logger.warning(
+                    "ADR-032: metadata persist failed for %s/%s (non-fatal)",
+                    node_id,
+                    port_name,
+                )
+
+    def _sync_checkpoint_to_store(self) -> None:
+        """Backfill metadata store from checkpoint data (ADR-032 Phase 2a).
+
+        Called after loading checkpoint data into ``_block_outputs`` during
+        ``execute_from()``.  Only inserts entries that are not already in the
+        store (no overwrites).  Gracefully degrades when the store is
+        unavailable.
+        """
+        try:
+            from scieasy.core.metadata_store import get_metadata_store
+
+            store = get_metadata_store()
+            if store is None:
+                return
+            for node_id, outputs in self._block_outputs.items():
+                if not isinstance(outputs, dict):
+                    continue
+                for port_name, value in outputs.items():
+                    if not isinstance(value, dict):
+                        continue
+                    if value.get("_collection"):
+                        for item in value.get("items", []):
+                            if isinstance(item, dict) and "metadata" in item:
+                                try:
+                                    store.put_wire_if_missing(
+                                        item,
+                                        workflow_id=self._workflow.id,
+                                        block_id=node_id,
+                                        port_name=port_name,
+                                    )
+                                except Exception:
+                                    logger.warning(
+                                        "ADR-032: checkpoint sync failed for item in %s/%s (non-fatal)",
+                                        node_id,
+                                        port_name,
+                                    )
+                    elif "metadata" in value:
+                        try:
+                            store.put_wire_if_missing(
+                                value,
+                                workflow_id=self._workflow.id,
+                                block_id=node_id,
+                                port_name=port_name,
+                            )
+                        except Exception:
+                            logger.warning(
+                                "ADR-032: checkpoint sync failed for %s/%s (non-fatal)",
+                                node_id,
+                                port_name,
+                            )
+        except Exception:
+            logger.warning(
+                "ADR-032: checkpoint-to-store sync failed (non-fatal)",
+                exc_info=True,
+            )
 
     async def _on_interactive_complete(self, event: EngineEvent) -> None:
         """Handle an interactive_complete event from the frontend.
@@ -1175,6 +1302,10 @@ class DAGScheduler:
                 self._block_states[node_id] = BlockState(checkpoint.block_states.get(node_id, "idle"))
                 if node_id in checkpoint.intermediate_refs:
                     self._block_outputs[node_id] = checkpoint.intermediate_refs[node_id]
+
+        # ADR-032 Phase 2a: backfill metadata store from checkpoint data.
+        # Only inserts missing entries (no overwrites).
+        self._sync_checkpoint_to_store()
 
         await self._event_bus.emit(
             EngineEvent(

--- a/tests/core/test_metadata_store.py
+++ b/tests/core/test_metadata_store.py
@@ -1,0 +1,301 @@
+"""Unit tests for MetadataStore (ADR-032).
+
+Covers: put/get round-trip, put_wire/get_wire round-trip,
+get_by_storage_path, ancestors, descendants, list_by_type,
+list_by_workflow, vacuum, upsert, missing object_id, empty db,
+WAL mode, schema version, close, put_wire_if_missing, delete.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scieasy.core.metadata_store import MetadataStore, get_metadata_store, set_metadata_store
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_wire_dict(
+    *,
+    object_id: str = "obj-001",
+    type_chain: list[str] | None = None,
+    derived_from: str | None = None,
+    created_at: str = "2026-04-12T00:00:00+00:00",
+    backend: str | None = "zarr",
+    path: str | None = "/data/zarr/test.zarr",
+    workflow_id: str | None = None,
+    block_id: str | None = None,
+) -> dict:
+    if type_chain is None:
+        type_chain = ["DataObject", "Array", "Image"]
+    return {
+        "backend": backend,
+        "path": path,
+        "format": None,
+        "metadata": {
+            "type_chain": type_chain,
+            "framework": {
+                "object_id": object_id,
+                "derived_from": derived_from,
+                "created_at": created_at,
+                "source": "",
+                "lineage_id": None,
+            },
+            "meta": None,
+            "user": {},
+        },
+    }
+
+
+@pytest.fixture()
+def store(tmp_path: Path) -> MetadataStore:
+    """Create a fresh MetadataStore backed by a temp directory."""
+    db_path = tmp_path / "metadata.db"
+    s = MetadataStore(db_path)
+    yield s
+    s.close()
+
+
+# ---------------------------------------------------------------------------
+# Phase 1a: Core MetadataStore class tests
+# ---------------------------------------------------------------------------
+
+
+class TestPutWireGetWireRoundTrip:
+    """put_wire() + get_wire() round-trip preserves the exact wire dict."""
+
+    def test_basic_round_trip(self, store: MetadataStore) -> None:
+        wire = _make_wire_dict()
+        store.put_wire(wire)
+        result = store.get_wire("obj-001")
+        assert result == wire
+
+    def test_missing_returns_none(self, store: MetadataStore) -> None:
+        assert store.get_wire("nonexistent") is None
+
+
+class TestPutGetRoundTrip:
+    """put() via DataObject + get() reconstructs a typed DataObject."""
+
+    def test_round_trip(self, store: MetadataStore) -> None:
+        from scieasy.core.types.base import DataObject
+
+        obj = DataObject()
+        store.put(obj)
+        restored = store.get(obj.framework.object_id)
+        assert restored is not None
+        assert restored.framework.object_id == obj.framework.object_id
+
+    def test_get_missing_returns_none(self, store: MetadataStore) -> None:
+        assert store.get("nonexistent") is None
+
+
+class TestGetByStoragePath:
+    def test_lookup_by_path(self, store: MetadataStore) -> None:
+        wire = _make_wire_dict(path="/data/zarr/my_array.zarr", type_chain=["DataObject", "Array"])
+        store.put_wire(wire)
+        result = store.get_by_storage_path("/data/zarr/my_array.zarr")
+        assert result is not None
+        assert result.framework.object_id == "obj-001"
+
+    def test_missing_path_returns_none(self, store: MetadataStore) -> None:
+        assert store.get_by_storage_path("/nonexistent") is None
+
+
+class TestAncestors:
+    def test_single_lineage_chain(self, store: MetadataStore) -> None:
+        # grandparent -> parent -> child
+        store.put_wire(_make_wire_dict(object_id="gp", derived_from=None))
+        store.put_wire(_make_wire_dict(object_id="parent", derived_from="gp"))
+        store.put_wire(_make_wire_dict(object_id="child", derived_from="parent"))
+
+        chain = store.ancestors("child")
+        ids = [r["object_id"] for r in chain]
+        assert ids == ["child", "parent", "gp"]
+
+    def test_no_ancestors(self, store: MetadataStore) -> None:
+        store.put_wire(_make_wire_dict(object_id="root", derived_from=None))
+        chain = store.ancestors("root")
+        assert len(chain) == 1
+        assert chain[0]["object_id"] == "root"
+
+    def test_nonexistent_object(self, store: MetadataStore) -> None:
+        chain = store.ancestors("nonexistent")
+        assert chain == []
+
+
+class TestDescendants:
+    def test_single_descendant_chain(self, store: MetadataStore) -> None:
+        store.put_wire(_make_wire_dict(object_id="root", derived_from=None))
+        store.put_wire(_make_wire_dict(object_id="child1", derived_from="root"))
+        store.put_wire(_make_wire_dict(object_id="child2", derived_from="root"))
+
+        desc = store.descendants("root")
+        ids = {r["object_id"] for r in desc}
+        assert ids == {"root", "child1", "child2"}
+
+    def test_nonexistent_object(self, store: MetadataStore) -> None:
+        desc = store.descendants("nonexistent")
+        assert desc == []
+
+
+class TestListByType:
+    def test_filter_by_type(self, store: MetadataStore) -> None:
+        store.put_wire(_make_wire_dict(object_id="img1", type_chain=["DataObject", "Array", "Image"]))
+        store.put_wire(_make_wire_dict(object_id="df1", type_chain=["DataObject", "DataFrame"]))
+        store.put_wire(_make_wire_dict(object_id="img2", type_chain=["DataObject", "Array", "Image"]))
+
+        images = store.list_by_type("Image")
+        assert len(images) == 2
+        ids = {r["object_id"] for r in images}
+        assert ids == {"img1", "img2"}
+
+    def test_no_results(self, store: MetadataStore) -> None:
+        assert store.list_by_type("NonexistentType") == []
+
+
+class TestListByWorkflow:
+    def test_filter_by_workflow(self, store: MetadataStore) -> None:
+        store.put_wire(_make_wire_dict(object_id="a"), workflow_id="wf-1", block_id="b1")
+        store.put_wire(_make_wire_dict(object_id="b"), workflow_id="wf-1", block_id="b2")
+        store.put_wire(_make_wire_dict(object_id="c"), workflow_id="wf-2", block_id="b1")
+
+        results = store.list_by_workflow("wf-1")
+        assert len(results) == 2
+        ids = {r["object_id"] for r in results}
+        assert ids == {"a", "b"}
+
+    def test_no_results(self, store: MetadataStore) -> None:
+        assert store.list_by_workflow("nonexistent") == []
+
+
+class TestDelete:
+    def test_delete_existing(self, store: MetadataStore) -> None:
+        store.put_wire(_make_wire_dict(object_id="to-delete"))
+        assert store.get_wire("to-delete") is not None
+        store.delete("to-delete")
+        assert store.get_wire("to-delete") is None
+
+    def test_delete_nonexistent_is_noop(self, store: MetadataStore) -> None:
+        store.delete("nonexistent")  # Should not raise
+
+
+class TestVacuum:
+    def test_removes_orphan_entries(self, store: MetadataStore) -> None:
+        store.put_wire(_make_wire_dict(object_id="alive", path="/data/alive.zarr"))
+        store.put_wire(_make_wire_dict(object_id="orphan", path="/data/orphan.zarr"))
+        store.put_wire(_make_wire_dict(object_id="no-path", path=None, backend=None))
+
+        removed = store.vacuum(existing_paths={"/data/alive.zarr"})
+        assert removed == 1
+        assert store.get_wire("alive") is not None
+        assert store.get_wire("orphan") is None
+        # Entries with no storage_path are not vacuumed
+        assert store.get_wire("no-path") is not None
+
+
+class TestUpsert:
+    def test_duplicate_object_id_replaces(self, store: MetadataStore) -> None:
+        wire1 = _make_wire_dict(object_id="dup", path="/old.zarr")
+        wire2 = _make_wire_dict(object_id="dup", path="/new.zarr")
+        store.put_wire(wire1)
+        store.put_wire(wire2)
+        result = store.get_wire("dup")
+        assert result is not None
+        assert result["path"] == "/new.zarr"
+
+
+class TestPutWireIfMissing:
+    def test_inserts_when_absent(self, store: MetadataStore) -> None:
+        wire = _make_wire_dict(object_id="new-obj")
+        store.put_wire_if_missing(wire)
+        assert store.get_wire("new-obj") is not None
+
+    def test_skips_when_present(self, store: MetadataStore) -> None:
+        wire1 = _make_wire_dict(object_id="existing", path="/old.zarr")
+        wire2 = _make_wire_dict(object_id="existing", path="/new.zarr")
+        store.put_wire(wire1)
+        store.put_wire_if_missing(wire2)
+        result = store.get_wire("existing")
+        assert result is not None
+        # Original value preserved, not overwritten
+        assert result["path"] == "/old.zarr"
+
+
+class TestEdgeCases:
+    def test_missing_object_id_silently_ignored(self, store: MetadataStore) -> None:
+        wire = {"backend": "zarr", "path": "/test", "format": None, "metadata": {"framework": {}}}
+        store.put_wire(wire)  # No crash
+        # Nothing stored
+        row = store._conn.execute("SELECT COUNT(*) FROM data_objects").fetchone()
+        assert row[0] == 0
+
+    def test_missing_metadata_dict_silently_ignored(self, store: MetadataStore) -> None:
+        store.put_wire({"backend": "zarr", "path": "/test"})
+        row = store._conn.execute("SELECT COUNT(*) FROM data_objects").fetchone()
+        assert row[0] == 0
+
+    def test_empty_database_queries(self, store: MetadataStore) -> None:
+        assert store.get("x") is None
+        assert store.get_wire("x") is None
+        assert store.get_by_storage_path("/x") is None
+        assert store.ancestors("x") == []
+        assert store.descendants("x") == []
+        assert store.list_by_type("Image") == []
+        assert store.list_by_workflow("wf") == []
+
+
+class TestWALMode:
+    def test_wal_mode_enabled(self, store: MetadataStore) -> None:
+        mode = store._conn.execute("PRAGMA journal_mode;").fetchone()[0]
+        assert mode.lower() == "wal"
+
+
+class TestSchemaVersion:
+    def test_user_version_set(self, store: MetadataStore) -> None:
+        version = store._conn.execute("PRAGMA user_version;").fetchone()[0]
+        assert version == 1
+
+
+class TestSingleton:
+    def test_default_is_none(self) -> None:
+        # Save and restore the global to avoid test pollution
+        original = get_metadata_store()
+        try:
+            set_metadata_store(None)
+            assert get_metadata_store() is None
+        finally:
+            set_metadata_store(original)
+
+    def test_set_and_get(self, store: MetadataStore) -> None:
+        original = get_metadata_store()
+        try:
+            set_metadata_store(store)
+            assert get_metadata_store() is store
+        finally:
+            set_metadata_store(original)
+
+
+class TestBookkeepingColumns:
+    """Verify workflow_id, block_id, port_name are stored and queryable."""
+
+    def test_bookkeeping_populated(self, store: MetadataStore) -> None:
+        wire = _make_wire_dict(object_id="bk-1")
+        store.put_wire(wire, workflow_id="wf-A", block_id="blk-1", port_name="output")
+
+        row = store._conn.execute(
+            "SELECT workflow_id, block_id, port_name FROM data_objects WHERE object_id = ?",
+            ("bk-1",),
+        ).fetchone()
+        assert row == ("wf-A", "blk-1", "output")
+
+
+class TestRepr:
+    def test_repr(self, store: MetadataStore) -> None:
+        r = repr(store)
+        assert "MetadataStore" in r
+        assert "metadata.db" in r


### PR DESCRIPTION
## Summary

Implements ADR-032: Project-Level Metadata Store -- a SQLite persistent mirror of DataObject metadata that preserves framework identity, typed plugin metadata, and user annotations across project reopens, checkpoint restores, and cross-workflow data reuse.

- **Phase 1a (#639)**: Core `MetadataStore` class with SQLite backend (WAL mode), singleton accessor, 12 public methods, 30 unit tests
- **Phase 1b (#640)**: Engine integration -- initialize store on project open, write metadata in scheduler after receiving worker outputs (engine-side per Addendum 1)
- **Phase 2a (#641)**: Checkpoint restore sync -- backfill metadata store from checkpoint data with insert-only semantics (no overwrites)

Closes #639, Closes #640, Closes #641, Closes #651

## Key Design Decisions

- **Engine-side writes** (ADR-032 Addendum 1): Metadata is written in the engine process after receiving wire-format outputs from worker subprocesses, not inside `_auto_flush()` which runs in worker subprocesses
- **Non-fatal**: All metadata writes are wrapped in try/except -- workflow execution is never impacted by metadata persistence failures
- **Wire-format mirror**: `put_wire()` accepts the exact dict produced by `_serialise_one()`, avoiding redundant serialize/deserialize round-trips
- **Singleton pattern**: Follows the established `flush_context.py` pattern

## Files Changed

| File | Action | Description |
|------|--------|-------------|
| `src/scieasy/core/metadata_store.py` | New | Core MetadataStore class + singleton |
| `src/scieasy/engine/scheduler.py` | Modified | `_persist_output_metadata()`, `_sync_checkpoint_to_store()` |
| `src/scieasy/api/runtime.py` | Modified | `_init_metadata_store()` in `open_project()` |
| `tests/core/test_metadata_store.py` | New | 30 unit tests |
| `docs/adr/ADR-032-draft.md` | Modified | Status: draft -> accepted |
| `CHANGELOG.md` | Modified | Added changelog entry |

## Test plan

- [x] 30 unit tests for MetadataStore (put/get round-trip, put_wire/get_wire, ancestors/descendants, list_by_type/workflow, vacuum, upsert, delete, put_wire_if_missing, WAL mode, schema version, singleton, edge cases, bookkeeping columns)
- [x] 790 core + engine tests pass (0 failures)
- [x] Frontend: 82 vitest tests pass, tsc --noEmit clean
- [x] ruff check + ruff format clean

Generated with [Claude Code](https://claude.com/claude-code)