### PR TITLE
fix(ci): add pytest-timeout to pyproject.toml dev deps (#1009)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dev = [
     "pytest>=8.0",
     "pytest-cov>=6.0",
     "pytest-xdist>=3.5",
+    "pytest-timeout>=2.3",  # ADR-040 preflight: hard wall-clock kill for hung tests (Windows subprocess/asyncio edge cases)
     "ruff>=0.11",
     "mypy>=1.15",
     "types-PyYAML>=6.0",
@@ -141,6 +142,12 @@ follow_imports = "skip"
 testpaths = ["tests"]
 # TEMP: lowered until ADR-034 Phase 1-3 restores test coverage. See PR #808 rollback context.
 addopts = "-ra -q --cov=scieasy --cov-report=term-missing --cov-fail-under=70"
+# ADR-040 preflight: per-test 60s wall-clock kill via pytest-timeout. Without
+# this, hung tests (Windows subprocess pipe issues, deadlocked asyncio) hang
+# pytest forever which hangs agents forever. ``thread`` method works on Windows
+# (signal method requires SIGALRM, POSIX-only).
+timeout = 60
+timeout_method = "thread"
 python_files = ["test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]


### PR DESCRIPTION
Closes #1009

## Summary

ADR-040 cascade preflight. Adds `pytest-timeout>=2.3` to `[project.optional-dependencies].dev` and configures `timeout = 60` + `timeout_method = "thread"` in `[tool.pytest.ini_options]` so the per-test wall-clock kill is on by default everywhere — sub-agent local runs, contributor laptops, CI alike.

Before this change, `pytest-timeout` was installed only via an explicit extra in CI (`.github/workflows/ci.yml:94`), and sub-agent pytest runs had no protection. Multiple agents in past cascades hung for tens of minutes on stuck tests.

## Out of scope

CI's redundant explicit `--timeout=60 --timeout-method=thread` flags and explicit `pytest-timeout` install (lines 94, 106, 108) become no-ops after this lands but remain working. Cleanup is a separate follow-up — keeping this preflight bytewise minimal.

## Test plan

- [ ] CI green on both 3.11 + 3.13
- [ ] `pip install -e ".[dev]"` brings `pytest-timeout` automatically
- [ ] pyproject.toml `timeout` setting honored when no CLI flag passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)