### PR TITLE
fix(#947): recover orphan Codex reconcile commit from PR #952

### DIFF
--- a/frontend/src/components/Git/ConflictMarkerDecoration.ts
+++ b/frontend/src/components/Git/ConflictMarkerDecoration.ts
@@ -325,28 +325,37 @@ export function resolveRegionText(
   const beforeLines = lines.slice(0, region.startLine - 1);
   const afterLines = lines.slice(region.incomingEndLine);
 
-  // Extract the three (or two) text sections.
-  // 2-way:
-  //   startLine                            (marker `<<<<<<<`)
-  //   startLine+1 .. currentEndLine-1     (current section)
-  //   currentEndLine                       (marker `=======`)
+  // Section boundaries (1-based line numbers from the parser):
+  //
+  // 2-way style:
+  //   startLine                              (marker `<<<<<<<`)
+  //   startLine+1 .. currentEndLine-1       (current section)
+  //   currentEndLine                         (marker `=======`)
   //   currentEndLine+1 .. incomingEndLine-1 (incoming section)
-  //   incomingEndLine                      (marker `>>>>>>>`)
-  // diff3:
-  //   startLine                            (marker `<<<<<<<`)
-  //   startLine+1 .. currentEndLine-1     (current section)
-  //   currentEndLine                       (marker `|||||||`)
-  //   currentEndLine+1 .. baseEndLine-1   (base section)
-  //   baseEndLine                          (marker `=======`)
-  //   baseEndLine+1 .. incomingEndLine-1  (incoming section)
-  //   incomingEndLine                      (marker `>>>>>>>`)
-  const currentEnd = region.baseEndLine ?? region.currentEndLine;
-  const currentSection = lines.slice(region.startLine, currentEnd - 1);
-  const baseStart = region.baseEndLine !== null ? region.baseEndLine : null;
-  const incomingStart =
+  //   incomingEndLine                        (marker `>>>>>>>`)
+  //
+  // diff3 style:
+  //   startLine                              (marker `<<<<<<<`)
+  //   startLine+1 .. currentEndLine-1       (current section)
+  //   currentEndLine                         (marker `|||||||`)
+  //   currentEndLine+1 .. baseEndLine-1     (base section — not echoed)
+  //   baseEndLine                            (marker `=======`)
+  //   baseEndLine+1 .. incomingEndLine-1    (incoming section)
+  //   incomingEndLine                        (marker `>>>>>>>`)
+  //
+  // Codex P1 (PR #952): the current section ALWAYS ends at
+  // `currentEndLine` (whether that's `=======` in 2-way or `|||||||` in
+  // diff3). The previous impl conflated diff3's `=======` with the end
+  // of the current section, which caused `accept_current` /
+  // `accept_both` to splice the diff3 marker + base block into the
+  // resolved file — leaving malformed text that git refused to stage.
+  const currentSection = lines.slice(region.startLine, region.currentEndLine - 1);
+  // Incoming section starts after the `=======` marker:
+  //   - 2-way: that's `currentEndLine`
+  //   - diff3: that's `baseEndLine` (since `currentEndLine` is `|||||||`)
+  const incomingMarkerLine =
     region.baseEndLine !== null ? region.baseEndLine : region.currentEndLine;
-  const incomingSection = lines.slice(incomingStart, region.incomingEndLine - 1);
-  void baseStart; // present for completeness; the impl never echoes base
+  const incomingSection = lines.slice(incomingMarkerLine, region.incomingEndLine - 1);
 
   let resolved: string[];
   switch (action.type) {

--- a/frontend/src/components/Git/GitGraph/interactions.ts
+++ b/frontend/src/components/Git/GitGraph/interactions.ts
@@ -18,6 +18,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import type React from "react";
 
 import { useAppStore } from "../../../store";
+import type { GitCommit } from "../../../types/api";
 
 import { ROW_HEIGHT } from "./colorPalette";
 
@@ -69,11 +70,18 @@ export function makeCommitClickHandler(
 export function useGraphInteractions(
   totalRows: number,
   onOpenDiff?: (sha: string) => void,
+  commits?: GitCommit[],
 ): GraphInteractionsApi {
   const setLastError = useAppStore((s) => s.setLastError);
 
   const [focusedRow, setFocusedRow] = useState<number | null>(null);
   const [hoveredSha, setHoveredSha] = useState<string | null>(null);
+
+  // Keep `commits` in a ref so the keyboard handler always sees the
+  // latest array without forcing the callback to recreate on every
+  // render.
+  const commitsRef = useRef<GitCommit[] | undefined>(commits);
+  commitsRef.current = commits;
 
   const scrollContainerRef = useRef<HTMLDivElement | null>(null);
   // Initial range covers ~80 rows (a typical desktop viewport at ROW_HEIGHT=22).
@@ -134,14 +142,25 @@ export function useGraphInteractions(
           const next = cur === null ? 0 : Math.max(0, cur - 1);
           return next;
         });
-      } else if (event.key === "Enter") {
+      } else if (event.key === "Enter" || event.key === " ") {
         event.preventDefault();
-        // Caller-side: read commits[focusedRow].sha and forward. We can
-        // only signal that Enter was pressed via the click handler — the
-        // panel binds focusedRow → sha lookup.
+        // Codex P2 on PR #952: Enter (and Space) opens the diff for the
+        // currently focused row. Without this branch keyboard nav was
+        // a dead-end — arrow keys moved the cursor but the user could
+        // not "activate" it.
+        setFocusedRow((cur) => {
+          if (cur === null) return cur;
+          const commits = commitsRef.current;
+          const commit = commits && commits[cur];
+          if (commit) {
+            setLastError(null);
+            onOpenDiff?.(commit.sha);
+          }
+          return cur;
+        });
       }
     },
-    [totalRows],
+    [totalRows, onOpenDiff, setLastError],
   );
 
   return {

--- a/frontend/src/components/Git/GitHistoryList.tsx
+++ b/frontend/src/components/Git/GitHistoryList.tsx
@@ -337,7 +337,11 @@ function GitGraphPane({
   onCommitClick: (sha: string) => void;
 }): JSX.Element {
   const data = useGraphData();
-  const interactions = useGraphInteractions(data.commits.length, onCommitClick);
+  const interactions = useGraphInteractions(
+    data.commits.length,
+    onCommitClick,
+    data.commits,
+  );
 
   if (data.loading) {
     return (

--- a/frontend/src/components/Git/__tests__/ConflictResolveView.test.tsx
+++ b/frontend/src/components/Git/__tests__/ConflictResolveView.test.tsx
@@ -165,6 +165,50 @@ describe("resolveRegionText (text splice)", () => {
     const out = resolveRegionText(content, region, { type: "manual_edit" });
     expect(out).toBe(content);
   });
+
+  // Codex P1 on PR #952: diff3 sections must use the correct boundaries
+  // — current section ends at `|||||||`, NOT at `=======`.
+  describe("diff3 boundaries (Codex P1 #952)", () => {
+    const diff3 = [
+      "before",
+      "<<<<<<< HEAD",
+      "ours-1",
+      "ours-2",
+      "||||||| base",
+      "base-1",
+      "=======",
+      "theirs-1",
+      ">>>>>>> feature-x",
+      "after",
+    ].join("\n");
+    const region3 = parseConflictRegions(diff3)[0];
+
+    it("accept_current keeps ONLY the current section (no base, no markers)", () => {
+      const out = resolveRegionText(diff3, region3, { type: "accept_current" });
+      expect(out.split("\n")).toEqual([
+        "before",
+        "ours-1",
+        "ours-2",
+        "after",
+      ]);
+    });
+
+    it("accept_incoming keeps ONLY the incoming section (no base, no markers)", () => {
+      const out = resolveRegionText(diff3, region3, { type: "accept_incoming" });
+      expect(out.split("\n")).toEqual(["before", "theirs-1", "after"]);
+    });
+
+    it("accept_both concatenates current + incoming (no base, no markers)", () => {
+      const out = resolveRegionText(diff3, region3, { type: "accept_both" });
+      expect(out.split("\n")).toEqual([
+        "before",
+        "ours-1",
+        "ours-2",
+        "theirs-1",
+        "after",
+      ]);
+    });
+  });
 });
 
 describe("ConflictResolveView (D39-2.4b)", () => {

--- a/frontend/src/components/Toolbar.tsx
+++ b/frontend/src/components/Toolbar.tsx
@@ -42,6 +42,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 
+import { useAppStore } from "../store";
 import type { ProjectResponse } from "../types/api";
 import { BranchPicker } from "./Git/BranchPicker";
 import { CommitDialog } from "./Git/CommitDialog";
@@ -536,6 +537,13 @@ export function Toolbar(props: ToolbarProps) {
         sourceBranch={mergeSource ?? ""}
         isOpen={mergeSource !== null}
         onClose={() => setMergeSource(null)}
+        onOpenFile={(path) => {
+          // Codex P2 on PR #952: wire "Open in editor" to the existing
+          // tab-open slice action so users can jump directly from the
+          // conflict list into Monaco. Without this the button was a
+          // no-op in production.
+          useAppStore.getState().openFileTab(path);
+        }}
       />
     </TooltipProvider>
   );


### PR DESCRIPTION
Closes #947 (already substantially closed by merged PR #952 + this orphan recovery)

## Why this PR exists

D39-2.4b agent (PR #952) was merged at 19:21:44Z. Codex auto-review posted at 19:21:18Z (26 seconds before merge). The agent's reconcile commit `6443533` was pushed at 19:24:57Z to its feature branch — **after** the PR had already merged. As a result, the merged PR contains only the initial implementation; the Codex P1 + P2 fixes are orphaned on `feat/issue-947/d39-2-4b-conflict-graph-impl`.

This is the discipline violation captured in the new memory rule `feedback_wait_for_agent_done_before_merge.md` (manager merged on CI-green instead of waiting for agent task-completion).

## What this PR adds

Cherry-pick of `6443533` onto `track/adr-039/git-versioning` containing:

- **P1**: `resolveRegionText` diff3 boundary fix — current section now always ends at `currentEndLine` regardless of 2-way vs diff3 style; previously `accept_current` / `accept_both` spliced the `|||||||` marker + base block into the resolved file. + 3 diff3-specific tests in `ConflictResolveView.test.tsx`.
- **P2**: `Toolbar.tsx` now mounts `<MergeFlow>` with `onOpenFile` wired to `useAppStore.getState().openFileTab(path)` — previously the 'Open in editor' button in ConflictResolveView was a no-op.
- **P2**: `useGraphInteractions` now receives the `commits` array; Enter/Space opens diff for the focused row via `onOpenDiff` — previously the kbd handler consumed Enter but did nothing.

## Risk

Low. Just the orphan commit re-applied to its intended target branch.