### PR TITLE
fix(#693): skip mypy follow_imports for zarr (PEP 695 syntax)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- [#693] Skip mypy follow_imports for zarr to avoid PEP 695 syntax error on Python 3.13 CI runner (@claude, 2026-05-12, branch: fix/issue-693/mypy-zarr-override, session: 20260512-170159-fix-silence-zarr-py3-12-syntax-error-in)
 - [#678] Remove 120s timeout from native file dialog; status-aware frontend fallback (only fall back to in-app picker on HTTP 500, not 504) (@claude, 2026-04-24, branch: fix/issue-678/native-dialog-no-timeout, session: 20260424-130419-fix-678-remove-native-dialog-timeout)
 - [#677] macOS AppBlock: launch .app bundles via `open -W -n -a` so Popen tracks the .app's lifetime instead of the short-lived `open` launcher, preventing PAUSED -> DONE skip on macOS (@claude, 2026-04-24, branch: fix/issue-677/macos-appblock-open-w, session: 20260424-130347-fix-677-macos-appblock-open-w)
 - [#665] Fix variadic port rendering: config-driven handles, dynamic layout, type dropdown (@claude, 2026-04-12, branch: fix/issue-665/variadic-port-frontend, session: 20260412-052953-fix-variadic-port-frontend-missing-handl)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,6 +126,14 @@ ignore_missing_imports = true
 mypy_path = "src"
 packages = ["scieasy"]
 
+# zarr 3.2+ uses PEP 695 generic syntax (`class Foo[T]:`) which is only valid
+# in Python 3.12+. Our mypy is pinned to python_version = "3.11", so it cannot
+# parse zarr's source. Skip following imports into zarr to avoid syntax errors.
+# See issue #693.
+[[tool.mypy.overrides]]
+module = ["zarr", "zarr.*"]
+follow_imports = "skip"
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 addopts = "-ra -q --cov=scieasy --cov-report=term-missing --cov-fail-under=85"


### PR DESCRIPTION
## Summary

CI Type Check job (Python 3.13 runner) currently fails on main because zarr 3.2.1's `zarr/core/array.py:304` uses PEP 695 generic syntax (`class Foo[T]:`). Our mypy is pinned to `python_version = 3.11` in `pyproject.toml`, so it cannot parse zarr's source and aborts before checking our code.

This adds a single mypy override that skips following imports into the `zarr` package, unblocking Type Check on main and on all downstream PRs that have rebased.

## Changes

- `pyproject.toml`: add `[[tool.mypy.overrides]]` entry for `zarr`/`zarr.*` with `follow_imports = skip`.
- `CHANGELOG.md`: Fixed entry under [Unreleased].

## Test plan

- Local: `mypy src/scieasy/ --ignore-missing-imports` -> clean
- CI Type Check job on this PR must pass.

## Related Issues

Closes #693

## ADR

- [x] No ADR needed (CI/mypy config only, no architectural change)

## Checklist

- [x] Gate workflow followed (task 20260512-170159-fix-silence-zarr-py3-12-syntax-error-in)
- [x] CHANGELOG updated
- [x] No runtime impact