### PR TITLE
hotfix(#674): ExtractSpectrum, scheduler/runner fixes, type legend

### DIFF
--- a/frontend/src/components/TypeLegend.tsx
+++ b/frontend/src/components/TypeLegend.tsx
@@ -1,6 +1,10 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 
-import { typeColorMap, subtypeRingColorMap } from "../config/typeColorMap";
+import type { TypeHierarchyEntry } from "../types/api";
+import {
+  resolveRingColor,
+  resolveTypeColor,
+} from "../config/typeColorMap";
 
 interface TypeLegendProps {
   /**
@@ -8,28 +12,29 @@ interface TypeLegendProps {
    * The legend only shows entries for types in this set.
    */
   activeTypes: Set<string>;
+  /** Type hierarchy from the backend schema, used for color resolution. */
+  typeHierarchy?: TypeHierarchyEntry[];
 }
 
-/** All possible legend entries, in display order. */
-const legendEntries: { name: string; fill: string; ring?: string }[] = [
-  { name: "Array", fill: typeColorMap.Array },
-  { name: "Image", fill: typeColorMap.Image, ring: subtypeRingColorMap.Image },
-  { name: "Mask", fill: typeColorMap.Mask, ring: subtypeRingColorMap.Mask },
-  { name: "DataFrame", fill: typeColorMap.DataFrame },
-  { name: "Series", fill: typeColorMap.Series },
-  { name: "Text", fill: typeColorMap.Text },
-  { name: "Artifact", fill: typeColorMap.Artifact },
-  { name: "CompositeData", fill: typeColorMap.CompositeData },
-  { name: "Label", fill: typeColorMap.Label, ring: subtypeRingColorMap.Label },
-  { name: "Any", fill: "#ffffff", ring: undefined },
-];
-
-export function TypeLegend({ activeTypes }: TypeLegendProps) {
+export function TypeLegend({ activeTypes, typeHierarchy }: TypeLegendProps) {
   const [collapsed, setCollapsed] = useState(true);
 
-  const visible = legendEntries.filter(
-    (entry) => activeTypes.has(entry.name) || (entry.name === "Any" && activeTypes.has("Any")),
-  );
+  const visible = useMemo(() => {
+    const entries: { name: string; fill: string; ring?: string }[] = [];
+    for (const name of activeTypes) {
+      const types = [name];
+      const fill = resolveTypeColor(types, typeHierarchy);
+      const ring = resolveRingColor(types, typeHierarchy);
+      entries.push({ name, fill, ring });
+    }
+    // Sort: put "Any" last, otherwise alphabetical.
+    entries.sort((a, b) => {
+      if (a.name === "Any") return 1;
+      if (b.name === "Any") return -1;
+      return a.name.localeCompare(b.name);
+    });
+    return entries;
+  }, [activeTypes, typeHierarchy]);
 
   if (visible.length === 0) return null;
 
@@ -46,11 +51,14 @@ export function TypeLegend({ activeTypes }: TypeLegendProps) {
         <span
           className="inline-block h-2.5 w-2.5 rounded-sm"
           style={{
-            background: "linear-gradient(135deg, #3b82f6, #f59e0b, #22c55e, #8b5cf6)",
+            background:
+              "linear-gradient(135deg, #3b82f6, #f59e0b, #22c55e, #8b5cf6)",
           }}
         />
         {collapsed ? "Legend" : "Type Legend"}
-        <span className="ml-auto text-[9px]">{collapsed ? "\u25B6" : "\u25BC"}</span>
+        <span className="ml-auto text-[9px]">
+          {collapsed ? "\u25B6" : "\u25BC"}
+        </span>
       </button>
       {!collapsed && (
         <div className="space-y-1 border-t border-stone-100 px-2.5 pb-2 pt-1.5">

--- a/frontend/src/components/WorkflowCanvas.tsx
+++ b/frontend/src/components/WorkflowCanvas.tsx
@@ -113,8 +113,8 @@ export function WorkflowCanvas(props: WorkflowCanvasProps) {
     selectedNodeId,
   } = props;
 
-  // Collect the set of type names present across all ports in the workflow
-  // for the TypeLegend component.
+  // Collect the set of type names and merged type hierarchy present across
+  // all ports in the workflow for the TypeLegend component.
   const activeTypes = useMemo<Set<string>>(() => {
     const types = new Set<string>();
     for (const node of nodes) {
@@ -132,6 +132,13 @@ export function WorkflowCanvas(props: WorkflowCanvasProps) {
     }
     return types;
   }, [nodes, schemas]);
+
+  const mergedTypeHierarchy = useMemo(() => {
+    for (const schema of Object.values(schemas)) {
+      if (schema?.type_hierarchy?.length) return schema.type_hierarchy;
+    }
+    return undefined;
+  }, [schemas]);
 
   // Track positions locally during drag so nodes follow the cursor smoothly.
   // ReactFlow is in controlled mode (nodes prop), so without this the node
@@ -355,7 +362,7 @@ export function WorkflowCanvas(props: WorkflowCanvasProps) {
         <Controls />
         <Background color="#d8d2c4" gap={20} size={1.2} />
       </ReactFlow>
-      <TypeLegend activeTypes={activeTypes} />
+      <TypeLegend activeTypes={activeTypes} typeHierarchy={mergedTypeHierarchy} />
     </div>
   );
 }

--- a/frontend/src/components/nodes/BlockNode.tsx
+++ b/frontend/src/components/nodes/BlockNode.tsx
@@ -659,16 +659,16 @@ export function BlockNode({ id: nodeId, data, selected }: NodeProps<Node<BlockNo
   const [portStartY, setPortStartY] = useState(80);
   useLayoutEffect(() => {
     if (configSectionRef.current) {
-      // The config section's bottom edge relative to the node's top gives us
-      // the Y coordinate where port handles should begin.
-      const rect = configSectionRef.current.getBoundingClientRect();
-      const parentRect = configSectionRef.current.closest(".react-flow__node")?.getBoundingClientRect();
-      if (parentRect) {
-        const offset = rect.bottom - parentRect.top + 8; // 8px padding
-        setPortStartY(offset);
-      }
+      // Use offsetTop + offsetHeight instead of getBoundingClientRect()
+      // because offset* properties are in the node's local coordinate
+      // system, unaffected by ReactFlow's CSS zoom transform.
+      const offset = configSectionRef.current.offsetTop + configSectionRef.current.offsetHeight + 8;
+      setPortStartY(offset);
     }
-  });
+    // Re-measure only when config properties or port lists change, not on
+    // every render (which causes port jitter during edge dragging).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [configProps.length, effectiveInputPorts.length, effectiveOutputPorts.length]);
 
   const handleConfigChange = (key: string, value: unknown) => {
     data.onUpdateConfig?.({ [key]: value });

--- a/frontend/src/config/typeColorMap.ts
+++ b/frontend/src/config/typeColorMap.ts
@@ -131,17 +131,12 @@ export function resolveRingColor(
       }
     }
   }
-  // Auto-derive ring color for hash-palette types (#543)
-  // Only apply if the type is not in the manual maps (i.e. it would get a hash color)
+  // Auto-derive ring color for types not in the manual maps (#543)
   if (typeNames.length > 0 && !typeColorMap[typeNames[0]]) {
-    const isKnownViaHierarchy = typeHierarchy?.some((t) => {
-      if (t.name !== typeNames[0]) return false;
-      return t.base_type && typeColorMap[t.base_type];
-    });
-    if (!isKnownViaHierarchy) {
-      const idx = hashTypeName(typeNames[0]) % HASH_PALETTE.length;
-      return darkenHex(HASH_PALETTE[idx], 0.3);
-    }
+    // Plugin subtypes that inherit a base color get a hash-derived ring
+    // to visually distinguish them from the base type.
+    const idx = hashTypeName(typeNames[0]) % HASH_PALETTE.length;
+    return darkenHex(HASH_PALETTE[idx], 0.3);
   }
   return undefined;
 }

--- a/frontend/src/store/workflowSlice.ts
+++ b/frontend/src/store/workflowSlice.ts
@@ -57,20 +57,32 @@ export const createWorkflowSlice: StateCreator<AppStore, [], [], WorkflowSlice> 
     }),
   setWorkflowName: (name) => set({ workflowName: name }),
   addNode: (block, position, defaultParams) =>
-    set((state) => ({
-      ...pushHistory(state),
-      workflowDirty: true,
-      workflowId: state.workflowId ?? "main",
-      workflowNodes: [
-        ...state.workflowNodes,
-        {
-          id: `${block.type_name}-${Date.now()}`,
-          block_type: block.type_name,
-          config: { params: defaultParams ?? {} },
-          layout: position,
-        },
-      ],
-    })),
+    set((state) => {
+      const nodeId = `${block.type_name}-${Date.now()}`;
+      const params: Record<string, unknown> = { ...(defaultParams ?? {}) };
+
+      // Auto-fill output_dir for AppBlock-category blocks with the
+      // project exchange directory so users see the default path.
+      const projectPath = (state as AppStore).currentProject?.path;
+      if (projectPath && block.base_category === "app" && !params.output_dir) {
+        params.output_dir = `${projectPath}/data/exchange/${nodeId}/outputs`;
+      }
+
+      return {
+        ...pushHistory(state),
+        workflowDirty: true,
+        workflowId: state.workflowId ?? "main",
+        workflowNodes: [
+          ...state.workflowNodes,
+          {
+            id: nodeId,
+            block_type: block.type_name,
+            config: { params },
+            layout: position,
+          },
+        ],
+      };
+    }),
   addAnnotationNode: (position) =>
     set((state) => ({
       ...pushHistory(state),

--- a/packages/scieasy-blocks-imaging/src/scieasy_blocks_imaging/interactive/napari_block.py
+++ b/packages/scieasy-blocks-imaging/src/scieasy_blocks_imaging/interactive/napari_block.py
@@ -53,10 +53,15 @@ class NapariBlock(AppBlock):
     def run(self, inputs: dict[str, Collection], config: BlockConfig) -> dict[str, Collection]:
         images = _input_images(inputs, "image", "NapariBlock")
         exchange_dir = _resolve_exchange_dir(config, prefix="scieasy_napari_")
-        _prepare_image_exchange(images, exchange_dir, tool_name=self.type_name, config=config)
+        staged_paths = _prepare_image_exchange(images, exchange_dir, tool_name=self.type_name, config=config)
         command = _resolve_command(config, app_command=self.app_command, override_key="napari_path")
         output_files = _run_external_app(
-            self, command=command, exchange_dir=exchange_dir, patterns=self.output_patterns, config=config
+            self,
+            command=command,
+            exchange_dir=exchange_dir,
+            patterns=self.output_patterns,
+            config=config,
+            launch_args=[str(p) for p in staged_paths],
         )
         return _collect_outputs(
             output_files, template_image=images[0] if images else None, allowed_ports={"image", "mask", "label"}

--- a/packages/scieasy-blocks-srs/src/scieasy_blocks_srs/spectral_extraction/extract_spectrum.py
+++ b/packages/scieasy-blocks-srs/src/scieasy_blocks_srs/spectral_extraction/extract_spectrum.py
@@ -88,17 +88,30 @@ class ExtractSpectrum(ProcessBlock):
         n_lambda = first.shape[lambda_axis] if first.shape else 0
         wavenumbers = _get_wavenumbers(first, n_lambda)
 
+        # Validate that all images have compatible lambda axes.
+        for idx, image in enumerate(images):
+            if "lambda" not in image.axes:
+                raise ValueError(f"ExtractSpectrum: image[{idx}] is missing the 'lambda' axis")
+            img_lambda = image.axes.index("lambda")
+            img_n = image.shape[img_lambda] if image.shape else 0
+            if img_n != n_lambda:
+                raise ValueError(
+                    f"ExtractSpectrum: image[{idx}] lambda size {img_n} != image[0] lambda size {n_lambda}"
+                )
+
         # Build columns: wavenumber + one per image-region.
         columns: dict[str, pa.Array] = {
             "wavenumber_cm1": pa.array(wavenumbers, type=pa.float64()),
         }
+        used_names: set[str] = set()
 
         for idx, image in enumerate(images):
             label = labels_list[idx]
             img_name = _derive_image_name(image, idx)
             spectra = _extract_spectra(image, label)
             for col_suffix, spectrum in spectra:
-                col_name = f"{img_name}_{col_suffix}"
+                col_name = _unique_column_name(f"{img_name}_{col_suffix}", used_names)
+                used_names.add(col_name)
                 columns[col_name] = pa.array(spectrum, type=pa.float64())
 
         table = pa.table(columns)
@@ -166,6 +179,16 @@ def _get_wavenumbers(image: Image, n_lambda: int) -> list[float]:
         if wn is not None:
             return list(wn)
     return [float(i) for i in range(n_lambda)]
+
+
+def _unique_column_name(candidate: str, used: set[str]) -> str:
+    """Return *candidate* if unused, otherwise append _2, _3, ... until unique."""
+    if candidate not in used:
+        return candidate
+    counter = 2
+    while f"{candidate}_{counter}" in used:
+        counter += 1
+    return f"{candidate}_{counter}"
 
 
 def _derive_image_name(image: Image, index: int) -> str:

--- a/packages/scieasy-blocks-srs/src/scieasy_blocks_srs/spectral_extraction/extract_spectrum.py
+++ b/packages/scieasy-blocks-srs/src/scieasy_blocks_srs/spectral_extraction/extract_spectrum.py
@@ -1,57 +1,54 @@
-"""ExtractSpectrum — ROI / Label / Mask + :class:`SRSImage` → long DataFrame.
+"""ExtractSpectrum — Label + :class:`SRSImage` → wide-format DataFrame.
 
-Critical-path block for the §11 cross-plugin E2E test. Output schema is
-the locked long format ``["region_id", "wavenumber_cm1", "intensity"]``
-per spec §8 Question 3.
-
-Skeleton placeholder — T-SRS-011 implementation agent fills the body.
-See ``docs/specs/phase11-srs-block-spec.md`` §9 T-SRS-011.
+Extracts per-ROI mean spectra from a Collection of SRSImages paired with
+a Collection of Labels. Output is a wide-format DataFrame where each row
+is a wavenumber and each column is a named spectrum (image_name + ROI id).
 """
 
 from __future__ import annotations
 
-from typing import Any, ClassVar
+import os
+from typing import Any, ClassVar, cast
 
-from scieasy_blocks_imaging.types import Label, Mask  # type: ignore[import-not-found]
+import numpy as np
+import pyarrow as pa
+from scieasy_blocks_imaging.types import Image, Label  # type: ignore[import-not-found]
 
 from scieasy.blocks.base.block import BlockConfig
 from scieasy.blocks.base.ports import InputPort, OutputPort
 from scieasy.blocks.process.process_block import ProcessBlock
+from scieasy.core.types.array import Array
+from scieasy.core.types.collection import Collection
 from scieasy.core.types.dataframe import DataFrame
 from scieasy_blocks_srs.types import SRSImage
 
-#: Locked long-format columns for the output DataFrame.
-OUTPUT_COLUMNS: tuple[str, ...] = ("region_id", "wavenumber_cm1", "intensity")
-
 
 class ExtractSpectrum(ProcessBlock):
-    """Extract per-region mean spectra into a long-format DataFrame.
+    """Extract per-region mean spectra into a wide-format DataFrame.
 
-    Three input ports (``image``, optional ``labels``, optional ``mask``)
-    so the block overrides :meth:`run` directly. Region-id semantics:
+    Two input ports: ``image`` (required) and ``labels`` (optional).
 
-    * No ROI → single row block with ``region_id == 0``.
-    * Mask → single row block with ``region_id == 1``.
-    * Label → one row block per non-zero label value.
+    Output columns: ``wavenumber_cm1``, then one column per image-region
+    combination named ``{image_name}_ROI{region_id}``.
 
-    v0.1 limitation: 5D inputs with extra ``c``/``t``/``z`` axes raise a
-    ``ValueError`` pointing at ``SelectSlice`` as the upstream remedy.
+    When no labels are provided, the entire image is averaged into a
+    single column named ``{image_name}_mean``.
     """
 
     name: ClassVar[str] = "Extract Spectrum"
     type_name: ClassVar[str] = "srs.extract_spectrum"
     description: ClassVar[str] = (
-        "Extract per-ROI mean spectra into a long-format DataFrame (region_id, wavenumber_cm1, intensity)."
+        "Extract per-ROI mean spectra into a wide-format DataFrame (wavenumber_cm1, image_ROI1, image_ROI2, ...)."
     )
-    version: ClassVar[str] = "0.1.0"
+    version: ClassVar[str] = "0.2.0"
     subcategory: ClassVar[str] = "spectral"
     algorithm: ClassVar[str] = "extract_spectrum"
 
     input_ports: ClassVar[list[InputPort]] = [
         InputPort(
             name="image",
-            accepted_types=[SRSImage],
-            description="SRSImage with y/x/lambda axes only (v0.1 limitation).",
+            accepted_types=[SRSImage, Image],
+            description="Image with y/x/lambda axes (SRSImage or Image).",
         ),
         InputPort(
             name="labels",
@@ -59,18 +56,12 @@ class ExtractSpectrum(ProcessBlock):
             description="Optional Label raster; non-zero values define regions.",
             required=False,
         ),
-        InputPort(
-            name="mask",
-            accepted_types=[Mask],
-            description="Optional boolean Mask; True pixels define region 1.",
-            required=False,
-        ),
     ]
     output_ports: ClassVar[list[OutputPort]] = [
         OutputPort(
             name="spectra",
             accepted_types=[DataFrame],
-            description="Long-format DataFrame: (region_id, wavenumber_cm1, intensity).",
+            description="Wide-format DataFrame: wavenumber_cm1 + one column per ROI.",
         ),
     ]
 
@@ -84,16 +75,150 @@ class ExtractSpectrum(ProcessBlock):
         inputs: dict[str, Any],
         config: BlockConfig,
     ) -> dict[str, Any]:
-        """Iterate the input Collection, extract per-region means, build DataFrame.
+        """Iterate input Collections, extract per-region mean spectra, build wide DataFrame."""
+        images = _coerce_images(inputs.get("image"))
+        labels_raw = inputs.get("labels")
+        labels_list = _coerce_labels(labels_raw, len(images))
 
-        T-SRS-011 impl agent: per spec §8 Question 3, dispatch to label /
-        mask / no-ROI branch, build rows with the locked
-        :data:`OUTPUT_COLUMNS` schema, wrap with ``DataFrame.from_pandas``.
-        """
-        raise NotImplementedError(
-            "T-SRS-011: ExtractSpectrum.run — impl pending (skeleton). "
-            "See docs/specs/phase11-srs-block-spec.md §9 T-SRS-011."
+        # All images must share the same wavenumber axis.
+        first = images[0]
+        if "lambda" not in first.axes:
+            raise ValueError("ExtractSpectrum: image must have a 'lambda' axis")
+        lambda_axis = first.axes.index("lambda")
+        n_lambda = first.shape[lambda_axis] if first.shape else 0
+        wavenumbers = _get_wavenumbers(first, n_lambda)
+
+        # Build columns: wavenumber + one per image-region.
+        columns: dict[str, pa.Array] = {
+            "wavenumber_cm1": pa.array(wavenumbers, type=pa.float64()),
+        }
+
+        for idx, image in enumerate(images):
+            label = labels_list[idx]
+            img_name = _derive_image_name(image, idx)
+            spectra = _extract_spectra(image, label)
+            for col_suffix, spectrum in spectra:
+                col_name = f"{img_name}_{col_suffix}"
+                columns[col_name] = pa.array(spectrum, type=pa.float64())
+
+        table = pa.table(columns)
+        result = DataFrame(
+            columns=list(table.column_names),
+            row_count=table.num_rows,
+            framework=first.framework.derive(),
+            data=table,
         )
+        return {"spectra": result}
 
 
-__all__ = ["OUTPUT_COLUMNS", "ExtractSpectrum"]
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _coerce_images(value: Any) -> list[Image]:
+    if value is None:
+        raise ValueError("ExtractSpectrum: missing required 'image' input")
+    if isinstance(value, Image):
+        return [value]
+    if isinstance(value, Collection):
+        items = [cast(Image, item) for item in value]
+        if not items:
+            raise ValueError("ExtractSpectrum: image collection is empty")
+        return items
+    raise ValueError(f"ExtractSpectrum: expected Image or Collection, got {type(value).__name__}")
+
+
+def _coerce_labels(value: Any, expected: int) -> list[Label | None]:
+    if value is None:
+        return [None] * expected
+    if isinstance(value, Label):
+        if expected != 1:
+            raise ValueError(f"ExtractSpectrum: got single Label but {expected} images; provide a Collection of Labels")
+        return [value]
+    if isinstance(value, Collection):
+        items: list[Label | None] = [cast(Label, item) for item in value]
+        if len(items) != expected:
+            raise ValueError(
+                f"ExtractSpectrum: labels Collection length ({len(items)}) != image Collection length ({expected})"
+            )
+        return items
+    raise ValueError(f"ExtractSpectrum: unexpected labels type {type(value).__name__}")
+
+
+def _get_image_data(image: Image) -> np.ndarray:
+    """Load image data into memory as float64."""
+    return np.asarray(image.to_memory(), dtype=np.float64)
+
+
+def _get_label_data(label: Label) -> np.ndarray:
+    """Get 2D integer label raster."""
+    raster = label.slots.get("raster")
+    if raster is None or not isinstance(raster, Array):
+        raise ValueError("ExtractSpectrum: Label input requires a populated 'raster' slot")
+    return np.asarray(raster.to_memory(), dtype=np.int32)
+
+
+def _get_wavenumbers(image: Image, n_lambda: int) -> list[float]:
+    """Retrieve wavenumber axis values, falling back to integer indices."""
+    if image.meta is not None:
+        wn = getattr(image.meta, "wavenumbers_cm1", None)
+        if wn is not None:
+            return list(wn)
+    return [float(i) for i in range(n_lambda)]
+
+
+def _derive_image_name(image: Image, index: int) -> str:
+    """Derive a short column-friendly name from the image metadata or index."""
+    if image.meta is not None and getattr(image.meta, "source_file", None):
+        base = os.path.splitext(os.path.basename(image.meta.source_file))[0]
+        # Sanitise for use as column name.
+        return base.replace(" ", "_").replace("-", "_")
+    return f"img{index}"
+
+
+def _extract_spectra(
+    image: Image,
+    label: Label | None,
+) -> list[tuple[str, list[float]]]:
+    """Extract spectra from one image + optional label.
+
+    Returns a list of (column_suffix, spectrum_values) pairs.
+    """
+    cube = _get_image_data(image)
+    axes = image.axes
+
+    if "lambda" not in axes:
+        raise ValueError("ExtractSpectrum: image must have a 'lambda' axis")
+
+    lambda_axis = axes.index("lambda")
+    n_lambda = cube.shape[lambda_axis]
+
+    # Reshape to (n_lambda, n_pixels) for easy masked averaging
+    cube_lf = np.moveaxis(cube, lambda_axis, 0)  # (lambda, y, x)
+    spatial_shape = cube_lf.shape[1:]
+    cube_2d = cube_lf.reshape(n_lambda, -1)  # (lambda, n_pixels)
+
+    results: list[tuple[str, list[float]]] = []
+
+    if label is not None:
+        label_data = _get_label_data(label)
+        if label_data.shape != spatial_shape:
+            raise ValueError(f"ExtractSpectrum: label shape {label_data.shape} != image spatial shape {spatial_shape}")
+        label_flat = label_data.ravel()
+        region_ids = np.unique(label_flat)
+        region_ids = region_ids[region_ids != 0]  # skip background
+
+        for rid in region_ids:
+            pixel_mask = label_flat == rid
+            mean_spectrum = cube_2d[:, pixel_mask].mean(axis=1)
+            results.append((f"ROI{int(rid)}", mean_spectrum.tolist()))
+    else:
+        # No ROI: average all pixels
+        mean_spectrum = cube_2d.mean(axis=1)
+        results.append(("mean", mean_spectrum.tolist()))
+
+    return results
+
+
+__all__ = ["ExtractSpectrum"]

--- a/src/scieasy/engine/resources.py
+++ b/src/scieasy/engine/resources.py
@@ -140,7 +140,7 @@ class ResourceManager:
         self,
         gpu_slots: int | None = None,
         cpu_workers: int = 4,
-        memory_high_watermark: float = 0.80,
+        memory_high_watermark: float = 0.90,
         memory_critical: float = 0.95,
         event_bus: Any | None = None,
     ) -> None:

--- a/src/scieasy/engine/runners/local.py
+++ b/src/scieasy/engine/runners/local.py
@@ -59,7 +59,14 @@ def _win_junction(target: str) -> str:
         )
     except (sp.CalledProcessError, FileNotFoundError) as exc:
         logger.warning("Failed to create junction %s -> %s: %s", junction, target, exc)
-        return target
+        # Fallback: use the short path as a real directory instead of a
+        # junction.  This avoids MAX_PATH failures when the target lives
+        # on a virtual filesystem (e.g. Box) that rejects junctions.
+        # Data will be written to the short path; it will NOT sync with
+        # cloud storage, but zarr operations will succeed.
+        junction.mkdir(parents=True, exist_ok=True)
+        logger.info("Fallback: using short path %s as real directory", junction)
+        return str(junction)
 
     logger.info("Created junction %s -> %s", junction, target)
     return str(junction)
@@ -179,6 +186,12 @@ class LocalRunner:
         )
 
         stdout, stderr = await proc.communicate(input=payload_bytes)
+
+        # Forward worker stderr so block-level diagnostics are visible.
+        if stderr:
+            for line in stderr.decode(errors="replace").splitlines():
+                if line.strip():
+                    logger.info("worker[%s] %s", block_id, line)
 
         if proc.returncode != 0:
             error_msg = stderr.decode(errors="replace") if stderr else "unknown error"

--- a/src/scieasy/engine/scheduler.py
+++ b/src/scieasy/engine/scheduler.py
@@ -251,9 +251,14 @@ class DAGScheduler:
         config_schema = getattr(block, "config_schema", None)
         if isinstance(config_schema, dict) and config_schema.get("required"):
             required_fields = config_schema["required"]
+            properties = config_schema.get("properties", {})
             params = node.config.get("params", {}) if isinstance(node.config.get("params"), dict) else {}
             top_level = node.config if isinstance(node.config, dict) else {}
-            missing = [f for f in required_fields if (params.get(f) is None and top_level.get(f) is None)]
+            missing = [
+                f
+                for f in required_fields
+                if (params.get(f) is None and top_level.get(f) is None and "default" not in properties.get(f, {}))
+            ]
             if missing:
                 error_str = f"Block '{node_id}' config is missing required field(s): {', '.join(sorted(missing))}"
                 logger.error("Pre-dispatch config validation failed for %s: %s", node_id, error_str)

--- a/tests/engine/test_resources.py
+++ b/tests/engine/test_resources.py
@@ -68,7 +68,7 @@ class TestResourceManagerInit:
         rm = ResourceManager(gpu_slots=0)
         assert rm.gpu_slots == 0
         assert rm.max_cpu_workers == 4
-        assert rm.memory_high_watermark == 0.80
+        assert rm.memory_high_watermark == 0.90
         assert rm.memory_critical == 0.95
         assert rm._gpu_in_use == 0
         assert rm._cpu_in_use == 0


### PR DESCRIPTION
## Summary

- **ExtractSpectrum implementation**: wide-format DataFrame output (wavenumber rows × image-ROI columns), accepts both SRSImage and Image, removed mask port
- **Junction fallback**: creates real directory when NTFS junction fails (Box virtual FS), preventing MAX_PATH overflow
- **Worker stderr forwarding**: block subprocess stderr now visible in main process logs
- **Pre-dispatch config validation**: respects `default` values in schema for required fields
- **Memory watermark**: raised from 80% to 90% to prevent false dispatch throttling
- **Dynamic TypeLegend**: auto-generated from workflow port types, includes plugin subtypes
- **Port ring colors**: plugin subtypes get hash-derived ring colors for visual distinction

## Related Issues
Closes #674

## Test plan
- [x] Verified workflow runs end-to-end with SRS calibrate → cellpose → extract_spectrum → save_data
- [x] Verified parallel block dispatch with memory at ~80%
- [x] Verified TypeLegend shows SRSImage with ring color
- [x] Verified extract_spectrum accepts both Image and SRSImage inputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)