### PR TITLE
chore(docs-audit): Phase 0.5 ADR-038/039 documentation audit (#906)

### DIFF
--- a/docs/audit/2026-05-15-adr-038-039-docs-audit.md
+++ b/docs/audit/2026-05-15-adr-038-039-docs-audit.md
@@ -1,0 +1,142 @@
+# Documentation audit — ADR-038 + ADR-039 Phase 0 refactor
+Date: 2026-05-15
+Auditor: no-context audit agent (Phase 0.5)
+Branch: docs/adr-038-039/architecture-refactor (parent PR #905)
+
+Files reviewed:
+- `docs/adr/ADR-038.md`
+- `docs/adr/ADR-039.md`
+- `docs/architecture/ARCHITECTURE.md` (focused on §3.1, §4.4, §4.6, §6.3, §6.7, §7.2, §9.8, §10, plus the §11 technology-stack table)
+- `docs/architecture/PROJECT_TREE.md`
+- `docs/adr/ADR.md` (focused on ADR-012, ADR-014, ADR-018, ADR-020, ADR-027 D5)
+- `docs/adr/ADR-031.md`
+- `docs/adr/ADR-032.md` (banner + status only)
+- `docs/adr/ADR-033.md`
+- `docs/adr/ADR-034.md` (grep-only — no in-scope hits)
+- `docs/adr/ADR-035.md` (grep-only — no in-scope hits)
+- `docs/adr/ADR-036.md` (grep-only — no in-scope hits)
+- `docs/adr/ADR-037.md`
+- `docs/block-development/architecture-for-block-devs.md`
+- `docs/block-development/memory-safety.md`
+- `docs/cli-integration.md`
+- `CHANGELOG.md` `[Unreleased]` most-recent `Changed` entry
+
+## Summary
+
+**Pass with fixes.** The Phase 0 refactor is substantively correct and internally consistent across `ARCHITECTURE.md`, `PROJECT_TREE.md`, the bulk of `ADR.md`, and the new ADR-038 / ADR-039 documents. The two-layer history model (git source / lineage runs) is described consistently, the four-table lineage schema is the same in every place it appears, and the supersession of ADR-032 is recorded with a prominent banner. However, three P1 issues need to land before merge: (a) **ADR-039 §10 Decision summary contradicts ADR-039 §3.1** — it still says `pygit2` is the engine after the document itself reversed that decision; (b) **ADR-038 §5.2 names the relocated checkpoint path `<project>/.scieasy/checkpoint/`** while every other doc (including ADR-038 §5.3 and §6) says `<project>/.scieasy/pause/`; (c) **ARCHITECTURE.md §11 still labels the SQLite store "Metadata DB"** — exactly the "metadata" terminology collision ADR-038 §2.2 set out to end. Counts: **3 P1, 4 P2, 4 P3, plus 1 out-of-scope finding.**
+
+## P1 findings (must fix before docs PR merges)
+
+- **P1-1**: ADR-039 §10 "Decision summary" still names `pygit2` as the engine after the rest of the ADR reversed that decision.
+  - **File**: `docs/adr/ADR-039.md:615`
+  - **Issue**: The summary paragraph reads "**Every SciEasy project is a git repository. `pygit2` is the engine.**" This contradicts the document's own §3.1 (line 56), §3.1 alternatives-rejected list (line 77), §4 alternative #3 (line 405), the entirety of the §5.1 file-impact list (which is built around `git_engine.py` + `git_binary.py` shelling out to a bundled binary), and the desktop-bundle integration in §5.2 + §6 Phase 1.
+  - **Evidence in ADR**: ADR-039 §3.1 line 56: *"SciEasy invokes a **bundled portable `git` binary** as a subprocess. The binary ships inside the ADR-037 desktop bundle (`<bundle>/resources/git/`)…"* And ADR-039 §4 line 405: *"`pygit2` (libgit2 binding) — Initial draft choice (~3 MB bundle). Reversed 2026-05-15: cross-platform wheel availability lags … Bundled git CLI (§3.1) chosen instead."* ARCHITECTURE.md §4.6 lines 657–668 also documents the reversal as the canonical decision; CHANGELOG.md line 24 records the cascade explicitly chose "bundled-git-CLI" "over `pygit2`".
+  - **Recommended fix**: Rewrite the first two sentences of §10 to read along the lines of: *"Every SciEasy project is a git repository. The engine is a **bundled portable `git` CLI binary** invoked via subprocess (MinGit on Windows ~30 MB, static `git` on macOS/Linux ~25 MB) shipped as part of the ADR-037 desktop bundle. Auto-init on project open."* Everything after that already matches the document body.
+
+- **P1-2**: ADR-038 §5.2 disagrees with the rest of the codebase about the relocated checkpoint directory name.
+  - **File**: `docs/adr/ADR-038.md:384`
+  - **Issue**: The row for `src/scieasy/engine/checkpoint.py` says: *"Relocate `<project>/checkpoints/<workflow_id>/` to **`<project>/.scieasy/checkpoint/`**"* (singular, no `s`, NOT "pause"). Every other doc-of-record says `<project>/.scieasy/pause/`. Two locations inside ADR-038 itself also say "pause/" — the §5.3 documentation-impact table (line 404) says *"move `checkpoints/` reference to **`.scieasy/pause/`**"* and §6 Phase 2 (line 450) says *"Move `<project>/checkpoints/` to **`<project>/.scieasy/pause/`**."*
+  - **Evidence in ADR**: ADR-038 §5.3 line 404 — `<project>/.scieasy/pause/`; ADR-038 §6 Phase 2 line 450 — `<project>/.scieasy/pause/`. Plus ARCHITECTURE.md §6.3 line 1937 — `{project}/.scieasy/pause/`; ARCHITECTURE.md §10 line 2862 — `pause/` directory; PROJECT_TREE.md line 777 + line 794 — `.scieasy/pause/`; ADR.md ADR-012 line 389 — `{project}/.scieasy/pause/`.
+  - **Recommended fix**: In `docs/adr/ADR-038.md:384`, change `<project>/.scieasy/checkpoint/` → `<project>/.scieasy/pause/` so all three checkpoint-related rows inside ADR-038 (and the rest of the documentation set) name the same path.
+
+- **P1-3**: ARCHITECTURE.md §11 technology-stack table still labels the SQLite store **"Metadata DB"** — the exact terminology collision ADR-038 set out to remove.
+  - **File**: `docs/architecture/ARCHITECTURE.md:3028`
+  - **Issue**: The table row reads `| Metadata DB | SQLite | Lineage records, project metadata |`. The Phase 0 refactor renamed the on-disk store from `metadata.db` to `lineage.db` and rewrote §4.4 around the unified four-table lineage schema specifically because, per ADR-038 §2.2, the word "metadata" collides with `DataObject.meta`, `DataObject.user`, plugin manifest metadata, and workflow YAML `metadata:` blocks. Leaving "Metadata DB" in the stack table re-introduces the very collision the refactor was supposed to end.
+  - **Evidence in ADR**: ADR-038 §2.1 (b) (lines 31): *"**`metadata.db` is misnamed.** Per ADR-032, `<project>/metadata.db` stores DataObject identity… The word 'metadata' collides with at least four other concepts… The naming itself drives user confusion when they encounter the term in a workflow context."* ADR-038 §10 Decision summary: *"The conflation of these two concerns into one 'metadata' subsystem ends here."*
+  - **Recommended fix**: Rename the row to something like `| Lineage DB | SQLite | Unified run lineage (ADR-038) — runs, block executions, data_objects, block_io |`. Optionally split into two rows so git is also recognised at the stack level, e.g. add `| Source version control | bundled git CLI | ADR-039 — workflow YAML / blocks / notes |`.
+
+## P2 findings (should fix; not release-blocking)
+
+- **P2-1**: ARCHITECTURE.md §3 layered-architecture description for Layer 1 says "lineage" but the §6.7 dataclass + the block-developer docs still leak the prior 5-key-packages model through `key_dependencies`.
+  - **File**: `docs/block-development/architecture-for-block-devs.md:205-220` ("Resource Hints") and `docs/block-development/memory-safety.md:277-290`.
+  - **Issue**: Both files show a block-author-declared `key_dependencies: ClassVar[list[str]] = ["torch>=2.0", ...]` ClassVar as a resource hint. ADR-038 explicitly changes the environment-snapshot default from "5 key packages" to a full `uv pip freeze`. ARCHITECTURE.md §6.7 (line 2215) was updated to reflect the new default but explains the *runtime* `EnvironmentSnapshot.key_packages` dict is now derived from the full freeze. There is a real semantic gap here: is `key_dependencies` still a meaningful block-author declaration in the post-ADR-038 world, given the framework now auto-captures the full closure? At minimum the block-developer docs should clarify the relationship (is `key_dependencies` a *palette display hint* only, distinct from the lineage capture?). If `key_dependencies` is being retired entirely, both files need to drop the example.
+  - **Evidence in ADR**: ADR-038 §5.1 line 342: *"`environment.py` # MODIFY: default full=True for uv pip freeze (current: 5 key packages)"*. ARCHITECTURE.md §6.7 line 2210–2215: full `uv pip freeze` is the default, `key_packages` is a derived dict.
+  - **Recommended fix**: Either (a) keep `key_dependencies` as documentation-only palette metadata and add a one-line note in both files clarifying it's distinct from the engine's runtime capture (which is now full freeze, per ADR-038), or (b) if it is being retired, remove the example and adjust the "Resource Hints" / "Memory Hints and Resource Declarations" sections to drop it. The cleanest move is (a) plus a cross-reference to ARCHITECTURE.md §6.7.
+
+- **P2-2**: ADR-038 plan item "ADR-031 Addenda — replace `metadata.db` refs with `lineage.db.data_objects`" is unactionable because ADR-031 contains no `metadata.db` or `MetadataStore` references.
+  - **File**: `docs/adr/ADR-031.md` (whole file) and `docs/adr/ADR-038.md:406`
+  - **Issue**: ADR-038's §5.3 documentation-impact table directs Phase 0 to "*Replace `metadata.db` references with `lineage.db.data_objects`*" in `docs/adr/ADR-031.md` Addenda. A grep of ADR-031.md for the strings `metadata.db`, `MetadataStore`, `lineage.db`, `ADR-038`, `bump_revision`, `If-Match` returns **zero matches** — there is nothing to replace. So either (a) the plan item is stale (likely — there has historically not been a `metadata.db` reference in ADR-031), or (b) ADR-031 needs an explicit cross-reference to ADR-038 explaining how the reference-only contract interacts with the new unified `lineage.db.data_objects.wire_payload` field.
+  - **Evidence in ADR**: ADR-038 §5.3 line 406 — *"`docs/adr/ADR-031.md` Addenda | Replace `metadata.db` references with `lineage.db.data_objects`"*. The ADR-038 §3.1 schema's `data_objects.wire_payload` column docstring says *"full wire-format JSON for reconstruction"* and §3.1 prose footnote on Collection unrolling pins it to *"~1-2 KB per ADR-031 reference-only contract"* — so the two ADRs *do* intersect at the wire-payload contract, and a forward-pointer would help.
+  - **Recommended fix**: Either delete this row from ADR-038 §5.3 (because there's nothing to replace), or add a short Addendum to ADR-031 reading something like *"**ADR-038 supersession note (2026-05-15)**: the reference-only `wire_payload` contract is now also the on-disk reconstruction format for `lineage.db.data_objects.wire_payload` — see ADR-038 §3.1."* The dispatcher (manager) should classify; from a docs-consistency standpoint, the second option is the more informative.
+
+- **P2-3**: ADR-038 §5.1 vs §5.2 disagree about where `LineageRecorder` ends up living, and which "Phase" the move is in.
+  - **File**: `docs/adr/ADR-038.md:341-342` and `docs/adr/ADR-038.md:378`
+  - **Issue**: §5.1 lists `recorder.py` under *new files* as `# MOVE FROM src/scieasy/engine/lineage_recorder.py + extend (per-run lifecycle hooks)`, in the `src/scieasy/core/lineage/` package. §5.2 lists `src/scieasy/engine/lineage_recorder.py` under *modified existing files* with the change description *"Move into `src/scieasy/core/lineage/recorder.py`; extend with run-lifecycle hooks; populate config/version/env from event data"* and **Phase = 1**. PROJECT_TREE.md line 777 also says "moved … per ADR-038" without specifying phase. Two inconsistencies: (a) §5.1 and §5.2 cover the same move twice, which is fine but the §5.2 phase column says Phase 1 while §5.1 itemises the destination as new, also Phase 1 implicitly — but the surrounding context across Phase 1 / Phase 2 (§6) is hard to follow because §6 Phase 1 doesn't itemize the move and §6 Phase 2 doesn't either. (b) The reader cannot tell from §5.1/§5.2 alone whether the new file is added or the old file is moved.
+  - **Evidence in ADR**: ADR-038 §5.1 line 341 (`recorder.py # MOVE FROM …`); ADR-038 §5.2 line 378 (`engine/lineage_recorder.py | Move into … | 1 | ±90`); §6 Phase 1 says only *"Move and extend `LineageRecorder`"* without naming the new location.
+  - **Recommended fix**: Resolve the redundancy by removing the `recorder.py` entry from §5.1's "new files" list (since §5.2 already covers it as a move), or alternatively reframe §5.1 as "Files added or moved into the new package" and explicitly say `recorder.py` is moved from the engine layer. Either approach makes the migration unambiguous.
+
+- **P2-4**: ADR-038 §5.2 row for `api/app.py` still references `set_metadata_store` shim, which is a transitional symbol from the now-superseded ADR-032 lifecycle, with no explicit note that this is a deprecation-window-only call.
+  - **File**: `docs/adr/ADR-038.md:383`
+  - **Issue**: The row reads *"Register new `runs` router; call `set_metadata_store` shim with the unified store for backward compat during deprecation window"*. The phrase "for backward compat during deprecation window" does mark this as transitional, but it's a single inline qualifier next to a function name that comes from ADR-032's deleted-by-this-ADR `metadata_store.py`. A first-time reader of ADR-038 has no way to tell whether `set_metadata_store` is a still-required API or a deprecation shim. The §5.2 row for `core/metadata_store.py` (line 381) does say "6-month deprecation shim", but the §5.2 row for `api/app.py` does not link the two.
+  - **Evidence in ADR**: ADR-038 §5.2 line 381: *"`src/scieasy/core/metadata_store.py` | **Delete**; replace with a 6-month deprecation shim that re-exports the unified store + emits DeprecationWarning"*.
+  - **Recommended fix**: Append to the §5.2 row for `api/app.py` something like *"(the `set_metadata_store` shim itself is the 6-month deprecation re-export described in the `core/metadata_store.py` row above)"* — or, cleaner, drop the inner-API name and write *"Register new `runs` router; thread the unified store into the deprecation shim so the legacy `MetadataStore` accessor (see `core/metadata_store.py` row) returns the new backend during the 6-month deprecation window."*
+
+## P3 findings (nits, polish, optional)
+
+- **P3-1**: ARCHITECTURE.md §3 layered diagram's "Layer 1: Data foundation" caption omits "versioning" even though §4.6 (newly added) ships the bundled-git engine inside `src/scieasy/core/versioning/`.
+  - **File**: `docs/architecture/ARCHITECTURE.md:60-61`
+  - **Issue**: The ASCII layer-six diagram caption for Layer 1 reads *"Type hierarchy · storage backends · lazy loading · lineage"*. Per ARCHITECTURE.md §4.6 and PROJECT_TREE.md lines 101-113, `core/versioning/` is now a sibling package alongside `core/lineage/` in Layer 1, but the diagram caption doesn't list "versioning". Cosmetic only — the §3.1 cross-cutting subsection two lines below does name both layers — but the diagram could be more accurate.
+  - **Evidence in ADR**: ADR-039 §5.1 line 427 places `core/versioning/` in `src/scieasy/core/`; PROJECT_TREE.md line 101 confirms.
+  - **Recommended fix**: Append "· versioning" to the Layer 1 caption (line 61).
+
+- **P3-2**: PROJECT_TREE.md still annotates `core/proxy.py` as "ViewProxy: lazy-loading accessor", but the Appendix B glossary (ARCHITECTURE.md line 3256) says ViewProxy was eliminated by ADR-031.
+  - **File**: `docs/architecture/PROJECT_TREE.md:83-84`
+  - **Issue**: PROJECT_TREE.md line 83–84 reads: *"`proxy.py` # ViewProxy: lazy-loading accessor (slice, iter_chunks, to_memory, shape). Injected into block.run() inputs."* But ARCHITECTURE.md Appendix B (line 3256) glosses ViewProxy as *"~~ViewProxy~~ *(Eliminated in ADR-031.)* Formerly a lazy-loading accessor…"*. This is **not caused by ADR-038/039** but the inconsistency is visible in the Phase 0 refactor's modified-file set and would be a candidate for inclusion in a "Phase 0.75 manager cleanup" pass if the manager wants this fixed in the same docs PR; otherwise it's a separate issue.
+  - **Evidence in ADR**: ARCHITECTURE.md Appendix B line 3256 marks ViewProxy as superseded by ADR-031.
+  - **Recommended fix**: Either remove the `proxy.py` row entirely (if the file is gone), or update its annotation to reflect the ADR-031 reality (e.g. *"`proxy.py` — historical ViewProxy implementation, superseded by direct methods on `DataObject` per ADR-031; preserved for compat shim during deprecation window"* if the file still exists). Best handled as an out-of-scope item — flagging here only for visibility.
+
+- **P3-3**: ADR-038 §5.3 instructions for ADR.md mention several individual ADR files (ADR-031, ADR-027, ADR-012, ADR-018, ADR-020) but ADR-031 sits in its own file (`ADR-031.md`) while ADR-012, ADR-018, ADR-020, ADR-027 live consolidated inside `ADR.md`. The row "ADR-031.md Addenda" is therefore correctly pointing at the right file, but the rows "ADR-027.md D5", "ADR-012.md", "ADR-018.md", "ADR-020.md" actually need edits applied to `ADR.md` (which is correct in practice — that's where those decisions live).
+  - **File**: `docs/adr/ADR-038.md:407-410`
+  - **Issue**: Plan rows say `docs/adr/ADR-027.md`, `docs/adr/ADR-012.md`, `docs/adr/ADR-018.md`, `docs/adr/ADR-020.md` — but none of those files exist; the content is consolidated into `docs/adr/ADR.md`. The edits described in the rows have all been applied correctly (verified in `ADR.md` lines 403, 474, 1308, 2303), so this is a cosmetic mis-naming of the destination file, not a missing change.
+  - **Evidence in ADR**: `ADR.md` headings — ADR-012 at the section starting line 369, ADR-018 starting line 736, ADR-020 starting line 1613, ADR-027 starting line 3877 (none have standalone `.md` files; only ADR-031 / ADR-032 / ADR-033 / ADR-034 / ADR-035 / ADR-036 / ADR-037 / ADR-038 / ADR-039 do).
+  - **Recommended fix**: Update §5.3 to point at `docs/adr/ADR.md` (with the section anchor) for the ADR-027/012/018/020 rows. The work is done; just the destination filename is wrong in the plan.
+
+- **P3-4**: ARCHITECTURE.md §6.7 paragraph below the dataclass says "*prior drafts captured only 5 key packages declared per-block via `key_dependencies`*" but the block-developer docs still document `key_dependencies` as the current API.
+  - **File**: `docs/architecture/ARCHITECTURE.md:2215` vs `docs/block-development/architecture-for-block-devs.md:214-220`, `docs/block-development/memory-safety.md:286`
+  - **Issue**: Same root cause as P2-1 but lower severity if the block-developer docs are interpreted as "block-author-side declaration, distinct from framework capture". ARCHITECTURE.md describes the framework-side change but doesn't clarify the relationship to the user-side ClassVar. See P2-1 for the proposed fix.
+
+## Cross-doc consistency check
+
+The newly-introduced two-layer history model is described consistently across `ARCHITECTURE.md` §3.1 / §4.4 / §4.6 / §6.3 / §6.7 / §10, `PROJECT_TREE.md`, `ADR.md` (ADR-012 scope clarification + ADR-014 project state model update + ADR-018 supersession note + ADR-020 supersession note + ADR-027 D5 docstring update), `ADR-032.md` (banner + status), `ADR-033.md` (MCP tool table), `ADR-037.md` (D27, D32, X4), `ADR-038.md`, `ADR-039.md`, `docs/cli-integration.md` ("Git compatibility" §), `docs/block-development/architecture-for-block-devs.md` ("Custom blocks alongside git" §), and `CHANGELOG.md`. The four lineage tables (`runs` / `block_executions` / `data_objects` / `block_io`) are spelled identically in every doc that names them. The `runs.workflow_git_commit` join key is consistently cited as the only join between the two layers. The bundled-git-CLI choice is consistently presented as having reversed an earlier pygit2 draft — **except** for the P1-1 finding above (ADR-039 §10 still says pygit2).
+
+The two paths that are inconsistent across docs:
+
+1. The relocated checkpoint directory — ADR-038 §5.2 says `.scieasy/checkpoint/` (singular), every other doc says `.scieasy/pause/`. See **P1-2**.
+2. The destination file for the ADR-027 / ADR-012 / ADR-018 / ADR-020 supersession notes — ADR-038 §5.3 names per-ADR `.md` files but those decisions live in the consolidated `ADR.md`. See **P3-3**. (Edits are applied correctly; only the plan-row file names are wrong.)
+
+No other inter-doc divergence detected.
+
+## Terminology audit
+
+The following table lists every place the deprecated terms still appear in in-scope docs. Each row notes whether the mention looks legitimate (historical / supersession context) or stale (needs replacement). The manager can override.
+
+| File / line | Term | Context | Legitimate or stale? |
+|---|---|---|---|
+| `docs/adr/ADR-032.md` (banner + §1–7) | `metadata.db`, `MetadataStore`, `<project_dir>/metadata.db`, "MetadataStore class" | The whole document is the now-superseded ADR-032; the banner at lines 1–13 explicitly preserves the body unmodified for historical context. | **Legitimate** — historical content, banner clearly marks supersession. No action. |
+| `docs/adr/ADR-038.md:12, 25-26, 31, 33, 48, 100, 213-215, 273, 315, 321, 342, 384, 399, 401, 404, 406, 410, 411, 443, 445, 450, 490, 528, 536` | `metadata.db`, `MetadataStore`, `input_hashes`, `output_hashes`, `5 key packages`, `key_packages`, `batch_info`, `metadata_store.py`, `checkpoints` | All within the ADR's own explanation of what is being superseded and how. ADR-038's purpose is to describe the unification, so it must name the old artefacts. | **Legitimate** — these are the artefacts being superseded; ADR-038 names them as part of its own context, alternatives-considered, and migration plan sections. |
+| `docs/adr/ADR-038.md:384` | `<project>/.scieasy/checkpoint/` (the relocated path) | The §5.2 row for `engine/checkpoint.py` uses the singular name `checkpoint/`. The §5.3 row two pages later (line 404) and §6 Phase 2 (line 450) say `pause/`. | **STALE** — see P1-2. The §5.2 row needs to change to `pause/` to match every other doc. |
+| `docs/adr/ADR-039.md:12, 24, 469, 472, 473, 525, 572, 615` | `bump_revision`, `If-Match`, `pygit2` | ADR-039's own §2.1 (context, line 24), §5.2 plan rows (469-473), §6 Phase 1 (line 525), §7.2 losses paragraph (line 572) all name the artefacts being replaced, which is correct. §10 (line 615) names `pygit2` as "the engine" which is wrong (see P1-1). | Mostly **legitimate** (§2.1, §4 alternatives, §5.2, §6, §7.2 all need to name what is being replaced). **STALE in §10** — see P1-1. |
+| `docs/adr/ADR.md:389, 403-409` | `<project>/checkpoints/`, "relocated from" wording | Part of the ADR-012 scope-clarification subsection added for ADR-038. Correct historical context. | **Legitimate**. |
+| `docs/adr/ADR.md:474-476` | `bump_revision`, `If-Match` | ADR-014 project-state-model-update subsection added for ADR-039 — names the removed mechanism. | **Legitimate**. |
+| `docs/adr/ADR.md:764` | `output_hashes` in the in-text description of the original `LineageRecord` dataclass | Inside ADR-018's context section enumerating the pre-refactor state. | **Legitimate** — historical context. |
+| `docs/adr/ADR.md:916, 1082-1083, 1101` | `output_hashes=[]`, `batch_info`, `LineageRecord` field references | All in ADR-018's pre-supersession plan tables and documentation-impact list. ADR-018's supersession note at line 1308 explicitly explains how these field names migrate to the new schema. | **Legitimate** — historical content with explicit supersession note added. |
+| `docs/adr/ADR.md:1308-1317` | `LineageRecord`, `input_hashes`, `output_hashes`, `batch_info`, `partial_output_refs` | The ADR-018 "Supersession note (ADR-038, 2026-05-15)" subsection — explicitly maps old field names to the new schema. | **Legitimate** — this *is* the supersession bridge. |
+| `docs/adr/ADR.md:1630, 1835-1836, 1877-1878` | `batch_info` | ADR-020's content explaining the removal of BatchExecutor / `batch_info` from the original lineage store. | **Legitimate** — ADR-020 historical content. |
+| `docs/adr/ADR.md:2303-2305` | `batch_info`, `core/lineage/store.py::_CREATE_TABLE` references | The ADR-020 "Supersession note (ADR-038, 2026-05-15)" subsection explaining the doubly-removed status of `batch_info`. | **Legitimate** — supersession bridge. |
+| `docs/adr/ADR-037.md:31, 101, 385, 387, 422, 425, 631, 742` | `metadata.db`, "supersedes ADR-032", `lineage.db` | All mentions are inside cross-reference wording explicitly tying ADR-037 to ADR-038's supersession of ADR-032 ("the unified `lineage.db` per ADR-038 — supersedes ADR-032's `metadata.db`"). | **Legitimate** — well-formed cross-reference. |
+| `docs/adr/ADR-033.md:258, 260, 754` | `MetadataStore`, `LineageStore` (unified) | The MCP tool table explicitly repoints `inspect_data` / `get_lineage` / `preview_data` from "ADR-032 MetadataStore" to "unified `LineageStore` (ADR-038)". | **Legitimate** — correct supersession wording. |
+| `docs/architecture/ARCHITECTURE.md:424, 460` | `metadata.db` | Inline cross-reference in §4.4: *"…(`metadata.db` per the now-superseded ADR-032 and a dormant `lineage.db` schema per the original ADR-007 §4.4)…"* and the §4.4 schema comment *"subsumes the old metadata.db role"*. | **Legitimate** — historical naming. |
+| `docs/architecture/ARCHITECTURE.md:738` | `bump_revision`, `If-Match` | The §4.6 paragraph titled *"Why this replaces the previous ETag scheme"* explicitly names the replaced mechanism. | **Legitimate**. |
+| `docs/architecture/ARCHITECTURE.md:1937` | `{project}/checkpoints/` | The §6.3 paragraph naming the prior path before relocation. | **Legitimate**. |
+| `docs/architecture/ARCHITECTURE.md:2211, 2215` | `key_packages: dict[str, str]`, `5 key packages` | §6.7 dataclass definition + the paragraph immediately below it explaining the new default. Internally consistent. | **Legitimate** — the field is the new derived `key_packages` (subset of full freeze), not the old declared `key_dependencies`. The phrase "5 key packages" appears only as the now-obsolete prior-default callout. |
+| `docs/architecture/ARCHITECTURE.md:2894` | `metadata.db`, `checkpoints/`, `lineage/` | The §10 "Note on relocations" paragraph explaining what is gone and what replaced it. | **Legitimate**. |
+| `docs/architecture/ARCHITECTURE.md:3028` | "Metadata DB" (table row) | §11 technology-stack table row. **STALE** — the on-disk store is now `lineage.db`, and using the term "Metadata DB" in the canonical architecture document re-introduces the very terminology collision ADR-038 §2.2 set out to remove. | **STALE** — see P1-3. |
+| `docs/architecture/PROJECT_TREE.md:86-87, 779, 791, 794` | `metadata.db`, `metadata_store.py`, "supersedes metadata.db", "If-Match", "bump_revision" | All inside "lineage" / "removed by" annotations explaining what's been collapsed. | **Legitimate** — all are supersession callouts in the project-tree annotations. |
+| `docs/architecture/PROJECT_TREE.md:342` | `bump_revision`, `If-Match` | Annotation inside the `api/routes/workflows.py` row explicitly noting *"removed by ADR-039"*. | **Legitimate**. |
+| `docs/block-development/architecture-for-block-devs.md:214-220`, `docs/block-development/memory-safety.md:286` | `key_dependencies: ClassVar[list[str]] = ["torch>=2.0", ...]` | Block-author-side ClassVar described as a current resource hint. **Possibly stale** if the prior "5 key packages" model has been retired in favor of full `uv pip freeze` capture; the block-developer docs do not clarify the relationship. | **STALE-ish** — see P2-1. At minimum needs a clarifying note. |
+| `docs/cli-integration.md` (entire "Git compatibility" §) | `auto:`, `agent:`, ADR-039, bundled binary path | New §3.4a-aligned content. Correct. | **Legitimate**. |
+| `CHANGELOG.md:24` | `metadata.db`, `bump_revision`, `If-Match`, `LineageRecorder`, etc. | The cascade-introducing entry naming what's being changed. Correct. | **Legitimate**. |
+
+## Out-of-scope findings (file via GitHub issue, not in this PR)
+
+- **OOS-1**: `docs/architecture/PROJECT_TREE.md` line 83–84 still annotates `core/proxy.py` as "ViewProxy: lazy-loading accessor", but ARCHITECTURE.md Appendix B (line 3256) marks ViewProxy as eliminated by ADR-031. This is pre-existing drift unrelated to ADR-038/039 and should be a separate GitHub issue (likely a small follow-up to ADR-031's implementation completeness). Listed here at P3-2 above for visibility, but the manager should file it as a separate ADR-031-followup issue rather than fix it in this PR.


### PR DESCRIPTION
Closes #906

Audit report at docs/audit/2026-05-15-adr-038-039-docs-audit.md. See file for P1/P2/P3 findings + terminology audit + out-of-scope items. Parent docs PR: #905. Phase 0.75 manager applies fixes.