### PR TITLE
fix(imaging): single-page TIFF persists to zarr — fixes downstream storage_ref error

### DIFF
--- a/packages/scieasy-blocks-imaging/src/scieasy_blocks_imaging/io/load_image.py
+++ b/packages/scieasy-blocks-imaging/src/scieasy_blocks_imaging/io/load_image.py
@@ -106,14 +106,23 @@ def _load_tiff(path: Path, axes_override: list[str] | None, block: Any = None, o
         if len(axes) != ndim:
             raise ValueError(f"LoadImage: axes override {axes!r} does not match array ndim={ndim} for {path}")
 
-        # ADR-031 D4: streaming path — write pages to zarr one at a time.
-        if block is not None and output_dir and n_pages > 1:
+        # ADR-031 D4: persist to zarr, return reference-only Image.
+        # Multi-page: stream page-by-page. Single-page: one-shot write.
+        # Never set _data — all data goes through storage_ref.
+        if block is not None and output_dir:
+            if n_pages > 1:
 
-            def page_chunks() -> Any:
-                for i, page in enumerate(tf.pages):
-                    yield (i, page.asarray())
+                def page_chunks() -> Any:
+                    for i, page in enumerate(tf.pages):
+                        yield (i, page.asarray())
 
-            ref = block.persist_array(page_chunks(), shape, page_dtype, output_dir)
+                ref = block.persist_array(page_chunks(), shape, page_dtype, output_dir)
+            else:
+                # Single page: one-shot persist (not streaming, but still
+                # returns storage_ref instead of _data).
+                data: np.ndarray = tf.asarray()
+                ref = block.persist_array(data, shape, page_dtype, output_dir)
+
             return Image(
                 axes=axes,
                 shape=shape,
@@ -123,8 +132,9 @@ def _load_tiff(path: Path, axes_override: list[str] | None, block: Any = None, o
                 storage_ref=ref,
             )
         else:
-            # Single-page or no block: read into memory (simple path).
-            data: np.ndarray = tf.asarray()
+            # Fallback: no block or output_dir (e.g., direct call outside
+            # workflow). Read into memory, rely on IOBlock auto-flush.
+            data = tf.asarray()
             img = Image(
                 axes=axes,
                 shape=tuple(data.shape),


### PR DESCRIPTION
## Summary

Single-page TIFFs were still using `_data` monkey-patch (ADR-031 violation). Downstream blocks received Image objects with no `storage_ref`, causing `ValueError: Cannot load data: no storage reference set`.

Fix: all TIFF loads (single and multi-page) now go through `persist_array()` when block+output_dir are available.

## Test plan

- [ ] Load single-page TIFF → downstream SRS Calibrate block runs without error
- [ ] Load multi-page TIFF → same behavior as before (streaming)

🤖 Generated with [Claude Code](https://claude.com/claude-code)