### PR TITLE
feat(#1237): add CodeBlock shell runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- [#1237] Add ADR-041 CodeBlock v2 shell runtime support for `.sh` scripts, including deterministic POSIX shell resolution, exchange-directory environment context, missing-shell diagnostics, focused shell backend tests, and Windows no-compatible-shell skips. (@agent, 2026-05-19, branch: feat/issue-1237/adr041-shell-runtime, session: 20260519-194957-adr-041-track-c4-shell-runtime-support)
+
 - [#1242] Add shared CodeBlock v2 interpreter family metadata for notebook, R, Quarto, shell, MATLAB, and Octave runtime backends so ADR-041 sibling tracks can implement complete runtime support without each modifying the shared interpreter type alias. (@agent, 2026-05-19, branch: track/adr-041/codeblock-v2, session: 20260519-194531-adr-041-shared-interpreter-family-litera)
 
 - [#1225] Integrate the ADR-041 CodeBlock v2 shared runtime layer with the Python `.py` backend, including exchange preparation, interpreter execution, typed output collection, provenance payload capture, timeout/nonzero diagnostics, and explicit legacy inline/function migration errors. (@agent, 2026-05-19, branch: feat/issue-1225/adr041-codeblock-python-execution, session: 20260519-185434-adr-041-track-c-codeblock-v2-python-exec)

--- a/docs/planning/adr-041-codeblock-v2-checklist.md
+++ b/docs/planning/adr-041-codeblock-v2-checklist.md
@@ -210,9 +210,9 @@ Scope:
 
 Tasks:
 
-- [ ] Add `.sh` execution through a compatible POSIX shell when available.
-- [ ] Pass exchange-directory context deterministically without adding hidden format semantics.
-- [ ] Add tests for successful output collection, nonzero exit diagnostics, missing shell diagnostics, and Windows compatibility behavior.
+- [x] Add `.sh` execution through a compatible POSIX shell when available. Evidence: commit `1cd50925`; `python -m pytest tests/blocks/code/test_codeblock_shell.py --timeout=30 --no-cov`.
+- [x] Pass exchange-directory context deterministically without adding hidden format semantics. Evidence: commit `1cd50925`; shell backend sets sorted `SCIEASY_CODEBLOCK_*` environment context and delegates file collection to shared exchange helpers.
+- [x] Add tests for successful output collection, nonzero exit diagnostics, missing shell diagnostics, and Windows compatibility behavior. Evidence: `python -m pytest tests/blocks/code/test_codeblock_shell.py --timeout=30 --no-cov` passed with 4 tests and 2 Windows/no-shell skips; `python -m ruff check src/scieasy/blocks/code/backends/shell.py tests/blocks/code/test_codeblock_shell.py` passed.
 
 Exit Criteria:
 
@@ -338,7 +338,7 @@ Exit Criteria:
 - [x] I41c dispatched for #1225. Evidence: worktree `C:\Users\jiazh\Desktop\workspace\SciEasy-adr041-I41c`, branch `feat/issue-1225/adr041-codeblock-python-execution`, gate session `20260519-185434-adr-041-track-c-codeblock-v2-python-exec`, PR #1239; retargeted on 2026-05-19 from Python-only MVP to shared runtime integration plus Python backend.
 - [ ] I41n dispatched for #1235.
 - [ ] I41r dispatched for #1238.
-- [ ] I41s dispatched for #1237.
+- [x] I41s dispatched for #1237. Evidence: worktree `C:\Users\jiazh\Desktop\workspace\SciEasy-adr041-I41s`, branch `feat/issue-1237/adr041-shell-runtime`, gate session `20260519-194957-adr-041-track-c4-shell-runtime-support`.
 - [ ] I41m dispatched for #1236.
 - [ ] I41d dispatched for #1226.
 - [ ] I41e dispatched for #1227.

--- a/docs/planning/adr-041-codeblock-v2-checklist.md
+++ b/docs/planning/adr-041-codeblock-v2-checklist.md
@@ -216,9 +216,9 @@ Tasks:
 
 Exit Criteria:
 
-- [ ] Track C4 PR targets `track/adr-041/codeblock-v2`.
-- [ ] Track C4 CI is green.
-- [ ] Checklist rows updated with PR/test evidence.
+- [x] Track C4 PR targets `track/adr-041/codeblock-v2`. Evidence: [PR #1248](https://github.com/zjzcpj/SciEasy/pull/1248).
+- [x] Track C4 CI is green. Evidence: PR #1248 checks passed on 2026-05-19/2026-05-20 UTC.
+- [x] Checklist rows updated with PR/test evidence. Evidence: PR #1248, commit `1cd50925`, focused pytest/Ruff commands, and CI evidence recorded above.
 
 ### Track C5 - MATLAB and Octave Runtime Support (Owner: I41m / #1236)
 

--- a/src/scieasy/blocks/code/backends/shell.py
+++ b/src/scieasy/blocks/code/backends/shell.py
@@ -1,0 +1,188 @@
+"""POSIX shell backend for CodeBlock v2."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from scieasy.blocks.code.code_block import (
+    CodeBlockRuntimeContext,
+    register_codeblock_backend,
+    run_codeblock_process,
+)
+from scieasy.blocks.code.config import CodeBlockConfig, InterpreterMode
+from scieasy.blocks.code.interpreters import InterpreterResolutionError, ResolvedInterpreter
+
+_SHELL_CANDIDATES = ("sh", "bash", "dash", "zsh")
+
+
+class ShellCodeBlockBackend:
+    """Shell `.sh` backend for the ADR-041 shared runtime."""
+
+    name = "shell"
+    extensions = frozenset({".sh"})
+
+    def supports(self, script_path: Path, config: CodeBlockConfig) -> bool:
+        return script_path.suffix.lower() in self.extensions
+
+    def resolve(self, context: CodeBlockRuntimeContext) -> ResolvedInterpreter:
+        executable = _resolve_shell_executable(
+            mode=context.config.interpreter_mode,
+            interpreter_path=context.config.interpreter_path,
+            environment_config=context.environment_config,
+        )
+        version, warnings = _probe_shell_version(executable)
+
+        return ResolvedInterpreter(
+            family="shell",
+            executable=executable,
+            argv=[executable, str(context.script_path)],
+            working_directory=context.exchange_dir.as_posix(),
+            environment=_environment_delta(context),
+            version=version,
+            warnings=warnings,
+        )
+
+    def run(
+        self,
+        context: CodeBlockRuntimeContext,
+        interpreter: ResolvedInterpreter,
+    ) -> subprocess.CompletedProcess[str]:
+        return run_codeblock_process(
+            argv=interpreter.argv,
+            cwd=context.exchange_dir,
+            env_delta=interpreter.environment,
+            timeout_seconds=context.config.timeout_seconds,
+        )
+
+
+def _resolve_shell_executable(
+    *,
+    mode: InterpreterMode,
+    interpreter_path: str | None,
+    environment_config: Mapping[str, Any],
+) -> str:
+    configured = interpreter_path or environment_config.get("interpreter_path") or environment_config.get("shell")
+    if mode == "existing":
+        if configured is None:
+            raise InterpreterResolutionError("interpreter_mode='existing' requires a POSIX shell executable path")
+        return _resolve_executable(str(configured), require_compatible=True)
+    if mode != "auto":
+        raise InterpreterResolutionError(f"Unsupported interpreter mode: {mode}")
+
+    if configured is not None:
+        return _resolve_executable(str(configured), require_compatible=True)
+
+    for candidate in _SHELL_CANDIDATES:
+        discovered = shutil.which(candidate)
+        if discovered is None:
+            continue
+        resolved = str(Path(discovered).resolve())
+        if _is_compatible_shell(resolved):
+            return resolved
+    raise InterpreterResolutionError(
+        "POSIX shell executable not found on PATH; install sh/bash/dash/zsh or set interpreter_path."
+    )
+
+
+def _resolve_executable(raw_executable: str, *, require_compatible: bool) -> str:
+    raw_executable = raw_executable.strip()
+    if not raw_executable:
+        raise InterpreterResolutionError("POSIX shell executable path must not be empty")
+
+    candidate = Path(raw_executable)
+    has_path_component = candidate.is_absolute() or any(part in raw_executable for part in ("/", "\\"))
+    if has_path_component:
+        resolved = candidate.expanduser().resolve()
+        if not resolved.exists() or not resolved.is_file():
+            raise InterpreterResolutionError(f"POSIX shell executable not found: {raw_executable}")
+        executable = str(resolved)
+        if require_compatible and not _is_compatible_shell(executable):
+            raise InterpreterResolutionError(f"POSIX shell executable is not usable: {raw_executable}")
+        return executable
+
+    discovered = shutil.which(raw_executable)
+    if discovered is None:
+        raise InterpreterResolutionError(f"POSIX shell executable not found on PATH: {raw_executable}")
+    executable = str(Path(discovered).resolve())
+    if require_compatible and not _is_compatible_shell(executable):
+        raise InterpreterResolutionError(f"POSIX shell executable is not usable: {raw_executable}")
+    return executable
+
+
+def _is_compatible_shell(executable: str) -> bool:
+    if _is_windows_system_bash(executable):
+        return False
+    try:
+        completed = subprocess.run(
+            [executable, "-c", "exit 0"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    return completed.returncode == 0
+
+
+def _is_windows_system_bash(executable: str) -> bool:
+    if os.name != "nt":
+        return False
+    path = Path(executable)
+    return path.name.lower() == "bash.exe" and path.parent.name.lower() == "system32"
+
+
+def _environment_delta(context: CodeBlockRuntimeContext) -> dict[str, str]:
+    env_delta = _configured_environment(context.environment_config)
+    exchange_dir = context.exchange_dir.resolve()
+    env_delta.update(
+        {
+            "SCIEASY_CODEBLOCK_EXCHANGE_DIR": str(exchange_dir),
+            "SCIEASY_CODEBLOCK_INPUTS_DIR": str((exchange_dir / "inputs").resolve()),
+            "SCIEASY_CODEBLOCK_OUTPUTS_DIR": str((exchange_dir / "outputs").resolve()),
+            "SCIEASY_CODEBLOCK_PROJECT_DIR": str(context.project_dir.resolve()),
+            "SCIEASY_CODEBLOCK_SCRIPT_PATH": str(context.script_path.resolve()),
+        }
+    )
+    return dict(sorted(env_delta.items()))
+
+
+def _configured_environment(environment_config: Mapping[str, Any]) -> dict[str, str]:
+    raw_delta = (
+        environment_config.get("environment_variables")
+        or environment_config.get("env")
+        or environment_config.get("environment")
+        or {}
+    )
+    if not isinstance(raw_delta, Mapping):
+        raise InterpreterResolutionError("environment variables must be a mapping")
+    return {str(key): str(value) for key, value in raw_delta.items()}
+
+
+def _probe_shell_version(executable: str) -> tuple[str | None, list[str]]:
+    try:
+        completed = subprocess.run(
+            [executable, "--version"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return None, [f"Could not capture shell version: {exc}"]
+
+    output = (completed.stdout or completed.stderr).strip()
+    if completed.returncode != 0:
+        return None, [f"Shell version command exited with {completed.returncode}"]
+    return output or None, []
+
+
+def register() -> None:
+    """Register the shell backend with the shared CodeBlock runtime."""
+
+    register_codeblock_backend(ShellCodeBlockBackend(), replace=True)

--- a/tests/blocks/code/test_codeblock_shell.py
+++ b/tests/blocks/code/test_codeblock_shell.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import os
+import shutil
+from pathlib import Path
+
+import pytest
+
+from scieasy.blocks.code.backends import shell
+from scieasy.blocks.code.backends.shell import ShellCodeBlockBackend
+from scieasy.blocks.code.code_block import CodeBlock, CodeBlockExecutionError, CodeBlockRuntimeContext
+from scieasy.blocks.code.config import CodeBlockConfig
+from scieasy.blocks.code.interpreters import InterpreterResolutionError
+from scieasy.core.types.base import DataObject
+from scieasy.core.types.collection import Collection
+from scieasy.core.types.text import Text
+
+
+def _live_shell() -> str | None:
+    for candidate in ("sh", "bash", "dash", "zsh"):
+        discovered = shutil.which(candidate)
+        if discovered is not None and shell._is_compatible_shell(discovered):
+            return discovered
+    return None
+
+
+def _write_script(project_dir: Path, body: str, *, name: str = "script.sh") -> Path:
+    scripts = project_dir / "scripts"
+    scripts.mkdir()
+    script = scripts / name
+    script.write_text(body, encoding="utf-8", newline="\n")
+    return script
+
+
+def _text_materialise(
+    obj: DataObject,
+    dest_dir: Path,
+    extension: str,
+    *,
+    filename_stem: str,
+    capability_id: str | None = None,
+) -> Path:
+    assert isinstance(obj, Text)
+    path = dest_dir / f"{filename_stem}{extension}"
+    path.write_text(obj.content or "", encoding=obj.encoding)
+    return path
+
+
+def _text_reconstruct(
+    path: Path,
+    target_type: type[DataObject],
+    extension: str,
+    *,
+    capability_id: str | None = None,
+) -> DataObject:
+    assert target_type is Text
+    assert extension == ".txt"
+    return Text(content=path.read_text(encoding="utf-8"))
+
+
+def _block_config(project_dir: Path, script_path: str, **params: object) -> dict[str, object]:
+    base: dict[str, object] = {
+        "project_dir": str(project_dir),
+        "script_path": script_path,
+        "interpreter_path": _live_shell(),
+        "interpreter_mode": "existing",
+        "exchange_root": "exchange",
+        "block_id": "shell-block",
+        "run_id": "run-1",
+        "materialise_adapter": _text_materialise,
+        "reconstruct_adapter": _text_reconstruct,
+    }
+    base.update(params)
+    return {"params": base}
+
+
+def _runtime_context(tmp_path: Path, config: CodeBlockConfig | None = None) -> CodeBlockRuntimeContext:
+    script = tmp_path / "scripts" / "script.sh"
+    script.parent.mkdir()
+    script.write_text("echo ok\n", encoding="utf-8")
+    exchange_dir = tmp_path / "exchange" / "codeblock-shell" / "run-1"
+    (exchange_dir / "inputs").mkdir(parents=True)
+    (exchange_dir / "outputs").mkdir()
+    return CodeBlockRuntimeContext(
+        config=config or CodeBlockConfig(script_path="scripts/script.sh"),
+        script_path=script,
+        project_dir=tmp_path,
+        exchange_dir=exchange_dir,
+        environment_config={"environment_variables": {"SHELL_BACKEND_TEST": "1"}},
+    )
+
+
+def test_shell_backend_supports_sh_scripts_only(tmp_path: Path) -> None:
+    backend = ShellCodeBlockBackend()
+    config = CodeBlockConfig(script_path="scripts/script.sh")
+
+    assert backend.supports(tmp_path / "script.sh", config) is True
+    assert backend.supports(tmp_path / "script.py", config) is False
+
+
+def test_shell_backend_constructs_deterministic_command_and_exchange_environment(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(shell.shutil, "which", lambda name: f"/toolchain/{name}" if name == "sh" else None)
+    monkeypatch.setattr(shell, "_is_compatible_shell", lambda executable: True)
+    backend = ShellCodeBlockBackend()
+    context = _runtime_context(tmp_path)
+
+    resolved = backend.resolve(context)
+
+    assert resolved.family == "shell"
+    assert resolved.executable == str(Path("/toolchain/sh").resolve())
+    assert resolved.argv == [resolved.executable, str(context.script_path)]
+    assert resolved.working_directory == context.exchange_dir.as_posix()
+    assert list(resolved.environment) == sorted(resolved.environment)
+    assert resolved.environment["SHELL_BACKEND_TEST"] == "1"
+    assert resolved.environment["SCIEASY_CODEBLOCK_EXCHANGE_DIR"] == str(context.exchange_dir.resolve())
+    assert resolved.environment["SCIEASY_CODEBLOCK_INPUTS_DIR"] == str((context.exchange_dir / "inputs").resolve())
+    assert resolved.environment["SCIEASY_CODEBLOCK_OUTPUTS_DIR"] == str((context.exchange_dir / "outputs").resolve())
+    assert resolved.environment["SCIEASY_CODEBLOCK_PROJECT_DIR"] == str(tmp_path.resolve())
+    assert resolved.environment["SCIEASY_CODEBLOCK_SCRIPT_PATH"] == str(context.script_path.resolve())
+
+
+def test_missing_shell_diagnostic_is_clear(tmp_path: Path) -> None:
+    missing_shell = tmp_path / "missing-sh"
+    config = CodeBlockConfig(
+        script_path="scripts/script.sh",
+        interpreter_mode="existing",
+        interpreter_path=str(missing_shell),
+    )
+    backend = ShellCodeBlockBackend()
+
+    with pytest.raises(InterpreterResolutionError, match="POSIX shell executable not found"):
+        backend.resolve(_runtime_context(tmp_path, config))
+
+
+@pytest.mark.skipif(_live_shell() is None, reason="POSIX shell is not available for live shell execution")
+def test_codeblock_runs_shell_script_through_exchange(tmp_path: Path) -> None:
+    _write_script(
+        tmp_path,
+        """
+set -eu
+mkdir -p outputs/summary
+input_file=$(ls inputs/prompt/*.txt | sort | sed -n '1p')
+cat "$input_file" > outputs/summary/result.txt
+""".strip()
+        + "\n",
+    )
+    block = CodeBlock(
+        config=_block_config(
+            tmp_path,
+            "scripts/script.sh",
+            inputs=[{"name": "prompt", "direction": "input", "data_type": "Text", "extension": ".txt"}],
+            outputs=[{"name": "summary", "direction": "output", "data_type": "Text", "extension": ".txt"}],
+        )
+    )
+
+    outputs = block.run({"prompt": Collection([Text(content="hello from shell")])}, block.config)
+
+    assert outputs["summary"][0].content == "hello from shell"
+    assert block.last_process is not None
+    assert block.last_process.returncode == 0
+    assert block.last_provenance_payload is not None
+    assert block.last_provenance_payload["interpreter"]["family"] == "shell"
+    assert "SCIEASY_CODEBLOCK_EXCHANGE_DIR" in block.last_provenance_payload["environment"]["environment_delta"]
+
+
+@pytest.mark.skipif(_live_shell() is None, reason="POSIX shell is not available for live shell execution")
+def test_codeblock_shell_nonzero_exit_preserves_diagnostics(tmp_path: Path) -> None:
+    _write_script(
+        tmp_path,
+        """
+echo "before shell failure"
+echo "shell boom" >&2
+exit 7
+""".strip()
+        + "\n",
+    )
+    block = CodeBlock(
+        config=_block_config(
+            tmp_path,
+            "scripts/script.sh",
+            outputs=[{"name": "summary", "direction": "output", "data_type": "Text", "extension": ".txt"}],
+        )
+    )
+
+    with pytest.raises(CodeBlockExecutionError) as exc_info:
+        block.run({}, block.config)
+
+    assert exc_info.value.returncode == 7
+    assert "before shell failure" in exc_info.value.stdout
+    assert "shell boom" in exc_info.value.stderr
+
+
+@pytest.mark.skipif(
+    os.name != "nt" or _live_shell() is not None,
+    reason="Documents the Windows path where no POSIX shell is installed.",
+)
+def test_windows_without_posix_shell_uses_missing_shell_diagnostic(tmp_path: Path) -> None:
+    config = CodeBlockConfig(script_path="scripts/script.sh")
+    backend = ShellCodeBlockBackend()
+
+    with pytest.raises(InterpreterResolutionError, match="POSIX shell executable not found on PATH"):
+        backend.resolve(_runtime_context(tmp_path, config))


### PR DESCRIPTION
## Summary
- Add the ADR-041 CodeBlock v2 `.sh` backend via the existing backend registration hook.
- Resolve a compatible POSIX shell deterministically, with explicit diagnostics for missing or unusable shells.
- Pass exchange-directory context through sorted `SCIEASY_CODEBLOCK_*` environment variables without adding format-specific semantics.
- Add focused shell backend tests and update the ADR-041 checklist/changelog.

## Verification
- `python -m pytest tests/blocks/code/test_codeblock_shell.py --timeout=30 --no-cov` (4 passed, 2 skipped on Windows because no compatible POSIX shell is available)
- `python -m ruff check src/scieasy/blocks/code/backends/shell.py tests/blocks/code/test_codeblock_shell.py`

## Related Issues
Closes #1237
Parent umbrella: #1222 / #1229