### PR TITLE
fix(#773): AIChat infinite render loop ('Maximum update depth') on '+ New chat'

### DIFF
--- a/frontend/src/components/AIChat/ChatMessageList.tsx
+++ b/frontend/src/components/AIChat/ChatMessageList.tsx
@@ -10,14 +10,21 @@
 import { useEffect, useRef } from "react";
 
 import { useAppStore } from "../../store";
+import type { AgentEvent } from "../../types/agentEvents";
 import { EventRenderer } from "./EventRenderer";
+
+// Issue #773 — module-level stable empty array. Zustand's useSyncExternalStore
+// requires getSnapshot to return a referentially stable value for unchanged
+// state; `?? []` creates a new array literal on every render and triggers
+// an infinite-render loop ("getSnapshot should be cached") in React 18.
+const EMPTY_EVENTS: ReadonlyArray<AgentEvent> = Object.freeze([]);
 
 export interface ChatMessageListProps {
   chatId: string;
 }
 
 export function ChatMessageList({ chatId }: ChatMessageListProps) {
-  const events = useAppStore((s) => s.eventsByChat[chatId] ?? []);
+  const events = useAppStore((s) => s.eventsByChat[chatId] ?? EMPTY_EVENTS);
   const scrollerRef = useRef<HTMLDivElement | null>(null);
 
   // Scroll to bottom whenever a new event arrives.


### PR DESCRIPTION
Closes #773

## Summary
`ChatMessageList`'s Zustand selector returned a new `[]` literal each call. Zustand v4's `useSyncExternalStore` requires referentially stable getSnapshot — `[] !== []` triggers React's nested-update guard (error #185) when '+ New chat' mounts ChatMessageList with no prior events.

## Fix
Hoist a module-level `const EMPTY_EVENTS: ReadonlyArray<AgentEvent> = Object.freeze([])` and return it from the selector.

## Verification cycle
1. Reproduced on production bundle — React #185 on '+ New chat' click.
2. Switched to Vite dev server → got unminified 'getSnapshot should be cached' warning pinpointing ChatMessageList.tsx.
3. Applied fix.
4. Reloaded → '+ New chat' opens cleanly, console clean.
5. 109/109 Vitest tests still pass.

## Why Phase 3 audit missed this
Static review + npm test passed. Never clicked the button in a real browser. Lesson captured in memory as `feedback_phase_audit_smoke_test`.