### PR TITLE
refactor(#660): ADR-031 Addendum 2 — declared _transient_data slot + typed data= constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- [#660] ADR-031 Addendum 2: declared _transient_data field + typed data= constructor for Array/DataFrame/Series, backward-compat _data/_arrow_table property bridges (@claude, 2026-04-12, branch: refactor/issue-660/adr-031-addendum2-transient-data, session: 20260412-050306-adr-031-addendum-2-declared-transient-da)
 - [#659] ADR-031 Addendum 1: hard gate enforcement at worker exit, persist helpers promoted to Block base class, IOBlock loaders migrated from _data to persist_array/persist_table (@claude, 2026-04-12, branch: refactor/issue-659/adr-031-addendum-hard-gate, session: 20260412-022128-adr-031-addendum-engine-layer-hard-gate)
 - [#627] ADR-031 Phase 3: Array.sel() zarr partial-read, SaveData streaming export (zarr-to-zarr copy, arrow-to-CSV/TSV/Parquet streaming), SaveImage streaming TIFF write, block-sdk.md "Working with Large Data" section (@claude, 2026-04-12, branch: refactor/issue-627/adr-031-phase3-streaming-optimization, session: 20260412-010609-adr-031-phase-3-process-side-streaming-o)
 - [#626] ADR-031 Phase 2: Eliminate ViewProxy class, move data access methods to DataObject, remove _data/_arrow_table backdoors from framework code, update checkpoint deserialization to construct typed DataObject instances (@claude, 2026-04-11, branch: refactor/issue-626/adr-031-phase2-viewproxy-elimination, session: 20260411-223446-adr-031-phase-2-viewproxy-elimination-an)

--- a/docs/adr/ADR-031-draft.md
+++ b/docs/adr/ADR-031-draft.md
@@ -1,7 +1,7 @@
 ## ADR-031: Data Object Reference-Only Contract, ViewProxy Elimination, and Lazy Loading Enforcement
 
-**Status**: accepted (Phase 1+2+3 implemented; Addendum 1 in progress)
-**Date**: 2026-04-11 (Addendum 1: 2026-04-12)
+**Status**: accepted (Phase 1+2+3 implemented; Addendum 1+2 in progress)
+**Date**: 2026-04-11 (Addendum 1: 2026-04-12, Addendum 2: 2026-04-12)
 **Supersedes**: ADR-027 Addendum 1 (~~proposed~~ → **deprecated**)
 **Amends**: ADR-007 (implementation alignment), ADR-017 (transport contract), ADR-028 (IOBlock contract)
 
@@ -894,6 +894,34 @@ ADR-027 Addendum 1 ("Worker subprocess type reconstruction returns typed DataObj
 | PhysicalQuantity Pydantic integration via `__get_pydantic_core_schema__` | **Retained** — unchanged, not in scope of ADR-031 |
 
 References to ADR-027 Addendum 1 in code comments should be updated to cite ADR-031 D7 for reconstruction contract and ADR-031 D2 for ViewProxy elimination.
+
+---
+
+### Addendum 2: Declared `_transient_data` Slot + Typed `data=` Constructor
+
+**Date**: 2026-04-12
+**Status**: Accepted
+
+#### Context
+
+After Addendum 1 enforced the hard gate (no `_data`/`_arrow_table` on objects crossing block boundaries), the remaining problem is that loaders and the `_auto_flush` transition still monkey-patch `_data` or `_arrow_table` onto DataObject instances. These are not declared fields — they are set via `obj._data = arr` without any class-level declaration, making them invisible to static analysis, serialization guards, and documentation.
+
+#### Decisions
+
+**A2-D1**: Add a declared `_transient_data: Any = None` field on `DataObject.__init__`. This is the single canonical slot for in-memory data that has not yet been persisted. It is never serialised.
+
+**A2-D2**: Add backward-compatible property bridges `_data` and `_arrow_table` on `DataObject` that read/write `_transient_data`. This preserves backward compatibility with existing code that uses `obj._data = arr` or `obj._arrow_table = table`.
+
+**A2-D3**: Simplify `get_in_memory_data()` and `Array.to_memory()` to check `self._transient_data is not None` instead of `hasattr(self, "_data")` / `hasattr(self, "_arrow_table")`.
+
+**A2-D4**: Add a typed `data=` constructor parameter to `Array`, `DataFrame`, and `Series`. When provided, it sets `_transient_data` in the constructor body.
+
+#### Consequences
+
+- All transient in-memory data is now stored in a declared, documented field.
+- Static analysis tools can see the field and reason about its lifecycle.
+- The `_serialise_one` / `_reconstruct_one` round-trip naturally excludes `_transient_data` because it is not part of `_serialise_extra_metadata`.
+- The property bridges will be removed in a future phase once all callers migrate to the `data=` constructor.
 
 ---
 

--- a/src/scieasy/core/types/array.py
+++ b/src/scieasy/core/types/array.py
@@ -72,6 +72,7 @@ class Array(DataObject):
         shape: tuple[int, ...] | None = None,
         dtype: Any = None,
         chunk_shape: tuple[int, ...] | None = None,
+        data: Any = None,
         **kwargs: Any,
     ) -> None:
         """Construct an Array with explicit axes and shape.
@@ -80,6 +81,11 @@ class Array(DataObject):
         slots (``framework``, ``meta``, ``user``, ``storage_ref``) are
         passed through ``**kwargs`` to
         :meth:`DataObject.__init__`.
+
+        Args:
+            data: Optional in-memory array data (e.g. numpy ndarray).
+                Stored in ``_transient_data``; never serialised.
+                ADR-031 Addendum 2.
 
         Raises:
             ValueError: if ``axes`` fails :meth:`_validate_axes` (missing
@@ -90,6 +96,8 @@ class Array(DataObject):
         self.shape: tuple[int, ...] | None = tuple(shape) if shape is not None else None
         self.dtype: Any = dtype
         self.chunk_shape: tuple[int, ...] | None = tuple(chunk_shape) if chunk_shape is not None else None
+        if data is not None:
+            self._transient_data = data
         self._validate_axes()
 
     def _validate_axes(self) -> None:
@@ -369,8 +377,9 @@ class Array(DataObject):
         """
         if self._storage_ref is not None:
             return super().to_memory()
-        if hasattr(self, "_data") and getattr(self, "_data", None) is not None:
-            return self._data  # type: ignore[attr-defined]
+        # ADR-031 Addendum 2: use the declared _transient_data slot.
+        if self._transient_data is not None:
+            return self._transient_data
         raise ValueError("Cannot load data: no storage reference set.")
 
     # -- worker subprocess reconstruction hooks (ADR-027 Addendum 1 §2) -----

--- a/src/scieasy/core/types/base.py
+++ b/src/scieasy/core/types/base.py
@@ -210,6 +210,11 @@ class DataObject:
         self._user: dict[str, Any] = dict(user) if user is not None else {}
         self._validate_user(self._user)
         self._storage_ref: StorageReference | None = storage_ref
+        # ADR-031 Addendum 2: declared transient in-memory data slot.
+        # Never serialised; used by loaders during the _auto_flush
+        # transition and by the typed ``data=`` constructor parameter on
+        # concrete subclasses (Array, DataFrame, Series).
+        self._transient_data: Any = None
 
     @staticmethod
     def _validate_user(user: dict[str, Any]) -> None:
@@ -355,6 +360,32 @@ class DataObject:
         """Set the storage reference."""
         self._storage_ref = ref
 
+    # -- ADR-031 Addendum 2: backward-compat property bridges ----------------
+    # These properties let legacy code that writes ``obj._data = arr`` or
+    # ``obj._arrow_table = table`` transparently use the declared
+    # ``_transient_data`` slot. They will be removed once all callers are
+    # migrated to the ``data=`` constructor parameter.
+
+    @property
+    def _data(self) -> Any:
+        """Backward-compat bridge: reads ``_transient_data``."""
+        return self._transient_data
+
+    @_data.setter
+    def _data(self, value: Any) -> None:
+        """Backward-compat bridge: writes ``_transient_data``."""
+        self._transient_data = value
+
+    @property
+    def _arrow_table(self) -> Any:
+        """Backward-compat bridge for DataFrame/Series: reads ``_transient_data``."""
+        return self._transient_data
+
+    @_arrow_table.setter
+    def _arrow_table(self, value: Any) -> None:
+        """Backward-compat bridge for DataFrame/Series: writes ``_transient_data``."""
+        self._transient_data = value
+
     # -- data access (ADR-031 D1/D2/D6: methods moved from ViewProxy) --------
 
     def to_memory(self) -> Any:
@@ -425,12 +456,10 @@ class DataObject:
         """
         if self._storage_ref is not None:
             return self.to_memory()
-        # Backward-compat: transient in-memory data set by loaders
-        # before _auto_flush persists to storage (ADR-031 D3 transition).
-        if hasattr(self, "_data") and self._data is not None:  # type: ignore[has-type]
-            return self._data  # type: ignore[has-type]
-        if hasattr(self, "_arrow_table") and self._arrow_table is not None:  # type: ignore[has-type]
-            return self._arrow_table  # type: ignore[has-type]
+        # ADR-031 Addendum 2: use the declared _transient_data slot
+        # instead of hasattr probing for _data / _arrow_table.
+        if self._transient_data is not None:
+            return self._transient_data
         raise ValueError(f"{type(self).__name__} has no in-memory data to persist.")
 
     def save(self, path: str | Path) -> StorageReference:

--- a/src/scieasy/core/types/base.py
+++ b/src/scieasy/core/types/base.py
@@ -376,6 +376,11 @@ class DataObject:
         """Backward-compat bridge: writes ``_transient_data``."""
         self._transient_data = value
 
+    @_data.deleter
+    def _data(self) -> None:
+        """Backward-compat bridge: clears ``_transient_data``."""
+        self._transient_data = None
+
     @property
     def _arrow_table(self) -> Any:
         """Backward-compat bridge for DataFrame/Series: reads ``_transient_data``."""
@@ -385,6 +390,11 @@ class DataObject:
     def _arrow_table(self, value: Any) -> None:
         """Backward-compat bridge for DataFrame/Series: writes ``_transient_data``."""
         self._transient_data = value
+
+    @_arrow_table.deleter
+    def _arrow_table(self) -> None:
+        """Backward-compat bridge for DataFrame/Series: clears ``_transient_data``."""
+        self._transient_data = None
 
     # -- data access (ADR-031 D1/D2/D6: methods moved from ViewProxy) --------
 

--- a/src/scieasy/core/types/dataframe.py
+++ b/src/scieasy/core/types/dataframe.py
@@ -29,6 +29,7 @@ class DataFrame(DataObject):
         columns: list[str] | None = None,
         row_count: int | None = None,
         schema: dict[str, Any] | None = None,
+        data: Any = None,
         **kwargs: Any,
     ) -> None:
         """Construct a DataFrame with optional column/schema information.
@@ -36,11 +37,18 @@ class DataFrame(DataObject):
         Standard :class:`DataObject` slots (``framework``, ``meta``,
         ``user``, ``storage_ref``) are passed through ``**kwargs`` to
         :meth:`DataObject.__init__`.
+
+        Args:
+            data: Optional in-memory tabular data (e.g. Arrow table).
+                Stored in ``_transient_data``; never serialised.
+                ADR-031 Addendum 2.
         """
         super().__init__(**kwargs)
         self.columns = columns
         self.row_count = row_count
         self.schema = schema
+        if data is not None:
+            self._transient_data = data
 
     # -- with_meta override (T-005's base only handles standard slots) ----
 

--- a/src/scieasy/core/types/series.py
+++ b/src/scieasy/core/types/series.py
@@ -31,6 +31,7 @@ class Series(DataObject):
         index_name: str | None = None,
         value_name: str | None = None,
         length: int | None = None,
+        data: Any = None,
         **kwargs: Any,
     ) -> None:
         """Construct a Series with optional axis labels and length.
@@ -38,11 +39,18 @@ class Series(DataObject):
         Standard :class:`DataObject` slots (``framework``, ``meta``,
         ``user``, ``storage_ref``) are passed through ``**kwargs`` to
         :meth:`DataObject.__init__`.
+
+        Args:
+            data: Optional in-memory series data (e.g. Arrow table).
+                Stored in ``_transient_data``; never serialised.
+                ADR-031 Addendum 2.
         """
         super().__init__(**kwargs)
         self.index_name = index_name
         self.value_name = value_name
         self.length = length
+        if data is not None:
+            self._transient_data = data
 
     # -- with_meta override (T-005's base only handles standard slots) ----
 

--- a/tests/core/test_transient_data.py
+++ b/tests/core/test_transient_data.py
@@ -1,0 +1,278 @@
+"""Tests for ADR-031 Addendum 2: _transient_data slot + typed data= constructor.
+
+Verifies:
+1. Array(data=...) sets _transient_data
+2. DataFrame(data=...) sets _transient_data
+3. Series(data=...) sets _transient_data
+4. obj._data = arr (backward compat bridge) writes _transient_data
+5. df._arrow_table = table (backward compat bridge) writes _transient_data
+6. get_in_memory_data() returns _transient_data when storage_ref is None
+7. to_memory() returns _transient_data when storage_ref is None (Array)
+8. _serialise_one(obj_with_transient_data_and_storage_ref) excludes _transient_data
+9. _reconstruct_one(wire) produces _transient_data=None
+10. No hasattr(self, "_data") / hasattr(self, "_arrow_table") in base.py/array.py
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import numpy as np
+import pyarrow as pa
+import pytest
+
+from scieasy.core.types.array import Array
+from scieasy.core.types.base import DataObject
+from scieasy.core.types.dataframe import DataFrame
+from scieasy.core.types.series import Series
+
+# ---------------------------------------------------------------------------
+# 1. Array(data=...) sets _transient_data
+# ---------------------------------------------------------------------------
+
+
+class TestArrayDataConstructor:
+    def test_array_data_parameter_sets_transient(self):
+        arr = np.zeros((100, 100), dtype="float32")
+        obj = Array(axes=["y", "x"], shape=(100, 100), dtype="float32", data=arr)
+        assert obj._transient_data is arr
+
+    def test_array_data_none_leaves_transient_none(self):
+        obj = Array(axes=["y", "x"], shape=(100, 100), dtype="float32")
+        assert obj._transient_data is None
+
+
+# ---------------------------------------------------------------------------
+# 2. DataFrame(data=...) sets _transient_data
+# ---------------------------------------------------------------------------
+
+
+class TestDataFrameDataConstructor:
+    def test_dataframe_data_parameter_sets_transient(self):
+        table = pa.table({"a": [1, 2, 3]})
+        obj = DataFrame(data=table)
+        assert obj._transient_data is table
+
+    def test_dataframe_data_none_leaves_transient_none(self):
+        obj = DataFrame()
+        assert obj._transient_data is None
+
+
+# ---------------------------------------------------------------------------
+# 3. Series(data=...) sets _transient_data
+# ---------------------------------------------------------------------------
+
+
+class TestSeriesDataConstructor:
+    def test_series_data_parameter_sets_transient(self):
+        table = pa.table({"col": [1, 2, 3]})
+        obj = Series(data=table)
+        assert obj._transient_data is table
+
+    def test_series_data_none_leaves_transient_none(self):
+        obj = Series()
+        assert obj._transient_data is None
+
+
+# ---------------------------------------------------------------------------
+# 4. obj._data = arr (backward compat bridge) writes _transient_data
+# ---------------------------------------------------------------------------
+
+
+class TestDataPropertyBridge:
+    def test_data_setter_writes_transient(self):
+        obj = Array(axes=["y", "x"], shape=(10, 10), dtype="float32")
+        arr = np.ones((10, 10))
+        obj._data = arr
+        assert obj._transient_data is arr
+
+    def test_data_getter_reads_transient(self):
+        arr = np.ones((10, 10))
+        obj = Array(axes=["y", "x"], shape=(10, 10), dtype="float32", data=arr)
+        assert obj._data is arr
+
+    def test_data_bridge_on_base_dataobject(self):
+        obj = DataObject()
+        obj._data = "sentinel"
+        assert obj._transient_data == "sentinel"
+        assert obj._data == "sentinel"
+
+
+# ---------------------------------------------------------------------------
+# 5. df._arrow_table = table (backward compat bridge) writes _transient_data
+# ---------------------------------------------------------------------------
+
+
+class TestArrowTablePropertyBridge:
+    def test_arrow_table_setter_writes_transient(self):
+        df = DataFrame()
+        table = pa.table({"x": [1, 2]})
+        df._arrow_table = table
+        assert df._transient_data is table
+
+    def test_arrow_table_getter_reads_transient(self):
+        table = pa.table({"x": [1, 2]})
+        df = DataFrame(data=table)
+        assert df._arrow_table is table
+
+    def test_arrow_table_bridge_on_series(self):
+        s = Series()
+        table = pa.table({"col": [1]})
+        s._arrow_table = table
+        assert s._transient_data is table
+        assert s._arrow_table is table
+
+
+# ---------------------------------------------------------------------------
+# 6. get_in_memory_data() returns _transient_data when storage_ref is None
+# ---------------------------------------------------------------------------
+
+
+class TestGetInMemoryData:
+    def test_returns_transient_data_when_no_storage_ref(self):
+        arr = np.zeros((5, 5))
+        obj = Array(axes=["y", "x"], shape=(5, 5), dtype="float64", data=arr)
+        assert obj.get_in_memory_data() is arr
+
+    def test_raises_when_no_transient_and_no_storage_ref(self):
+        obj = Array(axes=["y", "x"], shape=(5, 5), dtype="float64")
+        with pytest.raises(ValueError, match="no in-memory data"):
+            obj.get_in_memory_data()
+
+
+# ---------------------------------------------------------------------------
+# 7. Array.to_memory() returns _transient_data when storage_ref is None
+# ---------------------------------------------------------------------------
+
+
+class TestArrayToMemory:
+    def test_returns_transient_data_when_no_storage_ref(self):
+        arr = np.ones((3, 3))
+        obj = Array(axes=["y", "x"], shape=(3, 3), dtype="float64", data=arr)
+        assert obj.to_memory() is arr
+
+    def test_raises_when_no_transient_and_no_storage_ref(self):
+        obj = Array(axes=["y", "x"], shape=(3, 3), dtype="float64")
+        with pytest.raises(ValueError, match="no storage reference"):
+            obj.to_memory()
+
+
+# ---------------------------------------------------------------------------
+# 8. _serialise_one excludes _transient_data from wire format
+# ---------------------------------------------------------------------------
+
+
+class TestSerialiseExcludesTransient:
+    def test_transient_data_not_in_wire_format(self, tmp_path: Path):
+        """When an object has both storage_ref and _transient_data, the
+        wire format must NOT contain _transient_data."""
+        import zarr
+
+        from scieasy.core.storage.ref import StorageReference
+        from scieasy.core.types.serialization import _serialise_one
+
+        arr = np.zeros((5, 5))
+        zarr_path = str(tmp_path / "test.zarr")
+        zarr.save(zarr_path, arr)
+
+        obj = Array(
+            axes=["y", "x"],
+            shape=(5, 5),
+            dtype="float64",
+            data=arr,
+            storage_ref=StorageReference(
+                backend="zarr",
+                path=zarr_path,
+                metadata={"shape": [5, 5], "dtype": "float64"},
+            ),
+        )
+        assert obj._transient_data is arr  # confirm it's set
+
+        wire = _serialise_one(obj)
+        # _transient_data must not appear anywhere in the wire dict
+        assert "_transient_data" not in wire
+        assert "_transient_data" not in wire.get("metadata", {})
+        # Also check _data and _arrow_table are absent
+        assert "_data" not in wire.get("metadata", {})
+        assert "_arrow_table" not in wire.get("metadata", {})
+
+
+# ---------------------------------------------------------------------------
+# 9. _reconstruct_one produces _transient_data=None
+# ---------------------------------------------------------------------------
+
+
+class TestReconstructTransientIsNone:
+    def test_reconstructed_object_has_none_transient(self, tmp_path: Path):
+        import zarr
+
+        from scieasy.core.types.serialization import _reconstruct_one, _serialise_one
+
+        arr = np.zeros((4, 4))
+        zarr_path = str(tmp_path / "test.zarr")
+        zarr.save(zarr_path, arr)
+
+        from scieasy.core.storage.ref import StorageReference
+
+        obj = Array(
+            axes=["y", "x"],
+            shape=(4, 4),
+            dtype="float64",
+            storage_ref=StorageReference(
+                backend="zarr",
+                path=zarr_path,
+                metadata={"shape": [4, 4], "dtype": "float64"},
+            ),
+        )
+        wire = _serialise_one(obj)
+        reconstructed = _reconstruct_one(wire)
+        assert reconstructed._transient_data is None
+
+
+# ---------------------------------------------------------------------------
+# 10. No hasattr(self, "_data") / hasattr(self, "_arrow_table") in source
+# ---------------------------------------------------------------------------
+
+
+class TestNoHasattrPatterns:
+    """Static analysis: ensure no hasattr probing for _data/_arrow_table
+    remains in base.py or array.py."""
+
+    @staticmethod
+    def _check_no_hasattr(filepath: Path, attr_name: str) -> list[int]:
+        """Return line numbers where hasattr(self, attr_name) appears."""
+        source = filepath.read_text(encoding="utf-8")
+        tree = ast.parse(source, filename=str(filepath))
+        violations: list[int] = []
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Name)
+                and node.func.id == "hasattr"
+                and len(node.args) >= 2
+            ):
+                second = node.args[1]
+                if isinstance(second, ast.Constant) and second.value == attr_name:
+                    violations.append(node.lineno)
+        return violations
+
+    def test_no_hasattr_data_in_base(self):
+        base_path = Path(__file__).resolve().parents[2] / "src" / "scieasy" / "core" / "types" / "base.py"
+        violations = self._check_no_hasattr(base_path, "_data")
+        assert violations == [], f"hasattr(self, '_data') found at lines {violations} in base.py"
+
+    def test_no_hasattr_arrow_table_in_base(self):
+        base_path = Path(__file__).resolve().parents[2] / "src" / "scieasy" / "core" / "types" / "base.py"
+        violations = self._check_no_hasattr(base_path, "_arrow_table")
+        assert violations == [], f"hasattr(self, '_arrow_table') found at lines {violations} in base.py"
+
+    def test_no_hasattr_data_in_array(self):
+        array_path = Path(__file__).resolve().parents[2] / "src" / "scieasy" / "core" / "types" / "array.py"
+        violations = self._check_no_hasattr(array_path, "_data")
+        assert violations == [], f"hasattr(self, '_data') found at lines {violations} in array.py"
+
+    def test_no_hasattr_arrow_table_in_array(self):
+        array_path = Path(__file__).resolve().parents[2] / "src" / "scieasy" / "core" / "types" / "array.py"
+        violations = self._check_no_hasattr(array_path, "_arrow_table")
+        assert violations == [], f"hasattr(self, '_arrow_table') found at lines {violations} in array.py"


### PR DESCRIPTION
## Summary

- Add declared `_transient_data: Any = None` field on `DataObject` base class, replacing ad-hoc monkey-patched `_data`/`_arrow_table` attributes
- Add backward-compatible property bridges (`_data`, `_arrow_table`) that transparently read/write `_transient_data`
- Add typed `data=` constructor parameter to `Array`, `DataFrame`, and `Series`
- Simplify `get_in_memory_data()` and `Array.to_memory()` to use `_transient_data` directly instead of `hasattr` probing
- 22 new tests covering constructor, bridges, serialization exclusion, reconstruction, and static analysis

## Related Issues

Closes #660

## ADR

- [x] ADR-031 Addendum 2 added to `docs/adr/ADR-031-draft.md`

## Test plan

- [x] `Array(data=np.zeros(...))` sets `_transient_data`
- [x] `DataFrame(data=pa.table(...))` sets `_transient_data`
- [x] `Series(data=pa.table(...))` sets `_transient_data`
- [x] `obj._data = arr` backward compat bridge writes `_transient_data`
- [x] `df._arrow_table = table` backward compat bridge writes `_transient_data`
- [x] `get_in_memory_data()` returns `_transient_data` when no `storage_ref`
- [x] `Array.to_memory()` returns `_transient_data` when no `storage_ref`
- [x] `_serialise_one()` excludes `_transient_data` from wire format
- [x] `_reconstruct_one()` produces `_transient_data=None`
- [x] No `hasattr(self, "_data")` / `hasattr(self, "_arrow_table")` in base.py or array.py (static analysis)
- [x] All 517 existing core tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)