### PR TITLE
fix(adr-036): F36-skeleton — address 3 Codex P1 (route ordering + lockfile)

### DIFF
--- a/docs/planning/adr-035-036-checklist.md
+++ b/docs/planning/adr-035-036-checklist.md
@@ -104,7 +104,7 @@
 
 ### Audit & Fix (skeleton)
 - [ ] Audit-skeleton report posted on umbrella issue (Owner: A36-skeleton)
-- [ ] All P1 findings fixed (or explicitly justified deferral) (Owner: F36-skeleton, conditional)
+- [x] All P1 findings fixed (or explicitly justified deferral) (Owner: F36-skeleton, conditional) → fix PR (against `feat/issue-848/skeleton`)
 
 ### Audit & Fix (implementation)
 - [ ] Audit-implementation report posted on umbrella issue, includes Chrome smoke results (Owner: A36-impl)

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "scieasy-frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@monaco-editor/react": "^4.6.0",
         "@radix-ui/react-dropdown-menu": "^2.1.16",
         "@radix-ui/react-separator": "^1.1.8",
         "@radix-ui/react-slot": "^1.2.4",
@@ -1146,6 +1147,29 @@
       "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-3.0.0.tgz",
       "integrity": "sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==",
       "license": "ISC"
+    },
+    "node_modules/@monaco-editor/loader": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/loader/-/loader-1.7.0.tgz",
+      "integrity": "sha512-gIwR1HrJrrx+vfyOhYmCZ0/JcWqG5kbfG7+d3f/C1LXk2EvzAbHSg3MQ5lO2sMlo9izoAZ04shohfKLVT6crVA==",
+      "license": "MIT",
+      "dependencies": {
+        "state-local": "^1.0.6"
+      }
+    },
+    "node_modules/@monaco-editor/react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/react/-/react-4.7.0.tgz",
+      "integrity": "sha512-cyzXQCtO47ydzxpQtCGSQGOC8Gk3ZUeBXFAxD+CWXYFo5OqZyZUonFl0DwUlTyAfRHntBfw2p3w4s9R6oe1eCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@monaco-editor/loader": "^1.5.0"
+      },
+      "peerDependencies": {
+        "monaco-editor": ">= 0.25.0 < 1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -2777,6 +2801,14 @@
         "@types/geojson": "*"
       }
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
@@ -4282,6 +4314,16 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/dompurify": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
+      "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "peer": true,
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/draw-svg-path": {
       "version": "1.0.0",
@@ -5834,6 +5876,19 @@
       "integrity": "sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==",
       "license": "ISC"
     },
+    "node_modules/marked": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
+      "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/math-log2": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/math-log2/-/math-log2-1.0.1.tgz",
@@ -5912,6 +5967,17 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/monaco-editor": {
+      "version": "0.55.1",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
+      "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "dompurify": "3.2.7",
+        "marked": "14.0.0"
       }
     },
     "node_modules/mouse-change": {
@@ -7201,6 +7267,12 @@
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/state-local": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/state-local/-/state-local-1.0.7.tgz",
+      "integrity": "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==",
       "license": "MIT"
     },
     "node_modules/static-eval": {

--- a/src/scieasy/api/routes/blocks.py
+++ b/src/scieasy/api/routes/blocks.py
@@ -98,6 +98,70 @@ async def list_blocks(registry: BlockRegistryDep) -> BlockListResponse:
     return BlockListResponse(blocks=blocks)
 
 
+# ---------------------------------------------------------------------------
+# ADR-036 §3.12 — block template endpoint (skeleton, returns 501)
+#
+# The "New custom block" toolbar action (see ADR-036 §3.7) needs a starter
+# template that already wires up imports, ports, and a placeholder ``run()``
+# body. Rather than ship the template content in the frontend, we ship it
+# next to the package (``src/scieasy/blocks/_templates/``) and serve it via
+# this endpoint so the template stays in lockstep with whatever
+# ``scieasy.blocks.base`` actually exports.
+#
+# IMPORTANT — route ordering:
+# ``/template`` MUST be declared BEFORE the greedy ``/{block_type}``
+# (and ``/{block_type}/schema``) routes below. FastAPI matches in
+# declaration order; otherwise ``/api/blocks/template`` is swallowed by
+# ``get_block_schema`` with ``block_type="template"`` and never reaches
+# this handler. See ADR-036 audit
+# (docs/audit/2026-05-14-adr-036-skeleton.md, finding P1-2) for details.
+# ---------------------------------------------------------------------------
+
+
+class BlockTemplateResponse(BaseModel):
+    """Skeleton — response shape for GET /api/blocks/template (per ADR-036 §3.12)."""
+
+    kind: str
+    content: str
+    suggested_filename: str
+
+
+@router.get("/template", response_model=BlockTemplateResponse)
+async def get_block_template(kind: str = "basic") -> BlockTemplateResponse:
+    """Serve a block-scaffolding template. (ADR-036 §3.12 — SKELETON)
+
+    Implementation plan (per ADR-036 §3.12):
+      1. Validate ``kind`` against a known set (initially just ``"basic"``).
+         Unknown kind -> HTTP 400.
+      2. Resolve the template file inside the package via
+         ``importlib.resources.files("scieasy.blocks._templates") /
+         "block_base_template.py"``.
+      3. Read with ``encoding="utf-8"`` and return content + suggested
+         filename (default ``"my_block.py"``).
+      4. The frontend pipes ``content`` to PUT /api/projects/{id}/file with
+         path ``"blocks/<user-supplied-name>.py"``, then opens an editor
+         tab on the new file. None of that orchestration belongs here —
+         this endpoint is content-only.
+
+    Edge cases:
+      - kind not in known set -> HTTP 400.
+      - Template file missing from package (deployment bug) -> HTTP 500
+        with a clear "template asset missing" message.
+
+    Test plan (must be added by I36c):
+      - test_template_basic_returns_python_with_correct_imports: response
+        content contains the literal string
+        ``"from scieasy.blocks.base import Block, BlockSpec, PortSpec"``.
+      - test_template_basic_has_run_marker: response content contains
+        ``"# >>> EDIT THIS <<<"``.
+      - test_template_unknown_kind_400.
+
+    References: ADR-036 §3.12; template file at
+    ``src/scieasy/blocks/_templates/block_base_template.py``.
+    """
+    raise NotImplementedError("ADR-036 skeleton — implementation phase I36c fills this in")
+
+
 @router.get("/{block_type}/schema", response_model=BlockSchemaResponse)
 @router.get("/{block_type}", response_model=BlockSchemaResponse, include_in_schema=False)
 async def get_block_schema(
@@ -161,59 +225,3 @@ async def validate_connection_route(
 
     compatible, reason = validate_connection(source_port, target_port)
     return ConnectionValidationResponse(compatible=compatible, reason=reason)
-
-
-# ---------------------------------------------------------------------------
-# ADR-036 §3.12 — block template endpoint (skeleton, returns 501)
-#
-# The "New custom block" toolbar action (see ADR-036 §3.7) needs a starter
-# template that already wires up imports, ports, and a placeholder ``run()``
-# body. Rather than ship the template content in the frontend, we ship it
-# next to the package (``src/scieasy/blocks/_templates/``) and serve it via
-# this endpoint so the template stays in lockstep with whatever
-# ``scieasy.blocks.base`` actually exports.
-# ---------------------------------------------------------------------------
-
-
-class BlockTemplateResponse(BaseModel):
-    """Skeleton — response shape for GET /api/blocks/template (per ADR-036 §3.12)."""
-
-    kind: str
-    content: str
-    suggested_filename: str
-
-
-@router.get("/template", response_model=BlockTemplateResponse)
-async def get_block_template(kind: str = "basic") -> BlockTemplateResponse:
-    """Serve a block-scaffolding template. (ADR-036 §3.12 — SKELETON)
-
-    Implementation plan (per ADR-036 §3.12):
-      1. Validate ``kind`` against a known set (initially just ``"basic"``).
-         Unknown kind -> HTTP 400.
-      2. Resolve the template file inside the package via
-         ``importlib.resources.files("scieasy.blocks._templates") /
-         "block_base_template.py"``.
-      3. Read with ``encoding="utf-8"`` and return content + suggested
-         filename (default ``"my_block.py"``).
-      4. The frontend pipes ``content`` to PUT /api/projects/{id}/file with
-         path ``"blocks/<user-supplied-name>.py"``, then opens an editor
-         tab on the new file. None of that orchestration belongs here —
-         this endpoint is content-only.
-
-    Edge cases:
-      - kind not in known set -> HTTP 400.
-      - Template file missing from package (deployment bug) -> HTTP 500
-        with a clear "template asset missing" message.
-
-    Test plan (must be added by I36c):
-      - test_template_basic_returns_python_with_correct_imports: response
-        content contains the literal string
-        ``"from scieasy.blocks.base import Block, BlockSpec, PortSpec"``.
-      - test_template_basic_has_run_marker: response content contains
-        ``"# >>> EDIT THIS <<<"``.
-      - test_template_unknown_kind_400.
-
-    References: ADR-036 §3.12; template file at
-    ``src/scieasy/blocks/_templates/block_base_template.py``.
-    """
-    raise NotImplementedError("ADR-036 skeleton — implementation phase I36c fills this in")

--- a/src/scieasy/api/routes/projects.py
+++ b/src/scieasy/api/routes/projects.py
@@ -31,72 +31,6 @@ async def list_projects(runtime: RuntimeDep) -> list[ProjectResponse]:
     return [ProjectResponse(**runtime.project_response(project)) for project in runtime.list_projects()]
 
 
-@router.get("/{project_id:path}", response_model=ProjectResponse)
-async def get_project(project_id: str, runtime: RuntimeDep) -> ProjectResponse:
-    """Retrieve and open a project by identifier or filesystem path."""
-    try:
-        project = runtime.open_project(project_id)
-    except FileNotFoundError as exc:
-        raise HTTPException(status_code=404, detail=str(exc)) from exc
-    # ADR-034 Phase 2: refresh the workflow filesystem watcher to point at
-    # the newly active project. ``start_for_project`` is idempotent — if the
-    # caller re-opens the same project it returns immediately without
-    # disturbing the existing observer.
-    _restart_workflow_watcher(project.path)
-    return ProjectResponse(**runtime.project_response(project))
-
-
-def _restart_workflow_watcher(project_path: str) -> None:
-    """Best-effort: point the global watcher at *project_path*'s workflows/.
-
-    Failure to start the observer is logged but does not affect the project
-    open response — the canvas continues to work without auto-refresh and
-    the user sees their workflow YAMLs the next time they reload manually.
-    """
-    import asyncio
-    import logging
-    from pathlib import Path
-
-    from scieasy.api.routes import workflow_watcher as watcher_module
-
-    watcher = watcher_module.get_active_watcher()
-    if watcher is None:
-        return
-    try:
-        loop = asyncio.get_running_loop()
-    except RuntimeError:
-        return
-    try:
-        watcher.start_for_project(Path(project_path), loop)
-    except Exception:
-        logging.getLogger(__name__).warning("workflow_watcher: restart for %s failed", project_path, exc_info=True)
-
-
-@router.put("/{project_id:path}", response_model=ProjectResponse)
-async def update_project(
-    project_id: str,
-    body: ProjectUpdate,
-    runtime: RuntimeDep,
-) -> ProjectResponse:
-    """Update project metadata."""
-    try:
-        project = runtime.update_project(project_id, name=body.name, description=body.description)
-    except FileNotFoundError as exc:
-        raise HTTPException(status_code=404, detail=str(exc)) from exc
-    return ProjectResponse(**runtime.project_response(project))
-
-
-@router.delete("/{project_id:path}", status_code=204)
-async def delete_project(project_id: str, runtime: RuntimeDep) -> None:
-    """Delete a project and its associated resources."""
-    try:
-        runtime.delete_project(project_id)
-    except FileNotFoundError as exc:
-        raise HTTPException(status_code=404, detail=str(exc)) from exc
-    except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
-
-
 # ---------------------------------------------------------------------------
 # ADR-036 §3.2 — File read/write endpoints (skeleton, returns 501)
 #
@@ -105,6 +39,14 @@ async def delete_project(project_id: str, runtime: RuntimeDep) -> None:
 # extension allowlist and a hard size cap. The PUT path coordinates with the
 # workflow filesystem watcher so the user's own save does not echo back as
 # an external-change event.
+#
+# IMPORTANT — route ordering:
+# These ``/{project_id:path}/file`` routes MUST be declared BEFORE the
+# greedy ``/{project_id:path}`` GET/PUT/DELETE handlers below. FastAPI
+# matches routes in declaration order, and ``{project_id:path}`` would
+# otherwise swallow ``/<id>/file`` requests (with ``project_id="<id>/file"``)
+# and never reach these handlers. See ADR-036 audit
+# (docs/audit/2026-05-14-adr-036-skeleton.md, finding P1-1) for details.
 #
 # Implementation phase agents (I36a) replace each ``raise NotImplementedError``
 # below with the real handler. Read the docstring + comment block above each
@@ -249,3 +191,76 @@ async def write_project_file(
     ``runtime.save_workflow``.
     """
     raise NotImplementedError("ADR-036 skeleton — implementation phase I36a fills this in")
+
+
+# ---------------------------------------------------------------------------
+# Greedy ``/{project_id:path}`` handlers — declared AFTER the more specific
+# ``/{project_id:path}/file`` routes above so FastAPI matches the file
+# routes first. See ADR-036 audit P1-1 for why this ordering matters.
+# ---------------------------------------------------------------------------
+
+
+@router.get("/{project_id:path}", response_model=ProjectResponse)
+async def get_project(project_id: str, runtime: RuntimeDep) -> ProjectResponse:
+    """Retrieve and open a project by identifier or filesystem path."""
+    try:
+        project = runtime.open_project(project_id)
+    except FileNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    # ADR-034 Phase 2: refresh the workflow filesystem watcher to point at
+    # the newly active project. ``start_for_project`` is idempotent — if the
+    # caller re-opens the same project it returns immediately without
+    # disturbing the existing observer.
+    _restart_workflow_watcher(project.path)
+    return ProjectResponse(**runtime.project_response(project))
+
+
+def _restart_workflow_watcher(project_path: str) -> None:
+    """Best-effort: point the global watcher at *project_path*'s workflows/.
+
+    Failure to start the observer is logged but does not affect the project
+    open response — the canvas continues to work without auto-refresh and
+    the user sees their workflow YAMLs the next time they reload manually.
+    """
+    import asyncio
+    import logging
+    from pathlib import Path
+
+    from scieasy.api.routes import workflow_watcher as watcher_module
+
+    watcher = watcher_module.get_active_watcher()
+    if watcher is None:
+        return
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        return
+    try:
+        watcher.start_for_project(Path(project_path), loop)
+    except Exception:
+        logging.getLogger(__name__).warning("workflow_watcher: restart for %s failed", project_path, exc_info=True)
+
+
+@router.put("/{project_id:path}", response_model=ProjectResponse)
+async def update_project(
+    project_id: str,
+    body: ProjectUpdate,
+    runtime: RuntimeDep,
+) -> ProjectResponse:
+    """Update project metadata."""
+    try:
+        project = runtime.update_project(project_id, name=body.name, description=body.description)
+    except FileNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    return ProjectResponse(**runtime.project_response(project))
+
+
+@router.delete("/{project_id:path}", status_code=204)
+async def delete_project(project_id: str, runtime: RuntimeDep) -> None:
+    """Delete a project and its associated resources."""
+    try:
+        runtime.delete_project(project_id)
+    except FileNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc

--- a/tests/api/test_blocks_template_skeleton.py
+++ b/tests/api/test_blocks_template_skeleton.py
@@ -36,3 +36,62 @@ def test_template_basic_has_run_marker() -> None:
 def test_template_unknown_kind_400() -> None:
     """GET with kind="frobnicator" returns HTTP 400."""
     raise NotImplementedError
+
+
+# ---------------------------------------------------------------------------
+# Regression tests — ADR-036 audit P1-2.
+#
+# These do not depend on the real ``get_block_template`` implementation.
+# They assert the FastAPI route table registers ``/template`` BEFORE the
+# greedy ``/{block_type}`` so ``GET /api/blocks/template`` actually
+# reaches the template handler instead of being interpreted as
+# ``block_type="template"`` by ``get_block_schema``.
+# ---------------------------------------------------------------------------
+
+
+def test_template_route_registered_before_block_type() -> None:
+    """``/template`` MUST be declared before ``/{block_type}``.
+
+    See ADR-036 audit finding P1-2. Without this, the template endpoint
+    is unreachable (``get_block_schema`` returns 404 with detail
+    ``"Unknown block type: template"``).
+    """
+    from scieasy.api.routes.blocks import router
+
+    paths_in_order = [r.path for r in router.routes]
+    template = paths_in_order.index("/api/blocks/template")
+    block_type = paths_in_order.index("/api/blocks/{block_type}")
+    assert template < block_type, (
+        "ADR-036 P1-2 regression: /template must precede /{block_type} so "
+        f"FastAPI matches it first. Current order: {paths_in_order}"
+    )
+
+
+def test_template_route_resolves_to_template_handler_not_schema() -> None:
+    """A live ``GET /api/blocks/template`` reaches ``get_block_template``.
+
+    Skeleton raises NotImplementedError -> 500. If the catch-all is
+    intercepting, we instead see 404 ("Unknown block type: template").
+    """
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from scieasy.api.deps import get_block_registry, get_type_registry
+    from scieasy.api.routes.blocks import router
+
+    app = FastAPI()
+    app.include_router(router)
+    # Provide stub dependencies; the template endpoint does not consume them
+    # but get_block_schema would, and we do not want dependency-resolution
+    # 500s masking the real signal.
+    app.dependency_overrides[get_block_registry] = lambda: object()
+    app.dependency_overrides[get_type_registry] = lambda: object()
+
+    client = TestClient(app, raise_server_exceptions=False)
+    response = client.get("/api/blocks/template?kind=basic")
+    assert response.status_code == 500, (
+        f"Expected 500 from skeleton NotImplementedError in get_block_template, got "
+        f"{response.status_code}: {response.text!r}. If this is 404 with detail "
+        "'Unknown block type: template', the /{block_type} catch-all is "
+        "intercepting — P1-2 regression."
+    )

--- a/tests/api/test_file_endpoints_skeleton.py
+++ b/tests/api/test_file_endpoints_skeleton.py
@@ -105,3 +105,67 @@ def test_write_file_403_traversal() -> None:
 def test_write_file_415_extension() -> None:
     """PUT to a .exe path returns 415."""
     raise NotImplementedError
+
+
+# ---------------------------------------------------------------------------
+# Regression tests — ADR-036 audit P1-1.
+#
+# These DO NOT depend on a real implementation. They assert the FastAPI
+# route table registers ``/{project_id:path}/file`` BEFORE the greedy
+# ``/{project_id:path}`` catch-all so that ``GET /api/projects/<id>/file``
+# resolves to the file handler, not the project handler. They must remain
+# passing through the implementation phase.
+# ---------------------------------------------------------------------------
+
+
+def test_file_route_registered_before_catch_all() -> None:
+    """``/{project_id:path}/file`` MUST appear before ``/{project_id:path}``.
+
+    FastAPI matches routes in declaration order. If this test fails,
+    requests to GET/PUT ``/api/projects/<id>/file`` are silently swallowed
+    by ``get_project`` / ``update_project`` with ``project_id="<id>/file"``
+    and the editor file endpoints become unreachable. See ADR-036 audit
+    finding P1-1.
+    """
+    from scieasy.api.routes.projects import router
+
+    paths_in_order = [r.path for r in router.routes]
+    file_get = paths_in_order.index("/api/projects/{project_id:path}/file")
+    catch_all_get = paths_in_order.index("/api/projects/{project_id:path}")
+    assert file_get < catch_all_get, (
+        "ADR-036 P1-1 regression: /file routes must precede "
+        "/{project_id:path} catch-all so FastAPI matches them first. "
+        f"Current order: {paths_in_order}"
+    )
+
+
+def test_file_route_resolves_to_file_handler_not_catch_all() -> None:
+    """A live ``GET /api/projects/<id>/file`` reaches ``read_project_file``.
+
+    Use the FastAPI router's ``url_path_for`` to confirm the file endpoint
+    name is mapped, then exercise the ASGI matcher to confirm a request
+    against the URL hits ``read_project_file`` (skeleton raises
+    NotImplementedError -> we surface that exception class as the proof).
+    """
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from scieasy.api.routes.projects import router
+
+    app = FastAPI()
+    app.include_router(router)
+    # Stub the runtime dependency so dependency resolution does not fail.
+    from scieasy.api.deps import get_runtime
+
+    app.dependency_overrides[get_runtime] = lambda: object()
+
+    client = TestClient(app, raise_server_exceptions=False)
+    # The skeleton handler raises NotImplementedError; FastAPI converts that
+    # into a 500. We assert we DID hit the file handler (not the catch-all
+    # which would 200 OK or 404), confirmed by the 500 surface.
+    response = client.get("/api/projects/some-id/file?path=blocks/foo.py")
+    assert response.status_code == 500, (
+        f"Expected 500 from skeleton NotImplementedError in read_project_file, got "
+        f"{response.status_code}: {response.text!r}. If this is 200/404, the "
+        "catch-all /{project_id:path} is intercepting the request — P1-1 regression."
+    )


### PR DESCRIPTION
Refs #843, #848. Closes audit findings P1-1/2/3 from `docs/audit/2026-05-14-adr-036-skeleton.md`.

## Findings addressed

| Finding | Fix | Verification |
|---|---|---|
| **P1-1** `/{project_id:path}/file` unreachable behind greedy `/{project_id:path}` | Reorder routes in `src/scieasy/api/routes/projects.py` so the `/file` GET/PUT decorators are declared **before** the catch-all GET/PUT/DELETE | Live `TestClient` GET on `/api/projects/<id>/file` reaches `read_project_file` (raises NotImplementedError → 500) instead of `get_project`. Two new regression tests in `tests/api/test_file_endpoints_skeleton.py`. |
| **P1-2** `/template` unreachable behind `/{block_type}` | Reorder routes in `src/scieasy/api/routes/blocks.py` so `/template` is declared **before** `/{block_type}` (and its `/schema` alias) | Same approach: live request resolves to `get_block_template`. Two new regression tests in `tests/api/test_blocks_template_skeleton.py`. |
| **P1-3** `frontend/package-lock.json` missing 7 monaco packages → `npm ci` fails | Run `npm install` in `frontend/` to regenerate the lockfile | `cd frontend && rm -rf node_modules && npm ci` succeeds; `npm run build` green (15.7 s); `npx vitest run` 124 passed / 12 skipped. |

## Local CI

- `ruff format --check .` — 461 files already formatted
- `ruff check .` — All checks passed
- `mypy src/scieasy/api/ --ignore-missing-imports` — Success: no issues found in 18 source files
- `pytest tests/api -q --timeout=60` — 20 xfail (expected) + 4 new passing regression tests; 0 unexpected failures (the unrelated pre-existing `test_projects.py` Windows file-lock teardown failure is present on the unmodified skeleton branch too — confirmed via `git stash`).
- `cd frontend && npm ci && npm run build && npx vitest run` — green

## Checklist update

Ticked row "All P1 findings fixed (or explicitly justified deferral) (Owner: F36-skeleton)" in `docs/planning/adr-035-036-checklist.md`.

## Notes for reviewer

- Route reorder is mechanical; runtime contract unchanged. All skeleton tests still xfail; the 4 new regression tests pass and must keep passing through the implementation phase to prevent recurrence.
- Targeted at `feat/issue-848/skeleton` (not `track/adr-036/code-editor`) so the dispatcher can merge skeleton+fix as one unit into the tracking branch.
- No `pip install -e .` from worktree (verified `scieasy.__file__` resolves to repo root, not worktree).