### PR TITLE
ci: trigger on PRs into track/** for ADR-038/039 cascade

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,13 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+    branches:
+      - main
+      # ADR-038/039 cascade tracking branches — sub-agent PRs target these
+      # (NOT main) per docs/planning/adr-038-039-checklist.md. Without this,
+      # CI only runs at the eventual integration PR to main, leaving every
+      # intermediate sub-agent PR without a verification signal.
+      - 'track/**'
     types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
 


### PR DESCRIPTION
Sub-agent PRs in the ADR-038/039 cascade target tracking branches; this lets CI run on those PRs so we have a verification signal before merging into the tracking branch.