### PR TITLE
fix(#681): forward block terminal state from worker subprocess

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,11 +29,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
-<<<<<<< fix/issue-678/native-dialog-no-timeout
+- [#681] Forward terminal block state (CANCELLED/ERROR) from worker subprocess to orchestrator so blocks that call ``self.transition()`` from inside ``run()`` are recorded with the correct terminal state (@claude, 2026-04-24, branch: fix/issue-681/worker-ipc-terminal-state, session: 20260424-145324-fix-681-worker-ipc-terminal-state-propag)
 - [#678] Remove 120s timeout from native file dialog; status-aware frontend fallback (only fall back to in-app picker on HTTP 500, not 504) (@claude, 2026-04-24, branch: fix/issue-678/native-dialog-no-timeout, session: 20260424-130419-fix-678-remove-native-dialog-timeout)
-=======
 - [#677] macOS AppBlock: launch .app bundles via `open -W -n -a` so Popen tracks the .app's lifetime instead of the short-lived `open` launcher, preventing PAUSED -> DONE skip on macOS (@claude, 2026-04-24, branch: fix/issue-677/macos-appblock-open-w, session: 20260424-130347-fix-677-macos-appblock-open-w)
->>>>>>> main
 - [#665] Fix variadic port rendering: config-driven handles, dynamic layout, type dropdown (@claude, 2026-04-12, branch: fix/issue-665/variadic-port-frontend, session: 20260412-052953-fix-variadic-port-frontend-missing-handl)
 - [#630] Pass block registry to validate_workflow() in API save path so type compatibility and dangling port checks run (@claude, 2026-04-11, branch: fix/issue-638/validator-batch-improvements, session: 20260411-224417-batch-validator-improvements-registry-pa)
 - [#631] Add variadic port cardinality validation (Check 7) to workflow validator (@claude, 2026-04-11, branch: fix/issue-638/validator-batch-improvements, session: 20260411-224417-batch-validator-improvements-registry-pa)

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -1964,6 +1964,24 @@ All platform-specific process management is isolated in a single module:
 | Alive check | `os.kill(pid, 0)` | `OpenProcess()` + `GetExitCodeProcess()` |
 | Zombie cleanup | `os.waitpid(pid, WNOHANG)` | Not applicable (Windows auto-cleans) |
 
+#### Worker → orchestrator stdout envelope
+
+The worker subprocess writes a single JSON object to stdout when `block.run()` completes. The envelope shape is:
+
+```jsonc
+{
+  "outputs": { /* port-name -> wire-format dict */ },
+  "environment": { /* EnvironmentSnapshot fields, see §6.7 */ },
+  "final_state": "cancelled"  // optional; see below
+}
+```
+
+The `final_state` field (added in #681) is **only present when the block ended in a non-DONE terminal state** (`cancelled`, `error`, or `skipped`) by calling `self.transition()` from inside `run()`. The common case — block ends in `RUNNING`/`DONE` — omits the field entirely, preserving the original "no field == DONE" semantics for blocks that do not transition themselves.
+
+`LocalRunner` translates a present `final_state` into a `BlockTerminalStateReportedError` exception. The scheduler's `_run_and_finalize` catches it and finalises the block to the reported state, emitting `BLOCK_CANCELLED` / `BLOCK_ERROR` / `BLOCK_SKIPPED` and propagating skips downstream — the same downstream behaviour as the corresponding cancel-from-outside path. This contract decouples the in-process `Block.transition()` API (private to the worker) from the orchestrator's view of terminal state without requiring a sidecar IPC channel.
+
+The pattern is used by `AppBlock` when an external GUI exits without producing the expected output (see §5.3 / `AppBlock`): the block transitions to `CANCELLED` and returns `{}`, and the orchestrator records `CANCELLED` rather than incorrectly recording `DONE` with empty outputs.
+
 ### 6.6 Error handling within blocks (ADR-020)
 
 With Collection-based transport, error handling for individual items within a Collection is the block's responsibility, not the engine's. The engine only sees block-level outcomes: DONE, ERROR, CANCELLED, or SKIPPED.

--- a/src/scieasy/engine/runners/__init__.py
+++ b/src/scieasy/engine/runners/__init__.py
@@ -13,8 +13,10 @@ from scieasy.engine.runners.process_handle import (
     spawn_block_process,
 )
 from scieasy.engine.runners.process_monitor import ProcessMonitor
+from scieasy.engine.runners.terminal_state import BlockTerminalStateReportedError
 
 __all__ = [
+    "BlockTerminalStateReportedError",
     "LocalRunner",
     "PlatformOps",
     "ProcessExitInfo",

--- a/src/scieasy/engine/runners/local.py
+++ b/src/scieasy/engine/runners/local.py
@@ -218,10 +218,41 @@ class LocalRunner:
         if stdout:
             try:
                 parsed = json.loads(stdout.decode())
-                # Worker wraps outputs as {"outputs": {...}}. Unwrap the
-                # envelope so callers see port names at the top level.
+                # Worker wraps outputs as {"outputs": {...}, "environment": {...},
+                # "final_state": "<state>"?}. Unwrap the envelope so callers see
+                # port names at the top level.
                 if isinstance(parsed, dict) and "outputs" in parsed:
-                    return dict(parsed["outputs"])
+                    outputs_dict = dict(parsed["outputs"])
+                    # #681: when the worker reports a non-DONE terminal state
+                    # (block called ``self.transition()`` from inside ``run()``),
+                    # raise the typed exception so the scheduler's existing
+                    # exception path can finalise the block to that state.
+                    final_state_raw = parsed.get("final_state")
+                    if isinstance(final_state_raw, str):
+                        from scieasy.blocks.base.state import BlockState
+                        from scieasy.engine.runners.terminal_state import (
+                            BlockTerminalStateReportedError,
+                        )
+
+                        try:
+                            reported = BlockState(final_state_raw)
+                        except ValueError:
+                            logger.warning(
+                                "Worker reported unknown final_state %r for block %s",
+                                final_state_raw,
+                                block_id,
+                            )
+                        else:
+                            if reported in (
+                                BlockState.CANCELLED,
+                                BlockState.ERROR,
+                                BlockState.SKIPPED,
+                            ):
+                                raise BlockTerminalStateReportedError(
+                                    state=reported,
+                                    outputs=outputs_dict,
+                                )
+                    return outputs_dict
                 return dict(parsed)
             except (json.JSONDecodeError, UnicodeDecodeError) as exc:
                 raise RuntimeError(f"Failed to parse worker output: {exc}") from exc

--- a/src/scieasy/engine/runners/terminal_state.py
+++ b/src/scieasy/engine/runners/terminal_state.py
@@ -1,0 +1,38 @@
+"""Typed signal that a worker subprocess reported a non-DONE terminal state.
+
+Issue #681: ``Block.transition()`` only mutates the block's in-process state;
+the worker subprocess must forward terminal state changes (CANCELLED/ERROR/
+SKIPPED) to the parent so the orchestrator records the correct outcome.
+
+The worker emits a ``final_state`` field on its stdout JSON envelope when it
+detects a terminal non-DONE state on the block instance after ``run()``
+returns. ``LocalRunner.run()`` translates that field into this exception
+so the scheduler's existing exception path can finalise the block to the
+reported state without changing the public ``BlockRunner`` return contract.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from scieasy.blocks.base.state import BlockState
+
+
+class BlockTerminalStateReportedError(Exception):
+    """Raised by a runner when the worker reported a non-DONE terminal state.
+
+    Attributes
+    ----------
+    state:
+        The terminal :class:`BlockState` reported by the worker
+        (typically :attr:`BlockState.CANCELLED` or
+        :attr:`BlockState.ERROR`).
+    outputs:
+        The partial outputs the block returned, if any. Often an empty
+        dict for blocks that ``return {}`` after transitioning.
+    """
+
+    def __init__(self, state: BlockState, outputs: dict[str, Any] | None = None) -> None:
+        self.state = state
+        self.outputs = outputs if outputs is not None else {}
+        super().__init__(f"Worker reported terminal state: {state.value}")

--- a/src/scieasy/engine/runners/worker.py
+++ b/src/scieasy/engine/runners/worker.py
@@ -259,6 +259,26 @@ def main() -> None:
         # Execute.
         outputs = block.run(inputs, block_config)
 
+        # #681: capture the block's terminal state if it transitioned to a
+        # non-DONE terminal state (CANCELLED / ERROR / SKIPPED) from inside
+        # ``run()``. ``Block.transition()`` only mutates ``self.state`` in
+        # the worker process; without this readback the orchestrator never
+        # observes the change. The envelope's ``final_state`` field is
+        # absent for the common case where the block ends in RUNNING/DONE,
+        # so existing blocks that do not call ``transition()`` from inside
+        # ``run()`` keep the previous "no field == DONE" semantics.
+        final_state: str | None = None
+        if hasattr(block, "state"):
+            from scieasy.blocks.base.state import BlockState
+
+            block_state = getattr(block, "state", None)
+            if isinstance(block_state, BlockState) and block_state in (
+                BlockState.CANCELLED,
+                BlockState.ERROR,
+                BlockState.SKIPPED,
+            ):
+                final_state = block_state.value
+
         # Capture environment inside subprocess for accurate lineage (issue #54).
         from scieasy.core.lineage.environment import EnvironmentSnapshot
 
@@ -267,7 +287,10 @@ def main() -> None:
         # Serialize outputs via the typed wire format.
         result = serialise_outputs(outputs, output_dir) if isinstance(outputs, dict) else {"_result": str(outputs)}
 
-        print(json.dumps({"outputs": result, "environment": env_snapshot.to_dict()}))
+        envelope: dict[str, Any] = {"outputs": result, "environment": env_snapshot.to_dict()}
+        if final_state is not None:
+            envelope["final_state"] = final_state
+        print(json.dumps(envelope))
     except Exception:
         print(json.dumps({"error": traceback.format_exc()}))
         sys.exit(1)

--- a/src/scieasy/engine/scheduler.py
+++ b/src/scieasy/engine/scheduler.py
@@ -28,6 +28,7 @@ from scieasy.engine.events import (
     EventBus,
 )
 from scieasy.engine.resources import ResourceRequest
+from scieasy.engine.runners.terminal_state import BlockTerminalStateReportedError
 from scieasy.workflow.definition import WorkflowDefinition
 
 if TYPE_CHECKING:
@@ -324,6 +325,60 @@ class DAGScheduler:
                 # pre-subprocess path). State transition to CANCELLED is
                 # handled by the caller; re-raise so asyncio can finalise.
                 raise
+            except BlockTerminalStateReportedError as terminal:
+                # #681: the worker subprocess observed that the block ended
+                # in a non-DONE terminal state (CANCELLED / ERROR / SKIPPED)
+                # via ``self.transition()`` inside ``run()``. Honour that
+                # state directly — do NOT overwrite it with ERROR like the
+                # generic ``except Exception`` branch below.
+                logger.info(
+                    "Block %s reported terminal state %s from worker",
+                    node_id,
+                    terminal.state.value,
+                )
+                self._block_states[node_id] = terminal.state
+                # Persist any partial outputs the block returned alongside
+                # the terminal state, so downstream lineage and re-runs see
+                # the same view as the worker.
+                if terminal.outputs:
+                    self._block_outputs[node_id] = terminal.outputs
+                if terminal.state == BlockState.CANCELLED:
+                    await self._event_bus.emit(
+                        EngineEvent(
+                            event_type=BLOCK_CANCELLED,
+                            block_id=node_id,
+                            data={"workflow_id": self._workflow.id},
+                        )
+                    )
+                    await self._propagate_skip(node_id, "cancelled")
+                elif terminal.state == BlockState.ERROR:
+                    error_str = f"Block reported terminal state {terminal.state.value} from worker"
+                    await self._event_bus.emit(
+                        EngineEvent(
+                            event_type=BLOCK_ERROR,
+                            block_id=node_id,
+                            data={
+                                "workflow_id": self._workflow.id,
+                                "error": error_str,
+                                "error_summary": _extract_error_summary(error_str),
+                            },
+                        )
+                    )
+                    await self._propagate_skip(node_id, "error")
+                else:
+                    # SKIPPED: the block reported it cannot continue; emit
+                    # BLOCK_SKIPPED and propagate downstream.
+                    self.skip_reasons[node_id] = "block reported skipped"
+                    await self._event_bus.emit(
+                        EngineEvent(
+                            event_type=BLOCK_SKIPPED,
+                            block_id=node_id,
+                            data={"workflow_id": self._workflow.id},
+                        )
+                    )
+                    await self._propagate_skip(node_id, "skipped")
+                self.save_checkpoint(self._checkpoint_manager)
+                return
             except Exception as exc:
                 if self._block_states.get(node_id) == BlockState.CANCELLED:
                     logger.info("Block %s exited after cancellation", node_id)

--- a/src/scieasy/engine/scheduler.py
+++ b/src/scieasy/engine/scheduler.py
@@ -331,6 +331,23 @@ class DAGScheduler:
                 # via ``self.transition()`` inside ``run()``. Honour that
                 # state directly — do NOT overwrite it with ERROR like the
                 # generic ``except Exception`` branch below.
+                #
+                # #689 cancel-race guard: if ``_on_cancel_block`` already
+                # pre-set the block to CANCELLED while the worker was
+                # finalising its own terminal state (e.g. ERROR / SKIPPED),
+                # the CANCELLED state takes precedence. Mirror the generic
+                # ``except Exception`` branch's cancellation guard below —
+                # do not overwrite the state or emit a contradictory event
+                # sequence (BLOCK_CANCELLED followed by BLOCK_ERROR).
+                if self._block_states.get(node_id) == BlockState.CANCELLED:
+                    logger.info(
+                        "Block %s reported terminal state %s from worker "
+                        "but was already CANCELLED; preserving CANCELLED",
+                        node_id,
+                        terminal.state.value,
+                    )
+                    self.save_checkpoint(self._checkpoint_manager)
+                    return
                 logger.info(
                     "Block %s reported terminal state %s from worker",
                     node_id,

--- a/tests/engine/test_local_runner.py
+++ b/tests/engine/test_local_runner.py
@@ -241,6 +241,111 @@ class TestLocalRunnerRun:
         result = asyncio.run(runner.run(FakeBlock(), {}, {}))
         assert result == raw
 
+    @patch("scieasy.engine.runners.local.asyncio.create_subprocess_exec")
+    def test_run_raises_terminal_state_for_cancelled(self, mock_create_sub: AsyncMock) -> None:
+        """#681: run() should raise BlockTerminalStateReportedError(CANCELLED)
+        when the worker envelope contains ``final_state: "cancelled"``.
+        """
+        from scieasy.blocks.base.state import BlockState
+        from scieasy.engine.runners.terminal_state import BlockTerminalStateReportedError
+
+        envelope = {
+            "outputs": {},
+            "environment": {},
+            "final_state": "cancelled",
+        }
+        mock_proc = self._make_async_proc(json.dumps(envelope).encode(), b"", 0, pid=300)
+        mock_create_sub.return_value = mock_proc
+
+        bus = MagicMock()
+        bus.emit = AsyncMock()
+        runner = LocalRunner(event_bus=bus, registry=ProcessRegistry())
+
+        class FakeBlock:
+            pass
+
+        try:
+            asyncio.run(runner.run(FakeBlock(), {}, {}))
+        except BlockTerminalStateReportedError as exc:
+            assert exc.state == BlockState.CANCELLED
+            assert exc.outputs == {}
+        else:
+            raise AssertionError("Expected BlockTerminalStateReportedError to be raised")
+
+    @patch("scieasy.engine.runners.local.asyncio.create_subprocess_exec")
+    def test_run_raises_terminal_state_for_error(self, mock_create_sub: AsyncMock) -> None:
+        """#681: ``final_state: "error"`` raises BlockTerminalStateReportedError(ERROR)."""
+        from scieasy.blocks.base.state import BlockState
+        from scieasy.engine.runners.terminal_state import BlockTerminalStateReportedError
+
+        envelope = {
+            "outputs": {"partial": "value"},
+            "environment": {},
+            "final_state": "error",
+        }
+        mock_proc = self._make_async_proc(json.dumps(envelope).encode(), b"", 0, pid=301)
+        mock_create_sub.return_value = mock_proc
+
+        bus = MagicMock()
+        bus.emit = AsyncMock()
+        runner = LocalRunner(event_bus=bus, registry=ProcessRegistry())
+
+        class FakeBlock:
+            pass
+
+        try:
+            asyncio.run(runner.run(FakeBlock(), {}, {}))
+        except BlockTerminalStateReportedError as exc:
+            assert exc.state == BlockState.ERROR
+            assert exc.outputs == {"partial": "value"}
+        else:
+            raise AssertionError("Expected BlockTerminalStateReportedError to be raised")
+
+    @patch("scieasy.engine.runners.local.asyncio.create_subprocess_exec")
+    def test_run_ignores_done_final_state(self, mock_create_sub: AsyncMock) -> None:
+        """#681: ``final_state: "done"`` (non-terminal-failure) is treated as a
+        normal return — the runner does not raise. The worker only emits
+        ``final_state`` for non-DONE terminal states, but defensively the
+        runner must not raise on values like ``"done"`` or unknown values.
+        """
+        envelope = {
+            "outputs": {"port_a": "value"},
+            "environment": {},
+            "final_state": "done",
+        }
+        mock_proc = self._make_async_proc(json.dumps(envelope).encode(), b"", 0, pid=302)
+        mock_create_sub.return_value = mock_proc
+
+        bus = MagicMock()
+        bus.emit = AsyncMock()
+        runner = LocalRunner(event_bus=bus, registry=ProcessRegistry())
+
+        class FakeBlock:
+            pass
+
+        result = asyncio.run(runner.run(FakeBlock(), {}, {}))
+        assert result == {"port_a": "value"}
+
+    @patch("scieasy.engine.runners.local.asyncio.create_subprocess_exec")
+    def test_run_returns_outputs_when_final_state_absent(self, mock_create_sub: AsyncMock) -> None:
+        """#681 backward compat: envelope without ``final_state`` returns outputs."""
+        envelope = {
+            "outputs": {"port_a": "value"},
+            "environment": {},
+        }
+        mock_proc = self._make_async_proc(json.dumps(envelope).encode(), b"", 0, pid=303)
+        mock_create_sub.return_value = mock_proc
+
+        bus = MagicMock()
+        bus.emit = AsyncMock()
+        runner = LocalRunner(event_bus=bus, registry=ProcessRegistry())
+
+        class FakeBlock:
+            pass
+
+        result = asyncio.run(runner.run(FakeBlock(), {}, {}))
+        assert result == {"port_a": "value"}
+
 
 class TestLocalRunnerOutputDir:
     def test_derive_output_dir_prefers_project_scoped_path(self, tmp_path: Path) -> None:

--- a/tests/engine/test_scheduler.py
+++ b/tests/engine/test_scheduler.py
@@ -219,6 +219,113 @@ class TestSchedulerErrorPropagation:
 
 
 # ---------------------------------------------------------------------------
+# #681: Worker-reported terminal state propagation
+# ---------------------------------------------------------------------------
+
+
+class TestSchedulerWorkerReportedTerminalState:
+    """#681: when ``LocalRunner.run()`` raises ``BlockTerminalStateReportedError``,
+    the scheduler must record the block in the reported state (CANCELLED /
+    ERROR / SKIPPED) rather than ERROR (the default for arbitrary exceptions).
+    """
+
+    def test_runner_reports_cancelled_records_cancelled(self) -> None:
+        """A block whose worker subprocess reports CANCELLED ends up CANCELLED.
+
+        Regression for #681 / AppBlock cancellation: previously the scheduler
+        recorded the block as DONE because ``self.transition(CANCELLED)``
+        inside ``run()`` was lost when the worker only forwarded ``return {}``.
+        """
+        from scieasy.engine.runners.terminal_state import BlockTerminalStateReportedError
+
+        wf = _wf(
+            nodes=[("A", "proc"), ("B", "proc"), ("C", "proc")],
+            edges=[("A:out", "B:in"), ("B:out", "C:in")],
+        )
+
+        async def reports_cancelled(block: object, inputs: dict, config: dict, **kwargs: object) -> dict:
+            if block.id == "A":  # type: ignore[attr-defined]
+                raise BlockTerminalStateReportedError(
+                    state=BlockState.CANCELLED,
+                    outputs={},
+                )
+            return {"output": "ok"}
+
+        scheduler, _event_bus, runner = _make_scheduler(wf)
+        runner.run.side_effect = reports_cancelled
+
+        asyncio.run(scheduler.execute())
+
+        assert scheduler._block_states["A"] == BlockState.CANCELLED
+        assert scheduler._block_states["B"] == BlockState.SKIPPED
+        assert scheduler._block_states["C"] == BlockState.SKIPPED
+
+    def test_runner_reports_error_records_error_not_default(self) -> None:
+        """``BlockTerminalStateReportedError(ERROR)`` records ERROR via the
+        worker-reported path (and emits BLOCK_ERROR + propagates skip),
+        equivalent to the generic exception path in observable behaviour.
+        """
+        from scieasy.engine.runners.terminal_state import BlockTerminalStateReportedError
+
+        wf = _wf(
+            nodes=[("A", "proc"), ("B", "proc")],
+            edges=[("A:out", "B:in")],
+        )
+
+        async def reports_error(block: object, inputs: dict, config: dict, **kwargs: object) -> dict:
+            if block.id == "A":  # type: ignore[attr-defined]
+                raise BlockTerminalStateReportedError(
+                    state=BlockState.ERROR,
+                    outputs={},
+                )
+            return {"output": "ok"}
+
+        scheduler, _event_bus, runner = _make_scheduler(wf)
+        runner.run.side_effect = reports_error
+
+        asyncio.run(scheduler.execute())
+
+        assert scheduler._block_states["A"] == BlockState.ERROR
+        assert scheduler._block_states["B"] == BlockState.SKIPPED
+
+    def test_normal_block_returning_dict_still_records_done(self) -> None:
+        """Regression: a block that returns ``{outputs}`` without raising
+        ``BlockTerminalStateReportedError`` still records DONE — the new exception
+        path does not affect the happy path.
+        """
+        wf = _wf(nodes=[("A", "proc")])
+        scheduler, _event_bus, _runner = _make_scheduler(wf, runner_return={"output": "ok"})
+
+        asyncio.run(scheduler.execute())
+
+        assert scheduler._block_states["A"] == BlockState.DONE
+        assert scheduler._block_outputs["A"] == {"output": "ok"}
+
+    def test_runner_reports_cancelled_preserves_partial_outputs(self) -> None:
+        """When the worker forwards partial outputs alongside CANCELLED, the
+        scheduler stores them in ``_block_outputs`` so checkpoints / lineage
+        see the same view.
+        """
+        from scieasy.engine.runners.terminal_state import BlockTerminalStateReportedError
+
+        wf = _wf(nodes=[("A", "proc")])
+
+        async def reports_cancelled_with_partial(block: object, inputs: dict, config: dict, **kwargs: object) -> dict:
+            raise BlockTerminalStateReportedError(
+                state=BlockState.CANCELLED,
+                outputs={"partial": "value"},
+            )
+
+        scheduler, _event_bus, runner = _make_scheduler(wf)
+        runner.run.side_effect = reports_cancelled_with_partial
+
+        asyncio.run(scheduler.execute())
+
+        assert scheduler._block_states["A"] == BlockState.CANCELLED
+        assert scheduler._block_outputs.get("A") == {"partial": "value"}
+
+
+# ---------------------------------------------------------------------------
 # Cancellation
 # ---------------------------------------------------------------------------
 

--- a/tests/engine/test_scheduler.py
+++ b/tests/engine/test_scheduler.py
@@ -324,6 +324,45 @@ class TestSchedulerWorkerReportedTerminalState:
         assert scheduler._block_states["A"] == BlockState.CANCELLED
         assert scheduler._block_outputs.get("A") == {"partial": "value"}
 
+    def test_pre_cancelled_state_preserved_against_worker_error(self) -> None:
+        """#689 cancel-race guard: if ``_on_cancel_block`` already pre-set
+        the block to CANCELLED while the worker was finalising a different
+        terminal state (ERROR / SKIPPED), the CANCELLED state must be
+        preserved and the runner's reported state must not overwrite it.
+
+        Exercises ``_run_and_finalize`` directly with a pre-set CANCELLED
+        state to simulate the race window between ``_on_cancel_block``
+        marking CANCELLED and the worker's ``BlockTerminalStateReportedError``
+        unwinding through ``_run_and_finalize``.
+        """
+        from scieasy.engine.runners.terminal_state import BlockTerminalStateReportedError
+
+        wf = _wf(nodes=[("A", "proc")])
+        scheduler, event_bus, runner = _make_scheduler(wf)
+
+        async def reports_error(block: object, inputs: dict, config: dict, **kwargs: object) -> dict:
+            raise BlockTerminalStateReportedError(
+                state=BlockState.ERROR,
+                outputs={},
+            )
+
+        runner.run.side_effect = reports_error
+
+        # Capture any contradictory events that would follow CANCELLED.
+        emitted: list[str] = []
+        event_bus.subscribe(BLOCK_ERROR, lambda e: emitted.append(BLOCK_ERROR))
+
+        # Pre-set CANCELLED as _on_cancel_block would have done.
+        scheduler._block_states["A"] = BlockState.CANCELLED
+
+        block = MagicMock()
+        block.id = "A"
+        asyncio.run(scheduler._run_and_finalize("A", block, {}, {}))
+
+        # CANCELLED must win and the worker's ERROR must not be emitted.
+        assert scheduler._block_states["A"] == BlockState.CANCELLED
+        assert BLOCK_ERROR not in emitted
+
 
 # ---------------------------------------------------------------------------
 # Cancellation

--- a/tests/engine/test_worker.py
+++ b/tests/engine/test_worker.py
@@ -240,3 +240,113 @@ class _StubBlock:
 
     def run(self, inputs: dict, config: object) -> dict:
         return {"result": "ok"}
+
+
+# ---------------------------------------------------------------------------
+# main — final_state envelope field (#681)
+# ---------------------------------------------------------------------------
+
+
+class _CancellingStubBlock:
+    """Block stub that transitions to CANCELLED inside ``run()`` and returns ``{}``.
+
+    Mirrors the AppBlock cancellation pattern: when the block's internal
+    failure path fires (e.g. external app exited without producing output),
+    it calls ``self.transition(BlockState.CANCELLED)`` and returns an empty
+    outputs dict. Worker must forward the CANCELLED state via the envelope's
+    ``final_state`` field so the orchestrator records the block correctly.
+    """
+
+    def __init__(self) -> None:
+        from scieasy.blocks.base.state import BlockState
+
+        self.state = BlockState.IDLE
+
+    def transition(self, target: object) -> None:
+        # Mimic Block.transition() — direct assignment is enough for the
+        # worker's final-state readback contract.
+        self.state = target  # type: ignore[assignment]
+
+    def run(self, inputs: dict, config: object) -> dict:
+        from scieasy.blocks.base.state import BlockState
+
+        self.state = BlockState.CANCELLED
+        return {}
+
+
+class _ErroringStubBlock:
+    """Block stub that transitions to ERROR inside ``run()`` and returns ``{}``."""
+
+    def __init__(self) -> None:
+        from scieasy.blocks.base.state import BlockState
+
+        self.state = BlockState.IDLE
+
+    def run(self, inputs: dict, config: object) -> dict:
+        from scieasy.blocks.base.state import BlockState
+
+        self.state = BlockState.ERROR
+        return {}
+
+
+class TestWorkerFinalState:
+    """#681: worker must forward terminal non-DONE states via envelope.
+
+    These run the worker as a real subprocess and inspect the JSON envelope
+    on stdout. The synthetic block classes above transition to CANCELLED
+    or ERROR before returning ``{}``, simulating the AppBlock pattern.
+    """
+
+    def _run_worker(self, block_class_path: str) -> dict:
+        import json
+        import os
+        import subprocess
+        import sys
+        from pathlib import Path
+
+        payload = json.dumps(
+            {
+                "block_class": block_class_path,
+                "inputs": {},
+                "config": {},
+                "output_dir": "",
+            }
+        )
+        # Ensure the subprocess imports the same ``scieasy`` source tree as
+        # this checkout's ``src/`` rather than any other editable install
+        # that may be active in the active interpreter. Walk up from this
+        # test file to find ``<repo>/src``. Required when the test runs in
+        # a git worktree whose ``src`` is not the editable-install target.
+        env = os.environ.copy()
+        repo_src = Path(__file__).resolve().parents[2] / "src"
+        if repo_src.is_dir():
+            env["PYTHONPATH"] = str(repo_src) + os.pathsep + env.get("PYTHONPATH", "")
+        result = subprocess.run(
+            [sys.executable, "-m", "scieasy.engine.runners.worker"],
+            input=payload,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            env=env,
+        )
+        return dict(json.loads(result.stdout))
+
+    def test_cancelled_block_emits_final_state_in_envelope(self) -> None:
+        parsed = self._run_worker("tests.engine.test_worker._CancellingStubBlock")
+        # The block ran successfully — no error envelope.
+        assert "error" not in parsed, parsed
+        assert parsed.get("outputs") == {}
+        assert parsed.get("final_state") == "cancelled"
+
+    def test_error_block_emits_final_state_in_envelope(self) -> None:
+        parsed = self._run_worker("tests.engine.test_worker._ErroringStubBlock")
+        assert "error" not in parsed, parsed
+        assert parsed.get("outputs") == {}
+        assert parsed.get("final_state") == "error"
+
+    def test_normal_block_omits_final_state_field(self) -> None:
+        # _StubBlock does not call ``transition()`` — it has no ``state``
+        # attribute, so the envelope must NOT include ``final_state``.
+        parsed = self._run_worker("tests.engine.test_worker._StubBlock")
+        assert "error" not in parsed, parsed
+        assert "final_state" not in parsed


### PR DESCRIPTION
Closes #681

## Summary

Block.transition() only mutates the worker's in-process state. When a block calls `self.transition(BlockState.CANCELLED)` (or ERROR / SKIPPED) inside `run()` and returns, the worker previously forwarded only the outputs dict over stdout — the orchestrator never observed the state change and recorded the block as DONE with empty outputs. This affected AppBlock's cancellation path (and any future block that uses the same pattern).

This PR extends the worker's stdout JSON envelope with an optional `final_state` field carrying the block's terminal `BlockState` value when it ended in a non-DONE terminal state. `LocalRunner` translates the field into a typed `BlockTerminalStateReportedError` exception so the scheduler's existing exception path can finalise the block to that state without changing the public `BlockRunner` return contract.

Approach selected: **option (b)** from the issue — extend the worker → parent JSON envelope. Rejected (a) side-channel events (no need for streaming when only the final state matters) and (c) sentinel exception on the block side (backward-incompatible for existing AppBlock pattern).

## Wire-format change

```jsonc
{
  "outputs": {...},
  "environment": {...},
  "final_state": "cancelled"   // optional; only present when block.state is a non-DONE terminal state
}
```

Backward-compatible: blocks that do not call `transition()` inside `run()` emit no `final_state` and the parent treats absent === DONE.

## Files changed

| Layer | File | Change |
|---|---|---|
| Worker | `src/scieasy/engine/runners/worker.py` | Read `block.state` after `run()`; emit `final_state` for non-DONE terminal states |
| Runner | `src/scieasy/engine/runners/local.py` | Parse `final_state`; raise typed exception with partial outputs |
| Runner (new) | `src/scieasy/engine/runners/terminal_state.py` | `BlockTerminalStateReportedError` typed exception |
| Runner | `src/scieasy/engine/runners/__init__.py` | Export the exception |
| Scheduler | `src/scieasy/engine/scheduler.py` | Catch the exception in `_run_and_finalize`, transition to reported state, emit BLOCK_CANCELLED / BLOCK_ERROR / BLOCK_SKIPPED, propagate skip downstream |
| Tests | `tests/engine/test_worker.py` | 3 new subprocess tests covering CANCELLED, ERROR, and absence-on-normal-block |
| Tests | `tests/engine/test_local_runner.py` | 4 new mock-subprocess tests covering both terminal states + DONE/absent regressions |
| Tests | `tests/engine/test_scheduler.py` | 4 new scheduler tests including end-to-end CANCELLED → SKIPPED downstream propagation |
| Docs | `docs/architecture/ARCHITECTURE.md` | Document the envelope and `final_state` field in §6.5 |
| CHANGELOG | `CHANGELOG.md` | New `Fixed` entry under `[Unreleased]` |

## Note on CHANGELOG conflict markers

`origin/main`'s CHANGELOG has unresolved merge-conflict markers between the #677 and #678 entries (also visible if you look at line 32-36 of CHANGELOG.md on main). Since I had to add a new entry in that section, I removed the markers and kept both entries (they are both legitimate Fixed entries from already-merged PRs). If the project owner prefers a separate cleanup PR, I can rebase out that change.

## Testing

- All 86 tests under `tests/engine/test_worker.py`, `tests/engine/test_local_runner.py`, `tests/engine/test_scheduler.py` pass.
- Full `tests/engine/` suite: green.
- `tests/blocks/test_app_block.py`: green (existing AppBlock unit tests unaffected).
- `ruff check .` and `ruff format --check .`: clean.

### Verifying the AppBlock CANCELLED path

The new scheduler test `TestSchedulerWorkerReportedTerminalState::test_runner_reports_cancelled_records_cancelled` simulates the exact AppBlock pattern: the runner raises `BlockTerminalStateReportedError(state=CANCELLED)`, mimicking what `LocalRunner` will do when the worker emits `final_state: "cancelled"`. The test asserts the block ends up CANCELLED (not DONE) and downstream blocks SKIPPED — exactly the orchestrator-level behaviour previously broken by #681.

## Test plan

- [x] Unit test: synthetic block that transitions to CANCELLED and returns `{}` → orchestrator records CANCELLED
- [x] Unit test: synthetic block that transitions to ERROR and returns `{}` → orchestrator records ERROR
- [x] Regression test: a normal block returning `{outputs}` without transitioning → orchestrator records DONE
- [x] Subprocess test: real worker subprocess emits `final_state` in stdout envelope
- [x] Backward-compat test: envelope without `final_state` returns outputs unchanged