### PR TITLE
feat(#1026): S40d ADR-040 install-parity skeleton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- [#1026] S40d: install-parity skeleton — cross-install + codex project-scope signatures (@claude, 2026-05-16, branch: feat/issue-1026/adr-040-s40d-install-skeleton, session: 20260516-181020-s40d-adr-040-install-parity-skeleton)
+
 ### Fixed
 
 - [#1015] Wire backend-supplied per-block ``inputs`` / ``outputs`` through the frontend adapter. ``adaptBlockExecution`` (``frontend/src/lib/api.ts``) hardcoded ``inputs: []`` / ``outputs: []`` with a stale "future enhancement" comment from the D38-2.4c skeleton. #996 inlined the join server-side, so ``GET /api/runs/{id}`` already carried the data — but the frontend dropped it on the floor, and the Lineage block cards rendered "0 inputs / 0 outputs" even though the Methods export (which reads the recorder's joined SQL directly) showed the same DataObjects correctly. New ``adaptDataObjectRef`` maps each backend row's ``{direction, port_name, position, object_id, type_name, backend, storage_path, produced_by_execution}`` shape to the frontend's leaner ``LineageDataObjectRef`` (drops ``direction`` because the server-side bucket assignment already separated inputs from outputs, drops ``backend`` and ``produced_by_execution`` because the v1 card UI doesn't display them). 36/36 Lineage frontend tests pass. (@claude, 2026-05-16, branch: hotfix/issue-1004/graph-row-virtualization-spacer, session: n/a-hotfix-mode-§11.5)

--- a/src/scieasy/cli/install.py
+++ b/src/scieasy/cli/install.py
@@ -206,6 +206,14 @@ def _remove_claude(scope: str, cwd: Path) -> InstallResult:
 
 
 def _codex_config_path() -> Path:
+    """Return the user-scope Codex config path.
+
+    TODO(#1014): I40d Phase 2a — widen to ``_codex_config_path(scope, cwd)``
+    returning either ``~/.codex/config.toml`` (user) or
+    ``<cwd>/.codex/config.toml`` (project, per ADR-040 §3.7 — Codex 2026
+    project-scope support).
+    Out of scope per ADR-040 §3.7 (skeleton phase). Followup: #1014.
+    """
     return Path.home() / ".codex" / "config.toml"
 
 
@@ -285,6 +293,26 @@ def _strip_codex_block(existing: str) -> tuple[str, bool]:
 
 
 def _install_codex(scope: str, cwd: Path) -> InstallResult:
+    """Write ``[mcp_servers.scieasy]`` block to Codex's config file.
+
+    Today (skeleton phase) always writes to the **user-scope** path
+    (``~/.codex/config.toml``) regardless of *scope* — the project-scope
+    branch is **deferred to I40d Phase 2a** per ADR-040 §3.7. The
+    ``perform_install`` orchestrator currently routes ``scope=="project"``
+    requests through the "force user-scope for codex" fallback at the
+    elif-codex branch below; I40d removes that fallback and routes
+    project-scope requests through this function directly.
+
+    Reuses ``_render_codex_block(project_dir)`` unchanged. After I40d,
+    only the destination path differs by scope; block content reuses
+    ``project_dir`` to emit the ``[mcp_servers.scieasy.env]`` table.
+
+    TODO(#1014): I40d Phase 2a — implement project-scope branch writing
+    ``<cwd>/.codex/config.toml`` (Codex 2026 supports project-scope
+    discovery per ADR-040 §3.7). Use ``_codex_config_path(scope, cwd)``
+    after that helper is widened. Out of scope per ADR-040 §3.7 (skeleton
+    phase). Followup: #1014.
+    """
     if scope == "user":
         project_dir: Path | None = None
     elif scope == "project":
@@ -292,6 +320,10 @@ def _install_codex(scope: str, cwd: Path) -> InstallResult:
     else:
         raise ValueError(f"unsupported scope for codex: {scope!r}")
 
+    # TODO(#1014): I40d Phase 2a — switch to ``_codex_config_path(scope, cwd)``
+    # so project-scope writes land in ``<cwd>/.codex/config.toml``. Today
+    # this always returns the user-scope path; the perform_install
+    # fallback below short-circuits project-scope to user-scope.
     path = _codex_config_path()
     existing = _read_text_or_empty(path)
     stripped, had_existing = _strip_codex_block(existing)
@@ -357,6 +389,17 @@ def _remove_codex(scope: str, cwd: Path) -> InstallResult:
 
 
 def _skill_dest(scope: str, cwd: Path) -> Path:
+    """Return the Claude-side skill destination for *scope*.
+
+    TODO(#1014): I40d Phase 2a — widen to return a tuple
+    ``(claude_path, codex_path)`` of both destinations per ADR-040 §3.9.
+    Codex destination layout:
+
+      user scope:    ``~/.agents/skills/scieasy/``
+      project scope: ``<cwd>/.agents/skills/scieasy/``
+
+    Out of scope per ADR-040 §3.9 (skeleton phase). Followup: #1014.
+    """
     if scope == "user":
         return Path.home() / ".claude" / "skills" / MCP_SERVER_NAME
     if scope == "project":
@@ -393,12 +436,41 @@ def _find_skill_source() -> Path:
     )
 
 
-def _install_skill(scope: str, cwd: Path) -> InstallResult:
-    """Copy the bundled skill directory into Claude's skills tree.
+def _install_skill(scope: str, cwd: Path) -> list[InstallResult]:
+    """Cross-install the SciEasy skill bundle to both Claude and Codex paths.
+
+    **Return type widened in S40d skeleton from ``InstallResult`` to
+    ``list[InstallResult]`` per ADR-040 §3.9**, because the post-impl
+    contract writes to TWO destinations per call:
+
+      user scope:    ``~/.claude/skills/scieasy/`` AND ``~/.agents/skills/scieasy/``
+      project scope: ``<cwd>/.claude/skills/scieasy/`` AND ``<cwd>/.agents/skills/scieasy/``
+
+    Today (skeleton phase) the body still writes the single legacy
+    Claude-side destination only — the second (Codex / ``.agents/skills/``)
+    destination is **deferred to I40d Phase 2a**. The list-of-one return
+    shape preserves call-site compatibility while widening the contract;
+    ``perform_install`` consumes via ``results.extend(...)``.
 
     Always copies (never symlinks) for Windows compatibility — symlinks
     require admin / developer mode on Windows.
+
+    TODO(#1014): I40d Phase 2a — implement cross-install per ADR-040 §3.9.
+      1. Update ``_skill_dest`` to return ``(claude_path, codex_path)``.
+      2. Walk all 6 task-scoped sub-skills produced by Phase 2c Skills
+         track (``scieasy-build-workflow``, ``scieasy-write-block``,
+         ``scieasy-debug-run``, ``scieasy-inspect-data``,
+         ``scieasy-project-qa``, plus the root index).
+      3. Use ``importlib.resources.files("scieasy") / "_skills" / "scieasy"``
+         as source path (post-Phase 2c relocation per ADR §3.4). Fall back
+         to the current ``_find_skill_source`` walk-up for dev checkouts
+         where the packaged tree is empty.
+      4. Return one ``InstallResult`` per destination (2 per call).
+      Out of scope per ADR-040 §3.9 (skeleton phase). Followup: #1014.
     """
+    # TODO(#1014): I40d replaces the body below with the full cross-install
+    # loop described above. Current body writes only the Claude-side path.
+    # Out of scope per ADR-040 §3.9 (skeleton phase). Followup: #1014.
     src = _find_skill_source()
     dest = _skill_dest(scope, cwd)
     action = "updated" if dest.is_dir() else "installed"
@@ -407,21 +479,40 @@ def _install_skill(scope: str, cwd: Path) -> InstallResult:
         shutil.rmtree(dest)
     dest.parent.mkdir(parents=True, exist_ok=True)
     shutil.copytree(src, dest)
-    return InstallResult(
-        target="skill",
-        scope=scope,
-        path=dest,
-        action=action,
-        detail=f"copied {src} -> {dest}",
-    )
+    return [
+        InstallResult(
+            target="skill",
+            scope=scope,
+            path=dest,
+            action=action,
+            detail=f"copied {src} -> {dest}",
+        )
+    ]
 
 
-def _remove_skill(scope: str, cwd: Path) -> InstallResult:
+def _remove_skill(scope: str, cwd: Path) -> list[InstallResult]:
+    """Symmetric removal across both Claude and Codex skill trees.
+
+    **Return type widened in S40d skeleton from ``InstallResult`` to
+    ``list[InstallResult]`` per ADR-040 §3.9** to match ``_install_skill``.
+
+    Today (skeleton phase) the body removes only the legacy Claude-side
+    destination — the second (Codex / ``.agents/skills/``) destination is
+    deferred to I40d Phase 2a.
+
+    TODO(#1014): I40d Phase 2a — implement symmetric cross-removal per
+    ADR-040 §3.9. Each ``shutil.rmtree`` call yields one ``InstallResult``;
+    return both. Out of scope per ADR-040 §3.9 (skeleton phase).
+    Followup: #1014.
+    """
+    # TODO(#1014): I40d replaces with both-paths removal. Current body
+    # removes only the Claude-side path.
+    # Out of scope per ADR-040 §3.9 (skeleton phase). Followup: #1014.
     dest = _skill_dest(scope, cwd)
     if not dest.is_dir():
-        return InstallResult(target="skill", scope=scope, path=dest, action="noop", detail="not installed")
+        return [InstallResult(target="skill", scope=scope, path=dest, action="noop", detail="not installed")]
     shutil.rmtree(dest)
-    return InstallResult(target="skill", scope=scope, path=dest, action="removed", detail="directory removed")
+    return [InstallResult(target="skill", scope=scope, path=dest, action="removed", detail="directory removed")]
 
 
 # ---------------------------------------------------------------------------
@@ -484,6 +575,15 @@ def perform_install(
         if tgt == "claude":
             results.append(_remove_claude(scope, cwd) if remove else _install_claude(scope, cwd))
         elif tgt == "codex":
+            # TODO(#1014): I40d Phase 2a — replace this fallback block
+            # with a direct call to ``_install_codex(scope, cwd)`` /
+            # ``_remove_codex(scope, cwd)`` (which after impl handle
+            # project scope per ADR-040 §3.7). Codex 2026 supports
+            # project-scope ``.codex/config.toml`` so the "force
+            # user-scope" workaround is obsolete. The skeleton keeps
+            # the existing fallback inline to preserve test green.
+            # Out of scope per ADR-040 §3.9 (skeleton phase). Followup: #1014.
+            #
             # Codex has no project-scope config file; force user-scope
             # for codex even when the user picked --scope project for
             # claude. Surface that fact in the result's detail.
@@ -497,7 +597,12 @@ def perform_install(
                     detail=results[-1].detail + " (codex has no project-scope config file; wrote to user scope)",
                 )
     if do_skill:
-        results.append(_remove_skill(scope, cwd) if remove else _install_skill(scope, cwd))
+        # NOTE(S40d): ``_install_skill`` / ``_remove_skill`` return
+        # ``list[InstallResult]`` (widened in skeleton per ADR-040 §3.9)
+        # — use ``extend`` not ``append``. Currently each call yields a
+        # single-element list; I40d Phase 2a will yield two (Claude +
+        # Codex destinations). Followup: #1014.
+        results.extend(_remove_skill(scope, cwd) if remove else _install_skill(scope, cwd))
 
     return results
 

--- a/tests/cli/test_install.py
+++ b/tests/cli/test_install.py
@@ -223,3 +223,57 @@ def test_install_skill_with_missing_source_raises_clearly(fake_home: Path, fake_
         pytest.raises(FileNotFoundError),
     ):
         perform_install(target=None, scope="user", skill=True, do_all=False, remove=False, cwd=fake_cwd)
+
+
+# ---------------------------------------------------------------------------
+# ADR-040 §3.7 / §3.9 — Skeleton stubs (S40d). Bodies land in I40d Phase 2a.
+# TODO(#1014): unskip these when I40d implementation lands.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skip(reason="S40d skeleton — I40d impl in Phase 2a. TODO(#1014)")
+def test_install_skill_cross_install_user_scope() -> None:
+    """ADR-040 §3.9: user-scope skill install writes both `.claude/skills/` AND `.agents/skills/`."""
+    # Expected after I40d: perform_install(skill=True, scope="user") yields
+    # two skill InstallResults — one with path ~/.claude/skills/scieasy/,
+    # one with path ~/.agents/skills/scieasy/. Both contain the 6 task
+    # skill files relocated to src/scieasy/_skills/scieasy/.
+    pass
+
+
+@pytest.mark.skip(reason="S40d skeleton — I40d impl in Phase 2a. TODO(#1014)")
+def test_install_skill_cross_install_project_scope() -> None:
+    """ADR-040 §3.9: project-scope writes both <cwd>/.claude/skills/ AND <cwd>/.agents/skills/."""
+    # Expected after I40d: perform_install(skill=True, scope="project")
+    # yields two skill InstallResults targeting fake_cwd/.claude/skills/
+    # and fake_cwd/.agents/skills/.
+    pass
+
+
+@pytest.mark.skip(reason="S40d skeleton — I40d impl in Phase 2a. TODO(#1014)")
+def test_remove_skill_cross_removal() -> None:
+    """ADR-040 §3.9: `_remove_skill` cleans both paths symmetrically."""
+    # Expected after I40d: install then --remove yields two `removed`
+    # results, and both .claude/skills/scieasy/ and .agents/skills/scieasy/
+    # are gone from disk.
+    pass
+
+
+@pytest.mark.skip(reason="S40d skeleton — I40d impl in Phase 2a. TODO(#1014)")
+def test_install_codex_project_scope_writes_local_config() -> None:
+    """ADR-040 §3.7: `scieasy install --target codex --scope project` writes <cwd>/.codex/config.toml."""
+    # Expected after I40d: perform_install(target="codex", scope="project")
+    # writes fake_cwd/.codex/config.toml containing the [mcp_servers.scieasy]
+    # block with SCIEASY_PROJECT_DIR pinned to str(fake_cwd). User-scope
+    # ~/.codex/config.toml is NOT touched.
+    pass
+
+
+@pytest.mark.skip(reason="S40d skeleton — I40d impl in Phase 2a. TODO(#1014)")
+def test_perform_install_codex_no_longer_forces_user_scope() -> None:
+    """ADR-040 §3.9: removed fallback — 'wrote to user scope' detail no longer surfaces when scope=project."""
+    # Expected after I40d: perform_install(target="codex", scope="project")
+    # yields a single InstallResult whose detail does NOT contain the
+    # legacy "codex has no project-scope config file; wrote to user
+    # scope" suffix.
+    pass


### PR DESCRIPTION
Closes #1026.

Phase 1 skeleton for ADR-040 Install-parity track. Real bodies land in Phase 2a (I40d).

## Summary

Refactors `src/scieasy/cli/install.py` per ADR-040 §3.7 + §3.9:

- **`_install_skill(scope, cwd) -> list[InstallResult]`** — widened return type (was `InstallResult`). Body still writes the single legacy Claude-side destination only; second (`.agents/skills/`) destination is deferred to I40d with a detailed `TODO(#1014)` comment block.
- **`_remove_skill(scope, cwd) -> list[InstallResult]`** — symmetric widening, same skeleton treatment.
- **`_install_codex(scope, cwd)`** — return type unchanged. Added detailed `TODO(#1014)` docstring + inline comment describing the future project-scope branch per ADR-040 §3.7. Body is unchanged (would have broken existing tests if NotImplementedError) — fallback in `perform_install` still routes project-scope to user-scope.
- **`_skill_dest`** — `TODO(#1014)` describing future widening to `(claude_path, codex_path)` tuple.
- **`_codex_config_path`** — `TODO(#1014)` describing future widening to `(scope, cwd)` signature.
- **`perform_install`** codex elif-branch — `TODO(#1014)` comment block ABOVE the fallback documenting eventual removal; **fallback kept inline during skeleton phase** so `test_codex_project_scope_falls_back_with_caveat` stays green. Skill branch switched from `.append(...)` to `.extend(...)` for the widened return shape.

## Tests

`tests/cli/test_install.py`: 5 new `@pytest.mark.skip(reason="S40d skeleton — I40d impl in Phase 2a. TODO(#1014)")` stubs enumerating the upcoming I40d cases:

1. `test_install_skill_cross_install_user_scope`
2. `test_install_skill_cross_install_project_scope`
3. `test_remove_skill_cross_removal`
4. `test_install_codex_project_scope_writes_local_config`
5. `test_perform_install_codex_no_longer_forces_user_scope`

Existing tests stay green: `pytest tests/cli/test_install.py -n auto --timeout=60` → **16 passed, 5 skipped**.

## Preserved symbols (verified — no signature change)

- `MCP_SERVER_NAME`
- `_mcp_entry_payload`
- `_scieasy_command_for_env`
- `_render_codex_block`
- `InstallResult`
- `_install_claude`, `_remove_claude`
- `perform_install` entry signature

Consumers in `src/scieasy/__main__.py` and `src/scieasy/ai/agent/terminal.py` import cleanly (verified via `python -c "import scieasy.__main__; import scieasy.ai.agent.terminal"`). `tests/cli/test_dunder_main.py` passes.

## Judgment call (documented per CLAUDE.md §9.6)

Dispatch prompt asked for `NotImplementedError` bodies in `_install_skill` / `_remove_skill` / `_install_codex` AND for all existing `pytest tests/cli/test_install.py` tests to stay green. These conflict: 5 existing tests exercise those functions via `perform_install(..., skill=True, ...)` / `target="codex"`. Resolution: widened the **return type** of `_install_skill` / `_remove_skill` to `list[InstallResult]` (the substantive contract change for §3.9 cross-install), but kept the function bodies executing the legacy single-destination path. Added prominent `TODO(#1014)` comment blocks describing what I40d will replace. Same approach the dispatch prompt itself called for re: the `perform_install` codex fallback ("KEEP the existing fallback inline during skeleton phase to preserve test green"). For `_install_codex`, body is unchanged altogether; only docstring TODO + perform_install fallback TODO mark the future project-scope branch.

This trades a slightly less aggressive "fail-fast" skeleton for the explicit constraint that existing tests pass. The contract widening (list return type) IS visible at the type-check / API level, which is the substantive Phase-1 deliverable.

## Out of scope (TODO-tagged per CLAUDE.md §7.6)

All deferrals carry `TODO(#1014)` with ADR-040 section refs:

- Cross-install second destination (`.agents/skills/`)
- Codex project-scope path resolution
- Removal of the "force user-scope" fallback in `perform_install`
- Skill source path migration to `importlib.resources` (depends on Skills track Phase 2c relocation)

## Refs

- ADR-040 §3.7 (Codex project-scope MCP)
- ADR-040 §3.9 (Codex skill cross-install + remove fallback)
- `docs/planning/adr-040-code-scope.md` §3 (Install-parity track manifest)
- `docs/planning/adr-040-checklist.md` Track: Install-parity / Phase 1 / S40d
- Umbrella: #1014 (PR #1019)

## Test plan

- [x] `pytest tests/cli/test_install.py -n auto --timeout=60` → 16 passed, 5 skipped
- [x] `pytest tests/cli/test_dunder_main.py -n auto --timeout=60 --no-cov` → 1 passed
- [x] `ruff check src/scieasy/cli/install.py tests/cli/test_install.py` clean
- [x] `ruff format --check ...` clean
- [x] `mypy src/scieasy/cli/install.py --ignore-missing-imports` clean
- [x] Manual import check on `scieasy.__main__` + `scieasy.ai.agent.terminal`