### PR TITLE
feat(adr-035): Phase 2C — frontend block-tab integration (I35c #847)

### DIFF
--- a/frontend/src/components/AIChat/TerminalTab.tsx
+++ b/frontend/src/components/AIChat/TerminalTab.tsx
@@ -17,6 +17,7 @@
  */
 import { useCallback } from "react";
 
+import { sendWebSocketMessage } from "../../hooks/useWebSocket";
 import { useAppStore } from "../../store";
 import { SetupScreen, type SetupLaunchConfig } from "./SetupScreen";
 import { TerminalView } from "./TerminalView";
@@ -26,49 +27,120 @@ export interface TerminalTabProps {
 }
 
 /**
- * ADR-035 §3.9 skeleton: status badge for AI-Block-spawned tabs.
+ * ADR-035 §3.9 — status badge for AI-Block-spawned tabs.
  *
- * Implementation plan (I35c):
- *   - Read `tab.source` and `tab.aiBlockStatus` from the store.
- *   - Render one of: ✓ (DONE), ✗ (ERROR), ⏳ (PAUSED), nothing (RUNNING).
- *   - Tailwind classes mirror the canvas BlockNode status pills so the
- *     visual language is consistent.
+ * Renders an inline glyph reflecting the block's current state:
+ *   - "done"      → ✓  (emerald)
+ *   - "error"     → ✗  (rose)
+ *   - "cancelled" → ⊘  (stone, distinguishes from error)
+ *   - "paused"    → spinner (amber, the dominant state during a run)
+ *   - "running"   → green dot (transient state before PAUSED)
  *
- * Test plan (vitest):
- *   - test_renders_done_badge_when_status_done
- *   - test_renders_error_badge_when_status_error
- *   - test_renders_spinner_when_status_paused
- *   - test_renders_nothing_when_source_not_ai_block
+ * Returns null when the tab is not AI-Block-sourced. The badge mirrors the
+ * canvas BlockNode status pills (Tailwind palette) so the visual language
+ * is consistent across the app.
  *
  * References: ADR-035 §3.9
  */
-export function AiBlockStatusBadge(_props: { tabId: string }): JSX.Element | null {
-  // SKELETON: returns null until I35c wires real status from the store.
-  // See comment block above.
-  return null;
+export function AiBlockStatusBadge({ tabId }: { tabId: string }): JSX.Element | null {
+  const tab = useAppStore((s) => s.terminalTabs.find((t) => t.id === tabId));
+  if (!tab || tab.source !== "ai-block") return null;
+  const status = tab.blockStatus;
+  const testid = `ai-block-status-badge-${tabId}`;
+  if (status === "done") {
+    return (
+      <span
+        className="ml-1 inline-block text-emerald-600"
+        aria-label="AI Block done"
+        data-testid={testid}
+        data-status="done"
+      >
+        ✓
+      </span>
+    );
+  }
+  if (status === "error") {
+    return (
+      <span
+        className="ml-1 inline-block text-rose-600"
+        aria-label="AI Block error"
+        data-testid={testid}
+        data-status="error"
+      >
+        ✗
+      </span>
+    );
+  }
+  if (status === "cancelled") {
+    return (
+      <span
+        className="ml-1 inline-block text-stone-500"
+        aria-label="AI Block cancelled"
+        data-testid={testid}
+        data-status="cancelled"
+      >
+        ⊘
+      </span>
+    );
+  }
+  if (status === "paused") {
+    return (
+      <span
+        className="ml-1 inline-block h-2 w-2 animate-spin rounded-full border border-amber-500 border-t-transparent align-middle"
+        aria-label="AI Block paused — awaiting completion"
+        data-testid={testid}
+        data-status="paused"
+      />
+    );
+  }
+  // status === "running" or undefined — show a small live dot
+  return (
+    <span
+      className="ml-1 inline-block h-1.5 w-1.5 rounded-full bg-emerald-500 align-middle"
+      aria-label="AI Block running"
+      data-testid={testid}
+      data-status={status ?? "unknown"}
+    />
+  );
 }
 
 /**
- * ADR-035 §3.5 path (c) skeleton: "Mark done" escape-hatch button.
+ * ADR-035 §3.5 path (c) — "Mark done" escape-hatch button.
  *
- * Implementation plan (I35c):
- *   - Visible when `tab.source === "ai-block"` && `tab.aiBlockStatus === "paused"`.
- *   - On click, POST to `/api/blocks/ai/{block_run_id}/mark_done` (engine
- *     route added in I35b) — engine writes the `mark_done.json` signal
- *     file under the run_dir, the worker's CompletionWatcher picks it up.
- *   - Button is disabled (with tooltip) outside paused state.
+ * Visible only when the tab was spawned by an AI Block AND the block is
+ * currently in PAUSED state. On click sends a `block_user_marked_done` WS
+ * message addressed to the originating block run; the engine (I35b) writes
+ * a `mark_done.json` signal file the worker's CompletionWatcher polls.
  *
- * Test plan (vitest):
- *   - test_button_visible_when_ai_block_paused
- *   - test_button_hidden_when_not_ai_block_tab
- *   - test_button_click_calls_mark_done_api
+ * The button is rendered ONLY in the running TerminalView tab content
+ * (not in the tab strip) so it sits next to the agent's PTY where the user
+ * is actively reading the agent's output.
  *
  * References: ADR-035 §3.5 path (c), §3.9
  */
-export function MarkDoneButton(_props: { tabId: string }): JSX.Element | null {
-  // SKELETON: returns null until I35c wires the API call.
-  // See comment block above.
-  return null;
+export function MarkDoneButton({ tabId }: { tabId: string }): JSX.Element | null {
+  const tab = useAppStore((s) => s.terminalTabs.find((t) => t.id === tabId));
+  if (!tab) return null;
+  if (tab.source !== "ai-block") return null;
+  if (tab.blockStatus !== "paused") return null;
+  const handleClick = () => {
+    if (!tab.blockRunId) return;
+    sendWebSocketMessage({
+      type: "block_user_marked_done",
+      block_run_id: tab.blockRunId,
+      tab_id: tab.id,
+    });
+  };
+  return (
+    <button
+      type="button"
+      className="rounded-full bg-emerald-600 px-3 py-1 text-xs font-medium text-white shadow-sm hover:bg-emerald-700"
+      onClick={handleClick}
+      data-testid={`mark-done-btn-${tabId}`}
+    >
+      Mark done
+    </button>
+  );
 }
 
 export function TerminalTab({ tabId }: TerminalTabProps) {
@@ -138,15 +210,27 @@ export function TerminalTab({ tabId }: TerminalTabProps) {
         </div>
       );
     }
+    // ADR-035 §3.5 (c) / §3.9 — for AI-Block tabs, overlay a floating
+    // "Mark done" pill in the upper-right corner when the block is paused.
+    // Keeps TerminalView (xterm) logic untouched per dispatch scope.
     return (
-      <TerminalView
-        tabId={tabId}
-        projectDir={projectPath}
-        provider={tab.provider}
-        dangerous={tab.permissionMode === "dangerous"}
-        onExit={handleExit}
-        onError={handleError}
-      />
+      <div className="relative h-full" data-testid={`terminal-tab-running-${tabId}`}>
+        <TerminalView
+          tabId={tabId}
+          projectDir={projectPath}
+          provider={tab.provider}
+          dangerous={tab.permissionMode === "dangerous"}
+          onExit={handleExit}
+          onError={handleError}
+        />
+        {tab.source === "ai-block" ? (
+          <div className="pointer-events-none absolute right-3 top-2 z-10">
+            <div className="pointer-events-auto">
+              <MarkDoneButton tabId={tabId} />
+            </div>
+          </div>
+        ) : null}
+      </div>
     );
   }
 

--- a/frontend/src/components/AIChat/TerminalTabs.tsx
+++ b/frontend/src/components/AIChat/TerminalTabs.tsx
@@ -19,75 +19,13 @@
  */
 import { useCallback, useEffect, useState } from "react";
 
+import { sendWebSocketMessage } from "../../hooks/useWebSocket";
 import { useAppStore } from "../../store";
-import { TerminalTab } from "./TerminalTab";
+import { AiBlockStatusBadge, TerminalTab } from "./TerminalTab";
 
-/**
- * ADR-035 §3.10 skeleton: handle the `block_pty_opened` WS event.
- *
- * Implementation plan (I35c):
- *   1. The engine emits `{type: "block_pty_opened", tab_id, title,
- *      block_run_id, permission_mode}` over the main workflow WS when
- *      :func:`scieasy.api.routes.ai_pty.open_engine_initiated_tab` is
- *      called by an AI Block worker.
- *   2. This handler should call a new store action
- *      `addAiBlockTerminalTab({tabId, title, blockRunId, permissionMode})`
- *      that:
- *         - Pushes a new TerminalTab object with state="running",
- *           source="ai-block", aiBlockStatus="paused".
- *         - Sets it as the active tab.
- *         - The TerminalView mounts and connects to the existing
- *           `/api/ai/pty/{tab_id}` route, which finds the pre-spawned
- *           PTY in `_active_ptys` and bridges it.
- *   3. No SetupScreen for AI-Block tabs — they go straight to "running".
- *
- * Test plan (vitest):
- *   - test_handle_block_pty_opened_creates_tab
- *   - test_handle_block_pty_opened_sets_active
- *   - test_handle_block_pty_opened_skips_setup_screen
- *
- * References: ADR-035 §3.10
- */
-export function handleBlockPtyOpened(_payload: {
-  tab_id: string;
-  title: string;
-  block_run_id: string;
-  permission_mode: "safe" | "bypass";
-}): void {
-  // SKELETON: I35c implements the store action + dispatch.
-  // See comment block above.
-  throw new Error("not implemented — see comment above");
-}
-
-/**
- * ADR-035 §3.10 skeleton: handle the `block_pty_closed` WS event.
- *
- * Implementation plan (I35c):
- *   1. Engine emits `{type: "block_pty_closed", tab_id, block_run_id,
- *      result: "completed" | "cancelled" | "error", detail?: ...}` after
- *      the worker calls :func:`notify_block_pty_event`.
- *   2. Update the matching tab's `aiBlockStatus` to reflect result; the
- *      TerminalView stays connected (per ADR-035 §3.9: tab survives
- *      DONE/ERROR and remains interactive — user can keep chatting).
- *   3. Decorate the tab title with ✓ / ✗ via the AiBlockStatusBadge.
- *
- * Test plan (vitest):
- *   - test_handle_block_pty_closed_updates_status
- *   - test_handle_block_pty_closed_keeps_tab_open
- *   - test_handle_block_pty_closed_unknown_tab_id_is_noop
- *
- * References: ADR-035 §3.9, §3.10
- */
-export function handleBlockPtyClosed(_payload: {
-  tab_id: string;
-  block_run_id: string;
-  result: "completed" | "cancelled" | "error";
-  detail?: Record<string, unknown>;
-}): void {
-  // SKELETON: I35c implements the store action.
-  // See comment block above.
-  throw new Error("not implemented — see comment above");
-}
+// Re-export so existing imports / tests continue to work; canonical home is
+// blockPtyHandlers.ts (broken out to avoid the cycle with useWebSocket).
+export { handleBlockPtyClosed, handleBlockPtyOpened } from "./blockPtyHandlers";
 
 function ConfirmDialog({
   message,
@@ -252,7 +190,9 @@ export function TerminalTabs() {
                   data-testid={`terminal-tab-title-${tab.id}`}
                 >
                   {tab.title}
-                  {tab.state === "running" ? (
+                  {/* ADR-035 §3.9 — AI-Block status decoration on the tab strip. */}
+                  <AiBlockStatusBadge tabId={tab.id} />
+                  {tab.state === "running" && tab.source !== "ai-block" ? (
                     <span
                       className="ml-1 inline-block h-1.5 w-1.5 rounded-full bg-emerald-500"
                       aria-hidden
@@ -308,16 +248,36 @@ export function TerminalTabs() {
         ) : null}
       </div>
 
-      {pendingClose ? (
-        <ConfirmDialog
-          message="This terminal is still running. Closing will kill its subprocess."
-          onConfirm={() => {
-            closeTerminalTab(pendingClose);
-            setPendingClose(null);
-          }}
-          onCancel={() => setPendingClose(null)}
-        />
-      ) : null}
+      {pendingClose
+        ? (() => {
+            const closingTab = tabs.find((t) => t.id === pendingClose);
+            const isAiBlock = closingTab?.source === "ai-block";
+            return (
+              <ConfirmDialog
+                message={
+                  isAiBlock
+                    ? "This AI Block is still running. Closing will cancel the block run."
+                    : "This terminal is still running. Closing will kill its subprocess."
+                }
+                onConfirm={() => {
+                  // ADR-035 §3.9 — user-close-while-running emits cancel so the
+                  // engine can transition the block to CANCELLED and tear the
+                  // PTY down cleanly rather than leaking the process.
+                  if (isAiBlock && closingTab?.blockRunId) {
+                    sendWebSocketMessage({
+                      type: "block_user_cancel",
+                      block_run_id: closingTab.blockRunId,
+                      tab_id: closingTab.id,
+                    });
+                  }
+                  closeTerminalTab(pendingClose);
+                  setPendingClose(null);
+                }}
+                onCancel={() => setPendingClose(null)}
+              />
+            );
+          })()
+        : null}
     </div>
   );
 }

--- a/frontend/src/components/AIChat/__tests__/TerminalTab.test.tsx
+++ b/frontend/src/components/AIChat/__tests__/TerminalTab.test.tsx
@@ -1,0 +1,124 @@
+/**
+ * ADR-035 §3.5 / §3.9 — Tests for AiBlockStatusBadge and MarkDoneButton.
+ *
+ * The badge variants and the Mark-done button visibility rules are the two
+ * UI surfaces the user actually interacts with for the AI Block escape-hatch
+ * path. We render them in isolation (with the store pre-populated) rather
+ * than mounting the whole TerminalTabs container — keeps the suite snappy
+ * and lets us cover all four status variants without xterm side effects.
+ */
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useAppStore } from "../../../store";
+import type { AiBlockStatus, TerminalTab } from "../../../store/types";
+import { AiBlockStatusBadge, MarkDoneButton } from "../TerminalTab";
+
+vi.mock("../../../hooks/useWebSocket", () => ({
+  sendWebSocketMessage: vi.fn(),
+}));
+
+import { sendWebSocketMessage } from "../../../hooks/useWebSocket";
+
+function seedTab(partial: Partial<TerminalTab> & { id: string }) {
+  const tab: TerminalTab = {
+    title: "🤖 demo",
+    provider: "claude-code",
+    permissionMode: "safe",
+    state: "running",
+    source: "ai-block",
+    blockRunId: "run-x",
+    blockStatus: "paused",
+    ...partial,
+  };
+  useAppStore.setState({
+    terminalTabs: [tab],
+    activeTerminalTabId: tab.id,
+  });
+}
+
+beforeEach(() => {
+  useAppStore.setState({ terminalTabs: [], activeTerminalTabId: null });
+  (sendWebSocketMessage as unknown as { mockClear: () => void }).mockClear();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("AiBlockStatusBadge", () => {
+  it.each<[AiBlockStatus, string]>([
+    ["done", "done"],
+    ["error", "error"],
+    ["cancelled", "cancelled"],
+    ["paused", "paused"],
+    ["running", "running"],
+  ])("renders the %s variant", (status, expected) => {
+    seedTab({ id: `t-${status}`, blockStatus: status });
+    render(<AiBlockStatusBadge tabId={`t-${status}`} />);
+    const el = screen.getByTestId(`ai-block-status-badge-t-${status}`);
+    expect(el.getAttribute("data-status")).toBe(expected);
+  });
+
+  it("renders nothing when source is not ai-block", () => {
+    seedTab({ id: "user-tab", source: "user" });
+    const { container } = render(<AiBlockStatusBadge tabId="user-tab" />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders nothing when tab does not exist", () => {
+    const { container } = render(<AiBlockStatusBadge tabId="missing" />);
+    expect(container.firstChild).toBeNull();
+  });
+});
+
+describe("MarkDoneButton", () => {
+  it("renders the button when source=ai-block and status=paused", () => {
+    seedTab({ id: "btn-1", blockStatus: "paused" });
+    render(<MarkDoneButton tabId="btn-1" />);
+    expect(screen.getByTestId("mark-done-btn-btn-1")).toBeInTheDocument();
+  });
+
+  it.each<AiBlockStatus>(["done", "error", "cancelled", "running"])(
+    "is hidden when blockStatus=%s",
+    (status) => {
+      seedTab({ id: `btn-${status}`, blockStatus: status });
+      const { container } = render(
+        <MarkDoneButton tabId={`btn-${status}`} />,
+      );
+      expect(container.firstChild).toBeNull();
+    },
+  );
+
+  it("is hidden when source is not ai-block", () => {
+    seedTab({ id: "user-btn", source: "user" });
+    const { container } = render(<MarkDoneButton tabId="user-btn" />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("click sends block_user_marked_done WS message addressed to the run", () => {
+    seedTab({
+      id: "btn-click",
+      blockStatus: "paused",
+      blockRunId: "run-click",
+    });
+    render(<MarkDoneButton tabId="btn-click" />);
+    fireEvent.click(screen.getByTestId("mark-done-btn-btn-click"));
+    expect(sendWebSocketMessage).toHaveBeenCalledWith({
+      type: "block_user_marked_done",
+      block_run_id: "run-click",
+      tab_id: "btn-click",
+    });
+  });
+
+  it("click is a no-op when blockRunId is missing", () => {
+    seedTab({
+      id: "btn-no-run",
+      blockStatus: "paused",
+      blockRunId: undefined,
+    });
+    render(<MarkDoneButton tabId="btn-no-run" />);
+    fireEvent.click(screen.getByTestId("mark-done-btn-btn-no-run"));
+    expect(sendWebSocketMessage).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/AIChat/__tests__/TerminalTabs.test.tsx
+++ b/frontend/src/components/AIChat/__tests__/TerminalTabs.test.tsx
@@ -173,4 +173,200 @@ describe("TerminalTabs", () => {
     expect(rehydrated[0].state).toBe("closed");
     expect(rehydrated[0].exitCode).toBe(-1);
   });
+
+  // ADR-035 §3.10 — engine-initiated AI Block tabs.
+  describe("ADR-035 — engine-initiated AI Block tabs", () => {
+    it("handleBlockPtyOpened auto-creates a tab with source=ai-block", async () => {
+      const { handleBlockPtyOpened } = await import("../TerminalTabs");
+      act(() => {
+        handleBlockPtyOpened({
+          tab_id: "blk-1",
+          block_run_id: "run-1",
+          block_name: "extract_metadata",
+          permission_mode: "safe",
+        });
+      });
+      const tabs = useAppStore.getState().terminalTabs;
+      expect(tabs.length).toBe(1);
+      expect(tabs[0].id).toBe("blk-1");
+      expect(tabs[0].source).toBe("ai-block");
+      expect(tabs[0].state).toBe("running"); // skips SetupScreen
+      expect(tabs[0].blockStatus).toBe("paused");
+      expect(tabs[0].blockRunId).toBe("run-1");
+      expect(tabs[0].title).toBe("🤖 extract_metadata");
+    });
+
+    it("handleBlockPtyOpened sets the new tab as active", async () => {
+      const { handleBlockPtyOpened } = await import("../TerminalTabs");
+      // Pre-existing user tab.
+      act(() => {
+        useAppStore.getState().addTerminalTab();
+      });
+      act(() => {
+        handleBlockPtyOpened({
+          tab_id: "blk-2",
+          block_run_id: "run-2",
+          block_name: "extract",
+          permission_mode: "bypass",
+        });
+      });
+      expect(useAppStore.getState().activeTerminalTabId).toBe("blk-2");
+      const blkTab = useAppStore
+        .getState()
+        .terminalTabs.find((t) => t.id === "blk-2");
+      expect(blkTab?.permissionMode).toBe("dangerous");
+    });
+
+    it("handleBlockPtyOpened is idempotent on tab_id", async () => {
+      const { handleBlockPtyOpened } = await import("../TerminalTabs");
+      act(() => {
+        handleBlockPtyOpened({
+          tab_id: "blk-3",
+          block_run_id: "run-3",
+          block_name: "x",
+        });
+        handleBlockPtyOpened({
+          tab_id: "blk-3",
+          block_run_id: "run-3",
+          block_name: "x",
+        });
+      });
+      expect(
+        useAppStore.getState().terminalTabs.filter((t) => t.id === "blk-3").length,
+      ).toBe(1);
+    });
+
+    it("handleBlockPtyClosed updates blockStatus on the matching tab", async () => {
+      const { handleBlockPtyOpened, handleBlockPtyClosed } = await import(
+        "../TerminalTabs"
+      );
+      act(() => {
+        handleBlockPtyOpened({
+          tab_id: "blk-4",
+          block_run_id: "run-4",
+          block_name: "x",
+        });
+      });
+      act(() => {
+        handleBlockPtyClosed({ tab_id: "blk-4", status: "done" });
+      });
+      const t = useAppStore.getState().terminalTabs.find((x) => x.id === "blk-4");
+      expect(t?.blockStatus).toBe("done");
+    });
+
+    it("handleBlockPtyClosed maps legacy result=completed to status=done", async () => {
+      const { handleBlockPtyOpened, handleBlockPtyClosed } = await import(
+        "../TerminalTabs"
+      );
+      act(() => {
+        handleBlockPtyOpened({
+          tab_id: "blk-5",
+          block_run_id: "run-5",
+          block_name: "x",
+        });
+      });
+      act(() => {
+        handleBlockPtyClosed({ tab_id: "blk-5", result: "completed" });
+      });
+      expect(
+        useAppStore.getState().terminalTabs.find((t) => t.id === "blk-5")
+          ?.blockStatus,
+      ).toBe("done");
+    });
+
+    it("handleBlockPtyClosed keeps the tab open per ADR-035 §3.9", async () => {
+      const { handleBlockPtyOpened, handleBlockPtyClosed } = await import(
+        "../TerminalTabs"
+      );
+      act(() => {
+        handleBlockPtyOpened({
+          tab_id: "blk-6",
+          block_run_id: "run-6",
+          block_name: "x",
+        });
+      });
+      act(() => {
+        handleBlockPtyClosed({ tab_id: "blk-6", status: "error" });
+      });
+      // Tab still present, still in running state — block is done but the tab survives.
+      const t = useAppStore.getState().terminalTabs.find((x) => x.id === "blk-6");
+      expect(t).toBeDefined();
+      expect(t?.state).toBe("running");
+      expect(t?.blockStatus).toBe("error");
+    });
+
+    it("handleBlockPtyClosed on unknown tab_id is a no-op", async () => {
+      const { handleBlockPtyClosed } = await import("../TerminalTabs");
+      // Should not throw; should not create a tab.
+      act(() => {
+        handleBlockPtyClosed({ tab_id: "nonexistent", status: "done" });
+      });
+      expect(useAppStore.getState().terminalTabs.length).toBe(0);
+    });
+
+    it("handleBlockPtyOpened with missing tab_id logs a warning", async () => {
+      const { handleBlockPtyOpened } = await import("../TerminalTabs");
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      act(() => {
+        handleBlockPtyOpened({
+          tab_id: "",
+          block_run_id: "run-x",
+        });
+      });
+      expect(warnSpy).toHaveBeenCalled();
+      expect(useAppStore.getState().terminalTabs.length).toBe(0);
+      warnSpy.mockRestore();
+    });
+
+    it("close-while-running on AI-Block tab prompts confirm and shows AI-Block message", async () => {
+      const { handleBlockPtyOpened } = await import("../TerminalTabs");
+      render(<TerminalTabs />);
+      // Wait for the auto-created initial tab so we see only our AI Block tab too.
+      await waitFor(() =>
+        expect(useAppStore.getState().terminalTabs.length).toBe(1),
+      );
+      act(() => {
+        handleBlockPtyOpened({
+          tab_id: "blk-confirm",
+          block_run_id: "run-confirm",
+          block_name: "x",
+        });
+      });
+      // Click close on the AI Block tab.
+      act(() =>
+        fireEvent.click(
+          screen.getByTestId("terminal-tab-close-btn-blk-confirm"),
+        ),
+      );
+      const dialog = screen.getByTestId("terminal-confirm-dialog");
+      expect(dialog).toBeInTheDocument();
+      expect(dialog.textContent).toContain("AI Block");
+      // Dismiss; tab remains.
+      act(() => fireEvent.click(screen.getByTestId("terminal-confirm-cancel")));
+      expect(
+        useAppStore.getState().terminalTabs.some((t) => t.id === "blk-confirm"),
+      ).toBe(true);
+    });
+
+    it("rehydrate marks AI-Block running tabs as cancelled", async () => {
+      const { rehydrateTerminalTabs } = await import(
+        "../../../store/terminalTabsSlice"
+      );
+      const persisted = [
+        {
+          id: "blk-r",
+          title: "🤖 extract",
+          provider: "claude-code" as const,
+          permissionMode: "safe" as const,
+          state: "running" as const,
+          source: "ai-block" as const,
+          blockRunId: "run-r",
+          blockStatus: "paused" as const,
+        },
+      ];
+      const out = rehydrateTerminalTabs(persisted);
+      expect(out[0].state).toBe("closed");
+      expect(out[0].blockStatus).toBe("cancelled");
+    });
+  });
 });

--- a/frontend/src/components/AIChat/blockPtyHandlers.ts
+++ b/frontend/src/components/AIChat/blockPtyHandlers.ts
@@ -1,0 +1,114 @@
+/**
+ * ADR-035 §3.10 — engine-initiated PTY tab event handlers.
+ *
+ * Extracted from TerminalTabs.tsx into its own module to break the import
+ * cycle between `hooks/useWebSocket` and `components/AIChat/TerminalTabs`:
+ *   - `useWebSocket.ts` dispatches incoming WS frames here.
+ *   - `TerminalTabs.tsx` consumes `sendWebSocketMessage` from `useWebSocket.ts`.
+ * If both handlers lived in TerminalTabs.tsx, Rollup's circular-import
+ * resolution returned `undefined` for the lazily-bound exports at runtime
+ * (verified empirically — neither `addAiBlockTerminalTab` nor `appendLog`
+ * fired even though the WS message was correctly parsed and routed).
+ */
+import { useAppStore } from "../../store";
+import type { AiBlockStatus } from "../../store/types";
+
+/**
+ * Handle the `block_pty_opened` WS event.
+ *
+ * The engine emits this after :func:`scieasy.api.routes.ai_pty.open_engine_initiated_tab`
+ * spawns a PTY for an AI Block worker. We register the tab in the store with
+ * `source="ai-block"`, `state="running"` (skipping SetupScreen), and
+ * `blockStatus="paused"`. The matching TerminalView mounts and connects to
+ * the existing `/api/ai/pty/{tab_id}` route, joining the pre-spawned PTY.
+ *
+ * Field-name compatibility: the dispatch (I35c) pins the payload to
+ * `{tab_id, block_run_id, block_name, status}`; the skeleton stub for
+ * `open_engine_initiated_tab` mentions `title` instead of `block_name`. We
+ * accept either to keep the handler resilient against either backend choice.
+ * Title prefix `🤖` is added here so I35a/I35b don't have to remember it.
+ *
+ * References: ADR-035 §3.9, §3.10
+ */
+export function handleBlockPtyOpened(payload: {
+  tab_id: string;
+  block_run_id: string;
+  /** Either field is accepted; `block_name` wins if both present. */
+  block_name?: string;
+  title?: string;
+  /** Optional initial status. Defaults to "paused" per §3.9. */
+  status?: AiBlockStatus;
+  permission_mode?: "safe" | "bypass" | "dangerous";
+}): void {
+  const { tab_id, block_run_id } = payload;
+  if (!tab_id || !block_run_id) {
+    // eslint-disable-next-line no-console
+    console.warn("[block_pty_opened] missing tab_id / block_run_id; ignoring", payload);
+    return;
+  }
+  const rawName = payload.block_name ?? payload.title ?? "AI Block";
+  const title = rawName.startsWith("🤖") ? rawName : `🤖 ${rawName}`;
+  // Normalise permission_mode: backend uses "bypass", frontend tab uses "dangerous".
+  const permissionMode: "safe" | "dangerous" =
+    payload.permission_mode === "bypass" || payload.permission_mode === "dangerous"
+      ? "dangerous"
+      : "safe";
+  useAppStore.getState().addAiBlockTerminalTab({
+    tabId: tab_id,
+    title,
+    blockRunId: block_run_id,
+    permissionMode,
+  });
+  if (payload.status && payload.status !== "paused") {
+    useAppStore.getState().updateAiBlockStatus(tab_id, payload.status);
+  }
+}
+
+/** Map a backend close result to the corresponding `AiBlockStatus`. */
+function mapCloseResult(
+  result: "completed" | "cancelled" | "error" | "done" | string | undefined,
+): AiBlockStatus {
+  switch (result) {
+    case "completed":
+    case "done":
+      return "done";
+    case "cancelled":
+      return "cancelled";
+    case "error":
+      return "error";
+    default:
+      return "error"; // conservative default — better an ✗ than silent
+  }
+}
+
+/**
+ * Handle the `block_pty_closed` WS event.
+ *
+ * Engine emits this after the worker calls
+ * :func:`scieasy.engine.pty_control.notify_block_pty_event`. We update the
+ * matching tab's `blockStatus` to done / error / cancelled. Per §3.9, the
+ * TerminalView stays mounted — the tab remains interactive so the user can
+ * keep chatting with the agent (e.g. to debug a failed output).
+ *
+ * Idempotent: unknown tab_id is a no-op (e.g. tab was closed before the
+ * close event arrived).
+ *
+ * References: ADR-035 §3.9, §3.10
+ */
+export function handleBlockPtyClosed(payload: {
+  tab_id: string;
+  block_run_id?: string;
+  /** Dispatch-pinned status union; legacy `result` accepted too. */
+  status?: "done" | "error" | "cancelled";
+  result?: "completed" | "cancelled" | "error";
+  detail?: Record<string, unknown>;
+}): void {
+  const tabId = payload.tab_id;
+  if (!tabId) {
+    // eslint-disable-next-line no-console
+    console.warn("[block_pty_closed] missing tab_id; ignoring", payload);
+    return;
+  }
+  const status = mapCloseResult(payload.status ?? payload.result);
+  useAppStore.getState().updateAiBlockStatus(tabId, status);
+}

--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -1,5 +1,9 @@
 import { useEffect, useRef, useState, useCallback } from "react";
 
+import {
+  handleBlockPtyClosed,
+  handleBlockPtyOpened,
+} from "../components/AIChat/blockPtyHandlers";
 import { api } from "../lib/api";
 import type { WorkflowEventMessage } from "../types/api";
 import { useAppStore } from "../store";
@@ -151,13 +155,80 @@ export function useWorkflowWebSocket(enabled: boolean): { connected: boolean } {
       //
       // References: ADR-035 §3.10, §6.1
       if (payload.type === "block_pty_opened") {
-        // SKELETON: I35c will dispatch to handleBlockPtyOpened.
-        // See comment block above.
+        try {
+          // The wire payload may live at the top level OR nested under `data`,
+          // depending on which engine path emitted it. Tolerate both.
+          const src = (payload.data ?? {}) as Record<string, unknown>;
+          handleBlockPtyOpened({
+            tab_id:
+              ((payload as unknown as Record<string, unknown>).tab_id as string) ??
+              (src.tab_id as string),
+            block_run_id:
+              ((payload as unknown as Record<string, unknown>).block_run_id as string) ??
+              (src.block_run_id as string) ??
+              (payload.block_id ?? ""),
+            block_name: src.block_name as string | undefined,
+            title:
+              ((payload as unknown as Record<string, unknown>).title as string) ??
+              (src.title as string | undefined),
+            status: src.status as
+              | "running"
+              | "paused"
+              | "done"
+              | "error"
+              | "cancelled"
+              | undefined,
+            permission_mode: src.permission_mode as
+              | "safe"
+              | "bypass"
+              | "dangerous"
+              | undefined,
+          });
+          appendLog({
+            timestamp: payload.timestamp,
+            level: "info",
+            message: `[AI Block] tab opened: ${
+              (src.block_name as string) ??
+              ((payload as unknown as Record<string, unknown>).title as string) ??
+              "AI Block"
+            }`,
+            workflow_id: payload.workflow_id ?? null,
+            block_id: payload.block_id ?? null,
+          });
+        } catch (err) {
+          // eslint-disable-next-line no-console
+          console.warn("[block_pty_opened] dispatch failed:", err, payload);
+        }
         return;
       }
       if (payload.type === "block_pty_closed") {
-        // SKELETON: I35c will dispatch to handleBlockPtyClosed.
-        // See comment block above.
+        try {
+          const src = (payload.data ?? {}) as Record<string, unknown>;
+          handleBlockPtyClosed({
+            tab_id:
+              ((payload as unknown as Record<string, unknown>).tab_id as string) ??
+              (src.tab_id as string),
+            block_run_id:
+              ((payload as unknown as Record<string, unknown>).block_run_id as string) ??
+              (src.block_run_id as string) ??
+              (payload.block_id ?? undefined),
+            status: src.status as "done" | "error" | "cancelled" | undefined,
+            result: src.result as "completed" | "cancelled" | "error" | undefined,
+            detail: src.detail as Record<string, unknown> | undefined,
+          });
+          const label =
+            (src.status as string) ?? (src.result as string) ?? "closed";
+          appendLog({
+            timestamp: payload.timestamp,
+            level: label === "error" ? "error" : "info",
+            message: `[AI Block] tab ${label}`,
+            workflow_id: payload.workflow_id ?? null,
+            block_id: payload.block_id ?? null,
+          });
+        } catch (err) {
+          // eslint-disable-next-line no-console
+          console.warn("[block_pty_closed] dispatch failed:", err, payload);
+        }
         return;
       }
 

--- a/frontend/src/store/terminalTabsSlice.ts
+++ b/frontend/src/store/terminalTabsSlice.ts
@@ -1,6 +1,6 @@
 import type { StateCreator } from "zustand";
 
-import type { AppStore, TerminalTab, TerminalTabsSlice } from "./types";
+import type { AiBlockStatus, AppStore, TerminalTab, TerminalTabsSlice } from "./types";
 
 /**
  * Generate a short random tab id without pulling in `nanoid` as a new dep.
@@ -106,6 +106,44 @@ export const createTerminalTabsSlice: StateCreator<AppStore, [], [], TerminalTab
 
   setActiveTerminalTab: (id) => set({ activeTerminalTabId: id }),
 
+  // ADR-035 §3.10 — engine-initiated AI Block tab.
+  // The engine has already spawned the PTY before sending block_pty_opened,
+  // so we skip the SetupScreen and go straight to "running".
+  addAiBlockTerminalTab: ({ tabId, title, blockRunId, permissionMode }) =>
+    set((state) => {
+      const existing = state.terminalTabs.findIndex((t) => t.id === tabId);
+      const tab: TerminalTab = {
+        id: tabId,
+        title,
+        provider: "claude-code", // engine spawns claude (codex equivalent in I35b)
+        permissionMode,
+        state: "running",
+        source: "ai-block",
+        blockRunId,
+        blockStatus: "paused",
+      };
+      if (existing >= 0) {
+        // Idempotent: replace the entry. Belt-and-braces in case the engine
+        // ever resends the open event (e.g. on reconnect).
+        const next = state.terminalTabs.slice();
+        next[existing] = { ...next[existing], ...tab };
+        return { terminalTabs: next, activeTerminalTabId: tabId };
+      }
+      return {
+        terminalTabs: [...state.terminalTabs, tab],
+        activeTerminalTabId: tabId,
+      };
+    }),
+
+  updateAiBlockStatus: (id: string, status: AiBlockStatus) =>
+    set((state) => {
+      const idx = state.terminalTabs.findIndex((t) => t.id === id);
+      if (idx === -1) return state;
+      const next = state.terminalTabs.slice();
+      next[idx] = { ...next[idx], blockStatus: status };
+      return { terminalTabs: next };
+    }),
+
   // Test helper / rehydration hook — replace the whole slice atomically.
   _replaceTerminalTabs: (tabs, activeId) =>
     set({ terminalTabs: tabs, activeTerminalTabId: activeId }),
@@ -120,9 +158,17 @@ export const createTerminalTabsSlice: StateCreator<AppStore, [], [], TerminalTab
  * `onRehydrateStorage`.
  */
 export function rehydrateTerminalTabs(tabs: TerminalTab[]): TerminalTab[] {
-  return tabs.map((t) =>
-    t.state === "running" ? { ...t, state: "closed" as const, exitCode: -1 } : t,
-  );
+  return tabs.map((t) => {
+    if (t.state !== "running") return t;
+    // PTY didn't survive page unload. AI-Block tabs additionally get their
+    // blockStatus downgraded to "cancelled" — the workflow run is gone too.
+    return {
+      ...t,
+      state: "closed" as const,
+      exitCode: -1,
+      ...(t.source === "ai-block" ? { blockStatus: "cancelled" as const } : {}),
+    };
+  });
 }
 
 // Re-export for convenience.

--- a/frontend/src/store/types.ts
+++ b/frontend/src/store/types.ts
@@ -136,6 +136,24 @@ export interface PaletteSlice {
  * On exit: state -> closed, exitCode set (-1 means synthesised after reload
  * because the PTY did not survive page unload).
  */
+/**
+ * ADR-035 §3.9 / §3.10 — block-tab status union.
+ *
+ * Tracks the lifecycle of an AI Block tab the engine spawned:
+ *   - "running"   — agent process is alive, no completion signal yet
+ *   - "paused"    — block is in PAUSED state (default after spawn);
+ *                   the Mark-done escape-hatch button shows in this state
+ *   - "done"      — completion signal received and outputs validated
+ *   - "error"     — completion failed validation OR agent exited error
+ *   - "cancelled" — user closed the tab while running OR workflow cancelled mid-block
+ *
+ * "cancelled" is a terminal state distinct from "error" so the UI can
+ * distinguish user intent (the user closed the tab) from agent failure
+ * (the agent crashed). Per ADR-035 §3.9, tabs survive done/error/cancelled
+ * transitions and remain interactive.
+ */
+export type AiBlockStatus = "running" | "paused" | "done" | "error" | "cancelled";
+
 export interface TerminalTab {
   id: string;
   title: string;
@@ -143,6 +161,24 @@ export interface TerminalTab {
   permissionMode: "safe" | "dangerous" | null;
   state: "setup" | "running" | "closed";
   exitCode?: number;
+  /**
+   * ADR-035 §3.10 — origin of the tab.
+   *   - "user"     (default) — user clicked the `+` button or Ctrl+T
+   *   - "ai-block" — engine spawned the tab on behalf of an AI Block worker
+   * Optional for backwards-compat with persisted tabs from before ADR-035.
+   */
+  source?: "user" | "ai-block";
+  /**
+   * ADR-035 §3.10 — id of the originating AI Block run (matches the
+   * worker-side `RunDir.run_id`). Used by the Mark-done button to address
+   * the right block when sending the `block_user_marked_done` WS message.
+   */
+  blockRunId?: string;
+  /**
+   * ADR-035 §3.9 — current status of the AI Block. Only meaningful when
+   * `source === "ai-block"`.
+   */
+  blockStatus?: AiBlockStatus;
 }
 
 export interface TerminalTabsSlice {
@@ -160,6 +196,27 @@ export interface TerminalTabsSlice {
   markTerminalTabExited: (id: string, code: number) => void;
   reopenTerminalTab: (id: string) => void;
   setActiveTerminalTab: (id: string) => void;
+  /**
+   * ADR-035 §3.10 — register an engine-initiated AI Block tab.
+   *
+   * Pre-allocates a `TerminalTab` with `source="ai-block"`, `state="running"`
+   * (skipping the SetupScreen — the engine has already spawned the PTY),
+   * `blockStatus="paused"` (the block is paused waiting for completion),
+   * and makes it the active tab. Idempotent on `tabId` — calling twice with
+   * the same id replaces the existing entry rather than duplicating it.
+   */
+  addAiBlockTerminalTab: (args: {
+    tabId: string;
+    title: string;
+    blockRunId: string;
+    permissionMode: "safe" | "dangerous";
+  }) => void;
+  /**
+   * ADR-035 §3.9 — update the AI Block status for a tab. No-op if the tab
+   * does not exist (engine may emit a `block_pty_closed` for a tab the
+   * frontend never received the open event for, e.g. after a page reload).
+   */
+  updateAiBlockStatus: (tabId: string, status: AiBlockStatus) => void;
   /** Internal: replace the entire slice (used by tests + rehydration helper). */
   _replaceTerminalTabs: (tabs: TerminalTab[], activeId: string | null) => void;
 }


### PR DESCRIPTION
Closes #847

## Summary
Phase 2C of ADR-035: frontend integration for engine-spawned AI Block PTY tabs.

## Changes
- TerminalTabs handles block_pty_opened → auto-creates tab + switches focus
- TerminalTab: 🤖 prefix + status badge (✓/✗/spinner) + Mark-done when source=ai-block && PAUSED
- Tab close while running → confirmation modal → cancel
- Tab survives DONE/ERROR per ADR-035 §3.9
- useWebSocket: block_pty_opened / block_pty_closed cases
- terminalTabsSlice: ai-block source + status fields
- blockPtyHandlers.ts (new): event-handler module
- 15 new TerminalTab + 19 TerminalTabs tests, all green

## Manager-takeover note
Original I35c sub-agent left work uncommitted. Manager picked up in hotfix mode:
vitest run → 153/153 ✓, tsc --noEmit → clean, npm run build → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)