### PR TITLE
fix(#765): wire CodexProvider into /api/ai/status discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- [#765] Wire `CodexProvider` into `_discover_providers()` in `src/scieasy/api/routes/ai.py`. T-ECA-410 audit found that `GET /api/ai/status` only reported Claude Code, violating spec §8 T-ECA-402's acceptance criterion ("returns both providers when both binaries are installed"). Regression test pins both names in the response. (@claude, 2026-05-12, branch: fix/issue-748/codex-provider-discovery, session: 20260512-231752-fix-765-t-eca-410-follow-up-wire-codexpr)
+
 ### Removed
 
 - [#746] T-ECA-401 — Phase 4 scaffold: deleted legacy AI surfaces in line with ADR-033 §3 D9. Removed: `src/scieasy/ai/{generation,synthesis,optimization}/` (entire directories), `src/scieasy/ai/config.py`, the three legacy REST endpoints (`POST /api/ai/generate-block`, `POST /api/ai/suggest-workflow`, `POST /api/ai/optimize-params`) and their Pydantic schemas (`AIGenerateBlock*`, `AISuggestWorkflow*`, `AIOptimizeParams*`), plus all backing tests. AIBlock at `src/scieasy/blocks/ai/**` deliberately retained per ADR-033 §3 D9 narrow exception. (@claude, 2026-05-12, branch: feat/issue-746/eca-401-scaffold, session: dispatcher-takeover-from-agent-a1f17b717f01ee582)

--- a/src/scieasy/api/routes/ai.py
+++ b/src/scieasy/api/routes/ai.py
@@ -125,15 +125,16 @@ def _resolve_project_key(project_dir: str | Path) -> Path:
 def _discover_providers() -> list[ProviderStatusItem]:
     """Return ``ProviderStatusItem`` records for every registered agent provider.
 
-    Phase 1 ships only the Claude Code provider; the Codex provider lands
-    in Phase 4 (T-ECA-410). This helper is invoked by the
-    ``GET /api/ai/status`` route and is also reused by tests via DI
-    override.
+    Phase 1 shipped only Claude Code; Phase 4 (T-ECA-402) adds Codex.
+    Both providers are reported by ``GET /api/ai/status`` so the
+    frontend's Provider selector knows which CLIs are installed. This
+    helper is also reused by tests via DI override.
     """
     from scieasy.ai.agent.claude_code import ClaudeCodeProvider
+    from scieasy.ai.agent.codex import CodexProvider
 
     providers: list[ProviderStatusItem] = []
-    for provider_cls in (ClaudeCodeProvider,):
+    for provider_cls in (ClaudeCodeProvider, CodexProvider):
         status = provider_cls.discover()
         providers.append(
             ProviderStatusItem(

--- a/tests/api/test_ai_chat_route.py
+++ b/tests/api/test_ai_chat_route.py
@@ -67,6 +67,22 @@ def test_status_endpoint_returns_provider_list(app: Any, monkeypatch: pytest.Mon
         assert item["logged_in"] is True
 
 
+def test_status_endpoint_reports_both_providers(app: Any) -> None:
+    """T-ECA-410 follow-up: both Claude Code and Codex must appear in /api/ai/status.
+
+    The spec §8 T-ECA-402 acceptance criterion requires that
+    ``GET /api/ai/status`` returns both providers when both binaries are
+    installed. Prior to issue #765, only Claude Code was wired into
+    ``_discover_providers()``.
+    """
+    with TestClient(app) as client:
+        response = client.get("/api/ai/status")
+        body = response.json()
+        names = {p["name"] for p in body["providers"]}
+        assert "claude-code" in names
+        assert "codex" in names
+
+
 def test_status_endpoint_reports_missing_binary(app: Any, monkeypatch: pytest.MonkeyPatch) -> None:
     fake = ProviderStatus(
         name="claude-code",


### PR DESCRIPTION
Closes #765

## Summary
T-ECA-410 audit found that `GET /api/ai/status` only reported Claude Code, violating spec §8 T-ECA-402's acceptance criterion. `_discover_providers()` iterated `(ClaudeCodeProvider,)`; now also includes `CodexProvider`.

## Changes
- src/scieasy/api/routes/ai.py: add CodexProvider import + include in iteration tuple
- tests/api/test_ai_chat_route.py: new test pinning that both providers appear in /api/ai/status
- CHANGELOG.md: Fixed entry

## Test plan
- [x] test_status_endpoint_reports_both_providers passes
- [x] existing test_status_endpoint_reports_missing_binary still passes
- [x] ruff clean

## Spec compliance
ADR-033 §8 T-ECA-402 acceptance: '`GET /api/ai/status` returns both providers when both binaries are installed.'