### PR TITLE
fix(adr-034): codex shows not-installed on Windows (PATHEXT fallback)

### DIFF
--- a/src/scieasy/api/routes/ai.py
+++ b/src/scieasy/api/routes/ai.py
@@ -84,27 +84,51 @@ def _probe_codex() -> dict[str, Any]:
 def _binary_status(name: str) -> tuple[bool, str | None]:
     """Return ``(available, version_string_or_None)`` for ``name``.
 
-    Available iff ``shutil.which`` finds the binary AND ``<name> --version``
-    completes within 2 s with non-empty stdout.  Version is the trimmed
-    stdout.
+    Available iff some resolution of ``name`` runs ``--version`` within
+    2 s with non-empty stdout.  Version is the trimmed stdout.
+
+    Windows wrinkle (regression in #820): ``shutil.which("codex")``
+    returns the *no-extension* npm wrapper script that ships next to
+    ``codex.cmd``.  Running the no-extension file with
+    ``subprocess.run`` raises ``WinError 193 ("%1 is not a valid Win32
+    application")`` because Windows can't exec a bare bash script.
+    We retry through ``PATHEXT`` so on Windows we end up finding the
+    ``.cmd`` wrapper that actually works.  POSIX unaffected — the
+    fallback list is empty there.
     """
-    binary = shutil.which(name)
-    if not binary:
+    candidates: list[str] = []
+    primary = shutil.which(name)
+    if primary:
+        candidates.append(primary)
+    if sys.platform == "win32":
+        # Try each PATHEXT-style suffix that's executable on Windows.
+        # ``shutil.which`` is already aware of PATHEXT but only returns
+        # the first match — when the bare name (no extension) wins, we
+        # need to fall back manually.
+        for suffix in (".cmd", ".bat", ".exe", ".com"):
+            resolved = shutil.which(name + suffix)
+            if resolved and resolved not in candidates:
+                candidates.append(resolved)
+    if not candidates:
         return False, None
-    try:
-        result = subprocess.run(
-            [binary, "--version"],
-            capture_output=True,
-            text=True,
-            timeout=2,
-            check=False,
-        )
-    except (subprocess.TimeoutExpired, OSError):
-        return False, None
-    version = (result.stdout or result.stderr or "").strip()
-    if not version:
-        return False, None
-    return True, version
+
+    for binary in candidates:
+        try:
+            result = subprocess.run(
+                [binary, "--version"],
+                capture_output=True,
+                text=True,
+                timeout=2,
+                check=False,
+            )
+        except (subprocess.TimeoutExpired, OSError):
+            # OSError happens on Windows when ``binary`` is a Unix-style
+            # script (no .exe/.cmd) — fall through to the next candidate.
+            continue
+        version = (result.stdout or result.stderr or "").strip()
+        if version:
+            return True, version
+    return False, None
 
 
 def _claude_logged_in() -> bool:

--- a/tests/api/test_provider_discovery.py
+++ b/tests/api/test_provider_discovery.py
@@ -67,6 +67,42 @@ def test_status_version_timeout(client: TestClient, monkeypatch: pytest.MonkeyPa
         assert entry["version"] is None
 
 
+def test_status_windows_pathext_fallback(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Regression: ``shutil.which("codex")`` on Windows can return the bare
+    npm wrapper (no .exe/.cmd) which raises ``WinError 193`` when run.
+    The probe must fall back through PATHEXT-style suffixes so the
+    ``.cmd`` wrapper is found instead. Without this, codex installed via
+    ``npm i -g`` shows up as ``available=False`` even though it works
+    perfectly in a shell.
+    """
+    monkeypatch.setattr(ai_routes.sys, "platform", "win32")
+
+    def fake_which(name: str) -> str | None:
+        # First call (no ext) returns the bash wrapper; .cmd variant
+        # returns the executable wrapper; everything else is missing.
+        if name in ("claude", "codex"):
+            return f"C:/fake/npm/{name}"
+        if name in ("claude.cmd", "codex.cmd"):
+            return f"C:/fake/npm/{name}"
+        return None
+
+    def fake_run(argv: list[str], **_: object) -> subprocess.CompletedProcess[str]:
+        # The bare wrapper raises just like Windows does for a Unix script;
+        # the .cmd variant succeeds and prints a version.
+        if argv[0].endswith(".cmd"):
+            return subprocess.CompletedProcess(argv, 0, stdout="codex-cli 0.130.0\n", stderr="")
+        raise OSError("[WinError 193] %1 is not a valid Win32 application")
+
+    monkeypatch.setattr(ai_routes.shutil, "which", fake_which)
+    monkeypatch.setattr(ai_routes.subprocess, "run", fake_run)
+
+    res = client.get("/api/ai/status")
+    body = res.json()
+    codex = next(p for p in body["providers"] if p["name"] == "codex")
+    assert codex["available"] is True, body
+    assert codex["version"] == "codex-cli 0.130.0"
+
+
 def test_status_claude_logged_in_via_credentials_file(
     client: TestClient,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Symptom

GUI shows ``codex: not installed`` even though ``codex --version`` works fine in the shell. SciEasy backend's ``/api/ai/status`` returns ``{available: false, version: null}`` for codex while claude-code reports correctly.

Regression introduced in PR #820 (ADR-034 Phase 1.2 backend).

## Root cause

``npm i -g codex`` installs **two** wrapper files into ``%APPDATA%/npm``:
- ``codex`` (Unix-style bash wrapper, no extension)
- ``codex.cmd`` (Windows-executable wrapper)

``shutil.which(""codex"")`` returns the FIRST match, which is the bare bash file. ``subprocess.run([""C:/.../codex"", ""--version""])`` raises ``OSError [WinError 193] %1 is not a valid Win32 application`` because Windows can't exec a script without an interpreter. The except clause swallows the OSError → returns ``(False, None)``.

## Fix

On Windows only, fall back through ``PATHEXT`` suffixes (``.cmd``, ``.bat``, ``.exe``, ``.com``) when the initial probe raises ``OSError``. First candidate that produces non-empty ``--version`` output wins. POSIX path unaffected — the fallback list is only populated when ``sys.platform == ""win32""``.

## Verified live

Before:
``{""name"":""codex"",""available"":false,""version"":null,""logged_in"":true}``

After:
``{""name"":""codex"",""available"":true,""version"":""codex-cli 0.130.0"",""logged_in"":true}``

## Tests

New ``test_status_windows_pathext_fallback`` in ``tests/api/test_provider_discovery.py`` simulates the Windows shape and asserts the probe recovers. 7/7 pass.

## Refs

- ADR-034
- Regression introduced in PR #820

🤖 Generated with [Claude Code](https://claude.com/claude-code)