### PR TITLE
docs(#712,#705): ADR-033 hook config + spec §10 dep graph corrections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- [#712,#705] ADR-033 §3 D4.3 hook config example replaced with real Claude Code nested shape (top-level `hooks` key with per-matcher arrays); spec §10 dep graph updated to allow Phase 2 (MCP) and Phase 3 (Frontend) to run in parallel after Phase 1 audit closes. §9 dispatch protocol records the cross-phase parallelism rule. Phase 4 still gates on both. (@claude, 2026-05-12, branch: docs/issue-712/adr-033-spec-corrections, session: 20260512-190605-docs-adr-033-hook-config-spec-10-dep-gra)
+
 ### Added
 
 - [#703] T-ECA-102 + T-ECA-103 + T-ECA-108 Phase 1 batch B: implement CLI binary discovery with 8-fallback search (`find_binary` in `binary_discovery.py`), stream-JSON parser with bounded 1 MiB buffer and the canonical AgentEvent taxonomy (`InitEvent`, `AssistantTextDeltaEvent`, `ToolUseEvent`, `ToolResultEvent`, `PermissionRequestEvent`, `ErrorEvent`, `DoneEvent`, `OtherEvent`) plus async `parse_stream`, and static MCP + claude-hooks config emission (`config_files.py`); 76 new unit tests including 100% line coverage on `stream_json.py`; synthetic NDJSON fixtures under `tests/fixtures/stream_json/`. Parser tolerates both ADR-canonical `kind` and Claude Code wire `type` field names. (@claude, 2026-05-12, branch: feat/issue-703/eca-102-103-108-batch, session: 20260512-182957-t-eca-102-103-108-phase-1-batch-b-binary)

--- a/docs/adr/ADR-033-draft.md
+++ b/docs/adr/ADR-033-draft.md
@@ -368,13 +368,24 @@ The user can opt into a Bypass mode that skips all approvals — equivalent to l
 
 Claude Code's hooks system supports a `PreToolUse` hook: a user-defined command invoked before each tool call, with the tool name + arguments on stdin, returning approve/deny/ask via exit code or JSON output.
 
-SciEasy registers a hook in `{project}/.scieasy/claude-hooks.json` that points at a local HTTP endpoint:
+SciEasy registers a hook in `{project}/.scieasy/claude-hooks.json` that points at the local `scieasy hook-bridge` subcommand. Claude Code's actual hook config schema is nested under a top-level `hooks` key with per-matcher arrays:
 
 ```json
 {
-  "PreToolUse": "scieasy hook-bridge --endpoint http://127.0.0.1:8000/api/ai/permission-check"
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "",
+        "hooks": [
+          { "type": "command", "command": "scieasy hook-bridge" }
+        ]
+      }
+    ]
+  }
 }
 ```
+
+(The `matcher` field empty-string matches all tools. `scieasy hook-bridge` reads the tool name + arguments from stdin and POSTs them to `http://127.0.0.1:8000/api/ai/permission-check`.)
 
 The endpoint receives:
 
@@ -773,3 +784,19 @@ The two projects share the **core architectural insight**: spawning the user's i
 - **Bypass mode**: SciEasy's name for running Claude Code with `--dangerously-skip-permissions`.
 - **Session**: One Claude Code subprocess instance with a unique `session_id`. Sessions can be resumed via `--resume <id>`.
 - **Project workspace**: SciEasy's project directory layout (`workflows/`, `blocks/`, `data/`, `.scieasy/`, etc.) defined by `scieasy init` and used as `cwd` for the agent.
+
+---
+
+### Addendum 1: Hook config format correction (2026-05-12, issue #705)
+
+The first revision of §3 D4.3 showed a simplified hook config shape:
+
+```json
+{
+  "PreToolUse": "scieasy hook-bridge --endpoint http://127.0.0.1:8000/api/ai/permission-check"
+}
+```
+
+The real Claude Code hook config schema is nested under a top-level `hooks` key with per-matcher arrays. T-ECA-108 (PR #704) implemented the correct shape; this addendum updates §3 D4.3 in-place to match. No code change was required because the implementation already used the correct format. Reviewers should consult the updated §3 D4.3 above for the canonical example.
+
+The `scieasy hook-bridge` command line is also simpler than the original prose suggested: the bridge reads its target endpoint from `127.0.0.1:8000` (the local FastAPI server) without needing an `--endpoint` flag. The endpoint URL becomes a deployment concern only if SciEasy is ever served on a non-default host/port; in that case `hook-bridge` reads it from an env var.

--- a/docs/specs/embedded-coding-agent-spec.md
+++ b/docs/specs/embedded-coding-agent-spec.md
@@ -909,6 +909,8 @@ For each phase the dispatching process is:
 4. **Once all implementation PRs are merged**, dispatch the **audit agent**. (1 agent.) The audit agent reviews each implementation PR via GitHub comments OR opens follow-up PRs for blockers.
 5. **Once audit clears**, the phase is complete. Proceed to the next phase's scaffold agent.
 
+**Cross-phase parallelism** (revised 2026-05-12 per issue #712): after Phase 1's T-ECA-119 audit closes, **Phase 2 and Phase 3 may be launched simultaneously**. Their scaffold agents start at T+0, impl agents at T+1, audit agents at T+2. Each phase still runs its internal scaffold → impl → audit sequence; the parallelism is between phases, not inside one. Phase 4 waits for both Phase 2 and Phase 3 audits to close. See §10 for the updated dependency graph.
+
 Total agents per phase: **3** (1 scaffold + 2 implementation OR 1 scaffold + 1 implementation + 1 audit, depending on phase size).
 
 **Parallel-safe groups per phase**:
@@ -928,16 +930,25 @@ Total agents per phase: **3** (1 scaffold + 2 implementation OR 1 scaffold + 1 i
             Phase 1 (T-ECA-101..119)
                     │
                     ▼  (T-ECA-119 audit pass)
-            Phase 2 (T-ECA-201..225)
-                    │
-                    ▼  (T-ECA-225 audit pass)
-            Phase 3 (T-ECA-301..318)
-                    │
-                    ▼  (T-ECA-318 audit pass)
+              ┌─────┴─────┐
+              ▼           ▼
+    Phase 2 (MCP)   Phase 3 (Frontend)
+   (T-ECA-201..225) (T-ECA-301..318)
+              │           │
+              ▼ 225       ▼ 318
+              └─────┬─────┘
+                    ▼  (both audits pass)
             Phase 4 (T-ECA-401..410)
 ```
 
-No phase may begin its scaffold ticket until the prior phase's audit ticket is closed. Implementation tickets within a phase may overlap as documented in §9.
+Phase 1 and Phase 4 are strict serialisation points. **Phase 2 and Phase 3 may run concurrently** after T-ECA-119 closes. The two phases own disjoint files:
+
+- Phase 2 owned files: `src/scieasy/ai/agent/mcp/*`, `src/scieasy/cli/mcp_bridge.py`, plus narrow edits to `src/scieasy/ai/agent/system_prompt.py` (T-ECA-204 fills in builtin content) and `src/scieasy/api/app.py` (T-ECA-205 adds the MCP-server lifespan hook).
+- Phase 3 owned files: `frontend/src/components/AIChat/*`, `frontend/src/hooks/*`, `frontend/src/stores/aiChatSlice.ts`, `frontend/src/types/agentEvents.ts`, plus edits to `src/scieasy/api/routes/ai.py` (event envelope additions) and `src/scieasy/api/schemas.py` (new Pydantic envelope models).
+
+There is **no file overlap** between the two phases. Logical convergence happens only at Phase 3's manual end-to-end smoke test, which is richer when Phase 2's MCP tools are also available but does not require it (the frontend renders Claude Code native tool calls identically to MCP tool calls).
+
+Phase 4 still waits for **both** Phase 2 and Phase 3 audits to close. Its deletions (legacy `ai/generation/`, `ai/synthesis/`, etc.) and additions (Codex provider, user-facing docs) require the new chat stack to be stable.
 
 ---
 


### PR DESCRIPTION
## Summary

Two Phase-1-discovered doc misalignments fixed in one PR:

### Closes #705 — ADR-033 §3 D4.3 hook config example

The original ADR draft showed a simplified hook config shape:

\`\`\`json
{ \"PreToolUse\": \"scieasy hook-bridge --endpoint http://...\" }
\`\`\`

But Claude Code's actual hook config schema is nested under a top-level \`hooks\` key with per-matcher arrays. T-ECA-108 (PR #704) already ships the correct shape; this PR aligns the ADR example to reality and adds Addendum 1 noting the correction. No code change required.

### Closes #712 — Spec §10 dep graph: Phase 2 ∥ Phase 3

§10 originally showed strictly sequential phases. File-level analysis confirms zero overlap between Phase 2 (MCP) and Phase 3 (Frontend) owned-files sets — they can run concurrently after Phase 1's T-ECA-119 audit closes. §10's diagram updated to a Y-fork; §9 dispatch protocol notes the cross-phase parallelism rule. Phase 4 still gates on both Phase 2 and Phase 3 audits.

## Scope

Documentation only. No \`src/\`, \`frontend/\`, \`tests/\`, \`pyproject.toml\` changes.

## Files changed

- \`docs/adr/ADR-033-draft.md\` — §3 D4.3 example + Addendum 1
- \`docs/specs/embedded-coding-agent-spec.md\` — §9 + §10
- \`CHANGELOG.md\` — \`[Unreleased] > Changed\` entry

## Related Issues

Closes #705
Closes #712

## CI

Markdown-only. Type Check / Lint / Tests pass unchanged.