### PR TITLE
fix(storage): Windows MAX_PATH workaround for zarr/parquet persist paths

### DIFF
--- a/src/scieasy/blocks/base/block.py
+++ b/src/scieasy/blocks/base/block.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sys
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, ClassVar
 
@@ -369,8 +370,11 @@ class Block(ABC):
         if not output_dir:
             raise RuntimeError("persist_array requires output_dir but none is configured.")
 
-        store_name = f"{uuid.uuid4()}.zarr"
+        store_name = f"{uuid.uuid4().hex[:12]}.zarr"
         store_path = str(Path(output_dir) / store_name)
+        # Windows MAX_PATH (260) workaround: use \\?\ prefix for long paths.
+        if sys.platform == "win32" and len(store_path) > 200:
+            store_path = f"\\\\?\\{store_path}" if not store_path.startswith("\\\\?\\") else store_path
         Path(store_path).parent.mkdir(parents=True, exist_ok=True)
 
         np_dtype = np.dtype(dtype)
@@ -417,8 +421,10 @@ class Block(ABC):
         if not output_dir:
             raise RuntimeError("persist_table requires output_dir but none is configured.")
 
-        file_name = f"{uuid.uuid4()}.parquet"
+        file_name = f"{uuid.uuid4().hex[:12]}.parquet"
         file_path = str(Path(output_dir) / file_name)
+        if sys.platform == "win32" and len(file_path) > 200:
+            file_path = f"\\\\?\\{file_path}" if not file_path.startswith("\\\\?\\") else file_path
         Path(output_dir).mkdir(parents=True, exist_ok=True)
 
         backend = ArrowBackend()

--- a/src/scieasy/blocks/base/block.py
+++ b/src/scieasy/blocks/base/block.py
@@ -20,7 +20,21 @@ from scieasy.blocks.base.ports import (
 )
 from scieasy.blocks.base.state import BlockState, ExecutionMode
 
+
 # Valid state transitions (ADR-018: added CANCELLED, SKIPPED).
+def _win_long_path(path: str) -> str:
+    """Prepend Windows extended-length prefix when path risks exceeding MAX_PATH.
+
+    Regular paths:  ``C:\\foo``  → ``\\\\?\\C:\\foo``
+    UNC paths:      ``\\\\server\\share``  → ``\\\\?\\UNC\\server\\share``
+    """
+    if sys.platform != "win32" or len(path) <= 259 or path.startswith("\\\\?\\"):
+        return path
+    if path.startswith("\\\\"):
+        return "\\\\?\\UNC\\" + path[2:]
+    return "\\\\?\\" + path
+
+
 _VALID_TRANSITIONS: dict[BlockState, set[BlockState]] = {
     BlockState.IDLE: {BlockState.READY, BlockState.SKIPPED, BlockState.ERROR},
     BlockState.READY: {BlockState.RUNNING, BlockState.SKIPPED, BlockState.ERROR},
@@ -371,10 +385,7 @@ class Block(ABC):
             raise RuntimeError("persist_array requires output_dir but none is configured.")
 
         store_name = f"{uuid.uuid4().hex[:12]}.zarr"
-        store_path = str(Path(output_dir) / store_name)
-        # Windows MAX_PATH (260) workaround: use \\?\ prefix for long paths.
-        if sys.platform == "win32" and len(store_path) > 200:
-            store_path = f"\\\\?\\{store_path}" if not store_path.startswith("\\\\?\\") else store_path
+        store_path = _win_long_path(str(Path(output_dir) / store_name))
         Path(store_path).parent.mkdir(parents=True, exist_ok=True)
 
         np_dtype = np.dtype(dtype)
@@ -422,9 +433,7 @@ class Block(ABC):
             raise RuntimeError("persist_table requires output_dir but none is configured.")
 
         file_name = f"{uuid.uuid4().hex[:12]}.parquet"
-        file_path = str(Path(output_dir) / file_name)
-        if sys.platform == "win32" and len(file_path) > 200:
-            file_path = f"\\\\?\\{file_path}" if not file_path.startswith("\\\\?\\") else file_path
+        file_path = _win_long_path(str(Path(output_dir) / file_name))
         Path(output_dir).mkdir(parents=True, exist_ok=True)
 
         backend = ArrowBackend()

--- a/src/scieasy/engine/runners/local.py
+++ b/src/scieasy/engine/runners/local.py
@@ -32,9 +32,16 @@ def _derive_output_dir(block: Any, config: dict[str, Any]) -> str:
     block_id = str(config.get("block_id") or getattr(block, "id", "block"))
     workflow_id = str(config.get("workflow_id") or "adhoc")
     if isinstance(project_dir, str) and project_dir:
-        path = Path(project_dir) / "data" / "zarr" / workflow_id / block_id
-        path.mkdir(parents=True, exist_ok=True)
-        return str(path)
+        # Truncate block_id to avoid Windows MAX_PATH (260) overflow.
+        # block_id is typically "type_name-timestamp" — keep first 40 chars.
+        short_block_id = block_id[:40] if len(block_id) > 40 else block_id
+        path = Path(project_dir) / "data" / "zarr" / workflow_id / short_block_id
+        result = str(path)
+        # Windows long path workaround
+        if sys.platform == "win32" and len(result) > 200:
+            result = f"\\\\?\\{result}" if not result.startswith("\\\\?\\") else result
+        Path(result).mkdir(parents=True, exist_ok=True)
+        return result
 
     return tempfile.mkdtemp(prefix="scieasy-worker-")
 

--- a/src/scieasy/engine/runners/local.py
+++ b/src/scieasy/engine/runners/local.py
@@ -33,13 +33,11 @@ def _derive_output_dir(block: Any, config: dict[str, Any]) -> str:
     workflow_id = str(config.get("workflow_id") or "adhoc")
     if isinstance(project_dir, str) and project_dir:
         # Truncate block_id to avoid Windows MAX_PATH (260) overflow.
-        # block_id is typically "type_name-timestamp" — keep first 40 chars.
         short_block_id = block_id[:40] if len(block_id) > 40 else block_id
         path = Path(project_dir) / "data" / "zarr" / workflow_id / short_block_id
-        result = str(path)
-        # Windows long path workaround
-        if sys.platform == "win32" and len(result) > 200:
-            result = f"\\\\?\\{result}" if not result.startswith("\\\\?\\") else result
+        from scieasy.blocks.base.block import _win_long_path
+
+        result = _win_long_path(str(path))
         Path(result).mkdir(parents=True, exist_ok=True)
         return result
 


### PR DESCRIPTION
## Summary

Long project paths (Box sync, OneDrive, deeply nested directories) cause `FileNotFoundError: [WinError 3]` when `persist_array` or `_derive_output_dir` creates zarr stores exceeding Windows' 260-char MAX_PATH limit.

## Changes

- `block.py`: Shorten UUID filenames (`uuid4().hex[:12]`), add `\?\` long path prefix on Windows
- `local.py`: Truncate `block_id` to 40 chars in output dir derivation, add `\?\` prefix

## Test plan

- [ ] Load TIFF from a deep Box sync path (260+ chars total) — no FileNotFoundError

Closes #668