### PR TITLE
feat(#1236): add MATLAB and Octave CodeBlock backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- [#1236] Add ADR-041 CodeBlock v2 MATLAB/Octave runtime backend support for `.m` and `.mlx` scripts, including MATLAB-first executable selection, Octave fallback for `.m`, MATLAB-only `.mlx` diagnostics, deterministic process command construction, and optional live Octave test coverage. (@agent, 2026-05-19, branch: feat/issue-1236/adr041-matlab-octave-runtime, session: 20260519-195039-adr-041-track-c5-matlab-and-octave-runti)
+
 - [#1242] Add shared CodeBlock v2 interpreter family metadata for notebook, R, Quarto, shell, MATLAB, and Octave runtime backends so ADR-041 sibling tracks can implement complete runtime support without each modifying the shared interpreter type alias. (@agent, 2026-05-19, branch: track/adr-041/codeblock-v2, session: 20260519-194531-adr-041-shared-interpreter-family-litera)
 
 - [#1225] Integrate the ADR-041 CodeBlock v2 shared runtime layer with the Python `.py` backend, including exchange preparation, interpreter execution, typed output collection, provenance payload capture, timeout/nonzero diagnostics, and explicit legacy inline/function migration errors. (@agent, 2026-05-19, branch: feat/issue-1225/adr041-codeblock-python-execution, session: 20260519-185434-adr-041-track-c-codeblock-v2-python-exec)

--- a/docs/planning/adr-041-codeblock-v2-checklist.md
+++ b/docs/planning/adr-041-codeblock-v2-checklist.md
@@ -240,9 +240,9 @@ Tasks:
 
 Exit Criteria:
 
-- [ ] Track C5 PR targets `track/adr-041/codeblock-v2`.
+- [x] Track C5 PR targets `track/adr-041/codeblock-v2`. Evidence: [PR #1247](https://github.com/zjzcpj/SciEasy/pull/1247).
 - [ ] Track C5 CI is green.
-- [ ] Checklist rows updated with PR/test evidence.
+- [x] Checklist rows updated with PR/test evidence. Evidence: PR #1247 plus focused pytest/Ruff evidence recorded above.
 
 ## Phase 3 - Validation and Migration Diagnostics
 

--- a/docs/planning/adr-041-codeblock-v2-checklist.md
+++ b/docs/planning/adr-041-codeblock-v2-checklist.md
@@ -233,10 +233,10 @@ Scope:
 
 Tasks:
 
-- [ ] Add `.m` execution through MATLAB or Octave when available.
-- [ ] Add `.mlx` handling through MATLAB where available, with clear unsupported diagnostics when not available.
-- [ ] Add deterministic command construction, exchange-directory environment passing, and output collection.
-- [ ] Add tests for executable selection, missing executable diagnostics, command construction, and optional dependency skip behavior.
+- [x] Add `.m` execution through MATLAB or Octave when available. Evidence: commit `ce9ca4c8`; backend selects MATLAB first in auto mode and falls back to Octave for `.m`.
+- [x] Add `.mlx` handling through MATLAB where available, with clear unsupported diagnostics when not available. Evidence: commit `ce9ca4c8`; tests cover `.mlx` MATLAB requirement and Octave rejection.
+- [x] Add deterministic command construction, exchange-directory environment passing, and output collection. Evidence: commit `ce9ca4c8`; backend reuses shared CodeBlock process execution and tests assert argv/cwd/env/timeout handoff.
+- [x] Add tests for executable selection, missing executable diagnostics, command construction, and optional dependency skip behavior. Evidence: `PYTHONPATH=C:\Users\jiazh\Desktop\workspace\SciEasy-adr041-I41m\src python -m pytest tests/blocks/code/test_codeblock_matlab.py --timeout=30 --no-cov` passed with 10 tests and 1 optional Octave skip; Ruff passed for touched Python files.
 
 Exit Criteria:
 
@@ -339,7 +339,7 @@ Exit Criteria:
 - [ ] I41n dispatched for #1235.
 - [ ] I41r dispatched for #1238.
 - [ ] I41s dispatched for #1237.
-- [ ] I41m dispatched for #1236.
+- [x] I41m dispatched for #1236. Evidence: worktree `C:\Users\jiazh\Desktop\workspace\SciEasy-adr041-I41m`, branch `feat/issue-1236/adr041-matlab-octave-runtime`, gate session `20260519-195039-adr-041-track-c5-matlab-and-octave-runti`.
 - [ ] I41d dispatched for #1226.
 - [ ] I41e dispatched for #1227.
 - [ ] A41/F41 dispatched for #1228.

--- a/docs/planning/adr-041-codeblock-v2-checklist.md
+++ b/docs/planning/adr-041-codeblock-v2-checklist.md
@@ -241,7 +241,7 @@ Tasks:
 Exit Criteria:
 
 - [x] Track C5 PR targets `track/adr-041/codeblock-v2`. Evidence: [PR #1247](https://github.com/zjzcpj/SciEasy/pull/1247).
-- [ ] Track C5 CI is green.
+- [x] Track C5 CI is green. Evidence: PR #1247 `Verify Workflow Compliance` passed on 2026-05-19.
 - [x] Checklist rows updated with PR/test evidence. Evidence: PR #1247 plus focused pytest/Ruff evidence recorded above.
 
 ## Phase 3 - Validation and Migration Diagnostics

--- a/src/scieasy/blocks/code/backends/matlab.py
+++ b/src/scieasy/blocks/code/backends/matlab.py
@@ -1,0 +1,232 @@
+"""MATLAB and Octave backend for CodeBlock v2."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any, Literal
+
+from scieasy.blocks.code.code_block import (
+    CodeBlockRuntimeContext,
+    register_codeblock_backend,
+    run_codeblock_process,
+)
+from scieasy.blocks.code.config import CodeBlockConfig
+from scieasy.blocks.code.interpreters import InterpreterResolutionError, ResolvedInterpreter
+
+MatlabFamily = Literal["matlab", "octave"]
+
+
+class MatlabRuntimeResolutionError(InterpreterResolutionError):
+    """Raised when MATLAB-family interpreter selection fails."""
+
+
+class MatlabCodeBlockBackend:
+    """MATLAB `.m` and `.mlx` backend for the ADR-041 shared runtime."""
+
+    name = "matlab"
+    extensions = frozenset({".m", ".mlx"})
+
+    def supports(self, script_path: Path, config: CodeBlockConfig) -> bool:
+        return script_path.suffix.lower() in self.extensions
+
+    def resolve(self, context: CodeBlockRuntimeContext) -> ResolvedInterpreter:
+        suffix = context.script_path.suffix.lower()
+        executable, family = resolve_matlab_executable(
+            suffix=suffix,
+            mode=context.config.interpreter_mode,
+            interpreter_path=context.config.interpreter_path,
+            environment_config=context.environment_config,
+        )
+        argv = build_matlab_command(executable=executable, family=family, script_path=context.script_path)
+        version, warnings = probe_matlab_version(executable=executable, family=family)
+
+        return ResolvedInterpreter(
+            family=family,
+            executable=executable,
+            argv=argv,
+            working_directory=context.exchange_dir.as_posix(),
+            environment=environment_delta(context.environment_config),
+            version=version,
+            warnings=warnings,
+        )
+
+    def run(
+        self,
+        context: CodeBlockRuntimeContext,
+        interpreter: ResolvedInterpreter,
+    ) -> subprocess.CompletedProcess[str]:
+        return run_codeblock_process(
+            argv=interpreter.argv,
+            cwd=context.exchange_dir,
+            env_delta=interpreter.environment,
+            timeout_seconds=context.config.timeout_seconds,
+        )
+
+
+def resolve_matlab_executable(
+    *,
+    suffix: str,
+    mode: str,
+    interpreter_path: str | Path | None,
+    environment_config: Mapping[str, Any] | None = None,
+) -> tuple[str, MatlabFamily]:
+    """Resolve MATLAB or Octave for a MATLAB-family CodeBlock script."""
+
+    suffix = suffix.lower()
+    if suffix not in {".m", ".mlx"}:
+        raise MatlabRuntimeResolutionError(f"MATLAB backend does not support {suffix or '<none>'} scripts.")
+
+    environment_config = environment_config or {}
+    configured = interpreter_path or environment_config.get("interpreter_path")
+    if configured is None:
+        configured = environment_config.get("matlab") or environment_config.get("octave")
+
+    if mode == "existing":
+        if configured is None:
+            raise MatlabRuntimeResolutionError("interpreter_mode='existing' requires a MATLAB or Octave executable")
+        executable = resolve_executable(str(configured))
+        family = infer_matlab_family(executable, environment_config=environment_config)
+        validate_matlab_family_for_suffix(family=family, suffix=suffix)
+        return executable, family
+
+    if mode != "auto":
+        raise MatlabRuntimeResolutionError(f"Unsupported interpreter mode: {mode}")
+
+    if configured is not None:
+        executable = resolve_executable(str(configured))
+        family = infer_matlab_family(executable, environment_config=environment_config)
+        validate_matlab_family_for_suffix(family=family, suffix=suffix)
+        return executable, family
+
+    matlab = which_executable("matlab")
+    if matlab is not None:
+        return matlab, "matlab"
+
+    if suffix == ".mlx":
+        raise MatlabRuntimeResolutionError(
+            ".mlx CodeBlock scripts require MATLAB; no MATLAB executable was found on PATH."
+        )
+
+    octave = which_executable("octave")
+    if octave is not None:
+        return octave, "octave"
+
+    raise MatlabRuntimeResolutionError("No MATLAB or Octave executable was found on PATH for .m CodeBlock scripts.")
+
+
+def build_matlab_command(*, executable: str, family: MatlabFamily, script_path: Path) -> list[str]:
+    """Build the process command for MATLAB-family execution."""
+
+    script = script_path.resolve().as_posix()
+    if family == "matlab":
+        return [executable, "-batch", f"run('{escape_matlab_string(script)}')"]
+    return [executable, "--quiet", "--no-gui", script]
+
+
+def validate_matlab_family_for_suffix(*, family: MatlabFamily, suffix: str) -> None:
+    """Reject MATLAB live scripts when the selected executable is Octave."""
+
+    if suffix == ".mlx" and family != "matlab":
+        raise MatlabRuntimeResolutionError(".mlx CodeBlock scripts require MATLAB; Octave cannot execute live scripts.")
+
+
+def infer_matlab_family(
+    executable: str,
+    *,
+    environment_config: Mapping[str, Any] | None = None,
+) -> MatlabFamily:
+    """Infer MATLAB vs Octave from an explicit executable and optional hint."""
+
+    environment_config = environment_config or {}
+    raw_hint = environment_config.get("interpreter_family") or environment_config.get("runtime_family")
+    if raw_hint is not None:
+        hint = str(raw_hint).strip().lower()
+        if hint in {"matlab", "octave"}:
+            return hint  # type: ignore[return-value]
+        raise MatlabRuntimeResolutionError("MATLAB backend interpreter_family must be 'matlab' or 'octave'")
+
+    executable_name = Path(executable).name.lower()
+    if "octave" in executable_name:
+        return "octave"
+    return "matlab"
+
+
+def resolve_executable(raw_executable: str) -> str:
+    """Resolve an executable name or path."""
+
+    raw_executable = raw_executable.strip()
+    if not raw_executable:
+        raise MatlabRuntimeResolutionError("MATLAB-family executable must not be empty")
+
+    candidate = Path(raw_executable)
+    has_path_component = candidate.is_absolute() or any(part in raw_executable for part in ("/", "\\"))
+    if has_path_component:
+        resolved = candidate.expanduser().resolve()
+        if not resolved.exists() or not resolved.is_file():
+            raise MatlabRuntimeResolutionError(f"MATLAB-family executable not found: {raw_executable}")
+        return str(resolved)
+
+    discovered = which_executable(raw_executable)
+    if discovered is None:
+        raise MatlabRuntimeResolutionError(f"MATLAB-family executable not found on PATH: {raw_executable}")
+    return discovered
+
+
+def which_executable(name: str) -> str | None:
+    """Return a normalized executable path from PATH lookup."""
+
+    discovered = shutil.which(name)
+    if discovered is None:
+        return None
+    return str(Path(discovered).resolve())
+
+
+def environment_delta(environment_config: Mapping[str, Any]) -> dict[str, str]:
+    """Return environment variables that differ from the current process."""
+
+    raw_delta = (
+        environment_config.get("environment_variables")
+        or environment_config.get("env")
+        or environment_config.get("environment")
+        or {}
+    )
+    if not isinstance(raw_delta, Mapping):
+        raise MatlabRuntimeResolutionError("environment variables must be a mapping")
+    return {str(key): str(value) for key, value in raw_delta.items() if os.environ.get(str(key)) != str(value)}
+
+
+def probe_matlab_version(*, executable: str, family: MatlabFamily) -> tuple[str | None, list[str]]:
+    """Capture best-effort interpreter version metadata."""
+
+    command = [executable, "--version"] if family == "octave" else [executable, "-batch", "disp(version)"]
+    try:
+        completed = subprocess.run(
+            command,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return None, [f"Could not capture MATLAB-family interpreter version: {exc}"]
+
+    output = (completed.stdout or completed.stderr).strip()
+    if completed.returncode != 0:
+        return None, [f"MATLAB-family version command exited with {completed.returncode}"]
+    return output or None, []
+
+
+def escape_matlab_string(value: str) -> str:
+    """Escape a value for a single-quoted MATLAB string literal."""
+
+    return value.replace("'", "''")
+
+
+def register() -> None:
+    """Register the MATLAB-family backend with the shared CodeBlock runtime."""
+
+    register_codeblock_backend(MatlabCodeBlockBackend(), replace=True)

--- a/tests/blocks/code/test_codeblock_matlab.py
+++ b/tests/blocks/code/test_codeblock_matlab.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from scieasy.blocks.code.backends.matlab import (
+    MatlabCodeBlockBackend,
+    MatlabRuntimeResolutionError,
+    build_matlab_command,
+    register,
+    resolve_matlab_executable,
+)
+from scieasy.blocks.code.code_block import CodeBlockRuntimeContext, list_codeblock_backends
+from scieasy.blocks.code.config import CodeBlockConfig
+from scieasy.blocks.code.interpreters import ResolvedInterpreter
+
+
+def _write_script(project_dir: Path, name: str = "scripts/run.m") -> Path:
+    script = project_dir / name
+    script.parent.mkdir(parents=True, exist_ok=True)
+    script.write_text("disp('ok')\n", encoding="utf-8")
+    return script
+
+
+def _config(script_path: str, **kwargs: object) -> CodeBlockConfig:
+    return CodeBlockConfig(script_path=script_path, **kwargs)
+
+
+def _context(project_dir: Path, script_path: str, **kwargs: object) -> CodeBlockRuntimeContext:
+    script = _write_script(project_dir, script_path)
+    exchange_dir = project_dir / "exchange" / "block-run"
+    exchange_dir.mkdir(parents=True)
+    config = _config(script_path, **kwargs)
+    return CodeBlockRuntimeContext(
+        config=config,
+        script_path=script,
+        project_dir=project_dir,
+        exchange_dir=exchange_dir,
+        environment_config={"environment_variables": {"SCIEASY_CODEBLOCK_TEST": "1"}},
+    )
+
+
+def test_matlab_backend_supports_plain_and_live_scripts(tmp_path: Path) -> None:
+    backend = MatlabCodeBlockBackend()
+    config = _config("scripts/run.m")
+
+    assert backend.supports(tmp_path / "scripts" / "run.m", config) is True
+    assert backend.supports(tmp_path / "scripts" / "run.mlx", config) is True
+    assert backend.supports(tmp_path / "scripts" / "run.py", config) is False
+
+
+def test_register_adds_matlab_backend_extensions() -> None:
+    register()
+
+    backend = next(registered for registered in list_codeblock_backends() if registered.name == "matlab")
+    assert backend.extensions == frozenset({".m", ".mlx"})
+
+
+def test_auto_selection_prefers_matlab_for_plain_m(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_which(name: str) -> str | None:
+        return f"/toolchain/{name}" if name in {"matlab", "octave"} else None
+
+    monkeypatch.setattr("scieasy.blocks.code.backends.matlab.which_executable", fake_which)
+
+    executable, family = resolve_matlab_executable(suffix=".m", mode="auto", interpreter_path=None)
+
+    assert executable == "/toolchain/matlab"
+    assert family == "matlab"
+
+
+def test_auto_selection_uses_octave_for_plain_m_when_matlab_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_which(name: str) -> str | None:
+        return "/toolchain/octave" if name == "octave" else None
+
+    monkeypatch.setattr("scieasy.blocks.code.backends.matlab.which_executable", fake_which)
+
+    executable, family = resolve_matlab_executable(suffix=".m", mode="auto", interpreter_path=None)
+
+    assert executable == "/toolchain/octave"
+    assert family == "octave"
+
+
+def test_mlx_requires_matlab_in_auto_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_which(name: str) -> str | None:
+        return "/toolchain/octave" if name == "octave" else None
+
+    monkeypatch.setattr("scieasy.blocks.code.backends.matlab.which_executable", fake_which)
+
+    with pytest.raises(MatlabRuntimeResolutionError, match=r"\.mlx CodeBlock scripts require MATLAB"):
+        resolve_matlab_executable(suffix=".mlx", mode="auto", interpreter_path=None)
+
+
+def test_existing_octave_rejected_for_mlx(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("scieasy.blocks.code.backends.matlab.which_executable", lambda name: f"/toolchain/{name}")
+
+    with pytest.raises(MatlabRuntimeResolutionError, match="Octave cannot execute live scripts"):
+        resolve_matlab_executable(suffix=".mlx", mode="existing", interpreter_path="octave")
+
+
+def test_missing_executable_reports_matlab_family_diagnostic(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("scieasy.blocks.code.backends.matlab.which_executable", lambda name: None)
+
+    with pytest.raises(MatlabRuntimeResolutionError, match="No MATLAB or Octave executable"):
+        resolve_matlab_executable(suffix=".m", mode="auto", interpreter_path=None)
+
+
+def test_command_construction_is_deterministic_for_matlab_and_octave(tmp_path: Path) -> None:
+    script = _write_script(tmp_path)
+
+    matlab = build_matlab_command(executable="/bin/matlab", family="matlab", script_path=script)
+    octave = build_matlab_command(executable="/bin/octave", family="octave", script_path=script)
+
+    assert matlab == ["/bin/matlab", "-batch", f"run('{script.resolve().as_posix()}')"]
+    assert octave == ["/bin/octave", "--quiet", "--no-gui", script.resolve().as_posix()]
+
+
+def test_resolve_builds_runtime_metadata(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr("scieasy.blocks.code.backends.matlab.which_executable", lambda name: f"/toolchain/{name}")
+    monkeypatch.setattr(
+        "scieasy.blocks.code.backends.matlab.probe_matlab_version",
+        lambda *, executable, family: ("MATLAB test-version", []),
+    )
+    context = _context(tmp_path, "scripts/run.m")
+    backend = MatlabCodeBlockBackend()
+
+    resolved = backend.resolve(context)
+
+    assert resolved.family == "matlab"
+    assert resolved.executable == "/toolchain/matlab"
+    assert resolved.argv[0] == "/toolchain/matlab"
+    assert resolved.argv[1] == "-batch"
+    assert resolved.working_directory == context.exchange_dir.as_posix()
+    assert resolved.environment == {"SCIEASY_CODEBLOCK_TEST": "1"}
+    assert resolved.version == "MATLAB test-version"
+
+
+def test_run_reuses_shared_codeblock_process(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    context = _context(tmp_path, "scripts/run.m", timeout_seconds=5)
+    interpreter = ResolvedInterpreter(
+        family="matlab",
+        executable="/toolchain/matlab",
+        argv=["/toolchain/matlab", "-batch", "run('script.m')"],
+        working_directory=context.exchange_dir.as_posix(),
+        environment={"SCIEASY_CODEBLOCK_TEST": "1"},
+    )
+    calls: dict[str, object] = {}
+
+    def fake_run_codeblock_process(**kwargs: object) -> subprocess.CompletedProcess[str]:
+        calls.update(kwargs)
+        return subprocess.CompletedProcess(interpreter.argv, 0, stdout="ok", stderr="")
+
+    monkeypatch.setattr("scieasy.blocks.code.backends.matlab.run_codeblock_process", fake_run_codeblock_process)
+
+    completed = MatlabCodeBlockBackend().run(context, interpreter)
+
+    assert completed.returncode == 0
+    assert calls == {
+        "argv": interpreter.argv,
+        "cwd": context.exchange_dir,
+        "env_delta": interpreter.environment,
+        "timeout_seconds": 5.0,
+    }
+
+
+@pytest.mark.skipif(shutil.which("octave") is None, reason="Octave is optional for base CodeBlock CI")
+def test_optional_live_octave_execution(tmp_path: Path) -> None:
+    script = _write_script(tmp_path)
+    backend = MatlabCodeBlockBackend()
+    exchange_dir = tmp_path / "exchange"
+    exchange_dir.mkdir()
+    context = CodeBlockRuntimeContext(
+        config=_config("scripts/run.m", timeout_seconds=10),
+        script_path=script,
+        project_dir=tmp_path,
+        exchange_dir=exchange_dir,
+        environment_config={},
+    )
+    interpreter = ResolvedInterpreter(
+        family="octave",
+        executable=shutil.which("octave") or "octave",
+        argv=build_matlab_command(executable=shutil.which("octave") or "octave", family="octave", script_path=script),
+        working_directory=exchange_dir.as_posix(),
+    )
+
+    completed = backend.run(context, interpreter)
+
+    assert completed.returncode == 0


### PR DESCRIPTION
## Summary
- Add the ADR-041 CodeBlock v2 MATLAB-family backend module with `register()` support for `.m` and `.mlx`.
- Prefer MATLAB in auto mode, fall back to Octave for `.m`, and reject `.mlx` without MATLAB using explicit diagnostics.
- Add focused tests for support detection, executable selection, command construction, missing executable diagnostics, shared process handoff, registry registration, and optional live Octave execution skips.

## Related Issues
Closes #1236
Parent umbrella: #1222
Umbrella PR: #1229

## Verification
- `PYTHONPATH=C:\Users\jiazh\Desktop\workspace\SciEasy-adr041-I41m\src python -m pytest tests/blocks/code/test_codeblock_matlab.py --timeout=30 --no-cov` (10 passed, 1 skipped)
- `python -m ruff check src/scieasy/blocks/code/backends/matlab.py tests/blocks/code/test_codeblock_matlab.py`

## Scope Notes
- Target base: `track/adr-041/codeblock-v2`
- No ADR-043-owned files modified.
- No deferred CodeBlock MATLAB/Octave behavior added without a tracking artifact.