### PR TITLE
fix(#665): variadic port rendering — config-driven handles, dynamic layout, type dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- [#665] Fix variadic port rendering: config-driven handles, dynamic layout, type dropdown (@claude, 2026-04-12, branch: fix/issue-665/variadic-port-frontend, session: 20260412-052953-fix-variadic-port-frontend-missing-handl)
 - [#630] Pass block registry to validate_workflow() in API save path so type compatibility and dangling port checks run (@claude, 2026-04-11, branch: fix/issue-638/validator-batch-improvements, session: 20260411-224417-batch-validator-improvements-registry-pa)
 - [#631] Add variadic port cardinality validation (Check 7) to workflow validator (@claude, 2026-04-11, branch: fix/issue-638/validator-batch-improvements, session: 20260411-224417-batch-validator-improvements-registry-pa)
 - [#632] Validate block config required fields before dispatch to catch misconfiguration before subprocess creation (@claude, 2026-04-11, branch: fix/issue-638/validator-batch-improvements, session: 20260411-224417-batch-validator-improvements-registry-pa)

--- a/frontend/src/components/WorkflowCanvas.tsx
+++ b/frontend/src/components/WorkflowCanvas.tsx
@@ -13,7 +13,7 @@ import "@xyflow/react/dist/style.css";
 import { useCallback, useMemo, useState } from "react";
 
 import { resolveTypeColor } from "../config/typeColorMap";
-import type { BlockSchemaResponse, BlockSummary, WorkflowEdge, WorkflowNode } from "../types/api";
+import type { BlockPortResponse, BlockSchemaResponse, BlockSummary, WorkflowEdge, WorkflowNode } from "../types/api";
 import type { BlockNodeData } from "../types/ui";
 import { AnnotationNode } from "./nodes/AnnotationNode";
 import { BlockNode } from "./nodes/BlockNode";
@@ -27,6 +27,40 @@ const nodeTypes = {
   _group: GroupNode,
 };
 const edgeTypes = { typed: TypedEdge };
+
+/**
+ * For variadic blocks, merge config-driven ports with schema-level ports.
+ * Schema-level ports are empty ([]) for variadic blocks like DataRouter/PairEditor.
+ * The actual ports are stored in config.input_ports / config.output_ports as
+ * arrays of {name: string, types: string[]}.
+ */
+function resolveVariadicPorts(
+  schemaPorts: BlockPortResponse[],
+  config: Record<string, unknown>,
+  direction: "input" | "output",
+  schema?: BlockSchemaResponse,
+): BlockPortResponse[] {
+  const isVariadic =
+    direction === "input"
+      ? schema?.variadic_inputs === true
+      : schema?.variadic_outputs === true;
+  if (!isVariadic) return schemaPorts;
+
+  const configKey = direction === "input" ? "input_ports" : "output_ports";
+  const configPorts = config[configKey];
+  if (!Array.isArray(configPorts) || configPorts.length === 0) return schemaPorts;
+
+  // Convert config port dicts to BlockPortResponse shape.
+  return (configPorts as Array<{ name: string; types?: string[] }>).map((cp) => ({
+    name: cp.name,
+    direction,
+    accepted_types: cp.types ?? [],
+    required: false,
+    description: "",
+    constraint_description: "",
+    is_collection: false,
+  }));
+}
 
 function parsePortRef(ref: string): { nodeId: string; portName: string } {
   const [nodeId, portName] = ref.split(":");
@@ -184,8 +218,8 @@ export function WorkflowCanvas(props: WorkflowCanvasProps) {
           summary,
           schema,
           config: params,
-          inputPorts: schema?.input_ports ?? summary?.input_ports ?? [],
-          outputPorts: schema?.output_ports ?? summary?.output_ports ?? [],
+          inputPorts: resolveVariadicPorts(schema?.input_ports ?? summary?.input_ports ?? [], params, "input", schema),
+          outputPorts: resolveVariadicPorts(schema?.output_ports ?? summary?.output_ports ?? [], params, "output", schema),
           status: blockStates[node.id] ?? "idle",
           errorMessage: blockErrors[node.id],
           errorSummary: blockErrorSummaries[node.id],

--- a/frontend/src/components/nodes/BlockNode.tsx
+++ b/frontend/src/components/nodes/BlockNode.tsx
@@ -1,5 +1,5 @@
 import { type Node, Handle, Position, type NodeProps, useEdges, useReactFlow } from "@xyflow/react";
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useState, useEffect, useCallback, useRef, useLayoutEffect } from "react";
 
 import { resolveTypeColor, resolveRingColor, isAnyType, primaryTypeName } from "../../config/typeColorMap";
 import { api } from "../../lib/api";
@@ -653,6 +653,23 @@ export function BlockNode({ id: nodeId, data, selected }: NodeProps<Node<BlockNo
     "output",
   );
 
+  // Measure the header + config section height to position port handles
+  // below the variable-height content instead of using a hardcoded offset.
+  const configSectionRef = useRef<HTMLDivElement>(null);
+  const [portStartY, setPortStartY] = useState(80);
+  useLayoutEffect(() => {
+    if (configSectionRef.current) {
+      // The config section's bottom edge relative to the node's top gives us
+      // the Y coordinate where port handles should begin.
+      const rect = configSectionRef.current.getBoundingClientRect();
+      const parentRect = configSectionRef.current.closest(".react-flow__node")?.getBoundingClientRect();
+      if (parentRect) {
+        const offset = rect.bottom - parentRect.top + 8; // 8px padding
+        setPortStartY(offset);
+      }
+    }
+  });
+
   const handleConfigChange = (key: string, value: unknown) => {
     data.onUpdateConfig?.({ [key]: value });
   };
@@ -756,7 +773,7 @@ export function BlockNode({ id: nodeId, data, selected }: NodeProps<Node<BlockNo
       {/* ----------------------------------------------------------------- */}
       {/* Inline config                                                     */}
       {/* ----------------------------------------------------------------- */}
-      <div className="nodrag nowheel space-y-2 overflow-hidden border-b border-stone-100 px-3 py-2">
+      <div ref={configSectionRef} className="nodrag nowheel space-y-2 overflow-hidden border-b border-stone-100 px-3 py-2">
         {configProps.length > 0 ? (
           configProps.map((prop) => (
             <InlineConfigField
@@ -785,7 +802,7 @@ export function BlockNode({ id: nodeId, data, selected }: NodeProps<Node<BlockNo
         const anyType = isAnyType(port.accepted_types);
         const typeName = primaryTypeName(port.accepted_types);
         const borderColor = ringColor ?? (anyType ? "#d1d5db" : fillColor);
-        const portTop = 80 + index * 20;
+        const portTop = portStartY + index * 20;
         return (
           <span key={port.name} className="group">
             <Handle
@@ -821,7 +838,7 @@ export function BlockNode({ id: nodeId, data, selected }: NodeProps<Node<BlockNo
           type="button"
           className="nodrag absolute flex h-3.5 w-3.5 items-center justify-center rounded-full bg-stone-100 text-[9px] text-stone-500 transition-colors hover:bg-ember hover:text-white"
           title="Add input port"
-          style={{ left: 6, top: 80 + effectiveInputPorts.length * 20 - 1 }}
+          style={{ left: 6, top: portStartY + effectiveInputPorts.length * 20 - 1 }}
           onClick={() => handleAddPort("input")}
         >
           +
@@ -833,7 +850,7 @@ export function BlockNode({ id: nodeId, data, selected }: NodeProps<Node<BlockNo
         const anyType = isAnyType(port.accepted_types);
         const typeName = primaryTypeName(port.accepted_types);
         const borderColor = ringColor ?? (anyType ? "#d1d5db" : fillColor);
-        const portTop = 80 + index * 20;
+        const portTop = portStartY + index * 20;
         return (
           <span key={port.name} className="group">
             <Handle
@@ -869,7 +886,7 @@ export function BlockNode({ id: nodeId, data, selected }: NodeProps<Node<BlockNo
           type="button"
           className="nodrag absolute flex h-3.5 w-3.5 items-center justify-center rounded-full bg-stone-100 text-[9px] text-stone-500 transition-colors hover:bg-ember hover:text-white"
           title="Add output port"
-          style={{ right: 6, top: 80 + effectiveOutputPorts.length * 20 - 1 }}
+          style={{ right: 6, top: portStartY + effectiveOutputPorts.length * 20 - 1 }}
           onClick={() => handleAddPort("output")}
         >
           +

--- a/src/scieasy/blocks/process/builtins/data_router.py
+++ b/src/scieasy/blocks/process/builtins/data_router.py
@@ -43,8 +43,8 @@ class DataRouter(ProcessBlock):
 
     variadic_inputs: ClassVar[bool] = True
     variadic_outputs: ClassVar[bool] = True
-    allowed_input_types: ClassVar[list[type]] = [DataObject]
-    allowed_output_types: ClassVar[list[type]] = [DataObject]
+    allowed_input_types: ClassVar[list[type]] = []
+    allowed_output_types: ClassVar[list[type]] = []
     min_input_ports: ClassVar[int | None] = 1
     min_output_ports: ClassVar[int | None] = 1
 

--- a/src/scieasy/blocks/process/builtins/pair_editor.py
+++ b/src/scieasy/blocks/process/builtins/pair_editor.py
@@ -16,7 +16,6 @@ from typing import Any, ClassVar
 from scieasy.blocks.base.config import BlockConfig
 from scieasy.blocks.base.state import ExecutionMode
 from scieasy.blocks.process.process_block import ProcessBlock
-from scieasy.core.types.base import DataObject
 
 logger = logging.getLogger(__name__)
 
@@ -48,8 +47,8 @@ class PairEditor(ProcessBlock):
 
     variadic_inputs: ClassVar[bool] = True
     variadic_outputs: ClassVar[bool] = True
-    allowed_input_types: ClassVar[list[type]] = [DataObject]
-    allowed_output_types: ClassVar[list[type]] = [DataObject]
+    allowed_input_types: ClassVar[list[type]] = []
+    allowed_output_types: ClassVar[list[type]] = []
     min_input_ports: ClassVar[int | None] = 2
     max_input_ports: ClassVar[int | None] = 8
 

--- a/tests/blocks/test_data_router.py
+++ b/tests/blocks/test_data_router.py
@@ -36,8 +36,9 @@ class TestDataRouterMetadata:
         assert DataRouter.variadic_outputs is True
 
     def test_allowed_types(self) -> None:
-        assert DataRouter.allowed_input_types == [DataObject]
-        assert DataRouter.allowed_output_types == [DataObject]
+        # Empty list = accept all DataObject subtypes (#665).
+        assert DataRouter.allowed_input_types == []
+        assert DataRouter.allowed_output_types == []
 
     def test_min_ports(self) -> None:
         assert DataRouter.min_input_ports == 1

--- a/tests/blocks/test_pair_editor.py
+++ b/tests/blocks/test_pair_editor.py
@@ -40,8 +40,9 @@ class TestPairEditorMetadata:
         assert PairEditor.max_input_ports == 8
 
     def test_allowed_types(self) -> None:
-        assert PairEditor.allowed_input_types == [DataObject]
-        assert PairEditor.allowed_output_types == [DataObject]
+        # Empty list = accept all DataObject subtypes (#665).
+        assert PairEditor.allowed_input_types == []
+        assert PairEditor.allowed_output_types == []
 
 
 class TestPairEditorPreparePrompt:


### PR DESCRIPTION
## Summary
- **Problem 1 (missing port handles)**: WorkflowCanvas now merges `config.input_ports`/`config.output_ports` into `BlockNodeData` for variadic blocks, so config-added ports render as Handle components on canvas nodes
- **Problem 2 (button overlap)**: BlockNode uses `useLayoutEffect` + ref to measure the actual header+config section height, computing `portStartY` dynamically instead of hardcoded `top: 80`
- **Problem 3 (config changes don't refresh)**: Since ports are now derived from `config` (which is in the React Flow node data), config updates automatically trigger re-render with updated ports
- **Problem 4 (type dropdown incomplete)**: DataRouter and PairEditor now use `allowed_input_types = []` / `allowed_output_types = []` (empty = accept all DataObject subtypes), so the frontend PortEditorTable shows the full type hierarchy

## Related Issues
Closes #665

## Test plan
- [ ] Drop a DataRouter block on canvas — should show + button, add ports, see handles appear
- [ ] Drop a PairEditor block — same behavior
- [ ] Open port editor modal — type dropdown should show all types (Image, Spectrum, etc.), not just DataObject
- [ ] Add 3+ config fields to a block — port handles and +/- buttons should not overlap with config section
- [ ] Connect edges to config-added variadic ports — edges should snap to correct handles

🤖 Generated with [Claude Code](https://claude.com/claude-code)