### PR TITLE
refactor(#627): ADR-031 Phase 3 — process-side streaming optimization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- [#627] ADR-031 Phase 3: Array.sel() zarr partial-read, SaveData streaming export (zarr-to-zarr copy, arrow-to-CSV/TSV/Parquet streaming), SaveImage streaming TIFF write, block-sdk.md "Working with Large Data" section (@claude, 2026-04-12, branch: refactor/issue-627/adr-031-phase3-streaming-optimization, session: 20260412-010609-adr-031-phase-3-process-side-streaming-o)
 - [#626] ADR-031 Phase 2: Eliminate ViewProxy class, move data access methods to DataObject, remove _data/_arrow_table backdoors from framework code, update checkpoint deserialization to construct typed DataObject instances (@claude, 2026-04-11, branch: refactor/issue-626/adr-031-phase2-viewproxy-elimination, session: 20260411-223446-adr-031-phase-2-viewproxy-elimination-an)
 - [#629] Update architecture documentation to align with ADR-031 DataObject reference-only contract (@claude, 2026-04-11, branch: docs/issue-629/architecture-docs-adr-031-alignment, session: 20260411-130410-docs-update-architecture-docs-to-align-w)
 - [#625] ADR-031 Phase 1: IOBlock loader rewrite — persist data to storage, return reference-only objects; fix Series payload loss; streaming TIFF load; reference-only Zarr; remove pandas from LCMS user dicts; Artifact auto-flush exemption (@claude, 2026-04-11, branch: refactor/issue-625/adr-031-phase1-loader-rewrite, session: 20260411-130407-adr-031-phase-1-ioblock-loader-rewrite-c)

--- a/docs/guides/block-sdk.md
+++ b/docs/guides/block-sdk.md
@@ -1277,6 +1277,108 @@ threads in core runtime code.
 2 or Tier 3 when you need cross-item operations (e.g., PCA across all items,
 normalization requiring global statistics).
 
+### Working with large data (ADR-031)
+
+SciEasy stores all data objects in persistent storage (zarr for arrays, arrow/
+parquet for tables). When a block receives a `DataObject`, the instance carries
+only a lightweight `storage_ref` pointer -- the actual data remains on disk
+until the block explicitly requests it.
+
+Three data access methods are available on every `DataObject`:
+
+| Method | Memory cost | Use when |
+|--------|------------|----------|
+| `to_memory()` | O(full dataset) | Data fits in RAM and you need all of it |
+| `sel(**kwargs)` | O(slice) | Array: you need a sub-region (e.g., one z-plane, one channel) |
+| `iter_chunks(chunk_size)` | O(one chunk) | Streaming: process data in fixed-size pieces |
+
+**Simple path -- `to_memory()`**
+
+```python
+def process_item(self, item, config, state=None):
+    data = item.to_memory()   # loads full array/table into memory
+    result = my_transform(data)
+    return Array(axes=item.axes, shape=result.shape, dtype=result.dtype)
+```
+
+This is the simplest and most common pattern. A `ResourceWarning` is emitted
+when the data exceeds 2 GB to alert the block author that a streaming approach
+may be needed.
+
+**Partial read -- `sel()` (Array only)**
+
+```python
+def process_item(self, item, config, state=None):
+    # Read only z-plane 5 from a 3D image. For zarr-backed arrays,
+    # this reads only the relevant chunks from disk (no full load).
+    plane = item.sel(z=5)
+    data = plane.to_memory()
+    return Array(axes=plane.axes, shape=data.shape, dtype=data.dtype)
+```
+
+`sel()` supports integer indices (which remove the axis) and `slice` objects
+(which keep the axis). When the source Array is backed by zarr, `sel()` uses
+the zarr backend's native partial-read -- only the requested chunks are loaded
+from disk. For non-zarr backends, `sel()` falls back to full materialisation
+plus numpy indexing.
+
+**Streaming -- `iter_chunks()` (all types)**
+
+```python
+def process_item(self, item, config, state=None):
+    # Process a large array chunk by chunk
+    results = []
+    for chunk in item.iter_chunks(chunk_size=1024):
+        results.append(my_transform(chunk))
+    combined = np.concatenate(results)
+    return Array(axes=item.axes, shape=combined.shape, dtype=combined.dtype)
+```
+
+`iter_chunks()` yields successive pieces of the data from storage. For zarr,
+it reads chunks along axis 0. For arrow/parquet, it reads row-group batches.
+Peak memory is O(one chunk) rather than O(full dataset).
+
+**IOBlock persistence helpers -- `persist_array()` / `persist_table()`**
+
+IOBlock subclasses that load large files should use the persistence helpers
+provided by the `IOBlock` base class to write data to storage in streaming
+fashion:
+
+```python
+class MyLoader(IOBlock):
+    direction = "input"
+
+    def load(self, config, output_dir=""):
+        # Stream pages from a large TIFF without loading the whole file
+        import tifffile
+
+        path = config["path"]
+        with tifffile.TiffFile(path) as tf:
+            page0 = tf.pages[0]
+            shape = (len(tf.pages), *page0.shape)
+            dtype = page0.dtype
+
+            def page_iter():
+                for i, page in enumerate(tf.pages):
+                    yield (i, page.asarray())
+
+            ref = self.persist_array(page_iter(), shape, dtype, output_dir)
+
+        return Array(axes=["z", "y", "x"], shape=shape, dtype=dtype,
+                     storage_ref=ref)
+```
+
+For small files (< 1 GB), returning an in-memory object is fine -- the IOBlock
+base class auto-persists it to storage via `_auto_flush()`.
+
+**Decision guide**:
+
+| Data size | Recommended approach |
+|-----------|---------------------|
+| < 1 GB | `to_memory()` -- simple, fast |
+| 1-10 GB | `sel()` if only a subset is needed; `iter_chunks()` for full scans |
+| > 10 GB | `iter_chunks()` for processing; `persist_array()`/`persist_table()` for loading |
+
 ---
 
 ## 5. Testing

--- a/packages/scieasy-blocks-imaging/src/scieasy_blocks_imaging/io/save_image.py
+++ b/packages/scieasy-blocks-imaging/src/scieasy_blocks_imaging/io/save_image.py
@@ -38,13 +38,10 @@ _EXT_TO_FORMAT: dict[str, str] = {
 def _materialise(image: Image) -> np.ndarray:
     """Return the underlying ``numpy`` array backing *image*.
 
-    Lazy / storage-backed images are materialised through
-    :meth:`DataObject.to_memory`. Eager images populated via the
-    skeleton convention (``image._data``) are returned directly.
+    ADR-031 Phase 3: always routes through :meth:`DataObject.to_memory`
+    which reads from storage via the backend. The former ``_data``
+    backdoor is removed per ADR-031 D3.
     """
-    data_attr = getattr(image, "_data", None)
-    if data_attr is not None:
-        return np.asarray(data_attr)
     return np.asarray(image.to_memory())
 
 
@@ -87,10 +84,34 @@ def _resolve_format(path: Path, explicit: str | None) -> str:
 
 
 def _write_tiff(image: Image, path: Path) -> None:
+    """Write an Image to TIFF.
+
+    ADR-031 Phase 3 (Task 18): for zarr-backed images with a leading
+    z/t axis, writes page-by-page from zarr to avoid full
+    materialisation. Falls back to full materialisation for non-zarr
+    backends or 2D images.
+    """
     import tifffile
 
-    data = _materialise(image)
+    ref = getattr(image, "_storage_ref", None)
     axes_str = "".join(image.axes).upper()
+
+    # Streaming path: zarr-backed images with 3+ dimensions.
+    # Read one plane at a time from zarr and write as TIFF pages.
+    if ref is not None and ref.backend == "zarr" and image.shape is not None and len(image.shape) >= 3:
+        import zarr as zarr_lib
+
+        arr = zarr_lib.open_array(ref.path, mode="r")
+        with tifffile.TiffWriter(str(path)) as tw:
+            # Iterate over the first axis (typically z or t), writing
+            # each 2D+ plane as a separate TIFF page.
+            for i in range(arr.shape[0]):
+                plane = np.asarray(arr[i])
+                tw.write(plane, metadata={"axes": axes_str} if i == 0 else None)
+        return
+
+    # Fallback: full materialisation for non-zarr or 2D images.
+    data = _materialise(image)
     tifffile.imwrite(str(path), data, metadata={"axes": axes_str})
 
 

--- a/src/scieasy/blocks/io/savers/save_data.py
+++ b/src/scieasy/blocks/io/savers/save_data.py
@@ -105,6 +105,90 @@ def _check_pickle_gate(path: Path, config: BlockConfig) -> bool:
     return True
 
 
+# ---------------------------------------------------------------------------
+# ADR-031 Phase 3 (Task 18): Streaming export helpers
+# ---------------------------------------------------------------------------
+
+
+def _zarr_store_copy(src_path: str, dst_path: str) -> None:
+    """Copy a zarr store from *src_path* to *dst_path* without materialisation.
+
+    Uses ``shutil.copytree`` for a file-level copy of the zarr directory
+    store. This copies the compressed chunks directly, avoiding any
+    decompression/recompression round-trip.
+    """
+    dst = Path(dst_path)
+    if dst.exists():
+        shutil.rmtree(dst)
+    shutil.copytree(src_path, dst_path)
+
+
+def _streaming_save_dataframe_csv(obj: DataObject, path: Path, delimiter: str = ",") -> None:
+    """Stream a storage-backed DataFrame to CSV/TSV via row-group batches.
+
+    Reads from the arrow backend in chunks and writes each batch to the
+    output file, avoiding full materialisation of the entire table.
+    """
+    import pyarrow.csv as pcsv
+
+    ref = getattr(obj, "_storage_ref", None)
+    if ref is None or ref.backend != "arrow":
+        # Fallback: full materialisation
+        table = _dataframe_to_arrow_table(obj)  # type: ignore[arg-type]
+        pcsv.write_csv(
+            table,
+            str(path),
+            write_options=pcsv.WriteOptions(delimiter=delimiter),
+        )
+        return
+
+    from scieasy.core.storage.arrow_backend import ArrowBackend
+
+    backend = ArrowBackend()
+    # Write header from first chunk, then append remaining chunks
+    first_chunk = True
+    with open(str(path), "wb") as fh:
+        for chunk_table in backend.iter_chunks(ref, chunk_size=65536):
+            pcsv.write_csv(
+                chunk_table,
+                fh,
+                write_options=pcsv.WriteOptions(
+                    delimiter=delimiter,
+                    include_header=first_chunk,
+                ),
+            )
+            first_chunk = False
+
+
+def _streaming_save_dataframe_parquet(obj: DataObject, path: Path) -> None:
+    """Stream a storage-backed DataFrame to Parquet via row-group batches.
+
+    Reads from the arrow backend in chunks and writes each batch as a
+    separate row group, avoiding full materialisation.
+    """
+    import pyarrow.parquet as pq
+
+    ref = getattr(obj, "_storage_ref", None)
+    if ref is None or ref.backend != "arrow":
+        # Fallback: full materialisation
+        table = _dataframe_to_arrow_table(obj)  # type: ignore[arg-type]
+        pq.write_table(table, str(path))
+        return
+
+    from scieasy.core.storage.arrow_backend import ArrowBackend
+
+    backend = ArrowBackend()
+    writer = None
+    try:
+        for chunk_table in backend.iter_chunks(ref, chunk_size=65536):
+            if writer is None:
+                writer = pq.ParquetWriter(str(path), chunk_table.schema)
+            writer.write_table(chunk_table)
+    finally:
+        if writer is not None:
+            writer.close()
+
+
 class SaveData(IOBlock):
     """Dynamic-port core IO **output** block (ADR-028 Addendum 1 §C5/§C9).
 
@@ -280,6 +364,12 @@ def _unwrap_for_save(
 def _save_array(obj: DataObject, config: BlockConfig) -> None:
     """Save :class:`Array` to ``.npy`` / ``.npz`` / ``.zarr`` / ``.parquet`` / ``.pkl``.
 
+    ADR-031 Phase 3 (Task 18): streaming export paths are used when the
+    source Array is storage-backed by zarr and the target format supports
+    chunked writes. For zarr-to-zarr, ``shutil.copytree`` is used for
+    zero-materialization copy. For formats that do not support chunked
+    writes (``.npy``, ``.npz``), full materialization is still required.
+
     Pickle gating: ``.pkl`` / ``.pickle`` requires
     ``allow_pickle=True`` in the block config.
     """
@@ -287,9 +377,8 @@ def _save_array(obj: DataObject, config: BlockConfig) -> None:
     path = _require_path(config)
     suffix = path.suffix.lower()
 
-    data = obj.get_in_memory_data()
-
     if _check_pickle_gate(path, config):
+        data = obj.get_in_memory_data()
         with path.open("wb") as fh:
             pickle.dump(data, fh)
         return
@@ -297,12 +386,14 @@ def _save_array(obj: DataObject, config: BlockConfig) -> None:
     if suffix == ".npy":
         import numpy as np
 
+        data = obj.get_in_memory_data()
         np.save(str(path), np.asarray(data))
         return
 
     if suffix == ".npz":
         import numpy as np
 
+        data = obj.get_in_memory_data()
         np.savez(str(path), data=np.asarray(data))
         return
 
@@ -313,14 +404,18 @@ def _save_array(obj: DataObject, config: BlockConfig) -> None:
             raise ValueError(
                 "Saving Array to .zarr requires the 'zarr' package; install it via `pip install zarr`."
             ) from exc
+
+        # ADR-031 Phase 3: zarr-to-zarr streaming copy via store copy
+        # when the source is zarr-backed. Zero materialization.
+        ref = getattr(obj, "_storage_ref", None)
+        if ref is not None and ref.backend == "zarr":
+            _zarr_store_copy(ref.path, str(path))
+            return
+
         import numpy as np
 
+        data = obj.get_in_memory_data()
         arr = np.asarray(data)
-        # Use the modern zarr.save API which writes a single array store.
-        # Zarr's stub for ``save`` declares the second argument as
-        # ``NDArrayLike``, which mypy does not recognise as a numpy
-        # ndarray supertype. The runtime contract accepts any array-like
-        # input; suppress the false positive.
         zarr.save(str(path), arr)  # type: ignore[arg-type]
         return
 
@@ -332,6 +427,7 @@ def _save_array(obj: DataObject, config: BlockConfig) -> None:
         import pyarrow as pa
         import pyarrow.parquet as pq
 
+        data = obj.get_in_memory_data()
         arr = np.asarray(data)
         if arr.ndim != 1:
             raise ValueError(
@@ -349,7 +445,14 @@ def _save_array(obj: DataObject, config: BlockConfig) -> None:
 
 
 def _save_dataframe(obj: DataObject, config: BlockConfig) -> None:
-    """Save :class:`DataFrame` to ``.csv`` / ``.tsv`` / ``.parquet`` / ``.json`` / ``.pkl``."""
+    """Save :class:`DataFrame` to ``.csv`` / ``.tsv`` / ``.parquet`` / ``.json`` / ``.pkl``.
+
+    ADR-031 Phase 3 (Task 18): for CSV, TSV, and Parquet formats, uses
+    streaming export paths when the source DataFrame is storage-backed
+    by the arrow backend. This avoids full materialisation for large
+    tables. JSON export still requires full materialisation because
+    ``json.dump`` needs the complete record list.
+    """
     assert isinstance(obj, DataFrame), f"Expected DataFrame, got {type(obj).__name__}"
     path = _require_path(config)
     suffix = path.suffix.lower()
@@ -360,33 +463,24 @@ def _save_dataframe(obj: DataObject, config: BlockConfig) -> None:
             pickle.dump(data, fh)
         return
 
-    table = _dataframe_to_arrow_table(obj)
-
+    # ADR-031 Phase 3: streaming paths for CSV/TSV/Parquet when
+    # the source is arrow-backed.
     if suffix == ".csv":
-        import pyarrow.csv as pcsv
-
-        pcsv.write_csv(table, str(path))
+        _streaming_save_dataframe_csv(obj, path, delimiter=",")
         return
 
     if suffix == ".tsv":
-        import pyarrow.csv as pcsv
-
-        pcsv.write_csv(
-            table,
-            str(path),
-            write_options=pcsv.WriteOptions(delimiter="\t"),
-        )
+        _streaming_save_dataframe_csv(obj, path, delimiter="\t")
         return
 
     if suffix in (".parquet", ".pq"):
-        import pyarrow.parquet as pq
-
-        pq.write_table(table, str(path))
+        _streaming_save_dataframe_parquet(obj, path)
         return
 
     if suffix == ".json":
-        # Convert through pylist for stable, JSON-clean output. Arrow's
-        # native to_pylist preserves column order and column names.
+        # JSON export requires full materialisation — json.dump needs
+        # the complete record list.
+        table = _dataframe_to_arrow_table(obj)
         records = table.to_pylist()
         with path.open("w", encoding="utf-8") as fh:
             json.dump(records, fh, ensure_ascii=False, indent=2)

--- a/src/scieasy/core/types/array.py
+++ b/src/scieasy/core/types/array.py
@@ -159,10 +159,10 @@ class Array(DataObject):
         - ``user``: shallow copy.
         - ``axes``: reduced per the selection.
 
-        ADR-031 D3: always reads from storage via ``to_memory()``, slices
-        with numpy, then persists the slice result to a zarr store and
-        sets ``storage_ref`` on the returned instance. The Zarr-aware
-        partial-read path is deferred to Phase 3.
+        ADR-031 Phase 3 (Task 17): when the backing storage is zarr,
+        ``sel()`` delegates to ``ZarrBackend.slice()`` for partial reads
+        instead of materialising the full array. For non-zarr backends,
+        falls back to ``to_memory()`` + numpy indexing.
 
         Raises:
             ValueError: if any kwarg key is not in ``self.axes``, if any
@@ -205,8 +205,18 @@ class Array(DataObject):
             raise ValueError(
                 f"{type(self).__name__}.sel() requires backing data. This instance has no storage_ref set."
             )
-        full_data = self.to_memory()
-        sliced_data = full_data[tuple(indexer)]
+        # ADR-031 Phase 3 (Task 17): for zarr-backed Arrays, use the
+        # backend's native partial-read to avoid full materialisation.
+        # ZarrBackend.slice() reads only the requested chunks from disk.
+        if self._storage_ref.backend == "zarr":
+            from scieasy.core.storage.zarr_backend import ZarrBackend
+
+            backend = ZarrBackend()
+            sliced_data = backend.slice(self._storage_ref, *indexer)
+        else:
+            # Non-zarr backends: full materialisation + numpy indexing.
+            full_data = self.to_memory()
+            sliced_data = full_data[tuple(indexer)]
 
         # Metadata propagation per ADR-027 D5.
         new_framework = self._framework.derive()

--- a/tests/blocks/io/test_save_data.py
+++ b/tests/blocks/io/test_save_data.py
@@ -554,3 +554,100 @@ class TestSaveDataDispatchContract:
         block = SaveData(config={"params": {"core_type": "Array", "path": str(path)}})
         with pytest.raises(ValueError, match="must be a Array instance"):
             block.save(_make_dataframe(), block.config)
+
+
+# ---------------------------------------------------------------------------
+# ADR-031 Phase 3 (Task 18): Streaming export tests
+# ---------------------------------------------------------------------------
+
+
+def _make_storage_backed_array(tmp_path: Path, data: np.ndarray, axes: list[str]) -> Array:
+    """Create a zarr-backed Array for testing streaming export."""
+    import uuid
+
+    import zarr
+
+    from scieasy.core.storage.ref import StorageReference
+
+    zarr_path = str(tmp_path / f"{uuid.uuid4()}.zarr")
+    zarr.save(zarr_path, data)
+    ref = StorageReference(
+        backend="zarr",
+        path=zarr_path,
+        metadata={"shape": list(data.shape), "dtype": str(data.dtype)},
+    )
+    return Array(axes=axes, shape=data.shape, dtype=str(data.dtype), storage_ref=ref)
+
+
+def _make_storage_backed_dataframe(tmp_path: Path) -> DataFrame:
+    """Create an arrow-backed DataFrame for testing streaming export."""
+    import uuid
+
+    from scieasy.core.storage.ref import StorageReference
+
+    table = _make_arrow_table()
+    parquet_path = str(tmp_path / f"{uuid.uuid4()}.parquet")
+    pq.write_table(table, parquet_path)
+    ref = StorageReference(
+        backend="arrow",
+        path=parquet_path,
+        format="parquet",
+        metadata={"columns": table.column_names, "num_rows": table.num_rows},
+    )
+    return DataFrame(columns=table.column_names, row_count=table.num_rows, storage_ref=ref)
+
+
+class TestStreamingExportZarrToZarr:
+    """ADR-031 Phase 3: zarr-to-zarr copy via store copy (zero materialisation)."""
+
+    def test_zarr_to_zarr_streaming_copy(self, tmp_path: Path) -> None:
+        zarr = pytest.importorskip("zarr")
+        data = np.array([[1, 2, 3], [4, 5, 6]], dtype="int64")
+        arr = _make_storage_backed_array(tmp_path, data, ["y", "x"])
+
+        out_path = tmp_path / "output.zarr"
+        block = SaveData(config={"params": {"core_type": "Array", "path": str(out_path)}})
+        block.save(arr, block.config)
+
+        assert out_path.exists()
+        recovered = zarr.load(str(out_path))
+        np.testing.assert_array_equal(recovered, data)
+
+
+class TestStreamingExportDataFrame:
+    """ADR-031 Phase 3: streaming DataFrame export for CSV/TSV/Parquet."""
+
+    def test_streaming_dataframe_csv(self, tmp_path: Path) -> None:
+        df = _make_storage_backed_dataframe(tmp_path)
+        out_path = tmp_path / "out.csv"
+        block = SaveData(config={"params": {"core_type": "DataFrame", "path": str(out_path)}})
+        block.save(df, block.config)
+
+        assert out_path.exists()
+        recovered = pcsv.read_csv(str(out_path))
+        assert recovered.column_names == ["x", "y"]
+        assert recovered.to_pydict() == {"x": [1, 2, 3], "y": [4.0, 5.0, 6.0]}
+
+    def test_streaming_dataframe_tsv(self, tmp_path: Path) -> None:
+        df = _make_storage_backed_dataframe(tmp_path)
+        out_path = tmp_path / "out.tsv"
+        block = SaveData(config={"params": {"core_type": "DataFrame", "path": str(out_path)}})
+        block.save(df, block.config)
+
+        assert out_path.exists()
+        recovered = pcsv.read_csv(
+            str(out_path),
+            parse_options=pcsv.ParseOptions(delimiter="\t"),
+        )
+        assert recovered.column_names == ["x", "y"]
+
+    def test_streaming_dataframe_parquet(self, tmp_path: Path) -> None:
+        df = _make_storage_backed_dataframe(tmp_path)
+        out_path = tmp_path / "out.parquet"
+        block = SaveData(config={"params": {"core_type": "DataFrame", "path": str(out_path)}})
+        block.save(df, block.config)
+
+        assert out_path.exists()
+        recovered = pq.read_table(str(out_path))
+        assert recovered.column_names == ["x", "y"]
+        assert recovered.to_pydict() == {"x": [1, 2, 3], "y": [4.0, 5.0, 6.0]}

--- a/tests/core/test_array_axes.py
+++ b/tests/core/test_array_axes.py
@@ -237,6 +237,38 @@ class TestArraySel:
         result = arr.sel(y=0)
         assert type(result) is Array
 
+    def test_sel_zarr_partial_read(self) -> None:
+        """ADR-031 Phase 3 (Task 17): sel() uses zarr partial-read for
+        zarr-backed Arrays, avoiding full materialisation."""
+        data = np.arange(4 * 5 * 6, dtype="float32").reshape(4, 5, 6)
+        arr = _backed_array(["z", "y", "x"], data)
+        # Verify the source is zarr-backed
+        assert arr.storage_ref is not None
+        assert arr.storage_ref.backend == "zarr"
+        # Select a single z-plane — should use ZarrBackend.slice()
+        result = arr.sel(z=2)
+        assert result.axes == ["y", "x"]
+        assert result.shape == (5, 6)
+        np.testing.assert_array_equal(np.asarray(result), data[2])
+
+    def test_sel_zarr_partial_read_slice_range(self) -> None:
+        """ADR-031 Phase 3: sel() with slice range on zarr-backed Array."""
+        data = np.arange(10 * 5 * 5, dtype="float32").reshape(10, 5, 5)
+        arr = _backed_array(["z", "y", "x"], data)
+        result = arr.sel(z=slice(2, 7))
+        assert result.axes == ["z", "y", "x"]
+        assert result.shape == (5, 5, 5)
+        np.testing.assert_array_equal(np.asarray(result), data[2:7])
+
+    def test_sel_zarr_partial_read_multiple_axes(self) -> None:
+        """ADR-031 Phase 3: sel() with multiple axes on zarr-backed Array."""
+        data = np.arange(2 * 3 * 4 * 5 * 6, dtype="float32").reshape(2, 3, 4, 5, 6)
+        arr = _backed_array(["t", "z", "c", "y", "x"], data)
+        result = arr.sel(t=1, c=2)
+        assert result.axes == ["z", "y", "x"]
+        assert result.shape == (3, 5, 6)
+        np.testing.assert_array_equal(np.asarray(result), data[1, :, 2])
+
 
 # ---------------------------------------------------------------------------
 # iter_over()


### PR DESCRIPTION
## Summary
- **Task 17**: `Array.sel()` now uses `ZarrBackend.slice()` for zarr-backed Arrays, reading only the requested chunks from disk instead of materializing the full array via `to_memory()`. Non-zarr backends fall back to `to_memory()` + numpy indexing.
- **Task 18**: Streaming export paths in SaveData and SaveImage:
  - zarr-to-zarr: `shutil.copytree` for zero-materialization directory copy
  - arrow-to-CSV/TSV: `iter_chunks()` streaming write via `pyarrow.csv`
  - arrow-to-Parquet: `ParquetWriter` with per-batch row groups
  - zarr-to-TIFF: page-by-page zarr read for 3D+ images in SaveImage
  - SaveImage `_materialise()`: removed `_data` backdoor per ADR-031 D3
- **Task 19**: Added "Working with Large Data" section to `docs/guides/block-sdk.md` documenting `to_memory()`, `sel()`, `iter_chunks()`, and `persist_array()`/`persist_table()` patterns with decision guide by data size.

## Related Issues
Closes #627

## Test plan
- [x] `tests/core/test_array_axes.py` — 3 new tests for zarr partial-read in `sel()` (integer, slice range, multiple axes)
- [x] `tests/blocks/io/test_save_data.py` — 4 new tests for streaming export (zarr-to-zarr, arrow-to-CSV, arrow-to-TSV, arrow-to-Parquet)
- [x] All existing tests pass (217 targeted tests verified)
- [x] ruff check + ruff format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)