### PR TITLE
fix(#759): T-ECA-504 v1 — Codex P1+P2 corrections to e2e prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 
 - [#759] T-ECA-504 v0 — microplastics e2e test prompt draft at `docs/specs/eca-phase5-test-prompt-draft.md`. Dispatcher-authored per ADR-033 §8.5 (the prompt is the only mutable input to the Phase 5 e2e test). Will be migrated to `tests/e2e/microplastics/test_prompt.md` after T-ECA-501 (#749) lands. (@claude, 2026-05-12, branch: feat/issue-759/eca-504-test-prompt-draft, session: 20260512-223423-t-eca-504-draft-microplastics-e2e-test-p)
+- [#759] T-ECA-504 v1 — Codex P1+P2 fixes on the prompt draft: notebook-read instruction switched from `get_doc`/`read_block_source` (out of scope for ipynb path) to Claude Code's built-in `NotebookRead`; `run_workflow` completion criterion clarified to require explicit `get_run_status(run_id)` polling until terminal status, not submit-return. (@claude, 2026-05-12, branch: fix/issue-759/eca-504-prompt-v1, session: N/A — single-commit follow-up to merged PR #760)
 
 ### Fixed
 

--- a/docs/specs/eca-phase5-test-prompt-draft.md
+++ b/docs/specs/eca-phase5-test-prompt-draft.md
@@ -51,7 +51,10 @@ comparison (rtol=1e-3, atol=1e-6 for floats; exact equality for labels).
 
 # Method (you decide the details)
 
-- Read the notebook with `get_doc` or `read_block_source` (it's just text).
+- Read the source notebook using Claude Code's built-in `NotebookRead`
+  tool (the canonical reader for `.ipynb` files; lives outside the docs/
+  scope that the MCP `get_doc` tool covers). The notebook is the
+  reference for the analysis logic — read every cell.
 - Inspect the raw data with `inspect_data` and `preview_data` BEFORE
   designing any block. Confirm shapes, dtypes, axis conventions, and units
   match what the notebook assumes.
@@ -62,9 +65,12 @@ comparison (rtol=1e-3, atol=1e-6 for floats; exact equality for labels).
   block under `{project_dir}/blocks/`, then call `reload_blocks` to make
   it available in the registry. Document each custom block's purpose in
   its docstring; the audit will read these.
-- Run the workflow with `run_workflow`. Poll `get_run_status` until
-  completion (success or terminal error). Do not assume success — read the
-  status.
+- Submit the workflow with `run_workflow` — this returns a run id
+  *immediately*; it does NOT block until completion. Then poll
+  `get_run_status(run_id)` on a backoff (e.g. 2s → 8s → 30s) until the
+  status is a terminal value (`completed`, `failed`, or `cancelled`).
+  Treat any non-terminal status as "not done yet". Do not assume the
+  initial `run_workflow` response means the run is over.
 - For each output the notebook produces, read your run's equivalent with
   `inspect_data` + `preview_data` (or `get_block_output`) and verify
   shape/dtype/range look right BEFORE concluding the task is done.
@@ -90,7 +96,9 @@ comparison (rtol=1e-3, atol=1e-6 for floats; exact equality for labels).
 
 You are done when:
 
-1. `run_workflow` returned a successful terminal status,
+1. `get_run_status(run_id)` reports a terminal `completed` status (NOT
+   merely that `run_workflow` returned without error — the submit call
+   returns immediately with a run id),
 2. you have explicitly inspected (via `inspect_data` / `preview_data`)
    each output the notebook produces and confirmed it has the right
    shape, dtype, and order-of-magnitude,
@@ -129,6 +137,7 @@ Version history (append-only):
 | Version | Date | Trigger | Change |
 |---------|------|---------|--------|
 | v0 | 2026-05-12 | initial draft | n/a |
+| v1 | 2026-05-12 | Codex P1+P2 review on PR #760 (issue #759) | (P1) Replaced `get_doc`/`read_block_source` notebook-read instruction with Claude Code's built-in `NotebookRead` tool — `get_doc` is scoped to `docs/` and `read_block_source` reads block class source by name, neither can reach the microplastics ipynb. (P2) Tightened `run_workflow` completion criterion: explicit polling on `get_run_status(run_id)` until terminal `completed`, not initial submit return. |
 
 ## Why this prompt is the *only* mutable input
 


### PR DESCRIPTION
Closes #759 (continuation of merged PR #760).

## Summary

PR #760 (T-ECA-504 v0) was merged before its Codex auto-review landed. Two findings apply directly to the prompt; addressed here as v1 per the prompt's own iteration policy.

## Codex findings addressed

| Severity | Comment | Fix |
|----------|---------|-----|
| P1 | [#760 line 54](https://github.com/zjzcpj/SciEasy/pull/760#discussion_r... "notebook-read tools unreachable") | Notebook-read switched from MCP `get_doc`/`read_block_source` (cannot reach ipynb path) to Claude Code's built-in `NotebookRead` tool. |
| P2 | [#760 line 93](https://github.com/zjzcpj/SciEasy/pull/760#discussion_r... "run_workflow completion semantics") | Completion criterion now requires explicit `get_run_status(run_id)` polling until terminal; submit-return is no longer treated as done. |

## Why this is a follow-up, not a v0 revert

The prompt file already documented v1+ iteration as expected behaviour (see the version-history table); these findings exactly match the spec §8.5 expectation that the prompt be tuned across runs.

## Out of scope

- No code or test changes.
- Migration of `docs/specs/eca-phase5-test-prompt-draft.md` → `tests/e2e/microplastics/test_prompt.md` still owned by a future T-ECA-504 commit gated on T-ECA-501 (#749).

## Test plan

- [x] `git diff` review: only the prompt draft + CHANGELOG.
- [x] Verbiage cross-checked against ADR-033 §3 D4 (NotebookRead is in the auto-approved native-tool set) and MCP tool registry in `src/scieasy/ai/agent/mcp/_registry.py` (no `read_file`-like tool exists; `NotebookRead` is the right answer).
- [ ] CI green.