### PR TITLE
fix(#682): align variadic-port + button with handle column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- [#682] Align variadic-port + button with port-handle column (@claude, 2026-04-24, branch: fix/issue-682/variadic-add-port-alignment, session: 20260424-145113-fix-682-button-css-alignment)
 <<<<<<< fix/issue-678/native-dialog-no-timeout
 - [#678] Remove 120s timeout from native file dialog; status-aware frontend fallback (only fall back to in-app picker on HTTP 500, not 504) (@claude, 2026-04-24, branch: fix/issue-678/native-dialog-no-timeout, session: 20260424-130419-fix-678-remove-native-dialog-timeout)
 =======

--- a/frontend/src/components/nodes/BlockNode.tsx
+++ b/frontend/src/components/nodes/BlockNode.tsx
@@ -860,7 +860,7 @@ export function BlockNode({ id: nodeId, data, selected }: NodeProps<Node<BlockNo
           type="button"
           className="nodrag absolute flex h-3.5 w-3.5 items-center justify-center rounded-full bg-stone-100 text-[9px] text-stone-500 transition-colors hover:bg-ember hover:text-white"
           title="Add input port"
-          style={{ left: 6, top: portStartY + effectiveInputPorts.length * 20 - 1 }}
+          style={{ left: -7, top: portStartY + effectiveInputPorts.length * 20 - 1 }}
           onClick={() => handleAddPort("input")}
         >
           +
@@ -908,7 +908,7 @@ export function BlockNode({ id: nodeId, data, selected }: NodeProps<Node<BlockNo
           type="button"
           className="nodrag absolute flex h-3.5 w-3.5 items-center justify-center rounded-full bg-stone-100 text-[9px] text-stone-500 transition-colors hover:bg-ember hover:text-white"
           title="Add output port"
-          style={{ right: 6, top: portStartY + effectiveOutputPorts.length * 20 - 1 }}
+          style={{ right: -7, top: portStartY + effectiveOutputPorts.length * 20 - 1 }}
           onClick={() => handleAddPort("output")}
         >
           +


### PR DESCRIPTION
Closes #682

## Summary

The variadic-port `+` button (Add input/output port) was visually misaligned with the port-handle column. Port handles use `left: -7` / `right: -7` so they straddle the node edge, but the `+` button used `left: 6` / `right: 6` and rendered ~13px inside the node body.

## Fix

Move the `+` button to the same edge column as the handles:

| Button | Before | After |
|---|---|---|
| Input `+` | `left: 6`  | `left: -7`  |
| Output `+` | `right: 6` | `right: -7` |

`top` offset is unchanged. The `x` (remove) button stays at `left: 6` / `right: 6` intentionally, so the hover-revealed remove control does not visually conflict with the handle.

## Files changed

- `frontend/src/components/nodes/BlockNode.tsx` (2 lines)
- `CHANGELOG.md`

## Risk

CSS-only positioning change in two style props. No type, behavior, or contract change. `npx tsc --noEmit` passes.

## Out of scope

- `x` (remove port) button position is intentionally unchanged.
- Pre-existing merge-conflict markers in `CHANGELOG.md` (lines 32-36 around #678/#677) were left untouched — they exist on `main` already and resolving them belongs to a separate PR.