### PR TITLE
ci(#728): exempt dependabot PRs from Verify Workflow Compliance gate

### DIFF
--- a/.github/workflows/workflow-gate.yml
+++ b/.github/workflows/workflow-gate.yml
@@ -14,7 +14,12 @@ jobs:
     # claim the ticket on); failing its PRs on this check just blocks
     # security updates that are otherwise auto-greened by Lint / Tests /
     # Type Check / CodeQL. The substance gate (CI) still applies.
-    if: github.actor != 'dependabot[bot]' && !startsWith(github.head_ref, 'dependabot/')
+    # NOTE: actor-only check — NOT branch name. Branch names are
+    # user-controlled, so a human contributor could open a branch named
+    # "dependabot/..." and bypass the gate. The actor field is set by
+    # GitHub Actions itself based on who triggered the workflow and
+    # cannot be spoofed by a contributor. Per Codex P1 review on PR #729.
+    if: github.actor != 'dependabot[bot]'
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/workflow-gate.yml
+++ b/.github/workflows/workflow-gate.yml
@@ -9,6 +9,12 @@ jobs:
   workflow-gate:
     name: Verify Workflow Compliance
     runs-on: ubuntu-latest
+    # Exempt dependabot from the gate-workflow check. Dependabot does not
+    # run .workflow/gate.py and never will (it has no human author to
+    # claim the ticket on); failing its PRs on this check just blocks
+    # security updates that are otherwise auto-greened by Lint / Tests /
+    # Type Check / CodeQL. The substance gate (CI) still applies.
+    if: github.actor != 'dependabot[bot]' && !startsWith(github.head_ref, 'dependabot/')
     steps:
       - uses: actions/checkout@v6
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- [#728] CI Verify Workflow Compliance gate now skips dependabot PRs via `if: github.actor != 'dependabot[bot]'`. Unblocks #691 (fast-uri HIGH) and #686 (postcss). Substance CI checks still apply. (@claude, 2026-05-12, branch: ci/issue-728/exempt-dependabot, session: 20260512-213652-ci-exempt-dependabot-from-workflow-compl)
+
 ### Changed
 
 - [#712,#705] ADR-033 §3 D4.3 hook config example replaced with real Claude Code nested shape (top-level `hooks` key with per-matcher arrays); spec §10 dep graph updated to allow Phase 2 (MCP) and Phase 3 (Frontend) to run in parallel after Phase 1 audit closes. §9 dispatch protocol records the cross-phase parallelism rule. Phase 4 still gates on both. (@claude, 2026-05-12, branch: docs/issue-712/adr-033-spec-corrections, session: 20260512-190605-docs-adr-033-hook-config-spec-10-dep-gra)


### PR DESCRIPTION
Closes #728.\n\nDependabot does not run `.workflow/gate.py` and never will, so its PRs were permanently blocked. Adds `if: github.actor != "dependabot[bot]" \&\& !startsWith(github.head_ref, "dependabot/")` at the job level in `workflow-gate.yml`. Substance CI checks (Lint / Tests / Type Check / CodeQL / Architecture / Frontend) still apply.\n\nUnblocks: #691 (fast-uri HIGH severity), #686 (postcss).