### PR TITLE
fix(#759): T-ECA-504 v2 — blank-workspace clarification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- [#759] T-ECA-504 v2 — explicit blank-workspace clarification in the microplastics e2e test prompt draft. Per user instruction, the agent starts from a completely blank workspace (no pre-existing workflow, no custom blocks, no intermediate outputs) and must build everything itself using `list_blocks` + custom Tier-1 blocks. (@claude, 2026-05-12, branch: fix/issue-759/eca-504-prompt-v2, session: dispatcher-followup)
 - [#750] T-ECA-502+503 Phase 5 impl — e2e test harness (`tests/e2e/harness.py`), golden reference capture from the microplastics SRS notebook (`tests/e2e/microplastics/golden/*.csv`), and numerical comparator (`tests/e2e/microplastics/_compare.py`) with self-tests. The harness creates a fresh empty project workspace each run so the agent starts from a blank state per ADR-033 §8.5. (@claude, 2026-05-12, branch: feat/issue-750/eca-502-503-batch, session: dispatcher-takeover-from-agent-a91cbd6aa396e168b)
 
 ### Fixed

--- a/docs/specs/eca-phase5-test-prompt-draft.md
+++ b/docs/specs/eca-phase5-test-prompt-draft.md
@@ -38,8 +38,13 @@ building and running a SciEasy workflow.
   `{golden_dir}`.
 
 The harness has already created the workspace at `{project_dir}` and
-launched the SciEasy backend. You have full read/write access to the
-workspace via your MCP tools.
+launched the SciEasy backend. **The workspace is empty: no workflow,
+no custom blocks, no intermediate outputs.** You start from a blank
+canvas. Build everything you need yourself using the available
+built-in blocks (discoverable via `list_blocks`); if a step has no
+built-in equivalent, write your own Tier-1 custom block under
+`{project_dir}/blocks/` and call `reload_blocks`. You have full
+read/write access to the workspace via your MCP tools.
 
 # Goal
 
@@ -138,6 +143,7 @@ Version history (append-only):
 |---------|------|---------|--------|
 | v0 | 2026-05-12 | initial draft | n/a |
 | v1 | 2026-05-12 | Codex P1+P2 review on PR #760 (issue #759) | (P1) Replaced `get_doc`/`read_block_source` notebook-read instruction with Claude Code's built-in `NotebookRead` tool — `get_doc` is scoped to `docs/` and `read_block_source` reads block class source by name, neither can reach the microplastics ipynb. (P2) Tightened `run_workflow` completion criterion: explicit polling on `get_run_status(run_id)` until terminal `completed`, not initial submit return. |
+| v2 | 2026-05-12 | User clarification during Phase 5 cascade | Explicitly stated that the workspace is blank: no pre-existing workflow, no custom blocks, no intermediate outputs. The agent starts from scratch. This was previously implicit (the harness creates a fresh tmp project per run); making it explicit removes any risk the agent assumes a pre-built workflow exists. |
 
 ## Why this prompt is the *only* mutable input
 


### PR DESCRIPTION
Closes #759 (continuation).

Per user instruction during the Phase 5 cascade, the prompt now explicitly states the workspace is blank. This was previously implicit.