### PR TITLE
feat(#1223): add CodeBlock v2 config interpreter provenance helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- [#1223] Add ADR-041 Track A CodeBlock v2 support modules for typed script configuration, Python interpreter resolution, script/interpreter/environment provenance payloads, and focused config/interpreter/provenance tests. (@agent, 2026-05-19, branch: feat/issue-1223/adr041-config-interpreter-provenance, session: 20260519-182537-adr-041-track-a-codeblock-v2-config-inte)
+
 - [#1222] Add the ADR-041 CodeBlock v2 implementation cascade checklist, tracking branch plan, worker issue breakdown, ADR-043 conflict guardrails, and ADR-042 audit exit criteria. (@agent, 2026-05-19, branch: track/adr-041/codeblock-v2, session: 20260519-181608-adr-041-codeblock-v2-implementation-casc)
 
 - [#1208] Add an ADR-042-compliant implementation planning spec for ADR-041 CodeBlock v2, including user scenarios, functional requirements, affected files, implementation phases, signature-level contracts, verification plan, migration guidance, and regenerated ADR-042 facts. (@agent, 2026-05-19, branch: docs/issue-1208/adr-041-codeblock-v2-spec, session: 20260519-172454-adr-041-implementation-planning-spec-and)

--- a/docs/planning/adr-041-codeblock-v2-checklist.md
+++ b/docs/planning/adr-041-codeblock-v2-checklist.md
@@ -74,18 +74,18 @@ Scope:
 
 Tasks:
 
-- [ ] Define CodeBlock v2 config models for script path, inline code migration diagnostics, declared inputs, declared outputs, working directory, interpreter selection, environment variables, timeout, and exchange-directory policy.
-- [ ] Validate path-like fields without assuming the project fits in memory or that paths are local-only forever.
-- [ ] Implement Python interpreter resolution for `auto`, explicit executable path, and active environment fallback.
-- [ ] Implement provenance helpers that capture script path, content hash when available, interpreter identity, command argv, environment delta, and execution timestamps.
-- [ ] Add tests for valid config, invalid mixed inline/script config, missing script, interpreter resolution success/failure, and provenance payload stability.
-- [ ] Avoid `src/scieasy/blocks/code/code_block.py` in this track.
+- [x] Define CodeBlock v2 config models for script path, inline code migration diagnostics, declared inputs, declared outputs, working directory, interpreter selection, environment variables, timeout, and exchange-directory policy. Evidence: commit `2f72ae3b`.
+- [x] Validate path-like fields without assuming the project fits in memory or that paths are local-only forever. Evidence: commit `2f72ae3b`; focused config tests cover missing and outside-project scripts.
+- [x] Implement Python interpreter resolution for `auto`, explicit executable path, and active environment fallback. Evidence: commit `2f72ae3b`; focused interpreter tests cover auto, existing, missing, and unsupported extension paths.
+- [x] Implement provenance helpers that capture script path, content hash when available, interpreter identity, command argv, environment delta, and execution timestamps. Evidence: commit `2f72ae3b`; focused provenance tests cover hash/git state and stable payload shape.
+- [x] Add tests for valid config, invalid mixed inline/script config, missing script, interpreter resolution success/failure, and provenance payload stability. Evidence: `python -m pytest tests/blocks/code/test_codeblock_v2_config.py tests/blocks/code/test_codeblock_interpreters.py tests/blocks/code/test_codeblock_provenance.py --timeout=30 --no-cov` passed with 15 tests.
+- [x] Avoid `src/scieasy/blocks/code/code_block.py` in this track. Evidence: commit `2f72ae3b` touches only Track A support modules and tests.
 
 Exit Criteria:
 
-- [ ] Track A PR targets `track/adr-041/codeblock-v2`.
+- [~] Track A PR targets `track/adr-041/codeblock-v2`. Pending PR creation after changelog gate; branch is `feat/issue-1223/adr041-config-interpreter-provenance`.
 - [ ] Track A CI is green.
-- [ ] Checklist rows updated with PR/test evidence.
+- [~] Checklist rows updated with PR/test evidence. Test evidence recorded above; PR/CI evidence will be added after PR creation.
 
 ### Track B - Exchange Manifest Helpers (Owner: I41b / #1224)
 
@@ -227,7 +227,7 @@ Exit Criteria:
 
 ## Dispatch Log
 
-- [ ] I41a dispatched for #1223.
+- [x] I41a dispatched for #1223. Worktree: `C:\Users\jiazh\Desktop\workspace\SciEasy-adr041-I41a`; branch: `feat/issue-1223/adr041-config-interpreter-provenance`.
 - [ ] I41b dispatched for #1224.
 - [ ] I41c dispatched for #1225.
 - [ ] I41d dispatched for #1226.

--- a/docs/planning/adr-041-codeblock-v2-checklist.md
+++ b/docs/planning/adr-041-codeblock-v2-checklist.md
@@ -83,9 +83,9 @@ Tasks:
 
 Exit Criteria:
 
-- [~] Track A PR targets `track/adr-041/codeblock-v2`. Pending PR creation after changelog gate; branch is `feat/issue-1223/adr041-config-interpreter-provenance`.
-- [ ] Track A CI is green.
-- [~] Checklist rows updated with PR/test evidence. Test evidence recorded above; PR/CI evidence will be added after PR creation.
+- [x] Track A PR targets `track/adr-041/codeblock-v2`. Evidence: [PR #1231](https://github.com/zjzcpj/SciEasy/pull/1231).
+- [x] Track A CI is green. Evidence: PR #1231 checks passed on 2026-05-19.
+- [x] Checklist rows updated with PR/test evidence. Evidence: PR #1231 plus focused pytest/Ruff evidence recorded above.
 
 ### Track B - Exchange Manifest Helpers (Owner: I41b / #1224)
 

--- a/src/scieasy/blocks/code/config.py
+++ b/src/scieasy/blocks/code/config.py
@@ -1,0 +1,223 @@
+"""CodeBlock v2 configuration models.
+
+ADR-041 narrows CodeBlock v2 to project-local scripts that exchange data
+through files.  This module defines the small persisted config surface used by
+later runtime integration tracks; it intentionally does not execute scripts.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+PortDirection = Literal["input", "output"]
+InterpreterMode = Literal["auto", "existing"]
+ExchangeDirectoryPolicy = Literal["project", "custom"]
+
+
+class CodeBlockConfigError(ValueError):
+    """Raised when a CodeBlock v2 config violates ADR-041 constraints."""
+
+
+class PortFileConfig(BaseModel):
+    """File-exchange contract for one CodeBlock v2 port."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    direction: PortDirection
+    data_type: str
+    extension: str
+    capability_id: str | None = None
+    required: bool = True
+    exchange_folder: str | None = None
+
+    @field_validator("name", "data_type")
+    @classmethod
+    def _non_empty_identifier(cls, value: str) -> str:
+        value = value.strip()
+        if not value:
+            raise ValueError("value must not be empty")
+        return value
+
+    @field_validator("extension")
+    @classmethod
+    def _normalize_extension(cls, value: str) -> str:
+        value = value.strip().lower()
+        if not value:
+            raise ValueError("extension must not be empty")
+        if not value.startswith("."):
+            value = f".{value}"
+        return value
+
+    @field_validator("exchange_folder")
+    @classmethod
+    def _normalize_exchange_folder(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        normalized = value.replace("\\", "/").strip()
+        if not normalized:
+            raise ValueError("exchange_folder must not be empty")
+        return normalized.rstrip("/") + "/"
+
+    @model_validator(mode="after")
+    def _default_exchange_folder(self) -> PortFileConfig:
+        if self.exchange_folder is None:
+            self.exchange_folder = f"{'inputs' if self.direction == 'input' else 'outputs'}/{self.name}/"
+        return self
+
+
+class MigrationDiagnostic(BaseModel):
+    """Explicit diagnostic for legacy inline/function CodeBlock configs."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    legacy_mode: str
+    severity: Literal["warning", "error"]
+    message: str
+    suggested_target: str
+    reference: str = "ADR-041 Section 3.3"
+
+
+class CodeBlockConfig(BaseModel):
+    """Persisted CodeBlock v2 script configuration.
+
+    ``code`` and ``inline_code`` are accepted only so legacy/mixed configs can
+    fail with an explicit migration error instead of an opaque extra-field
+    failure.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    script_path: str
+    code: str | None = None
+    inline_code: str | None = None
+    entry_function: str | None = None
+    working_directory: str = "."
+    interpreter_mode: InterpreterMode = "auto"
+    interpreter_path: str | None = None
+    environment: Mapping[str, Any] = Field(default_factory=dict)
+    environment_variables: dict[str, str] = Field(default_factory=dict)
+    timeout_seconds: float | None = Field(default=None, gt=0)
+    exchange_directory_policy: ExchangeDirectoryPolicy = "project"
+    exchange_root: str = "exchange"
+    inputs: list[PortFileConfig] = Field(default_factory=list)
+    outputs: list[PortFileConfig] = Field(default_factory=list)
+
+    @field_validator("script_path", "working_directory", "exchange_root")
+    @classmethod
+    def _non_empty_pathlike(cls, value: str) -> str:
+        value = value.strip()
+        if not value:
+            raise ValueError("path-like value must not be empty")
+        return value
+
+    @field_validator("environment_variables")
+    @classmethod
+    def _stringify_environment(cls, value: dict[str, str]) -> dict[str, str]:
+        return {str(key): str(env_value) for key, env_value in value.items()}
+
+    @model_validator(mode="after")
+    def _reject_legacy_inline_or_function_mode(self) -> CodeBlockConfig:
+        if self.code or self.inline_code:
+            raise CodeBlockConfigError(
+                "CodeBlock v2 does not support inline code; save code as a project-local script "
+                "or migrate framework-shaped logic to a ProcessBlock/custom block."
+            )
+        if self.entry_function:
+            raise CodeBlockConfigError(
+                "CodeBlock v2 does not call SciEasy entry functions; scripts must use file exchange."
+            )
+        if self.interpreter_mode == "existing" and not self.interpreter_path:
+            raise CodeBlockConfigError("interpreter_mode='existing' requires interpreter_path")
+        return self
+
+    def resolve_script_path(self, project_dir: Path) -> Path:
+        """Return the validated project-local script path."""
+
+        return resolve_project_path(self.script_path, project_dir=project_dir, field_name="script_path")
+
+    def resolve_working_directory(self, project_dir: Path) -> Path:
+        """Return the project-local working directory for interpreter launch."""
+
+        return resolve_project_path(
+            self.working_directory,
+            project_dir=project_dir,
+            field_name="working_directory",
+            must_exist=False,
+            allow_file=False,
+        )
+
+    def resolve_exchange_root(self, project_dir: Path) -> Path:
+        """Return the project-local exchange root."""
+
+        return resolve_project_path(
+            self.exchange_root,
+            project_dir=project_dir,
+            field_name="exchange_root",
+            must_exist=False,
+            allow_file=False,
+        )
+
+
+def resolve_project_path(
+    raw_path: str | Path,
+    *,
+    project_dir: Path,
+    field_name: str,
+    must_exist: bool = True,
+    allow_file: bool = True,
+) -> Path:
+    """Resolve *raw_path* and require it to stay inside *project_dir*.
+
+    The check resolves symlinks before comparing paths, matching ADR-041's
+    project-local source requirement without scanning the project tree.
+    """
+
+    project_root = project_dir.resolve()
+    candidate = Path(raw_path)
+    if not candidate.is_absolute():
+        candidate = project_root / candidate
+    resolved = candidate.resolve(strict=must_exist)
+    try:
+        resolved.relative_to(project_root)
+    except ValueError as exc:
+        raise CodeBlockConfigError(f"{field_name} must resolve inside the project directory") from exc
+    if must_exist and not resolved.exists():
+        raise FileNotFoundError(f"{field_name} does not exist: {raw_path}")
+    if not allow_file and resolved.exists() and not resolved.is_dir():
+        raise CodeBlockConfigError(f"{field_name} must be a directory")
+    if allow_file and must_exist and not resolved.is_file():
+        raise CodeBlockConfigError(f"{field_name} must be a file")
+    return resolved
+
+
+def legacy_migration_diagnostics(config: Mapping[str, Any]) -> list[MigrationDiagnostic]:
+    """Classify legacy CodeBlock config fields without mutating the config."""
+
+    diagnostics: list[MigrationDiagnostic] = []
+    mode = str(config.get("mode", "")).strip().lower()
+    has_inline = bool(config.get("code") or config.get("inline_code") or config.get("script"))
+    has_entry = bool(config.get("entry_function"))
+    if mode == "inline" or has_inline:
+        diagnostics.append(
+            MigrationDiagnostic(
+                legacy_mode=mode or "inline",
+                severity="error",
+                message="Inline CodeBlock configs are not valid CodeBlock v2 configs.",
+                suggested_target="Save the code as a project-local script, or use ProcessBlock/custom block authoring.",
+            )
+        )
+    if has_entry:
+        diagnostics.append(
+            MigrationDiagnostic(
+                legacy_mode=mode or "script",
+                severity="error",
+                message="Entry-function script configs are framework-shaped legacy CodeBlock configs.",
+                suggested_target="Adapt the script to ADR-041 file exchange or keep the logic in a ProcessBlock.",
+            )
+        )
+    return diagnostics

--- a/src/scieasy/blocks/code/interpreters.py
+++ b/src/scieasy/blocks/code/interpreters.py
@@ -1,0 +1,160 @@
+"""Interpreter resolution helpers for CodeBlock v2.
+
+Track A supports deterministic Python interpreter resolution only.  Later
+tracks can add more families behind this same narrow surface.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from scieasy.blocks.code.config import InterpreterMode, resolve_project_path
+
+InterpreterFamily = Literal["python"]
+
+
+class InterpreterResolutionError(RuntimeError):
+    """Raised when CodeBlock v2 cannot produce a safe interpreter command."""
+
+
+class UnsupportedScriptExtensionError(InterpreterResolutionError):
+    """Raised when Track A does not support a script extension."""
+
+
+class ResolvedInterpreter(BaseModel):
+    """Resolved command metadata for launching a CodeBlock v2 script."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    family: InterpreterFamily
+    executable: str
+    argv: list[str]
+    working_directory: str
+    environment: dict[str, str] = Field(default_factory=dict)
+    version: str | None = None
+    warnings: list[str] = Field(default_factory=list)
+
+
+def resolve_script_interpreter(
+    script_path: Path,
+    *,
+    environment_config: Mapping[str, Any] | None = None,
+    project_dir: Path,
+    mode: InterpreterMode = "auto",
+    interpreter_path: Path | str | None = None,
+) -> ResolvedInterpreter:
+    """Resolve an interpreter for *script_path* under ADR-041 constraints."""
+
+    environment_config = environment_config or {}
+    resolved_script = resolve_project_path(script_path, project_dir=project_dir, field_name="script_path")
+    if resolved_script.suffix.lower() != ".py":
+        raise UnsupportedScriptExtensionError(
+            f"CodeBlock v2 Track A supports .py scripts only; got {resolved_script.suffix or '<none>'}"
+        )
+
+    executable = _resolve_python_executable(
+        mode=mode,
+        interpreter_path=interpreter_path,
+        environment_config=environment_config,
+    )
+    working_directory = _resolve_working_directory(environment_config, project_dir=project_dir)
+    relative_script = resolved_script.relative_to(project_dir.resolve()).as_posix()
+    env_delta = _environment_delta(environment_config)
+    version, warnings = _probe_version(executable)
+
+    return ResolvedInterpreter(
+        family="python",
+        executable=executable,
+        argv=[executable, relative_script],
+        working_directory=working_directory.as_posix(),
+        environment=env_delta,
+        version=version,
+        warnings=warnings,
+    )
+
+
+def _resolve_python_executable(
+    *,
+    mode: InterpreterMode,
+    interpreter_path: Path | str | None,
+    environment_config: Mapping[str, Any],
+) -> str:
+    configured = interpreter_path or environment_config.get("interpreter_path") or environment_config.get("python")
+    if mode == "existing":
+        if configured is None:
+            raise InterpreterResolutionError("interpreter_mode='existing' requires an interpreter path")
+        return _resolve_executable(str(configured))
+    if mode != "auto":
+        raise InterpreterResolutionError(f"Unsupported interpreter mode: {mode}")
+
+    if configured is not None:
+        return _resolve_executable(str(configured))
+    return _resolve_executable(sys.executable)
+
+
+def _resolve_executable(raw_executable: str) -> str:
+    raw_executable = raw_executable.strip()
+    if not raw_executable:
+        raise InterpreterResolutionError("interpreter executable must not be empty")
+
+    candidate = Path(raw_executable)
+    has_path_component = candidate.is_absolute() or any(part in raw_executable for part in ("/", "\\"))
+    if has_path_component:
+        resolved = candidate.expanduser().resolve()
+        if not resolved.exists() or not resolved.is_file():
+            raise InterpreterResolutionError(f"interpreter executable not found: {raw_executable}")
+        return str(resolved)
+
+    discovered = shutil.which(raw_executable)
+    if discovered is None:
+        raise InterpreterResolutionError(f"interpreter executable not found on PATH: {raw_executable}")
+    return str(Path(discovered).resolve())
+
+
+def _resolve_working_directory(environment_config: Mapping[str, Any], *, project_dir: Path) -> Path:
+    raw_working_dir = environment_config.get("working_directory", ".")
+    return resolve_project_path(
+        str(raw_working_dir),
+        project_dir=project_dir,
+        field_name="working_directory",
+        must_exist=False,
+        allow_file=False,
+    )
+
+
+def _environment_delta(environment_config: Mapping[str, Any]) -> dict[str, str]:
+    raw_delta = (
+        environment_config.get("environment_variables")
+        or environment_config.get("env")
+        or environment_config.get("environment")
+        or {}
+    )
+    if not isinstance(raw_delta, Mapping):
+        raise InterpreterResolutionError("environment variables must be a mapping")
+    return {str(key): str(value) for key, value in raw_delta.items() if os.environ.get(str(key)) != str(value)}
+
+
+def _probe_version(executable: str) -> tuple[str | None, list[str]]:
+    try:
+        completed = subprocess.run(
+            [executable, "--version"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return None, [f"Could not capture interpreter version: {exc}"]
+
+    output = (completed.stdout or completed.stderr).strip()
+    if completed.returncode != 0:
+        return None, [f"Interpreter version command exited with {completed.returncode}"]
+    return output or None, []

--- a/src/scieasy/blocks/code/provenance.py
+++ b/src/scieasy/blocks/code/provenance.py
@@ -1,0 +1,163 @@
+"""Provenance helpers for CodeBlock v2 support modules."""
+
+from __future__ import annotations
+
+import hashlib
+import subprocess
+from collections.abc import Mapping
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from scieasy.blocks.code.config import InterpreterMode, resolve_project_path
+from scieasy.blocks.code.interpreters import ResolvedInterpreter
+
+GitStatus = Literal["tracked-clean", "tracked-modified", "untracked"]
+
+
+class ScriptProvenance(BaseModel):
+    """Source identity for a selected CodeBlock v2 script."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    relative_path: str
+    resolved_path: str
+    content_sha256: str
+    git_commit: str | None = None
+    git_status: GitStatus
+    size_bytes: int
+    mtime_ns: int
+
+
+class EnvironmentSnapshot(BaseModel):
+    """Best-effort interpreter/environment reproducibility evidence."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    mode: InterpreterMode
+    interpreter_path: str
+    version: str | None = None
+    environment_delta: dict[str, str] = Field(default_factory=dict)
+    warnings: list[str] = Field(default_factory=list)
+
+
+class CodeBlockProvenancePayload(BaseModel):
+    """Stable lineage-owned payload for a CodeBlock v2 run."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    script: ScriptProvenance
+    interpreter: ResolvedInterpreter
+    environment: EnvironmentSnapshot
+    started_at: str
+    completed_at: str | None = None
+    selected_capabilities: dict[str, str] = Field(default_factory=dict)
+    exchange_manifest: dict[str, Any] = Field(default_factory=dict)
+
+
+def utc_now_iso() -> str:
+    """Return a timezone-aware UTC timestamp with second precision."""
+
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def capture_script_provenance(script_path: Path, *, project_dir: Path) -> ScriptProvenance:
+    """Capture project-local script hash and git evidence."""
+
+    resolved_script = resolve_project_path(script_path, project_dir=project_dir, field_name="script_path")
+    project_root = project_dir.resolve()
+    relative_path = resolved_script.relative_to(project_root).as_posix()
+    stat = resolved_script.stat()
+
+    return ScriptProvenance(
+        relative_path=relative_path,
+        resolved_path=resolved_script.as_posix(),
+        content_sha256=_sha256_file(resolved_script),
+        git_commit=_git_commit(project_root),
+        git_status=_git_status(project_root, relative_path),
+        size_bytes=stat.st_size,
+        mtime_ns=stat.st_mtime_ns,
+    )
+
+
+def capture_environment_snapshot(
+    resolved_interpreter: ResolvedInterpreter,
+    *,
+    mode: InterpreterMode,
+    environment_delta: Mapping[str, str] | None = None,
+) -> EnvironmentSnapshot:
+    """Build a stable environment snapshot from interpreter resolution."""
+
+    delta = dict(environment_delta or resolved_interpreter.environment)
+    return EnvironmentSnapshot(
+        mode=mode,
+        interpreter_path=resolved_interpreter.executable,
+        version=resolved_interpreter.version,
+        environment_delta={str(key): str(value) for key, value in sorted(delta.items())},
+        warnings=list(resolved_interpreter.warnings),
+    )
+
+
+def build_codeblock_provenance_payload(
+    *,
+    script: ScriptProvenance,
+    interpreter: ResolvedInterpreter,
+    environment: EnvironmentSnapshot,
+    started_at: str,
+    completed_at: str | None = None,
+    selected_capabilities: Mapping[str, str] | None = None,
+    exchange_manifest: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Return a JSON-stable provenance payload for lineage storage."""
+
+    payload = CodeBlockProvenancePayload(
+        script=script,
+        interpreter=interpreter,
+        environment=environment,
+        started_at=started_at,
+        completed_at=completed_at,
+        selected_capabilities=dict(sorted((selected_capabilities or {}).items())),
+        exchange_manifest=dict(exchange_manifest or {}),
+    )
+    return payload.model_dump(mode="json")
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _git_commit(project_dir: Path) -> str | None:
+    completed = _run_git(project_dir, "rev-parse", "HEAD")
+    if completed.returncode != 0:
+        return None
+    return completed.stdout.strip() or None
+
+
+def _git_status(project_dir: Path, relative_path: str) -> GitStatus:
+    tracked = _run_git(project_dir, "ls-files", "--error-unmatch", "--", relative_path)
+    if tracked.returncode != 0:
+        return "untracked"
+    status = _run_git(project_dir, "status", "--porcelain", "--", relative_path)
+    if status.returncode != 0:
+        return "tracked-modified"
+    return "tracked-modified" if status.stdout.strip() else "tracked-clean"
+
+
+def _run_git(project_dir: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    try:
+        return subprocess.run(
+            ["git", *args],
+            cwd=project_dir,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return subprocess.CompletedProcess(["git", *args], returncode=1, stdout="", stderr=str(exc))

--- a/tests/blocks/code/test_codeblock_interpreters.py
+++ b/tests/blocks/code/test_codeblock_interpreters.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from scieasy.blocks.code.interpreters import (
+    InterpreterResolutionError,
+    UnsupportedScriptExtensionError,
+    resolve_script_interpreter,
+)
+
+
+def _write_script(project_dir: Path, name: str = "scripts/run.py") -> Path:
+    script = project_dir / name
+    script.parent.mkdir(parents=True, exist_ok=True)
+    script.write_text("print('ok')\n", encoding="utf-8")
+    return script
+
+
+def test_auto_interpreter_resolution_uses_active_python(tmp_path: Path) -> None:
+    script = _write_script(tmp_path)
+
+    resolved = resolve_script_interpreter(script, project_dir=tmp_path)
+
+    assert resolved.family == "python"
+    assert Path(resolved.executable).resolve() == Path(sys.executable).resolve()
+    assert resolved.argv == [resolved.executable, "scripts/run.py"]
+    assert resolved.working_directory == tmp_path.resolve().as_posix()
+    assert resolved.version is None or "Python" in resolved.version
+
+
+def test_existing_interpreter_resolution_accepts_explicit_executable(tmp_path: Path) -> None:
+    script = _write_script(tmp_path)
+
+    resolved = resolve_script_interpreter(
+        script,
+        project_dir=tmp_path,
+        mode="existing",
+        interpreter_path=sys.executable,
+        environment_config={"environment_variables": {"SCIEASY_CODEBLOCK_TEST": "1"}},
+    )
+
+    assert Path(resolved.executable).resolve() == Path(sys.executable).resolve()
+    assert resolved.environment == {"SCIEASY_CODEBLOCK_TEST": "1"}
+
+
+def test_existing_interpreter_resolution_requires_executable(tmp_path: Path) -> None:
+    script = _write_script(tmp_path)
+
+    with pytest.raises(InterpreterResolutionError, match="requires an interpreter path"):
+        resolve_script_interpreter(script, project_dir=tmp_path, mode="existing")
+
+
+def test_missing_interpreter_path_fails(tmp_path: Path) -> None:
+    script = _write_script(tmp_path)
+    missing = tmp_path / "missing-python.exe"
+
+    with pytest.raises(InterpreterResolutionError, match="not found"):
+        resolve_script_interpreter(script, project_dir=tmp_path, mode="existing", interpreter_path=missing)
+
+
+def test_unsupported_script_extension_fails_before_interpreter_lookup(tmp_path: Path) -> None:
+    script = _write_script(tmp_path, "scripts/run.R")
+
+    with pytest.raises(UnsupportedScriptExtensionError, match=r"supports \.py scripts only"):
+        resolve_script_interpreter(script, project_dir=tmp_path)

--- a/tests/blocks/code/test_codeblock_provenance.py
+++ b/tests/blocks/code/test_codeblock_provenance.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import hashlib
+import subprocess
+import sys
+from pathlib import Path
+
+from scieasy.blocks.code.interpreters import resolve_script_interpreter
+from scieasy.blocks.code.provenance import (
+    build_codeblock_provenance_payload,
+    capture_environment_snapshot,
+    capture_script_provenance,
+)
+
+
+def _write_script(project_dir: Path) -> Path:
+    script = project_dir / "scripts" / "run.py"
+    script.parent.mkdir(parents=True, exist_ok=True)
+    script.write_text("print('tracked')\n", encoding="utf-8")
+    return script
+
+
+def _git(project_dir: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=project_dir, check=True, capture_output=True, text=True)
+
+
+def test_capture_script_provenance_records_hash_and_tracked_state(tmp_path: Path) -> None:
+    script = _write_script(tmp_path)
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "agent@example.com")
+    _git(tmp_path, "config", "user.name", "SciEasy Agent")
+    _git(tmp_path, "add", "scripts/run.py")
+    _git(tmp_path, "commit", "-m", "add script")
+
+    provenance = capture_script_provenance(script, project_dir=tmp_path)
+
+    expected_hash = hashlib.sha256(script.read_bytes()).hexdigest()
+    assert provenance.relative_path == "scripts/run.py"
+    assert provenance.content_sha256 == expected_hash
+    assert provenance.git_status == "tracked-clean"
+    assert provenance.git_commit is not None
+    assert provenance.size_bytes == len(script.read_bytes())
+
+
+def test_capture_script_provenance_marks_untracked_scripts(tmp_path: Path) -> None:
+    script = _write_script(tmp_path)
+
+    provenance = capture_script_provenance(script, project_dir=tmp_path)
+
+    assert provenance.git_status == "untracked"
+    assert provenance.git_commit is None
+
+
+def test_environment_snapshot_uses_sorted_delta(tmp_path: Path) -> None:
+    script = _write_script(tmp_path)
+    resolved = resolve_script_interpreter(
+        script,
+        project_dir=tmp_path,
+        mode="existing",
+        interpreter_path=sys.executable,
+        environment_config={"environment_variables": {"Z_VAR": "2", "A_VAR": "1"}},
+    )
+
+    snapshot = capture_environment_snapshot(resolved, mode="existing")
+
+    assert snapshot.mode == "existing"
+    assert Path(snapshot.interpreter_path).resolve() == Path(sys.executable).resolve()
+    assert list(snapshot.environment_delta) == ["A_VAR", "Z_VAR"]
+
+
+def test_codeblock_provenance_payload_shape_is_stable(tmp_path: Path) -> None:
+    script = _write_script(tmp_path)
+    script_provenance = capture_script_provenance(script, project_dir=tmp_path)
+    interpreter = resolve_script_interpreter(script, project_dir=tmp_path)
+    environment = capture_environment_snapshot(interpreter, mode="auto")
+
+    payload = build_codeblock_provenance_payload(
+        script=script_provenance,
+        interpreter=interpreter,
+        environment=environment,
+        started_at="2026-05-19T00:00:00Z",
+        completed_at="2026-05-19T00:00:01Z",
+        selected_capabilities={"output:table": "core.dataframe.csv.load", "input:image": "imaging.image.tiff.save"},
+        exchange_manifest={"outputs": ["outputs/table/result.csv"]},
+    )
+
+    assert list(payload) == [
+        "script",
+        "interpreter",
+        "environment",
+        "started_at",
+        "completed_at",
+        "selected_capabilities",
+        "exchange_manifest",
+    ]
+    assert payload["script"]["relative_path"] == "scripts/run.py"
+    assert list(payload["selected_capabilities"]) == ["input:image", "output:table"]
+    assert payload["interpreter"]["argv"][1] == "scripts/run.py"

--- a/tests/blocks/code/test_codeblock_v2_config.py
+++ b/tests/blocks/code/test_codeblock_v2_config.py
@@ -66,9 +66,7 @@ def test_outside_project_script_path_is_rejected(tmp_path: Path) -> None:
 
 
 def test_legacy_migration_diagnostics_are_explicit() -> None:
-    diagnostics = legacy_migration_diagnostics(
-        {"mode": "inline", "script": "result = data", "entry_function": "run"}
-    )
+    diagnostics = legacy_migration_diagnostics({"mode": "inline", "script": "result = data", "entry_function": "run"})
 
     assert [diagnostic.legacy_mode for diagnostic in diagnostics] == ["inline", "inline"]
     assert all(diagnostic.severity == "error" for diagnostic in diagnostics)

--- a/tests/blocks/code/test_codeblock_v2_config.py
+++ b/tests/blocks/code/test_codeblock_v2_config.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from scieasy.blocks.code.config import (
+    CodeBlockConfig,
+    CodeBlockConfigError,
+    PortFileConfig,
+    legacy_migration_diagnostics,
+)
+
+
+def test_valid_codeblock_v2_config_resolves_project_local_paths(tmp_path: Path) -> None:
+    script = tmp_path / "scripts" / "segment.py"
+    script.parent.mkdir()
+    script.write_text("print('ok')\n", encoding="utf-8")
+
+    config = CodeBlockConfig(
+        script_path="scripts/segment.py",
+        working_directory=".",
+        exchange_root="exchange",
+        inputs=[PortFileConfig(name="image", direction="input", data_type="Image", extension="tif")],
+        outputs=[PortFileConfig(name="table", direction="output", data_type="DataFrame", extension=".CSV")],
+        timeout_seconds=10,
+    )
+
+    assert config.resolve_script_path(tmp_path) == script.resolve()
+    assert config.resolve_working_directory(tmp_path) == tmp_path.resolve()
+    assert config.resolve_exchange_root(tmp_path) == (tmp_path / "exchange").resolve()
+    assert config.inputs[0].extension == ".tif"
+    assert config.inputs[0].exchange_folder == "inputs/image/"
+    assert config.outputs[0].extension == ".csv"
+    assert config.outputs[0].exchange_folder == "outputs/table/"
+
+
+def test_mixed_inline_and_script_config_is_rejected() -> None:
+    with pytest.raises(ValidationError, match="does not support inline code"):
+        CodeBlockConfig(script_path="scripts/segment.py", inline_code="print('legacy')")
+
+
+def test_entry_function_script_config_is_rejected() -> None:
+    with pytest.raises(ValidationError, match="does not call SciEasy entry functions"):
+        CodeBlockConfig(script_path="scripts/segment.py", entry_function="run")
+
+
+def test_missing_script_path_fails_project_validation(tmp_path: Path) -> None:
+    config = CodeBlockConfig(script_path="scripts/missing.py")
+
+    with pytest.raises(FileNotFoundError):
+        config.resolve_script_path(tmp_path)
+
+
+def test_outside_project_script_path_is_rejected(tmp_path: Path) -> None:
+    outside = tmp_path.parent / "outside_codeblock_v2.py"
+    outside.write_text("print('outside')\n", encoding="utf-8")
+    config = CodeBlockConfig(script_path=str(outside))
+
+    try:
+        with pytest.raises(CodeBlockConfigError, match="inside the project"):
+            config.resolve_script_path(tmp_path)
+    finally:
+        outside.unlink(missing_ok=True)
+
+
+def test_legacy_migration_diagnostics_are_explicit() -> None:
+    diagnostics = legacy_migration_diagnostics(
+        {"mode": "inline", "script": "result = data", "entry_function": "run"}
+    )
+
+    assert [diagnostic.legacy_mode for diagnostic in diagnostics] == ["inline", "inline"]
+    assert all(diagnostic.severity == "error" for diagnostic in diagnostics)
+    assert all("ADR-041" in diagnostic.reference for diagnostic in diagnostics)


### PR DESCRIPTION
Closes #1223

## Summary
- Add CodeBlock v2 config models for ADR-041 script mode, port file contracts, project-local path validation, and legacy inline/function diagnostics.
- Add Python interpreter resolution for auto and existing modes with stable command metadata and environment deltas.
- Add provenance helpers for script hash/git state, interpreter/environment snapshots, and stable lineage payload shape.
- Update Track A checklist rows and changelog entry.

## Verification
- `PYTHONPATH=src python -m pytest tests/blocks/code/test_codeblock_v2_config.py tests/blocks/code/test_codeblock_interpreters.py tests/blocks/code/test_codeblock_provenance.py --timeout=30 --no-cov` -> 15 passed.
- `PYTHONPATH=src python -m ruff check src/scieasy/blocks/code/config.py src/scieasy/blocks/code/interpreters.py src/scieasy/blocks/code/provenance.py tests/blocks/code/test_codeblock_v2_config.py tests/blocks/code/test_codeblock_interpreters.py tests/blocks/code/test_codeblock_provenance.py` -> passed.
- `PYTHONPATH=src python -m ruff format --check src/scieasy/blocks/code/config.py src/scieasy/blocks/code/interpreters.py src/scieasy/blocks/code/provenance.py tests/blocks/code/test_codeblock_v2_config.py tests/blocks/code/test_codeblock_interpreters.py tests/blocks/code/test_codeblock_provenance.py` -> passed.

## Scope Notes
- PR targets `track/adr-041/codeblock-v2`, not `main`.
- No edits to `src/scieasy/blocks/code/code_block.py` or ADR-043 conflict files.
- ADR/spec frontmatter lint is N/A for this track because only the planning checklist was edited.