### PR TITLE
docs(#1011): ADR-040 cascade tracking checklist

### DIFF
--- a/docs/planning/adr-040-checklist.md
+++ b/docs/planning/adr-040-checklist.md
@@ -1,0 +1,531 @@
+# ADR-040 Implementation Checklist
+
+> **Mandatory tracking doc.** Every agent edits the rows it owns and only those rows.
+> Drift = protocol violation. The dispatcher (Claude as agent manager) sweeps after every phase.
+> Plan file: `~/.claude/plans/bubbly-popping-frost.md`. Session start: 2026-05-16.
+> ADR: [ADR-040](../adr/ADR-040.md). Cascade umbrella issue: **#1011**.
+
+## Conventions
+
+- `[ ]` not started · `[~]` in progress · `[x]` done · `[!]` blocked
+- "Owner" is the agent role label (e.g. `S40a`, `I40c`, `A1`, `A_int`) or `manager` for hands-on work
+- Each row references the relevant ADR section in `[brackets]`
+- When you tick a box, append a one-line note: `→ <PR-or-commit-link>` or `→ <test-name passes>` or `→ <report-file-path>`
+- Out-of-scope file lists per agent are encoded inside each dispatch prompt (manager curates from `docs/planning/adr-040-code-scope.md`)
+- Owner labels:
+  - `S40<x>` — skeleton agents (one per track + skill-structure-only): `S40a` FastMCP, `S40b` skill-structure, `S40c` provisioning, `S40d` install-parity
+  - `I40<x>` — impl agents: `I40a` FastMCP, `I40c` provisioning, `I40d` install-parity, `I40b` skills (Phase 2c, dispatched after MCP impl + skill-design investigation)
+  - `A40-skel` — Phase 1.5 skeleton auditor (single, all 4 tracks)
+  - `A40-impl` — Phase 2a.5 impl auditor (single, batch 1)
+  - `A40-skill` — Phase 2c.5 skill content auditor
+  - `A1` / `A2` / `A3` — Phase 3 three parallel auditors (ADR completeness / MCP wiring+docs / agent-POV)
+  - `A_int` — Phase 3.5 cross-track integration auditor
+  - `F40-*` — fix agents dispatched on demand
+
+## Manager discipline (non-negotiable for this cascade)
+
+1. Every `Agent` dispatch uses `isolation: "worktree"`, `model: "opus"` (impl) or `"sonnet"` (audit/diagnostic), `subagent_type: "general-purpose"`, `run_in_background: true`.
+2. **MANDATORY**: After every Agent dispatch, the manager MUST immediately enter a foreground `until` loop polling for the next concrete artifact (branch on origin, PR open, report file present). Never reply "Waiting" and let the stop-hook fire repeatedly. Pattern: `until [ -n "$(git ls-remote origin '<branch-pattern>' 2>/dev/null)" ]; do sleep 60; done` or `until [ -f <report-path> ]; do sleep 60; done`.
+3. Worktree isolation forbids `pip install -e .` from within the worktree (see `feedback_editable_install_contamination` memory).
+4. Every `pytest` invocation uses `--timeout=60`. Plugin (`pytest-timeout>=2.3`) is in `pyproject.toml [project.optional-dependencies].dev` after preflight PR #1010.
+5. No `npm run dev` background processes — use `vitest run` and `npm run build`.
+6. Every agent PR body contains `Closes #N`.
+7. CI must be green before any agent reports done.
+8. Mandatory live Chrome smoke for any UI-touching phase before report-done (Phase 4 is the heavy UI work; earlier phases mostly backend).
+9. Codex P1/P2 findings on agent PRs override auditor "defer" calls — manager fixes in-PR per overnight merge protocol (`feedback_audit_p1_override`).
+10. Tracking-branch convention: agent feature branches target the tracking branch (NOT main); umbrella PR `[DO NOT MERGE]` per track points to main for visibility only.
+11. **Out-of-scope work leaves `# TODO(#NNN): <reason> — Out of scope per <ref>. Followup: <link>.` in the repo** per CLAUDE.md §7.6 (new rule, merged in #1007). Verbal "we'll do later" is silent tech debt. Dispatch prompts pre-enumerate expected out-of-scope items so agents TODO-tag rather than silently skip.
+12. Manager waits for `<task-notification status="completed">` before merging an agent PR — Codex auto-review fires after first CI run; agent reconciles in a follow-up commit. Cap Codex reconcile at ONE round per agent.
+13. Wait-discipline reminder: `until` loops ONLY when waiting on a dispatched agent (per user direction 2026-05-16). For CI polling and other non-agent waits, just poll briefly and move on.
+
+---
+
+## Phase 0 — Manager preflight
+
+### 0.0 — CLAUDE.md §7.6 TODO rule
+
+- [x] §7.6 added to CLAUDE.md; agent-manager skill hygiene rule #11 mirrors it; memory `feedback_out_of_scope_todo` written
+- [x] PR opened + merged → [PR #1007](https://github.com/zjzcpj/SciEasy/pull/1007) → main commit `5059599`
+- [x] Issue tracker → [#1008](https://github.com/zjzcpj/SciEasy/issues/1008)
+
+### 0.1-0.2 — State hygiene + toolchain
+
+- [x] `git fetch origin --prune` + `git pull origin main` (main at `627dc4f` after pytest-timeout fix)
+- [x] Tool versions verified: Python 3.13.12, pytest 9.0.2, ruff 0.15.9, mypy 1.20.0, gh 2.89.0, claude 2.1.143, codex-cli 0.130.0, node v24.14.0
+- [x] `python -c "import scieasy; print(scieasy.__file__)"` → source path, no editable-install pollution
+- [x] CI baseline on main: last 5 runs green
+- [ ] **Deferred**: separate manager worktree at `../scieasy-mgr-adr-040/`. Justified: as long as every sub-agent uses `isolation: "worktree"`, my main checkout is safe. Will create if HEAD drift observed.
+
+### 0.3 — pytest-timeout preflight fix
+
+- [x] `pytest-timeout>=2.3` added to `pyproject.toml [project.optional-dependencies].dev`; `timeout = 60` + `timeout_method = "thread"` added to `[tool.pytest.ini_options]`
+- [x] Issue → [#1009](https://github.com/zjzcpj/SciEasy/issues/1009)
+- [x] PR merged → [PR #1010](https://github.com/zjzcpj/SciEasy/pull/1010) → main commit `627dc4f`
+- [ ] **Followup**: clean up CI's now-redundant explicit `--timeout=60 --timeout-method=thread` flags and `pytest-timeout` install at `.github/workflows/ci.yml:94, 106, 108`. Out of scope here per CLAUDE.md §7.6 — TODO-tag deferred to a separate small PR after the cascade ships.
+
+### 0.4 — Issues opened
+
+- [x] #824 / #825 / #832 / #875 reopened (closed prematurely when ADR docs PR #987 squash-merged) — implementation has not shipped, ADR is the plan not the ship
+- [x] #903 confirmed open (parent umbrella, NOT closed by this cascade per ADR-040 §3.10)
+- [x] **#1011** ADR-040 cascade umbrella opened (links to #824/#825/#832/#875, ADR doc, plan file)
+- [x] **#1012** ADR-040 track: FastMCP migration (ADR §3.1, §3.2, §3.2a, §3.3)
+- [x] **#1013** ADR-040 track: prod-env agent provisioning (ADR §3.5, §3.6, §3.7, §3.8)
+- [x] **#1014** ADR-040 track: scieasy install Codex parity (ADR §3.9)
+- [x] **#1015** ADR-041 placeholder: Layer 7 filesystem ACL on `<project>/blocks/` (for TODO tags during cascade)
+- [x] **#1016** ADR-041 placeholder: BlockRegistry runtime rejection of `DataObject`-typed ports (for TODO tags during cascade)
+- [ ] Skills track issue (`#NNN`) opened at Phase 2b after skill-design investigation completes
+
+### 0.5 — Tracking branches + umbrella PRs
+
+- [x] `track/adr-040/fastmcp` off main, pushed → [seed commit `dbfc257`](https://github.com/zjzcpj/SciEasy/commit/dbfc257)
+- [x] `track/adr-040/provisioning` off main, pushed → [seed commit `7f0ed35`](https://github.com/zjzcpj/SciEasy/commit/7f0ed35)
+- [x] `track/adr-040/install-parity` off main, pushed → [seed commit `a4f600e`](https://github.com/zjzcpj/SciEasy/commit/a4f600e)
+- [x] **[PR #1017]** umbrella `[DO NOT MERGE]` → `track/adr-040/fastmcp` → main (draft)
+- [x] **[PR #1018]** umbrella `[DO NOT MERGE]` → `track/adr-040/provisioning` → main (draft)
+- [x] **[PR #1019]** umbrella `[DO NOT MERGE]` → `track/adr-040/install-parity` → main (draft)
+- [ ] Skills tracking branch `track/adr-040/skills` + umbrella PR opened at Phase 2b
+
+### 0.6 — Checklist authoring
+
+- [~] This file (`docs/planning/adr-040-checklist.md`) authored, mirroring 038/039 quality bar
+- [ ] Docs PR for checklist opened + merged
+
+### 0.7-0.8 — Discipline hook + Chrome MCP probe
+
+- [x] `scripts/hooks/remind-checklist-discipline.sh` present
+- [x] `.claude/settings.json` wires PostToolUse on Edit|Write|MultiEdit|NotebookEdit + TaskCreate|TaskUpdate|TaskStop|TodoWrite (verified — already configured)
+- [x] PreToolUse Bash hooks wire gate-check on `git push` and `gh pr create`; PreToolUse Agent wires template check
+- [x] Chrome MCP loadable (`mcp__claude-in-chrome__tabs_context_mcp` schema fetched)
+- [ ] **Phase 4 prereq**: actual Chrome probe + scieasy-blocks-imaging plugin install + Codex CLI 2026+ project-scope `.codex/config.toml` support verification
+
+---
+
+## Phase 0.5 — Code-scope investigation agent (Owner: AC40, single Explore agent)
+
+**Goal**: per-track owner-file manifest with every symbol, cross-ref, test-impact pre-mapped so Phase 1 skeleton agents dispatch with zero re-grepping.
+
+- [ ] Single Explore agent dispatched with: ADR-040 + Phase 1 Explore findings inline + read-only mandate; output to `docs/planning/adr-040-code-scope.md`
+- [ ] Per-track sections produced:
+  - FastMCP (every file in `src/scieasy/ai/agent/mcp/`, every `MCPServer`/`TOOL_REGISTRY`/`_render_tool_catalog`/`_load_skill_md`/`compose_system_prompt` callsite, every test, TypeRegistry surface for §3.2a, frontend touch-points)
+  - Provisioning (ADR-039 live wiring in `api/runtime.py`+`cli/main.py`, ADR-038 lineage.db touch-points, `open_project` idempotency model, existing project template, Chrome/PTY codepath for hook firing, session_id payload format)
+  - Install-parity (`_install_skill`/`_remove_skill`/`_install_codex`/`_render_codex_block`/`perform_install` exact shape, "force user-scope for codex" fallback location, `~/.agents/skills/` references, skill-source path resolution)
+  - Skills (current `skills/scieasy/SKILL.md` structure for identity continuity — deep skill-design research deferred to Phase 2b)
+  - Cross-cutting (`tests/fixtures/`, `tests/conftest.py`, import-linter rules, mypy strict-mode boundaries, per-track out-of-scope file lists)
+- [ ] **Discrepancies from ADR-040 §5 inventory** (pre-discovered, agent confirms + extends):
+  - Tool count is **27** (25 baseline + `finish_ai_block` from ADR-035 §3.5 skeleton, already in `_registry.py:246-252`), ADR says 26
+  - `src/scieasy/ai/agent/mcp/_context.py` + `__init__.py` missing from ADR §5.1 inventory
+  - ADR-039 git auto-init is **production-live** at `api/runtime.py:598-608` + `:686-701` + `cli/main.py:130-158` — not skeleton
+- [ ] Manifest committed to main via small docs PR; folded into Phase 1 dispatch prompts
+
+---
+
+## Track: FastMCP (`track/adr-040/fastmcp`, sub-issue #1012, umbrella PR #1017)
+
+### Phase 1 / S40a — Skeleton (Owner: S40a)
+
+**Branch**: `feat/issue-NNN/adr-040-s40a-fastmcp-skeleton` off `track/adr-040/fastmcp`. **PR target**: tracking branch (NOT main).
+
+- [ ] Sub-issue opened for S40a
+- [ ] `src/scieasy/ai/agent/mcp/server.py` — new shape: `mcp = FastMCP(...)` placeholder, `serve()` stub raises `NotImplementedError` with detailed TODO comment per ADR §3.1
+- [ ] All 27 `@mcp.tool()` decorated stubs with type hints + Pydantic return models DEFINED (signatures real, bodies `NotImplementedError`) across `tools_workflow.py`, `tools_authoring.py`, `tools_inspection.py`, `tools_qa.py`
+- [ ] `_registry.py` — delete (FastMCP discovers by decorator); if any callsite imports from it, fix or TODO-tag
+- [ ] `system_prompt.py::_load_skill_md` — switched to `importlib.resources` (stub returns placeholder)
+- [ ] `system_prompt.py::_render_tool_catalog` — switched to enumerate from FastMCP `list_tools()` (stub returns hardcoded placeholder)
+- [ ] `system_prompt.py::_render_project_context(project_dir)` — stub with section structure + TODO referencing #825
+- [ ] `pyproject.toml` — add `fastmcp>=3.1,<4` to deps
+- [ ] `tests/ai/test_mcp_fastmcp.py` (new) — parity test scaffold (skipped); `tests/ai/test_system_prompt.py` — wheel-layout + project_context test stubs added (skipped)
+- [ ] All NotImplementedError stubs carry `# TODO(#1012): <reason>` per CLAUDE.md §7.6; any deferred behavior carries `# TODO(#1015)` (Layer 7 ACL) or `# TODO(#1016)` (port-type rejection)
+- [ ] PR opened against tracking branch; CI green; `Closes #<sub-issue>` in body
+
+### Phase 1.5 / A40-skel — Skeleton audit
+
+- [ ] Stubs raise NotImplementedError with TODO comment block meeting CLAUDE.md §7.6 form
+- [ ] Comment blocks describe impl approach sufficient for I40a to fill without re-deriving design
+- [ ] File scopes match Phase 0.5 manifest
+- [ ] No out-of-scope files touched (frozen core, frontend, ADR/spec edits)
+- [ ] Test stubs use `@pytest.mark.skip(reason=...)` paired with TODO referencing impl ticket
+- [ ] Codex auto-review reconciled (accept / defer-issue / reject-on-record); P1/P2 deferred → manager override per merge protocol
+- [ ] Manager merges S40a PR into `track/adr-040/fastmcp` once green
+
+### Phase 1.6 / F40-skel — Skeleton fix (conditional)
+
+- [ ] Only if A40-skel found P1; fix agent dispatched to address in-PR
+
+### Phase 2a / I40a — Implementation
+
+**Branch**: `feat/issue-NNN/adr-040-i40a-fastmcp-impl` off `track/adr-040/fastmcp` (after S40a merged).
+
+- [ ] All 27 `@mcp.tool()` functions implemented with Pydantic return models including `next_step: str` on write-class tools
+- [ ] `scaffold_block` returns `warnings: list[str]` per §3.2a (generic-`DataObject` port detection, unregistered type detection); both warnings carry `# TODO(#1016)` referencing the hard-validation followup
+- [ ] All 27 docstrings rewritten per §3.2 style guide (imperative first line; "Use when … Do NOT use to …"; `next_step` reasoning)
+- [ ] `_render_project_context` implemented per §3.3: git/non-git/empty-workflows handling, top-3-by-mtime workflow listing, BlockRegistry plugin enumeration, <100ms perf budget
+- [ ] FastMCP `serve()` wired into `runtime.py` adapter (standalone-bridge entry point preserved)
+- [ ] `_registry.py` fully deleted; no backward-compat shim per CLAUDE.md "no compat shims" guidance
+- [ ] `<!-- project_context:begin/end -->` marker present in skill base path (real splice in `compose_system_prompt`; placeholder marker added by S40b)
+- [ ] Tests:
+  - 27-tool parity (name/description/schema/next_step shape matches expected snapshots)
+  - `inputSchema` malformed-call rejection at MCP boundary
+  - `_render_project_context` across git/non-git/empty/1000-workflow scenarios + <100ms perf assertion
+  - Wheel-layout regression for `_load_skill_md` via `importlib.resources`
+- [ ] CHANGELOG entry: `[#1012] FastMCP migration + tool catalog rewrite + project_context injection (@claude, 2026-05-1X, branch: feat/issue-NNN/adr-040-i40a-fastmcp-impl, session: <task-id>)`
+- [ ] CI green; PR merged into tracking branch
+
+---
+
+## Track: Provisioning (`track/adr-040/provisioning`, sub-issue #1013, umbrella PR #1018)
+
+### Phase 1 / S40c — Skeleton (Owner: S40c)
+
+**Branch**: `feat/issue-NNN/adr-040-s40c-provisioning-skeleton` off `track/adr-040/provisioning`.
+
+- [ ] Sub-issue opened for S40c
+- [ ] `src/scieasy/agent_provisioning/` package created:
+  - `__init__.py`
+  - `_orchestrate.py` — `install_project_agent_assets(project_dir, *, force=False) -> ProvisionResult` stub raising NotImplementedError with TODO covering orchestration order, idempotent top-up, version-marker handling per §3.8
+  - `claude_agents_md.py` — `write_claude_agents_md(project_dir)` stub
+  - `hooks.py` — `write_hooks(project_dir)` stub
+  - `skills.py` — `write_skills(project_dir)` stub
+  - `codex_config.py` — `write_codex_config(project_dir)` stub
+- [ ] `src/scieasy/agent_provisioning/templates/` with placeholder files:
+  - `claude_agents_md.md` (1-line TODO; content authored in Phase 2c)
+  - `codex_config.toml` (TODO with structure outline per §3.7)
+  - `hook_deny_scieasy_cli.py` (stub with matcher + exit-code semantics comment per §3.6)
+  - `hook_protect_workflow_yaml.py` (same)
+  - `hook_enforce_list_blocks_before_block_write.py` (same; session-marker scheme comment) — header carries `# TODO(#1015)` Layer 7 ACL placeholder
+  - `hook_remind_poll_status.py` (PostToolUse; always exit 0 — comment block)
+  - `hook_mark_list_blocks_called.py` (PostToolUse; writes session marker)
+  - `hook_enforce_concrete_port_types.py` (PostToolUse AST scan; comment block) — header carries `# TODO(#1016)` hard-validation placeholder
+- [ ] `SCIEASY_PROVISION_VERSION` constant + version-marker file path stubbed
+- [ ] Stub call sites wired in `api/runtime.py::create_project` and `::open_project` and `cli/main.py::init` — wrapped in try/except per ADR §7 "non-fatal" semantics; current bodies pass (real call in I40c)
+- [ ] `tests/agent_provisioning/` directory + 6 test files with skipped stubs and docstring test plans
+- [ ] PR opened against tracking branch; CI green; `Closes #<sub-issue>` in body
+
+### Phase 1.5 / A40-skel — Skeleton audit
+
+See FastMCP track's A40-skel; covers all 4 skeleton PRs in one pass.
+
+### Phase 2a / I40c — Implementation
+
+**Branch**: `feat/issue-NNN/adr-040-i40c-provisioning-impl` off `track/adr-040/provisioning`.
+
+- [ ] CLAUDE.md/AGENTS.md template body authored (~50 LOC; identical content; end-user-agent purpose-written; distinct from SciEasy source repo's 800-line dev CLAUDE.md) — content blueprint comes from Phase 2c skill investigation; here I40c writes the *template*, while Phase 2c writes the *content*. **Coordination**: I40c lands the template *file* with placeholder body; Phase 2c fills the body. Alternatively merge order: Phase 2c first → I40c fills template from Phase 2c output. Manager picks at dispatch time.
+- [ ] `codex_config.toml` template authored per §3.7 (`[mcp_servers.scieasy]` block with `command = "<sys.executable>"`, `args = ["-m", "scieasy", "mcp-bridge"]`, env `SCIEASY_PROJECT_DIR`)
+- [ ] All 6 hook scripts implemented:
+  - `deny_scieasy_cli.py`: regex `^\s*(.*/)?scieasy[\s$]` on `tool_input.command`; exit 2 with guidance
+  - `protect_workflow_yaml.py`: regex `workflows/.*\.ya?ml$` on `tool_input.file_path`; exit 2
+  - `enforce_list_blocks_before_block_write.py`: session-keyed marker at `<project>/.scieasy/.session-state/<session_id>/list_blocks_called`; multi-matcher (Edit|Write|Bash|mcp__scieasy__scaffold_block); regex for block-file Bash writes
+  - `remind_poll_status.py`: always exit 0; injects stderr feedback
+  - `mark_list_blocks_called.py`: writes session marker; always exit 0
+  - `enforce_concrete_port_types.py`: AST-parse `blocks/*.py` for `PortSpec(type="DataObject")` and unregistered type names; emit stderr advisories
+- [ ] `install_project_agent_assets` orchestrates all writes; idempotent (respects version-marker compare)
+- [ ] Lifecycle wiring real calls in `api/runtime.py::{create_project, open_project}` (next to existing ADR-039 git init at `:598-608` and `:686-701`) and `cli/main.py::init` (`:130-158`)
+- [ ] `terminal.py::spawn_codex` docstring updated (drop outdated "asymmetry with claude" comment)
+- [ ] `SCIEASY_PROVISION_VERSION` constant defined; marker file `<project>/.claude/.scieasy-provision-version` written on install
+- [ ] `.gitignore` default template: add `.scieasy/.session-state/`
+- [ ] `docs/agent-provisioning.md` (new) — one-page operational doc per ADR §5.3
+- [ ] `docs/architecture/ARCHITECTURE.md` — new subsection "Prod-env agent reliability stack" + explicit dev/prod env boundary diagram
+- [ ] Tests:
+  - All assets land at expected paths on fresh `create_project`
+  - `open_project` idempotent top-up: missing files restored, customized files preserved (version-marker compare)
+  - Each of 6 hook scripts behaves correctly against synthetic stdin payloads (block + pass cases)
+  - Lifecycle integration: GUI create → all assets present + hooks executable + spawned Claude sees them
+  - Hook script Windows-execute smoke test (CI is Ubuntu-only — manual Windows verification required, captured here)
+- [ ] CHANGELOG entry under `[Unreleased] > Added`
+- [ ] CI green; PR merged into tracking branch
+
+---
+
+## Track: Install-parity (`track/adr-040/install-parity`, sub-issue #1014, umbrella PR #1019)
+
+### Phase 1 / S40d — Skeleton (Owner: S40d)
+
+**Branch**: `feat/issue-NNN/adr-040-s40d-install-skeleton` off `track/adr-040/install-parity`.
+
+- [ ] Sub-issue opened for S40d
+- [ ] `_install_skill` signature refactored to support multi-skill walking + cross-install (Claude + Codex paths); body NotImplementedError + comment per ADR §3.9
+- [ ] `_remove_skill` refactored to symmetric cross-removal
+- [ ] `_install_codex` refactored to support `--scope project` writing `<cwd>/.codex/config.toml`; body NotImplementedError + comment describing removal of "force user-scope" fallback at current `install.py:489-498`
+- [ ] `_render_codex_block` reused; no signature change
+- [ ] `tests/cli/test_install.py` extensions: cross-install + codex project-scope test stubs (skipped)
+- [ ] PR opened against tracking branch; CI green; `Closes #<sub-issue>` in body
+
+### Phase 1.5 / A40-skel
+
+See FastMCP track.
+
+### Phase 2a / I40d — Implementation
+
+**Branch**: `feat/issue-NNN/adr-040-i40d-install-impl` off `track/adr-040/install-parity`.
+
+- [ ] `_install_skill` walks `src/scieasy/_skills/scieasy/` (post-FastMCP `importlib.resources` relocation), cross-installs to both `.claude/skills/` AND `.agents/skills/` trees (user or project scope)
+- [ ] `_remove_skill` symmetric removal across both providers
+- [ ] `_install_codex` project-scope branch writes `<cwd>/.codex/config.toml`; "force user-scope for codex" fallback at `install.py:489-498` removed
+- [ ] `perform_install` docstring updated (cross-install + project-scope codex now supported)
+- [ ] `docs/cli-integration.md` — update `--skill` cross-installs both providers; `--target codex --scope project` writes project config
+- [ ] Tests:
+  - Cross-install writes all 6 skill files to both `.claude/skills/scieasy/` and `.agents/skills/scieasy/`
+  - Remove cleans both trees
+  - Codex project-scope writes correct `[mcp_servers.scieasy]` TOML block
+- [ ] CHANGELOG entry
+- [ ] CI green; PR merged into tracking branch
+
+---
+
+## Track: Skills (`track/adr-040/skills` — opened at Phase 2b)
+
+### Phase 1 / S40b — Skeleton structure-only (Owner: S40b)
+
+**Branch**: `feat/issue-NNN/adr-040-s40b-skill-structure` off **main** (no skills tracking branch yet — opened later at Phase 2b).
+
+- [ ] Sub-issue opened for S40b
+- [ ] `src/scieasy/_skills/scieasy/SKILL.md` created (~5 LOC: frontmatter `name: scieasy` + identity stub + TODO referencing Phase 2c)
+- [ ] 5 task-skill directories created with stub SKILL.md (frontmatter `name:` + `description:` placeholder + body TODO):
+  - `scieasy-build-workflow/SKILL.md`
+  - `scieasy-write-block/SKILL.md`
+  - `scieasy-debug-run/SKILL.md`
+  - `scieasy-inspect-data/SKILL.md`
+  - `scieasy-project-qa/SKILL.md`
+- [ ] `pyproject.toml [tool.setuptools.package-data]` extended: `scieasy = ["api/static/**/*", "cli/templates/**/*.tpl", "_skills/scieasy/**/*.md"]`
+- [ ] `skills/scieasy/SKILL.md` at repo root **kept** (retired by I40b in Phase 2c, not now)
+- [ ] `tests/packaging/test_wheel_skills.py` (skipped) — wheel-layout regression scaffold
+- [ ] PR opened against main (small docs+packaging PR); CI green; `Closes #<sub-issue>` in body
+
+### Phase 2b — Skill-design investigation agent (Owner: AC40-skill, Explore agent)
+
+- [ ] After I40a + I40c + I40d merge into their tracking branches: dispatch single Explore agent
+- [ ] Deliverable: `docs/planning/adr-040-skill-design.md` covering:
+  1. Workflow development patterns in SciEasy (canonical YAML, common pitfalls, real examples beyond docs)
+  2. Block development patterns (`Block` base contract, `config_schema` MRO merge per ADR-030, `_spec_from_class` strict version, plugin entry-points per ADR-025, working example from `tests/integration/test_block_sdk_e2e.py`)
+  3. Finalized MCP tool shape post-Phase 2a (all 27 tools, docstrings, Pydantic models, `next_step`, `warnings`)
+  4. External harness prior art: n8n, Langflow/LangChain, Dify, Goose/Continue/Cursor, Anthropic Skills SDK best practices, OpenAI Codex Skills
+  5. Recommended SKILL content structure per task skill (sections, examples, tool-call sequences)
+  6. Recommended CLAUDE.md/AGENTS.md template content (~50 LOC shape with each rule paragraph drafted + motivated + cross-skill discoverability mapping)
+  7. Identified gaps where MCP affordance lacks → skills must compensate
+- [ ] Skills track issue opened (`#NNN`) + tracking branch `track/adr-040/skills` off main + umbrella PR `[DO NOT MERGE]`
+- [ ] Manifest committed to main via small docs PR
+
+### Phase 2c / I40b — Skill implementation (Owner: I40b)
+
+**Branch**: `feat/issue-NNN/adr-040-i40b-skills` off `track/adr-040/skills`.
+
+- [ ] Sub-issue opened for I40b
+- [ ] `src/scieasy/_skills/scieasy/SKILL.md` thin base body authored (~50 LOC: identity, skill index, `<!-- project_context -->` marker, "available skills, when to use each")
+- [ ] 5 task skill bodies authored per Phase 2b blueprint:
+  - `scieasy-build-workflow`: YAML schema teaching + pitfalls + worked example + tool-call sequence
+  - `scieasy-write-block`: block-reuse rule (#875) + port-type selection rule (§3.2a + `list_types` mandate) + worked example
+  - `scieasy-debug-run`: lineage.db query patterns + log retrieval + common error signatures
+  - `scieasy-inspect-data`: data ref handling + preview semantics + lineage navigation
+  - `scieasy-project-qa`: meta-questions, docs lookup, project structure
+- [ ] `src/scieasy/agent_provisioning/templates/claude_agents_md.md` content authored (~50 LOC) — coordinates with I40c which authored the template skeleton
+- [ ] `skills/scieasy/SKILL.md` at repo root **DELETED** (canonical location is now packaged path)
+- [ ] Tests:
+  - Each skill frontmatter parses
+  - Base index references all 5
+  - CLAUDE.md/AGENTS.md template renders verbatim into both files
+  - `tests/packaging/test_wheel_skills.py` flipped from skip → pass: `pip install dist/*.whl && python -c "from importlib.resources import files; …"` returns content
+- [ ] CHANGELOG entry
+- [ ] CI green; PR merged into tracking branch
+
+### Phase 2c.5 / A40-skill — Skill content audit
+
+- [ ] Factual accuracy vs current MCP / block contract
+- [ ] Internal consistency (no skill contradicts another)
+- [ ] Discoverability: frontmatter `description` triggers correct skill on plausible user requests
+- [ ] Code-block examples actually parse + run
+- [ ] CLAUDE.md/AGENTS.md template wording reviewed by user before ship per ADR-040 §8 OQ-3
+
+---
+
+## Phase 2a.5 / A40-impl — Batch 1 implementation audit (Owner: A40-impl, single auditor)
+
+Reviews all 3 impl PRs (I40a + I40c + I40d) together.
+
+- [ ] ADR §3.x verbatim compliance per track
+- [ ] Hook script edge cases: regex bypass patterns, session-marker race, exit-code semantics, stderr formatting
+- [ ] Pydantic return model correctness vs FastMCP wire format
+- [ ] Cross-track wiring: lifecycle hooks → provisioning entry; FastMCP `serve()` → runtime.py adapter
+- [ ] TODO tags present, traceable, conform to CLAUDE.md §7.6 form (audit signal: `grep -rn "TODO[^(]" src/` returns ZERO)
+- [ ] Codex auto-review reconciled (P1/P2 deferred → manager override)
+
+## Phase 2a.6 / F40-impl — Batch 1 fix (conditional)
+
+- [ ] Manager triages A40-impl P1/P2 + Codex P1/P2; fix agents dispatched in-PR
+- [ ] After all green: manager merges 3 impl PRs into respective tracking branches
+
+---
+
+## Phase 3 — 3 parallel audit agents
+
+### A1 — ADR completeness + bugs + edge cases (Owner: A1, opus)
+
+- [ ] Per §3.x decision in ADR-040, verify implementation matches
+- [ ] For each Pydantic return model: walk every field's serialization → MCP wire round-trip
+- [ ] For each hook script: exhaustive edge-case review (regex bypass, race, exit-code, stderr, session-marker file race)
+- [ ] For `_render_project_context`: 0 workflows, 10000 workflows, corrupt git, non-git, project_name with special chars, mtime skew, BlockRegistry empty
+- [ ] For `install_project_agent_assets`: existing file with user edits, missing parent dir, permission denied, version-marker drift, partial install rollback
+- [ ] Output: `docs/planning/adr-040-a1-report.md` + GitHub issues for findings
+- [ ] Codex auto-review reconciled
+
+### A2 — MCP wiring + cross-doc consistency (Owner: A2, opus)
+
+- [ ] FastMCP migration completeness: every old `ToolEntry` has `@mcp.tool()` counterpart; no orphans; no dead `_registry.py` imports
+- [ ] Cross-file wiring: `system_prompt.py::_render_tool_catalog` correctly enumerates from FastMCP; `runtime.py` correctly exposes FastMCP in standalone-bridge mode; frontend (if any) doesn't break
+- [ ] Cross-doc consistency sweep: ADR-040 vs ARCHITECTURE.md vs ADR-034 (PTY) vs ADR-035 (`finish_ai_block`) vs ADR-038 (lineage) vs ADR-039 (git auto-init) vs `docs/specs/embedded-coding-agent-spec.md` — contradictions, outdated refs, missing cross-links flagged
+- [ ] CHANGELOG entries verified per CLAUDE.md format
+- [ ] Output: `docs/planning/adr-040-a2-report.md` + issues
+- [ ] Codex auto-review reconciled
+
+### A3 — Agent-POV prompt + skill review (Owner: A3, opus)
+
+- [ ] Simulate fresh prod-env agent: read rendered system prompt verbatim (call `compose_system_prompt` against fixture project); read each task skill's frontmatter; read body when triggered
+- [ ] For each of 7 e2e test cases (Phase 4), assess: does current skill+prompt+CLAUDE.md give agent enough to succeed? Where would agent guess wrong?
+- [ ] For e2e (g) "write thresholding block, zero hints": read `scieasy-write-block` SKILL.md cold and predict failure modes
+- [ ] Review tool description ergonomics: do `next_step` hints guide correct sequences? Are warning messages actionable?
+- [ ] Cross-check Claude vs Codex: would a Codex agent (no hooks) be misled because rules assume hook backup?
+- [ ] Output: `docs/planning/adr-040-a3-report.md` with concrete rewrite suggestions for any risky content
+- [ ] Codex auto-review reconciled
+
+---
+
+## Phase 3.5 / A_int — Cross-track integration audit
+
+- [ ] FastMCP `list_tools()` → `_render_tool_catalog` → SKILL.md splice → agent's view: end-to-end string identity check
+- [ ] Project provisioning → hooks → MCP runtime: full lifecycle dry-run on fresh + existing project fixtures
+- [ ] Install parity: install on Claude side + install on Codex side both yield functionally equivalent prod-env behavior
+- [ ] Documentation graph: every ADR/spec/changelog reference resolves; no broken cross-links
+- [ ] Output: `docs/planning/adr-040-int-report.md`
+
+## Phase 3.6 / F40-3 — Audit fix dispatch
+
+- [ ] Manager triages findings from A1+A2+A3+A_int; groups by file scope
+- [ ] Fix agents dispatched in parallel (1 per scope); each fix lands in the relevant tracking-branch PR (not new PRs unless cross-cutting)
+- [ ] Re-run CI on tracking branches after fix
+- [ ] Update drift log for non-trivial findings
+- [ ] All P1/P2 resolved; CI green on all tracking branches
+
+---
+
+## Phase 4 — e2e in Chrome (manager hotfix mode)
+
+**Setup**:
+- [ ] Manager enters hotfix mode (per CLAUDE.md §11.5)
+- [ ] Fresh test project at `~/scieasy-test-adr-040/` created via **GUI** (tests GUI provisioning path), not CLI
+- [ ] `scieasy-blocks-imaging` plugin installed in test env (needed for e2e (g) thresholding context)
+- [ ] Codex CLI version 2026+ confirmed; project-scope `.codex/config.toml` discovery works
+- [ ] Chrome MCP active; GIF recording per multi-step test
+- [ ] Both Claude Code and Codex CLIs spawn-able from GUI
+
+**Test (a) — All MCP tools usable from spawned agent**
+- [ ] Claude: prompt agent to call every of 27 MCP tools in order; agent reports 27/27 success; GIF captured
+- [ ] Codex: same prompt; agent reports 27/27 success; GIF captured
+
+**Test (b) — MCP schema strictness against malformed calls**
+- [ ] Claude: prompt for malformed calls; FastMCP `inputSchema` rejects with field-path errors; PASS
+- [ ] Codex: same; PASS
+- [ ] Regression baseline: `additionalProperties: true` gone — verified
+
+**Test (c) — Git commit with agent prefix per skill rules**
+- [ ] Claude: prompt "commit a small workflow YAML change"; `git log` shows skill-mandated prefix/format; ADR-039 hooks didn't reject; ADR-038 lineage.db updated with commit SHA join key
+- [ ] Codex: same
+
+**Test (d) — Lineage view + export parity**
+- [ ] Seed lineage.db with manual workflow run
+- [ ] Claude: prompt "view lineage for run X, export to methods.md"; output byte-equal to `GET /api/runs/{run_id}/methods` (`src/scieasy/api/routes/runs.py`)
+- [ ] Codex: same
+
+**Test (e) — Skill catalog completeness (provider-agnostic static check)**
+- [ ] Every of 27 MCP tools referenced in at least one skill with: correct name, accurate parameter list, ≥1 usage example
+- [ ] No skill teaches stale params (cross-check against FastMCP `list_tools()` output)
+
+**Test (f) — Hooks block known-bad operations**
+- [ ] Claude: prompt (i) `Bash(scieasy run)`, (ii) create workflow + run without validate, (iii) Edit `workflows/*.yaml` directly → all 3 blocked with informative stderr; agent pivots to correct MCP call in next turn
+- [ ] Codex: same prompts; expected outcome is operations go through unhooked (per ADR §3.10 "Codex hook governance deferred"); documented expected-gap not a blocker; TODO-tag references #1015 for future Codex hook coverage
+
+**Test (g) — Agent writes thresholding block with ZERO hints**
+- [ ] Claude: prompt "write a simple image thresholding block — input image, output binary mask, threshold parameter"
+  - Agent first calls `list_blocks` (#875 reuse rule)
+  - Agent calls `list_types` to pick concrete `Image`/`Array` port type, not `DataObject` (§3.2a)
+  - Block subclasses `scieasy.blocks.base.block.Block` correctly
+  - Block registers + loads
+  - `run()` produces valid output of declared port type
+  - Hooks don't trigger (operation within rules)
+- [ ] Codex: same prompt; same pass criteria
+
+**Phase 4 cross-provider summary**
+
+| Test | Claude Code | Codex |
+|---|---|---|
+| (a) MCP tools usable | [ ] | [ ] |
+| (b) MCP strictness | [ ] | [ ] |
+| (c) Git commit | [ ] | [ ] |
+| (d) Lineage export | [ ] | [ ] |
+| (e) Skill catalog (static) | [ ] (provider-agnostic) | — |
+| (f) Hook enforcement | [ ] PASS | [ ] EXPECTED-GAP (documented) |
+| (g) Thresholding block | [ ] | [ ] |
+
+**Ship criterion**: every cell PASS except (f) Codex which is documented expected-gap.
+
+---
+
+## Final merge phase (manager)
+
+- [ ] Manager opens 4 clean PRs: `track/adr-040/<x>` → main (NOT the umbrella [DO NOT MERGE] drafts)
+- [ ] Each clean PR rebased to latest main; CI green; user sign-off
+- [ ] Squash-merge into main, branches deleted
+- [ ] Umbrella PRs #1017 + #1018 + #1019 + (skills umbrella) closed WITHOUT merge with comment pointing at clean merge PRs
+- [ ] Tracking branches deleted from origin
+- [ ] Worktrees pruned
+- [ ] Cascade umbrella #1011 closed
+- [ ] Closed by cascade: #824, #825, #832, #875 (auto-close via clean PR bodies' `Closes #N`)
+- [ ] `docs/planning/adr-040-e2e-results.md` committed with 14 test outcomes
+
+---
+
+## Acceptance criteria (cascade ship gate)
+
+- [ ] All Phase 0 — Phase 3.6 checkboxes ticked with artifact links
+- [ ] Drift log empty OR every entry resolved with linked fix commit
+- [ ] All 4 tracking-branch CI green
+- [ ] All Codex P1/P2 findings on agent PRs resolved (none deferred to follow-ups)
+- [ ] `grep -rn "TODO[^(]" src/` returns ZERO matches (every TODO carries `(#NNN)` tracking ref) — CLAUDE.md §7.6 audit signal
+- [ ] Every of 27 MCP tools enumerable via `mcp__scieasy__list_tools` from a spawned agent
+- [ ] Fresh GUI-created project has CLAUDE.md + AGENTS.md + .claude/hooks/*.py × 6 + .claude/skills/scieasy/* × 6 + .agents/skills/scieasy/* × 6 + .codex/config.toml + .claude/.scieasy-provision-version
+- [ ] Phase 4: 13/14 cells PASS + 1/14 Codex (f) expected-gap documented
+- [ ] CHANGELOG `[Unreleased]` has 1 entry per merged sub-PR with mandatory metadata
+
+---
+
+## Drift log (append-only)
+
+> Format: `YYYY-MM-DD HH:MM — <owner> <action>. Reason: <quote>. Resolution: <fix-link>`
+
+(empty)
+
+---
+
+## Known issues queue (cascade-discovered, document root cause + resolution path)
+
+> Format: `<short-title> — <root cause one-liner> — Resolution: <fix-link or "tracked at #NNN">`
+
+- 2026-05-16 — #824/#825/#832/#875 closed prematurely by ADR-040 docs PR #987 squash-merge. Cause: PR body carried "Closes" prefixes. Resolution: reopened by manager in Phase 0.4 with explanatory comments.
+- 2026-05-16 — pytest-timeout was only in CI args, missing from pyproject.toml dev deps. Cause: original install via explicit `uv pip install` extra. Resolution: added to `[project.optional-dependencies].dev` in PR #1010.
+- 2026-05-16 — ADR-040 §5.1 inventory undercounts MCP tools (says 26, actually 27 including `finish_ai_block` from ADR-035 skeleton). Cause: ADR drafted before finish_ai_block landed. Resolution: dispatch prompts + checklist reference 27; ADR text not edited (ship cascade first, follow-up docs PR if needed).
+- 2026-05-16 — ADR-040 §5.1 missed `src/scieasy/ai/agent/mcp/_context.py` and `__init__.py`. Cause: drafting oversight. Resolution: dispatch prompts list them in S40a + I40a owned-files; ADR text not edited.
+
+---
+
+## Out-of-scope from this cascade (TODO-tag references)
+
+Per CLAUDE.md §7.6, every deferred item has an in-repo TODO pointing here.
+
+- Layer 7 filesystem ACL on `<project>/blocks/` → tracked at **#1015** (ADR-041 placeholder)
+- BlockRegistry runtime rejection of `DataObject`-typed ports → tracked at **#1016** (ADR-041 placeholder)
+- Per-turn system-prompt re-composition → tracked under #903 dimension D
+- Empirical prompt evaluation framework → tracked under #903 dimension E
+- Codex hook coverage for `apply_patch` / MCP calls (upstream OpenAI gap) → tracked under #1015 (Codex hook governance)
+- Sub-agent dispatch via Claude Code `Task` tool inside SciEasy MCP → future ADR
+- Custom slash commands (`.claude/commands/`) for SciEasy-specific workflows → future ADR
+- Per-skill telemetry → future enhancement
+- Project-level / per-machine prompt overlays → tracked under #903 dimension D
+- CI workflow cleanup of redundant `pytest-timeout` install + `--timeout=60` CLI flags (now in pyproject.toml) → follow-up small PR after cascade ships
+- Dev environment `.claude/`, dev CLAUDE.md content, dev-env hooks → out of scope per ADR-040 §2.1 (explicit binding boundary; never touched by this cascade)


### PR DESCRIPTION
Closes #1011 (partial — acceptance criterion: checklist authored before first agent dispatches)

## Summary

Authors \`docs/planning/adr-040-checklist.md\` mirroring \`adr-038-039-checklist.md\` gold-standard quality (~531 lines). Single source of truth for the 4-track cascade.

## What's in it

- 13 Manager discipline rules (worktree isolation, foreground until-loop, pytest --timeout, Codex P1 override, CLAUDE.md §7.6 TODO mandate, etc.)
- Per-phase rows with owner labels (S40a/b/c/d, I40a/c/d, I40b, A40-skel/impl/skill, A1/A2/A3, A_int, F40-*)
- Phase 4 e2e: 7 tests × 2 providers = 14 cells, with explicit Codex (f) expected-gap documentation
- Drift log + Known issues queue (4 cascade-discovered issues already documented)
- Out-of-scope TODO-reference table pointing at #1015/#1016 ADR-041 placeholders + #903 dimensions

## Discrepancies surfaced

- Tool count is **27** not 26 (ADR §5.1 undercounts; \`finish_ai_block\` from ADR-035 skeleton already in registry)
- ADR §5.1 missed \`src/scieasy/ai/agent/mcp/_context.py\` + \`__init__.py\`
- ADR-039 git auto-init is **production-live** at \`api/runtime.py:598-608\` + \`:686-701\` + \`cli/main.py:130-158\` — not skeleton; I40c inherits live wiring
- pytest-timeout was missing from pyproject.toml dev deps (fixed in PR #1010)
- #824/#825/#832/#875 closed prematurely by ADR docs PR #987 squash (reopened in Phase 0.4)

## Test plan

- [ ] CI green (docs-only change)
- [ ] Architecture tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)