### PR TITLE
fix(#678): remove 120s timeout from native file dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- [#678] Remove 120s timeout from native file dialog; status-aware frontend fallback (only fall back to in-app picker on HTTP 500, not 504) (@claude, 2026-04-24, branch: fix/issue-678/native-dialog-no-timeout, session: 20260424-130419-fix-678-remove-native-dialog-timeout)
 - [#665] Fix variadic port rendering: config-driven handles, dynamic layout, type dropdown (@claude, 2026-04-12, branch: fix/issue-665/variadic-port-frontend, session: 20260412-052953-fix-variadic-port-frontend-missing-handl)
 - [#630] Pass block registry to validate_workflow() in API save path so type compatibility and dangling port checks run (@claude, 2026-04-11, branch: fix/issue-638/validator-batch-improvements, session: 20260411-224417-batch-validator-improvements-registry-pa)
 - [#631] Add variadic port cardinality validation (Check 7) to workflow validator (@claude, 2026-04-11, branch: fix/issue-638/validator-batch-improvements, session: 20260411-224417-batch-validator-improvements-registry-pa)

--- a/frontend/src/components/nodes/BlockNode.test.tsx
+++ b/frontend/src/components/nodes/BlockNode.test.tsx
@@ -1,4 +1,5 @@
 import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { ReactFlowProvider } from "@xyflow/react";
 
@@ -11,11 +12,28 @@ import type {
 import type { BlockNodeData } from "../../types/ui";
 
 // api module mock — browse endpoints removed (#467), stub for remaining tests.
+// `openNativeDialog` is a `vi.fn()` so individual tests can stub it per-case.
+const openNativeDialogMock = vi.fn();
 vi.mock("../../lib/api", () => ({
-  api: {},
+  api: {
+    get openNativeDialog() {
+      return openNativeDialogMock;
+    },
+  },
+  ApiError: class ApiError extends Error {
+    status: number;
+    constructor(message: string, status: number) {
+      super(message);
+      this.name = "ApiError";
+      this.status = status;
+    }
+  },
 }));
 
-afterEach(() => cleanup());
+afterEach(() => {
+  cleanup();
+  openNativeDialogMock.mockReset();
+});
 
 // ---------------------------------------------------------------------------
 // Test fixtures
@@ -441,3 +459,77 @@ describe("BlockNode — sanity smoke", () => {
   });
 });
 
+
+// ---------------------------------------------------------------------------
+// Native dialog fallback behavior (#678)
+// ---------------------------------------------------------------------------
+
+describe("BlockNode - native dialog status-aware fallback (#678)", () => {
+  // A non-io block with a file_browser config field renders a Browse "..." button.
+  function renderBrowseField() {
+    return renderNode({
+      category: "process",
+      blockType: "test_block",
+      schema: makeSchema({
+        base_category: "process",
+        type_name: "test_block",
+        config_schema: {
+          type: "object",
+          properties: {
+            path: { type: "string", ui_widget: "file_browser", ui_priority: 0 },
+          },
+        },
+      }),
+    });
+  }
+
+  function findBrowseButton(): HTMLElement {
+    const btn = screen.getByTitle("Browse filesystem");
+    expect(btn).toBeInTheDocument();
+    return btn;
+  }
+
+  function getFileBrowserHeading(): HTMLElement | null {
+    return screen.queryByText("Select File");
+  }
+
+  it("falls back to in-app FileBrowserModal when native dialog returns HTTP 500", async () => {
+    const { ApiError } = await import("../../lib/api");
+    openNativeDialogMock.mockRejectedValueOnce(
+      new ApiError("Native dialog command not available on this platform (Linux)", 500),
+    );
+
+    renderBrowseField();
+    expect(getFileBrowserHeading()).toBeNull();
+    await userEvent.click(findBrowseButton());
+
+    // Modal opens (heading "Select File" is the modal's title).
+    expect(getFileBrowserHeading()).toBeInTheDocument();
+  });
+
+  it("does NOT open in-app FileBrowserModal when native dialog returns HTTP 504", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { ApiError } = await import("../../lib/api");
+    openNativeDialogMock.mockRejectedValueOnce(
+      new ApiError("Dialog timed out", 504),
+    );
+
+    renderBrowseField();
+    await userEvent.click(findBrowseButton());
+
+    // Modal must NOT open on a 504 - that is the deprecated picker we
+    // are explicitly avoiding (#678).
+    expect(getFileBrowserHeading()).toBeNull();
+    expect(consoleError).toHaveBeenCalled();
+    consoleError.mockRestore();
+  });
+
+  it("falls back to in-app FileBrowserModal on a non-ApiError network failure", async () => {
+    openNativeDialogMock.mockRejectedValueOnce(new Error("network down"));
+
+    renderBrowseField();
+    await userEvent.click(findBrowseButton());
+
+    expect(getFileBrowserHeading()).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/nodes/BlockNode.tsx
+++ b/frontend/src/components/nodes/BlockNode.tsx
@@ -2,7 +2,7 @@ import { type Node, Handle, Position, type NodeProps, useEdges, useReactFlow } f
 import { useState, useEffect, useCallback, useRef, useLayoutEffect } from "react";
 
 import { resolveTypeColor, resolveRingColor, isAnyType, primaryTypeName } from "../../config/typeColorMap";
-import { api } from "../../lib/api";
+import { api, ApiError } from "../../lib/api";
 import type { FilesystemEntry } from "../../types/api";
 import type { BlockNodeData } from "../../types/ui";
 import { computeEffectivePorts } from "../../utils/computeEffectivePorts";
@@ -464,8 +464,30 @@ function InlineConfigField({
         }
       }
       // If paths is empty, user cancelled — do nothing
-    } catch {
-      // Native dialog failed — fall back to in-app FileBrowserModal
+    } catch (err) {
+      // Status-aware fallback (#678):
+      //  - HTTP 500 = native dialog tool not installed on this platform → fall
+      //    back to the deprecated in-app FileBrowserModal so the user can still
+      //    pick a path.
+      //  - HTTP 504 = dialog timed out. Backend no longer enforces a timeout
+      //    so this should not happen in practice; if it does, do NOT fall back
+      //    silently — surface the error so we notice. Just log; the deprecated
+      //    in-app picker is a worse experience than a no-op.
+      //  - Any other error (network failure, unknown) → fall back defensively.
+      if (err instanceof ApiError) {
+        if (err.status === 504) {
+          // eslint-disable-next-line no-console
+          console.error(
+            "Native file dialog timed out (HTTP 504); not falling back to in-app picker.",
+            err,
+          );
+          return;
+        }
+        // 500 and any other HTTP error: fall back to in-app picker.
+        setBrowseOpen(true);
+        return;
+      }
+      // Non-ApiError (network failure, etc.): fall back defensively.
       setBrowseOpen(true);
     }
   };

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -21,13 +21,31 @@ const JSON_HEADERS = {
   "Content-Type": "application/json",
 };
 
+/**
+ * Error thrown by `apiFetch` for non-2xx responses. Exposes the HTTP status
+ * code so callers can branch on it (e.g. fall back on 500 but not on 504).
+ * See issue #678.
+ */
+export class ApiError extends Error {
+  status: number;
+
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = "ApiError";
+    this.status = status;
+  }
+}
+
 async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> {
   const response = await fetch(path, init);
   if (!response.ok) {
     const payload = (await response.json().catch(() => ({ detail: response.statusText }))) as {
       detail?: string;
     };
-    throw new Error(payload.detail ?? `Request failed with ${response.status}`);
+    throw new ApiError(
+      payload.detail ?? `Request failed with ${response.status}`,
+      response.status,
+    );
   }
   if (response.status === 204) {
     return undefined as T;

--- a/src/scieasy/api/routes/filesystem.py
+++ b/src/scieasy/api/routes/filesystem.py
@@ -362,11 +362,13 @@ public static class FolderPicker {
             f"$d.InitialDirectory = '{initial_dir or ''}';"
             "if ($d.ShowDialog() -eq 'OK') { ($d.FileNames -join '|') } else { '' }"
         )
+    # No timeout: this is a desktop-local server and the user may legitimately
+    # spend an arbitrary amount of time browsing the dialog (#678).
     result = subprocess.run(
         ["powershell", "-NoProfile", "-NonInteractive", "-Command", ps_script],
         capture_output=True,
         text=True,
-        timeout=120,
+        timeout=None,
     )
     selected = result.stdout.strip()
     if not selected:
@@ -402,11 +404,13 @@ def _native_dialog_macos(
             )
         else:
             script = 'choose file with prompt "Select File" with multiple selections allowed'
+    # No timeout: this is a desktop-local server and the user may legitimately
+    # spend an arbitrary amount of time browsing the dialog (#678).
     result = subprocess.run(
         ["osascript", "-e", script],
         capture_output=True,
         text=True,
-        timeout=120,
+        timeout=None,
     )
     selected = result.stdout.strip()
     if not selected:
@@ -454,7 +458,9 @@ def _native_dialog_linux(
         cmd.extend(["--separator", "|"])
     if initial_dir:
         cmd.extend(["--filename", initial_dir + "/"])
-    result = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
+    # No timeout: this is a desktop-local server and the user may legitimately
+    # spend an arbitrary amount of time browsing the dialog (#678).
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=None)
     selected = result.stdout.strip()
     if not selected:
         return []

--- a/tests/api/test_native_dialog.py
+++ b/tests/api/test_native_dialog.py
@@ -68,3 +68,56 @@ class TestNativeDialogWindowsDirectory:
         assert "OpenFileDialog" in ps_script
         assert "FolderPicker" not in ps_script
         assert result == [r"C:\file1.txt", r"C:\file2.txt"]
+
+
+class TestNativeDialogNoTimeout:
+    """Regression for #678: the native dialog must NOT enforce a 120s timeout.
+
+    On a desktop-local server the user may legitimately spend many minutes
+    browsing for a file. The previous 120s timeout killed the dialog process
+    from under the user. These tests assert each platform helper invokes
+    ``subprocess.run`` with ``timeout=None`` (or no ``timeout`` kwarg).
+    """
+
+    @staticmethod
+    def _assert_no_timeout(mock_run: MagicMock) -> None:
+        timeout = mock_run.call_args.kwargs.get("timeout", None)
+        assert timeout is None, (
+            f"native dialog must not enforce a finite subprocess timeout (got {timeout!r}); see #678"
+        )
+
+    def test_windows_dialog_has_no_timeout(self) -> None:
+        from scieasy.api.routes.filesystem import _native_dialog_windows
+
+        mock_result = MagicMock()
+        mock_result.stdout = ""
+        mock_result.returncode = 0
+
+        with patch("scieasy.api.routes.filesystem.subprocess.run", return_value=mock_result) as mock_run:
+            _native_dialog_windows("directory", None)
+
+        self._assert_no_timeout(mock_run)
+
+    def test_macos_dialog_has_no_timeout(self) -> None:
+        from scieasy.api.routes.filesystem import _native_dialog_macos
+
+        mock_result = MagicMock()
+        mock_result.stdout = ""
+        mock_result.returncode = 0
+
+        with patch("scieasy.api.routes.filesystem.subprocess.run", return_value=mock_result) as mock_run:
+            _native_dialog_macos("file", None)
+
+        self._assert_no_timeout(mock_run)
+
+    def test_linux_dialog_has_no_timeout(self) -> None:
+        from scieasy.api.routes.filesystem import _native_dialog_linux
+
+        mock_result = MagicMock()
+        mock_result.stdout = ""
+        mock_result.returncode = 0
+
+        with patch("scieasy.api.routes.filesystem.subprocess.run", return_value=mock_result) as mock_run:
+            _native_dialog_linux("file", None)
+
+        self._assert_no_timeout(mock_run)


### PR DESCRIPTION
Closes #678

## Summary

The native file dialog endpoint (`/api/filesystem/native-dialog`) imposed a 120-second `subprocess.run(..., timeout=120)` on PowerShell / osascript / zenity. After two minutes of legitimate browsing, the parent process killed the dialog command, returned HTTP 504, and the frontend (`BlockNode.handleBrowseClick`) fell back to the deprecated in-app `FileBrowserModal` on **any** thrown error — including the 504. Reported on macOS, root cause is cross-platform.

## Changes

### Backend (`src/scieasy/api/routes/filesystem.py`)
- Drop `timeout=120` from all three platform helpers (`_native_dialog_windows`, `_native_dialog_macos`, `_native_dialog_linux`); use `timeout=None`. This is a desktop-local server with no adversarial scenario; the user may legitimately spend any amount of time in the dialog.
- The `except subprocess.TimeoutExpired` handler is left in place as defensive dead code (no harm).

### Frontend (`frontend/src/lib/api.ts`)
- Introduce `ApiError` extending `Error` with a `.status: number` field.
- `apiFetch` now throws `ApiError(detail, response.status)` so callers can branch on the HTTP status. Existing callers that only read `error.message` are unaffected.

### Frontend (`frontend/src/components/nodes/BlockNode.tsx`)
- Replace the bare `catch` with status-aware fallback:
  - **HTTP 500** (native dialog tool not installed) -> fall back to the in-app `FileBrowserModal`. This preserves usability on platforms missing PowerShell/osascript/zenity.
  - **HTTP 504** (defensive; should no longer happen) -> log and surface; do **not** silently fall back to the deprecated picker.
  - Network or other non-`ApiError` failure -> fall back defensively.

### Tests
- `tests/api/test_native_dialog.py`: new `TestNativeDialogNoTimeout` regression class asserting `subprocess.run` is invoked with `timeout=None` (or no timeout kwarg) for all three platform helpers.
- `frontend/src/components/nodes/BlockNode.test.tsx`: three new cases verifying the status-aware fallback (500 opens modal, 504 does not, network failure opens modal). All 21 tests pass locally.

## Verification

- `python -m pytest tests/api/test_native_dialog.py -v` -> 6 passed (with PYTHONPATH set to the worktree to bypass globally-installed `scieasy`)
- `npx vitest run src/components/nodes/BlockNode.test.tsx` -> 21 tests passed
- `python -m ruff check .` and `python -m ruff format --check .` -> clean
- `npx tsc --noEmit` -> clean

## ADR / Spec
- No ADR or spec needed: timeout removal is a clear bug fix on internal behavior; the public API surface is unchanged.