### PR TITLE
docs(#1011): ADR-040 corrective sweep — drift log + new manager discipline rules

### DIFF
--- a/docs/planning/adr-040-checklist.md
+++ b/docs/planning/adr-040-checklist.md
@@ -37,6 +37,9 @@
 11. **Out-of-scope work leaves `# TODO(#NNN): <reason> — Out of scope per <ref>. Followup: <link>.` in the repo** per CLAUDE.md §7.6 (new rule, merged in #1007). Verbal "we'll do later" is silent tech debt. Dispatch prompts pre-enumerate expected out-of-scope items so agents TODO-tag rather than silently skip.
 12. Manager waits for `<task-notification status="completed">` before merging an agent PR — Codex auto-review fires after first CI run; agent reconciles in a follow-up commit. Cap Codex reconcile at ONE round per agent.
 13. Wait-discipline reminder: `until` loops ONLY when waiting on a dispatched agent (per user direction 2026-05-16). For CI polling and other non-agent waits, just poll briefly and move on.
+14. **Dispatch prompts compose `templates/00-common-boilerplate.md` + `templates/<role>-agent.md` VERBATIM** (codified 2026-05-16 after I broke this rule 8 times in Phase 0/1). Custom-tailored prompts produce inconsistent agent behavior. Every dispatch starts with `[DISPATCH-TEMPLATE-V1: <role>]` marker (enforced by `scripts/hooks/check-agent-template.sh`). Include common-boilerplate rule #9 verbatim: "GitHub CI MUST be green before you report done." Do NOT tell agents to skip CI polling — that's a direct rule violation. See [[feedback_skill_rules_are_protocol_not_guidance]].
+15. **One umbrella PR per ADR**, not per sub-track (codified 2026-05-16 after I created 4 umbrellas for ADR-040). 035/036 precedent: 2 ADRs → 2 umbrellas. ADR-040 cascade: 1 umbrella PR (#1040) on `track/adr-040`. Sub-tracks (FastMCP / Provisioning / Install-parity / Skills) are workstreams that merge into the single tracking branch, not separate tracking branches.
+16. **Audit reports MUST land at `docs/audit/<YYYY-MM-DD>-adr-<NNN>-<phase>.md`** per audit-agent.md §8 — not `docs/planning/`. Branch named `chore/audit-report-N` — not `feat/issue-N/...`.
 
 ---
 
@@ -75,15 +78,18 @@
 - [x] **#1016** ADR-041 placeholder: BlockRegistry runtime rejection of `DataObject`-typed ports (for TODO tags during cascade)
 - [ ] Skills track issue (`#NNN`) opened at Phase 2b after skill-design investigation completes
 
-### 0.5 — Tracking branches + umbrella PRs
+### 0.5 — Tracking branch + umbrella PR (consolidated 2026-05-16 corrective sweep)
 
-- [x] `track/adr-040/fastmcp` off main, pushed → [seed commit `dbfc257`](https://github.com/zjzcpj/SciEasy/commit/dbfc257)
-- [x] `track/adr-040/provisioning` off main, pushed → [seed commit `7f0ed35`](https://github.com/zjzcpj/SciEasy/commit/7f0ed35)
-- [x] `track/adr-040/install-parity` off main, pushed → [seed commit `a4f600e`](https://github.com/zjzcpj/SciEasy/commit/a4f600e)
-- [x] **[PR #1017]** umbrella `[DO NOT MERGE]` → `track/adr-040/fastmcp` → main (draft)
-- [x] **[PR #1018]** umbrella `[DO NOT MERGE]` → `track/adr-040/provisioning` → main (draft)
-- [x] **[PR #1019]** umbrella `[DO NOT MERGE]` → `track/adr-040/install-parity` → main (draft)
-- [ ] Skills tracking branch `track/adr-040/skills` + umbrella PR opened at Phase 2b
+**Original (incorrect) 4-track structure was closed 2026-05-16:**
+- ~~`track/adr-040/fastmcp` + umbrella PR #1017~~ — closed; commits merged into `track/adr-040` via `174e3bd`
+- ~~`track/adr-040/provisioning` + umbrella PR #1018~~ — closed; commits merged via `568fd94`
+- ~~`track/adr-040/install-parity` + umbrella PR #1019~~ — closed; commits merged via `ace277a`
+- ~~`track/adr-040/skills` + umbrella PR #1032~~ — closed; commits merged via `90e6391`
+
+**Current (correct, 1-track-per-ADR per agent-manager skill convention):**
+- [x] `track/adr-040` consolidated branch created off main 2026-05-16 → contains all 4 sub-track skeletons merged in dependency order
+- [x] **[PR #1040]** single umbrella `[DO NOT MERGE]` → `track/adr-040` → main (draft) — visibility only, closes without merge when final clean PR(s) land on main
+- See Drift log for full details of why this consolidation was needed.
 
 ### 0.6 — Checklist authoring
 
@@ -94,7 +100,8 @@
 
 - [x] `scripts/hooks/remind-checklist-discipline.sh` present
 - [x] `.claude/settings.json` wires PostToolUse on Edit|Write|MultiEdit|NotebookEdit + TaskCreate|TaskUpdate|TaskStop|TodoWrite (verified — already configured)
-- [x] PreToolUse Bash hooks wire gate-check on `git push` and `gh pr create`; PreToolUse Agent wires template check
+- [x] PreToolUse Bash hooks wire gate-check on `git push` and `gh pr create`; PreToolUse Agent wires template check (`check-agent-template.sh` validates `[DISPATCH-TEMPLATE-V1: <role>]` marker)
+- [x] **Hook file-path filter GENERALISED**: PR #1042 (issue #1041) patches `remind-checklist-discipline.sh` to glob `*adr-*-checklist.md*` instead of hardcoded `adr-035-036-checklist.md`. Without this fix, the discipline reminder never fired for the ADR-040 cascade — silent rule violation since I'd never see "verify drift, re-read memory" reminders.
 - [x] Chrome MCP loadable (`mcp__claude-in-chrome__tabs_context_mcp` schema fetched)
 - [ ] **Phase 4 prereq**: actual Chrome probe + scieasy-blocks-imaging plugin install + Codex CLI 2026+ project-scope `.codex/config.toml` support verification
 
@@ -499,7 +506,12 @@ Reviews all 3 impl PRs (I40a + I40c + I40d) together.
 
 > Format: `YYYY-MM-DD HH:MM — <owner> <action>. Reason: <quote>. Resolution: <fix-link>`
 
-(empty)
+- **2026-05-16 22:30 — manager broke agent-manager skill convention "1 umbrella PR per ADR" by creating 4 umbrella PRs (#1017/#1018/#1019/#1032) for ADR-040.** Reason: I interpreted the skill's "1 umbrella PR per tracking branch" too literally — past cascades (035/036) had 1 tracking branch per ADR, giving 1:1 ratio. I instead invented 4 tracking branches for 1 ADR and created 4 umbrellas. User correction. **Resolution**: closed #1017/#1018/#1019/#1032; consolidated 4 sub-track branches into single `track/adr-040`; opened single umbrella PR #1040.
+- **2026-05-16 22:30 — manager dispatched first 4 skeleton agents (S40a/b/c/d) using custom prompts instead of composing `templates/00-common-boilerplate.md` + `templates/skeleton-agent.md` verbatim.** Reason: rationalised "more focused = more efficient". Cost: agent prompts explicitly instructed "Do NOT poll CI" — directly contradicting common-boilerplate rule #9 ("CI MUST be green before report done"). All 4 agents reported done with CI red; manager hotfixed 3 PRs in-PR (#1029 arch test, #1030 `_load_skill_md`, #1030 `MCPServer.start`). **Resolution**: lesson saved to `feedback_skill_rules_are_protocol_not_guidance` user memory. Phase 2a+ dispatches will compose templates verbatim with `[DISPATCH-TEMPLATE-V1: <role>]` marker.
+- **2026-05-16 22:30 — A40-skel audit report at wrong path.** Reason: per audit-agent.md §8, report MUST go to `docs/audit/<YYYY-MM-DD>-adr-<NNN>-<phase>.md`. Manager dispatched A40-skel to write to `docs/planning/adr-040-a40-skel-report.md` instead. Branch was `feat/issue-1033/adr-040-a40-skel-audit` instead of `chore/audit-report-N`. **Resolution**: report content is correct; followup small PR will move file from `docs/planning/` → `docs/audit/2026-05-16-adr-040-skeleton.md` (tracked as TODO; deferred since the report's content is already merged + cited in this checklist).
+- **2026-05-16 22:30 — `scripts/hooks/remind-checklist-discipline.sh` hardcoded file-path filter to `adr-035-036-checklist.md`.** Reason: hook authored during 035/036 cascade and never generalised. As a result the discipline reminder NEVER fired during ADR-038/039 or ADR-040 cascade — silent rule violation. **Resolution**: PR #1042 generalises filter to `*adr-*-checklist.md*`. Issue #1041.
+- **2026-05-16 22:30 — manager deferred skills tracking branch creation to Phase 2b** in original plan. S40b skeleton agent shipped during Phase 1 with no umbrella protection; agent retroactively created `track/adr-040/skills` branch + I retroactively created umbrella PR #1032 mid-cascade. **Resolution**: moot after the consolidation above — all 4 sub-track branches collapsed into single `track/adr-040`.
+- **2026-05-16 22:30 — manager pushed multiple in-PR fixes for S40a (PR #1030) rather than dispatching a F40-skel fix agent.** Per playbook: "if small (~10 lines), push directly; else dispatch fix agent". My fixes totaled ~60 LOC across 3 commits (legacy walk-up restoration, `MCPServer.start/stop/serve` no-ops, lint format). **Resolution**: accept as historical; document here. The S40a PR is merged; the manager fixes are part of the consolidated `track/adr-040` history.
 
 ---
 
@@ -509,7 +521,7 @@ Reviews all 3 impl PRs (I40a + I40c + I40d) together.
 
 - 2026-05-16 — #824/#825/#832/#875 closed prematurely by ADR-040 docs PR #987 squash-merge. Cause: PR body carried "Closes" prefixes. Resolution: reopened by manager in Phase 0.4 with explanatory comments.
 - 2026-05-16 — pytest-timeout was only in CI args, missing from pyproject.toml dev deps. Cause: original install via explicit `uv pip install` extra. Resolution: added to `[project.optional-dependencies].dev` in PR #1010.
-- 2026-05-16 — ADR-040 §5.1 inventory undercounts MCP tools (says 26, actually 27 including `finish_ai_block` from ADR-035 skeleton). Cause: ADR drafted before finish_ai_block landed. Resolution: dispatch prompts + checklist reference 27; ADR text not edited (ship cascade first, follow-up docs PR if needed).
+- 2026-05-16 — ADR-040 §5.1 inventory says "26 tools"; ADR-040 §2.4 says "26"; AC40 manifest verified live count is **26** (25 baseline + `finish_ai_block` = 26). Initial checklist note "27" was an arithmetic error — fixed in this corrective sweep. ADR figure is correct as-is. Test `tests/ai/test_system_prompt.py:28` and `tests/ai/test_finish_ai_block_skeleton.py:30` both assert `len(TOOL_REGISTRY) == 26`. Reference: code-scope manifest §1.2.
 - 2026-05-16 — ADR-040 §5.1 missed `src/scieasy/ai/agent/mcp/_context.py` and `__init__.py`. Cause: drafting oversight. Resolution: dispatch prompts list them in S40a + I40a owned-files; ADR text not edited.
 
 ---


### PR DESCRIPTION
Closes #1044

## Summary

Documents 6 manager protocol violations from Phase 0 + Phase 1 of the ADR-040 cascade + the corrective sweep applied 2026-05-16. Adds 3 new manager-discipline rules (§14, §15, §16) to prevent recurrence. Part of #1011.

## Drift entries logged

| # | Violation | Resolution |
|---|---|---|
| 1 | 4 umbrella PRs (one per sub-track) instead of 1 per ADR | Closed #1017/#1018/#1019/#1032; consolidated 4 sub-track branches into single \`track/adr-040\`; opened umbrella PR #1040 |
| 2 | First 4 skeleton dispatches used custom prompts + told agents "do NOT poll CI" — violates common-boilerplate rule #9 | Lesson saved as \`feedback_skill_rules_are_protocol_not_guidance\` user memory. Phase 2a+ dispatches will compose templates verbatim |
| 3 | A40-skel audit report at \`docs/planning/\` instead of \`docs/audit/\` per audit-agent.md §8 | Followup small PR will move file |
| 4 | \`remind-checklist-discipline.sh\` hardcoded to \`adr-035-036-checklist.md\` filter — never fired for ADR-040 | PR #1042 generalises filter |
| 5 | Skills tracking branch creation deferred to Phase 2b in plan; needed mid-cascade retroactive creation | Moot after consolidation |
| 6 | Manager in-PR fixes for S40a totaled ~60 LOC across 3 commits where a fix agent would have been more traceable | Accept as historical; documented in drift log |

## New manager discipline rules

- §14: dispatch prompts MUST compose templates verbatim with \`[DISPATCH-TEMPLATE-V1: <role>]\` marker
- §15: one umbrella PR per ADR (not per sub-track)
- §16: audit reports MUST land at \`docs/audit/\`

## Tool count correction

Live count is **26** (25 baseline + finish_ai_block = 26), verified by AC40 manifest §1.2 + 2 test assertions. The earlier "27" arithmetic error in the checklist is fixed.

## Test plan

- [ ] CI green (docs-only change)
- [ ] Architecture tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)