### PR TITLE
fix: wire Codex provider into AI chat

### DIFF
--- a/docs/guides/ai-chat.md
+++ b/docs/guides/ai-chat.md
@@ -81,6 +81,11 @@ varies by platform; the canonical instructions live at
 that SciEasy expects from Codex are documented in
 [`docs/specs/eca-spike-codex-format.md`][spike].
 
+SciEasy uses Codex through `codex exec --json` and resumes later turns
+with `codex exec --json ... resume <thread_id> -`. Unlike Claude Code,
+Codex is spawned once per user turn rather than held open as one
+long-running stdin session.
+
 [spike]: ../specs/eca-spike-codex-format.md
 
 Verify the install:

--- a/docs/planning/codex-provider-gap-plan.md
+++ b/docs/planning/codex-provider-gap-plan.md
@@ -1,0 +1,288 @@
+# Codex Provider Gap Analysis and Implementation Plan
+
+Date: 2026-05-13
+Owner context: ADR-033 embedded coding agent
+
+## Summary
+
+Claude Code is wired to SciEasy's current agent runtime and can start real chat
+sessions. Codex is not functionally integrated yet, even though the repo
+contains a `CodexProvider` scaffold and the frontend exposes a provider picker.
+
+There are two independent blockers:
+
+1. The frontend/backend session start path never selects Codex at all.
+2. The current `CodexProvider` is built around Claude-style assumptions that do
+   not match the real `codex` CLI.
+
+Because of (2), simply wiring the provider selector would still not make Codex
+work.
+
+## Evidence
+
+### 1. Provider selection is not wired
+
+- Frontend settings expose a `codex` option, but that state is only stored
+  locally and never sent over the WebSocket:
+  - `frontend/src/components/AIChat/SettingsPanel.tsx`
+  - `frontend/src/hooks/useAgentWebSocket.ts`
+- The chat WebSocket message schema does not carry provider/model/permission
+  fields:
+  - `src/scieasy/api/schemas.py`
+- Backend session creation always instantiates `ClaudeCodeProvider()` and always
+  starts in bypass mode:
+  - `src/scieasy/api/routes/ai.py`
+
+### 2. The current Codex provider assumes a Claude-like CLI contract
+
+Current `CodexProvider` assumes:
+
+- one long-lived subprocess per chat session
+- stdin accepts JSON chat envelopes
+- stdout emits Claude-style `stream-json`
+- spawn flags include:
+  - `--output-format stream-json`
+  - `--append-system-prompt @<path>`
+  - `--mcp-config @<path>`
+  - `--resume <session_id>`
+
+Those assumptions are encoded in:
+
+- `src/scieasy/ai/agent/codex.py`
+- `tests/fixtures/stub_codex.py`
+- `tests/ai/test_codex_provider.py`
+- `docs/specs/eca-spike-codex-format.md`
+
+### 3. Real Codex CLI behavior differs materially
+
+Observed on this machine (`codex-cli 0.118.0`):
+
+- `codex --help` shows the non-interactive path is `codex exec`, not bare
+  `codex --output-format ...`
+- `codex exec --help` exposes `--json`, not `--output-format stream-json`
+- `codex exec` does not accept `-a/--ask-for-approval`
+- `codex login status` exists and returns `Logged in using ChatGPT`
+- `codex exec --json "Reply with exactly hi and nothing else."` emits JSONL
+  events like:
+  - `thread.started`
+  - `turn.started`
+  - `item.completed`
+  - `turn.completed`
+- `codex exec --json ... resume <thread_id> -` resumes successfully, which means
+  Codex supports session continuity, but via new-process-per-turn resume rather
+  than a Claude-style long-lived stdin session
+
+## Root-cause analysis
+
+### Blocker A: control-plane gap
+
+SciEasy's chat startup flow is still effectively hard-coded for Claude Code.
+The provider dropdown is UI-only.
+
+Impact:
+
+- selecting `Codex` in the UI has no effect
+- permission mode in the UI also does not control backend session startup
+
+### Blocker B: provider contract mismatch
+
+`AgentSession` and `CodexSession` are currently shaped around Claude's
+"persistent subprocess + repeated `send_user_message()` over stdin" model.
+
+Real Codex appears to fit a different model:
+
+- one process per turn (`codex exec --json`)
+- session continuity through `exec resume <thread_id>`
+- different event taxonomy
+- likely different MCP/config injection surface
+- no Claude-style hook contract exposed in current local help
+
+Impact:
+
+- the current `CodexProvider.start_session()` argv is invalid for real Codex
+- even if spawn succeeded, `stream_json.parse_stream()` would classify real
+  Codex events as mostly `OtherEvent`
+- current tests give false confidence because the stub reproduces the same wrong
+  assumptions
+
+### Blocker C: docs and tests are assumption-locked
+
+The current spike doc and tests document/verify the scaffolded assumption set,
+not the real CLI behavior.
+
+Impact:
+
+- green tests do not imply real Codex compatibility
+- user-facing guide currently overstates support
+
+## Implementation plan
+
+### Phase 1: wire provider selection end-to-end
+
+Goal: make the chosen provider explicit in the protocol and session metadata.
+
+Changes:
+
+- extend `ChatClientMessage` with:
+  - `provider`
+  - `permission_mode`
+  - optional `model`
+- update `useAgentWebSocket` to include those fields on first `user_message`
+- change `_start_default_session()` into a provider-aware factory
+- stop hard-coding `ClaudeCodeProvider()` and `PermissionMode.BYPASS`
+- persist the selected provider and permission mode in session metadata
+
+Acceptance:
+
+- selecting `codex` reaches the backend factory
+- selecting strict/bypass affects session startup
+- backend tests cover both providers at the session-factory boundary
+
+### Phase 2: redesign Codex runtime integration around exec/resume
+
+Goal: implement a real Codex provider instead of a Claude-shaped shim.
+
+Recommended design:
+
+- keep the public `AgentProvider` interface if possible
+- change `CodexSession` internals to "spawn per turn"
+- on first turn:
+  - run `codex exec --json ...`
+  - capture `thread_id` from `thread.started`
+- on later turns:
+  - run `codex exec --json ... resume <thread_id> -`
+- `send_user_message()` should enqueue the next prompt text, then spawn a fresh
+  subprocess for that turn
+- `stream_events()` should stream events from the active turn subprocess only
+
+Open design choice:
+
+- either generalize `AgentSession` docs to support per-turn subprocesses, or
+- keep the protocol and let Codex satisfy it via an internal turn-runner state
+
+Acceptance:
+
+- first-turn + resumed-turn smoke tests pass against a real local Codex binary
+- metadata stores the real Codex `thread_id`
+
+### Phase 3: add Codex event normalization
+
+Goal: translate real Codex JSONL into SciEasy's canonical chat event taxonomy.
+
+Changes:
+
+- add Codex-specific event normalization before canonical event construction
+- map at minimum:
+  - `thread.started` -> `InitEvent`
+  - `item.completed(agent_message)` -> `AssistantTextDeltaEvent` or final
+    assistant message event(s)
+  - tool-related item events -> `ToolUseEvent` / `ToolResultEvent` where
+    present
+  - `turn.completed` -> `DoneEvent`
+- keep unknown Codex frames as `OtherEvent`
+
+Acceptance:
+
+- simple prompt renders correctly in SciEasy chat
+- resumed prompt renders correctly
+- parser tests use captured real Codex fixtures instead of the current
+  Claude-style stub stream
+
+### Phase 4: solve MCP injection for Codex
+
+Goal: make SciEasy MCP tools visible to Codex without mutating global user state.
+
+Tasks:
+
+- determine the supported per-invocation MCP config surface for Codex
+- prefer ephemeral config override over `codex mcp add` global mutation
+- if needed, generate a temporary Codex config TOML and launch with `-c` /
+  profile overrides
+- pass `SCIEASY_CHAT_ID` and `SCIEASY_PROJECT_DIR` through the MCP server
+  launch env
+
+Acceptance:
+
+- Codex can call a read-only SciEasy MCP tool such as `list_blocks`
+- no persistent mutation of the user's global Codex MCP config is required
+
+### Phase 5: permission-model strategy for Codex
+
+Goal: replace the Claude-specific permission assumption with a Codex-compatible
+strategy.
+
+Tasks:
+
+- verify whether Codex exposes a pre-tool hook comparable to Claude's
+  `PreToolUse`
+- if yes, integrate through the existing permission-check backend
+- if no, define fallback behavior explicitly:
+  - use Codex sandbox/approval flags where available
+  - keep SciEasy write-side MCP tools gated server-side
+  - document reduced parity for native file/shell tools if unavoidable
+
+Acceptance:
+
+- strict mode has a defined enforcement path for Codex
+- bypass mode has a defined low-friction path for Codex
+- limitations are documented if Codex cannot match Claude hook parity
+
+### Phase 6: replace fake-confidence tests with real-contract tests
+
+Goal: ensure CI distinguishes scaffold assumptions from actual upstream support.
+
+Changes:
+
+- split tests into:
+  - pure unit tests for normalization helpers
+  - real-binary smoke tests guarded by `skipif(find_binary("codex") is None)`
+- replace `stub_codex.py` as the primary acceptance oracle
+- add captured fixture files from real `codex exec --json` runs
+- add an integration test for:
+  - first turn
+  - resumed turn
+  - MCP tool call once MCP wiring lands
+
+Acceptance:
+
+- a green Codex test suite implies compatibility with the real CLI surface,
+  not just the stub
+
+### Phase 7: docs cleanup
+
+Update:
+
+- `docs/specs/eca-spike-codex-format.md`
+- `docs/guides/ai-chat.md`
+- `README.md`
+- ADR-033 addendum if the provider model diverges from the original assumption
+
+Must document:
+
+- actual command surface (`exec`, `exec resume`, `--json`)
+- actual login-status behavior
+- any permission-model caveats
+- whether Codex has full parity or partial parity with Claude Code
+
+## Recommended PR breakdown
+
+1. Provider selection plumbing
+2. Codex session/runtime redesign
+3. Codex event normalization + fixture-based tests
+4. Codex MCP integration
+5. Codex permission handling
+6. Docs and guide corrections
+
+## Recommended immediate next step
+
+Start with Phase 1 plus a minimal slice of Phase 2:
+
+- wire provider selection through the WebSocket
+- add a real `CodexSession` prototype that can run:
+  - `codex exec --json`
+  - `codex exec --json ... resume <thread_id> -`
+- do not attempt MCP or strict permissions in the same PR
+
+That creates a small but honest milestone: "Codex can chat in SciEasy using
+real upstream commands," after which MCP and permission parity can be layered on
+without keeping the current false-positive scaffold in place.

--- a/docs/specs/eca-spike-codex-format.md
+++ b/docs/specs/eca-spike-codex-format.md
@@ -1,151 +1,127 @@
 # Spike: Codex CLI stream format
 
-> **Status**: spike / assumption-led
+> **Status**: observed and implemented
 > **Ticket**: T-ECA-403
-> **Related**: ADR-033 §3 D1, `docs/specs/embedded-coding-agent-spec.md` §8 T-ECA-402
-> **Author**: implementation agent for #747
-> **Date**: 2026-05-12
-
----
+> **Related**: ADR-033 Section 3 D1, `docs/specs/embedded-coding-agent-spec.md` Section 8 T-ECA-402
+> **Date**: 2026-05-13
 
 ## 1. Purpose
 
-This document captures what we know — and explicitly what we assume — about the
-upstream `codex` CLI's stream-JSON output format, so that the implementation in
-`src/scieasy/ai/agent/codex.py` (T-ECA-402) can be reasoned about and audited
-against a single source of truth.
+This document records the Codex CLI surface that SciEasy's `CodexProvider`
+adapts into the ADR-033 canonical agent event taxonomy.
 
-The spike is **not** an experimental report. It is a contract for the Codex
-provider that says: "Given these assumptions about how the Codex CLI behaves,
-the provider will produce the canonical event taxonomy listed below; if any
-assumption is observed to be false in production, file a follow-up ticket and
-update this document."
+The important gap from the original scaffold is that Codex is not a
+Claude-Code-shaped long-running stdin process. In non-interactive mode, Codex
+runs one turn per process:
 
-## 2. Empirical status
+```bash
+codex exec --json --skip-git-repo-check -C <project_dir> -
+codex exec --json --skip-git-repo-check -C <project_dir> resume <thread_id> -
+```
 
-**The Codex CLI was not run during this spike.** The implementation host
-(Windows 11, ADR-033 Phase 4 worktree) has the Claude Code CLI installed but
-not the Codex CLI. Two consequences follow:
+SciEasy therefore treats `CodexSession` as a logical chat session and spawns a
+new Codex subprocess for each user turn.
 
-1. The provider's discovery, spawn flags, login probe, and stream-format
-   normalisation are written against the assumptions enumerated in §3
-   below.
-2. The test fixture (`tests/fixtures/stub_codex.py`) is hand-written to
-   exercise the canonical event taxonomy via the SciEasy stream-JSON parser
-   directly, without simulating Codex CLI quirks that we cannot verify.
+## 2. Observed CLI Surface
 
-This is consistent with ADR-033 §3 D1.3 which permits provider implementations
-to be authored against documented assumptions and refined via follow-up
-tickets once the upstream CLI is observed in situ.
+Observed on a local Windows development host with `codex-cli 0.118.0`:
 
-## 3. Assumptions
-
-### A1 — Subprocess invocation surface
-
-The Codex CLI:
-
-1. Reads user-turn messages from stdin one JSON envelope per line.
-2. Writes a stream of JSON events to stdout, one event per line (NDJSON).
-3. Exits cleanly when stdin is closed.
-4. Accepts the following flags, with the listed semantics:
-   - `--output-format stream-json` — enable NDJSON streaming.
-   - `--append-system-prompt @<path>` — append the contents of `<path>` to
-     the system prompt.
-   - `--mcp-config @<path>` — load MCP server config from `<path>`.
-   - `--resume <session_id>` — resume a prior session.
-   - `--model <name>` — override the model.
-
-**Where Codex flag spellings differ**, the SciEasy provider's `start_session`
-will need a small adapter. We assume — pending observation — that the flag
-spellings above are either accepted directly or trivially aliased.
-
-### A2 — Login subcommand
-
-The Codex CLI exposes `codex login status` and returns exit code 0 if a
-session token is present. If that subcommand is absent on the installed
-version, the discovery probe returns non-zero and the provider correctly
-degrades to `logged_in=False` — see
-`test_discover_treats_login_probe_nonzero_as_logged_out`.
-
-### A3 — Event framing
-
-Each event is a JSON object with **either** a top-level `kind` field (the
-ADR-033 canonical name) **or** a top-level `type` field (the field Claude
-Code currently uses). The SciEasy stream-JSON parser
-(`scieasy.ai.agent.stream_json._extract_kind`) accepts both, so a Codex CLI
-that emits either spelling will be normalised correctly.
-
-### A4 — Event kinds
-
-The Codex CLI emits — or can be normalised onto — the following canonical
-event kinds:
-
-| Canonical kind | Required fields | Notes |
+| Concern | Observed behavior | SciEasy implementation |
 |---|---|---|
-| `init` | `session_id` (str); optional `model`, `schema_version` | First event in every session. |
-| `assistant_text_delta` | `delta` (str) or `text` (str) | Multiple deltas per turn. |
-| `tool_use` | `tool_name`/`name`, `tool_input`/`input`, `tool_use_id`/`id` | Both spellings accepted by the parser. |
-| `tool_result` | `tool_use_id`, `output`/`content`, optional `is_error` | Correlated with the matching `tool_use`. |
-| `permission_request` | `tool_name`, `tool_input`, `request_id` | Synthesised by the hook bridge, not the raw CLI. |
-| `error` | `message` or `error` | Stream-level provider error. |
-| `done` | none | Terminal event marking end of turn. |
-| `other` | n/a | Catch-all for unknown kinds (spec §3 OQ5). |
+| Non-interactive run | `codex exec` | `CodexSession.send_user_message()` spawns `codex exec` |
+| JSON stream | `--json` emits JSONL frames | `CodexSession.stream_events()` reads stdout line by line |
+| Working directory | `-C <dir>` | Passed for every turn |
+| Resume | `codex exec ... resume <thread_id> -` | `thread.started.thread_id` is latched as `session_id` and reused |
+| Prompt input | `-` reads prompt from stdin | SciEasy writes system prompt plus user message, then closes stdin |
+| Model override | `--model <name>` | Passed when the frontend/API provides `model` |
+| Bypass mode | `--dangerously-bypass-approvals-and-sandbox` | Used for `PermissionMode.BYPASS` |
+| Strict mode | No Claude-style approval flag | SciEasy uses `--sandbox read-only` as the safe default |
+| Login probe | `codex login status` | Used by `CodexProvider.discover()` as a best-effort heuristic |
 
-The provider does **not** itself translate Codex-specific event names. The
-parser's dispatch table is the single point of canonicalisation. If Codex
-emits a kind that is not in the table above (e.g. `usage`, `tokens`,
-`metadata`), it will surface as an `OtherEvent` with the original payload
-preserved in `event.raw`, as required by ADR-033 §3 OQ5.
+## 3. Event Normalisation
 
-### A5 — Permission requests
+Codex emits provider-specific JSONL frames. SciEasy maps the observed frames to
+the canonical event types used by the frontend and transcript writer:
 
-Per ADR-033 §3 D5, permission gating is implemented through the
-`PreToolUse` hook **and not** through inline stream events. The Codex
-provider is therefore not responsible for emitting `permission_request`
-events directly — those are synthesised by the hook bridge identically to
-the Claude Code case. The provider's responsibility ends at injecting
-`SCIEASY_CHAT_ID` and `SCIEASY_PROJECT_DIR` into the subprocess env so the
-hook bridge can route the request back to `/api/ai/permission-check`
-(issue #723).
+| Codex frame | Canonical event |
+|---|---|
+| `{"type": "thread.started", "thread_id": "..."}` | `InitEvent(kind="init", session_id=thread_id)` |
+| `{"type": "turn.started"}` | hidden `OtherEvent` |
+| `{"type": "item.completed", "item": {"type": "agent_message", "text": "..."}}` | `AssistantTextDeltaEvent` |
+| `{"type": "item.completed", "item": {"type": "function_call", ...}}` | `ToolUseEvent` |
+| `{"type": "item.completed", "item": {"type": "function_call_output", ...}}` | `ToolResultEvent` |
+| `{"type": "turn.completed"}` | `DoneEvent` |
+| `{"type": "turn.failed"}` or `{"type": "error"}` | `ErrorEvent` |
+| Anything else | `OtherEvent` with the raw payload preserved |
 
-## 4. Divergence handling
+The normaliser lives in `src/scieasy/ai/agent/codex.py` rather than the shared
+Claude stream parser because Codex's `item.completed` envelope requires
+provider-specific extraction.
 
-If a divergence between an assumption above and the real Codex CLI is
-observed:
+## 4. MCP Configuration
 
-1. Open a follow-up ticket labelled `eca-codex-spike`.
-2. Patch the assumption in this file with the observed behaviour.
-3. If the divergence requires provider-specific normalisation logic (e.g.
-   the Codex CLI uses a Codex-only event kind that does not map to any
-   canonical kind in §3-A4), add a `_normalize_event` method to
-   `CodexProvider` and route the relevant kinds through it before the
-   canonical parser. Until then, an `OtherEvent` is acceptable.
-4. Re-run `tests/ai/test_codex_provider.py` and confirm the canonical
-   taxonomy is still produced end-to-end.
+Codex does not use Claude Code's `--mcp-config @file` flag. SciEasy injects the
+project-local MCP server with Codex config overrides:
 
-## 5. Risks
+```bash
+-c mcp_servers.scieasy.command="scieasy"
+-c mcp_servers.scieasy.args=["mcp-bridge"]
+-c mcp_servers.scieasy.env={SCIEASY_CHAT_ID="...", SCIEASY_PROJECT_DIR="..."}
+```
 
-| Risk | Likelihood | Impact | Mitigation |
-|---|---|---|---|
-| Codex flag spellings differ from CC's | Medium | Spawn fails immediately; user sees install-hint banner. | Add Codex-specific flag aliases in `start_session` once observed. |
-| Codex emits stream events without `kind` or `type` field | Low | Events surface as `OtherEvent` with INFO log. | Acceptable for v1; tighten the parser only if real Codex output requires it. |
-| `codex login status` subcommand does not exist | Medium | Login probe returns non-zero; user sees "not logged in" banner. | Already handled — see `test_discover_treats_login_probe_nonzero_as_logged_out`. |
-| Codex CLI's session-resume semantics differ from CC | Medium | `--resume <id>` rejected; provider falls back to a fresh session. | Acceptable for v1; refine once observed. |
+SciEasy also injects the same environment variables into the Codex subprocess
+environment:
 
-## 6. Open questions for follow-up tickets
+| Variable | Purpose |
+|---|---|
+| `SCIEASY_CHAT_ID` | Correlates MCP/hook requests with the active chat |
+| `SCIEASY_PROJECT_DIR` | Gives tools the trusted project root |
+| `SCIEASY_PERMISSION_MODE` | Exposes strict/bypass mode to child processes |
 
-1. **Does Codex's CLI accept `--append-system-prompt @<path>`** or is the
-   prompt-injection mechanism different (e.g. an env var, a config file)?
-2. **Does Codex emit a `permission_request` event natively** or — like
-   Claude Code — does it always go through a hook subprocess?
-3. **Does Codex have a hook surface comparable to Claude Code's
-   `PreToolUse`?** If not, the Codex provider may need a different
-   permission-gating strategy (e.g. wrapping every tool call in an MCP
-   middleware tool).
-4. **What is the Codex CLI's exit semantics on `Ctrl-C` / `SIGTERM`?**
-   We currently assume identical behaviour to Claude Code; if Codex
-   propagates differently, the cancellation tree-kill path may need
-   adjusting on POSIX.
+## 5. Permission Model
 
-These questions are recorded here so that whoever first runs Codex against
-SciEasy can answer them by observation and close them out via doc patches.
+Claude Code strict mode is built around the `PreToolUse` hook. Codex does not
+currently expose the same approval flag surface in `codex exec`, so SciEasy's
+Codex strict mode is intentionally conservative:
+
+1. Native Codex filesystem/tool access is limited with `--sandbox read-only`.
+2. Bypass mode maps to Codex's explicit dangerous bypass flag.
+3. SciEasy MCP tools still receive `SCIEASY_PERMISSION_MODE`; write-like MCP
+   enforcement must stay in the SciEasy tool layer.
+
+This is not exact behavioral parity with Claude Code's per-tool GUI approval.
+It is the safest observed mapping for the current Codex CLI.
+
+## 6. Tests
+
+The primary regression tests are:
+
+| Test | Purpose |
+|---|---|
+| `tests/ai/test_codex_provider.py` | Provider discovery, per-turn spawn, resume, cancellation, event taxonomy, env injection |
+| `tests/fixtures/stub_codex.py` | Codex-shaped `exec --json` and `exec resume --json` JSONL fixture |
+| `tests/api/test_ai_chat_route.py` | Provider selection and permission-mode forwarding |
+| `frontend/src/components/AIChat/__tests__/useAgentWebSocket.test.ts` | Frontend sends selected provider and permission mode |
+
+Run the backend tests with the current worktree's `src` first on `PYTHONPATH`
+if another editable SciEasy checkout is installed:
+
+```powershell
+$env:PYTHONPATH='C:\path\to\SciEasy\src'
+pytest tests/ai/test_codex_provider.py tests/api/test_ai_chat_route.py tests/api/test_ai_chat_ws_v2.py -q --no-cov
+```
+
+Run the frontend hook test from `frontend/`:
+
+```bash
+npm test -- --run src/components/AIChat/__tests__/useAgentWebSocket.test.ts
+```
+
+## 7. Open Follow-Ups
+
+1. Verify the strict-mode MCP write path end-to-end against a real Codex CLI and
+   confirm SciEasy tools deny or prompt consistently.
+2. Capture a small real Codex JSONL transcript fixture when the upstream event
+   schema stabilizes enough to commit a sanitized sample.
+3. Revisit strict-mode behavior if Codex adds a native per-tool approval
+   mechanism for `codex exec`.

--- a/frontend/src/components/AIChat/SettingsPanel.tsx
+++ b/frontend/src/components/AIChat/SettingsPanel.tsx
@@ -2,7 +2,7 @@
  * Agent settings panel.
  *
  * Provides:
- *  - Provider selector ("claude-code" / "codex"; codex lands Phase 4)
+ *  - Provider selector ("claude-code" / "codex")
  *  - Permission mode (strict / bypass)
  *  - Future: concurrent-chat cap input
  *
@@ -59,7 +59,7 @@ export function SettingsPanel() {
           className="rounded border border-gray-300 px-2 py-1"
         >
           <option value="claude-code">Claude Code</option>
-          <option value="codex">Codex (Phase 4)</option>
+          <option value="codex">Codex</option>
         </select>
       </label>
       <label className="flex items-center gap-2">

--- a/frontend/src/components/AIChat/__tests__/useAgentWebSocket.test.ts
+++ b/frontend/src/components/AIChat/__tests__/useAgentWebSocket.test.ts
@@ -94,6 +94,35 @@ describe("useAgentWebSocket", () => {
     expect(useAppStore.getState().eventsByChat["chat-1"]).toHaveLength(1);
   });
 
+  it("sends selected provider and permission mode with user messages", () => {
+    useAppStore.setState({
+      providerName: "codex",
+      permissionMode: "bypass",
+    });
+    const { result } = renderHook(() => useAgentWebSocket("chat-send", "/tmp/proj"));
+    const ws = createdSockets[0];
+
+    act(() => {
+      ws.readyState = MockWebSocket.OPEN;
+      ws.onopen?.({} as Event);
+    });
+
+    let sent = false;
+    act(() => {
+      sent = result.current.sendMessage("hello codex");
+    });
+
+    expect(sent).toBe(true);
+    expect(ws.send).toHaveBeenCalledWith(
+      JSON.stringify({
+        type: "user_message",
+        content: "hello codex",
+        provider: "codex",
+        permission_mode: "bypass",
+      }),
+    );
+  });
+
   it("routes permission_request to pendingPermissions", () => {
     renderHook(() => useAgentWebSocket("chat-2", "/tmp/proj"));
     const ws = createdSockets[0];

--- a/frontend/src/hooks/useAgentWebSocket.ts
+++ b/frontend/src/hooks/useAgentWebSocket.ts
@@ -23,7 +23,12 @@ import type { AgentEvent, PermissionDecision, PermissionMode } from "../types/ag
 /** WS connection state surfaced to UI. */
 export type WSConnectionState = "idle" | "connecting" | "open" | "closed" | "reconnecting";
 
-type OutboundUserMessage = { type: "user_message"; content: string };
+type OutboundUserMessage = {
+  type: "user_message";
+  content: string;
+  provider: string;
+  permission_mode: string;
+};
 type OutboundCancel = { type: "cancel" };
 type OutboundPermissionDecision = {
   type: "permission_decision";
@@ -71,6 +76,7 @@ export function useAgentWebSocket(
   const setPendingPermission = useAppStore((s) => s.setPendingPermission);
   const markSessionEnded = useAppStore((s) => s.markSessionEnded);
   const permissionMode: PermissionMode = useAppStore((s) => s.permissionMode);
+  const providerName = useAppStore((s) => s.providerName);
 
   const [state, setState] = useState<WSConnectionState>("idle");
   const socketRef = useRef<WebSocket | null>(null);
@@ -209,8 +215,14 @@ export function useAgentWebSocket(
   }, []);
 
   const sendMessage = useCallback(
-    (content: string): boolean => send({ type: "user_message", content }),
-    [send],
+    (content: string): boolean =>
+      send({
+        type: "user_message",
+        content,
+        provider: providerName,
+        permission_mode: permissionMode,
+      }),
+    [send, providerName, permissionMode],
   );
   const cancel = useCallback((): boolean => send({ type: "cancel" }), [send]);
   const sendPermissionDecision = useCallback(

--- a/src/scieasy/ai/agent/codex.py
+++ b/src/scieasy/ai/agent/codex.py
@@ -1,68 +1,15 @@
-"""Codex CLI provider implementation (T-ECA-402).
+"""Codex CLI provider implementation.
 
-Conforms to :class:`scieasy.ai.agent.provider.AgentProvider`; wraps the
-locally-installed ``codex`` CLI as a subprocess and exposes its
-stream-JSON output as canonical
-:class:`scieasy.ai.agent.provider.AgentEvent` instances.
+The real Codex CLI differs from Claude Code in two important ways:
 
-This provider deliberately mirrors :class:`scieasy.ai.agent.claude_code.ClaudeCodeProvider`:
+* non-interactive streaming is exposed through ``codex exec --json``;
+* conversation continuity is exposed by spawning a new process with
+  ``codex exec --json ... resume <thread_id> -``.
 
-* Same :class:`AgentProvider` Protocol surface.
-* Same canonical event taxonomy on the output side (``init``,
-  ``assistant_text_delta``, ``tool_use``, ``tool_result``,
-  ``permission_request``, ``done``, ``error``, ``other``).
-* Same subprocess lifecycle, cancellation strategy, and temp-file
-  cleanup contract.
-
-The differences are intentionally local:
-
-* ``name = "codex"``, ``binary_name = "codex"``.
-* The spawn flags follow the Codex CLI's flag surface as documented in
-  ``docs/specs/eca-spike-codex-format.md``. Where the Codex CLI lacks a
-  direct equivalent of a Claude Code flag, the spike doc records the
-  assumption and the provider degrades gracefully (e.g. by serialising
-  the system prompt + MCP config to temp files and pointing at them
-  through the closest Codex flag, or omitting the flag entirely if no
-  equivalent exists).
-* Stream-format normalisation goes through the same
-  :func:`scieasy.ai.agent.stream_json.parse_stream` parser. The parser
-  is already tolerant of both ``{"kind": ...}`` (ADR canonical) and
-  ``{"type": ...}`` (CC wire) framings, so it handles either Codex
-  framing without provider-specific code.
-
-Implementation notes (spec §8 T-ECA-402, ADR-033 §3 D1):
-
-* Discovery uses :func:`scieasy.ai.agent.binary_discovery.find_binary`
-  with ``binary_name = "codex"``, probes ``codex --version`` (5-second
-  timeout) for availability, and ``codex login status`` (2-second
-  timeout) for the login-state heuristic. If the login subcommand
-  returns non-zero we fall back to ``logged_in=False`` rather than
-  raising — exactly the same contract as Claude Code's
-  ``installMethod`` probe.
-* Session spawn flags mirror Claude Code's surface:
-  ``--output-format stream-json --append-system-prompt @<prompt_file>
-  --mcp-config @<mcp_file>`` plus ``--resume <id>`` if resuming and
-  ``--model <m>`` if specified. The actual Codex flag spellings are
-  documented in the spike addendum; the implementation here assumes
-  flag parity. If a real Codex CLI rejects a flag we observe the
-  failure in the ``codex --version`` probe (which becomes
-  ``logged_in=False`` and the user sees the install hint).
-* The subprocess is spawned via :func:`asyncio.create_subprocess_exec`
-  with stdin/stdout/stderr pipes and ``cwd=project_dir``. On Windows
-  the ``CREATE_NEW_PROCESS_GROUP`` flag is set; on POSIX
-  ``start_new_session=True`` produces an equivalent group-killable
-  subprocess tree.
-* Cancellation uses ``os.killpg`` on POSIX and ``taskkill /T /F /PID``
-  on Windows; both are idempotent.
-* :meth:`CodexSession.send_user_message` writes a JSON envelope to
-  stdin and flushes — stdin is NOT closed, so multi-turn sessions are
-  supported over one process (matches CC convention).
-
-The :class:`CodexProvider` constructor accepts a ``binary_override``
-keyword that points at a Python stub script (resolved as
-``[sys.executable, str(binary_override), ...]``) — used by the
-``tests/fixtures/stub_codex.py`` test fixture to exercise the spawn
-plumbing without a real Codex binary.
+This module adapts that per-turn process model to SciEasy's
+``AgentSession`` protocol. A ``CodexSession`` is a logical chat session;
+each user message starts one Codex subprocess and ``stream_events()``
+keeps waiting for subsequent turns until the SciEasy session is closed.
 """
 
 from __future__ import annotations
@@ -81,19 +28,21 @@ from pathlib import Path
 from typing import Any, ClassVar
 
 from scieasy.ai.agent.binary_discovery import find_binary
-from scieasy.ai.agent.errors import (
-    AgentLaunchError,
-    AgentNotInstalledError,
-)
+from scieasy.ai.agent.errors import AgentLaunchError, AgentNotInstalledError
 from scieasy.ai.agent.provider import (
     AgentEvent,
     AgentProvider,
     AgentSession,
+    AssistantTextDeltaEvent,
+    DoneEvent,
+    ErrorEvent,
     InitEvent,
+    OtherEvent,
     PermissionMode,
     ProviderStatus,
+    ToolResultEvent,
+    ToolUseEvent,
 )
-from scieasy.ai.agent.stream_json import parse_stream
 
 logger = logging.getLogger(__name__)
 
@@ -105,226 +54,313 @@ _CLOSE_GRACE_SECONDS = 5.0
 _INSTALL_HINT = "Install the Codex CLI: see https://github.com/openai/codex for installation and login instructions."
 
 
-async def _read_subprocess_stream(stream: asyncio.StreamReader) -> AsyncIterator[bytes]:
-    """Adapt an :class:`asyncio.StreamReader` into an async byte-chunk iterator."""
+def _toml_string(value: str) -> str:
+    """Return a TOML-compatible quoted string for ``codex -c`` overrides."""
+    return json.dumps(value)
+
+
+def _toml_array(values: list[str]) -> str:
+    return "[" + ", ".join(_toml_string(v) for v in values) + "]"
+
+
+async def _read_stderr(stream: asyncio.StreamReader | None) -> str:
+    if stream is None:
+        return ""
+    chunks: list[bytes] = []
     while True:
         chunk = await stream.read(4096)
         if not chunk:
+            break
+        chunks.append(chunk)
+    return b"".join(chunks).decode("utf-8", errors="replace")
+
+
+async def _read_stdout_lines(stream: asyncio.StreamReader) -> AsyncIterator[bytes]:
+    while True:
+        line = await stream.readline()
+        if not line:
             return
-        yield chunk
+        yield line
+
+
+def _normalise_codex_event(payload: dict[str, Any]) -> AgentEvent | list[AgentEvent]:
+    """Translate Codex JSONL frames to SciEasy's canonical event taxonomy."""
+    event_type = payload.get("type")
+
+    if event_type == "thread.started":
+        thread_id = payload.get("thread_id")
+        if isinstance(thread_id, str) and thread_id:
+            return InitEvent(kind="init", raw=payload, session_id=thread_id)
+        return OtherEvent(kind="thread.started", raw=payload)
+
+    if event_type == "turn.started":
+        return OtherEvent(kind="turn.started", raw={**payload, "_chat_hidden": True})
+
+    if event_type == "turn.completed":
+        return DoneEvent(kind="done", raw=payload)
+
+    if event_type in {"turn.failed", "error"}:
+        message = payload.get("message") or payload.get("error") or json.dumps(payload)
+        return ErrorEvent(kind="error", raw=payload, message=str(message), error_type=str(event_type))
+
+    if event_type in {"item.completed", "item.started", "item.updated"}:
+        item = payload.get("item")
+        if not isinstance(item, dict):
+            return OtherEvent(kind=str(event_type), raw=payload)
+        item_type = item.get("type")
+        if item_type == "agent_message":
+            text = item.get("text")
+            if isinstance(text, str) and text:
+                return AssistantTextDeltaEvent(kind="assistant_text_delta", raw=payload, delta=text)
+            return OtherEvent(kind="agent_message", raw={**payload, "_chat_hidden": True})
+        if item_type in {"function_call", "tool_call"}:
+            name = item.get("name") or item.get("tool_name")
+            arguments = item.get("arguments") or item.get("input") or item.get("tool_input") or {}
+            if isinstance(arguments, str):
+                try:
+                    parsed = json.loads(arguments)
+                    arguments = parsed if isinstance(parsed, dict) else {"arguments": parsed}
+                except json.JSONDecodeError:
+                    arguments = {"arguments": arguments}
+            call_id = item.get("call_id") or item.get("id")
+            if isinstance(name, str) and isinstance(arguments, dict) and isinstance(call_id, str):
+                return ToolUseEvent(
+                    kind="tool_use",
+                    raw=payload,
+                    tool_name=name,
+                    tool_input=arguments,
+                    tool_use_id=call_id,
+                )
+        if item_type in {"function_call_output", "tool_call_output"}:
+            call_id = item.get("call_id") or item.get("tool_use_id") or item.get("id")
+            output = item.get("output") or item.get("content") or ""
+            if isinstance(call_id, str):
+                return ToolResultEvent(
+                    kind="tool_result",
+                    raw=payload,
+                    tool_use_id=call_id,
+                    output=output,
+                    is_error=bool(item.get("is_error", False)),
+                )
+        return OtherEvent(kind=f"{event_type}/{item_type}" if item_type else str(event_type), raw=payload)
+
+    return OtherEvent(kind=str(event_type) if isinstance(event_type, str) else "other", raw=payload)
 
 
 class CodexSession:
-    """Live ``codex`` subprocess + IPC channels.
-
-    Conforms structurally to :class:`scieasy.ai.agent.provider.AgentSession`.
-
-    Invariants
-    ----------
-    * Exactly one OS subprocess per instance.
-    * ``send_user_message`` may be called repeatedly; stdin is held open
-      until :meth:`close` is invoked.
-    * :meth:`cancel` is idempotent; calling it twice is a no-op.
-    * Temp files written by the provider (system prompt, MCP config) are
-      released in :meth:`close`; failures during unlink are logged at
-      WARNING and swallowed.
-    """
+    """Logical Codex chat session backed by one subprocess per user turn."""
 
     def __init__(
         self,
         *,
-        proc: asyncio.subprocess.Process,
-        temp_files: list[Path],
+        argv0: list[str],
         project_dir: Path,
+        chat_id: str,
+        system_prompt: str,
+        mcp_config: dict[str, Any],
+        permission_mode: PermissionMode,
+        model: str | None,
+        resume_session_id: str | None,
+        temp_files: list[Path],
     ) -> None:
-        self._proc: asyncio.subprocess.Process = proc
-        self._temp_files: list[Path] = list(temp_files)
-        self._project_dir: Path = project_dir
-        self._closed: bool = False
-        self._cancelled: bool = False
+        self._argv0 = argv0
+        self._project_dir = project_dir
+        self._chat_id = chat_id
+        self._system_prompt = system_prompt
+        self._mcp_config = mcp_config
+        self._permission_mode = permission_mode
+        self._model = model
+        self._temp_files = list(temp_files)
+        self._turn_ready = asyncio.Event()
+        self._closed = False
+        self._cancelled = False
+        self._active_proc: asyncio.subprocess.Process | None = None
+        self._stderr_task: asyncio.Task[str] | None = None
 
-        # AgentSession Protocol public attributes.
-        self.session_id: str | None = None
-        self.pid: int = proc.pid
+        self.session_id: str | None = resume_session_id
+        self.pid: int = 0
 
     @property
     def temp_files(self) -> list[Path]:
-        """Tracked temp-file paths (read-only view); useful for tests."""
         return list(self._temp_files)
 
     async def send_user_message(self, content: str) -> None:
-        """Send a user-turn message to the agent subprocess.
+        if self._closed:
+            raise AgentLaunchError("codex session is closed; cannot send_user_message")
+        if self._active_proc is not None and self._active_proc.returncode is None:
+            raise AgentLaunchError("codex turn already in progress")
 
-        Writes a JSON envelope ``{"type": "user", "content": ...}`` to
-        stdin followed by a newline, then flushes. Stdin is NOT closed
-        — the Codex CLI is assumed to support multi-turn over one
-        process; if a future Codex CLI requires stdin EOF per turn the
-        provider can override this method without touching the wider
-        runtime.
+        argv = self._build_turn_argv()
+        env = os.environ.copy()
+        env["SCIEASY_PERMISSION_MODE"] = self._permission_mode.value
+        env["SCIEASY_CHAT_ID"] = self._chat_id
+        env["SCIEASY_PROJECT_DIR"] = str(self._project_dir)
 
-        Raises
-        ------
-        AgentLaunchError
-            If the subprocess has already exited or stdin was lost.
-        """
-        if self._proc.stdin is None or self._proc.stdin.is_closing():
-            raise AgentLaunchError("subprocess stdin is closed; cannot send_user_message")
-        envelope = json.dumps({"type": "user", "content": content})
-        logger.debug(
-            "CodexSession.send_user_message: writing %d bytes to stdin",
-            len(envelope),
-        )
-        self._proc.stdin.write(envelope.encode("utf-8") + b"\n")
+        creationflags = subprocess.CREATE_NEW_PROCESS_GROUP if sys.platform == "win32" else 0
+
+        logger.info("CodexSession.send_user_message: spawning argv=%r cwd=%s", argv, self._project_dir)
         try:
-            await self._proc.stdin.drain()
-        except (BrokenPipeError, ConnectionResetError) as exc:
-            raise AgentLaunchError(f"subprocess stdin write failed: {exc}") from exc
+            proc = await _spawn(argv=argv, cwd=self._project_dir, env=env, creationflags=creationflags)
+        except OSError as exc:
+            raise AgentLaunchError(f"failed to spawn codex subprocess: {exc}") from exc
+
+        self._active_proc = proc
+        self.pid = proc.pid
+        self._stderr_task = asyncio.create_task(_read_stderr(proc.stderr))
+
+        if proc.stdin is None:
+            raise AgentLaunchError("codex subprocess stdin is not piped")
+        proc.stdin.write(self._compose_prompt(content).encode("utf-8"))
+        with contextlib.suppress(BrokenPipeError, ConnectionResetError):
+            await proc.stdin.drain()
+        with contextlib.suppress(OSError):
+            proc.stdin.close()
+        with contextlib.suppress(OSError, asyncio.CancelledError, AttributeError):
+            await proc.stdin.wait_closed()
+        self._turn_ready.set()
 
     async def stream_events(self) -> AsyncIterator[AgentEvent]:
-        """Yield canonical :class:`AgentEvent`s from the subprocess stdout.
+        while True:
+            await self._turn_ready.wait()
+            if self._closed:
+                return
 
-        Latches ``self.session_id`` from the first :class:`InitEvent`.
-        The iterator terminates cleanly when stdout EOF is reached.
-        """
-        if self._proc.stdout is None:
-            raise AgentLaunchError("subprocess stdout is not piped")
+            proc = self._active_proc
+            if proc is None:
+                self._turn_ready.clear()
+                continue
+            if proc.stdout is None:
+                raise AgentLaunchError("codex subprocess stdout is not piped")
 
-        chunk_iter = _read_subprocess_stream(self._proc.stdout)
-        async for event in parse_stream(chunk_iter):
-            if isinstance(event, InitEvent) and self.session_id is None:
-                self.session_id = event.session_id
-                logger.info(
-                    "CodexSession: session_id latched as %s",
-                    event.session_id,
+            async for line in _read_stdout_lines(proc.stdout):
+                try:
+                    payload = json.loads(line.decode("utf-8", errors="replace"))
+                except json.JSONDecodeError as exc:
+                    logger.warning("CodexSession.stream_events: non-JSON stdout line ignored: %s", exc)
+                    continue
+                if not isinstance(payload, dict):
+                    yield OtherEvent(kind="other", raw={"payload": payload})
+                    continue
+                event_or_events = _normalise_codex_event(payload)
+                events = event_or_events if isinstance(event_or_events, list) else [event_or_events]
+                for event in events:
+                    if isinstance(event, InitEvent):
+                        self.session_id = event.session_id
+                    yield event
+
+            returncode = await proc.wait()
+            stderr = ""
+            if self._stderr_task is not None:
+                stderr = await self._stderr_task
+            self._active_proc = None
+            self._stderr_task = None
+            self._turn_ready.clear()
+
+            if returncode != 0 and not self._cancelled:
+                yield ErrorEvent(
+                    kind="error",
+                    raw={"returncode": returncode, "stderr": stderr},
+                    message=stderr.strip() or f"codex exited with status {returncode}",
+                    error_type="CodexExitError",
                 )
-            logger.debug("CodexSession.stream_events: yield kind=%s", event.kind)
-            yield event
+
+    def _build_turn_argv(self) -> list[str]:
+        argv = [*self._argv0, "exec"]
+        argv += ["--json", "--skip-git-repo-check", "-C", str(self._project_dir)]
+        if self._model is not None:
+            argv += ["--model", self._model]
+        if self._permission_mode is PermissionMode.BYPASS:
+            argv += ["--dangerously-bypass-approvals-and-sandbox"]
+        else:
+            argv += ["--sandbox", "read-only"]
+        argv += self._mcp_overrides()
+        if self.session_id is not None:
+            argv += ["resume", self.session_id, "-"]
+        else:
+            argv.append("-")
+        return argv
+
+    def _mcp_overrides(self) -> list[str]:
+        server = (self._mcp_config.get("mcpServers") or {}).get("scieasy")
+        if not isinstance(server, dict):
+            return []
+        command = server.get("command")
+        args = server.get("args", [])
+        env = server.get("env", {})
+        if not isinstance(command, str) or not isinstance(args, list):
+            return []
+
+        overrides = [
+            "-c",
+            f"mcp_servers.scieasy.command={_toml_string(command)}",
+            "-c",
+            f"mcp_servers.scieasy.args={_toml_array([str(arg) for arg in args])}",
+        ]
+        if isinstance(env, dict):
+            entries = [f"{key}={_toml_string(str(value))}" for key, value in sorted(env.items())]
+            if entries:
+                overrides += ["-c", "mcp_servers.scieasy.env={" + ", ".join(entries) + "}"]
+        return overrides
+
+    def _compose_prompt(self, content: str) -> str:
+        return (
+            "System instructions for this SciEasy embedded agent session:\n"
+            f"{self._system_prompt}\n\n"
+            "User message:\n"
+            f"{content}\n"
+        )
 
     def _kill_process_tree(self, *, caller: str) -> None:
-        """Tree-kill the subprocess group on POSIX, taskkill /T /F on Windows.
-
-        Used by both :meth:`cancel` and :meth:`close` (timeout path).
-        Without this, ``self._proc.kill()`` only signals the parent and
-        any tool children (long-running ``Bash`` commands) survive
-        teardown. POSIX sessions are spawned with
-        ``start_new_session=True`` so ``killpg`` reliably hits the whole
-        tree; Windows uses the existing CREATE_NEW_PROCESS_GROUP +
-        ``taskkill /T /F``.
-        """
+        proc = self._active_proc
+        if proc is None or proc.returncode is not None:
+            return
         if sys.platform == "win32":
-            try:
-                subprocess.run(
-                    ["taskkill", "/T", "/F", "/PID", str(self._proc.pid)],
-                    check=False,
-                    capture_output=True,
-                )
-                logger.info(
-                    "CodexSession.%s: taskkill /T /F issued for PID %s",
-                    caller,
-                    self._proc.pid,
-                )
-            except OSError as exc:  # pragma: no cover - taskkill rarely raises
-                logger.warning("CodexSession.%s: taskkill failed: %s", caller, exc)
+            with contextlib.suppress(OSError):
+                subprocess.run(["taskkill", "/T", "/F", "/PID", str(proc.pid)], check=False, capture_output=True)
         else:
-            try:
-                pgid = os.getpgid(self._proc.pid)
-                os.killpg(pgid, signal.SIGKILL)
-                logger.info("CodexSession.%s: SIGKILL sent to pgid %s", caller, pgid)
-            except (ProcessLookupError, PermissionError) as exc:
-                logger.warning("CodexSession.%s: killpg failed: %s", caller, exc)
+            with contextlib.suppress(ProcessLookupError, PermissionError):
+                os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+        logger.info("CodexSession.%s: killed active turn process pid=%s", caller, proc.pid)
 
     async def cancel(self) -> None:
-        """Cancel any in-flight agent turn by tree-killing the subprocess group.
-
-        Idempotent: calling ``cancel`` on an already-cancelled or
-        already-exited session is a no-op.
-
-        Uses SIGKILL via :meth:`_kill_process_tree` to guarantee child
-        tool processes (e.g. long-running Bash commands) are also
-        terminated. Cancellation is a user-driven hard abort; SIGTERM-
-        with-grace is not appropriate here because we cannot trust the
-        agent to honour it promptly.
-        """
-        if self._cancelled or self._proc.returncode is not None:
-            self._cancelled = True
-            return
         self._cancelled = True
         self._kill_process_tree(caller="cancel")
 
     async def close(self) -> None:
-        """Await subprocess exit (with grace) and release temp files.
-
-        Idempotent: calling ``close`` twice is a no-op.
-        """
         if self._closed:
             return
         self._closed = True
+        self._turn_ready.set()
 
-        if self._proc.stdin is not None and not self._proc.stdin.is_closing():
-            with contextlib.suppress(OSError):
-                self._proc.stdin.close()
-            # Force the underlying FD to release before we await proc.wait().
-            # Required on Windows asyncio Proactor pipes — without this the
-            # child may never observe stdin EOF, blocking on readline()
-            # forever and forcing this close() through the grace-timeout
-            # kill path on every single session.
-            with contextlib.suppress(OSError, asyncio.CancelledError, AttributeError):
-                await self._proc.stdin.wait_closed()
-
-        if self._proc.returncode is None:
+        proc = self._active_proc
+        if proc is not None and proc.returncode is None:
             try:
-                await asyncio.wait_for(self._proc.wait(), timeout=_CLOSE_GRACE_SECONDS)
+                await asyncio.wait_for(proc.wait(), timeout=_CLOSE_GRACE_SECONDS)
             except TimeoutError:
-                logger.warning(
-                    "CodexSession.close: subprocess did not exit in %.1fs; tree-killing",
-                    _CLOSE_GRACE_SECONDS,
-                )
                 self._kill_process_tree(caller="close")
                 with contextlib.suppress(TimeoutError):
-                    await asyncio.wait_for(self._proc.wait(), timeout=1.0)
-
+                    await asyncio.wait_for(proc.wait(), timeout=1.0)
+        if self._stderr_task is not None:
+            with contextlib.suppress(Exception):
+                await self._stderr_task
         for path in self._temp_files:
-            try:
+            with contextlib.suppress(OSError):
                 path.unlink(missing_ok=True)
-            except OSError as exc:
-                logger.warning("CodexSession.close: failed to unlink %s: %s", path, exc)
 
 
 class CodexProvider:
-    """Provider for the ``codex`` CLI.
-
-    Structural conformance with :class:`AgentProvider` (PEP 544) is
-    verified at the type level — see ``_PROTOCOL_CONFORMANCE`` at the
-    bottom of this module.
-
-    Parameters
-    ----------
-    binary_override
-        If provided, points at a Python script used in place of the real
-        ``codex`` binary. The session is spawned as
-        ``[sys.executable, str(binary_override), ...]``. Used by the
-        ``tests/fixtures/stub_codex.py`` test fixture.
-    """
+    """Provider for the real ``codex`` CLI."""
 
     name: ClassVar[str] = "codex"
     binary_name: ClassVar[str] = "codex"
 
     def __init__(self, *, binary_override: Path | None = None) -> None:
-        self._binary_override: Path | None = binary_override
+        self._binary_override = binary_override
 
     @classmethod
     def discover(cls) -> ProviderStatus:
-        """Locate the ``codex`` binary and probe version + login state.
-
-        The login-state probe runs ``codex login status``; if the
-        Codex CLI version installed lacks that subcommand the call
-        returns non-zero and we degrade to ``logged_in=False`` rather
-        than raising. This matches Claude Code's ``installMethod``
-        probe contract.
-        """
         binary_path = find_binary(cls.binary_name)
         if binary_path is None:
-            logger.info("CodexProvider.discover: codex binary not found")
             return ProviderStatus(
                 name=cls.name,
                 available=False,
@@ -347,12 +383,6 @@ class CodexProvider:
             if completed.returncode == 0:
                 version = (completed.stdout or completed.stderr or "").strip() or None
                 available = True
-            else:
-                logger.warning(
-                    "CodexProvider.discover: --version exited %d: %s",
-                    completed.returncode,
-                    (completed.stderr or "").strip(),
-                )
         except (subprocess.TimeoutExpired, OSError) as exc:
             logger.warning("CodexProvider.discover: --version probe failed: %s", exc)
 
@@ -370,13 +400,6 @@ class CodexProvider:
             except (subprocess.TimeoutExpired, OSError) as exc:
                 logger.debug("CodexProvider.discover: login probe failed: %s", exc)
 
-        logger.info(
-            "CodexProvider.discover: available=%s version=%s logged_in=%s path=%s",
-            available,
-            version,
-            logged_in,
-            binary_path,
-        )
         return ProviderStatus(
             name=cls.name,
             available=available,
@@ -397,19 +420,6 @@ class CodexProvider:
         permission_mode: PermissionMode,
         model: str | None = None,
     ) -> AgentSession:
-        """Spawn a ``codex`` subprocess and return a live session handle.
-
-        See :meth:`AgentProvider.start_session` for parameter semantics.
-
-        Raises
-        ------
-        AgentNotInstalledError
-            If no binary override is set and ``find_binary`` returns
-            ``None``.
-        AgentLaunchError
-            If :func:`asyncio.create_subprocess_exec` itself raises.
-        """
-        argv0: list[str]
         if self._binary_override is not None:
             argv0 = [sys.executable, str(self._binary_override)]
         else:
@@ -421,61 +431,20 @@ class CodexProvider:
         with tempfile.NamedTemporaryFile(mode="w", suffix=".md", encoding="utf-8", delete=False) as prompt_handle:
             prompt_handle.write(system_prompt)
             prompt_path = Path(prompt_handle.name)
-
         with tempfile.NamedTemporaryFile(mode="w", suffix=".json", encoding="utf-8", delete=False) as mcp_handle:
             json.dump(mcp_config, mcp_handle)
             mcp_path = Path(mcp_handle.name)
 
-        temp_files = [prompt_path, mcp_path]
-
-        argv = [
-            *argv0,
-            "--output-format",
-            "stream-json",
-            "--append-system-prompt",
-            f"@{prompt_path}",
-            "--mcp-config",
-            f"@{mcp_path}",
-        ]
-        if resume_session_id is not None:
-            argv += ["--resume", resume_session_id]
-        if model is not None:
-            argv += ["--model", model]
-
-        env = os.environ.copy()
-        env["SCIEASY_PERMISSION_MODE"] = permission_mode.value
-        # Mirrors ClaudeCodeProvider env injection (issue #723): hook bridge
-        # subprocesses need SCIEASY_CHAT_ID and SCIEASY_PROJECT_DIR to route
-        # permission requests back to /api/ai/permission-check.
-        env["SCIEASY_CHAT_ID"] = chat_id
-        env["SCIEASY_PROJECT_DIR"] = str(project_dir)
-
-        creationflags = 0
-        if sys.platform == "win32":
-            creationflags = subprocess.CREATE_NEW_PROCESS_GROUP
-
-        logger.info(
-            "CodexProvider.start_session: spawning argv=%r cwd=%s",
-            argv,
-            project_dir,
-        )
-        try:
-            proc = await _spawn(
-                argv=argv,
-                cwd=project_dir,
-                env=env,
-                creationflags=creationflags,
-            )
-        except OSError as exc:
-            for path in temp_files:
-                with contextlib.suppress(OSError):
-                    path.unlink(missing_ok=True)
-            raise AgentLaunchError(f"failed to spawn codex subprocess: {exc}") from exc
-
         return CodexSession(
-            proc=proc,
-            temp_files=temp_files,
+            argv0=argv0,
             project_dir=project_dir,
+            chat_id=chat_id,
+            system_prompt=system_prompt,
+            mcp_config=mcp_config,
+            permission_mode=permission_mode,
+            model=model,
+            resume_session_id=resume_session_id,
+            temp_files=[prompt_path, mcp_path],
         )
 
 
@@ -486,7 +455,6 @@ async def _spawn(
     env: dict[str, str],
     creationflags: int,
 ) -> asyncio.subprocess.Process:
-    """Thin wrapper around :func:`asyncio.create_subprocess_exec` for testability."""
     kwargs: dict[str, Any] = dict(
         stdin=asyncio.subprocess.PIPE,
         stdout=asyncio.subprocess.PIPE,
@@ -501,7 +469,4 @@ async def _spawn(
     return await asyncio.create_subprocess_exec(*argv, **kwargs)
 
 
-# Type-level conformance check: assigning the class to an
-# ``AgentProvider``-typed name catches Protocol drift at mypy time
-# without requiring runtime ``isinstance`` machinery.
 _PROTOCOL_CONFORMANCE: type[AgentProvider] = CodexProvider

--- a/src/scieasy/api/routes/ai.py
+++ b/src/scieasy/api/routes/ai.py
@@ -295,7 +295,9 @@ async def chat_ws(
                             manager=manager,
                             project_dir=project_path,
                             chat_id=chat_id,
-                            permission_mode_str=permission_mode,
+                            provider_name=msg.provider,
+                            permission_mode_str=msg.permission_mode or permission_mode,
+                            model=msg.model,
                         )
                     except Exception as exc:
                         logger.error("chat_ws: start_session failed: %s", exc)
@@ -366,9 +368,11 @@ async def _start_default_session(
     manager: Any,
     project_dir: Path,
     chat_id: str,
+    provider_name: str | None = None,
     permission_mode_str: str = "strict",
+    model: str | None = None,
 ) -> Any:
-    """Spawn a Claude Code session with the real SciEasy system prompt + MCP config.
+    """Spawn the selected agent provider with the real SciEasy prompt + MCP config.
 
     Issue #775: replaced Phase 1 placeholders with calls to the real
     composers — without these the spawned agent has no idea what
@@ -380,10 +384,24 @@ async def _start_default_session(
     frontend selection, which made STRICT mode unreachable.
     """
     from scieasy.ai.agent.claude_code import ClaudeCodeProvider
+    from scieasy.ai.agent.codex import CodexProvider
     from scieasy.ai.agent.provider import PermissionMode
     from scieasy.ai.agent.system_prompt import compose_system_prompt
 
-    provider = ClaudeCodeProvider()
+    selected_provider = provider_name or ClaudeCodeProvider.name
+    provider_map = {
+        ClaudeCodeProvider.name: ClaudeCodeProvider,
+        CodexProvider.name: CodexProvider,
+    }
+    provider_cls = provider_map.get(selected_provider)
+    if provider_cls is None:
+        raise ValueError(f"unknown agent provider: {selected_provider!r}")
+    provider = provider_cls()
+
+    try:
+        selected_permission_mode = PermissionMode(permission_mode_str)
+    except ValueError as exc:
+        raise ValueError(f"unknown permission mode: {permission_mode_str!r}") from exc
     # Re-run the trusted-root sanitiser so CodeQL's taint flow stops
     # at this function boundary even though the WS route already
     # validated the same value. ``os.path.realpath`` +
@@ -406,15 +424,14 @@ async def _start_default_session(
             }
         }
     }
-    # Map the wire-format string to the enum value.
-    permission_mode = PermissionMode.BYPASS if permission_mode_str == "bypass" else PermissionMode.STRICT
     return await manager.start_session(
         project_dir=project_dir,
         chat_id=chat_id,
         provider=provider,
         system_prompt=system_prompt,
         mcp_config=mcp_config,
-        permission_mode=permission_mode,
+        permission_mode=selected_permission_mode,
+        model=model,
     )
 
 

--- a/src/scieasy/api/schemas.py
+++ b/src/scieasy/api/schemas.py
@@ -286,6 +286,9 @@ class ChatClientMessage(BaseModel):
     content: str | None = None
     request_id: str | None = None
     decision: str | None = None
+    provider: str | None = None
+    permission_mode: str | None = None
+    model: str | None = None
 
 
 class AgentEventEnvelope(BaseModel):

--- a/tests/ai/test_codex_provider.py
+++ b/tests/ai/test_codex_provider.py
@@ -33,6 +33,7 @@ from scieasy.ai.agent.provider import (
     AgentProvider,
     AssistantTextDeltaEvent,
     DoneEvent,
+    ErrorEvent,
     InitEvent,
     PermissionMode,
     ToolResultEvent,
@@ -46,6 +47,15 @@ STUB_PATH = Path(__file__).resolve().parent.parent / "fixtures" / "stub_codex.py
 def project_dir(tmp_path: Path) -> Path:
     """Disposable project dir under pytest's tmp_path."""
     return tmp_path
+
+
+async def _collect_until_terminal(session: CodexSession) -> list[Any]:
+    events: list[Any] = []
+    async for event in session.stream_events():
+        events.append(event)
+        if isinstance(event, (DoneEvent, ErrorEvent)):
+            break
+    return events
 
 
 # ---------------------------------------------------------------------------
@@ -171,7 +181,7 @@ async def test_start_session_spawns_and_returns_session(project_dir: Path) -> No
     )
     try:
         assert isinstance(session, CodexSession)
-        assert session.pid > 0
+        assert session.pid == 0
         # Temp files were written.
         assert len(session.temp_files) == 2
         for path in session.temp_files:
@@ -213,13 +223,13 @@ async def test_session_stream_events_yields_canonical_taxonomy(project_dir: Path
     )
     try:
         await session.send_user_message("list files")
-        events = [event async for event in session.stream_events()]
+        events = await _collect_until_terminal(session)
     finally:
         await session.close()
 
     assert events, "stream produced no events"
     assert isinstance(events[0], InitEvent)
-    assert events[0].session_id.startswith("stub-codex-session-")
+    assert events[0].session_id.startswith("stub-codex-thread-")
     assert isinstance(events[-1], DoneEvent)
     # The canonical event taxonomy must be present.
     assert any(isinstance(e, AssistantTextDeltaEvent) for e in events)
@@ -227,7 +237,7 @@ async def test_session_stream_events_yields_canonical_taxonomy(project_dir: Path
     assert any(isinstance(e, ToolResultEvent) for e in events)
     # session_id was latched on the InitEvent.
     assert session.session_id is not None
-    assert session.session_id.startswith("stub-codex-session-")
+    assert session.session_id.startswith("stub-codex-thread-")
 
 
 @pytest.mark.asyncio
@@ -243,8 +253,11 @@ async def test_session_resume_echoes_session_id(project_dir: Path) -> None:
         permission_mode=PermissionMode.STRICT,
     )
     try:
+        argv = session._build_turn_argv()  # noqa: SLF001 - assert real CLI flag ordering.
+        assert argv.index("-C") < argv.index("resume")
+        assert argv.index("--sandbox") < argv.index("resume")
         await session.send_user_message("continue")
-        events = [event async for event in session.stream_events()]
+        events = await _collect_until_terminal(session)
     finally:
         await session.close()
     init_events = [e for e in events if isinstance(e, InitEvent)]
@@ -263,7 +276,7 @@ async def test_session_send_user_message_after_close_raises(project_dir: Path) -
         permission_mode=PermissionMode.STRICT,
     )
     await session.send_user_message("hi")
-    _ = [event async for event in session.stream_events()]
+    _ = await _collect_until_terminal(session)
     await session.close()
     with pytest.raises(AgentLaunchError):
         await session.send_user_message("after close")
@@ -316,15 +329,6 @@ async def test_session_close_timeout_uses_kill_process_tree(project_dir: Path, m
         permission_mode=PermissionMode.STRICT,
     )
 
-    wait_calls = {"n": 0}
-
-    async def _stubbed_wait() -> int:
-        wait_calls["n"] += 1
-        if wait_calls["n"] == 1:
-            await asyncio.sleep(3600)
-        return 0
-
-    monkeypatch.setattr(session._proc, "wait", _stubbed_wait)
     monkeypatch.setattr("scieasy.ai.agent.codex._CLOSE_GRACE_SECONDS", 0.1)
 
     calls: list[str] = []
@@ -333,7 +337,16 @@ async def test_session_close_timeout_uses_kill_process_tree(project_dir: Path, m
         calls.append(caller)
 
     monkeypatch.setattr(session, "_kill_process_tree", _spy_kill_tree)
-    monkeypatch.setattr(type(session._proc), "returncode", property(lambda self: None))
+
+    class _FakeProc:
+        pid = 1234
+        returncode = None
+
+        async def wait(self) -> int:
+            await asyncio.sleep(3600)
+            return 0
+
+    session._active_proc = _FakeProc()  # type: ignore[assignment]
 
     await session.close()
     assert calls == ["close"], f"close() should call _kill_process_tree(caller='close') exactly once, got {calls}"
@@ -351,6 +364,7 @@ async def test_session_cancel_kills_subprocess(project_dir: Path) -> None:
         permission_mode=PermissionMode.STRICT,
     )
     try:
+        await session.send_user_message("cancel me")
         await session.cancel()
         # Cancel is idempotent.
         await session.cancel()
@@ -399,7 +413,7 @@ def test_spawn_uses_windows_creation_flags(monkeypatch: pytest.MonkeyPatch) -> N
 
 @pytest.mark.asyncio
 async def test_session_stream_events_handles_stub_crash(project_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """When the stub crashes via STUB_CODEX_CRASH=1 the stream terminates cleanly."""
+    """When the stub crashes via STUB_CODEX_CRASH=1 an error event is surfaced."""
     monkeypatch.setenv("STUB_CODEX_CRASH", "1")
     provider = CodexProvider(binary_override=STUB_PATH)
     session = await provider.start_session(
@@ -411,8 +425,9 @@ async def test_session_stream_events_handles_stub_crash(project_dir: Path, monke
         permission_mode=PermissionMode.STRICT,
     )
     try:
-        events = [event async for event in session.stream_events()]
-        assert events == []
+        await session.send_user_message("boom")
+        events = await _collect_until_terminal(session)
+        assert isinstance(events[-1], ErrorEvent)
     finally:
         await session.close()
 
@@ -438,12 +453,25 @@ async def test_start_session_injects_chat_id_into_subprocess_env(
         captured["env"] = env
         captured["argv"] = argv
 
+        class _FakeStdin:
+            def write(self, _data: bytes) -> None:
+                return None
+
+            async def drain(self) -> None:
+                return None
+
+            def close(self) -> None:
+                return None
+
+            async def wait_closed(self) -> None:
+                return None
+
         class _FakeProc:
             pid = 4242
-            returncode = None
-            stdin = None
-            stdout = None
-            stderr = None
+            returncode = 0
+            stdin = _FakeStdin()
+            stdout = asyncio.StreamReader()
+            stderr = asyncio.StreamReader()
 
             async def wait(self) -> int:
                 return 0
@@ -461,6 +489,7 @@ async def test_start_session_injects_chat_id_into_subprocess_env(
         resume_session_id=None,
         permission_mode=PermissionMode.STRICT,
     )
+    await session.send_user_message("env")
     for path in session.temp_files:
         path.unlink(missing_ok=True)
 

--- a/tests/api/test_ai_chat_route.py
+++ b/tests/api/test_ai_chat_route.py
@@ -103,6 +103,44 @@ def test_status_endpoint_reports_missing_binary(app: Any, monkeypatch: pytest.Mo
         assert body["providers"][0]["install_hint"] == "install claude"
 
 
+@pytest.mark.asyncio
+async def test_start_default_session_uses_requested_provider_and_permission(tmp_path: Path) -> None:
+    captured: dict[str, Any] = {}
+
+    class _FakeManager:
+        async def start_session(self, **kwargs: Any) -> object:
+            captured.update(kwargs)
+            return object()
+
+    await ai_routes._start_default_session(
+        manager=_FakeManager(),
+        project_dir=tmp_path,
+        chat_id="chat-codex",
+        provider_name="codex",
+        permission_mode_str="strict",
+        model="gpt-test",
+    )
+
+    assert captured["provider"].name == "codex"
+    assert captured["permission_mode"] is PermissionMode.STRICT
+    assert captured["model"] == "gpt-test"
+
+
+@pytest.mark.asyncio
+async def test_start_default_session_rejects_unknown_provider(tmp_path: Path) -> None:
+    class _FakeManager:
+        async def start_session(self, **kwargs: Any) -> object:
+            return object()
+
+    with pytest.raises(ValueError, match="unknown agent provider"):
+        await ai_routes._start_default_session(
+            manager=_FakeManager(),
+            project_dir=tmp_path,
+            chat_id="chat-bad",
+            provider_name="not-a-provider",
+        )
+
+
 # ---------------------------------------------------------------------------
 # WS /api/ai/chat/{chat_id}
 # ---------------------------------------------------------------------------
@@ -122,6 +160,8 @@ def _patch_start_default_session(monkeypatch: pytest.MonkeyPatch) -> None:
         project_dir: Path,
         chat_id: str,
         permission_mode_str: str = "strict",
+        provider_name: str | None = None,
+        model: str | None = None,
     ) -> Any:
         # Issue #791: honour the wire-level permission_mode_str so STRICT
         # vs BYPASS routing is exercised end-to-end in WS tests.

--- a/tests/api/test_ai_chat_ws_v2.py
+++ b/tests/api/test_ai_chat_ws_v2.py
@@ -69,6 +69,8 @@ def _patch_start(monkeypatch: pytest.MonkeyPatch) -> None:
         project_dir: Path,
         chat_id: str,
         permission_mode_str: str = "strict",
+        provider_name: str | None = None,
+        model: str | None = None,
     ) -> Any:
         # Issue #791: route now passes permission_mode_str through.
         mode = PermissionMode.BYPASS if permission_mode_str == "bypass" else PermissionMode.STRICT

--- a/tests/fixtures/stub_codex.py
+++ b/tests/fixtures/stub_codex.py
@@ -1,43 +1,18 @@
-"""Stand-in for the real ``codex`` CLI used by T-ECA-402 tests.
+"""Stand-in for the real ``codex`` CLI used by provider tests.
 
-Invoked by :class:`scieasy.ai.agent.codex.CodexProvider` when its
-``binary_override`` argument points at this file. The provider spawns
-``[sys.executable, str(stub_codex.py), ...]`` so we read the same argv
-pattern as the real CLI:
+The stub mirrors the observed Codex non-interactive shape:
 
 ```
-stub_codex.py --output-format stream-json \
-    --append-system-prompt @<prompt> --mcp-config @<mcp> \
-    [--resume <id>] [--model <m>]
+codex exec --json ... -
+codex exec --json ... resume <thread_id> -
 ```
 
-Behaviour:
-
-* Reads one JSON envelope from stdin (the user message). If stdin
-  closes without sending a message, we still emit the canned stream so
-  spawn-only tests work.
-* Emits a Codex-flavoured event stream that — once normalised by
-  :mod:`scieasy.ai.agent.stream_json` — produces the exact same
-  canonical event taxonomy as the Claude Code stub: ``init``,
-  ``assistant_text_delta`` (3x), ``tool_use``, ``tool_result``,
-  ``done``.
-* Each event line is followed by a 50 ms sleep to simulate real
-  streaming.
-* Exit code 0 on normal flow; exit code 2 if the
-  ``STUB_CODEX_CRASH=1`` environment variable is set (used by the
-  crash test).
-
-The stub uses the wire-format ``type`` field rather than ``kind`` to
-exercise the parser's fallback path (the parser accepts both — see
-:func:`scieasy.ai.agent.stream_json._extract_kind`). This is the only
-intentional difference from ``stub_claude.py`` and is the value of
-having two stubs: it gives us a regression check that the canonical
-event taxonomy is provider-neutral.
+It emits Codex-style JSONL frames that ``CodexSession`` normalises into
+SciEasy's canonical event taxonomy.
 """
 
 from __future__ import annotations
 
-import argparse
 import contextlib
 import json
 import os
@@ -48,31 +23,20 @@ import time
 import uuid
 from typing import Any
 
-# Wall-clock budget for reading one line from stdin before we give up
-# and proceed to emit the canned stream. Windows asyncio Proactor pipes
-# do not propagate EOF synchronously when the parent calls
-# StreamWriter.close(), so sys.stdin.readline() can block indefinitely.
-# The reader thread is a daemon, so any never-returned read is reaped
-# on process exit.
+
 _STDIN_READ_TIMEOUT_SECONDS = 1.0
 
 
-def _try_read_one_line(timeout: float) -> str:
-    """Read one line from stdin with a wall-clock timeout.
-
-    Returns the line on success, or an empty string on timeout / EOF /
-    read error. Avoids blocking forever on Windows pipes that never
-    deliver EOF.
-    """
+def _try_read_stdin(timeout: float) -> str:
     q: _queue.Queue[str] = _queue.Queue(maxsize=1)
 
     def _reader() -> None:
         try:
-            line = sys.stdin.readline()
+            text = sys.stdin.read()
         except (BrokenPipeError, OSError, ValueError):
-            line = ""
+            text = ""
         with contextlib.suppress(_queue.Full):
-            q.put_nowait(line)
+            q.put_nowait(text)
 
     threading.Thread(target=_reader, daemon=True).start()
     try:
@@ -81,65 +45,65 @@ def _try_read_one_line(timeout: float) -> str:
         return ""
 
 
-def _parse_args(argv: list[str]) -> argparse.Namespace:
-    parser = argparse.ArgumentParser(allow_abbrev=False)
-    parser.add_argument("--output-format", default=None)
-    parser.add_argument("--append-system-prompt", default=None)
-    parser.add_argument("--mcp-config", default=None)
-    parser.add_argument("--resume", default=None)
-    parser.add_argument("--model", default=None)
-    return parser.parse_args(argv)
-
-
 def _emit(event: dict[str, Any]) -> None:
     sys.stdout.write(json.dumps(event) + "\n")
     sys.stdout.flush()
-    time.sleep(0.05)
+    time.sleep(0.02)
 
 
-def _emit_canned_stream(*, session_id: str) -> None:
-    # Use ``type`` rather than ``kind`` to exercise the parser's
-    # wire-format fallback. The downstream canonical event taxonomy is
-    # identical to the Claude Code stub's.
-    _emit({"type": "init", "session_id": session_id, "model": "stub-codex-model"})
-    for delta in ("Reading ", "the SciEasy ", "project."):
-        _emit({"type": "assistant_text_delta", "delta": delta})
+def _session_id_from_args(argv: list[str]) -> str:
+    if argv and argv[0] == "exec" and "resume" in argv:
+        resume_index = argv.index("resume")
+        # The real provider passes exec-level options before "resume",
+        # then the id immediately after it.
+        for value in argv[resume_index + 1 :]:
+            if not value.startswith("-"):
+                return value
+    return f"stub-codex-thread-{uuid.uuid4()}"
+
+
+def _emit_stream(session_id: str) -> None:
+    _emit({"type": "thread.started", "thread_id": session_id})
+    _emit({"type": "turn.started"})
+    _emit({"type": "item.completed", "item": {"id": "item_0", "type": "agent_message", "text": "Reading the SciEasy project."}})
     _emit(
         {
-            "type": "tool_use",
-            "tool_name": "Read",
-            "tool_input": {"path": "."},
-            "tool_use_id": "stub-codex-tool-1",
+            "type": "item.completed",
+            "item": {
+                "id": "item_1",
+                "type": "function_call",
+                "name": "Read",
+                "arguments": {"path": "."},
+                "call_id": "stub-codex-tool-1",
+            },
         }
     )
     _emit(
         {
-            "type": "tool_result",
-            "tool_use_id": "stub-codex-tool-1",
-            "output": "stub-codex: listed directory\n",
-            "is_error": False,
+            "type": "item.completed",
+            "item": {
+                "id": "item_2",
+                "type": "function_call_output",
+                "call_id": "stub-codex-tool-1",
+                "output": "stub-codex: listed directory\n",
+            },
         }
     )
-    _emit({"type": "done"})
+    _emit({"type": "turn.completed", "usage": {"input_tokens": 1, "output_tokens": 1}})
 
 
 def main(argv: list[str] | None = None) -> int:
-    args = _parse_args(argv if argv is not None else sys.argv[1:])
-
+    args = argv if argv is not None else sys.argv[1:]
     if os.environ.get("STUB_CODEX_CRASH") == "1":
         sys.stderr.write("stub_codex: simulated crash\n")
         return 2
+    if not args or args[0] != "exec":
+        sys.stderr.write("stub_codex: expected exec command\n")
+        return 2
 
-    session_id = args.resume or f"stub-codex-session-{uuid.uuid4()}"
-
-    # Try to read one user message; tolerate stdin EOF / blocked pipe
-    # for spawn-only tests. Bounded wait keeps Windows tests from
-    # hanging when the parent's StreamWriter.close() does not deliver
-    # EOF synchronously.
-    line = _try_read_one_line(timeout=_STDIN_READ_TIMEOUT_SECONDS)
-    _ = line  # touch so static analysers don't flag as unused
-
-    _emit_canned_stream(session_id=session_id)
+    session_id = _session_id_from_args(args)
+    _ = _try_read_stdin(_STDIN_READ_TIMEOUT_SECONDS)
+    _emit_stream(session_id)
     return 0
 
 


### PR DESCRIPTION
## Summary
- Wire the AI chat frontend/backend path so selected provider, permission mode, and model can reach session startup.
- Rework `CodexProvider` around the real Codex CLI per-turn model (`codex exec --json ... -` and `codex exec --json ... resume <thread_id> -`).
- Normalize Codex JSONL frames into SciEasy canonical agent events and inject SciEasy MCP configuration through Codex `-c` overrides.
- Update Codex docs, gap plan, stub fixture, and regression tests.

## Testing
- `$env:PYTHONPATH='C:\Users\jiazh\.codex\worktrees\54e8\SciEasy\src'; pytest tests/ai/test_codex_provider.py tests/api/test_ai_chat_route.py tests/api/test_ai_chat_ws_v2.py -q --no-cov`
- `npm test -- --run src/components/AIChat/__tests__/useAgentWebSocket.test.ts`

Note: backend tests pass with existing Windows Proactor transport warnings in a few WebSocket tests.