### PR TITLE
feat(#680): AppBlock variadic ports with extension-based output binning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- [#680] AppBlock variadic input/output ports with extension-based output binning; per-port extension field, case-insensitive matching, duplicate-extension config validation, unmatched-file warning (@claude, 2026-04-24, branch: feat/issue-680/appblock-variadic-extension-binning, session: 20260424-145408-feat-680-appblock-variadic-ports-extensi)
 - [#652] Block Developer SDK rewrite: 9-document suite in docs/block-development/ plus 3 complete examples, replacing outdated docs/guides/block-sdk.md (@claude, 2026-04-12, branch: docs/issue-652/block-sdk-rewrite, session: 20260412-003237-block-developer-sdk-documentation-rewrit)
 - [#651] Implement ADR-032 MetadataStore — SQLite persistent mirror of DataObject metadata with engine-side writes, checkpoint restore sync, and 30 unit tests (@claude, 2026-04-12, branch: feat/issue-651/adr-032-metadata-store, session: 20260412-003142-implement-adr-032-metadatastore-639-640)
 - [#644] Implement DataRouter + PairEditor interactive variadic blocks — first consumers of ADR-029 variadic ports, with interactive PAUSED execution mode, drag-and-drop routing modal, sortable pairing modal, and scheduler interactive flow (@claude, 2026-04-11, branch: feat/issue-644/data-router-pair-editor, session: 20260411-225938-implement-datarouter-paireditor-interact)

--- a/docs/block-development/block-contract.md
+++ b/docs/block-development/block-contract.md
@@ -464,3 +464,73 @@ input_ports: ClassVar[list[InputPort]] = [
 The `validate()` hook calls `validate_port_constraint(port, value)` for
 each input. If the constraint function returns `False`, validation fails
 with the `constraint_description` message.
+
+---
+
+## AppBlock: variadic ports + extension-based output binning
+
+**Issue #680**: All AppBlock subclasses (Fiji, Napari, ElMAVEN, custom
+external-app blocks) inherit:
+
+- `variadic_inputs = True` and `variadic_outputs = True` — the user
+  defines input and output ports via the standard ADR-029 port editor.
+- A required `extension` field on every output port entry. The runtime
+  uses this string (no leading dot, case-insensitive) to bin saved
+  files into ports.
+- A generic binner method `_bin_outputs_by_extension(output_files,
+  config)` that subclasses call after their watcher returns.
+
+### Routing rules
+
+After the external app produces output files, the binner:
+
+1. For each port, finds files whose suffix (case-insensitively) matches
+   the port's declared extension and wraps them as
+   `Artifact(file_path=..., mime_type=..., description=...)` instances
+   in a `Collection(item_type=port.accepted_types[0])`.
+2. Raises `ValueError("Port 'X' required, no '.ext' files in output dir")`
+   when a required port receives zero files.
+3. Logs `WARNING — Unmatched output file 'name.ext'` for files whose
+   extension matches no port and continues.
+
+### Config-save validation
+
+The workflow validator's **Check 8** rejects configurations where two
+output ports on the same variadic-output block declare the same
+extension (case-insensitive):
+
+```
+Node 'A': Duplicate extension 'tif' across output ports {images, masks}
+```
+
+This catches the only ambiguity in the routing model at save time,
+before the workflow runs.
+
+### Subclass authoring
+
+Concrete AppBlock subclasses keep their `output_ports` ClassVar as a
+**default scaffold** that the user may override via the editor. The
+`run()` method ends with:
+
+```python
+if config.get("output_ports"):
+    return self._bin_outputs_by_extension(output_files, config)
+# Backwards-compatible fallback when no ports are declared:
+from scieasy.blocks.app.bridge import _guess_mime
+from scieasy.core.types.artifact import Artifact
+from scieasy.core.types.collection import Collection
+artifacts = [
+    Artifact(file_path=p, mime_type=_guess_mime(p), description=p.name)
+    for p in output_files
+]
+return {"image": Collection(artifacts, item_type=Artifact)} if artifacts else {}
+```
+
+### What the binner does NOT do
+
+- No file content inspection or type inference (the user is responsible
+  for saving the right kind of data into the declared extension).
+- No multi-extension ports (one extension per port — Collections are
+  homogeneous by type).
+- No per-port glob fields.
+- No automatic port creation based on saved content.

--- a/docs/specs/appblock-variadic-ports.md
+++ b/docs/specs/appblock-variadic-ports.md
@@ -1,0 +1,115 @@
+# AppBlock Variadic Ports + Extension-Based Output Binning
+
+**Issue**: [#680](https://github.com/zjzcpj/SciEasy/issues/680)
+**Status**: Implemented
+**Builds on**: ADR-029 (variadic port editor), ADR-030 (config_schema MRO merge)
+**Related (out of scope)**: #679 (per-app `output_dir` injection)
+
+---
+
+## Goal
+
+Let users define input and output ports on every AppBlock instance via
+the existing port editor, and route files saved by the external
+application into the declared output ports by file extension.
+
+---
+
+## Editor Contract
+
+The port editor (`frontend/src/components/PortEditorTable.tsx`) renders:
+
+- **Input ports** — name + type (existing fields).
+- **Output ports** — name + type + **extension** (new).
+
+Per-port `extension` semantics:
+
+- One string per port (no list, no glob).
+- Stored without a leading dot, lowercased on input.
+  `"TIF"`, `".tif"`, and `"tif"` all canonicalise to `"tif"`.
+- Required field; the schema marks it `"required": ["name", "extension"]`.
+
+The frontend writes the resulting list into
+`node.config.params.output_ports` as `[{name, types, extension}, ...]`.
+
+---
+
+## Backend Binner
+
+`AppBlock._bin_outputs_by_extension(output_files, config)` runs after
+`watcher.wait_for_output()` returns. Its rules are:
+
+| File condition | Behaviour |
+|---|---|
+| Suffix (case-insensitive) matches a port's `extension` | Wrap as `Artifact(file_path=...)` and append to that port's `Collection`. |
+| Required port receives 0 matching files | Raise `ValueError("Port 'X' required, no '.ext' files in output dir")`. |
+| Optional port receives 0 matching files | Return an empty `Collection`. |
+| File matches no port | Log a `WARNING` (`"Unmatched output file 'name.ext'"`) and continue. |
+
+Effective port resolution priority:
+
+1. `config["output_ports"]` (run-time, from the workflow/scheduler).
+2. `self.get_effective_output_ports()` (instance-level
+   `self.config["output_ports"]` -> ClassVar fallback).
+
+`Collection.item_type` is set to `port.accepted_types[0]` (or `Artifact`
+when the port declares no types). Downstream blocks consume the
+`Artifact` collection via standard load blocks if they need to
+materialise the data.
+
+---
+
+## Validator: duplicate-extension check
+
+`scieasy.workflow.validator.validate_workflow` adds **Check 8**:
+
+> For every node whose `BlockSpec.variadic_outputs` is `True`, scan
+> `node.config["output_ports"]` and reject configurations where two
+> ports declare the same extension (case-insensitive). Emit
+> `Node 'X': Duplicate extension 'tif' across output ports {a, b}`.
+
+The check runs at workflow save time so users discover the conflict
+before they run the graph.
+
+---
+
+## Subclass Migration
+
+Concrete AppBlock subclasses (FijiBlock, NapariBlock, ElMAVENBlock):
+
+- Keep their `output_ports` ClassVar as a **default scaffold** the user
+  may override via the editor.
+- Drop plugin-private file-->port heuristics
+  (`_collect_outputs` / `_guess_output_port` in the imaging plugin
+  were deleted; ElMAVEN's `_classify_export` /
+  `_collect_elmaven_outputs` are deprecated and no longer called from
+  `run()`).
+- Their `run()` ends with a one-liner delegating to
+  `self._bin_outputs_by_extension(output_files, config)` when
+  `config["output_ports"]` is set, falling back to a single-port
+  Artifact wrap for backwards compatibility.
+- Broaden their watcher patterns at run time to include each declared
+  extension, so files of those types are not filtered out before they
+  reach the binner.
+
+---
+
+## Non-Goals
+
+- No file content inspection / type inference.
+- No multi-extension ports.
+- No per-port glob fields.
+- No automatic port creation based on saved content.
+- No upper-bound count rules.
+
+---
+
+## Test Coverage
+
+| Layer | Test |
+|---|---|
+| Base class | `tests/blocks/test_app_block.py::TestAppBlockVariadicPorts` |
+| Binner | `tests/blocks/test_app_block.py::TestAppBlockExtensionBinner` |
+| Workflow validator | `tests/workflow/test_validator.py::TestValidatorAppBlockDuplicateExtensions` |
+| Frontend editor | `frontend/src/components/PortEditorTable.test.tsx` |
+| End-to-end FijiBlock | `packages/scieasy-blocks-imaging/tests/test_interactive_blocks.py::test_fiji_block_routes_outputs_into_user_declared_ports_by_extension` |

--- a/frontend/src/components/PortEditorTable.test.tsx
+++ b/frontend/src/components/PortEditorTable.test.tsx
@@ -1,0 +1,91 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { type PortRow, PortEditorTable } from "./PortEditorTable";
+
+const TYPE_HIERARCHY = [
+  { name: "DataObject", base_type: "DataObject", description: "" },
+  { name: "Image", base_type: "Image", description: "" },
+];
+
+describe("PortEditorTable", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders an extension column for output ports (issue #680)", () => {
+    const ports: PortRow[] = [
+      { name: "images", types: ["Image"], extension: "tif" },
+    ];
+    render(
+      <PortEditorTable
+        allowedTypes={[]}
+        direction="output"
+        onChange={() => {}}
+        ports={ports}
+        typeHierarchy={TYPE_HIERARCHY}
+      />,
+    );
+
+    const extInput = screen.getByLabelText("extension for images") as HTMLInputElement;
+    expect(extInput).toBeInTheDocument();
+    expect(extInput.value).toBe("tif");
+  });
+
+  it("does NOT render an extension column for input ports", () => {
+    const ports: PortRow[] = [{ name: "data", types: ["DataObject"] }];
+    render(
+      <PortEditorTable
+        allowedTypes={[]}
+        direction="input"
+        onChange={() => {}}
+        ports={ports}
+        typeHierarchy={TYPE_HIERARCHY}
+      />,
+    );
+
+    expect(screen.queryByLabelText("extension for data")).toBeNull();
+  });
+
+  it("normalises typed extensions: lowercases and strips leading dots", () => {
+    const ports: PortRow[] = [{ name: "tables", types: ["DataObject"], extension: "" }];
+    const onChange = vi.fn();
+    render(
+      <PortEditorTable
+        allowedTypes={[]}
+        direction="output"
+        onChange={onChange}
+        ports={ports}
+        typeHierarchy={TYPE_HIERARCHY}
+      />,
+    );
+
+    const extInput = screen.getByLabelText("extension for tables");
+    fireEvent.change(extInput, { target: { value: ".CSV" } });
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange.mock.calls[0][0]).toEqual([
+      { name: "tables", types: ["DataObject"], extension: "csv" },
+    ]);
+  });
+
+  it("seeds new output rows with an empty extension field", () => {
+    const onChange = vi.fn();
+    render(
+      <PortEditorTable
+        allowedTypes={[]}
+        direction="output"
+        onChange={onChange}
+        ports={[]}
+        typeHierarchy={TYPE_HIERARCHY}
+      />,
+    );
+
+    fireEvent.click(screen.getByText("+ Add Port"));
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const next = onChange.mock.calls[0][0] as PortRow[];
+    expect(next).toHaveLength(1);
+    expect(next[0].extension).toBe("");
+  });
+});

--- a/frontend/src/components/PortEditorTable.tsx
+++ b/frontend/src/components/PortEditorTable.tsx
@@ -3,6 +3,10 @@ import type { TypeHierarchyEntry } from "../types/api";
 export interface PortRow {
   name: string;
   types: string[];
+  /** Issue #680: file extension (no leading dot, case-insensitive) used by the
+   *  AppBlock runtime to bin saved files into output ports. Only meaningful
+   *  for output ports. */
+  extension?: string;
 }
 
 interface PortEditorTableProps {
@@ -16,9 +20,34 @@ interface PortEditorTableProps {
   minPorts?: number | null;
   /** ADR-029 Addendum 1: maximum number of ports. null/undefined = no maximum. */
   maxPorts?: number | null;
+  /** Issue #680: when true, render the extension column for output ports.
+   *  Defaults to true for output direction. Input ports never show this
+   *  column because they have no file context. */
+  showExtensionColumn?: boolean;
 }
 
-export function PortEditorTable({ direction, ports, allowedTypes, typeHierarchy, onChange, minPorts, maxPorts }: PortEditorTableProps) {
+/**
+ * Normalise an extension string the same way the backend does:
+ * lowercase, strip any leading dots. Returns "" for empty input.
+ */
+function normalizeExtension(raw: string): string {
+  let text = raw.trim();
+  while (text.startsWith(".")) {
+    text = text.slice(1);
+  }
+  return text.toLowerCase();
+}
+
+export function PortEditorTable({
+  direction,
+  ports,
+  allowedTypes,
+  typeHierarchy,
+  onChange,
+  minPorts,
+  maxPorts,
+  showExtensionColumn,
+}: PortEditorTableProps) {
   const availableTypes =
     allowedTypes.length > 0
       ? typeHierarchy.filter((t) => allowedTypes.includes(t.name))
@@ -30,6 +59,11 @@ export function PortEditorTable({ direction, ports, allowedTypes, typeHierarchy,
   const canAdd = maxPorts == null || ports.length < maxPorts;
   const canRemove = minPorts == null || ports.length > minPorts;
 
+  // Issue #680: input ports never show the extension column; output ports
+  // show it by default unless the caller explicitly opts out.
+  const renderExtension =
+    direction === "output" && (showExtensionColumn ?? true);
+
   function handleNameChange(index: number, name: string) {
     onChange(ports.map((p, i) => (i === index ? { ...p, name } : p)));
   }
@@ -38,12 +72,24 @@ export function PortEditorTable({ direction, ports, allowedTypes, typeHierarchy,
     onChange(ports.map((p, i) => (i === index ? { ...p, types: [typeName] } : p)));
   }
 
+  function handleExtensionChange(index: number, extension: string) {
+    onChange(
+      ports.map((p, i) =>
+        i === index ? { ...p, extension: normalizeExtension(extension) } : p,
+      ),
+    );
+  }
+
   function handleRemove(index: number) {
     onChange(ports.filter((_, i) => i !== index));
   }
 
   function handleAdd() {
-    onChange([...ports, { name: `port_${ports.length + 1}`, types: [defaultType] }]);
+    const next: PortRow = { name: `port_${ports.length + 1}`, types: [defaultType] };
+    if (renderExtension) {
+      next.extension = "";
+    }
+    onChange([...ports, next]);
   }
 
   return (
@@ -75,6 +121,15 @@ export function PortEditorTable({ direction, ports, allowedTypes, typeHierarchy,
                 <option value="DataObject">DataObject</option>
               )}
             </select>
+            {renderExtension && (
+              <input
+                aria-label={`extension for ${port.name}`}
+                className="w-24 rounded-xl border border-stone-300 bg-white px-3 py-1.5 text-sm"
+                onChange={(e) => handleExtensionChange(index, e.target.value)}
+                placeholder="ext (e.g. tif)"
+                value={port.extension ?? ""}
+              />
+            )}
             <button
               className={`rounded-lg px-2 py-1 text-xs ${canRemove ? "text-stone-500 hover:bg-red-100 hover:text-red-700" : "cursor-not-allowed text-stone-300"}`}
               disabled={!canRemove}

--- a/packages/scieasy-blocks-imaging/src/scieasy_blocks_imaging/interactive/__init__.py
+++ b/packages/scieasy-blocks-imaging/src/scieasy_blocks_imaging/interactive/__init__.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import csv
 import json
 import logging
 import platform
@@ -11,21 +10,15 @@ import tempfile
 from collections.abc import Mapping
 from contextlib import suppress
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, cast
-
-import numpy as np
-import pyarrow as pa
+from typing import TYPE_CHECKING, Any
 
 from scieasy.blocks.app.app_block import AppBlock, _PopenProcessAdapter
 from scieasy.blocks.app.bridge import FileExchangeBridge
 from scieasy.blocks.app.watcher import FileWatcher, ProcessExitedWithoutOutputError
 from scieasy.blocks.base.config import BlockConfig
 from scieasy.blocks.base.state import BlockState
-from scieasy.core.types.array import Array
 from scieasy.core.types.collection import Collection
-from scieasy.core.types.dataframe import DataFrame
-from scieasy_blocks_imaging.io.load_image import _default_axes_for_ndim, _load_tiff, _load_zarr
-from scieasy_blocks_imaging.types import Image, Label, Mask
+from scieasy_blocks_imaging.types import Image
 
 logger = logging.getLogger(__name__)
 
@@ -70,13 +63,19 @@ def _input_images(inputs: Mapping[str, Collection | Image], port_name: str, bloc
 def _prepare_image_exchange(
     images: list[Image], exchange_dir: Path, *, tool_name: str, config: BlockConfig
 ) -> list[Path]:
+    import numpy as np
     import tifffile
 
     input_dir = exchange_dir / "inputs"
     paths: list[Path] = []
     for index, image in enumerate(images):
         path = input_dir / f"image_{index:04d}.tif"
-        tifffile.imwrite(str(path), _image_data(image), metadata={"axes": "".join(image.axes).upper()})
+        # Materialise image data (in-memory or from storage_ref).
+        if image.storage_ref is None and getattr(image, "_data", None) is not None:
+            data = np.asarray(image._data)  # type: ignore[attr-defined]
+        else:
+            data = np.asarray(image.to_memory())
+        tifffile.imwrite(str(path), data, metadata={"axes": "".join(image.axes).upper()})
         paths.append(path)
 
     manifest = {
@@ -205,165 +204,13 @@ def _run_external_app(
     return output_files
 
 
-def _collect_outputs(
-    output_files: list[Path], *, template_image: Image | None, allowed_ports: set[str]
-) -> dict[str, Collection]:
-    grouped: dict[str, list[Any]] = {}
-    axes_hint = list(template_image.axes) if template_image is not None else None
-
-    for path in output_files:
-        port = _guess_output_port(path, allowed_ports)
-        grouped.setdefault(port, []).append(_load_output(path, port=port, axes_hint=axes_hint))
-
-    collections: dict[str, Collection] = {}
-    for port_name, items in grouped.items():
-        collections[port_name] = Collection(items=cast(list[Any], items), item_type=type(items[0]))
-    return collections
-
-
-def _guess_output_port(path: Path, allowed_ports: set[str]) -> str:
-    suffix = path.suffix.lower()
-    stem = path.stem.lower()
-    if suffix == ".csv" and "measurements" in allowed_ports:
-        return "measurements"
-    if any(token in stem for token in ("mask", "segmentation_mask")) and "mask" in allowed_ports:
-        return "mask"
-    if any(token in stem for token in ("label", "labels", "annotation")) and "label" in allowed_ports:
-        return "label"
-    if suffix in {".geojson", ".roi", ".zip", ".qpdata"} and "label" in allowed_ports:
-        return "label"
-    if "image" in allowed_ports:
-        return "image"
-    if "label" in allowed_ports:
-        return "label"
-    if "measurements" in allowed_ports:
-        return "measurements"
-    raise ValueError(f"Could not route output file {path.name!r} to a known port")
-
-
-def _load_output(path: Path, *, port: str, axes_hint: list[str] | None) -> Image | Mask | Label | DataFrame:
-    if port == "measurements":
-        return _dataframe_from_csv(path)
-    if port == "label" and path.suffix.lower() in {".geojson", ".roi", ".zip", ".qpdata"}:
-        return _annotation_label(path)
-
-    image = _load_image_like(path, axes_hint=axes_hint)
-    if port == "image":
-        return image
-    if port == "mask":
-        return _mask_from_image(image)
-    return _label_from_image(image)
-
-
-def _load_image_like(path: Path, *, axes_hint: list[str] | None) -> Image:
-    suffix = path.suffix.lower()
-    if suffix in {".tif", ".tiff"}:
-        return _load_tiff(path, axes_hint)
-    if suffix == ".zarr":
-        return _load_zarr(path, axes_hint)
-    if suffix == ".npy":
-        data = np.load(path)
-        axes = axes_hint or _default_axes_for_ndim(data.ndim)
-        return _image_from_array(np.asarray(data), axes=axes, source_file=str(path))
-    if suffix == ".png":
-        import imageio.v2 as imageio
-
-        data = np.asarray(imageio.imread(path))
-        if data.ndim == 2:
-            return _image_from_array(data, axes=["y", "x"], source_file=str(path))
-        if data.ndim == 3 and data.shape[2] in {3, 4}:
-            return _image_from_array(np.moveaxis(data[..., :3], -1, 0), axes=["c", "y", "x"], source_file=str(path))
-    raise ValueError(f"Unsupported interactive output format {suffix!r} for {path}")
-
-
-def _image_from_array(data: np.ndarray, *, axes: list[str], source_file: str) -> Image:
-    image = Image(axes=axes, shape=tuple(data.shape), dtype=data.dtype, meta=Image.Meta(source_file=source_file))
-    image._data = data  # type: ignore[attr-defined]
-    return image
-
-
-def _mask_from_image(image: Image) -> Mask:
-    data = _image_data(image).astype(bool, copy=False)
-    mask = Mask(
-        axes=list(image.axes),
-        shape=tuple(data.shape),
-        dtype=bool,
-        framework=image.framework.derive(),
-        meta=image.meta,
-        user=dict(image.user),
-    )
-    mask._data = data  # type: ignore[attr-defined]
-    return mask
-
-
-def _label_from_image(image: Image) -> Label:
-    data = np.asarray(_image_data(image), dtype=np.int32)
-    raster = Array(
-        axes=list(image.axes),
-        shape=tuple(data.shape),
-        dtype=data.dtype,
-        framework=image.framework.derive(),
-        user=dict(image.user),
-    )
-    raster._data = data  # type: ignore[attr-defined]
-    source_file = image.meta.source_file if isinstance(image.meta, Image.Meta) else None
-    return Label(
-        slots={"raster": raster},
-        framework=image.framework.derive(),
-        meta=Label.Meta(source_file=source_file, n_objects=int(np.max(data)) if data.size else 0),
-        user=dict(image.user),
-    )
-
-
-def _annotation_label(path: Path) -> Label:
-    if path.suffix.lower() == ".geojson":
-        payload = json.loads(path.read_text(encoding="utf-8"))
-        features = payload.get("features", []) if isinstance(payload, dict) else []
-        rows = [
-            {
-                "source_path": str(path),
-                "geometry_type": feature.get("geometry", {}).get("type"),
-                "properties": json.dumps(feature.get("properties", {}), sort_keys=True),
-            }
-            for feature in features
-            if isinstance(feature, dict)
-        ]
-        if not rows:
-            rows = [{"source_path": str(path), "geometry_type": None, "properties": "{}"}]
-    else:
-        rows = [{"source_path": str(path), "format": path.suffix.lower().lstrip(".")}]
-
-    polygons = _dataframe_from_rows(rows)
-    return Label(slots={"polygons": polygons}, meta=Label.Meta(source_file=str(path), n_objects=len(rows)))
-
-
-def _dataframe_from_csv(path: Path) -> DataFrame:
-    with path.open("r", encoding="utf-8", newline="") as handle:
-        reader = csv.DictReader(handle)
-        rows = list(reader)
-        if reader.fieldnames is None:
-            raise ValueError(f"Interactive measurements file {path} has no header row")
-        if rows:
-            table = pa.table({name: [row.get(name) for row in rows] for name in reader.fieldnames})
-        else:
-            table = pa.table({name: pa.array([]) for name in reader.fieldnames})
-    dataframe = DataFrame(columns=list(table.column_names), row_count=table.num_rows)
-    dataframe._arrow_table = table  # type: ignore[attr-defined]
-    return dataframe
-
-
-def _dataframe_from_rows(rows: list[dict[str, Any]]) -> DataFrame:
-    column_names = list(rows[0].keys()) if rows else ["source_path"]
-    table = pa.table({name: pa.array([row.get(name) for row in rows]) for name in column_names})
-    dataframe = DataFrame(columns=list(table.column_names), row_count=table.num_rows)
-    dataframe._arrow_table = table  # type: ignore[attr-defined]
-    return dataframe
-
-
-def _image_data(image: Image) -> np.ndarray:
-    if image.storage_ref is None and hasattr(image, "_data") and getattr(image, "_data", None) is not None:
-        return np.asarray(image._data)  # type: ignore[attr-defined]
-    return np.asarray(image.to_memory())
+# Issue #680: per-plugin output classification heuristics
+# (``_collect_outputs`` / ``_guess_output_port``) were removed in favour of
+# the generic extension-based binner on ``AppBlock`` itself. Subclasses now
+# return ``self._bin_outputs_by_extension(output_files, config)`` after
+# launching the external app. Image-specific loaders (Mask/Label/DataFrame
+# constructors) are no longer needed here — downstream blocks consume the
+# resulting ``Artifact`` Collections via standard load blocks.
 
 
 __all__ = ["FijiBlock", "NapariBlock"]

--- a/packages/scieasy-blocks-imaging/src/scieasy_blocks_imaging/interactive/fiji_block.py
+++ b/packages/scieasy-blocks-imaging/src/scieasy_blocks_imaging/interactive/fiji_block.py
@@ -10,7 +10,6 @@ from scieasy.blocks.base.ports import InputPort, OutputPort
 from scieasy.blocks.base.state import ExecutionMode
 from scieasy.core.types.collection import Collection
 from scieasy_blocks_imaging.interactive import (
-    _collect_outputs,
     _input_images,
     _prepare_image_exchange,
     _resolve_command,
@@ -82,14 +81,39 @@ class FijiBlock(AppBlock):
         if not macro_path:
             launch_args = [str(p) for p in staged_paths]
 
+        # Issue #680: when the user declares output ports (with extensions)
+        # via the editor, broaden the watcher patterns to include each
+        # declared extension so files of those types are not missed.
+        patterns = list(self.output_patterns)
+        configured_ports = config.get("output_ports") or []
+        if isinstance(configured_ports, list):
+            for entry in configured_ports:
+                if isinstance(entry, dict) and entry.get("extension"):
+                    ext = str(entry["extension"]).strip().lstrip(".").lower()
+                    if ext and f"*.{ext}" not in patterns:
+                        patterns.append(f"*.{ext}")
         output_files = _run_external_app(
             self,
             command=command,
             exchange_dir=exchange_dir,
-            patterns=self.output_patterns,
+            patterns=patterns,
             config=config,
             launch_args=launch_args,
         )
-        return _collect_outputs(
-            output_files, template_image=images[0] if images else None, allowed_ports={"image", "mask", "label"}
-        )
+        # Issue #680: route output files into user-declared ports by
+        # extension. Falls back to legacy single-Artifact-per-file behaviour
+        # only when no ports are declared in config (the ClassVar
+        # ``output_ports`` above is the default scaffold the user may
+        # override via the port editor).
+        if config.get("output_ports"):
+            return self._bin_outputs_by_extension(output_files, config)
+        # Backwards-compatible single-port fallback: emit every file as an
+        # Artifact under the "image" output port so existing graphs keep
+        # working until the user opens the port editor.
+        from scieasy.blocks.app.bridge import _guess_mime
+        from scieasy.core.types.artifact import Artifact
+
+        artifacts = [Artifact(file_path=p, mime_type=_guess_mime(p), description=p.name) for p in output_files]
+        if not artifacts:
+            return {}
+        return {"image": Collection(artifacts, item_type=Artifact)}

--- a/packages/scieasy-blocks-imaging/src/scieasy_blocks_imaging/interactive/napari_block.py
+++ b/packages/scieasy-blocks-imaging/src/scieasy_blocks_imaging/interactive/napari_block.py
@@ -10,7 +10,6 @@ from scieasy.blocks.base.ports import InputPort, OutputPort
 from scieasy.blocks.base.state import ExecutionMode
 from scieasy.core.types.collection import Collection
 from scieasy_blocks_imaging.interactive import (
-    _collect_outputs,
     _input_images,
     _prepare_image_exchange,
     _resolve_command,
@@ -55,14 +54,30 @@ class NapariBlock(AppBlock):
         exchange_dir = _resolve_exchange_dir(config, prefix="scieasy_napari_")
         staged_paths = _prepare_image_exchange(images, exchange_dir, tool_name=self.type_name, config=config)
         command = _resolve_command(config, app_command=self.app_command, override_key="napari_path")
+        # Issue #680: broaden watcher patterns with each declared extension.
+        patterns = list(self.output_patterns)
+        configured_ports = config.get("output_ports") or []
+        if isinstance(configured_ports, list):
+            for entry in configured_ports:
+                if isinstance(entry, dict) and entry.get("extension"):
+                    ext = str(entry["extension"]).strip().lstrip(".").lower()
+                    if ext and f"*.{ext}" not in patterns:
+                        patterns.append(f"*.{ext}")
         output_files = _run_external_app(
             self,
             command=command,
             exchange_dir=exchange_dir,
-            patterns=self.output_patterns,
+            patterns=patterns,
             config=config,
             launch_args=[str(p) for p in staged_paths],
         )
-        return _collect_outputs(
-            output_files, template_image=images[0] if images else None, allowed_ports={"image", "mask", "label"}
-        )
+        # Issue #680: extension-based binning (see FijiBlock for rationale).
+        if config.get("output_ports"):
+            return self._bin_outputs_by_extension(output_files, config)
+        from scieasy.blocks.app.bridge import _guess_mime
+        from scieasy.core.types.artifact import Artifact
+
+        artifacts = [Artifact(file_path=p, mime_type=_guess_mime(p), description=p.name) for p in output_files]
+        if not artifacts:
+            return {}
+        return {"image": Collection(artifacts, item_type=Artifact)}

--- a/packages/scieasy-blocks-imaging/tests/test_interactive_blocks.py
+++ b/packages/scieasy-blocks-imaging/tests/test_interactive_blocks.py
@@ -1,4 +1,12 @@
-"""Tests for interactive imaging AppBlocks using fake external tools."""
+"""Tests for interactive imaging AppBlocks using fake external tools.
+
+Issue #680: per-plugin output classification heuristics
+(``_collect_outputs`` / ``_guess_output_port``) were removed in favour of
+the generic extension-based binner on ``AppBlock``. These tests now assert
+that output files are wrapped as :class:`Artifact` instances and routed
+into the user-declared output ports (or the fallback ``image`` port when
+no ports are declared).
+"""
 
 from __future__ import annotations
 
@@ -12,6 +20,7 @@ from scieasy_blocks_imaging.types import Image
 
 from scieasy.blocks.base.config import BlockConfig
 from scieasy.blocks.base.state import BlockState
+from scieasy.core.types.artifact import Artifact
 from scieasy.core.types.collection import Collection
 
 
@@ -59,7 +68,8 @@ shutil.copyfile(tiff_path, output_dir / "image_reviewed.tif")
 
     assert "image" in result
     assert result["image"].length == 1
-    assert result["image"][0].shape == image.shape
+    assert isinstance(result["image"][0], Artifact)
+    assert result["image"][0].file_path is not None
 
 
 def test_fiji_block_passes_staged_tiff_paths_to_fiji_when_no_macro(tmp_path: Path) -> None:
@@ -185,11 +195,12 @@ from pathlib import Path
 import shutil
 import sys
 
-exchange = Path(sys.argv[-1])
-source = next((exchange / "inputs").glob("*.tif"))
-target = exchange / "outputs" / "image_layer.tif"
-target.parent.mkdir(exist_ok=True)
-shutil.copyfile(source, target)
+# NapariBlock passes the staged TIFF path as the trailing arg
+# (consistent with FijiBlock #420).
+tiff_path = Path(sys.argv[-1])
+output_dir = tiff_path.parent.parent / "outputs"
+output_dir.mkdir(exist_ok=True)
+shutil.copyfile(tiff_path, output_dir / "image_layer.tif")
 """.strip(),
     )
     block = _make_running(NapariBlock())
@@ -202,4 +213,52 @@ shutil.copyfile(source, target)
 
     assert "image" in result
     assert result["image"].length == 1
-    assert result["image"][0].shape == image.shape
+    assert isinstance(result["image"][0], Artifact)
+    assert result["image"][0].file_path is not None
+
+
+def test_fiji_block_routes_outputs_into_user_declared_ports_by_extension(tmp_path: Path) -> None:
+    """Issue #680: when the user declares output_ports with extensions, the
+    binner routes saved files into those ports — bypassing the legacy
+    fallback path. Verify FijiBlock end-to-end with a user-defined port set.
+    """
+    script = _write_fake_tool(
+        tmp_path,
+        """
+from pathlib import Path
+import shutil
+import sys
+
+# Save a .tif AND a .csv to outputs/.
+tiff_path = Path(sys.argv[-1])
+out = tiff_path.parent.parent / "outputs"
+out.mkdir(exist_ok=True)
+shutil.copyfile(tiff_path, out / "result.tif")
+(out / "summary.csv").write_text("col\\n1\\n", encoding="utf-8")
+""".strip(),
+    )
+    block = _make_running(FijiBlock())
+    image = _make_image(np.arange(16, dtype=np.uint8).reshape(4, 4))
+
+    result = block.run(
+        {"image": Collection(items=[image], item_type=Image)},
+        BlockConfig(
+            params={
+                "app_command": [sys.executable, str(script)],
+                "watch_timeout": 5,
+                "output_patterns": ["*.tif", "*.csv"],
+                "output_ports": [
+                    {"name": "images", "types": ["DataObject"], "extension": "tif"},
+                    {"name": "tables", "types": ["DataObject"], "extension": "csv"},
+                ],
+            }
+        ),
+    )
+
+    assert set(result.keys()) == {"images", "tables"}
+    assert result["images"].length == 1
+    assert result["tables"].length == 1
+    assert isinstance(result["images"][0], Artifact)
+    assert result["images"][0].file_path is not None
+    assert result["images"][0].file_path.suffix.lower() == ".tif"
+    assert result["tables"][0].file_path.suffix.lower() == ".csv"

--- a/packages/scieasy-blocks-lcms/src/scieasy_blocks_lcms/external/elmaven_block.py
+++ b/packages/scieasy-blocks-lcms/src/scieasy_blocks_lcms/external/elmaven_block.py
@@ -189,7 +189,13 @@ def _run_external_app(
 
 
 def _collect_elmaven_outputs(output_files: list[Path]) -> dict[str, Collection]:
-    """Classify and load exported files into typed output collections."""
+    """Classify and load exported files into typed output collections.
+
+    .. deprecated:: 2026-04 (issue #680)
+       Replaced by ``AppBlock._bin_outputs_by_extension``. The function is
+       retained as a deprecated import for backwards compatibility with
+       existing test imports; ``ElMAVENBlock.run()`` no longer calls it.
+    """
     peak_tables: list[PeakTable] = []
     mid_tables: list[MIDTable] = []
     for file_path in output_files:
@@ -217,6 +223,12 @@ def _classify_export(path: Path) -> str:
 
     Heuristic: MID tables have a column named ``C13`` or ``H2`` in the
     header row; peak tables typically have ``medMz`` / ``mz`` instead.
+
+    .. deprecated:: 2026-04 (issue #680)
+       Routing is now driven by user-declared port extensions on the
+       AppBlock; this column-header heuristic is no longer used by
+       ``ElMAVENBlock.run()``. Retained for backwards compatibility with
+       existing test imports.
     """
     import pandas as pd
 
@@ -332,14 +344,38 @@ class ElMAVENBlock(_LCMSBlockMixin, AppBlock):
 
         # 5. Launch and wait (shared helper manages state transitions).
         # Pass raw file paths as positional args so ElMAVEN loads them on launch.
+        # Issue #680: broaden watcher patterns to cover each declared extension.
+        patterns = list(self.output_patterns)
+        configured_ports = config.get("output_ports") or []
+        if isinstance(configured_ports, list):
+            for entry in configured_ports:
+                if isinstance(entry, dict) and entry.get("extension"):
+                    ext = str(entry["extension"]).strip().lstrip(".").lower()
+                    if ext and f"*.{ext}" not in patterns:
+                        patterns.append(f"*.{ext}")
         output_files = _run_external_app(
             self,
             command=command,
             exchange_dir=exchange_dir,
-            patterns=self.output_patterns,
+            patterns=patterns,
             config=config,
             launch_args=raw_paths,
         )
 
-        # 6. Classify and load outputs.
-        return _collect_elmaven_outputs(output_files)
+        # 6. Route output files into user-declared ports by extension
+        # (issue #680). The legacy column-header heuristic
+        # (``_collect_elmaven_outputs`` / ``_classify_export``) has been
+        # replaced by the generic binner — users declare peak_table vs
+        # mid_table ports with distinct extensions in the port editor.
+        if config.get("output_ports"):
+            return self._bin_outputs_by_extension(output_files, config)
+        # Backwards-compatible fallback: wrap every exported file as an
+        # Artifact under ``peak_table`` until the user opens the port
+        # editor and declares extensions.
+        from scieasy.blocks.app.bridge import _guess_mime
+        from scieasy.core.types.artifact import Artifact
+
+        artifacts = [Artifact(file_path=p, mime_type=_guess_mime(p), description=p.name) for p in output_files]
+        if not artifacts:
+            return {}
+        return {"peak_table": Collection(artifacts, item_type=Artifact)}

--- a/src/scieasy/blocks/app/app_block.py
+++ b/src/scieasy/blocks/app/app_block.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
+import logging
 import shutil
 import subprocess
 import tempfile
 from pathlib import Path
 from typing import Any, ClassVar
 
-from scieasy.blocks.app.bridge import FileExchangeBridge
+from scieasy.blocks.app.bridge import FileExchangeBridge, _guess_mime
 from scieasy.blocks.app.command_validator import validate_app_command
 from scieasy.blocks.base.block import Block
 from scieasy.blocks.base.config import BlockConfig
@@ -17,6 +18,22 @@ from scieasy.blocks.base.state import BlockState, ExecutionMode
 from scieasy.core.types.artifact import Artifact
 from scieasy.core.types.base import DataObject
 from scieasy.core.types.collection import Collection
+
+logger = logging.getLogger(__name__)
+
+
+def _normalize_extension(raw: Any) -> str:
+    """Lowercase, strip leading dots, return ``""`` for null/empty inputs.
+
+    Used by both the binner and the duplicate-extension validator so the
+    matching rule is identical at config-save time and at runtime.
+    """
+    if raw is None:
+        return ""
+    text = str(raw).strip()
+    while text.startswith("."):
+        text = text[1:]
+    return text.lower()
 
 
 class _PopenProcessAdapter:
@@ -57,6 +74,13 @@ class AppBlock(Block):
     execution_mode: ClassVar[ExecutionMode] = ExecutionMode.EXTERNAL
     output_patterns: ClassVar[list[str]] = ["*"]
     terminate_grace_sec: ClassVar[float] = 10.0
+
+    # Issue #680: AppBlock ports are user-configurable via the port editor.
+    # The ClassVar values below act as default scaffolds — subclasses may
+    # override them, and any user can replace them at config time through
+    # the port editor (ADR-029).
+    variadic_inputs: ClassVar[bool] = True
+    variadic_outputs: ClassVar[bool] = True
 
     name: ClassVar[str] = "App Block"
     description: ClassVar[str] = "Delegate work to an external GUI application"
@@ -106,6 +130,9 @@ class AppBlock(Block):
                 "ui_widget": "port_editor",
                 "ui_priority": 10,
             },
+            # Issue #680: each output port entry carries an additional
+            # ``extension`` field (string, no leading dot, case-insensitive)
+            # that the runtime uses to bin saved files into ports.
             "output_ports": {
                 "type": "array",
                 "items": {
@@ -113,7 +140,9 @@ class AppBlock(Block):
                     "properties": {
                         "name": {"type": "string"},
                         "types": {"type": "array", "items": {"type": "string"}},
+                        "extension": {"type": "string"},
                     },
+                    "required": ["name", "extension"],
                 },
                 "default": [],
                 "title": "Output Ports",
@@ -124,12 +153,115 @@ class AppBlock(Block):
         "required": ["app_command"],
     }
 
+    # ------------------------------------------------------------------
+    # Issue #680: extension-based output binning
+    # ------------------------------------------------------------------
+
+    def _output_port_extensions(self, config: BlockConfig) -> dict[str, str]:
+        """Return ``{port_name: normalized_extension}`` from the configured output ports.
+
+        Reads ``config["output_ports"]`` (the user-edited list of port dicts),
+        normalises each ``extension`` value (lowercased, leading dots stripped)
+        and returns the resulting mapping.  Falls back to an empty dict when
+        the user has not declared any output ports — callers treat that as
+        "use legacy bridge.collect() behaviour".
+        """
+        configured = config.get("output_ports")
+        if not configured or not isinstance(configured, list):
+            return {}
+        mapping: dict[str, str] = {}
+        for entry in configured:
+            if not isinstance(entry, dict):
+                continue
+            name = str(entry.get("name", "")).strip()
+            if not name:
+                continue
+            mapping[name] = _normalize_extension(entry.get("extension"))
+        return mapping
+
+    def _bin_outputs_by_extension(
+        self,
+        output_files: list[Path],
+        config: BlockConfig,
+    ) -> dict[str, Collection]:
+        """Bin *output_files* into the configured output ports by file extension.
+
+        Issue #680 routing rules (case-insensitive):
+
+        - A file whose suffix matches a port's declared ``extension`` is
+          appended to that port's Collection (typed as the first entry of
+          ``port.accepted_types``).
+        - A required port that receives zero files raises ``ValueError``.
+        - A file whose extension matches no port emits a warning log and
+          is otherwise ignored.
+
+        Returns a dict mapping each declared port name (regardless of
+        whether it received any files — empty optional ports get an empty
+        Collection) to its Collection of :class:`Artifact` instances.
+
+        Effective output ports are resolved from *config* first (so that
+        run-time ``config["output_ports"]`` always wins) and only fall back
+        to ``self.get_effective_output_ports()`` when the runtime config
+        does not specify any.  This keeps the binner usable both from
+        scheduler-driven runs (where ``self.config`` mirrors the node
+        config) and from direct ``block.run(config=...)`` test harnesses.
+        """
+        from scieasy.blocks.base.ports import ports_from_config_dicts
+
+        config_ports = config.get("output_ports")
+        if config_ports and isinstance(config_ports, list):
+            ports = list(ports_from_config_dicts(config_ports, "output"))
+        else:
+            ports = self.get_effective_output_ports()
+        if not ports:
+            return {}
+
+        port_extensions = self._output_port_extensions(config)
+        ext_to_port: dict[str, OutputPort] = {}
+        for port in ports:
+            ext = port_extensions.get(port.name, "")
+            if not ext:
+                # Port was declared in the editor but its extension field is
+                # empty; treat it as unmatched. Required ports will raise
+                # below, optional ports stay empty.
+                continue
+            ext_to_port[ext] = port
+
+        grouped: dict[str, list[Artifact]] = {port.name: [] for port in ports}
+        unmatched: list[Path] = []
+        for path in output_files:
+            suffix = path.suffix.lstrip(".").lower()
+            target = ext_to_port.get(suffix)
+            if target is None:
+                unmatched.append(path)
+                continue
+            grouped[target.name].append(Artifact(file_path=path, mime_type=_guess_mime(path), description=path.name))
+
+        for path in unmatched:
+            logger.warning("Unmatched output file %r", path.name)
+
+        for port in ports:
+            if port.required and not grouped[port.name]:
+                ext = port_extensions.get(port.name, "")
+                raise ValueError(f"Port {port.name!r} required, no '.{ext}' files in output dir")
+
+        result: dict[str, Collection] = {}
+        for port in ports:
+            items = grouped[port.name]
+            item_type = port.accepted_types[0] if port.accepted_types else Artifact
+            result[port.name] = Collection(items, item_type=item_type)
+        return result
+
     def run(self, inputs: dict[str, Collection], config: BlockConfig) -> dict[str, Collection]:
         """Prepare inputs, launch the external app, and collect outputs.
 
         ADR-018: Handles CANCELLED transitions when external process exits unexpectedly.
         ADR-019: Stores ProcessHandle from bridge for cancellation support.
         ADR-020: Accepts and returns Collection-wrapped data.
+
+        Issue #680: when the user has declared output ports via the port
+        editor, output files are binned by extension instead of being
+        passed through the legacy ``bridge.collect()`` path.
 
         Resource cleanup (#338, #339):
         - Subprocess is always waited on / terminated / killed in finally block.
@@ -215,6 +347,13 @@ class AppBlock(Block):
                 watcher.stop()
 
             # Step 4: Collect results.
+            # Issue #680: when the user has declared output ports via the
+            # port editor, route files into those ports by extension; the
+            # legacy ``bridge.collect()`` path (one Artifact per file,
+            # keyed by file stem) is only used when no ports are declared.
+            if config.get("output_ports"):
+                return self._bin_outputs_by_extension(output_files, config)
+
             results = bridge.collect(output_files)
 
             # ADR-020: Wrap output artifacts in Collection.

--- a/src/scieasy/blocks/app/app_block.py
+++ b/src/scieasy/blocks/app/app_block.py
@@ -230,6 +230,33 @@ class AppBlock(Block):
                 continue
             ext_to_port[ext] = port
 
+        # #690 audit fix: determine the typed item class per port up front so
+        # that constructed items satisfy ``Collection.item_type`` homogeneity.
+        # ``port.accepted_types`` holds resolved Python classes (see
+        # ``ports_from_config_dicts``). Only ``Artifact`` and its subclasses
+        # share the file-path constructor signature; for any other declared
+        # type (Array/Image/PeakTable/etc.) we fall back to ``Artifact`` and
+        # warn, because we cannot construct those from just a file path.
+        port_item_types: dict[str, type] = {}
+        for port in ports:
+            declared = port.accepted_types[0] if port.accepted_types else Artifact
+            if isinstance(declared, type) and issubclass(declared, Artifact):
+                port_item_types[port.name] = declared
+            else:
+                # Fall back to Artifact for types we cannot construct from
+                # only a file path (Array/Image require axes; plugin types
+                # generally need more than a path). The output is still
+                # "loadable but not yet structured" — downstream loader
+                # blocks can convert.
+                if declared is not Artifact:
+                    logger.warning(
+                        "Output port %r declared type %r is not constructible from a "
+                        "file path; falling back to Artifact",
+                        port.name,
+                        getattr(declared, "__name__", declared),
+                    )
+                port_item_types[port.name] = Artifact
+
         grouped: dict[str, list[DataObject]] = {port.name: [] for port in ports}
         unmatched: list[Path] = []
         for path in output_files:
@@ -238,7 +265,8 @@ class AppBlock(Block):
             if target is None:
                 unmatched.append(path)
                 continue
-            grouped[target.name].append(Artifact(file_path=path, mime_type=_guess_mime(path), description=path.name))
+            item_cls = port_item_types[target.name]
+            grouped[target.name].append(item_cls(file_path=path, mime_type=_guess_mime(path), description=path.name))
 
         for path in unmatched:
             logger.warning("Unmatched output file %r", path.name)
@@ -251,8 +279,9 @@ class AppBlock(Block):
         result: dict[str, Collection] = {}
         for port in ports:
             items = grouped[port.name]
-            item_type = port.accepted_types[0] if port.accepted_types else Artifact
-            result[port.name] = Collection(items, item_type=item_type)
+            # Collection.item_type must match the constructed items, not the
+            # originally-declared port type (we may have fallen back above).
+            result[port.name] = Collection(items, item_type=port_item_types[port.name])
         return result
 
     def run(self, inputs: dict[str, Collection], config: BlockConfig) -> dict[str, Collection]:

--- a/src/scieasy/blocks/app/app_block.py
+++ b/src/scieasy/blocks/app/app_block.py
@@ -7,7 +7,7 @@ import shutil
 import subprocess
 import tempfile
 from pathlib import Path
-from typing import Any, ClassVar
+from typing import Any, ClassVar, cast
 
 from scieasy.blocks.app.bridge import FileExchangeBridge, _guess_mime
 from scieasy.blocks.app.command_validator import validate_app_command
@@ -209,8 +209,11 @@ class AppBlock(Block):
         from scieasy.blocks.base.ports import ports_from_config_dicts
 
         config_ports = config.get("output_ports")
+        ports: list[OutputPort]
         if config_ports and isinstance(config_ports, list):
-            ports = list(ports_from_config_dicts(config_ports, "output"))
+            # ports_from_config_dicts returns list[InputPort] | list[OutputPort];
+            # we requested direction="output" so the runtime type is list[OutputPort].
+            ports = cast(list[OutputPort], list(ports_from_config_dicts(config_ports, "output")))
         else:
             ports = self.get_effective_output_ports()
         if not ports:
@@ -227,7 +230,7 @@ class AppBlock(Block):
                 continue
             ext_to_port[ext] = port
 
-        grouped: dict[str, list[Artifact]] = {port.name: [] for port in ports}
+        grouped: dict[str, list[DataObject]] = {port.name: [] for port in ports}
         unmatched: list[Path] = []
         for path in output_files:
             suffix = path.suffix.lstrip(".").lower()

--- a/src/scieasy/workflow/validator.py
+++ b/src/scieasy/workflow/validator.py
@@ -88,6 +88,11 @@ def validate_workflow(
        ``min_input_ports`` / ``max_input_ports`` / ``min_output_ports`` /
        ``max_output_ports`` limits declared on the ``BlockSpec`` (only when
        *registry* is provided).
+    8. **AppBlock duplicate output-port extensions** -- two output ports on
+       a single variadic-output block declaring the same file extension
+       (case-insensitive) would make extension-based binning ambiguous, so
+       such configurations are rejected at workflow save time
+       (issue #680).
 
     Parameters
     ----------
@@ -286,5 +291,37 @@ def validate_workflow(
                 errors.append(
                     f"Node '{node.id}': variadic output port count {n_out} exceeds maximum {spec.max_output_ports}"
                 )
+
+    # ------------------------------------------------------------------
+    # Check 8: AppBlock duplicate output-port extensions (issue #680)
+    # ------------------------------------------------------------------
+    # AppBlock subclasses route output files into ports by file extension.
+    # Two ports declaring the same extension would be ambiguous, so reject
+    # such configurations at save time. Case-insensitive comparison; ports
+    # that omit the ``extension`` field are skipped (the runtime binner
+    # will leave them empty / raise on its own if required).
+    for node in workflow.nodes:
+        spec = registry.get_spec(node.block_type)
+        if spec is None or not spec.variadic_outputs:
+            continue
+        configured = node.config.get("output_ports")
+        if not isinstance(configured, list):
+            continue
+        ext_to_ports: dict[str, list[str]] = {}
+        for entry in configured:
+            if not isinstance(entry, dict):
+                continue
+            port_name = str(entry.get("name", "")).strip()
+            ext_raw = entry.get("extension")
+            if not port_name or ext_raw in (None, ""):
+                continue
+            ext = str(ext_raw).strip().lstrip(".").lower()
+            if not ext:
+                continue
+            ext_to_ports.setdefault(ext, []).append(port_name)
+        for ext, names in ext_to_ports.items():
+            if len(names) > 1:
+                joined = ", ".join(sorted(set(names)))
+                errors.append(f"Node '{node.id}': Duplicate extension {ext!r} across output ports {{{joined}}}")
 
     return errors

--- a/src/scieasy/workflow/validator.py
+++ b/src/scieasy/workflow/validator.py
@@ -300,11 +300,24 @@ def validate_workflow(
     # such configurations at save time. Case-insensitive comparison; ports
     # that omit the ``extension`` field are skipped (the runtime binner
     # will leave them empty / raise on its own if required).
+    #
+    # #690 audit fix: the frontend port editor writes ``output_ports`` under
+    # ``node.config["params"]["output_ports"]`` (mirroring the
+    # :class:`BlockConfig` two-tier layout used at runtime), so the original
+    # root-level read here never matched real configs and Check 8 silently
+    # passed every workflow. Read ``params.output_ports`` first; fall back
+    # to the root-level key so direct API callers and existing tests that
+    # construct configs without a ``params`` envelope still work.
     for node in workflow.nodes:
         spec = registry.get_spec(node.block_type)
         if spec is None or not spec.variadic_outputs:
             continue
-        configured = node.config.get("output_ports")
+        params = node.config.get("params")
+        configured: Any = None
+        if isinstance(params, dict):
+            configured = params.get("output_ports")
+        if configured is None:
+            configured = node.config.get("output_ports")
         if not isinstance(configured, list):
             continue
         ext_to_ports: dict[str, list[str]] = {}

--- a/tests/blocks/test_app_block.py
+++ b/tests/blocks/test_app_block.py
@@ -6,6 +6,7 @@ import os
 import time
 from pathlib import Path
 from threading import Thread
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
@@ -807,3 +808,220 @@ class TestAppBlockTempDirCleanup:
 
         # Even on error, temp dir should be cleaned up.
         assert not temp_dir.exists(), "Temp dir not cleaned up after error (#339)"
+
+
+# ---------------------------------------------------------------------------
+# Issue #680: AppBlock variadic ports + extension-based output binning
+# ---------------------------------------------------------------------------
+
+
+class TestAppBlockVariadicPorts:
+    """Issue #680: ``config.{input,output}_ports`` overrides ClassVar ports."""
+
+    def test_effective_input_ports_use_config_when_set(self) -> None:
+        from scieasy.blocks.app.app_block import AppBlock
+
+        block = AppBlock(
+            config={
+                "params": {
+                    "input_ports": [
+                        {"name": "alpha", "types": ["DataObject"]},
+                        {"name": "beta", "types": ["DataObject"]},
+                    ]
+                }
+            }
+        )
+
+        ports = block.get_effective_input_ports()
+        assert [p.name for p in ports] == ["alpha", "beta"]
+
+    def test_effective_output_ports_use_config_when_set(self) -> None:
+        from scieasy.blocks.app.app_block import AppBlock
+
+        block = AppBlock(
+            config={
+                "params": {
+                    "output_ports": [
+                        {"name": "tables", "types": ["DataObject"], "extension": "csv"},
+                    ]
+                }
+            }
+        )
+
+        ports = block.get_effective_output_ports()
+        assert [p.name for p in ports] == ["tables"]
+
+    def test_falls_back_to_classvar_when_config_unset(self) -> None:
+        from scieasy.blocks.app.app_block import AppBlock
+
+        block = AppBlock()
+        # ClassVar ports remain visible when no config override is given.
+        assert [p.name for p in block.get_effective_input_ports()] == ["data"]
+        assert [p.name for p in block.get_effective_output_ports()] == ["result"]
+
+
+class TestAppBlockExtensionBinner:
+    """Issue #680: ``_bin_outputs_by_extension`` routing rules."""
+
+    def _make_block_with_ports(self, port_dicts: list[dict[str, Any]]) -> Any:
+        from scieasy.blocks.app.app_block import AppBlock
+
+        return AppBlock(config={"params": {"output_ports": port_dicts}})
+
+    def test_routes_files_by_extension_case_insensitive(self, tmp_path: Path) -> None:
+        from scieasy.blocks.base.config import BlockConfig
+
+        f1 = tmp_path / "image.TIF"
+        f2 = tmp_path / "image2.tif"
+        f3 = tmp_path / "summary.csv"
+        for f in (f1, f2, f3):
+            f.write_text("x", encoding="utf-8")
+
+        block = self._make_block_with_ports(
+            [
+                {"name": "images", "types": ["DataObject"], "extension": "TIF"},
+                {"name": "tables", "types": ["DataObject"], "extension": "csv"},
+            ]
+        )
+        config = BlockConfig(
+            params={
+                "output_ports": [
+                    {"name": "images", "types": ["DataObject"], "extension": "TIF"},
+                    {"name": "tables", "types": ["DataObject"], "extension": "csv"},
+                ]
+            }
+        )
+
+        result = block._bin_outputs_by_extension([f1, f2, f3], config)
+
+        assert set(result.keys()) == {"images", "tables"}
+        assert result["images"].length == 2
+        assert result["tables"].length == 1
+
+    def test_required_port_with_no_files_raises(self, tmp_path: Path) -> None:
+        from scieasy.blocks.base.config import BlockConfig
+
+        f1 = tmp_path / "image.tif"
+        f1.write_text("x", encoding="utf-8")
+
+        block = self._make_block_with_ports(
+            [
+                {"name": "images", "types": ["DataObject"], "extension": "tif"},
+                {"name": "labels", "types": ["DataObject"], "extension": "png"},
+            ]
+        )
+        config = BlockConfig(
+            params={
+                "output_ports": [
+                    {"name": "images", "types": ["DataObject"], "extension": "tif"},
+                    {"name": "labels", "types": ["DataObject"], "extension": "png"},
+                ]
+            }
+        )
+
+        with pytest.raises(ValueError, match=r"Port 'labels' required, no '\.png' files"):
+            block._bin_outputs_by_extension([f1], config)
+
+    def test_unmatched_files_emit_warning_log(self, tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+        import logging
+
+        from scieasy.blocks.base.config import BlockConfig
+
+        f1 = tmp_path / "image.tif"
+        f2 = tmp_path / "stray.txt"
+        f1.write_text("x", encoding="utf-8")
+        f2.write_text("y", encoding="utf-8")
+
+        block = self._make_block_with_ports([{"name": "images", "types": ["DataObject"], "extension": "tif"}])
+        config = BlockConfig(
+            params={
+                "output_ports": [
+                    {"name": "images", "types": ["DataObject"], "extension": "tif"},
+                ]
+            }
+        )
+
+        with caplog.at_level(logging.WARNING, logger="scieasy.blocks.app.app_block"):
+            result = block._bin_outputs_by_extension([f1, f2], config)
+
+        assert result["images"].length == 1
+        assert any("Unmatched output file" in record.message for record in caplog.records)
+
+    def test_classvar_optional_port_with_no_files_returns_empty_collection(self) -> None:
+        """ClassVar-declared optional ports stay empty without raising.
+
+        Per issue #680, every port declared via the editor is required.
+        Optional ports only exist as ClassVar scaffolds on subclasses;
+        the binner honours their ``required=False`` flag.
+        """
+        from typing import ClassVar
+
+        from scieasy.blocks.app.app_block import AppBlock
+        from scieasy.blocks.base.config import BlockConfig
+        from scieasy.blocks.base.ports import OutputPort
+
+        class _OptionalPortBlock(AppBlock):
+            variadic_outputs: ClassVar[bool] = False
+            output_ports: ClassVar[list[OutputPort]] = [
+                OutputPort(name="optional_csv", accepted_types=[], required=False),
+            ]
+
+        block = _OptionalPortBlock()
+        # No runtime config['output_ports'] -> falls back to ClassVar.
+        result = block._bin_outputs_by_extension([], BlockConfig(params={}))
+        # ClassVar port has no extension declared, so it stays empty (not raised).
+        assert "optional_csv" in result
+        assert result["optional_csv"].length == 0
+
+    def test_run_uses_binner_when_output_ports_in_config(self, tmp_path: Path) -> None:
+        """End-to-end run() goes through the binner when ports are declared."""
+        from unittest.mock import MagicMock, patch
+
+        from scieasy.blocks.app.app_block import AppBlock
+        from scieasy.blocks.base.config import BlockConfig
+        from scieasy.blocks.base.state import BlockState
+
+        block = AppBlock()
+        block.transition(BlockState.READY)
+        block.transition(BlockState.RUNNING)
+
+        config = BlockConfig(
+            params={
+                "app_command": "echo hello",
+                "output_ports": [
+                    {"name": "tables", "types": ["DataObject"], "extension": "csv"},
+                ],
+            }
+        )
+
+        f1 = tmp_path / "result.csv"
+        f1.write_text("a,b\n1,2\n", encoding="utf-8")
+
+        with (
+            patch("scieasy.blocks.app.app_block.FileExchangeBridge") as mock_bridge_cls,
+            patch("scieasy.blocks.app.app_block.validate_app_command", return_value=["echo", "hello"]),
+            patch(
+                "scieasy.blocks.app.app_block.tempfile.mkdtemp",
+                return_value=str(tmp_path / "ex"),
+            ),
+        ):
+            mock_bridge = MagicMock()
+            mock_bridge_cls.return_value = mock_bridge
+            mock_proc = MagicMock()
+            mock_proc.poll.return_value = None
+            mock_proc.pid = 1
+            mock_proc.wait.return_value = 0
+            mock_bridge.launch.return_value = mock_proc
+
+            with patch("scieasy.blocks.app.watcher.FileWatcher") as mock_watcher_cls:
+                mock_watcher = MagicMock()
+                mock_watcher_cls.return_value = mock_watcher
+                mock_watcher.wait_for_output.return_value = [f1]
+
+                result = block.run(inputs={}, config=config)
+
+            # bridge.collect should NOT be called because the binner ran.
+            mock_bridge.collect.assert_not_called()
+
+        assert "tables" in result
+        assert result["tables"].length == 1

--- a/tests/blocks/test_app_block.py
+++ b/tests/blocks/test_app_block.py
@@ -947,6 +947,72 @@ class TestAppBlockExtensionBinner:
         assert result["images"].length == 1
         assert any("Unmatched output file" in record.message for record in caplog.records)
 
+    def test_binner_constructs_typed_artifact_items(self, tmp_path: Path) -> None:
+        """#690 audit fix: when an output port declares an ``Artifact`` (or
+        subclass) type, the binner must construct items of that class so the
+        resulting ``Collection.item_type`` homogeneity check passes.
+
+        Previously the binner unconditionally instantiated ``Artifact``,
+        which would be rejected by a Collection whose declared ``item_type``
+        was a strict ``Artifact`` subclass.
+        """
+        from scieasy.blocks.base.config import BlockConfig
+        from scieasy.core.types.artifact import Artifact
+
+        f1 = tmp_path / "report.pdf"
+        f1.write_text("x", encoding="utf-8")
+
+        block = self._make_block_with_ports([{"name": "reports", "types": ["Artifact"], "extension": "pdf"}])
+        config = BlockConfig(
+            params={
+                "output_ports": [
+                    {"name": "reports", "types": ["Artifact"], "extension": "pdf"},
+                ]
+            }
+        )
+
+        result = block._bin_outputs_by_extension([f1], config)
+        coll = result["reports"]
+        assert coll.length == 1
+        assert coll.item_type is Artifact
+        assert isinstance(next(iter(coll)), Artifact)
+
+    def test_binner_falls_back_to_artifact_for_non_constructible_type(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """#690 audit fix: when the declared port type cannot be constructed
+        from a file path (e.g. ``Array`` / ``Image`` need axes), the binner
+        falls back to ``Artifact`` and logs a warning. The Collection's
+        ``item_type`` is then ``Artifact`` so homogeneity holds.
+        """
+        import logging
+
+        from scieasy.blocks.base.config import BlockConfig
+        from scieasy.core.types.artifact import Artifact
+
+        f1 = tmp_path / "image.tif"
+        f1.write_text("x", encoding="utf-8")
+
+        # "Array" is registered but not a subclass of Artifact and cannot be
+        # built from just a file path; the binner must fall back to Artifact.
+        block = self._make_block_with_ports([{"name": "imgs", "types": ["Array"], "extension": "tif"}])
+        config = BlockConfig(
+            params={
+                "output_ports": [
+                    {"name": "imgs", "types": ["Array"], "extension": "tif"},
+                ]
+            }
+        )
+
+        with caplog.at_level(logging.WARNING, logger="scieasy.blocks.app.app_block"):
+            result = block._bin_outputs_by_extension([f1], config)
+
+        coll = result["imgs"]
+        assert coll.length == 1
+        assert coll.item_type is Artifact
+        assert isinstance(next(iter(coll)), Artifact)
+        assert any("not constructible from a file path" in r.message for r in caplog.records)
+
     def test_classvar_optional_port_with_no_files_returns_empty_collection(self) -> None:
         """ClassVar-declared optional ports stay empty without raising.
 

--- a/tests/workflow/test_validator.py
+++ b/tests/workflow/test_validator.py
@@ -519,3 +519,121 @@ class TestValidatorVariadicCardinality:
         errors = validate_workflow(wf, registry=reg)
         cardinality_errors = [e for e in errors if "variadic" in e]
         assert cardinality_errors == []
+
+
+# ---------------------------------------------------------------------------
+# Issue #680: AppBlock duplicate output-port extension validation (Check 8)
+# ---------------------------------------------------------------------------
+
+
+class TestValidatorAppBlockDuplicateExtensions:
+    """Check 8: variadic-output blocks must not declare two ports with the same extension."""
+
+    def test_duplicate_extension_emits_error(self) -> None:
+        spec = BlockSpec(
+            name="app_block_test",
+            variadic_inputs=True,
+            variadic_outputs=True,
+            input_ports=[],
+            output_ports=[],
+        )
+        reg = _registry_from_specs(spec)
+
+        wf = WorkflowDefinition(
+            nodes=[
+                NodeDef(
+                    id="A",
+                    block_type="app_block_test",
+                    config={
+                        "output_ports": [
+                            {"name": "images", "types": ["DataObject"], "extension": "tif"},
+                            {"name": "masks", "types": ["DataObject"], "extension": "tif"},
+                        ]
+                    },
+                )
+            ],
+        )
+        errors = validate_workflow(wf, registry=reg)
+        dup_errors = [e for e in errors if "Duplicate extension" in e]
+        assert len(dup_errors) == 1
+        assert "'tif'" in dup_errors[0]
+        assert "images" in dup_errors[0]
+        assert "masks" in dup_errors[0]
+
+    def test_duplicate_extension_is_case_insensitive(self) -> None:
+        spec = BlockSpec(
+            name="app_block_case",
+            variadic_inputs=True,
+            variadic_outputs=True,
+        )
+        reg = _registry_from_specs(spec)
+
+        wf = WorkflowDefinition(
+            nodes=[
+                NodeDef(
+                    id="A",
+                    block_type="app_block_case",
+                    config={
+                        "output_ports": [
+                            {"name": "images", "types": ["DataObject"], "extension": "TIF"},
+                            {"name": "masks", "types": ["DataObject"], "extension": ".tif"},
+                        ]
+                    },
+                )
+            ],
+        )
+        errors = validate_workflow(wf, registry=reg)
+        dup_errors = [e for e in errors if "Duplicate extension" in e]
+        assert len(dup_errors) == 1
+
+    def test_distinct_extensions_pass(self) -> None:
+        spec = BlockSpec(
+            name="app_block_ok",
+            variadic_inputs=True,
+            variadic_outputs=True,
+        )
+        reg = _registry_from_specs(spec)
+
+        wf = WorkflowDefinition(
+            nodes=[
+                NodeDef(
+                    id="A",
+                    block_type="app_block_ok",
+                    config={
+                        "output_ports": [
+                            {"name": "images", "types": ["DataObject"], "extension": "tif"},
+                            {"name": "tables", "types": ["DataObject"], "extension": "csv"},
+                        ]
+                    },
+                )
+            ],
+        )
+        errors = validate_workflow(wf, registry=reg)
+        dup_errors = [e for e in errors if "Duplicate extension" in e]
+        assert dup_errors == []
+
+    def test_non_variadic_block_skips_extension_check(self) -> None:
+        spec = BlockSpec(
+            name="static_block",
+            variadic_inputs=False,
+            variadic_outputs=False,
+        )
+        reg = _registry_from_specs(spec)
+
+        wf = WorkflowDefinition(
+            nodes=[
+                NodeDef(
+                    id="A",
+                    block_type="static_block",
+                    config={
+                        "output_ports": [
+                            {"name": "a", "extension": "tif"},
+                            {"name": "b", "extension": "tif"},
+                        ]
+                    },
+                )
+            ],
+        )
+        errors = validate_workflow(wf, registry=reg)
+        dup_errors = [e for e in errors if "Duplicate extension" in e]
+        assert dup_errors == []

--- a/tests/workflow/test_validator.py
+++ b/tests/workflow/test_validator.py
@@ -612,6 +612,44 @@ class TestValidatorAppBlockDuplicateExtensions:
         dup_errors = [e for e in errors if "Duplicate extension" in e]
         assert dup_errors == []
 
+    def test_duplicate_extension_under_params_envelope(self) -> None:
+        """#690 audit fix: the frontend writes ``output_ports`` under
+        ``config.params.output_ports`` (the :class:`BlockConfig` two-tier
+        layout). Check 8 must read from that nested path so real configs
+        produced by the port editor are validated, not silently skipped.
+        """
+        spec = BlockSpec(
+            name="app_block_params",
+            variadic_inputs=True,
+            variadic_outputs=True,
+            input_ports=[],
+            output_ports=[],
+        )
+        reg = _registry_from_specs(spec)
+
+        wf = WorkflowDefinition(
+            nodes=[
+                NodeDef(
+                    id="A",
+                    block_type="app_block_params",
+                    config={
+                        "params": {
+                            "output_ports": [
+                                {"name": "images", "types": ["DataObject"], "extension": "tif"},
+                                {"name": "masks", "types": ["DataObject"], "extension": "tif"},
+                            ]
+                        }
+                    },
+                )
+            ],
+        )
+        errors = validate_workflow(wf, registry=reg)
+        dup_errors = [e for e in errors if "Duplicate extension" in e]
+        assert len(dup_errors) == 1
+        assert "'tif'" in dup_errors[0]
+        assert "images" in dup_errors[0]
+        assert "masks" in dup_errors[0]
+
     def test_non_variadic_block_skips_extension_check(self) -> None:
         spec = BlockSpec(
             name="static_block",


### PR DESCRIPTION
## Summary

- Mark `AppBlock` `variadic_inputs/outputs = True` so all subclasses (Fiji, Napari, ElMAVEN, ...) inherit user-configurable port lists from the ADR-029 port editor.
- Add a required `extension` field to every output-port entry. The runtime uses this string (no leading dot, case-insensitive) to bin saved files into ports.
- Implement `AppBlock._bin_outputs_by_extension(output_files, config)`:
  - Files matching a port's extension are wrapped as `Artifact(file_path=...)` instances in a `Collection(item_type=port.accepted_types[0])`.
  - Required port with 0 matching files → `ValueError("Port 'X' required, no '.ext' files in output dir")`.
  - Files matching no port → `WARNING — Unmatched output file 'name.ext'` and continue.
- Workflow validator **Check 8**: reject configurations where two output ports on the same variadic-output block declare the same extension at config save time.
- `PortEditorTable.tsx`: render an `extension` column for output ports only; normalise input (lowercase, strip leading dots).
- Replace plugin-private heuristics:
  - imaging plugin: delete `_collect_outputs` / `_guess_output_port` / image-loaders; FijiBlock and NapariBlock defer to the binner when `output_ports` is configured.
  - lcms plugin: ElMAVENBlock defers to the binner; legacy `_classify_export` / `_collect_elmaven_outputs` kept as deprecated shims.

## Tests

- `tests/blocks/test_app_block.py`: variadic ports + binner unit tests (case-insensitive routing, missing-required error, unmatched warn, run() integration).
- `tests/workflow/test_validator.py`: duplicate-extension Check 8 (incl. case-insensitive, distinct extensions pass, non-variadic skipped).
- `frontend/src/components/PortEditorTable.test.tsx`: extension column rendering, input-port suppression, normalisation, default-row seeding.
- `packages/scieasy-blocks-imaging/tests/test_interactive_blocks.py`: end-to-end FijiBlock test with user-defined `output_ports` (2 distinct extensions).

## Documentation

- `docs/block-development/block-contract.md` — new "AppBlock: variadic ports + extension-based output binning" section.
- `docs/specs/appblock-variadic-ports.md` — short spec covering editor + binner contract, validator placement, subclass migration notes.

## Out of Scope

- #679 (per-app `output_dir` injection / launch path) — separate PR.
- File content type inference, multi-extension ports, per-port glob fields — explicit non-goals per the issue.

## Related Issues

Closes #680