### PR TITLE
feat(#759): T-ECA-504 v0 — microplastics e2e test prompt draft

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- [#759] T-ECA-504 v0 — microplastics e2e test prompt draft at `docs/specs/eca-phase5-test-prompt-draft.md`. Dispatcher-authored per ADR-033 §8.5 (the prompt is the only mutable input to the Phase 5 e2e test). Will be migrated to `tests/e2e/microplastics/test_prompt.md` after T-ECA-501 (#749) lands. (@claude, 2026-05-12, branch: feat/issue-759/eca-504-test-prompt-draft, session: 20260512-223423-t-eca-504-draft-microplastics-e2e-test-p)
+
 ### Fixed
 
 - [#742] Dependabot Verify Workflow Compliance exemption now checks PR author (`github.event.pull_request.user.login`) not `github.actor`. Without this, running `gh pr update-branch` on a dependabot PR as a human re-fires the workflow with the human as actor and reverts the exemption. (@claude, 2026-05-13, branch: fix/issue-742/dependabot-pr-author, session: 20260512-220337-fix-728-followup-gate-exemption-uses-pr)

--- a/docs/specs/eca-phase5-test-prompt-draft.md
+++ b/docs/specs/eca-phase5-test-prompt-draft.md
@@ -1,0 +1,141 @@
+# Microplastics e2e test prompt — draft (T-ECA-504 v0)
+
+> **Status**: Draft. This file is the dispatcher-authored v0 of the e2e test
+> prompt for ADR-033 Phase 5. It currently lives under `docs/specs/`
+> because the canonical landing path `tests/e2e/microplastics/test_prompt.md`
+> belongs to T-ECA-501 (Phase 5 scaffold). When T-ECA-501 lands, this
+> file will be moved verbatim into `tests/e2e/microplastics/test_prompt.md`
+> by a T-ECA-504 migration commit.
+>
+> **Editing rules (per ADR-033 spec §8.5 T-ECA-504)**: only the dispatcher
+> author edits this file. Implementation agents must not modify it during
+> the test run. The prompt is the load-bearing test contract; iterate on
+> prompt wording rather than on workflow YAML or custom block code.
+
+---
+
+## The prompt (delivered verbatim to the agent)
+
+Below is the literal message body the e2e harness will paste into the
+agent's chat input. Everything between the BEGIN and END markers is the
+prompt; nothing else.
+
+```text
+BEGIN PROMPT --------------------------------------------------------------
+
+You are a scientific workflow agent operating inside the SciEasy GUI. Your
+goal is to reproduce the analysis in the microplastics SRS notebook by
+building and running a SciEasy workflow.
+
+# Inputs
+
+- Source notebook (read-only reference for the analysis logic and expected
+  outputs): `{microplastics_ipynb_path}`.
+- Raw data directory: `{microplastics_raw_data_dir}`.
+- Project workspace (your scratch space — workflow YAML, custom blocks,
+  intermediate outputs all live here): `{project_dir}`.
+- Reference outputs directory (DO NOT read until you are ready to compare):
+  `{golden_dir}`.
+
+The harness has already created the workspace at `{project_dir}` and
+launched the SciEasy backend. You have full read/write access to the
+workspace via your MCP tools.
+
+# Goal
+
+Produce a workflow that, when run, generates the same per-sample numerical
+outputs as the source notebook (peak tables, classification labels, summary
+statistics, plot data — whatever the notebook produces). "Same" means the
+numerical comparator at `tests/e2e/microplastics/_compare.py` accepts the
+comparison (rtol=1e-3, atol=1e-6 for floats; exact equality for labels).
+
+# Method (you decide the details)
+
+- Read the notebook with `get_doc` or `read_block_source` (it's just text).
+- Inspect the raw data with `inspect_data` and `preview_data` BEFORE
+  designing any block. Confirm shapes, dtypes, axis conventions, and units
+  match what the notebook assumes.
+- Build the workflow using `list_blocks`, `get_block_schema`, and
+  `write_workflow`. Prefer built-in blocks whenever they cover the step.
+- If a step in the notebook has no clean built-in equivalent (custom peak
+  picker, custom classifier, custom preprocessing), write a Tier-1 custom
+  block under `{project_dir}/blocks/`, then call `reload_blocks` to make
+  it available in the registry. Document each custom block's purpose in
+  its docstring; the audit will read these.
+- Run the workflow with `run_workflow`. Poll `get_run_status` until
+  completion (success or terminal error). Do not assume success — read the
+  status.
+- For each output the notebook produces, read your run's equivalent with
+  `inspect_data` + `preview_data` (or `get_block_output`) and verify
+  shape/dtype/range look right BEFORE concluding the task is done.
+
+# Discipline reminders
+
+- Self-verify each step. After every `write_workflow` call, run
+  `validate_workflow` and read the result. After every `run_workflow`
+  invocation, wait for `get_run_status` to report a terminal state.
+- If a block errors, read `get_block_logs` for that block before patching.
+  Most failures are config drift (wrong column name, wrong axis order),
+  not block bugs.
+- Do not ask the user to intervene. If a block is missing, write one.
+  If a config is wrong, fix it. If the data shape doesn't match what the
+  notebook assumes, slice/transpose in a preprocessing block — do not
+  silently change tolerances.
+- Do not edit the source notebook. Treat it as a read-only spec.
+- Do not read files under `{golden_dir}` until the workflow run finished
+  and you are ready to compare. The harness uses the same comparator the
+  test will use; do not optimise your blocks against the golden directly.
+
+# Completion criterion
+
+You are done when:
+
+1. `run_workflow` returned a successful terminal status,
+2. you have explicitly inspected (via `inspect_data` / `preview_data`)
+   each output the notebook produces and confirmed it has the right
+   shape, dtype, and order-of-magnitude,
+3. you have written a short summary in the chat naming each output and
+   where it lives in the workspace.
+
+The harness will then run the numerical comparison against
+`{golden_dir}`. If the comparison fails, the harness will append a diff
+report to this conversation and you will get one more iteration to
+adjust. If the comparison passes, the test passes.
+
+END PROMPT ----------------------------------------------------------------
+```
+
+## Placeholder bindings (filled by the harness)
+
+The braces in the prompt are runtime-bound by `tests/e2e/harness.py`:
+
+| Placeholder | Source |
+|-------------|--------|
+| `{microplastics_ipynb_path}` | constant in the test, points at the user's Box ipynb location |
+| `{microplastics_raw_data_dir}` | constant — the ipynb's input directory |
+| `{project_dir}` | tmp directory created per test run |
+| `{golden_dir}` | `tests/e2e/microplastics/golden/` |
+
+## Versioning
+
+- **v0** (this file): initial draft, written before any e2e run has been
+  attempted. Wording is principled but unverified.
+- **v1+**: tuned based on diff reports from T-ECA-505 runs. Each version
+  bump must record: which run revealed the gap, what prompt change
+  addressed it, and whether the next run passed.
+
+Version history (append-only):
+
+| Version | Date | Trigger | Change |
+|---------|------|---------|--------|
+| v0 | 2026-05-12 | initial draft | n/a |
+
+## Why this prompt is the *only* mutable input
+
+Per ADR-033 §8.5 the hard operating constraint is: the dispatcher author
+is FORBIDDEN from touching the workflow canvas, editing the workflow
+YAML, writing or repairing custom blocks, or otherwise intervening in the
+agent's work product during the test. If the agent fails despite prompt
+iteration, that is the test's signal that ADR-033's agent design has gaps
+— record them in the T-ECA-510 audit report rather than fixing them by
+hand.


### PR DESCRIPTION
## Summary

Dispatcher-authored v0 of the Phase 5 e2e test prompt per `docs/specs/embedded-coding-agent-spec.md` §8.5 T-ECA-504. The prompt is the only mutable input to the e2e acceptance test (ADR-033 hard operating constraint).

## What this lands

- `docs/specs/eca-phase5-test-prompt-draft.md`: the verbatim prompt the harness will paste into the agent's chat input, plus placeholder bindings, versioning policy, and the rationale for the no-intervention rule.

## Why a draft path

The canonical landing path is `tests/e2e/microplastics/test_prompt.md`, but that directory belongs to T-ECA-501 (Phase 5 scaffold, #749) which has not yet dispatched. Drafting to `docs/specs/` lets the wording be reviewed and iterated while T-ECA-501..503 work proceeds. A follow-up commit (under #759 once #749 merges) will move the file into place verbatim.

## Why this PR is decoupled from Phase 4 / Phase 5

T-ECA-504 is explicitly dispatcher-owned and has no code dependencies on Phase 4 or earlier Phase 5 tickets. It only needs the spec (already merged in #735). Drafting now reduces overnight idle time without violating spec §9's dispatch order — no implementation-agent territory is touched.

## Out of scope

- No test code, no harness, no fixtures — those are T-ECA-501/502/503/505.
- No edit to the workflow runtime, blocks, or canvas. The hard constraint in spec §8.5 also binds this PR.

## Test plan

- [x] `git diff` review: only `docs/specs/eca-phase5-test-prompt-draft.md` + `CHANGELOG.md`.
- [x] Prompt content reviewed against spec §8.5 T-ECA-504 content principles (goal-specific, method-general, workspace-concrete, discipline reminders, conflict-resolution rule).
- [ ] CI green.

Closes #759