### PR TITLE
feat(#1262): configure Sentrux architecture rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@ htmlcov/
 .ruff_cache/
 .import_linter_cache/
 
+# Local architecture sensor binary
+sentrux.exe
+
 # Generated QA facts (regenerate locally with scripts/audit/generate_facts.py)
 docs/facts/generated.yaml
 

--- a/.sentrux/rules.toml
+++ b/.sentrux/rules.toml
@@ -1,0 +1,81 @@
+[constraints]
+# Lock the current baseline first, then ratchet down toward zero cycles.
+# Baseline observed by sentrux on 2026-05-20: cycles = 5.
+max_cycles = 5
+# Baseline observed by sentrux on 2026-05-20: highest function CC = 75.
+max_cc = 75
+no_god_files = false
+
+[[layers]]
+name = "frontend"
+paths = ["frontend/src/*"]
+order = 0
+
+[[layers]]
+name = "interfaces"
+paths = [
+  "src/scieasy/api/*",
+  "src/scieasy/cli/*",
+  "src/scieasy/ai/*",
+  "src/scieasy/agent_provisioning/*",
+]
+order = 1
+
+[[layers]]
+name = "extensions"
+paths = ["packages/*"]
+order = 2
+
+[[layers]]
+name = "runtime"
+paths = [
+  "src/scieasy/workflow/*",
+  "src/scieasy/engine/*",
+  "src/scieasy/blocks/*",
+]
+order = 3
+
+[[layers]]
+name = "core"
+paths = ["src/scieasy/core/*"]
+order = 4
+
+[[boundaries]]
+from = "src/scieasy/core/*"
+to = "src/scieasy/api/*"
+reason = "Core contracts must not depend on API or UI entrypoints."
+
+[[boundaries]]
+from = "src/scieasy/core/*"
+to = "src/scieasy/cli/*"
+reason = "Core contracts must not depend on CLI orchestration."
+
+[[boundaries]]
+from = "src/scieasy/core/*"
+to = "src/scieasy/ai/*"
+reason = "AI orchestration must not leak into core contracts."
+
+[[boundaries]]
+from = "src/scieasy/core/*"
+to = "src/scieasy/blocks/*"
+reason = "Core should define primitive contracts, not depend on block implementations."
+
+[[boundaries]]
+from = "src/scieasy/engine/*"
+to = "src/scieasy/api/*"
+reason = "Runtime execution must not depend on API presentation."
+
+[[boundaries]]
+from = "src/scieasy/engine/*"
+to = "src/scieasy/cli/*"
+reason = "Runtime execution must not depend on CLI entrypoints."
+
+[[boundaries]]
+from = "packages/*"
+to = "src/scieasy/api/*"
+reason = "Plugin packages should depend on runtime and block contracts, not API internals."
+
+[[boundaries]]
+from = "packages/*"
+to = "src/scieasy/cli/*"
+reason = "Plugin packages should not depend on CLI internals."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- [#1262] Add conservative Sentrux architecture rules, document the layer/boundary model, and ignore the local `sentrux.exe` binary. (@agent, 2026-05-20, branch: feat/issue-1262/sentrux-rules, session: 20260519-212320-configure-sentrux-architecture-rules)
+
 - [#1253] Stop tracking generated ADR-042 facts by ignoring `docs/facts/generated.yaml` and removing the generated snapshot from the repository index to avoid repeated merge conflicts. (@agent, 2026-05-19, branch: chore/issue-1253/ignore-generated-facts-yaml, session: 20260519-202639-ignore-generated-facts-yaml)
 
 - [#1213] Add ADR-043 explicit pilot `FormatCapability` declarations for shipped imaging TIFF/Zarr IO and LCMS table/raw IO, with package tests, README capability IDs, metadata fidelity notes, and #1204 full-migration deferral markers. (@agent, 2026-05-19, branch: feat/issue-1213/adr043-package-pilot, session: 20260519-175914-adr-043-package-capability-pilot)

--- a/docs/architecture/sentrux-rules.md
+++ b/docs/architecture/sentrux-rules.md
@@ -1,0 +1,51 @@
+# Sentrux Architecture Rules
+
+SciEasy uses Sentrux as a lightweight architecture sensor for dependency
+health, layering, and boundary checks. The executable rule file lives at
+`.sentrux/rules.toml`.
+
+## Rule Intent
+
+The initial ruleset is deliberately conservative. It protects the project
+boundaries that matter most while avoiding a sudden failure on known baseline
+debt:
+
+- `core` owns primitive data, storage, metadata, lineage, and versioning
+  contracts.
+- `runtime` owns workflow definitions, execution, and block contracts.
+- `extensions` owns plugin packages outside the core package.
+- `interfaces` owns API, CLI, AI orchestration, and provisioning entrypoints.
+- `frontend` owns the React user interface.
+
+Imports should flow from outer entrypoints toward the stable core. The
+executable `order` values in `.sentrux/rules.toml` therefore place outer
+surfaces first and the core last, matching the direction enforced by the
+current Sentrux MCP check on this repository. The explicit boundary rules
+reinforce this by preventing core and engine code from importing API, CLI, AI,
+or block implementation surfaces where that would collapse ownership
+boundaries.
+
+## Baseline Constraints
+
+The current baseline keeps `max_cycles = 5` and `max_cc = 75`, matching the
+observed Sentrux scan before introducing the ruleset. This makes the rule file
+useful immediately: new changes should not worsen the cycle count or exceed
+the current complexity ceiling, while future work can ratchet both numbers
+downward.
+
+`no_god_files` is initially disabled because several existing registry,
+scheduler, and API runtime modules are large historical files. Turn it on only
+after those files are split under issue-tracked refactors.
+
+## Tightening Path
+
+Future architecture cleanup should tighten these constraints in small,
+traceable steps:
+
+1. Reduce `max_cycles` toward `0`.
+2. Reduce `max_cc` below the current baseline as complex functions are split.
+3. Enable `no_god_files = true` after large historical modules are split.
+4. Add more package-specific boundaries once plugin ownership settles.
+
+Each tightening step should go through the normal issue, change plan, branch,
+test, documentation, changelog, and PR workflow.


### PR DESCRIPTION
Closes #1262

## Summary
- Add .sentrux/rules.toml with conservative architecture constraints, layers, and boundaries.
- Ignore the local sentrux.exe binary/tool artifact.
- Document the rule intent, baseline thresholds, and tightening path.

## Verification
- Sentrux MCP scan on new worktree: quality_signal = 4161.
- Sentrux MCP check_rules: pass, 0 violations.
- git check-ignore -v sentrux.exe confirms the binary is ignored.

## Risks
- Rules intentionally use baseline thresholds (max_cycles = 5, max_cc = 75) to avoid blocking existing debt while preventing worse drift.