### PR TITLE
chore(#1103): importlinter — carve out blocks/app → engine.materialisation (D8)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -191,12 +191,25 @@ name = "Blocks must not depend on engine, api, or ai services"
 type = "forbidden"
 source_modules = ["scieasy.blocks"]
 forbidden_modules = ["scieasy.engine", "scieasy.api", "scieasy.ai"]
-# ADR-035 §3.10 explicitly carves out scieasy.engine.pty_control as the
-# AI Block worker → engine IPC surface. AIBlock.run() must call back to
-# the engine to allocate a PTY tab and notify completion. Allow that one
-# import without weakening the broader boundary.
+# Narrow carve-outs for engine-layer dispatch surfaces that block-layer
+# code must call. Each entry cites the ADR that justifies the boundary
+# crossing. NEW carve-outs require the same justification shape.
+#
+# ADR-035 §3.10: AIBlock.run() must call back to the engine to allocate
+# a PTY tab and notify completion.
+#
+# ADR-028 §D8 (Phase -1 sprint, issues #1079 + #1080): AppBlock's
+# `_bin_outputs_by_extension` (app_block.py) and `FileExchangeBridge.prepare`
+# (bridge.py) dispatch to `engine.materialisation.{reconstruct_from_file,
+# materialise_to_file}` for typed DataObject ↔ file conversion. The
+# helpers live in `engine/` because they consume `BlockRegistry` from
+# `blocks/` (a core/-layer placement would violate Core ↔ Blocks). Both
+# imports are lazy (function-body) and execute only inside the per-run
+# AppBlock dispatch path.
 ignore_imports = [
     "scieasy.blocks.ai.ai_block -> scieasy.engine.pty_control",
+    "scieasy.blocks.app.app_block -> scieasy.engine.materialisation",
+    "scieasy.blocks.app.bridge -> scieasy.engine.materialisation",
 ]
 
 [[tool.importlinter.contracts]]


### PR DESCRIPTION
Closes #1103 partially — unblocks PR #1116 (#1079) Import Contracts failure caused by lazy import of \`scieasy.engine.materialisation\` inside \`AppBlock._bin_outputs_by_extension\`.

## Why this is needed

ADR-028 §D8's two consumer issues (#1079 + #1080) require the AppBlock dispatch path to call \`engine.materialisation.{reconstruct_from_file, materialise_to_file}\` for typed DataObject ↔ file conversion. The helpers landed in PR #1112 (#1078) at \`src/scieasy/engine/materialisation.py\` (NOT \`core/\`, because they consume \`BlockRegistry\` from \`blocks/\`).

Importlinter's \"Blocks must not depend on engine, api, or ai services\" contract correctly flagged the lazy imports on:
- \`scieasy.blocks.app.app_block:230\` → \`scieasy.engine.materialisation\` (#1079)
- \`scieasy.blocks.app.bridge:283\` → \`scieasy.engine.materialisation\` (#1080; not yet flagged but same pattern)

## Resolution

Add two narrow carve-outs to the \`Blocks must not depend on engine\` contract's \`ignore_imports\` list. Pattern mirrors the existing ADR-035 §3.10 carve-out for \`ai_block → engine.pty_control\`.

## Justification template (for future carve-outs)

The comment block above the \`ignore_imports\` list now explicitly names each crossing and the ADR that justifies it, so future carve-outs follow the same shape:

\`\`\`
# ADR-XXX §Y: <one-sentence rationale>
# <ADR/issue cross-reference>
\`\`\`

## Verification

After merge:
- #1116 (#1079) will re-run Import Contracts and pass.
- #1117 (#1080) will re-run Import Contracts and pass (proactively, before its lazy import would otherwise trip the same rule on a future refresh).

## Scope

Single-file change to \`pyproject.toml\`. No source code changes; no behavior change at runtime. Carve-out is one named import per file.