### PR TITLE
fix(ui): variadic port name focus loss + canvas + icon alignment (#700)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- [#700] Variadic port UI: stop port-name input from dropping focus after one keystroke (row React key no longer embeds the controlled value), and align the on-canvas "+ Add port" button with the existing port-handle column via the same `translate(-50%, -50%)` convention React Flow's Handle uses (@claude, 2026-05-12, branch: fix/issue-700/variadic-port-ui-focus-and-alignment, session: 20260512-181447-fix-variadic-port-ui-focus-loss-icon-col)
 - [#681] Forward terminal block state (CANCELLED/ERROR) from worker subprocess to orchestrator so blocks that call ``self.transition()`` from inside ``run()`` are recorded with the correct terminal state (@claude, 2026-04-24, branch: fix/issue-681/worker-ipc-terminal-state, session: 20260424-145324-fix-681-worker-ipc-terminal-state-propag)
 - [#682] Align variadic-port + button with port-handle column (@claude, 2026-04-24, branch: fix/issue-682/variadic-add-port-alignment, session: 20260424-145113-fix-682-button-css-alignment)
 - [#693] Skip mypy follow_imports for zarr to avoid PEP 695 syntax error on Python 3.13 CI runner (@claude, 2026-05-12, branch: fix/issue-693/mypy-zarr-override, session: 20260512-170159-fix-silence-zarr-py3-12-syntax-error-in)

--- a/frontend/src/components/PortEditorTable.test.tsx
+++ b/frontend/src/components/PortEditorTable.test.tsx
@@ -1,4 +1,5 @@
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { useState } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { type PortRow, PortEditorTable } from "./PortEditorTable";
@@ -67,6 +68,42 @@ describe("PortEditorTable", () => {
     expect(onChange.mock.calls[0][0]).toEqual([
       { name: "tables", types: ["DataObject"], extension: "csv" },
     ]);
+  });
+
+  it("keeps the port-name input focused across rapid edits (issue #700)", () => {
+    // Regression: the row was keyed by `port.name + index`, so each keystroke
+    // changed the React key, remounted the <input>, and dropped focus after
+    // a single character. The fix uses a stable index-based key.
+    function Harness() {
+      const [ports, setPorts] = useState<PortRow[]>([
+        { name: "a", types: ["DataObject"] },
+      ]);
+      return (
+        <PortEditorTable
+          allowedTypes={[]}
+          direction="input"
+          onChange={setPorts}
+          ports={ports}
+          typeHierarchy={TYPE_HIERARCHY}
+        />
+      );
+    }
+    render(<Harness />);
+
+    const nameInput = screen.getByPlaceholderText("port name") as HTMLInputElement;
+    nameInput.focus();
+    expect(document.activeElement).toBe(nameInput);
+
+    // Three rapid edits — focus must survive every one of them.
+    fireEvent.change(nameInput, { target: { value: "ab" } });
+    expect(document.activeElement).toBe(screen.getByPlaceholderText("port name"));
+    fireEvent.change(nameInput, { target: { value: "abc" } });
+    expect(document.activeElement).toBe(screen.getByPlaceholderText("port name"));
+    fireEvent.change(nameInput, { target: { value: "abcd" } });
+
+    const finalInput = screen.getByPlaceholderText("port name") as HTMLInputElement;
+    expect(document.activeElement).toBe(finalInput);
+    expect(finalInput.value).toBe("abcd");
   });
 
   it("seeds new output rows with an empty extension field", () => {

--- a/frontend/src/components/PortEditorTable.tsx
+++ b/frontend/src/components/PortEditorTable.tsx
@@ -99,7 +99,11 @@ export function PortEditorTable({
       </h3>
       <div className="flex flex-col gap-1.5">
         {ports.map((port, index) => (
-          <div className="flex items-center gap-2" key={port.name + '-' + index}>
+          // Use the row index as the React key. Embedding `port.name` here
+          // would remount the row on every keystroke in the name input
+          // (since the controlled value changes), which drops focus after
+          // a single character.
+          <div className="flex items-center gap-2" key={index}>
             <input
               className="w-32 rounded-xl border border-stone-300 bg-white px-3 py-1.5 text-sm"
               onChange={(e) => handleNameChange(index, e.target.value)}

--- a/frontend/src/components/nodes/BlockNode.tsx
+++ b/frontend/src/components/nodes/BlockNode.tsx
@@ -860,7 +860,14 @@ export function BlockNode({ id: nodeId, data, selected }: NodeProps<Node<BlockNo
           type="button"
           className="nodrag absolute flex h-3.5 w-3.5 items-center justify-center rounded-full bg-stone-100 text-[9px] text-stone-500 transition-colors hover:bg-ember hover:text-white"
           title="Add input port"
-          style={{ left: -7, top: portStartY + effectiveInputPorts.length * 20 - 1 }}
+          // translate(-50%, -50%) matches React Flow's <Handle> convention so
+          // the button center aligns with the port-handle column (x = block_left - 7)
+          // and sits on the next-port row (y = portStartY + N * 20).
+          style={{
+            left: -7,
+            top: portStartY + effectiveInputPorts.length * 20,
+            transform: "translate(-50%, -50%)",
+          }}
           onClick={() => handleAddPort("input")}
         >
           +
@@ -908,7 +915,13 @@ export function BlockNode({ id: nodeId, data, selected }: NodeProps<Node<BlockNo
           type="button"
           className="nodrag absolute flex h-3.5 w-3.5 items-center justify-center rounded-full bg-stone-100 text-[9px] text-stone-500 transition-colors hover:bg-ember hover:text-white"
           title="Add output port"
-          style={{ right: -7, top: portStartY + effectiveOutputPorts.length * 20 - 1 }}
+          // See input button above: translate(-50%, -50%) keeps this aligned with
+          // the output port-handle column on the right edge.
+          style={{
+            right: -7,
+            top: portStartY + effectiveOutputPorts.length * 20,
+            transform: "translate(50%, -50%)",
+          }}
           onClick={() => handleAddPort("output")}
         >
           +


### PR DESCRIPTION
Closes #700

## Summary

Two narrow frontend bug fixes on the variadic-port surface:

1. **Port-name input loses focus after every keystroke** — caused by `key={port.name + '-' + index}` on each row in `PortEditorTable`. Typing changed the controlled value, changed the React key, remounted the row, dropped focus. Fixed by using a stable index-based key.
2. **`+ Add port` button on the canvas BlockNode sits in a different column than the port handles** — React Flow's `<Handle>` uses `transform: translate(-50%, -50%)` so `left:-7` centers the handle at x=-7; the `+` button used the same `left:-7` without translate, so its top-left was at -7 and its center at x=0 (block edge), ~7px to the right of the handle column. Fixed by applying the same `translate(-50%, -50%)` (mirrored as `translate(50%, -50%)` on the output side) and dropping the now-stale `-1` top fudge.

DOM measurement after fix confirms: input handle center x = `+` button center x (1849.77 in the test session); + button sits exactly one row below the last port handle.

## Verified

- `vitest run` — 5/5 pass in `PortEditorTable.test.tsx`, including a new regression test that types `abcd` into a focused name input and asserts both `document.activeElement` and the input value.
- `tsc -b` — clean.
- Manually reproduced and re-verified both bugs in Chrome against `localhost:5173` (Data Router on the SRS Calibration project).

## ADR / spec

None — simple UI bugs per CLAUDE.md Appendix C Step 0. No public API, schema, contract, or architectural impact.

## Risk

Low. `key={index}` is the standard React pattern for editable form rows that don't reorder. The CSS shift is two style objects on two buttons; no state, no behavior, no layout change to existing port handles.

## Files

- `frontend/src/components/PortEditorTable.tsx` — row key change + comment.
- `frontend/src/components/nodes/BlockNode.tsx` — `transform` on the two `+` buttons + comment.
- `frontend/src/components/PortEditorTable.test.tsx` — focus regression test.
- `CHANGELOG.md` — Unreleased / Fixed entry per gate protocol.