### PR TITLE
fix(hooks): generalise checklist-discipline filter to any adr-*-checklist.md (#1041)

### DIFF
--- a/scripts/hooks/remind-checklist-discipline.sh
+++ b/scripts/hooks/remind-checklist-discipline.sh
@@ -1,10 +1,14 @@
 #!/usr/bin/env bash
 # PostToolUse hook — fires after:
-#  (a) Edit/Write/MultiEdit on docs/planning/adr-035-036-checklist.md
+#  (a) Edit/Write/MultiEdit on docs/planning/adr-*-checklist.md (any cascade)
 #  (b) any TaskCreate / TaskUpdate / TaskStop call on the inline TodoWrite list
 #
 # Reminds the dispatcher to re-read memory, verify the Drift log, and
 # confirm every ticked row has an artifact link.
+#
+# Pre-2026-05-16 the filter was hard-coded to adr-035-036-checklist.md;
+# this missed all subsequent cascades (ADR-038/039, ADR-040, ...). Generalised
+# to glob *adr-*-checklist.md* so every cascade gets the reminder.
 
 INPUT="$(cat 2>/dev/null || true)"
 
@@ -28,7 +32,7 @@ should_fire=false
 case "$TOOL" in
   Edit|Write|MultiEdit|NotebookEdit)
     case "$FILE_PATH" in
-      *adr-035-036-checklist.md*) should_fire=true ;;
+      *adr-*-checklist.md*) should_fire=true ;;
     esac
     ;;
   TaskCreate|TaskUpdate|TaskStop|TodoWrite)
@@ -40,19 +44,29 @@ if [ "$should_fire" != "true" ]; then
   exit 0
 fi
 
-cat <<'EOF'
-[checklist-discipline reminder]
-You just modified a checklist (TaskCreate/TaskUpdate/TaskStop on the inline list, or Edit/Write on docs/planning/adr-035-036-checklist.md).
+# Derive cascade name from the file path when we have one (e.g. adr-040,
+# adr-035-036). Falls back to "the current cascade" when fired by a Task tool.
+CASCADE=$(printf '%s' "$FILE_PATH" | python -c "
+import sys, re
+p = sys.stdin.read().strip()
+m = re.search(r'(adr-[0-9]+(?:-[0-9]+)*)-checklist\.md', p)
+print(m.group(1).upper() if m else 'the current cascade')
+" 2>/dev/null)
+
+cat <<EOF
+[checklist-discipline reminder — $CASCADE]
+You just modified a checklist (TaskCreate/TaskUpdate/TaskStop on the inline list, or Edit/Write on docs/planning/$CASCADE-checklist.md).
 
 Before continuing, perform these steps:
 
 1. RE-READ relevant memory entries:
+   - feedback_skill_rules_are_protocol_not_guidance.md (read SKILL + templates + hooks IN FULL before dispatching; do not customize)
    - feedback_multi_agent_checklist_protocol.md  (drift rules, artifact-link requirement)
-   - project_adr035_036_overnight_dispatch.md    (current dispatch state, branches, scope)
    - feedback_ticket_dispatch_playbook.md        (dispatch prompt template)
    - feedback_audit_p1_override.md               (override deferred Codex P1)
    - feedback_mandatory_chrome_smoke_test.md     (UI-touching audit must do live Chrome)
    - feedback_agent_discipline_and_pytest_timeout.md  (--timeout=60 + scope discipline)
+   - feedback_out_of_scope_todo.md               (CLAUDE.md §7.6 — every deferral needs TODO(#NNN))
 
 2. VERIFY every box you ticked in the checklist doc has an inline artifact link
    ( -> <PR-or-commit-link> or -> <test name passes> ).
@@ -63,9 +77,13 @@ Before continuing, perform these steps:
 
 4. SWEEP stale [~] markers — bump to [x] (with artifact) or [!] (with reason).
 
-5. INLINE LIST: confirm task #1..#8 statuses match reality (no task marked
-   completed before its artifacts exist; no task stuck in_progress when work
-   is actually done).
+5. INLINE LIST: confirm task statuses match reality (no task marked completed before its artifacts exist; no task stuck in_progress when work is actually done).
+
+6. AGENT-MANAGER SKILL COMPLIANCE: if you're about to dispatch a sub-agent,
+   verify the prompt is composed from \`templates/00-common-boilerplate.md\`
+   + \`templates/<role>-agent.md\` VERBATIM, includes the
+   \`[DISPATCH-TEMPLATE-V1: <role>]\` marker on the first line, and tells the
+   agent that CI MUST be green before report-done (common-boilerplate rule #9).
 
 If you intentionally made a meta-change (added a new section, restructured
 the checklist), acknowledge the reminder and continue.


### PR DESCRIPTION
Closes #1041

## Summary

Generalises \`scripts/hooks/remind-checklist-discipline.sh\` so the discipline reminder fires for ANY \`adr-*-checklist.md\` filename, not just the hardcoded \`adr-035-036-checklist.md\`.

## Impact

- Backward compat: still fires on \`adr-035-036-checklist.md\`
- ADR-038/039 cascade: reminder NOW fires (was silent)
- ADR-040 cascade: reminder NOW fires (was silent)
- Future cascades: covered

## Bonus improvements

- Cascade name derived from filename in the reminder header
- Body references the new \`feedback_skill_rules_are_protocol_not_guidance\` user memory
- Added agent-manager skill-compliance reminder for dispatch operations (template marker, CI-must-be-green rule, etc.)

## Test plan

- [ ] CI green (hook script, no behavior change to source)
- [ ] Manual test: \`echo '{"tool_name":"Write","tool_input":{"file_path":"docs/planning/adr-040-checklist.md"}}' | bash scripts/hooks/remind-checklist-discipline.sh\` prints "[checklist-discipline reminder — ADR-040]" header ✓ (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)