### PR TITLE
docs: export agent-manager skill to docs/skills/

### DIFF
--- a/docs/skills/agent-manager/SKILL.md
+++ b/docs/skills/agent-manager/SKILL.md
@@ -1,0 +1,246 @@
+---
+name: agent-manager
+description: Use this skill when acting as an agent manager — dispatching multiple sub-agents in parallel across multi-phase work (skeleton → implementation → audit → fix → e2e). Provides standard role-templates (skeleton/implement/audit/fix), a mandatory-checklist pattern, a discipline hook, and tracking-branch convention. Trigger when the user says "dispatch agents", "派出多个agent", "parallel implementation", "ADR cascade", "multi-phase rollout", or describes work across ≥3 sub-agents.
+allowed-tools: Read Write Edit Bash Glob Grep Agent
+license: MIT
+metadata:
+    skill-author: Claude (self-authored 2026-05-14)
+---
+
+# Agent Manager
+
+## Overview
+
+Codifies the multi-agent dispatch protocol learned from past cascade failures (#810/#811 scope drift, #800 silent UI breakage, #834 hotfix bundle, ADR-033 Phase 1 rollback). When the user asks for parallel multi-agent execution across multiple phases, this skill ensures:
+
+1. **Single source of truth checklist** — one document, every agent edits its own rows, drift is detected mechanically.
+2. **Standard role templates** — skeleton / implement / audit / fix prompts with mandatory boilerplate burned in.
+3. **Tracking branch convention** — agent feature branches → tracking branch (mergeable after audit) → DO NOT MERGE umbrella PR against main (visibility only).
+4. **PostToolUse hook** — fires on checklist edits + TodoWrite/TaskUpdate, reminds to verify drift + artifact links + scope.
+5. **Hygiene defaults** — worktree isolation, no `pip install -e .` from worktree, `pytest --timeout=60`, no `npm run dev` background processes.
+
+## When to use this skill
+
+Trigger when:
+- The user describes parallel work across ≥3 sub-agents.
+- The user asks for an "ADR cascade", "multi-phase rollout", "overnight dispatch", "agent manager mode".
+- You're about to dispatch 4+ Agent calls and need to ensure consistency.
+- Past cascades have shown drift / scope creep / silent breakage.
+
+Do NOT trigger for:
+- Single-agent dispatches.
+- Read-only research dispatches (Explore agents).
+- One-off bugfixes.
+
+## Standard phase structure
+
+```
+Phase 0: Pre-flight (manager runs)
+   - Tool checks (python, pytest, ruff, mypy, node, npm, gh, claude CLI)
+   - Verify no editable-install pollution: `python -c "import <pkg>; print(<pkg>.__file__)"`
+   - Chrome MCP probe (if e2e involves browser)
+   - CI baseline (`gh run list --branch main --limit 5`)
+   - Stash leftover working tree
+   - Create checklist at `docs/planning/<scope>-checklist.md`
+   - Install discipline hook (see scripts/remind-checklist-discipline.sh)
+   - Create tracking branches off main, push
+   - Open umbrella issues (one per track) + per-phase sub-issues
+   - Open umbrella PRs (`[DO NOT MERGE]` against main)
+
+Phase 1: Skeleton (parallel, 1 agent per track)
+   - Use templates/skeleton-agent.md
+   - All function bodies raise NotImplementedError + detailed comment block
+   - Test stubs marked xfail/skip with test plan in docstring
+
+Phase 1.5: Skeleton audit (parallel, 1 auditor per track)
+   - Use templates/audit-agent.md
+   - Verify checklist accuracy, comment-block sufficiency, Codex review reconcile
+
+Phase 1.6: Skeleton fix (conditional, parallel)
+   - Use templates/fix-agent.md
+   - Only if audit found P1 issues
+
+   → Manager merges skeleton PRs into tracking branches
+
+Phase 2: Implementation (parallel, 2-4 agents per track)
+   - Use templates/implement-agent.md
+   - Each agent has stable skeleton interface
+   - Sequence sibling agents that touch same file
+
+Phase 2.5: Implementation audit (parallel, 1 auditor per track)
+   - Use templates/audit-agent.md
+   - Mandatory live Chrome smoke for UI-touching tracks
+
+Phase 2.6: Implementation fix (parallel)
+   - Use templates/fix-agent.md
+   - Override deferred Codex P1
+
+Phase 3: e2e (manager runs in hotfix mode)
+   - Small fixes committed straight to tracking branch, one commit per blocker
+```
+
+## Goal-hook waiting rule (avoid frequent re-prompts)
+
+When a session-scoped Stop hook with a multi-phase completion condition is active and you are genuinely waiting on a dispatched subagent, do NOT just reply `Waiting` and end the turn. The Stop hook re-fires on every turn end, burning tokens to reaffirm `Waiting` over and over.
+
+Instead, run a **foreground bash `until` loop** that polls for the next concrete artifact (e.g. all expected branch names on origin):
+
+```bash
+until [ -n "$(git ls-remote origin 'feat/issue-XXX/*' 2>/dev/null)" ]; do sleep 60; done
+```
+
+This pauses the conversation while the loop runs (no stop-hook ping-pong). The harness still notifies you immediately if a subagent completes, AND notifies you when the loop itself exits (condition met).
+
+The harness blocks bare `sleep N` but allows `until <condition>; do sleep N; done` even with long inner sleeps. Some `until` loops still get auto-backgrounded by the harness — that's fine; rely on subagent completion notifications to break out of waiting.
+
+Rule of thumb: every time you'd otherwise reply `Waiting` more than twice in a row, replace it with a foreground until-loop watching the actual condition.
+
+## Mandatory checklist structure
+
+Create `docs/planning/<scope>-checklist.md` with sections:
+
+```markdown
+# <Scope> Implementation Checklist
+> Mandatory tracking doc. Every agent edits the rows it owns and only those rows.
+> Drift = protocol violation.
+
+## Conventions
+- [ ] not started · [~] in progress · [x] done · [!] blocked
+- Each tick MUST append → <PR-or-commit-link> or → <test-name>
+
+## <Track 1>
+### Skeleton (Owner: S<n>)
+- [ ] <row> [§<ADR-section>]
+...
+### Phase 2A (Owner: I<n>a)
+...
+
+## <Track 2>
+...
+
+## Test phase checklist (e2e — manager runs)
+- [ ] <test step verbatim from user spec>
+
+## Acceptance criteria
+- [ ] All sub-issue PRs opened, audited, fixed, merged into tracking branches
+- [ ] Both umbrella PRs remain [DO NOT MERGE] open
+- [ ] Every checkbox checked
+- [ ] e2e PASSES = identical (or other binary criterion)
+
+## Drift log (append-only)
+(empty until first violation)
+```
+
+## Standard agent roles
+
+The four templates in `templates/` are the dispatch prompts. Each begins with the role marker `[DISPATCH-TEMPLATE-V1: <role>]` so the discipline hook (see below) can detect them.
+
+- `templates/00-common-boilerplate.md` — shared rules (worktree isolation, no -e install, pytest --timeout=60, branch from tracking, PR target, `Closes #N`, CI must be green, Codex reconcile, checklist update, scope rules)
+- `templates/skeleton-agent.md` — Phase 1: scaffold + comment-driven test plans
+- `templates/implement-agent.md` — Phase 2: fill skeleton bodies + tests
+- `templates/audit-agent.md` — Phase 1.5/2.5: verify + report (no PR)
+- `templates/fix-agent.md` — Phase 1.6/2.6: address audit findings
+
+Read the template, fill in the `## Task content` section at the bottom with the dispatch-specific details (branch name, files in scope, files out of scope, sub-issue number, sibling-agent coordination notes), then pass the combined prompt to `Agent`.
+
+## Discipline hook
+
+Install `scripts/remind-checklist-discipline.sh` at `<project>/scripts/hooks/remind-checklist-discipline.sh` (see the script for the source). Wire into `<project>/.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit|NotebookEdit",
+        "hooks": [{"type": "command", "command": "bash scripts/hooks/remind-checklist-discipline.sh"}]
+      },
+      {
+        "matcher": "TaskCreate|TaskUpdate|TaskStop|TodoWrite",
+        "hooks": [{"type": "command", "command": "bash scripts/hooks/remind-checklist-discipline.sh"}]
+      }
+    ]
+  }
+}
+```
+
+The hook fires after every checklist-related edit, reminds the manager to verify drift / artifact links / scope. The script filters internally on `*-checklist.md` for Edit-family tools and always fires for Task-family tools.
+
+## Tracking branch convention
+
+For each track:
+- `track/<scope>/<short-name>` is the integration branch
+- Agent feature branches: `feat/issue-<sub>/short-desc` off the tracking branch
+- Agent PR target: tracking branch (NOT main); mergeable after audit
+- One umbrella PR per tracking branch → main, titled `[DO NOT MERGE]`, kept open for visibility
+
+This isolates parallel tracks and keeps main clean. The umbrella PR eventually closes (without merge) when the manager rebases changes to main via a separate clean PR.
+
+## Hygiene rules — burn into every dispatch prompt
+
+1. `isolation: "worktree"` mandatory on every Agent call (see [[feedback_agent_worktree]]).
+2. No `pip install -e .` from a worktree (see [[project_editable_install_contamination]]).
+3. `pytest --timeout=60` on every pytest call (see [[feedback_agent_discipline_and_pytest_timeout]]).
+4. No `npm run dev` background (see [[feedback_stale_dev_server_hygiene]]). Prefer `vitest run`.
+5. PR body has `Closes #N` (see [[feedback_pr_must_close_issue]]).
+6. CI must be green before report-done (see CLAUDE.md §6.4 in any project enforcing this).
+7. UI-touching dispatches require live Chrome smoke (see [[feedback_mandatory_chrome_smoke_test]] and [[feedback_phase_audit_smoke_test]]).
+8. Audit must reconcile every Codex auto-review comment (see [[feedback_audit_agent_codex_review]]).
+9. Fix agents override deferred Codex P1 (see [[feedback_audit_p1_override]]).
+10. Hotfix mode (Phase 3 e2e by manager) per [[feedback_hotfix_vs_refactor_scope]] — small fixes only, one commit per blocker.
+11. **Out-of-scope work MUST leave a TODO in the repo** (see [[feedback_out_of_scope_todo]]). Any v1→v2 deferral, ADR-explicit out-of-scope item, "good-enough-for-now" approximation, or known gap MUST be marked with `# TODO(#NNN): <reason> — Out of scope per <ADR §>. Followup: <issue/section>.` Verbal "we'll do that later" is silent tech debt. Burn this into every dispatch prompt: agents must TODO-tag (with tracking link) anything they choose not to implement, rather than silently skipping or pretending it doesn't exist. The dispatch prompt should pre-enumerate the known out-of-scope items so the agent knows where TODOs are mandatory.
+
+## Out-of-scope rules — codify per track
+
+For each track, list explicit out-of-scope directories at the top of the dispatch prompt. Examples (from SciEasy ADR-035/036 dispatch):
+
+- `src/<pkg>/core/` — frozen contracts
+- `src/<pkg>/blocks/base/` or analogous foundational classes
+- `src/<pkg>/engine/runners/` or analogous scheduler
+- ANY ADR / spec / changelog except as authorized
+
+If an agent believes it needs to modify a forbidden file, STOP, post on umbrella issue, exit. Manager escalates to user.
+
+## Stuck-agent diagnosis
+
+If a sub-agent runs longer than expected:
+- Check stale processes: `Get-Process` for vite / pytest survivors
+- TaskStop the agent if hung
+- Inspect its worktree commit history; if it pushed partial work, decide: continue manually or revert
+- Don't dispatch a replacement immediately — diagnose root cause first
+
+See [[feedback_agent_discipline_and_pytest_timeout]] and [[feedback_stale_dev_server_hygiene]].
+
+## End-of-dispatch summary template
+
+When all phases land, post a summary to the user:
+1. Render checklist with current state (% complete per section)
+2. Links to all sub-issue PRs + merge status
+3. Links to umbrella `[DO NOT MERGE]` PRs
+4. e2e GIFs / screenshots from Chrome MCP
+5. Any blockers escalated (with agent's exit comment quoted)
+6. Diff of critical files vs main for user sanity-check
+
+## Files in this skill
+
+- `SKILL.md` (this file)
+- `templates/00-common-boilerplate.md`
+- `templates/skeleton-agent.md`
+- `templates/implement-agent.md`
+- `templates/audit-agent.md`
+- `templates/fix-agent.md`
+- `scripts/remind-checklist-discipline.sh` — the hook script (copy into project's `scripts/hooks/`)
+
+## Related memory
+
+- [[feedback_multi_agent_checklist_protocol]]
+- [[feedback_ticket_dispatch_playbook]]
+- [[feedback_agent_dispatch_lessons]]
+- [[feedback_audit_p1_override]]
+- [[feedback_mandatory_chrome_smoke_test]]
+- [[feedback_phase_audit_smoke_test]]
+- [[feedback_agent_discipline_and_pytest_timeout]]
+- [[feedback_stale_dev_server_hygiene]]
+- [[feedback_pr_must_close_issue]]
+- [[feedback_audit_agent_codex_review]]
+- [[feedback_hotfix_vs_refactor_scope]]

--- a/docs/skills/agent-manager/scripts/check-agent-template.sh
+++ b/docs/skills/agent-manager/scripts/check-agent-template.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# PreToolUse hook on Agent — enforces the [DISPATCH-TEMPLATE-V1: <role>] marker
+# on every non-Explore Agent dispatch for the ADR-035/036 cascade.
+#
+# Behavior: warns on stderr (does NOT block) when the marker is absent.
+# Codex auto-review on PR #852 flagged the original boilerplate as referring
+# to a non-existent hook (P2); this script closes that gap.
+
+INPUT="$(cat 2>/dev/null || true)"
+
+PARSED=$(printf '%s' "$INPUT" | python -c "
+import sys, json
+try:
+    d = json.load(sys.stdin)
+    ti = d.get('tool_input', {})
+    sub = ti.get('subagent_type', '')
+    prompt = ti.get('prompt', '')
+    has_marker = '[DISPATCH-TEMPLATE-V1:' in prompt
+    print(f'sub={sub}|marker={has_marker}')
+except Exception:
+    print('sub=|marker=true')
+" 2>/dev/null)
+
+# Parse "sub=...|marker=..."
+SUBAGENT=$(printf '%s' "$PARSED" | sed -n 's/^sub=\(.*\)|.*$/\1/p')
+HAS_MARKER=$(printf '%s' "$PARSED" | sed -n 's/^.*|marker=\(.*\)$/\1/p')
+
+# Read-only Explore agents don't need the marker
+case "$SUBAGENT" in
+  Explore|explore|""|claude-code-guide|statusline-setup|Plan|plan)
+    exit 0
+    ;;
+esac
+
+# Non-Explore agents: enforce the marker
+if [ "$HAS_MARKER" = "True" ]; then
+  exit 0
+fi
+
+cat >&2 <<'EOF'
+[agent-template enforcement]
+You are dispatching a non-Explore Agent without the [DISPATCH-TEMPLATE-V1: <role>] marker.
+
+For ADR-035/036 cascade dispatches, prompts MUST start with one of:
+  [DISPATCH-TEMPLATE-V1: skeleton]
+  [DISPATCH-TEMPLATE-V1: implement]
+  [DISPATCH-TEMPLATE-V1: audit]
+  [DISPATCH-TEMPLATE-V1: fix]
+
+These templates live at docs/planning/agent-prompt-templates/<role>-agent.md
+and contain the mandatory hygiene + scope + CI rules.
+
+If this is an unrelated Agent call (not part of the ADR-035/036 cascade),
+ignore this warning and continue. The hook does not block; it only flags
+potential drift from the dispatch protocol.
+
+Reference: PR #852 Codex P2 closure — scripts/hooks/check-agent-template.sh
+ships in the repo and is wired in .claude/settings.json (PreToolUse, Agent
+matcher).
+EOF
+
+exit 0

--- a/docs/skills/agent-manager/scripts/remind-checklist-discipline.sh
+++ b/docs/skills/agent-manager/scripts/remind-checklist-discipline.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# PostToolUse hook — fires after:
+#  (a) Edit/Write/MultiEdit on docs/planning/adr-035-036-checklist.md
+#  (b) any TaskCreate / TaskUpdate / TaskStop call on the inline TodoWrite list
+#
+# Reminds the dispatcher to re-read memory, verify the Drift log, and
+# confirm every ticked row has an artifact link.
+
+INPUT="$(cat 2>/dev/null || true)"
+
+# Parse tool name + relevant arg using Python (no jq on this Windows shell).
+TOOL=$(printf '%s' "$INPUT" | python -c "import sys,json
+try:
+    d=json.load(sys.stdin)
+    print(d.get('tool_name', ''))
+except Exception:
+    print('')" 2>/dev/null)
+
+FILE_PATH=$(printf '%s' "$INPUT" | python -c "import sys,json
+try:
+    d=json.load(sys.stdin)
+    ti=d.get('tool_input',{})
+    print(ti.get('file_path','') or ti.get('path',''))
+except Exception:
+    print('')" 2>/dev/null)
+
+should_fire=false
+case "$TOOL" in
+  Edit|Write|MultiEdit|NotebookEdit)
+    case "$FILE_PATH" in
+      *adr-035-036-checklist.md*) should_fire=true ;;
+    esac
+    ;;
+  TaskCreate|TaskUpdate|TaskStop|TodoWrite)
+    should_fire=true
+    ;;
+esac
+
+if [ "$should_fire" != "true" ]; then
+  exit 0
+fi
+
+cat <<'EOF'
+[checklist-discipline reminder]
+You just modified a checklist (TaskCreate/TaskUpdate/TaskStop on the inline list, or Edit/Write on docs/planning/adr-035-036-checklist.md).
+
+Before continuing, perform these steps:
+
+1. RE-READ relevant memory entries:
+   - feedback_multi_agent_checklist_protocol.md  (drift rules, artifact-link requirement)
+   - project_adr035_036_overnight_dispatch.md    (current dispatch state, branches, scope)
+   - feedback_ticket_dispatch_playbook.md        (dispatch prompt template)
+   - feedback_audit_p1_override.md               (override deferred Codex P1)
+   - feedback_mandatory_chrome_smoke_test.md     (UI-touching audit must do live Chrome)
+   - feedback_agent_discipline_and_pytest_timeout.md  (--timeout=60 + scope discipline)
+
+2. VERIFY every box you ticked in the checklist doc has an inline artifact link
+   ( -> <PR-or-commit-link> or -> <test name passes> ).
+   A tick without artifact = drift. Log under "Drift log" and revert if needed.
+
+3. CONFIRM no out-of-scope rows touched. Each agent edits ONLY its own rows.
+   Out-of-scope edit = drift; log + escalate.
+
+4. SWEEP stale [~] markers — bump to [x] (with artifact) or [!] (with reason).
+
+5. INLINE LIST: confirm task #1..#8 statuses match reality (no task marked
+   completed before its artifacts exist; no task stuck in_progress when work
+   is actually done).
+
+If you intentionally made a meta-change (added a new section, restructured
+the checklist), acknowledge the reminder and continue.
+EOF
+
+exit 0

--- a/docs/skills/agent-manager/templates/00-common-boilerplate.md
+++ b/docs/skills/agent-manager/templates/00-common-boilerplate.md
@@ -1,0 +1,75 @@
+# [DISPATCH-COMMON-V1] Mandatory boilerplate for ADR-035/036 sub-agents
+
+> Every dispatch prompt for ADR-035 / ADR-036 work MUST start with the
+> role-specific marker (e.g. `[DISPATCH-TEMPLATE-V1: skeleton]`) and
+> include the rules below verbatim. The dispatch hook
+> (`scripts/hooks/check-agent-template.sh`) checks for these markers
+> on every `Agent` tool call.
+
+## Identity & boundaries
+
+- You are working on the SciEasy repository, on a tracking branch for either ADR-035 (AI Block on PTY) or ADR-036 (embedded code editor) — your dispatch will tell you which.
+- The plan file is `~/.claude/plans/gentle-snuggling-ripple.md` (read-only context).
+- The single source of truth for what's done is `docs/planning/adr-035-036-checklist.md`. You **MUST** edit only the rows you own. You **MUST** append a `→ <PR-or-commit-link>` artifact to every box you tick. Drift is logged and reverted.
+- The dispatch tells you (a) which sub-issue (`#N`) you own, (b) which feature branch to create off the tracking branch, and (c) the exact list of files in your scope.
+
+## Hard scope rules — DO NOT MODIFY
+
+These directories / files are out of scope for ALL ADR-035/036 work, no exceptions. Touching one without explicit authorization in the dispatch = protocol violation. Stop, post on umbrella issue, exit.
+
+- `src/scieasy/core/` (entire core data-type system; ADR-027 D2 freezes the seven core types)
+- `src/scieasy/blocks/base/` (Block ABC, BlockSpec, PortSpec, state machine)
+- `src/scieasy/engine/runners/` (process_handle.py, scheduler.py)
+- `src/scieasy/engine/events.py` (EventBus contract — you may **subscribe**, may NOT add new event types)
+- `src/scieasy/blocks/registry.py` (BlockRegistry; call `hot_reload()`, do NOT modify)
+- `src/scieasy/api/routes/ai_pty.py` — the EXISTING `WS /api/ai/pty/{tab_id}` route is frozen. ADR-035 may add a sibling helper but must not modify the existing handler.
+- ANY ADR / spec / ROADMAP / changelog except where your dispatch explicitly authorizes
+- ANY file owned by another agent in the same phase (avoid cross-agent collisions)
+
+If you genuinely believe your task requires touching one of these, STOP, post a comment on your umbrella issue describing why, and exit. The dispatcher escalates.
+
+## Hygiene rules — mandatory
+
+1. **Worktree isolation**: you are running in a worktree (`isolation: "worktree"`). Never operate on the user's main checkout.
+2. **No `pip install -e .` from this worktree** — it pollutes the user's global `scieasy` import. Document any dep change in the PR body so the user runs the install in main.
+3. **`pytest --timeout=60`** on every pytest invocation. Stuck pytest processes survive your exit and waste minutes.
+4. **No `npm run dev` background processes** — they survive worktree teardown and serve stale UI from the next agent's perspective. Use `npm run build`, `vitest run`, or `npm test -- --run`. If you genuinely need a live dev server (rare), kill it explicitly before exit.
+5. **Branch from the tracking branch** (NOT main):
+   ```
+   git fetch origin
+   git checkout -b <your-branch> origin/track/adr-XXX/...
+   ```
+6. **Push order**: feature branch → wait for first CI run → only then `gh pr create`. Reviewers must see real status.
+7. **PR target = tracking branch** (NOT main):
+   ```
+   gh pr create --base track/adr-XXX/... --head <your-branch> --title "..." --body "..."
+   ```
+8. **PR body MUST contain `Closes #N`** where N is your sub-issue number. After PR opens, verify the issue is linked. After merge, verify the issue actually closed.
+9. **GitHub CI MUST be green** before you report done. After PR opens, run `gh pr checks <N> --watch` and DO NOT exit until all checks pass. If CI fails: diagnose, push fix commit, repeat. A red PR is not done. (Per CLAUDE.md §6.4.)
+10. **Reconcile Codex auto-review**: after the first CI run, Codex posts review comments on the PR. Read each one and reply explicitly with one of `accepted (fixed in <commit>)`, `deferred (reason: ...)`, `rejected (reason: ...)`. Silence on a Codex P1 = drift.
+11. **Update the checklist** `docs/planning/adr-035-036-checklist.md` — tick the rows you complete, append `→ <PR/commit/test-link>`. Edit only your rows.
+12. **Run the same checks CI runs** locally before push:
+    - `ruff format --check .`
+    - `ruff check .`
+    - `pytest -q --timeout=60` (or scoped to your changed dirs)
+    - `mypy src/scieasy/ --ignore-missing-imports` (where applicable)
+    - `cd frontend && npm run build && vitest run` (frontend touch)
+
+## Definition of Done (every agent)
+
+- All checklist rows you own are ticked with artifact links.
+- PR opens, all CI checks green.
+- Codex review comments all reconciled (accepted / deferred / rejected on the record).
+- For UI-touching dispatches (ADR-035 frontend agent, ADR-036 frontend agents, every audit on UI work): live Chrome smoke test via Chrome MCP demonstrating the change works in a real browser. Unit tests do NOT replace this.
+- PR body has `Closes #N`.
+- Audit / Fix agents additionally post their report as a comment on the umbrella issue.
+
+## When to STOP and escalate (don't push through)
+
+- A scope rule above would force you to modify a forbidden file.
+- An existing test is failing in a way unrelated to your change AND you can't quickly identify the cause.
+- CI fails with an environment / dependency error you can't reproduce locally.
+- Codex auto-review reports a P1 that requires changes outside your scope.
+- The dispatch's task description contradicts the ADR.
+
+In every case: post a one-paragraph comment on your umbrella issue explaining the blocker, set the relevant checklist row to `[!]` with reason, exit cleanly. Do NOT push half-finished work or thrash.

--- a/docs/skills/agent-manager/templates/audit-agent.md
+++ b/docs/skills/agent-manager/templates/audit-agent.md
@@ -1,0 +1,99 @@
+# [DISPATCH-TEMPLATE-V1: audit]
+
+> Use for A35-skeleton / A35-impl / A36-skeleton / A36-impl (Phase 1.5 + Phase 2.5 audits).
+> Read `00-common-boilerplate.md` first — every rule there applies.
+
+## Role-specific rules — Audit
+
+You are reviewing the merged work of one phase on one tracking branch. Your job is to verify ticked checklist rows match reality, the implementation matches the ADR, CI is green, and the live behavior works (for UI dispatches).
+
+**Hard rules unique to this role:**
+
+1. **You do NOT write feature code.** You only WRITE: an audit report (as a comment on the umbrella issue), checklist edits (only on the audit-related rows), and Codex-review reply comments on the merged PRs.
+
+2. **Pull the tracking branch fresh** (`git fetch origin && git checkout -b <audit-branch> origin/track/adr-XXX/...`). Inspect every PR that landed since the previous audit phase.
+
+3. **Verify checklist accuracy.** For every box ticked in this phase's section, confirm:
+   - The artifact link points to a real commit / PR / test that exists
+   - The artifact actually does what the row claims
+   - No untracked work was done (nothing merged outside the checklist's ownership)
+   If a tick is unsupported: flag in the audit report, log in the Drift log, recommend revert.
+
+4. **Verify ADR compliance.** Read the ADR section numbers referenced in each checklist row. Compare the implementation to what the ADR prescribes. Note ANY divergence: design or contract differences, missing edge cases, missing error envelopes.
+
+5. **Run the full local CI** on the tracking branch:
+   - `ruff format --check .`
+   - `ruff check .`
+   - `pytest -q --timeout=60`
+   - `mypy src/scieasy/ --ignore-missing-imports`
+   - `cd frontend && npm run build && vitest run`
+   Report any failure as P1.
+
+6. **MANDATORY live Chrome smoke test for UI-touching phases** (per memory `mandatory_chrome_smoke_test` and `phase_audit_smoke_test`):
+   - Use `mcp__claude-in-chrome__*` tools
+   - Start `scieasy gui` on a free port; navigate; perform the user-visible flow your phase enabled
+   - Take screenshots; for ADR-035: open AI Block tab, verify status badge transitions; for ADR-036: open editor for a `.py`, edit + save, see lint markers, verify View source readonly
+   - Without this evidence, the audit cannot pass — unit tests do NOT replace it (PR #800 shipped 3 broken features with all CI green)
+
+7. **Reconcile every Codex auto-review comment** on every merged PR:
+   - For each comment, post a reply: `accepted (will fix in audit-fix branch)` / `deferred (reason: ...)` / `rejected (reason: ...)`
+   - Per memory `audit_p1_override`: if you call a Codex P1 "deferred" non-blocking, the dispatcher overrides and forces a fix-in-PR. Don't defer P1.
+   - Per memory `audit_agent_codex_review`: silence on a Codex comment is drift.
+
+8. **Audit report MUST be saved as a markdown file under `docs/audit/`**, in addition to being posted as a comment on the umbrella issue. Filename convention:
+   ```
+   docs/audit/<YYYY-MM-DD>-adr-<NNN>-<phase>.md
+   ```
+   Examples:
+   - `docs/audit/2026-05-14-adr-035-skeleton.md`
+   - `docs/audit/2026-05-14-adr-035-implementation.md`
+   - `docs/audit/2026-05-14-adr-036-skeleton.md`
+   - `docs/audit/2026-05-14-adr-036-implementation.md`
+
+   Commit the file on a tiny `chore/audit-report-N` branch off the tracking branch and PR back. **Audit-output PRs are exempt** from the "no audit-PR" rule in the section below — they only add the report file, no code change. The PR body has `Closes #<umbrella>` and references the audit comment.
+
+   Why: a permanent searchable archive separate from GitHub issue comments (which scroll out of sight). The dispatcher and any future session reviewing this work goes here first.
+
+9. **Audit report format** — identical content for both the file and the umbrella-issue comment:
+
+   ```markdown
+   # Audit report — <phase> (track/adr-XXX/...)
+   Date: <YYYY-MM-DD>
+   PRs reviewed: #N1, #N2, #N3
+   Checklist rows verified: <X / Y>
+
+   ## Summary
+   <pass | pass-with-fixes | block> — 1-2 sentences
+
+   ## Checklist drift
+   <list of ticks without artifact, or out-of-scope edits, or rows the auditor un-ticked>
+
+   ## ADR compliance
+   <list of any divergence from the ADR — major / minor>
+
+   ## CI status
+   ruff: <pass/fail>; pytest: <X/Y passed>; mypy: <pass/fail>; vitest: <X/Y passed>; smoke: <pass/fail with screenshots>
+
+   ## Findings (P1 — must fix; P2 — should fix; P3 — nice to have)
+   - **P1**: <description>. Recommended fix: <pointer>. Affected file: <path:line>.
+   - **P2**: ...
+   - **P3**: ...
+
+   ## Codex reconciliation
+   - PR #N1 has <X> Codex comments. Resolved as: <bulletwise list>.
+
+   ## Recommendation for fix agent
+   <ordered list of fix tasks>
+   ```
+
+10. **Set checklist Audit row to `[x]`** with links to BOTH the `docs/audit/` file (commit hash) AND the umbrella-issue comment. Do NOT tick anyone else's rows — even if the work looks done, the agent who owns the row ticks it.
+
+## PR vs comment
+
+Audit dispatch produces ONE small PR — the `docs/audit/<YYYY-MM-DD>-adr-<NNN>-<phase>.md` report file (per §8). Other than that one PR, output is comments (umbrella issue + Codex replies) + checklist Audit-row tick. If you find you need to push code beyond the report file, you've blurred into the Fix agent's role — STOP and post a recommendation in the audit report instead.
+
+## Task content (filled in by dispatcher)
+
+(below this line is task-specific: which tracking branch, which PRs to review, which checklist sections to verify, which UI flow to smoke-test)
+
+---

--- a/docs/skills/agent-manager/templates/fix-agent.md
+++ b/docs/skills/agent-manager/templates/fix-agent.md
@@ -1,0 +1,80 @@
+# [DISPATCH-TEMPLATE-V1: fix]
+
+> Use for F35-skeleton / F35-impl / F36-skeleton / F36-impl (Phase 1.6 + Phase 2.6 fixes).
+> Read `00-common-boilerplate.md` first — every rule there applies.
+
+## Role-specific rules — Fix
+
+You are addressing audit findings from a previous audit phase. Your job is to investigate each finding for accuracy, fix the genuine ones, document any rejection, and land mini-PRs against the tracking branch.
+
+**Hard rules unique to this role:**
+
+1. **Read the audit report comment in full** before doing anything. The report lives on the umbrella issue, tagged `audit-skeleton` or `audit-implementation`.
+
+2. **Investigate every P1 finding for accuracy.** An audit finding is a recommendation, not a fact. Reproduce the issue locally; if you can't reproduce, post a reply on the audit comment (`Cannot reproduce — <details>`) and ask the dispatcher to clarify. Don't blindly apply audit recommendations.
+
+3. **Fix every confirmed P1 finding in-PR.** Per memory `audit_p1_override`: if the auditor deferred a Codex P1 to "non-blocking", the dispatcher OVERRIDES and you fix it in this fix-PR cycle anyway. Do not skip P1 just because the auditor said it was OK to defer — the dispatcher's standard is stricter.
+
+4. **P2 / P3 findings**: fix if cheap (under ~10 LOC each); otherwise file a follow-up issue and link from the fix-PR body.
+
+5. **Mini-PR per finding cluster.** Group related findings into a single PR (~3-4 fixes per PR, per memory `ticket_batching`). Don't try to land 12 mini-PRs in parallel — collisions on the tracking branch get expensive.
+
+6. **Each fix-PR follows the standard rules**:
+   - Branch off the tracking branch
+   - PR target = tracking branch (NOT main)
+   - PR body has `Closes #<umbrella>` (so umbrella issue tracks closure) plus a section listing audit findings addressed
+   - All CI checks green before report-done
+   - Reconcile Codex review comments on the fix-PR itself
+
+7. **Update the checklist Audit & Fix row** with `[x] → <PR-link>` for each fix-PR landed.
+
+8. **Live Chrome smoke after fixing UI bugs** — same rules as audit. If your fix is "the lint markers don't show in the editor", you must show in Chrome that they now show. PR description includes screenshot.
+
+9. **No scope drift.** Fix-PR scope is bounded by the audit findings. If during fixing you spot another bug not in the audit report, file a new issue (`fix(adr-XXX-bug-NNN): ...`) — do not add to the fix-PR.
+
+10. **If a finding is genuinely a `reject`** (auditor was wrong): document in the fix-PR body under `## Findings rejected` with reason, mark the corresponding audit-report bullet as `[NOT-FIXED: <reason>]` via reply on the audit comment, do NOT modify the audited code.
+
+## Fix-PR body template
+
+```markdown
+Closes #<umbrella-issue>
+Addresses audit comment: <link>
+
+## Findings addressed
+
+| Audit finding | Severity | Fix | File / commit |
+|---|---|---|---|
+| <one-line description> | P1 | <one-line summary of fix> | `path/to/file.py:42` (commit abc1234) |
+| ... | ... | ... | ... |
+
+## Findings rejected
+
+| Finding | Reason rejected |
+|---|---|
+| <description> | <why the auditor was wrong / why the recommended fix is incorrect> |
+
+## Findings deferred to follow-up issue
+
+| Finding | New issue |
+|---|---|
+| ... | #NNN |
+
+## Tests added / modified
+
+- <test name> — <what it covers / regression for which finding>
+
+## Live smoke (if UI)
+
+<screenshot or GIF link>
+
+## CI status
+
+[ ] All CI checks green
+[ ] Codex auto-review on this fix-PR reconciled
+```
+
+## Task content (filled in by dispatcher)
+
+(below this line is task-specific: which audit report, which findings cluster to address, which tracking branch to PR against)
+
+---

--- a/docs/skills/agent-manager/templates/implement-agent.md
+++ b/docs/skills/agent-manager/templates/implement-agent.md
@@ -1,0 +1,77 @@
+# [DISPATCH-TEMPLATE-V1: implement]
+
+> Use for I35a / I35b / I35c / I36a / I36b / I36c (Phase 2 implementation).
+> Read `00-common-boilerplate.md` first — every rule there applies.
+
+## Role-specific rules — Implement
+
+You are filling in the bodies of the skeleton stubs landed in Phase 1. Your job is to follow the skeleton's implementation comments, write the real logic + tests, and merge cleanly.
+
+**Hard rules unique to this role:**
+
+1. **Follow the skeleton's implementation comments.** Each function you implement has a comment block describing Purpose / Signature contract / Implementation steps / Edge cases / Test plan / References. Do NOT redesign the contract; if you think the comment is wrong, STOP and post on the umbrella issue — escalation, not silent change.
+
+2. **Write the tests the skeleton's test plan listed.** Convert each xfail/skip test into a real pytest / vitest test. Add additional tests for things you discover during implementation. Tests that exercise integration points (not just one function) belong in `tests/integration/` not the unit dirs.
+
+3. **Stay within your dispatched scope.** Your dispatch lists exact files in scope. Do NOT touch files outside that list — even if "while you're there, this related thing also needs fixing". File a follow-up issue and let it be a separate PR. Per memory `agent_discipline_and_pytest_timeout`, scope drift was a major cause of past breakage (#810/#811).
+
+4. **Coordinate with sibling agents.** If your phase has 3 parallel agents (e.g. I35a + I35b + I35c), they all branch from the **same** tracking branch and PR back to it. If two PRs touch the same file (e.g. Toolbar.tsx in I36b + I36c), the second one merges with `git merge origin/track/...` after the first lands and resolves conflicts. The dispatcher sequences sibling agents to minimize collisions.
+
+5. **Test coverage threshold.** Your PR must include tests for every code path the skeleton's test plan lists. If you skip one, justify in the PR body with `Test deferred: <reason>` — and the auditor will judge.
+
+6. **Run the full local CI before push** (per common boilerplate §12). PRs blocked by lint or formatting waste reviewer time.
+
+7. **For UI-touching changes (any frontend agent)**: include screenshots / a short GIF in the PR body. Use Chrome MCP if available. Without visible-behavior evidence, the audit phase cannot verify your change.
+
+8. **Update the checklist as you go.** Every checklist row in your "Phase 2X" section gets ticked with `→ <commit-sha or test-name>` as soon as the implementation lands. Don't batch ticks at the end — that loses the artifact mapping.
+
+## PR body template — Implement
+
+```markdown
+Closes #<issue>
+
+## What this implements
+
+ADR-0<35|36> §<sections>, building on the Phase 1 skeleton from PR #<skeleton-PR>.
+
+## Files modified
+
+- <path 1> — <one-line summary of change>
+- <path 2> — ...
+
+## Tests added
+
+- <test file>::<test name> — <what it covers>
+- ...
+
+## Test plan coverage
+
+Every test plan from the skeleton's comments is implemented:
+- [x] <test from skeleton plan>
+- [ ] <test from skeleton plan> — deferred, reason: <...>
+
+## Cross-agent coordination
+
+(if applicable) This PR touches `<file>` which is also in scope for #<other-PR>. Merged after #<other-PR> with conflict resolution at <line range>.
+
+## Screenshots / GIF
+
+(UI changes only) <embed link>
+
+## Checklist updates
+
+Ticked rows in `docs/planning/adr-035-036-checklist.md` under
+`Phase 2X — ... (I##)`:
+- <bullet list with → commit-sha or PR comment link>
+
+## CI status
+
+[ ] All CI checks green
+[ ] Codex auto-review reconciled (every comment accepted / deferred / rejected)
+```
+
+## Task content (filled in by dispatcher)
+
+(below this line is task-specific: dispatch lists exact files in scope, exact files out of scope for this agent, exact skeleton PR to build on, exact sibling-agent coordination notes)
+
+---

--- a/docs/skills/agent-manager/templates/skeleton-agent.md
+++ b/docs/skills/agent-manager/templates/skeleton-agent.md
@@ -1,0 +1,99 @@
+# [DISPATCH-TEMPLATE-V1: skeleton]
+
+> Use for S35 / S36 (Phase 1 skeleton scaffolding).
+> Read `00-common-boilerplate.md` first — every rule there applies.
+
+## Role-specific rules — Skeleton
+
+You are creating the **scaffolding** for an ADR. Your job is to make sure every file the implementation phase will need exists, with the right signatures, and with **detailed comments telling the next agent what to build and how to test it**.
+
+**Hard rules unique to this role:**
+
+1. **NO real logic.** Every function/method body is `raise NotImplementedError("see comment block above")` (Python) or `throw new Error("not implemented — see comment above")` (TypeScript) — except for trivial type definitions / dataclass declarations / pure scaffolding constants.
+
+2. **Every NotImplementedError is preceded by a docstring + structured implementation-plan comment** with:
+   - **Purpose**: 1 sentence, what this function does
+   - **Signature contract**: arg types, return type, raised exceptions, error envelopes
+   - **Implementation steps**: numbered list, the algorithm in pseudocode
+   - **Edge cases**: list of "what if X happens" with the answer
+   - **Test plan**: list of test cases the implementation phase MUST add (positive, negative, edge)
+   - **References**: ADR section numbers + line ranges of any existing code being mirrored
+
+   Example shape:
+   ```python
+   def write_manifest(self, path: Path, inputs: list[InputPort], outputs: list[OutputPort]) -> None:
+       """Write the AI Block manifest.json.
+
+       Implementation plan (per ADR-035 §3.4):
+         1. Build the dict shape shown in §3.4 of ADR-035
+         2. Resolve each input's storage_ref to absolute path
+         3. Write atomically (tempfile + rename)
+
+       Edge cases:
+         - input is in memory only (no storage_ref): materialize first via `to_memory()`
+         - output port has no expected_path: default to ./{block_name}_outputs/{port}.{ext}
+
+       Test plan:
+         - test_write_manifest_basic: 1 input, 1 output, verify JSON shape matches ADR §3.4
+         - test_write_manifest_atomic: kill mid-write, file remains old or new (never partial)
+         - test_write_manifest_inmemory_input: triggers materialization
+
+       References: ADR-035 §3.4, src/scieasy/blocks/app/bridge.py:31-142 (similar pattern)
+       """
+       raise NotImplementedError("see comment block above")
+   ```
+
+3. **Tests are also stubs.** Create test files with the test-case skeletons described in your test plan, marked `@pytest.mark.xfail(reason="skeleton — implementation phase fills in")` or `it.skip("skeleton")` for vitest. Each test docstring contains the test plan.
+
+4. **No new dependencies in skeleton phase** unless they are listed in the dispatch as required for skeleton (typically just listing in `package.json` for frontend without installing). Document any required dep in PR body.
+
+5. **Skeleton must build** — `pytest --collect-only` runs without errors; `npm run build` (or `tsc --noEmit`) passes; `ruff check` passes; `mypy` passes. xfail tests are fine.
+
+6. **Skeleton coverage matches the checklist exactly** — for every box under your "Skeleton (S##)" section, there is a corresponding stub file or stub function. Tick boxes as you go (with `→ <commit-sha>` artifact).
+
+## PR body template — Skeleton
+
+```markdown
+Closes #<issue>
+
+## Skeleton scope
+
+This is the **Phase 1 skeleton** for ADR-0<35|36>. No real logic — all
+function bodies raise NotImplementedError with detailed implementation
+plans + test plans in the preceding comments. Implementation phase
+agents will fill them in.
+
+## Files added / modified
+
+- <list of paths>
+
+## Comment-block coverage
+
+Every NotImplementedError has a preceding docstring with: Purpose,
+Signature contract, Implementation steps, Edge cases, Test plan,
+References. Implementation agents should be able to start coding
+without re-reading the ADR.
+
+## Test stubs
+
+- <list of test files added>
+
+All tests are xfail (Python) or skip (vitest) with the test plan in
+the docstring.
+
+## Checklist updates
+
+Ticked rows in `docs/planning/adr-035-036-checklist.md` under
+`Skeleton (S##)`:
+- <bullet list with → commit-sha for each>
+
+## CI status
+
+[ ] All CI checks green (filled in after PR opens + checks complete)
+```
+
+## Task content (filled in by dispatcher)
+
+(below this line is task-specific)
+
+---


### PR DESCRIPTION
## Summary

Verbatim export of the user-level `agent-manager` skill into `docs/skills/agent-manager/` so collaborators can reference the multi-agent dispatch protocol used in recent ADR cascades.

## Contents

- `docs/skills/agent-manager/SKILL.md` — protocol overview, phase structure, hygiene rules, related-memory pointers
- `docs/skills/agent-manager/templates/` — `00-common-boilerplate.md`, `skeleton-agent.md`, `implement-agent.md`, `audit-agent.md`, `fix-agent.md`
- `docs/skills/agent-manager/scripts/` — `remind-checklist-discipline.sh`, `check-agent-template.sh`

## Notes

- Files copied as-is from `~/.claude/skills/agent-manager/`; no edits.
- Docs-only addition; no code, tests, or settings affected.
- `[[memory-link]]` references in SKILL.md point to the original author's local memory and are kept verbatim for fidelity.
- Hook script is **not** wired into `.claude/settings.json` in this PR. Manager activates it per cascade as needed.

## Test plan

- [x] No runtime code touched; CI lint/test should be unaffected.