### PR TITLE
feat(#1025): ADR-040 S40c agent_provisioning skeleton + lifecycle wiring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- [#1025] S40c: agent_provisioning module skeleton + lifecycle wiring stubs (@claude, 2026-05-16, branch: feat/issue-1025/adr-040-s40c-provisioning-skeleton, session: 20260516-180934-s40c-adr-040-provisioning-skeleton)
+
 ### Fixed
 
 - [#1015] Wire backend-supplied per-block ``inputs`` / ``outputs`` through the frontend adapter. ``adaptBlockExecution`` (``frontend/src/lib/api.ts``) hardcoded ``inputs: []`` / ``outputs: []`` with a stale "future enhancement" comment from the D38-2.4c skeleton. #996 inlined the join server-side, so ``GET /api/runs/{id}`` already carried the data — but the frontend dropped it on the floor, and the Lineage block cards rendered "0 inputs / 0 outputs" even though the Methods export (which reads the recorder's joined SQL directly) showed the same DataObjects correctly. New ``adaptDataObjectRef`` maps each backend row's ``{direction, port_name, position, object_id, type_name, backend, storage_path, produced_by_execution}`` shape to the frontend's leaner ``LineageDataObjectRef`` (drops ``direction`` because the server-side bucket assignment already separated inputs from outputs, drops ``backend`` and ``produced_by_execution`` because the v1 card UI doesn't display them). 36/36 Lineage frontend tests pass. (@claude, 2026-05-16, branch: hotfix/issue-1004/graph-row-virtualization-spacer, session: n/a-hotfix-mode-§11.5)

--- a/src/scieasy/agent_provisioning/__init__.py
+++ b/src/scieasy/agent_provisioning/__init__.py
@@ -1,0 +1,25 @@
+"""Prod-env agent provisioning module (ADR-040 §3.5-3.8).
+
+Owns the orchestration that writes per-project agent assets (CLAUDE.md +
+AGENTS.md, Claude Code hooks, multi-skill split, Codex MCP config) at
+project lifecycle events (create_project / open_project / cli init).
+
+This package is intentionally narrow — it is filesystem-only (no API, no
+engine, no block-registry imports) and runs as a non-fatal degraded-mode
+operation per ADR §7. Failures log at WARNING; the project still opens.
+
+S40c (this skeleton) defines the module shape with NotImplementedError
+bodies. I40c (Phase 2a, #1013) fills in real implementations.
+"""
+
+from scieasy.agent_provisioning._orchestrate import (
+    SCIEASY_PROVISION_VERSION,
+    ProvisionResult,
+    install_project_agent_assets,
+)
+
+__all__ = [
+    "SCIEASY_PROVISION_VERSION",
+    "ProvisionResult",
+    "install_project_agent_assets",
+]

--- a/src/scieasy/agent_provisioning/_orchestrate.py
+++ b/src/scieasy/agent_provisioning/_orchestrate.py
@@ -1,0 +1,105 @@
+"""Top-level orchestration entry point (ADR-040 §3.8).
+
+The orchestrator coordinates per-project provisioning:
+
+  - CLAUDE.md + AGENTS.md (§3.5)         → ``claude_agents_md.py``
+  - .claude/settings.json + hook scripts (§3.6) → ``hooks.py``
+  - Skill cross-install to .claude/skills + .agents/skills (§3.4/§3.5/§3.8) → ``skills.py``
+  - .codex/config.toml (§3.7)            → ``codex_config.py``
+
+A version-marker file at ``<project>/.claude/.scieasy-provision-version``
+governs upgrade behavior on later SciEasy releases (§9 OQ-1; design
+deferred to Phase 3, see #1013).
+
+Per ADR §7, failures are NOT fatal — they log at WARNING and return a
+``ProvisionResult`` summarizing what succeeded. Callers continue with
+project open / create flow regardless.
+
+S40c skeleton: all bodies raise NotImplementedError. I40c (#1013)
+implements the real flow in Phase 2a.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# TODO(#1011): bump SCIEASY_PROVISION_VERSION on the first real release.
+#   Out of scope per ADR-040 §3.8 / §9 OQ-1 (version-marker upgrade design
+#   deferred to Phase 3). Followup: open as part of ADR-040 Phase 3.
+SCIEASY_PROVISION_VERSION = "0.1.0-skeleton"
+
+
+@dataclass
+class ProvisionResult:
+    """Structured result of a provisioning run.
+
+    Fields:
+      written        — list of project-relative paths that were created.
+      skipped        — list of project-relative paths that already existed
+                       and were preserved (force=False).
+      failed         — list of ``(path, reason)`` tuples for sub-steps that
+                       errored. Surfacing failures here (instead of raising)
+                       supports ADR §7 non-fatal degraded mode.
+      version        — value written to the marker file
+                       ``<project>/.claude/.scieasy-provision-version``.
+    """
+
+    written: list[str] = field(default_factory=list)
+    skipped: list[str] = field(default_factory=list)
+    failed: list[tuple[str, str]] = field(default_factory=list)
+    version: str = SCIEASY_PROVISION_VERSION
+
+
+def install_project_agent_assets(
+    project_dir: Path,
+    *,
+    force: bool = False,
+) -> ProvisionResult:
+    """Install all prod-env agent assets into ``project_dir``.
+
+    Inputs:
+      project_dir : Path to the SciEasy project root (already exists).
+      force       : When True, overwrite existing files. Default False
+                    preserves user customizations on idempotent top-up
+                    paths (e.g. ``open_project`` re-entry).
+
+    Outputs (files written under ``project_dir``):
+      - CLAUDE.md           (§3.5; ~50-line guide)
+      - AGENTS.md           (§3.5; identical content; Codex mirror)
+      - .claude/settings.json   (§3.6; PreToolUse + PostToolUse hook config)
+      - .claude/hooks/*.py      (§3.6; 6 hook scripts — 3 PreToolUse, 3 PostToolUse)
+      - .claude/skills/scieasy/<6 dirs>/SKILL.md   (§3.4 + §3.8)
+      - .agents/skills/scieasy/<6 dirs>/SKILL.md   (§3.4 + §3.8; Codex mirror)
+      - .codex/config.toml      (§3.7; project-scope MCP)
+      - .claude/.scieasy-provision-version  (version marker; §3.8 + §9 OQ-1)
+
+    Returns:
+      ProvisionResult — summarizes written/skipped/failed paths plus the
+      version stamp. Never raises (per ADR §7 degraded-mode contract);
+      sub-step failures are recorded in ``ProvisionResult.failed`` and
+      surfaced upstream as logger.warning calls.
+
+    Idempotency:
+      With force=False (default), every sub-writer checks file existence
+      before writing. Already-present files are appended to
+      ``ProvisionResult.skipped``. This is the contract for the
+      open_project idempotent top-up path (ADR §3.8 third row).
+
+    Error handling:
+      The orchestrator catches per-step exceptions (claude_agents_md,
+      hooks, skills, codex_config), records them in ProvisionResult.failed,
+      and continues with the next sub-step. The caller in api/runtime.py /
+      cli/main.py only needs to wrap the whole call in its own try/except
+      defensive pattern.
+
+    Version marker:
+      The marker file ``.claude/.scieasy-provision-version`` is rewritten
+      on every run (its value is the constant ``SCIEASY_PROVISION_VERSION``).
+      Phase 3 design (deferred per #1011) decides whether to use the marker
+      to detect stale provisioning and re-write specific files.
+    """
+    # TODO(#1013): I40c Phase 2a — implement the orchestration per ADR
+    # §3.8. Out of scope per ADR-040 §3.8 (S40c skeleton).
+    # Followup: https://github.com/zjzcpj/SciEasy/issues/1013.
+    raise NotImplementedError("S40c skeleton — I40c impl in Phase 2a (#1013)")

--- a/src/scieasy/agent_provisioning/claude_agents_md.py
+++ b/src/scieasy/agent_provisioning/claude_agents_md.py
@@ -1,0 +1,51 @@
+"""Write CLAUDE.md + AGENTS.md sub-step (ADR-040 §3.5).
+
+Both files are written verbatim from a single template at
+``src/scieasy/agent_provisioning/templates/claude_agents_md.md``. Claude
+Code reads ``<project>/CLAUDE.md``; Codex reads ``<project>/AGENTS.md``;
+content is identical on both sides to ensure symmetric agent behavior.
+
+S40c skeleton: NotImplementedError stub. I40c (#1013) implements.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def write_claude_agents_md(
+    project_dir: Path,
+    *,
+    force: bool = False,
+) -> list[str]:
+    """Write ``<project>/CLAUDE.md`` and ``<project>/AGENTS.md``.
+
+    Inputs:
+      project_dir : Path to project root.
+      force       : True to overwrite existing files; False to preserve.
+
+    Outputs (returned list of relative paths actually written):
+      - "CLAUDE.md"
+      - "AGENTS.md"
+
+    Idempotency (force=False default):
+      If a target already exists, this function does NOT overwrite it.
+      The path is omitted from the return list — caller categorizes it
+      as ``skipped`` in ``ProvisionResult``.
+
+    Error handling:
+      May raise OSError / PermissionError on a failing write. The
+      orchestrator catches and records in ``ProvisionResult.failed``;
+      callers do not see this exception.
+
+    Template source:
+      The single template file lives at
+      ``src/scieasy/agent_provisioning/templates/claude_agents_md.md``.
+      I40c will load via ``importlib.resources.files("scieasy")
+      / "agent_provisioning" / "templates" / "claude_agents_md.md"``
+      so the template survives wheel installation (#824 precedent).
+    """
+    # TODO(#1013): I40c Phase 2a — implement per ADR §3.5.
+    #   Out of scope per ADR-040 §3.5 (S40c skeleton).
+    #   Followup: https://github.com/zjzcpj/SciEasy/issues/1013.
+    raise NotImplementedError("S40c skeleton — I40c impl in Phase 2a (#1013)")

--- a/src/scieasy/agent_provisioning/codex_config.py
+++ b/src/scieasy/agent_provisioning/codex_config.py
@@ -1,0 +1,74 @@
+"""Write project-scope Codex MCP config (ADR-040 §3.7).
+
+Writes ``<project>/.codex/config.toml`` with a single
+``[mcp_servers.scieasy]`` block + nested ``[mcp_servers.scieasy.env]``
+table pinning ``SCIEASY_PROJECT_DIR`` to the absolute project path.
+
+Codex 2026 walks from project root to cwd loading every
+``.codex/config.toml`` — so the project-scope file takes precedence over
+``~/.codex/config.toml`` for sessions opened inside this project. Combined
+with ADR §3.5's ``AGENTS.md``, this brings Codex prod-env to parity with
+Claude Code: no argv changes in ``spawn_codex`` needed.
+
+Implementation MUST reuse ``install._render_codex_block(project_dir)``
+from ``src/scieasy/cli/install.py`` so the §3.7 auto-provisioned TOML is
+byte-identical to what ``scieasy install --target codex --scope project``
+emits (Install-parity track owns the function). This is the contract
+contractually enforced by integration test in I40c+I40d.
+
+Trust-model note: Codex honors project-scope ``.codex/config.toml`` only
+for projects the user has marked trusted. First-open prompt is acceptable
+UX per ADR §3.7.
+
+S40c skeleton: NotImplementedError stub. I40c (#1013) implements.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def write_codex_config(
+    project_dir: Path,
+    *,
+    force: bool = False,
+) -> list[str]:
+    """Write ``<project>/.codex/config.toml``.
+
+    Inputs:
+      project_dir : Path to project root (absolute path is encoded into
+                    the TOML as the ``SCIEASY_PROJECT_DIR`` env var value).
+      force       : True to overwrite; False to preserve.
+
+    Outputs (returned list):
+      - ".codex/config.toml"
+
+    Idempotency (force=False):
+      Preserves existing file. Note: a user-managed project-scope
+      config may legitimately exist; preserving it is the safe default.
+      I40c may evolve to a structural merge ("only inject our
+      ``[mcp_servers.scieasy]`` block if absent") in Phase 3 if user
+      reports surface — flag for Phase 3 design.
+
+    TOML content (per ADR §3.7):
+      [mcp_servers.scieasy]
+      command = "<sys.executable>"
+      args = ["-m", "scieasy", "mcp-bridge"]
+
+      [mcp_servers.scieasy.env]
+      SCIEASY_PROJECT_DIR = "<absolute project path>"
+
+    Implementation note for I40c:
+      Import ``_render_codex_block`` from ``scieasy.cli.install`` and
+      pass ``project_dir`` so the same string is emitted as
+      ``scieasy install --target codex --scope project`` would emit
+      against the same cwd. This is the §3.7 / §3.9 unification point.
+
+    Error handling:
+      OSError / PermissionError on write surfaces to orchestrator as
+      a ``ProvisionResult.failed`` entry.
+    """
+    # TODO(#1013): I40c Phase 2a — implement per ADR §3.7.
+    #   Out of scope per ADR-040 §3.7 (S40c skeleton).
+    #   Followup: https://github.com/zjzcpj/SciEasy/issues/1013.
+    raise NotImplementedError("S40c skeleton — I40c impl in Phase 2a (#1013)")

--- a/src/scieasy/agent_provisioning/hooks.py
+++ b/src/scieasy/agent_provisioning/hooks.py
@@ -1,0 +1,83 @@
+"""Write project-scoped hook config + scripts (ADR-040 §3.6).
+
+Provisions ``<project>/.claude/settings.json`` and the 6 hook scripts at
+``<project>/.claude/hooks/`` for Claude Code's hook system.
+
+Per ADR §3.6, the hook set is:
+
+  PreToolUse (3):
+    - hook_deny_scieasy_cli.py                      (matcher: Bash)
+    - hook_protect_workflow_yaml.py                 (matcher: Edit|Write)
+    - hook_enforce_list_blocks_before_block_write.py
+        (matcher: Edit|Write|Bash|mcp__scieasy__scaffold_block)
+
+  PostToolUse (3):
+    - hook_remind_poll_status.py                    (matcher: mcp__scieasy__run_workflow)
+    - hook_mark_list_blocks_called.py               (matcher: mcp__scieasy__list_blocks)
+    - hook_enforce_concrete_port_types.py
+        (matcher: Edit|Write|mcp__scieasy__scaffold_block)
+
+Hook scripts read JSON from stdin (Claude Code's hook stdin contract);
+exit code 2 blocks the tool call (PreToolUse only); exit code 0 passes.
+Codex's hook system has documented gaps (ADR §3.10) — these hooks govern
+Claude Code only.
+
+S40c skeleton: NotImplementedError stub + 6 hook templates as exit-0
+placeholders. I40c (#1013) authors real hook bodies.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def write_hooks(
+    project_dir: Path,
+    *,
+    force: bool = False,
+) -> list[str]:
+    """Write ``<project>/.claude/settings.json`` + 6 hook scripts.
+
+    Inputs:
+      project_dir : Path to project root.
+      force       : True to overwrite; False to preserve user edits.
+
+    Outputs (returned list of relative paths actually written):
+      - ".claude/settings.json"
+      - ".claude/hooks/deny_scieasy_cli.py"
+      - ".claude/hooks/protect_workflow_yaml.py"
+      - ".claude/hooks/enforce_list_blocks_before_block_write.py"
+      - ".claude/hooks/remind_poll_status.py"
+      - ".claude/hooks/mark_list_blocks_called.py"
+      - ".claude/hooks/enforce_concrete_port_types.py"
+
+    Idempotency (force=False default):
+      Each file is checked for existence before write. Already-present
+      files are omitted from the return list. settings.json in particular
+      may have user-added hook entries — DO NOT clobber.
+
+    Hook templates source:
+      Source-of-truth templates live at
+      ``src/scieasy/agent_provisioning/templates/hook_*.py``. I40c will
+      load each via ``importlib.resources`` (wheel-safe per #824) and
+      copy to ``<project>/.claude/hooks/<name>.py`` (template prefix
+      stripped). On POSIX, chmod +x is applied; on Windows, file is
+      written as-is (Python interpreter is invoked explicitly in the
+      settings.json command lines so the executable bit is not required).
+
+    Error handling:
+      May raise on filesystem failures. The orchestrator catches and
+      records in ``ProvisionResult.failed``.
+
+    Marker directory:
+      The runtime marker directory ``<project>/.scieasy/.session-state/``
+      (used by ``enforce_list_blocks_before_block_write.py`` /
+      ``mark_list_blocks_called.py``) is gitignored by ADR-039's default
+      .gitignore via the ``.scieasy/`` rule (per manifest §2.7).
+      Creation of the directory itself is the hook's job (lazy on first
+      ``mark_list_blocks_called`` invocation), not this provisioner's.
+    """
+    # TODO(#1013): I40c Phase 2a — implement per ADR §3.6.
+    #   Out of scope per ADR-040 §3.6 (S40c skeleton).
+    #   Followup: https://github.com/zjzcpj/SciEasy/issues/1013.
+    raise NotImplementedError("S40c skeleton — I40c impl in Phase 2a (#1013)")

--- a/src/scieasy/agent_provisioning/skills.py
+++ b/src/scieasy/agent_provisioning/skills.py
@@ -1,0 +1,76 @@
+"""Write multi-skill split to both provider trees (ADR-040 §3.4 + §3.5 + §3.8).
+
+Per ADR §3.4, the monolithic ``SKILL.md`` is split into 1 base index +
+5 task-scoped skills (6 total). Per ADR §3.8, all 6 are auto-installed
+under both:
+
+  - ``<project>/.claude/skills/scieasy/<name>/SKILL.md`` (Claude Code)
+  - ``<project>/.agents/skills/scieasy/<name>/SKILL.md`` (Codex)
+
+Skill names (per ADR §3.4):
+
+  1. scieasy                  — base index (~50 LOC; tool catalog markers)
+  2. scieasy-build-workflow   — design a new workflow
+  3. scieasy-write-block      — author a custom block (#875 + §3.4 port rules)
+  4. scieasy-debug-run        — diagnose a failed run
+  5. scieasy-inspect-data     — explore data references / lineage
+  6. scieasy-project-qa       — project structure / docs Q&A
+
+The skill *content* is owned by the Skills track (Phase 2b — S40b
+scaffolds the dirs in ``src/scieasy/_skills/``; I40b authors body in
+Phase 2c). This module is responsible only for **copying** the
+already-prepared files from package resources into the project tree.
+
+S40c skeleton: NotImplementedError stub. I40c (#1013) implements copy.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def write_skills(
+    project_dir: Path,
+    *,
+    force: bool = False,
+) -> list[str]:
+    """Cross-install 6 skill files to both provider trees.
+
+    Inputs:
+      project_dir : Path to project root.
+      force       : True to overwrite; False to preserve.
+
+    Outputs (12 paths total, returned as relative strings):
+      - ".claude/skills/scieasy/scieasy/SKILL.md"
+      - ".claude/skills/scieasy/scieasy-build-workflow/SKILL.md"
+      - ".claude/skills/scieasy/scieasy-write-block/SKILL.md"
+      - ".claude/skills/scieasy/scieasy-debug-run/SKILL.md"
+      - ".claude/skills/scieasy/scieasy-inspect-data/SKILL.md"
+      - ".claude/skills/scieasy/scieasy-project-qa/SKILL.md"
+      - ".agents/skills/scieasy/scieasy/SKILL.md"  (Codex mirror)
+      - ".agents/skills/scieasy/scieasy-build-workflow/SKILL.md"
+      - ".agents/skills/scieasy/scieasy-write-block/SKILL.md"
+      - ".agents/skills/scieasy/scieasy-debug-run/SKILL.md"
+      - ".agents/skills/scieasy/scieasy-inspect-data/SKILL.md"
+      - ".agents/skills/scieasy/scieasy-project-qa/SKILL.md"
+
+    Idempotency (force=False):
+      Each destination is checked individually; preserved on existence.
+
+    Source:
+      Skill source lives at ``src/scieasy/_skills/scieasy/<name>/SKILL.md``
+      after the relocation in ADR §3.4 (owned by Skills track, S40b
+      scaffold + I40b content). I40c loads each via
+      ``importlib.resources.files("scieasy") / "_skills" / "scieasy"
+      / <name> / "SKILL.md"`` to support wheel installs (#824).
+
+    Error handling:
+      Missing source files (e.g. if Skills track has not yet shipped the
+      relocation) should raise FileNotFoundError. The orchestrator records
+      in ``ProvisionResult.failed``; the project still opens. This is a
+      known sequencing concern flagged for the integration auditor.
+    """
+    # TODO(#1013): I40c Phase 2a — implement per ADR §3.4 / §3.8.
+    #   Out of scope per ADR-040 §3.8 (S40c skeleton).
+    #   Followup: https://github.com/zjzcpj/SciEasy/issues/1013.
+    raise NotImplementedError("S40c skeleton — I40c impl in Phase 2a (#1013)")

--- a/src/scieasy/agent_provisioning/templates/claude_agents_md.md
+++ b/src/scieasy/agent_provisioning/templates/claude_agents_md.md
@@ -1,0 +1,12 @@
+# SciEasy project — agent guide
+
+<!-- TODO(#1013): I40c Phase 2a — replace this placeholder with the ~50-line -->
+<!--    prod-env content per ADR-040 §3.5. -->
+<!--    Out of scope per ADR-040 §3.5 (S40c skeleton). -->
+<!--    Followup: https://github.com/zjzcpj/SciEasy/issues/1013. -->
+
+This file is a SciEasy provisioning template placeholder. Phase 2c
+authors the real ~50-line content per ADR-040 §3.5; the body shape is
+specified there. Auto-installed to both ``<project>/CLAUDE.md`` (Claude
+Code) and ``<project>/AGENTS.md`` (Codex) — content is identical on both
+sides per §3.5.

--- a/src/scieasy/agent_provisioning/templates/codex_config.toml
+++ b/src/scieasy/agent_provisioning/templates/codex_config.toml
@@ -1,0 +1,18 @@
+# SciEasy project-scope Codex MCP config (ADR-040 §3.7)
+#
+# TODO(#1013): I40c Phase 2a — this template is a structural outline only.
+#   The real file is *rendered* at provisioning time by
+#   ``scieasy.cli.install._render_codex_block(project_dir)`` so the
+#   ``command`` field reflects the current sys.executable + args list and
+#   ``SCIEASY_PROJECT_DIR`` reflects the absolute project path. This
+#   template is kept only as a documentation reference for the expected
+#   TOML shape.
+#   Out of scope per ADR-040 §3.7 (S40c skeleton).
+#   Followup: https://github.com/zjzcpj/SciEasy/issues/1013.
+
+[mcp_servers.scieasy]
+command = "<sys.executable rendered at provisioning time>"
+args = ["-m", "scieasy", "mcp-bridge"]
+
+[mcp_servers.scieasy.env]
+SCIEASY_PROJECT_DIR = "<absolute project path rendered at provisioning time>"

--- a/src/scieasy/agent_provisioning/templates/hook_deny_scieasy_cli.py
+++ b/src/scieasy/agent_provisioning/templates/hook_deny_scieasy_cli.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+"""hook_deny_scieasy_cli.py — PreToolUse / Bash matcher (ADR-040 §3.6).
+
+Purpose:
+  Block ``scieasy <subcommand>`` invocations via Bash to enforce
+  MCP-only access. Closes the CLI-vs-MCP half of issue #875.
+
+Hook contract (Claude Code):
+  - Stdin: JSON payload with ``tool_input.command`` for Bash matchers.
+  - Matcher (settings.json): ``"Bash"``.
+  - Exit 2 + stderr line: blocks the tool call, surfaces stderr to agent.
+  - Exit 0: allows the tool call.
+
+Behavior to implement in I40c:
+  1. Read stdin as JSON.
+  2. Extract ``tool_input.command``.
+  3. Regex ``^\\s*(.*/)?scieasy[\\s$]`` — matches ``scieasy ...``,
+     ``./scieasy ...``, ``/abs/path/to/scieasy ...``.
+  4. On match: print to stderr
+       "SciEasy CLI calls bypass the GUI and lineage. Use
+        mcp__scieasy__* tools instead: list_blocks, write_workflow,
+        run_workflow, get_run_status."
+     then ``sys.exit(2)``.
+  5. Otherwise ``sys.exit(0)``.
+
+S40c skeleton: exits 0 unconditionally so this hook is a NO-OP until
+I40c authors the matcher. Importantly, S40c MUST NOT exit 2 — a
+half-finished blocker would break every Bash call in a provisioned
+project.
+
+TODO(#1013): I40c Phase 2a — implement matcher + stderr message per
+  ADR §3.6. Out of scope per ADR-040 §3.6 (S40c skeleton).
+  Followup: https://github.com/zjzcpj/SciEasy/issues/1013.
+"""
+
+import sys
+
+# TODO(#1013): regex matcher + exit 2 (see module docstring above).
+sys.exit(0)

--- a/src/scieasy/agent_provisioning/templates/hook_enforce_concrete_port_types.py
+++ b/src/scieasy/agent_provisioning/templates/hook_enforce_concrete_port_types.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python
+"""hook_enforce_concrete_port_types.py — PostToolUse (ADR-040 §3.6).
+
+Purpose:
+  After a write touched ``<project>/blocks/*.py``, AST-parse the file and
+  scan for generic-typed ports (``PortSpec(type="DataObject")`` or
+  references to type names not registered in TypeRegistry). Stderr-warn
+  the agent so the next turn corrects the type. Companion to §3.2a
+  MCP-result soft validation; this hook catches the Edit/Write-bypass
+  path that goes around ``scaffold_block``.
+
+Hook contract:
+  - Stdin: JSON payload.
+  - Matcher: ``"Edit|Write|mcp__scieasy__scaffold_block"``.
+  - Always exit 0 (PostToolUse cannot block); stderr surfaces in next
+    agent turn.
+
+Behavior to implement in I40c:
+  1. Read stdin JSON.
+  2. Determine target file:
+     - Edit/Write: ``tool_input.file_path``; skip unless matches
+       ``blocks/.*\\.py$``.
+     - scaffold_block: pull the written path from the tool response.
+  3. Read the file; ``ast.parse`` it.
+  4. Walk the AST for ``PortSpec(type="DataObject")``, ``type=DataObject``
+     (Name node, not subscript), and type names absent from a known
+     TypeRegistry snapshot (call out via subprocess to MCP tool
+     ``list_types`` — design decision deferred to I40c).
+  5. For each finding, print to stderr:
+       Block at {file}:{lineno} declares port '{port_name}' with generic
+       DataObject. This degrades preview & edge-time type-check. Call
+       mcp__scieasy__list_types and pick a concrete type; DataObject is
+       reserved for SubWorkflowBlock and generic AppBlock-class blocks.
+  6. sys.exit(0).
+
+Known blind spot (per ADR §3.6 / §7.3):
+  Exotic Bash writes can land in ``blocks/`` without this hook firing,
+  same as ``hook_enforce_list_blocks_before_block_write.py``.
+
+# TODO(#1016): BlockRegistry runtime rejection of DataObject-typed ports
+#   is the hard enforcement — out of scope per ADR-040 §3.10 (cross-cutting
+#   policy decision affecting human-authored blocks too; deferred to a
+#   future ADR / ADR-041 if pursued).
+#   Followup: https://github.com/zjzcpj/SciEasy/issues/1016.
+
+S40c skeleton: exits 0 unconditionally.
+
+TODO(#1013): I40c Phase 2a — implement AST scan + stderr per
+  ADR §3.6. Out of scope per ADR-040 §3.6 (S40c skeleton).
+  Followup: https://github.com/zjzcpj/SciEasy/issues/1013.
+"""
+
+import sys
+
+# TODO(#1013): AST scan + stderr findings; always exit 0.
+sys.exit(0)

--- a/src/scieasy/agent_provisioning/templates/hook_enforce_list_blocks_before_block_write.py
+++ b/src/scieasy/agent_provisioning/templates/hook_enforce_list_blocks_before_block_write.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+"""hook_enforce_list_blocks_before_block_write.py — PreToolUse (ADR-040 §3.6).
+
+Purpose:
+  Enforce the block-reuse half of #875: BEFORE writing a custom block,
+  the agent MUST have called ``mcp__scieasy__list_blocks`` in the current
+  session so they can confirm no existing block matches the I/O contract.
+
+Hook contract:
+  - Stdin: JSON payload. Required fields: ``tool_input``, ``session_id``.
+  - Matcher: ``"Edit|Write|Bash|mcp__scieasy__scaffold_block"``.
+  - Exit 2 = block; exit 0 = allow.
+
+Behavior to implement in I40c:
+  1. Read stdin JSON.
+  2. Determine whether the call is about to write a block file:
+       - Edit/Write: ``tool_input.file_path`` matches ``blocks/.*\\.py$``.
+       - Bash:       ``tool_input.command`` contains ``> blocks/``,
+                     ``>> blocks/``, ``tee blocks/``, ``cp ... blocks/``.
+       - scaffold_block: always-on (always counts as block authoring).
+  3. If yes, look for the session marker at
+     ``$CLAUDE_PROJECT_DIR/.scieasy/.session-state/<session_id>/list_blocks_called``.
+     - Marker present: exit 0.
+     - Marker absent: print to stderr
+         "Authoring a custom block requires calling
+          mcp__scieasy__list_blocks first to confirm no existing block
+          matches your I/O contract. Call list_blocks now, then retry."
+       then sys.exit(2).
+  4. If no block write detected, exit 0.
+
+Known hook-layer blind spot (per ADR §3.6 + §7.3):
+  Exotic Bash writes (``python -c '...'``, ``mv``, here-doc piping
+  through ``sh -c``) bypass the regex. This is defense-in-depth, not
+  absolute prevention.
+
+# TODO(#1015): Layer 7 filesystem ACL on <project>/blocks/ is the
+#   bulletproof escalation path — out of scope per ADR-040 §3.10 (cross-cutting
+#   policy decision affecting human-authored blocks too; deferred to a
+#   future ADR if drift surfaces in production).
+#   Followup: https://github.com/zjzcpj/SciEasy/issues/1015.
+
+S40c skeleton: exits 0 unconditionally.
+
+TODO(#1013): I40c Phase 2a — implement matcher + marker lookup + stderr.
+  Out of scope per ADR-040 §3.6 (S40c skeleton).
+  Followup: https://github.com/zjzcpj/SciEasy/issues/1013.
+"""
+
+import sys
+
+# TODO(#1013): block-detection + marker lookup + exit 2 (see docstring).
+sys.exit(0)

--- a/src/scieasy/agent_provisioning/templates/hook_mark_list_blocks_called.py
+++ b/src/scieasy/agent_provisioning/templates/hook_mark_list_blocks_called.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+"""hook_mark_list_blocks_called.py — PostToolUse / list_blocks (ADR-040 §3.6).
+
+Purpose:
+  After ``mcp__scieasy__list_blocks`` returns, write a session-keyed
+  marker file the companion PreToolUse hook
+  (``hook_enforce_list_blocks_before_block_write.py``) reads to gate
+  block-authoring tool calls.
+
+Hook contract:
+  - Stdin: JSON payload. Must include ``session_id``.
+  - Matcher: ``"mcp__scieasy__list_blocks"``.
+  - Always exit 0 (PostToolUse cannot block).
+
+Behavior to implement in I40c:
+  1. Read stdin JSON; extract ``session_id``.
+  2. ``$CLAUDE_PROJECT_DIR`` is set by Claude Code; use it to compute
+     ``<project>/.scieasy/.session-state/<session_id>/``.
+  3. ``mkdir -p`` the directory (parents=True, exist_ok=True).
+  4. ``Path(dir / "list_blocks_called").touch()``.
+  5. sys.exit(0).
+
+Marker semantics:
+  - Session-keyed: a fresh chat tab gets a fresh session_id, so the
+    confirmation does not persist across sessions (intentional per
+    ADR §3.6).
+  - Directory cleanup: stale ``<session_id>`` directories older than
+    7 days are best-effort pruned on ``open_project`` — a Phase 3 task,
+    not S40c / I40c responsibility.
+  - Gitignored: ``.scieasy/`` is gitignored by ADR-039's default
+    .gitignore, so this marker tree never lands in git.
+
+S40c skeleton: exits 0 with no side effects.
+
+TODO(#1013): I40c Phase 2a — implement marker write per ADR §3.6.
+  Out of scope per ADR-040 §3.6 (S40c skeleton).
+  Followup: https://github.com/zjzcpj/SciEasy/issues/1013.
+"""
+
+import sys
+
+# TODO(#1013): read stdin, mkdir + touch marker, exit 0.
+sys.exit(0)

--- a/src/scieasy/agent_provisioning/templates/hook_protect_workflow_yaml.py
+++ b/src/scieasy/agent_provisioning/templates/hook_protect_workflow_yaml.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+"""hook_protect_workflow_yaml.py — PreToolUse / Edit|Write (ADR-040 §3.6).
+
+Purpose:
+  Block direct ``Edit`` / ``Write`` tool calls targeting
+  ``workflows/*.yaml`` so workflow edits flow through the schema-validated
+  MCP path (``write_workflow`` / ``update_block_config``). The latter
+  preserves YAML comments and triggers ADR-038 lineage updates; the
+  former does not.
+
+Hook contract:
+  - Stdin: JSON payload with ``tool_input.file_path`` for Edit/Write.
+  - Matcher (settings.json): ``"Edit|Write"``.
+  - Exit 2 = block; exit 0 = allow.
+
+Behavior to implement in I40c:
+  1. Read stdin JSON.
+  2. Extract ``tool_input.file_path``.
+  3. Regex ``workflows/.*\\.ya?ml$``.
+  4. On match: print to stderr
+       "workflows/*.yaml is managed by mcp__scieasy__write_workflow
+        (schema-validated) and mcp__scieasy__update_block_config
+        (preserves comments). Direct Edit/Write bypasses validation."
+     then ``sys.exit(2)``.
+  5. Otherwise ``sys.exit(0)``.
+
+S40c skeleton: exits 0 unconditionally.
+
+TODO(#1013): I40c Phase 2a — implement matcher + stderr message per
+  ADR §3.6. Out of scope per ADR-040 §3.6 (S40c skeleton).
+  Followup: https://github.com/zjzcpj/SciEasy/issues/1013.
+"""
+
+import sys
+
+# TODO(#1013): regex matcher + exit 2.
+sys.exit(0)

--- a/src/scieasy/agent_provisioning/templates/hook_remind_poll_status.py
+++ b/src/scieasy/agent_provisioning/templates/hook_remind_poll_status.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+"""hook_remind_poll_status.py — PostToolUse / run_workflow (ADR-040 §3.6).
+
+Purpose:
+  After ``mcp__scieasy__run_workflow`` returns, inject a reminder telling
+  the agent to poll ``get_run_status`` until the run reaches a terminal
+  state. PostToolUse hooks cannot block the call — they can only surface
+  stderr feedback for the agent's next turn.
+
+Hook contract:
+  - Stdin: JSON payload (includes the tool response).
+  - Matcher: ``"mcp__scieasy__run_workflow"``.
+  - Always exit 0 (PostToolUse cannot block).
+  - Stderr appears in the agent's next-turn context.
+
+Behavior to implement in I40c:
+  1. Read stdin JSON (the run_workflow response).
+  2. Print to stderr a short reminder, e.g.
+       "run_workflow has been kicked off. Poll
+        mcp__scieasy__get_run_status periodically until status is
+        'completed', 'failed', or 'cancelled' before proceeding."
+  3. Optionally extract and echo the run_id from the response for
+     concrete context.
+  4. sys.exit(0).
+
+S40c skeleton: exits 0 unconditionally with no stderr.
+
+TODO(#1013): I40c Phase 2a — implement reminder injection per
+  ADR §3.6. Out of scope per ADR-040 §3.6 (S40c skeleton).
+  Followup: https://github.com/zjzcpj/SciEasy/issues/1013.
+"""
+
+import sys
+
+# TODO(#1013): print stderr reminder; always exit 0.
+sys.exit(0)

--- a/src/scieasy/api/runtime.py
+++ b/src/scieasy/api/runtime.py
@@ -608,6 +608,30 @@ class ApiRuntime:
                 project_path,
                 exc_info=True,
             )
+        # ------------------------------------------------------------------
+        # ADR-040 §3.8 prod-env agent provisioning wiring (create_project).
+        # ------------------------------------------------------------------
+        # Implementation lands in I40c Phase 2a (#1013). Skeleton no-op
+        # preserves the call site so ADR-039 git-init ordering is locked
+        # in by S40c — the initial commit (above) precedes provisioning,
+        # and ``open_project`` (below) runs after. Failures are non-fatal
+        # per ADR §7; degraded mode keeps the project openable.
+        try:
+            from scieasy.agent_provisioning import install_project_agent_assets
+
+            install_project_agent_assets(project_path, force=False)
+        except NotImplementedError:
+            # TODO(#1013): I40c Phase 2a — remove this except branch once
+            #   install_project_agent_assets is implemented.
+            #   Out of scope per ADR-040 §3.8 (S40c skeleton).
+            #   Followup: https://github.com/zjzcpj/SciEasy/issues/1013.
+            pass
+        except Exception:  # pragma: no cover — defensive
+            logger.warning(
+                "ADR-040: agent provisioning failed at %s (non-fatal)",
+                project_path,
+                exc_info=True,
+            )
         self.open_project(project.id)
         return project
 
@@ -696,6 +720,30 @@ class ApiRuntime:
         except Exception:
             logger.warning(
                 "ADR-039: re-init failed at %s (degraded mode)",
+                candidate.path,
+                exc_info=True,
+            )
+        # ------------------------------------------------------------------
+        # ADR-040 §3.8 idempotent top-up wiring (open_project).
+        # ------------------------------------------------------------------
+        # Same provisioning entry, called with force=False so existing
+        # user-edited files (CLAUDE.md tweaks, hook customizations) are
+        # preserved on every project open. This is how alpha-stage
+        # projects created before ADR-040 lands acquire the new assets.
+        # Implementation in I40c Phase 2a (#1013).
+        try:
+            from scieasy.agent_provisioning import install_project_agent_assets
+
+            install_project_agent_assets(Path(candidate.path), force=False)
+        except NotImplementedError:
+            # TODO(#1013): I40c Phase 2a — remove this except branch once
+            #   install_project_agent_assets is implemented.
+            #   Out of scope per ADR-040 §3.8 (S40c skeleton).
+            #   Followup: https://github.com/zjzcpj/SciEasy/issues/1013.
+            pass
+        except Exception:  # pragma: no cover — defensive
+            logger.warning(
+                "ADR-040: agent provisioning top-up failed at %s (non-fatal)",
                 candidate.path,
                 exc_info=True,
             )

--- a/src/scieasy/cli/main.py
+++ b/src/scieasy/cli/main.py
@@ -173,6 +173,30 @@ def init(name: str = typer.Argument("my_project", help="Project workspace name")
     except Exception as exc:  # pragma: no cover — defensive
         typer.echo(f"WARNING: git auto-init errored: {exc}", err=True)
 
+    # ------------------------------------------------------------------
+    # ADR-040 §3.8 prod-env agent provisioning wiring (cli init).
+    # ------------------------------------------------------------------
+    # Implementation lands in I40c Phase 2a (#1013). Skeleton no-op
+    # preserves the call site so ADR-039 git-init ordering is locked in
+    # by S40c. Failures are non-fatal per ADR §7 and surfaced via
+    # ``typer.echo`` on stderr, mirroring the ADR-039 degraded-mode
+    # pattern above.
+    try:
+        from scieasy.agent_provisioning import install_project_agent_assets
+
+        install_project_agent_assets(project_path, force=False)
+    except NotImplementedError:
+        # TODO(#1013): I40c Phase 2a — remove this except branch once
+        #   install_project_agent_assets is implemented.
+        #   Out of scope per ADR-040 §3.8 (S40c skeleton).
+        #   Followup: https://github.com/zjzcpj/SciEasy/issues/1013.
+        pass
+    except Exception as exc:  # pragma: no cover — defensive
+        typer.echo(
+            f"WARNING: ADR-040 agent provisioning failed: {exc}",
+            err=True,
+        )
+
     typer.echo(f"Created project workspace: {name}/")
 
 

--- a/tests/agent_provisioning/test_claude_agents_md.py
+++ b/tests/agent_provisioning/test_claude_agents_md.py
@@ -1,0 +1,44 @@
+"""Test scaffold for ``agent_provisioning.claude_agents_md`` (ADR-040 §3.5).
+
+All tests skipped pending I40c Phase 2a impl (#1013).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.skip(reason="S40c skeleton — I40c impl in Phase 2a. TODO(#1013)")
+def test_writes_both_files_identical(tmp_project_dir):
+    """CLAUDE.md and AGENTS.md exist and have byte-identical content.
+
+    Test plan (I40c):
+      1. Call write_claude_agents_md(tmp_project_dir).
+      2. Read <project>/CLAUDE.md and <project>/AGENTS.md.
+      3. Assert both exist.
+      4. Assert content is byte-identical (ADR §3.5 requirement).
+    """
+
+
+@pytest.mark.skip(reason="S40c skeleton — I40c impl in Phase 2a. TODO(#1013)")
+def test_idempotent_force_false_preserves_user_edits(tmp_project_dir):
+    """Second call with force=False does not overwrite user edits.
+
+    Test plan (I40c):
+      1. Call write_claude_agents_md once.
+      2. Append text to CLAUDE.md.
+      3. Call again with force=False.
+      4. Assert the appended text is preserved.
+    """
+
+
+@pytest.mark.skip(reason="S40c skeleton — I40c impl in Phase 2a. TODO(#1013)")
+def test_force_true_overwrites(tmp_project_dir):
+    """force=True restores template content.
+
+    Test plan (I40c):
+      1. Call write_claude_agents_md once.
+      2. Replace CLAUDE.md with garbage.
+      3. Call again with force=True.
+      4. Assert content matches template.
+    """

--- a/tests/agent_provisioning/test_codex_config.py
+++ b/tests/agent_provisioning/test_codex_config.py
@@ -1,0 +1,45 @@
+"""Test scaffold for ``agent_provisioning.codex_config`` (ADR-040 §3.7).
+
+All tests skipped pending I40c Phase 2a impl (#1013).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.skip(reason="S40c skeleton — I40c impl in Phase 2a. TODO(#1013)")
+def test_writes_codex_config_toml(tmp_project_dir):
+    """``.codex/config.toml`` exists with expected mcp_servers.scieasy block.
+
+    Test plan (I40c):
+      1. Call write_codex_config(tmp_project_dir).
+      2. Read <project>/.codex/config.toml.
+      3. Parse with tomllib.
+      4. Assert ``mcp_servers.scieasy.command`` references sys.executable.
+      5. Assert ``mcp_servers.scieasy.args == ["-m", "scieasy", "mcp-bridge"]``.
+      6. Assert ``mcp_servers.scieasy.env.SCIEASY_PROJECT_DIR`` == absolute tmp_project_dir.
+    """
+
+
+@pytest.mark.skip(reason="S40c skeleton — I40c impl in Phase 2a. TODO(#1013)")
+def test_codex_config_matches_install_render(tmp_project_dir):
+    """Auto-provisioned TOML is byte-identical to scieasy install --target codex output.
+
+    Test plan (I40c):
+      1. Call write_codex_config.
+      2. Read <project>/.codex/config.toml.
+      3. Call _render_codex_block(tmp_project_dir) from scieasy.cli.install.
+      4. Assert string equality (ADR §3.7 / §3.9 unification contract).
+    """
+
+
+@pytest.mark.skip(reason="S40c skeleton — I40c impl in Phase 2a. TODO(#1013)")
+def test_idempotent_preserves_user_managed_toml(tmp_project_dir):
+    """Pre-existing config.toml preserved on force=False.
+
+    Test plan (I40c):
+      1. Write a manual <project>/.codex/config.toml.
+      2. Call write_codex_config with force=False.
+      3. Assert file unchanged.
+    """

--- a/tests/agent_provisioning/test_hooks.py
+++ b/tests/agent_provisioning/test_hooks.py
@@ -1,0 +1,60 @@
+"""Test scaffold for ``agent_provisioning.hooks`` (ADR-040 §3.6).
+
+All tests skipped pending I40c Phase 2a impl (#1013).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.skip(reason="S40c skeleton — I40c impl in Phase 2a. TODO(#1013)")
+def test_write_hooks_creates_settings_json(tmp_project_dir):
+    """``.claude/settings.json`` exists with PreToolUse + PostToolUse arrays.
+
+    Test plan (I40c):
+      1. Call write_hooks(tmp_project_dir).
+      2. Read <project>/.claude/settings.json.
+      3. Assert ``hooks.PreToolUse`` length == 3.
+      4. Assert ``hooks.PostToolUse`` length == 3.
+      5. Assert each entry references a python interpreter + hook script path.
+    """
+
+
+@pytest.mark.skip(reason="S40c skeleton — I40c impl in Phase 2a. TODO(#1013)")
+def test_write_hooks_copies_six_scripts(tmp_project_dir):
+    """All 6 hook scripts copied from templates to .claude/hooks/.
+
+    Test plan (I40c):
+      1. Call write_hooks.
+      2. For each of [deny_scieasy_cli, protect_workflow_yaml,
+         enforce_list_blocks_before_block_write, remind_poll_status,
+         mark_list_blocks_called, enforce_concrete_port_types],
+         assert <project>/.claude/hooks/<name>.py exists.
+      3. Assert content matches the template byte-for-byte (or up to
+         template substitution, if I40c introduces any).
+    """
+
+
+@pytest.mark.skip(reason="S40c skeleton — I40c impl in Phase 2a. TODO(#1013)")
+def test_write_hooks_idempotent_preserves_user_edits(tmp_project_dir):
+    """force=False does not overwrite user-customized settings.json.
+
+    Test plan (I40c):
+      1. Call write_hooks(force=False).
+      2. Append a custom hook entry to <project>/.claude/settings.json.
+      3. Call write_hooks(force=False) again.
+      4. Assert the custom entry is still present (no clobber).
+    """
+
+
+@pytest.mark.skip(reason="S40c skeleton — I40c impl in Phase 2a. TODO(#1013)")
+def test_hook_template_smoke_exit_zero(tmp_path):
+    """Each hook template, when invoked with empty JSON stdin, exits 0.
+
+    Test plan (I40c — once real bodies land, expand to exit-2 cases too):
+      1. For each template name, invoke ``python <template_path>`` with
+         stdin '{}' via subprocess.run.
+      2. Assert returncode == 0 for the skeleton (since all are exit-0
+         stubs). I40c will replace this with full behavior tests.
+    """

--- a/tests/agent_provisioning/test_lifecycle_integration.py
+++ b/tests/agent_provisioning/test_lifecycle_integration.py
@@ -1,0 +1,64 @@
+"""Lifecycle integration tests for ADR-040 §3.8 wiring.
+
+All tests skipped pending I40c Phase 2a impl (#1013).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.skip(reason="S40c skeleton — I40c impl in Phase 2a. TODO(#1013)")
+def test_create_project_provisions_assets(tmp_path):
+    """ApiRuntime.create_project triggers install_project_agent_assets.
+
+    Test plan (I40c):
+      1. Instantiate ApiRuntime with tmp_path as parent.
+      2. Call create_project("test").
+      3. Assert <project>/CLAUDE.md, AGENTS.md, .claude/settings.json,
+         .codex/config.toml all exist.
+      4. Assert wiring ran AFTER git init by checking .git/ also exists
+         and .git/HEAD points to a commit that DOES include the
+         provisioned files (verifies ADR-039 → ADR-040 ordering).
+    """
+
+
+@pytest.mark.skip(reason="S40c skeleton — I40c impl in Phase 2a. TODO(#1013)")
+def test_open_project_idempotent_top_up(tmp_path):
+    """open_project on a pre-ADR-040 project provisions missing assets.
+
+    Test plan (I40c):
+      1. Create a project on disk WITHOUT provisioning (simulate
+         pre-ADR-040 project — git init only).
+      2. Call open_project on it.
+      3. Assert provisioning files appeared.
+      4. Mutate one file.
+      5. Call open_project again.
+      6. Assert mutation preserved (force=False contract).
+    """
+
+
+@pytest.mark.skip(reason="S40c skeleton — I40c impl in Phase 2a. TODO(#1013)")
+def test_cli_init_provisions_assets(tmp_path, capsys):
+    """``scieasy init`` triggers provisioning after git init.
+
+    Test plan (I40c):
+      1. chdir to tmp_path.
+      2. Invoke ``scieasy init testproj`` via typer.testing.CliRunner.
+      3. Assert <tmp_path>/testproj/CLAUDE.md etc. exist.
+      4. Assert ``Created project workspace: testproj/`` is in stdout
+         (final echo not gated by provisioning success).
+    """
+
+
+@pytest.mark.skip(reason="S40c skeleton — I40c impl in Phase 2a. TODO(#1013)")
+def test_provisioning_failure_degraded_mode(tmp_path, monkeypatch, caplog):
+    """Provisioning failure logs WARNING but project still opens.
+
+    Test plan (I40c — covers ADR §7 non-fatal contract):
+      1. Monkeypatch install_project_agent_assets to raise OSError.
+      2. Call create_project.
+      3. Assert project IS created (project.yaml exists, KnownProject returned).
+      4. Assert caplog contains "ADR-040: agent provisioning failed".
+      5. Assert open_project still succeeds.
+    """

--- a/tests/agent_provisioning/test_orchestrate.py
+++ b/tests/agent_provisioning/test_orchestrate.py
@@ -1,0 +1,72 @@
+"""Test scaffold for ``agent_provisioning._orchestrate`` (ADR-040 §3.8).
+
+All tests skipped pending I40c Phase 2a impl (#1013).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.skip(reason="S40c skeleton — I40c impl in Phase 2a. TODO(#1013)")
+def test_install_project_agent_assets_fresh_project(tmp_project_dir):
+    """Fresh project → ProvisionResult.written contains all expected paths.
+
+    Test plan (I40c):
+      1. Call install_project_agent_assets(tmp_project_dir, force=False).
+      2. Assert ProvisionResult.version == SCIEASY_PROVISION_VERSION.
+      3. Assert written includes CLAUDE.md, AGENTS.md,
+         .claude/settings.json, all 6 hook scripts, .codex/config.toml,
+         and 12 skill files (6 per provider tree).
+      4. Assert each file actually exists on disk.
+      5. Assert ProvisionResult.failed is empty.
+    """
+
+
+@pytest.mark.skip(reason="S40c skeleton — I40c impl in Phase 2a. TODO(#1013)")
+def test_install_project_agent_assets_idempotent(tmp_project_dir):
+    """Second call with force=False preserves user edits.
+
+    Test plan (I40c):
+      1. Call install once.
+      2. Mutate <project>/CLAUDE.md (simulate user customization).
+      3. Call install again with force=False.
+      4. Assert CLAUDE.md content is unchanged.
+      5. Assert ProvisionResult.skipped contains "CLAUDE.md".
+    """
+
+
+@pytest.mark.skip(reason="S40c skeleton — I40c impl in Phase 2a. TODO(#1013)")
+def test_install_project_agent_assets_force(tmp_project_dir):
+    """force=True overwrites existing files.
+
+    Test plan (I40c):
+      1. Call install once.
+      2. Mutate <project>/CLAUDE.md.
+      3. Call install with force=True.
+      4. Assert CLAUDE.md content matches the template (not the mutation).
+    """
+
+
+@pytest.mark.skip(reason="S40c skeleton — I40c impl in Phase 2a. TODO(#1013)")
+def test_install_project_agent_assets_partial_failure(tmp_project_dir, monkeypatch):
+    """Sub-step failure recorded in ProvisionResult.failed, others succeed.
+
+    Test plan (I40c):
+      1. Monkeypatch ``write_codex_config`` to raise OSError.
+      2. Call install.
+      3. Assert ProvisionResult.failed has one entry referencing codex_config.
+      4. Assert ProvisionResult.written still contains CLAUDE.md etc.
+      5. Assert no exception propagates to the caller.
+    """
+
+
+@pytest.mark.skip(reason="S40c skeleton — I40c impl in Phase 2a. TODO(#1013)")
+def test_version_marker_written(tmp_project_dir):
+    """``.claude/.scieasy-provision-version`` contains SCIEASY_PROVISION_VERSION.
+
+    Test plan (I40c):
+      1. Call install.
+      2. Read <project>/.claude/.scieasy-provision-version.
+      3. Assert equality with SCIEASY_PROVISION_VERSION constant.
+    """

--- a/tests/agent_provisioning/test_skills.py
+++ b/tests/agent_provisioning/test_skills.py
@@ -1,0 +1,45 @@
+"""Test scaffold for ``agent_provisioning.skills`` (ADR-040 §3.4 + §3.8).
+
+All tests skipped pending I40c Phase 2a impl (#1013).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.skip(reason="S40c skeleton — I40c impl in Phase 2a. TODO(#1013)")
+def test_write_skills_cross_installs_both_trees(tmp_project_dir):
+    """All 6 skills land in both .claude/skills/ and .agents/skills/.
+
+    Test plan (I40c):
+      1. Call write_skills(tmp_project_dir).
+      2. For each of [scieasy, scieasy-build-workflow, scieasy-write-block,
+         scieasy-debug-run, scieasy-inspect-data, scieasy-project-qa]:
+         a. Assert <project>/.claude/skills/scieasy/<name>/SKILL.md exists.
+         b. Assert <project>/.agents/skills/scieasy/<name>/SKILL.md exists.
+      3. Assert the two files at each name pair have identical content.
+    """
+
+
+@pytest.mark.skip(reason="S40c skeleton — I40c impl in Phase 2a. TODO(#1013)")
+def test_write_skills_idempotent(tmp_project_dir):
+    """Second call preserves user-edited skill files.
+
+    Test plan (I40c):
+      1. Call write_skills.
+      2. Append text to one of the SKILL.md files.
+      3. Call write_skills again (force=False).
+      4. Assert appended text is still present.
+    """
+
+
+@pytest.mark.skip(reason="S40c skeleton — I40c impl in Phase 2a. TODO(#1013)")
+def test_write_skills_missing_source_handled(tmp_project_dir, monkeypatch):
+    """Missing skill source raises FileNotFoundError handled upstream.
+
+    Test plan (I40c):
+      1. Monkeypatch importlib.resources to make one source missing.
+      2. Call write_skills.
+      3. Assert it raises FileNotFoundError (orchestrator catches).
+    """

--- a/tests/architecture/test_placement.py
+++ b/tests/architecture/test_placement.py
@@ -145,6 +145,7 @@ def test_no_py_files_outside_known_packages() -> None:
         "utils",
         "cli",
         "testing",
+        "agent_provisioning",  # ADR-040 §3.5-3.8: prod-env agent provisioning module
     }
     stray: list[str] = []
     for filepath in SRC_ROOT.rglob("*.py"):


### PR DESCRIPTION
Closes #1025

## Summary

Scaffolds the `src/scieasy/agent_provisioning/` module per ADR-040 §3.5/§3.6/§3.7/§3.8 with all function bodies raising `NotImplementedError`. Real implementations land in I40c Phase 2a (#1013).

### Files created

- `src/scieasy/agent_provisioning/__init__.py` — re-exports
- `src/scieasy/agent_provisioning/_orchestrate.py` — `install_project_agent_assets` stub + `ProvisionResult` dataclass + `SCIEASY_PROVISION_VERSION` constant
- `src/scieasy/agent_provisioning/claude_agents_md.py` — §3.5 stub
- `src/scieasy/agent_provisioning/hooks.py` — §3.6 stub (settings.json + 6 hooks)
- `src/scieasy/agent_provisioning/skills.py` — §3.4 + §3.8 stub (cross-install both provider trees)
- `src/scieasy/agent_provisioning/codex_config.py` — §3.7 stub
- `src/scieasy/agent_provisioning/templates/claude_agents_md.md` — Phase 2c placeholder
- `src/scieasy/agent_provisioning/templates/codex_config.toml` — TOML structural outline
- `src/scieasy/agent_provisioning/templates/hook_*.py` (×6) — exit-0 stubs with detailed headers for the 3 PreToolUse + 3 PostToolUse hooks per ADR §3.6
- `tests/agent_provisioning/test_*.py` (×6) — 22 test scaffolds, all `@pytest.mark.skip` with docstring test plans

### Lifecycle wiring (narrow inserts)

- `src/scieasy/api/runtime.py`:
  - `create_project`: try/except no-op call to `install_project_agent_assets` AFTER ADR-039 git init (line 610), BEFORE `open_project` (line 611). ADR-039 block at 598-610 UNCHANGED.
  - `open_project`: idempotent top-up call AFTER ADR-039 re-init (originally line 701), BEFORE `_publish_mcp_port`. ADR-039 re-init block at original 686-701 UNCHANGED (now shifted by my insertions above but byte-identical).
- `src/scieasy/cli/main.py`:
  - `init`: try/except no-op call AFTER ADR-039 git init (line 174), BEFORE final `typer.echo` (line 176). ADR-039 block at 155-174 UNCHANGED. Mirrors the `typer.echo(..., err=True)` degraded-mode pattern.

All three wiring stubs catch `NotImplementedError` (expected during S40c) and `Exception` (defensive) so the skeleton is invisible to existing callers and tests.

### Out-of-scope items (TODO-tagged per CLAUDE.md §7.6)

- `#1013` — I40c Phase 2a implementation (referenced in every stub)
- `#1015` — Layer 7 filesystem ACL on `blocks/` (ADR §3.10 explicit deferral; TODO in `hook_enforce_list_blocks_before_block_write.py` header)
- `#1016` — BlockRegistry runtime rejection of `DataObject`-typed ports (ADR §3.10 explicit deferral; TODO in `hook_enforce_concrete_port_types.py` header)
- `#1011` — bump `SCIEASY_PROVISION_VERSION` on first real release (TODO in `_orchestrate.py`)

### Verification

- `ruff check` + `ruff format --check` clean on all touched files.
- `mypy src/scieasy/agent_provisioning/ --ignore-missing-imports` — Success: no issues found in 12 source files.
- `pytest tests/agent_provisioning/ -n auto --timeout=60 --no-cov` — 22 skipped (expected).
- `pytest tests/api/test_projects.py tests/api/test_open_project_degraded_modes.py tests/cli/test_init_git_init.py -n auto --timeout=60 --no-cov` — 9 passed (no regression in ADR-039 / lifecycle paths).

## Related

- Umbrella: #1011 (ADR-040 cascade)
- Sub-track: #1013 (provisioning track)
- Tracking branch: `track/adr-040/provisioning` (umbrella PR #1018)
- ADR: docs/adr/ADR-040.md §3.5-3.8
- Manifest: docs/planning/adr-040-code-scope.md §2 (Provisioning track)

## Branch target

This PR targets `track/adr-040/provisioning` per the ADR-040 cascade convention (NOT main). Umbrella PR #1018 will merge tracking branch → main once Phase 2-3 complete.
