### PR TITLE
fix(#663): register DataRouter + PairEditor entry points

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,8 @@ merge_collection = "scieasy.blocks.process.builtins.merge_collection:MergeCollec
 split_collection = "scieasy.blocks.process.builtins.split_collection:SplitCollection"
 filter_collection = "scieasy.blocks.process.builtins.filter_collection:FilterCollection"
 slice_collection = "scieasy.blocks.process.builtins.slice_collection:SliceCollection"
+data_router = "scieasy.blocks.process.builtins.data_router:DataRouter"
+pair_editor = "scieasy.blocks.process.builtins.pair_editor:PairEditor"
 
 # T-TRK-004 / ADR-028 §D4: the ``scieasy.adapters`` entry-point group
 # has been removed. Plugin-owned IO blocks now register via the


### PR DESCRIPTION
## Summary

Closes #663

`DataRouter` and `PairEditor` (added in PR #646) were missing from `[project.entry-points."scieasy.blocks"]` in `pyproject.toml`. The block registry uses entry points for discovery, so these blocks were invisible to the palette.

## Changes

- Add `data_router` and `pair_editor` entry points to `pyproject.toml`

## Test plan

- [ ] `pip install -e .` then verify blocks appear in palette
- [ ] `scieasy gui` shows DataRouter and PairEditor in the block palette

🤖 Generated with [Claude Code](https://claude.com/claude-code)