### PR TITLE
chore: add gate + CI enforcement hook scripts for Claude Code agents

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,8 @@ merge_collection = "scieasy.blocks.process.builtins.merge_collection:MergeCollec
 split_collection = "scieasy.blocks.process.builtins.split_collection:SplitCollection"
 filter_collection = "scieasy.blocks.process.builtins.filter_collection:FilterCollection"
 slice_collection = "scieasy.blocks.process.builtins.slice_collection:SliceCollection"
+data_router = "scieasy.blocks.process.builtins.data_router:DataRouter"
+pair_editor = "scieasy.blocks.process.builtins.pair_editor:PairEditor"
 
 # T-TRK-004 / ADR-028 §D4: the ``scieasy.adapters`` entry-point group
 # has been removed. Plugin-owned IO blocks now register via the

--- a/scripts/hooks/check-ci-after-pr.sh
+++ b/scripts/hooks/check-ci-after-pr.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Claude Code PostToolUse hook: after gh pr create, remind agent to check CI.
+# Outputs a blocking message that the agent must address.
+
+set -e
+
+INPUT=$(cat)
+CMD=$(echo "$INPUT" | python -c "import sys,json; print(json.load(sys.stdin).get('tool_input',{}).get('command',''))" 2>/dev/null || echo "")
+
+# Only trigger after gh pr create
+if ! echo "$CMD" | grep -qE 'gh pr create'; then
+  exit 0
+fi
+
+# Extract PR number from tool output (stdout)
+STDOUT=$(echo "$INPUT" | python -c "import sys,json; print(json.load(sys.stdin).get('stdout',''))" 2>/dev/null || echo "")
+PR_URL=$(echo "$STDOUT" | grep -oE 'https://github.com/[^ ]+/pull/[0-9]+' | head -1)
+
+if [ -z "$PR_URL" ]; then
+  exit 0
+fi
+
+PR_NUM=$(echo "$PR_URL" | grep -oE '[0-9]+$')
+
+cat <<EOF
+⚠️ MANDATORY CI CHECK: PR #${PR_NUM} created.
+You MUST now:
+1. Wait 2-3 minutes for CI to start
+2. Run: gh pr checks ${PR_NUM} --watch
+3. If ANY check fails: diagnose, fix, push, repeat until ALL GREEN
+4. Do NOT report the PR as done until CI passes
+
+This is a NON-NEGOTIABLE requirement per CLAUDE.md §6.4.
+EOF

--- a/scripts/hooks/check-gate-before-pr.sh
+++ b/scripts/hooks/check-gate-before-pr.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# Claude Code PreToolUse hook: check workflow gate before gh pr create
+# Ensures agents complete update_docs + update_changelog before creating PR.
+
+set -e
+
+INPUT=$(cat)
+CMD=$(echo "$INPUT" | python -c "import sys,json; print(json.load(sys.stdin).get('tool_input',{}).get('command',''))" 2>/dev/null || echo "")
+
+# Only intercept gh pr create commands
+if ! echo "$CMD" | grep -qE 'gh pr create'; then
+  echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow"}}'
+  exit 0
+fi
+
+# Only enforce for branches that require gates (feat/, fix/, refactor/)
+BRANCH=$(git branch --show-current 2>/dev/null || echo "")
+if ! echo "$BRANCH" | grep -qE '^(feat|fix|refactor)/'; then
+  echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow"}}'
+  exit 0
+fi
+
+# Check if there's an active workflow
+GATE_OUTPUT=$(python .workflow/gate.py list 2>/dev/null || echo "")
+
+if [ -z "$GATE_OUTPUT" ]; then
+  echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow"}}'
+  exit 0
+fi
+
+ACTIVE=$(echo "$GATE_OUTPUT" | grep "active" | head -1)
+if [ -z "$ACTIVE" ]; then
+  echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow"}}'
+  exit 0
+fi
+
+TASK_ID=$(echo "$ACTIVE" | awk '{print $1}')
+STATUS=$(python .workflow/gate.py status "$TASK_ID" 2>/dev/null || echo "")
+
+# Check that update_changelog is DONE (gate 5 of 6, right before submit_pr)
+if echo "$STATUS" | grep -q "Update Changelog.*DONE"; then
+  echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow"}}'
+  exit 0
+fi
+
+# Check which gates are missing
+MISSING=""
+echo "$STATUS" | grep -q "Update Documentation.*DONE" || MISSING="update_docs "
+echo "$STATUS" | grep -q "Update Changelog.*DONE" || MISSING="${MISSING}update_changelog"
+
+echo "{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"WORKFLOW GATE: Missing stages before PR: ${MISSING}. Run: python .workflow/gate.py status $TASK_ID\"}}"
+exit 0

--- a/scripts/hooks/check-gate-before-pr.sh
+++ b/scripts/hooks/check-gate-before-pr.sh
@@ -38,15 +38,15 @@ TASK_ID=$(echo "$ACTIVE" | awk '{print $1}')
 STATUS=$(python .workflow/gate.py status "$TASK_ID" 2>/dev/null || echo "")
 
 # Check that update_changelog is DONE (gate 5 of 6, right before submit_pr)
-if echo "$STATUS" | grep -q "Update Changelog.*DONE"; then
+if echo "$STATUS" | grep -q "\[DONE\].*Update Changelog"; then
   echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow"}}'
   exit 0
 fi
 
 # Check which gates are missing
 MISSING=""
-echo "$STATUS" | grep -q "Update Documentation.*DONE" || MISSING="update_docs "
-echo "$STATUS" | grep -q "Update Changelog.*DONE" || MISSING="${MISSING}update_changelog"
+echo "$STATUS" | grep -q "\[DONE\].*Update Documentation" || MISSING="update_docs "
+echo "$STATUS" | grep -q "\[DONE\].*Update Changelog" || MISSING="${MISSING}update_changelog"
 
 echo "{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"WORKFLOW GATE: Missing stages before PR: ${MISSING}. Run: python .workflow/gate.py status $TASK_ID\"}}"
 exit 0

--- a/scripts/hooks/check-gate-before-push.sh
+++ b/scripts/hooks/check-gate-before-push.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# Claude Code PreToolUse hook: check workflow gate before git push
+# Ensures agents complete docs + changelog gates before pushing.
+
+set -e
+
+INPUT=$(cat)
+CMD=$(echo "$INPUT" | python -c "import sys,json; print(json.load(sys.stdin).get('tool_input',{}).get('command',''))" 2>/dev/null || echo "")
+
+# Only intercept git push commands
+if ! echo "$CMD" | grep -qE '^git push'; then
+  echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow"}}'
+  exit 0
+fi
+
+# Extract branch name from push command or current branch
+BRANCH=$(git branch --show-current 2>/dev/null || echo "")
+
+# Only enforce for branches that require gates (feat/, fix/, refactor/)
+if [ -z "$BRANCH" ] || ! echo "$BRANCH" | grep -qE '^(feat|fix|refactor)/'; then
+  echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow"}}'
+  exit 0
+fi
+
+# Check if there's an active workflow for this branch
+GATE_OUTPUT=$(python .workflow/gate.py list 2>/dev/null || echo "")
+
+# If no gate.py or no workflows, allow (not all branches use gates)
+if [ -z "$GATE_OUTPUT" ]; then
+  echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow"}}'
+  exit 0
+fi
+
+# Find active workflow matching this branch (heuristic: check if any active workflow exists)
+ACTIVE=$(echo "$GATE_OUTPUT" | grep "active" | head -1)
+if [ -z "$ACTIVE" ]; then
+  # No active workflow — either completed or not using gates
+  echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow"}}'
+  exit 0
+fi
+
+# Extract task ID from the active workflow line
+TASK_ID=$(echo "$ACTIVE" | awk '{print $1}')
+
+# Check gate status
+STATUS=$(python .workflow/gate.py status "$TASK_ID" 2>/dev/null || echo "")
+
+# Check that create_branch is at least DONE (minimum for pushing)
+if echo "$STATUS" | grep -q "Create Branch.*DONE"; then
+  echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow"}}'
+  exit 0
+fi
+
+# Block: gate not ready for push
+echo "{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"WORKFLOW GATE: create_branch stage not completed. Run: python .workflow/gate.py status $TASK_ID\"}}"
+exit 0

--- a/scripts/hooks/check-gate-before-push.sh
+++ b/scripts/hooks/check-gate-before-push.sh
@@ -46,7 +46,7 @@ TASK_ID=$(echo "$ACTIVE" | awk '{print $1}')
 STATUS=$(python .workflow/gate.py status "$TASK_ID" 2>/dev/null || echo "")
 
 # Check that create_branch is at least DONE (minimum for pushing)
-if echo "$STATUS" | grep -q "Create Branch.*DONE"; then
+if echo "$STATUS" | grep -q "\[DONE\].*Create Branch"; then
   echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow"}}'
   exit 0
 fi


### PR DESCRIPTION
## Summary

Add hook scripts to `scripts/hooks/` that enforce workflow gate discipline and CI checking. Referenced by `.claude/settings.json` (gitignored, per-machine config).

| Script | Trigger | Action |
|--------|---------|--------|
| `check-gate-before-push.sh` | `git push` | Blocks if `create_branch` gate not done |
| `check-gate-before-pr.sh` | `gh pr create` | Blocks if docs/changelog gates not done |
| `check-ci-after-pr.sh` | After `gh pr create` | Outputs mandatory CI check reminder |

Only enforced on `feat/`, `fix/`, `refactor/` branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)