### PR TITLE
docs(#1264): add ADR-042 gate record addendum

### DIFF
--- a/docs/adr/ADR-042-addendum1.md
+++ b/docs/adr/ADR-042-addendum1.md
@@ -23,8 +23,10 @@ governs:
     - scieasy.qa.governance.core_change_guard
     - scieasy.qa.governance.pr_merge_guard
     - scieasy.qa.schemas.frontmatter
+    - scieasy.qa.audit.architecture_drift
   contracts:
     - scieasy.qa.schemas.frontmatter.ArchitectureFrontmatter
+    - scieasy.qa.audit.architecture_drift.check
     - scieasy.qa.governance.gate_record.GateRecord
     - scieasy.qa.governance.gate_record.CheckEvidence
     - scieasy.qa.governance.gate_record.SentruxEvidence
@@ -61,6 +63,7 @@ tests:
   - tests/qa/test_core_change_guard.py
   - tests/qa/test_pr_merge_guard.py
   - tests/qa/test_audit_frontmatter_lint.py
+  - tests/qa/test_architecture_drift.py
 agent_editable: false
 assisted_by:
   - "Codex:gpt-5"
@@ -93,6 +96,7 @@ governance:
 | D9. Conflict-prone generated artifacts | Ignore generated gate/audit artifacts and explicitly migrate any tracked workflow files before treating them as ignored | `.gitignore`, review, and gate implementation docs | Section 3 |
 | D10. AI gate CLI | Require agents to use the repository-owned gate-record CLI for each gate stage | Agent workflow, local hooks, and CI consume the same committed record | Section 3 |
 | D11. Architecture frontmatter audit | Include `docs/architecture/ARCHITECTURE.md` in ADR-042 frontmatter audit coverage | Full audit and frontmatter lint fail invalid architecture metadata | Section 5 |
+| D12. Architecture truthfulness audit | Validate architecture-document code blocks and referenced function/class names against repository facts | Full audit fails architecture drift unless an example is explicitly non-normative | Section 5 |
 
 This addendum supersedes ADR-042 Section 7.2 only where that section defines
 gate state as local-only state under `.git/scieasy/gates/`. Local gate state may
@@ -116,6 +120,7 @@ still exist as a pre-commit helper, but it is not sufficient for delivery.
 | Generated workflow artifacts cause noisy merge conflicts | Agents repeatedly resolve conflicts in files that should be local evidence, not canonical text | Ignore generated gate/audit artifacts and explicitly migrate any tracked canonical workflow files | Section 3 |
 | Agents need a concrete command surface | Agents otherwise treat the workflow as prose and skip durable state updates | Define a mandatory `gate_record` CLI for AI use | Section 3 |
 | Architecture metadata can drift outside audit coverage | The top-level architecture document can become stale or ownerless despite having frontmatter | Validate architecture frontmatter in `frontmatter_lint` | Section 5 |
+| Architecture prose can lie about implementation | Function signatures, class names, module paths, or code examples can drift from the repo while frontmatter still passes | Add architecture drift checks for code blocks and symbol references | Section 5 |
 
 ## 2. Sentrux Free-Tier Integration
 
@@ -445,6 +450,8 @@ Pre-commit should block AI-authored commits when:
 - governance files are touched without `governance_touch=true`;
 - required checks, including applicable Sentrux evidence, are missing;
 - QA full audit evidence is missing when the tool is available;
+- architecture drift evidence is missing or failing when `docs/architecture/ARCHITECTURE.md`
+  is changed;
 - Sentrux free-tier checks fail for applicable changes.
 
 Commit-message hooks should require machine-readable trailers:
@@ -467,6 +474,9 @@ fails when:
   or modifying test files;
 - required docs, tests, changelog, or N/A rationales are missing;
 - QA full audit evidence is missing;
+- architecture drift checks find stale code blocks, stale function or class
+  names, stale module paths, or stale signatures in
+  `docs/architecture/ARCHITECTURE.md`;
 - Sentrux is applicable but missing or failing;
 - the record claims Pro-only Sentrux evidence;
 - governance or Sentrux rules are weakened without owner-approved scope.
@@ -488,6 +498,23 @@ repository findings without immediately blocking every PR. The gate record must
 still include the full-audit result, output path, and classification of any
 known debt. After the owner accepts the baseline or cleanup queue, missing full
 audit evidence or unclassified full-audit failures become CI-blocking.
+
+Architecture truthfulness checks are part of QA full audit. The audit must treat
+the architecture document as normative by default:
+
+- fenced code blocks that declare Python, shell, TOML, YAML, JSON, or no language
+  must be parsed when possible and checked against repository facts;
+- referenced Python module paths, class names, function names, and method names
+  in prose or backticks must resolve against generated code facts when they look
+  like repository symbols;
+- function or method signatures shown in the architecture document must match
+  the actual implementation signature;
+- examples that are intentionally illustrative or not tied to current code must
+  be explicitly marked non-normative in prose or fence metadata.
+
+Unmarked stale architecture references are drift findings. This rule is stricter
+than spec signature contracts because `docs/architecture/ARCHITECTURE.md` is the
+project-wide architecture source of truth.
 
 ## 6. Scope, Non-Goals, And Consequences
 

--- a/docs/adr/ADR-042-addendum1.md
+++ b/docs/adr/ADR-042-addendum1.md
@@ -22,7 +22,9 @@ governs:
     - scieasy.qa.governance.human_bypass_guard
     - scieasy.qa.governance.core_change_guard
     - scieasy.qa.governance.pr_merge_guard
+    - scieasy.qa.schemas.frontmatter
   contracts:
+    - scieasy.qa.schemas.frontmatter.ArchitectureFrontmatter
     - scieasy.qa.governance.gate_record.GateRecord
     - scieasy.qa.governance.gate_record.CheckEvidence
     - scieasy.qa.governance.gate_record.SentruxEvidence
@@ -40,6 +42,7 @@ governs:
     - docs/adr/ADR-042-addendum1.md
     - docs/specs/adr-042-gate-record-sentrux-workflow.md
     - docs/contributing/workflows/human-bypass.md
+    - docs/architecture/ARCHITECTURE.md
     - .workflow/**
     - .sentrux/rules.toml
     - .github/workflows/**
@@ -57,6 +60,7 @@ tests:
   - tests/qa/test_human_bypass_guard.py
   - tests/qa/test_core_change_guard.py
   - tests/qa/test_pr_merge_guard.py
+  - tests/qa/test_audit_frontmatter_lint.py
 agent_editable: false
 assisted_by:
   - "Codex:gpt-5"
@@ -88,6 +92,7 @@ governance:
 | D8. Legacy gate removal | Delete `.workflow/gate.py` and replace the old `.workflow/active` CI lookup with committed gate-record validation | Workflow-gate CI has one normative gate authority | Section 3 |
 | D9. Conflict-prone generated artifacts | Ignore generated gate/audit artifacts and explicitly migrate any tracked workflow files before treating them as ignored | `.gitignore`, review, and gate implementation docs | Section 3 |
 | D10. AI gate CLI | Require agents to use the repository-owned gate-record CLI for each gate stage | Agent workflow, local hooks, and CI consume the same committed record | Section 3 |
+| D11. Architecture frontmatter audit | Include `docs/architecture/ARCHITECTURE.md` in ADR-042 frontmatter audit coverage | Full audit and frontmatter lint fail invalid architecture metadata | Section 5 |
 
 This addendum supersedes ADR-042 Section 7.2 only where that section defines
 gate state as local-only state under `.git/scieasy/gates/`. Local gate state may
@@ -110,6 +115,7 @@ still exist as a pre-commit helper, but it is not sufficient for delivery.
 | The legacy CI gate can remain as a parallel source of truth | A PR can pass or fail against obsolete `.workflow/gate.py` or `.workflow/active` state instead of the committed record | Delete `.workflow/gate.py` and replace the legacy workflow-gate state lookup with gate-record validation | Section 3 |
 | Generated workflow artifacts cause noisy merge conflicts | Agents repeatedly resolve conflicts in files that should be local evidence, not canonical text | Ignore generated gate/audit artifacts and explicitly migrate any tracked canonical workflow files | Section 3 |
 | Agents need a concrete command surface | Agents otherwise treat the workflow as prose and skip durable state updates | Define a mandatory `gate_record` CLI for AI use | Section 3 |
+| Architecture metadata can drift outside audit coverage | The top-level architecture document can become stale or ownerless despite having frontmatter | Validate architecture frontmatter in `frontmatter_lint` | Section 5 |
 
 ## 2. Sentrux Free-Tier Integration
 

--- a/docs/adr/ADR-042-addendum1.md
+++ b/docs/adr/ADR-042-addendum1.md
@@ -85,8 +85,9 @@ governance:
 | D5. Free-tier honesty rule | Forbid claiming Sentrux Pro-only diagnostics or unchecked rules as completed gate evidence | Local hooks, CI, and review | Section 2 |
 | D6. Override-label consistency | Reuse ADR-042's administrator labels for human bypass, AI override, protected core changes, and merge automation | CI validates label provenance through ADR-042 guards | Section 5 |
 | D7. Implementation tests required | Require implementation-category tasks to add or modify tests as part of the PR | Local hooks and CI reject implementation work without test changes | Section 3 |
-| D8. Legacy CI gate replacement | Replace the old `.workflow/active` CI lookup with committed gate-record validation | Workflow-gate CI has one normative gate authority | Section 3 |
+| D8. Legacy gate removal | Delete `.workflow/gate.py` and replace the old `.workflow/active` CI lookup with committed gate-record validation | Workflow-gate CI has one normative gate authority | Section 3 |
 | D9. Conflict-prone generated artifacts | Ignore generated gate/audit artifacts and explicitly migrate any tracked workflow files before treating them as ignored | `.gitignore`, review, and gate implementation docs | Section 3 |
+| D10. AI gate CLI | Require agents to use the repository-owned gate-record CLI for each gate stage | Agent workflow, local hooks, and CI consume the same committed record | Section 3 |
 
 This addendum supersedes ADR-042 Section 7.2 only where that section defines
 gate state as local-only state under `.git/scieasy/gates/`. Local gate state may
@@ -106,8 +107,9 @@ still exist as a pre-commit helper, but it is not sufficient for delivery.
 | QA full audit evidence is not yet part of the gate | ADR-042 consistency tools can be skipped even when available | Require full-audit evidence, with temporary technical-debt handling before hard fail | Section 5 |
 | Override labels can drift between docs and implementation | Human bypass or admin approval checks can disagree about valid labels | Reuse one fixed label set from ADR-042 and validate it in CI | Section 5 |
 | Implementation tasks can claim tests were run without adding tests | Bug fixes and features can land without regression or behavior coverage | Require changed test files for implementation-category tasks | Section 3 |
-| The legacy CI gate can remain as a parallel source of truth | A PR can pass or fail against obsolete `.workflow/active` state instead of the committed record | Replace the legacy workflow-gate state lookup with gate-record validation | Section 3 |
+| The legacy CI gate can remain as a parallel source of truth | A PR can pass or fail against obsolete `.workflow/gate.py` or `.workflow/active` state instead of the committed record | Delete `.workflow/gate.py` and replace the legacy workflow-gate state lookup with gate-record validation | Section 3 |
 | Generated workflow artifacts cause noisy merge conflicts | Agents repeatedly resolve conflicts in files that should be local evidence, not canonical text | Ignore generated gate/audit artifacts and explicitly migrate any tracked canonical workflow files | Section 3 |
+| Agents need a concrete command surface | Agents otherwise treat the workflow as prose and skip durable state updates | Define a mandatory `gate_record` CLI for AI use | Section 3 |
 
 ## 2. Sentrux Free-Tier Integration
 
@@ -147,12 +149,12 @@ The canonical gate has six stages:
 | 5. Test And Checks | Required checks after docs landing, QA full audit evidence, command or tool id, exit code/status, timestamp, output path or compact result | Missing or failing required checks fail local hooks and CI, subject to temporary debt handling for known full-audit findings |
 | 6. Commit And Submit PR | Commit trailers, gate record path, closing issue link, PR URL or CI-discoverable PR association | Missing durable provenance or missing issue-closing keywords fails commit-msg hooks or CI |
 
-Existing `.workflow/gate.py` records may remain as a legacy helper during
-migration, but they are not the normative ADR-042 gate unless they produce the
-committed gate record described here and pass CI validation. The existing
-workflow-gate CI step that searches `.workflow/active` for local state must be
-replaced by committed gate-record validation; CI must not keep both checks as
-parallel authorities.
+Existing `.workflow/gate.py` records and commands are obsolete for ADR-042 gate
+compliance, and `.workflow/gate.py` must be deleted from the repository. Agents
+must not use `.workflow/gate.py` as the gate entry point, local evidence source,
+or CI evidence source. The existing workflow-gate CI step that searches
+`.workflow/active` for local state must be replaced by committed gate-record
+validation; CI must not keep both checks as parallel authorities.
 
 Generated gate and audit outputs that are not canonical repository
 documentation should be ignored to avoid recurring branch conflicts. If the
@@ -161,7 +163,72 @@ project decides that an already tracked canonical workflow file such as
 remove it from the Git index and update gate semantics; adding a tracked file
 to `.gitignore` alone is not sufficient.
 
-### 3.1 Required Agent Procedure
+### 3.1 Required AI Gate CLI
+
+AI agents must use the repository-owned gate-record CLI to create and update
+the committed gate record. The command surface is:
+
+```bash
+python -m scieasy.qa.governance.gate_record start \
+  --task-kind feature|bugfix|hotfix|refactor|docs|maintenance|manager \
+  --issue <number> \
+  --branch <branch> \
+  --owner-directive "<owner instruction>" \
+  --include <path-or-glob> \
+  --exclude <path-or-glob> \
+  --record .workflow/records/<issue>-<task-slug>.json
+
+python -m scieasy.qa.governance.gate_record plan \
+  --record .workflow/records/<issue>-<task-slug>.json \
+  --files <path-or-glob> \
+  --docs <path-or-na> \
+  --tests <path-or-na> \
+  --checks ruff,format,pytest,full_audit,sentrux
+
+python -m scieasy.qa.governance.gate_record amend \
+  --record .workflow/records/<issue>-<task-slug>.json \
+  --reason "<why scope changed>" \
+  --include <path-or-glob>
+
+python -m scieasy.qa.governance.gate_record docs \
+  --record .workflow/records/<issue>-<task-slug>.json \
+  --updated <path> \
+  --na <doc-class>:<reason>
+
+python -m scieasy.qa.governance.gate_record check \
+  --record .workflow/records/<issue>-<task-slug>.json \
+  --name <check-name> \
+  --command "<command or MCP tool id>" \
+  --status pass|fail|skipped \
+  --exit-code <code> \
+  --output <path-or-summary>
+
+python -m scieasy.qa.governance.gate_record sentrux \
+  --record .workflow/records/<issue>-<task-slug>.json \
+  --mode free-tier \
+  --status pass|fail|skipped \
+  --evidence <json-path-or-summary>
+
+python -m scieasy.qa.governance.gate_record finalize \
+  --record .workflow/records/<issue>-<task-slug>.json \
+  --commit <sha> \
+  --pr <url> \
+  --closes "#<issue>"
+
+python -m scieasy.qa.governance.gate_record pre-commit --staged
+python -m scieasy.qa.governance.gate_record commit-msg <commit-msg-file>
+python -m scieasy.qa.governance.gate_record ci \
+  --gate-record .workflow/records/<issue>-<task-slug>.json \
+  --base <base-ref> \
+  --head <head-ref> \
+  --pr-body <path-or-text>
+```
+
+The CLI may expose additional convenience aliases, but the commands above are
+the normative AI-facing interface. They must update the committed gate record or
+validate it; self-attestation in chat is not gate evidence.
+
+### 3.2 Required Agent Procedure
 
 Agents must execute the gate as an explicit sequence. Each step updates the
 committed gate record before moving to the next step.
@@ -170,7 +237,8 @@ committed gate record before moving to the next step.
 
 The agent must:
 
-1. Create or update `.workflow/records/<issue>-<task-slug>.json`.
+1. Create or update `.workflow/records/<issue>-<task-slug>.json` with
+   `python -m scieasy.qa.governance.gate_record start`.
 2. Record `task_kind`, `branch`, `owner_directive`, `scope.include`,
    `scope.exclude`, `governance_touch`, and expected artifact classes.
 3. Link an existing issue or create a new issue before implementation work is
@@ -195,7 +263,8 @@ No AI-authored PR is ready when the gate record lacks issue linkage.
 
 The agent must:
 
-1. Record planned files and directories.
+1. Record planned files and directories with
+   `python -m scieasy.qa.governance.gate_record plan`.
 2. Record expected docs, tests, changelog, ADR/spec/addendum, and checklist
    landing.
 3. Record required checks. At minimum, source or governance changes require:
@@ -216,8 +285,9 @@ agent stages or commits the extra files.
 The agent must:
 
 1. Keep changes within `scope.include` and outside `scope.exclude`.
-2. Update the gate record with amendments before touching newly discovered
-   files outside the original plan.
+2. Update the gate record with
+   `python -m scieasy.qa.governance.gate_record amend` before touching newly
+   discovered files outside the original plan.
 3. For implementation-category tasks, add or modify at least one test file in
    the same PR.
 4. Record deferred work only with tracked issues. Untracked TODOs or deferrals
@@ -234,7 +304,8 @@ is explicit rather than inferred after the fact.
 The agent must:
 
 1. Update required docs, specs, ADR addenda, changelog entries, and checklists.
-2. Record the updated paths in the gate record.
+2. Record the updated paths in the gate record with
+   `python -m scieasy.qa.governance.gate_record docs`.
 3. For each documentation class that is not required, record an explicit N/A
    rationale.
 4. Update the plan amendment if documentation work expands the file scope.
@@ -258,6 +329,10 @@ python -m scieasy.qa.audit.full_audit \
   --format json \
   --output docs/audit/full-audit-latest.json
 ```
+
+Each completed check must be recorded with
+`python -m scieasy.qa.governance.gate_record check`; Sentrux evidence must be
+recorded with `python -m scieasy.qa.governance.gate_record sentrux`.
 
 When generated facts are part of the change or full audit reports stale facts,
 the agent must also run:
@@ -312,10 +387,12 @@ Assisted-by: <runtime>:<model-or-agent-id>
 ```
 
 3. Push the branch and open the PR.
-4. Ensure the PR body names the gate record path and closes every issue listed
+4. Record final commit and PR evidence with
+   `python -m scieasy.qa.governance.gate_record finalize`.
+5. Ensure the PR body names the gate record path and closes every issue listed
    in the gate record using GitHub closing keywords: `Closes #N`, `Fixes #N`,
    or `Resolves #N`.
-5. Let CI re-run gate validation, QA full audit, and Sentrux checks. Local
+6. Let CI re-run gate validation, QA full audit, and Sentrux checks. Local
    evidence helps review; CI evidence is authoritative.
 
 Referencing an issue without a closing keyword is not sufficient. If a gate

--- a/docs/adr/ADR-042-addendum1.md
+++ b/docs/adr/ADR-042-addendum1.md
@@ -85,6 +85,8 @@ governance:
 | D5. Free-tier honesty rule | Forbid claiming Sentrux Pro-only diagnostics or unchecked rules as completed gate evidence | Local hooks, CI, and review | Section 2 |
 | D6. Override-label consistency | Reuse ADR-042's administrator labels for human bypass, AI override, protected core changes, and merge automation | CI validates label provenance through ADR-042 guards | Section 5 |
 | D7. Implementation tests required | Require implementation-category tasks to add or modify tests as part of the PR | Local hooks and CI reject implementation work without test changes | Section 3 |
+| D8. Legacy CI gate replacement | Replace the old `.workflow/active` CI lookup with committed gate-record validation | Workflow-gate CI has one normative gate authority | Section 3 |
+| D9. Conflict-prone generated artifacts | Ignore generated gate/audit artifacts and explicitly migrate any tracked workflow files before treating them as ignored | `.gitignore`, review, and gate implementation docs | Section 3 |
 
 This addendum supersedes ADR-042 Section 7.2 only where that section defines
 gate state as local-only state under `.git/scieasy/gates/`. Local gate state may
@@ -104,6 +106,8 @@ still exist as a pre-commit helper, but it is not sufficient for delivery.
 | QA full audit evidence is not yet part of the gate | ADR-042 consistency tools can be skipped even when available | Require full-audit evidence, with temporary technical-debt handling before hard fail | Section 5 |
 | Override labels can drift between docs and implementation | Human bypass or admin approval checks can disagree about valid labels | Reuse one fixed label set from ADR-042 and validate it in CI | Section 5 |
 | Implementation tasks can claim tests were run without adding tests | Bug fixes and features can land without regression or behavior coverage | Require changed test files for implementation-category tasks | Section 3 |
+| The legacy CI gate can remain as a parallel source of truth | A PR can pass or fail against obsolete `.workflow/active` state instead of the committed record | Replace the legacy workflow-gate state lookup with gate-record validation | Section 3 |
+| Generated workflow artifacts cause noisy merge conflicts | Agents repeatedly resolve conflicts in files that should be local evidence, not canonical text | Ignore generated gate/audit artifacts and explicitly migrate any tracked canonical workflow files | Section 3 |
 
 ## 2. Sentrux Free-Tier Integration
 
@@ -145,7 +149,17 @@ The canonical gate has six stages:
 
 Existing `.workflow/gate.py` records may remain as a legacy helper during
 migration, but they are not the normative ADR-042 gate unless they produce the
-committed gate record described here and pass CI validation.
+committed gate record described here and pass CI validation. The existing
+workflow-gate CI step that searches `.workflow/active` for local state must be
+replaced by committed gate-record validation; CI must not keep both checks as
+parallel authorities.
+
+Generated gate and audit outputs that are not canonical repository
+documentation should be ignored to avoid recurring branch conflicts. If the
+project decides that an already tracked canonical workflow file such as
+`CHANGELOG.md` should no longer be version-controlled, the implementation must
+remove it from the Git index and update gate semantics; adding a tracked file
+to `.gitignore` alone is not sufficient.
 
 ### 3.1 Required Agent Procedure
 

--- a/docs/adr/ADR-042-addendum1.md
+++ b/docs/adr/ADR-042-addendum1.md
@@ -1,0 +1,434 @@
+---
+adr: 42
+addendum: 1
+title: "CI-Reviewed Gate Records And Sentrux Free-Tier Checks"
+status: Accepted
+date_created: 2026-05-20
+date_accepted: 2026-05-20
+date_superseded: null
+
+supersedes: []
+superseded_by: null
+related: [42]
+closes_issues: []
+tracking_issue: null
+
+is_code_implementation: true
+governs:
+  modules:
+    - scieasy.qa.governance
+    - scieasy.qa.governance.gate_record
+    - scieasy.qa.governance.sentrux_gate
+    - scieasy.qa.governance.human_bypass_guard
+    - scieasy.qa.governance.core_change_guard
+    - scieasy.qa.governance.pr_merge_guard
+  contracts:
+    - scieasy.qa.governance.gate_record.GateRecord
+    - scieasy.qa.governance.gate_record.CheckEvidence
+    - scieasy.qa.governance.gate_record.SentruxEvidence
+    - scieasy.qa.governance.gate_record.FullAuditEvidence
+    - scieasy.qa.governance.gate_record.validate_gate_record
+    - scieasy.qa.governance.gate_record.check_pre_commit
+    - scieasy.qa.governance.gate_record.check_commit_msg
+    - scieasy.qa.governance.gate_record.check_pr
+    - scieasy.qa.governance.sentrux_gate.verify_free_tier_claims
+    - scieasy.qa.governance.human_bypass_guard.check
+    - scieasy.qa.governance.core_change_guard.check
+    - scieasy.qa.governance.pr_merge_guard.check
+  entry_points: []
+  files:
+    - docs/adr/ADR-042-addendum1.md
+    - docs/specs/adr-042-gate-record-sentrux-workflow.md
+    - docs/contributing/workflows/human-bypass.md
+    - .workflow/**
+    - .sentrux/rules.toml
+    - .github/workflows/**
+    - .pre-commit-config.yaml
+    - scripts/hooks/**
+    - src/scieasy/qa/**
+    - tests/qa/**
+  excludes: []
+
+tests:
+  - tests/qa/test_gate_record.py
+  - tests/qa/test_gate_record_hooks.py
+  - tests/qa/test_gate_record_ci.py
+  - tests/qa/test_sentrux_gate.py
+  - tests/qa/test_human_bypass_guard.py
+  - tests/qa/test_core_change_guard.py
+  - tests/qa/test_pr_merge_guard.py
+agent_editable: false
+assisted_by:
+  - "Codex:gpt-5"
+
+phase: planning
+tags: [qa, ci, ai-governance, workflow-gate, sentrux]
+owner: "@jiazhenz026"
+co_authors: ["@codex"]
+language_source: en
+translations: []
+---
+
+# ADR-042 Addendum 1: CI-Reviewed Gate Records And Sentrux Free-Tier Checks
+
+## 1. Decision Summary
+
+This addendum makes the following decisions for ADR-042 gate and architecture
+governance:
+
+| Decision | Change | Enforcement target | Detailed section |
+|---|---|---|---|
+| D1. Sentrux free-tier architecture evidence | Add Sentrux free-tier checks and metrics to required gate evidence for architecture-relevant changes | Local check recording and CI verification | Section 2 |
+| D2. Committed gate records | Replace ADR-042 Section 7.2 local-only gate state with repository-visible gate records | CI validates the committed record against the PR diff | Section 3 |
+| D3. Six-stage gate | Define the canonical stages as Scope And Issue, Plan, Implement, Update Docs, Test And Checks, Commit And Submit PR | Local hooks and CI gate validation | Section 3 |
+| D4. QA full audit requirement | Require ADR-042 QA full audit evidence in the gate when the tool is available; unresolved failures are tracked as technical debt during the transition | CI ultimately blocks non-compliant PRs after the debt-handling phase | Section 5 |
+| D5. Free-tier honesty rule | Forbid claiming Sentrux Pro-only diagnostics or unchecked rules as completed gate evidence | Local hooks, CI, and review | Section 2 |
+| D6. Override-label consistency | Reuse ADR-042's administrator labels for human bypass, AI override, protected core changes, and merge automation | CI validates label provenance through ADR-042 guards | Section 5 |
+| D7. Implementation tests required | Require implementation-category tasks to add or modify tests as part of the PR | Local hooks and CI reject implementation work without test changes | Section 3 |
+
+This addendum supersedes ADR-042 Section 7.2 only where that section defines
+gate state as local-only state under `.git/scieasy/gates/`. Local gate state may
+still exist as a pre-commit helper, but it is not sufficient for delivery.
+
+### 1.1 Problems Addressed
+
+| Problem | Risk | Decision | Detailed section |
+|---|---|---|---|
+| Local-only gate state cannot be reviewed by CI | A PR can claim gate completion without durable evidence | Commit a gate record and validate it in CI | Section 3 |
+| Issue linkage was separated from scope | Agents can plan or implement work before traceability is established | Combine scope and issue linkage as the first gate stage | Section 3 |
+| Documentation landing happened too late or too vaguely | Full audit and drift checks catch documentation problems only after docs exist | Add an explicit Update Docs stage before Test And Checks | Section 3 |
+| Commit and PR submission were split across two handoff points | Agents can leave work half-delivered after commit or before PR | Treat commit and PR submission as one final gate stage | Section 3 |
+| PRs can reference but not close issues | Completed work leaves zombie issues open | Require closing keywords for every gate issue before PR readiness | Section 3 |
+| Architecture checks need a deterministic gate signal | Layering and dependency drift can pass ordinary tests | Require Sentrux free-tier evidence where applicable | Section 2 |
+| Sentrux Pro is unavailable | Gate rules could depend on checks the project cannot run | Limit blocking semantics to free-tier executed checks | Section 2 |
+| QA full audit evidence is not yet part of the gate | ADR-042 consistency tools can be skipped even when available | Require full-audit evidence, with temporary technical-debt handling before hard fail | Section 5 |
+| Override labels can drift between docs and implementation | Human bypass or admin approval checks can disagree about valid labels | Reuse one fixed label set from ADR-042 and validate it in CI | Section 5 |
+| Implementation tasks can claim tests were run without adding tests | Bug fixes and features can land without regression or behavior coverage | Require changed test files for implementation-category tasks | Section 3 |
+
+## 2. Sentrux Free-Tier Integration
+
+Sentrux is adopted as an architecture sensor for dependency health, layering,
+boundary checks, cycle count, complexity ceilings, and quality-signal evidence.
+The executable rule source is `.sentrux/rules.toml`.
+
+During the free-tier period:
+
+- gate and CI may require `sentrux check` or MCP `check_rules` to pass;
+- gate records must identify the execution mode as `free-tier`;
+- gate records may store `quality_signal`, cycle count, complexity ceiling,
+  DSM summary, and test-gap summary as evidence;
+- blocking claims are limited to rules the free-tier tool reports as checked;
+- Pro-only diagnostics, complete root-cause analysis, or unchecked rules must
+  not be described as completed gate evidence.
+
+Sentrux evidence is required when a PR changes source, package, workflow,
+architecture, governance, or Sentrux rule files. Documentation-only changes may
+record Sentrux as not applicable unless they modify architecture or governance
+rules.
+
+## 3. Gate Workflow Supersession
+
+This addendum replaces ADR-042 Section 7.2's local-only gate workflow with a
+CI-reviewed gate-record workflow. The gate remains a development lifecycle, not
+a substitute for issue tracking, branch protection, review, or CI.
+
+The canonical gate has six stages:
+
+| Stage | Required record | Blocking rule |
+|---|---|---|
+| 1. Scope And Issue | Task kind, owner directive, branch, in-scope paths, out-of-scope paths, governance-touch flag, issue link | No committed scope and issue linkage means no AI-authored PR readiness |
+| 2. Plan | Planned files, expected docs/tests/checks, expected Sentrux applicability, ADR/spec/changelog expectation, implementation-test expectation | Diff outside plan requires a recorded amendment |
+| 3. Implement | Changed files remain within scope; amendments explain any scope change | Scope violations fail local hooks and CI |
+| 4. Update Docs | Required docs, specs, ADR addenda, changelog, checklist, or explicit N/A rationale | Missing documentation landing fails local hooks and CI |
+| 5. Test And Checks | Required checks after docs landing, QA full audit evidence, command or tool id, exit code/status, timestamp, output path or compact result | Missing or failing required checks fail local hooks and CI, subject to temporary debt handling for known full-audit findings |
+| 6. Commit And Submit PR | Commit trailers, gate record path, closing issue link, PR URL or CI-discoverable PR association | Missing durable provenance or missing issue-closing keywords fails commit-msg hooks or CI |
+
+Existing `.workflow/gate.py` records may remain as a legacy helper during
+migration, but they are not the normative ADR-042 gate unless they produce the
+committed gate record described here and pass CI validation.
+
+### 3.1 Required Agent Procedure
+
+Agents must execute the gate as an explicit sequence. Each step updates the
+committed gate record before moving to the next step.
+
+#### Step 1. Scope And Issue
+
+The agent must:
+
+1. Create or update `.workflow/records/<issue>-<task-slug>.json`.
+2. Record `task_kind`, `branch`, `owner_directive`, `scope.include`,
+   `scope.exclude`, `governance_touch`, and expected artifact classes.
+3. Link an existing issue or create a new issue before implementation work is
+   considered committable.
+4. Record the issue number and URL in the gate record. For hotfix batches,
+   record every issue fixed by the batch.
+5. If Sentrux is available, start a Sentrux session baseline:
+
+```text
+mcp__sentrux__.scan(path=<repo-root>)
+mcp__sentrux__.session_start()
+```
+
+6. Record the Sentrux session start result in the gate record when available.
+
+If Sentrux MCP is unavailable, the gate record must state that explicitly and
+record the fallback command expected in CI, usually `sentrux check .`.
+
+No AI-authored PR is ready when the gate record lacks issue linkage.
+
+#### Step 2. Plan
+
+The agent must:
+
+1. Record planned files and directories.
+2. Record expected docs, tests, changelog, ADR/spec/addendum, and checklist
+   landing.
+3. Record required checks. At minimum, source or governance changes require:
+   `ruff`, relevant tests, ADR-042 QA full audit, and Sentrux applicability
+   evidence. Frontend changes require the configured frontend checks.
+4. For implementation-category tasks, record the expected test files that will
+   be added or modified. Implementation-category tasks include feature, bugfix,
+   hotfix, refactor, and maintenance work that changes source, package,
+   frontend, workflow, gate, or governance implementation files.
+5. Record whether Sentrux applies. If it does not apply, record a short N/A
+   rationale.
+
+Scope additions after this point require a gate-record amendment before the
+agent stages or commits the extra files.
+
+#### Step 3. Implement
+
+The agent must:
+
+1. Keep changes within `scope.include` and outside `scope.exclude`.
+2. Update the gate record with amendments before touching newly discovered
+   files outside the original plan.
+3. For implementation-category tasks, add or modify at least one test file in
+   the same PR.
+4. Record deferred work only with tracked issues. Untracked TODOs or deferrals
+   violate the gate.
+5. Avoid weakening governance, CI, Sentrux, or quality thresholds unless the
+   owner directive explicitly authorized that scope.
+
+#### Step 4. Update Docs
+
+The agent must update documentation before running the final test and audit
+stage. This mirrors ADR-042's original requirement that documentation landing
+is explicit rather than inferred after the fact.
+
+The agent must:
+
+1. Update required docs, specs, ADR addenda, changelog entries, and checklists.
+2. Record the updated paths in the gate record.
+3. For each documentation class that is not required, record an explicit N/A
+   rationale.
+4. Update the plan amendment if documentation work expands the file scope.
+
+This step must happen before QA full audit because full audit, frontmatter
+lint, doc drift, fact drift, signature drift, and closure checks evaluate
+documentation state.
+
+#### Step 5. Test And Checks
+
+The agent must run and record the checks declared in the plan after Update Docs
+is complete. For a typical source, governance, or architecture-relevant change,
+the required check set is:
+
+```bash
+ruff check .
+ruff format --check .
+pytest <targeted-tests-or-test-directory>
+python -m scieasy.qa.audit.full_audit \
+  --repo-root . \
+  --format json \
+  --output docs/audit/full-audit-latest.json
+```
+
+When generated facts are part of the change or full audit reports stale facts,
+the agent must also run:
+
+```bash
+python scripts/audit/generate_facts.py --check
+```
+
+For Sentrux MCP-capable sessions, the agent must run:
+
+```text
+mcp__sentrux__.rescan()
+mcp__sentrux__.check_rules()
+mcp__sentrux__.health()
+mcp__sentrux__.session_end()
+```
+
+When Sentrux MCP is unavailable but the CLI is available, the agent must run:
+
+```bash
+sentrux scan .
+sentrux check .
+```
+
+The gate record must store each check's command or MCP tool id, status or exit
+code, timestamp, and output path or compact machine-readable result. For QA full
+audit, the record must store the output path, `blocks_merge` status when
+reported, and any known-debt classification. During the technical-debt handling
+phase, known full-audit findings may be recorded without immediately blocking
+every PR, but missing full-audit evidence is still a gate violation.
+
+For implementation-category tasks, the gate record must also store the changed
+test paths. Running tests is not sufficient when no test file is added or
+modified.
+
+For Sentrux, the record must store `free-tier` mode, `rules_checked`,
+`total_rules_defined` when reported, pass/fail status, relevant thresholds from
+`.sentrux/rules.toml`, and `pro_required: false`.
+
+#### Step 6. Commit And Submit PR
+
+The agent must:
+
+1. Commit the gate record with the code or documentation change.
+2. Include these commit trailers:
+
+```text
+Gate-Record: .workflow/records/<record>.json
+Task-Kind: hotfix|bugfix|feature|docs|maintenance|manager
+Issue: #<number>
+Assisted-by: <runtime>:<model-or-agent-id>
+```
+
+3. Push the branch and open the PR.
+4. Ensure the PR body names the gate record path and closes every issue listed
+   in the gate record using GitHub closing keywords: `Closes #N`, `Fixes #N`,
+   or `Resolves #N`.
+5. Let CI re-run gate validation, QA full audit, and Sentrux checks. Local
+   evidence helps review; CI evidence is authoritative.
+
+Referencing an issue without a closing keyword is not sufficient. If a gate
+record lists multiple issues, the PR body must close all of them or explicitly
+mark non-closed issues as follow-up references with owner-approved rationale.
+
+## 4. Required Gate Record
+
+Gate records are repository-visible artifacts committed with the PR. The
+recommended location is `.workflow/records/<issue>-<task-slug>.json`.
+
+Each gate record must contain:
+
+- `task_id`, `task_kind`, `branch`, `owner_directive`;
+- linked `issues`;
+- `scope.include`, `scope.exclude`, and `governance_touch`;
+- planned files and recorded amendments;
+- changed test paths for implementation-category tasks;
+- administrator labels and provenance when an override is used;
+- required checks and check results;
+- ADR-042 QA full audit evidence when the tool is available;
+- documentation landing records or explicit N/A rationales;
+- Sentrux evidence when applicable;
+- final commit and PR provenance.
+
+Sentrux evidence must include at least:
+
+- `name: "sentrux.free_tier"`;
+- execution method, such as CLI command or MCP tool id;
+- `status`;
+- `rules_checked` when reported by the tool;
+- `total_rules_defined` when reported by the tool;
+- relevant threshold values from `.sentrux/rules.toml`;
+- `pro_required: false`.
+
+## 5. Interception And CI Semantics
+
+Local hooks provide early feedback. CI is the final gate verifier.
+
+Pre-commit should block AI-authored commits when:
+
+- no gate record exists for the branch;
+- staged files are outside `scope.include` or inside `scope.exclude`;
+- governance files are touched without `governance_touch=true`;
+- required checks, including applicable Sentrux evidence, are missing;
+- QA full audit evidence is missing when the tool is available;
+- Sentrux free-tier checks fail for applicable changes.
+
+Commit-message hooks should require machine-readable trailers:
+
+```text
+Gate-Record: .workflow/records/<record>.json
+Task-Kind: hotfix|bugfix|feature|docs|maintenance|manager
+Issue: #<number>
+Assisted-by: <runtime>:<model-or-agent-id>
+```
+
+CI must re-read the committed gate record and compare it with the PR diff. CI
+fails when:
+
+- no gate record is present for AI-authored work;
+- the record branch, issue, or changed files do not match the PR;
+- the PR body does not close every issue listed in the gate record;
+- changed files exceed scope without an amendment;
+- an implementation-category task changes implementation files without adding
+  or modifying test files;
+- required docs, tests, changelog, or N/A rationales are missing;
+- QA full audit evidence is missing;
+- Sentrux is applicable but missing or failing;
+- the record claims Pro-only Sentrux evidence;
+- governance or Sentrux rules are weakened without owner-approved scope.
+
+The valid administrator labels are exactly:
+
+| Label | Meaning |
+|---|---|
+| `human-authored` | Human-authored PR bypass for AI-only harness requirements |
+| `admin-approved:ai-override` | One-off AI harness override |
+| `admin-approved:core-change` | Protected core component change approval |
+| `admin-approved:merge` | Approved merge automation |
+
+CI must validate label provenance through the ADR-042 guard contracts. The
+label vocabulary in code, CI, specs, and contributor docs must stay identical.
+
+During the initial technical-debt handling phase, QA full audit may report known
+repository findings without immediately blocking every PR. The gate record must
+still include the full-audit result, output path, and classification of any
+known debt. After the owner accepts the baseline or cleanup queue, missing full
+audit evidence or unclassified full-audit failures become CI-blocking.
+
+## 6. Scope, Non-Goals, And Consequences
+
+In scope:
+
+- committed gate records;
+- CI validation of gate completeness;
+- Sentrux free-tier check evidence;
+- ADR-042 QA full audit evidence;
+- local hooks as fast feedback.
+
+Out of scope:
+
+- requiring Sentrux Pro;
+- replacing review, branch protection, or normal CI;
+- treating Sentrux quality signal as a universal score gate before a baseline
+  policy is accepted;
+- automatic approval of governance changes by tools.
+
+Positive consequences:
+
+- gate evidence becomes reviewable and durable;
+- CI can validate scope, checks, and Sentrux evidence;
+- architecture drift receives an early automated signal.
+
+Negative consequences:
+
+- each AI-authored PR gains one committed process artifact;
+- gate record schema and CI validators must be maintained;
+- QA full audit findings need a temporary baseline or cleanup queue before
+  full hard-fail enforcement;
+- Sentrux free-tier limits must be represented honestly in records and docs.
+
+## 7. Alternatives Considered
+
+| Alternative | Reason rejected |
+|---|---|
+| Keep gate state local-only | CI cannot verify completeness or scope claims |
+| Depend on Sentrux Pro | Pro is not available and still under development |
+| Use Sentrux quality signal as the only architecture gate | A single score is useful evidence but does not replace explicit rule checks |
+| Keep commit and PR as separate gate stages | The handoff can leave AI work committed but not delivered for review |

--- a/docs/contributing/workflows/human-bypass.md
+++ b/docs/contributing/workflows/human-bypass.md
@@ -1,0 +1,164 @@
+---
+title: "Human Bypass Workflow"
+status: Draft
+owners:
+  - "@jiazhenz026"
+related_adrs:
+  - 42
+related_specs:
+  - adr-042-gate-record-sentrux-workflow
+---
+
+# Human Bypass Workflow
+
+## 1. Change Summary
+
+This workflow explains how human maintainers bypass AI-only gate requirements
+without bypassing repository quality checks. It implements ADR-042 Section 9 and
+ADR-042 Addendum 1.
+
+Human bypass is reviewable. Human maintainers may skip local hooks, including
+all hooks, when they judge that local enforcement is blocking legitimate work.
+Final code quality is decided through PR review and CI.
+
+## 2. What Can Be Bypassed
+
+Human-authored PRs may bypass AI-only evidence checks when the
+`human-authored` label is applied by an authorized maintainer:
+
+- committed AI gate record requirement;
+- AI-only local gate session requirement;
+- AI commit trailers such as `Assisted-by`;
+- persona-policy checks that apply only to AI runtime configuration;
+- AI-only artifact and codemod requirements when the PR has no AI-authored
+  commits.
+
+## 3. What Cannot Be Bypassed
+
+Human bypass does not decide final repository quality. PR review and CI remain
+the final quality boundary.
+
+Recommended local checks for human-authored changes are:
+
+```bash
+ruff check .
+ruff format --check .
+pytest <targeted-tests-or-test-directory>
+python -m scieasy.qa.audit.full_audit --repo-root . --format json --output docs/audit/full-audit-latest.json
+```
+
+Humans may skip all local hooks when needed:
+
+```bash
+git commit --no-verify
+```
+
+If local hooks are skipped, the PR should say so briefly. The reviewer decides
+whether the submitted checks and CI signal are sufficient.
+
+## 4. Local Procedure
+
+1. Confirm the PR is human-authored.
+2. Prefer running the standard human check set:
+
+```bash
+ruff check .
+ruff format --check .
+pytest <targeted-tests-or-test-directory>
+python -m scieasy.qa.audit.full_audit --repo-root . --format json --output docs/audit/full-audit-latest.json
+```
+
+3. If only one AI-only hook is blocking you, you may skip only that hook:
+
+```bash
+SKIP=scieasy-gate-record-pre-commit git commit
+```
+
+4. If several local hooks block legitimate human work, skip all local hooks:
+
+```bash
+git commit --no-verify
+```
+
+5. Mention skipped hooks in the PR body if relevant. PR review is the final
+   quality decision.
+
+## 5. PR Procedure
+
+1. Open the PR normally.
+2. The PR body must close the issue delivered by the PR:
+
+```text
+Closes #1234
+```
+
+3. In the PR body, add a short human-authored statement:
+
+```text
+Human-authored PR. Requesting human-authored label for AI-only gate bypass.
+Quality checks run:
+- ruff check .
+- ruff format --check .
+- pytest ...
+- full audit ...
+Local hooks skipped: yes/no
+```
+
+4. Ask an authorized maintainer to apply the `human-authored` label.
+5. Wait for CI and review. CI may mark AI-only gate checks as `skipped-human`.
+   Reviewers decide whether the submitted check evidence is sufficient.
+6. If the PR contains AI-authored commits, `Assisted-by` trailers, or an active
+   AI gate record, `human-authored` alone is not enough. Either provide normal
+   AI gate evidence or request an administrator override such as
+   `admin-approved:ai-override`.
+
+## 6. Administrator Override Procedure
+
+Use administrator overrides only for narrow recovery cases.
+
+1. Record the reason in the PR body or review comment.
+2. Apply the specific label:
+   - `human-authored` for human-authored PRs;
+   - `admin-approved:ai-override` for one-off AI harness override;
+   - `admin-approved:core-change` for protected core changes;
+   - `admin-approved:merge` for approved merge automation.
+3. Ensure CI verifies the actor who applied the label.
+4. Override labels do not merge PRs by themselves; reviewers still decide final
+   quality.
+
+## 7. CI Expectations
+
+CI treats human bypass as follows:
+
+- AI-only gate checks may report `skipped-human`;
+- `human_bypass_guard` verifies label provenance;
+- invalid label provenance fails CI;
+- AI evidence in the PR disables the simple `human-authored` bypass unless an
+  administrator override is also recorded.
+
+## 8. Examples
+
+Human docs PR:
+
+```text
+Closes #1300
+
+Human-authored PR. Requesting human-authored label for AI-only gate bypass.
+Quality checks run:
+- python -m scieasy.qa.audit.full_audit --repo-root . --format json --output docs/audit/full-audit-latest.json
+Local hooks skipped: no
+```
+
+Human source PR:
+
+```text
+Closes #1301
+
+Human-authored PR. Requesting human-authored label for AI-only gate bypass.
+Quality checks run:
+- ruff check .
+- ruff format --check .
+- pytest tests/qa/test_example.py
+- python -m scieasy.qa.audit.full_audit --repo-root . --format json --output docs/audit/full-audit-latest.json
+Local hooks skipped: yes
+```

--- a/docs/specs/adr-042-gate-record-sentrux-workflow.md
+++ b/docs/specs/adr-042-gate-record-sentrux-workflow.md
@@ -26,6 +26,7 @@ scope:
     - ADR-042 QA full audit evidence and technical-debt classification.
     - Local pre-commit, commit-msg, pre-push, and PR-create interception.
     - GitHub Actions workflow-gate updates.
+    - `.gitignore` handling for generated gate/audit artifacts and any explicit migration away from conflict-prone tracked workflow files.
   out:
     - Requiring Sentrux Pro or Pro-only diagnostics.
     - Replacing normal CI, branch protection, owner review, or GitHub issue tracking.
@@ -98,6 +99,7 @@ governs:
     - tests/qa/test_pr_merge_guard.py
     - .workflow/records/.gitkeep
     - .workflow/gate-record.schema.json
+    - .gitignore
     - .pre-commit-config.yaml
     - .github/workflows/workflow-gate.yml
     - scripts/hooks/check-gate-before-pr.sh
@@ -157,6 +159,18 @@ The override label vocabulary is fixed by ADR-042 and ADR-042 Addendum 1:
 `human-authored`, `admin-approved:ai-override`,
 `admin-approved:core-change`, and `admin-approved:merge`. Implementation code,
 CI, specs, and contributor docs must use these exact strings.
+
+The implementation must also replace the legacy CI gate check. The old
+`.workflow/active` local-state lookup in `.github/workflows/workflow-gate.yml`
+must not remain as a parallel source of authority after committed gate records
+are implemented.
+
+Generated or local workflow artifacts that cause recurring branch conflicts
+must be ignored where they are not canonical repository documentation. If an
+already tracked canonical file such as `CHANGELOG.md` is intentionally moved out
+of version control, the implementation must remove it from the index with
+`git rm --cached` and update the gate semantics accordingly; adding an already
+tracked file to `.gitignore` alone is not sufficient.
 
 ## 2. User Scenarios & Testing
 
@@ -487,10 +501,11 @@ applicable changes rather than silently treating evidence as complete.
 | `src/scieasy/qa/governance/__init__.py` | modify | Export gate-record public contracts |
 | `.workflow/gate-record.schema.json` | create | JSON Schema mirror for committed gate records |
 | `.workflow/records/.gitkeep` | create | Keep committed gate-record directory present |
+| `.gitignore` | modify | Ignore generated gate/audit artifacts and document tracked-file migration requirements |
 | `.pre-commit-config.yaml` | modify | Add gate-record pre-commit and commit-msg hooks |
 | `scripts/hooks/check-gate-before-push.sh` | modify | Block push when gate record is incomplete |
 | `scripts/hooks/check-gate-before-pr.sh` | modify | Block PR creation when final gate evidence is incomplete |
-| `.github/workflows/workflow-gate.yml` | modify | Validate gate record, closing issues, full audit, Sentrux, and weakening checks |
+| `.github/workflows/workflow-gate.yml` | modify | Replace legacy local-state gate check with gate record, closing issue, full audit, Sentrux, and weakening validation |
 | `tests/qa/test_gate_record.py` | create | Schema and scope validation tests |
 | `tests/qa/test_gate_record_hooks.py` | create | Pre-commit and commit-msg behavior tests |
 | `tests/qa/test_gate_record_ci.py` | create | PR body, issue closing, diff matching, technical-debt phase tests |
@@ -588,12 +603,13 @@ ready, including closing issue text and gate record path.
 
 `.github/workflows/workflow-gate.yml` must add or replace steps with:
 
-1. Discover gate records changed in the PR.
-2. Validate exactly one primary gate record for AI-authored task branches unless
+1. Remove the legacy `.workflow/active` branch-state lookup as a CI authority.
+2. Discover gate records changed in the PR.
+3. Validate exactly one primary gate record for AI-authored task branches unless
    the PR is an approved human-authored bypass.
-3. Fetch PR changed files, PR body, labels, label actor provenance, and review
+4. Fetch PR changed files, PR body, labels, label actor provenance, and review
    approval metadata.
-4. Run:
+5. Run:
 
 ```bash
 python -m scieasy.qa.governance.gate_record ci \
@@ -603,7 +619,7 @@ python -m scieasy.qa.governance.gate_record ci \
   --pr-body "$PR_BODY"
 ```
 
-5. Run full audit and upload/report the output:
+6. Run full audit and upload/report the output:
 
 ```bash
 python -m scieasy.qa.audit.full_audit \
@@ -612,21 +628,21 @@ python -m scieasy.qa.audit.full_audit \
   --output docs/audit/full-audit-latest.json
 ```
 
-6. Run Sentrux free-tier checks for applicable changes:
+7. Run Sentrux free-tier checks for applicable changes:
 
 ```bash
 sentrux scan .
 sentrux check .
 ```
 
-7. Fail if Sentrux is applicable and the CLI is unavailable, unless the owner
+8. Fail if Sentrux is applicable and the CLI is unavailable, unless the owner
    explicitly marks the PR as part of the tool-install bootstrap issue.
-8. Fail if PR body does not close every gate-record issue.
-9. Fail if full audit evidence is missing, or if unclassified full-audit
+9. Fail if PR body does not close every gate-record issue.
+10. Fail if full audit evidence is missing, or if unclassified full-audit
    failures remain after the technical-debt handling phase.
-10. Fail if an implementation-category task changes implementation files
+11. Fail if an implementation-category task changes implementation files
     without changed test files.
-11. Fail if override labels are misspelled, missing, or applied by unauthorized
+12. Fail if override labels are misspelled, missing, or applied by unauthorized
     actors. The only valid override labels are `human-authored`,
     `admin-approved:ai-override`, `admin-approved:core-change`, and
     `admin-approved:merge`.
@@ -646,10 +662,14 @@ sentrux check .
 8. Add full-audit evidence validation with known-debt classification support.
 9. Add CLI subcommands for `pre-commit`, `commit-msg`, and `ci`.
 10. Wire `.pre-commit-config.yaml` hooks.
-11. Update shell wrappers for push and PR creation.
-12. Update GitHub Actions workflow-gate job.
-13. Add `docs/contributing/workflows/human-bypass.md`.
-14. Add migration documentation in gate-record command help and PR template text
+11. Update `.gitignore` for generated gate/audit artifacts and explicitly
+    migrate any tracked canonical conflict-prone file before treating it as
+    ignored.
+12. Update shell wrappers for push and PR creation.
+13. Replace the legacy GitHub Actions workflow-gate job with gate-record
+    validation.
+14. Add `docs/contributing/workflows/human-bypass.md`.
+15. Add migration documentation in gate-record command help and PR template text
    if needed.
 
 ### 5.7 Verification Plan
@@ -689,7 +709,8 @@ sentrux check .
 | Gate records become stale boilerplate | CI compares records against PR diff and fails mismatches |
 | Agents forget to close issues | CI checks PR body closing keywords against gate-record issues |
 | Human maintainers bypass all hooks with `--no-verify` | Document that this is allowed for humans and make PR review plus CI the final quality decision |
-| Existing `.workflow/gate.py` conflicts with the new model | Keep it as legacy helper only until it emits committed gate records |
+| Existing `.workflow/gate.py` conflicts with the new model | Keep it as legacy helper only until it emits committed gate records; remove old `.workflow/active` CI lookup |
+| Conflict-prone generated artifacts create repeated merge conflicts | Ignore generated gate/audit artifacts; migrate already tracked canonical files explicitly before relying on ignore rules |
 
 Rollback is limited to disabling the new CI gate job while preserving normal
 CI, branch protection, and owner review. Rollback must not remove the gate

--- a/docs/specs/adr-042-gate-record-sentrux-workflow.md
+++ b/docs/specs/adr-042-gate-record-sentrux-workflow.md
@@ -25,6 +25,8 @@ scope:
     - Six-stage gate workflow from ADR-042 Addendum 1.
     - Sentrux free-tier evidence collection and CI verification.
     - ADR-042 QA full audit evidence and technical-debt classification.
+    - Architecture document truthfulness checks for code blocks, symbol names,
+      module paths, and signatures in `docs/architecture/ARCHITECTURE.md`.
     - Local pre-commit, commit-msg, pre-push, and PR-create interception.
     - GitHub Actions workflow-gate updates.
     - `.gitignore` handling for generated gate/audit artifacts and any explicit migration away from conflict-prone tracked workflow files.
@@ -39,6 +41,7 @@ governs:
     - scieasy.qa.governance
     - scieasy.qa.schemas.frontmatter
     - scieasy.qa.audit.frontmatter_lint
+    - scieasy.qa.audit.architecture_drift
     - scieasy.qa.governance.gate_record
     - scieasy.qa.governance.sentrux_gate
     - scieasy.qa.governance.issue_link
@@ -53,6 +56,7 @@ governs:
     - scieasy.qa.schemas.frontmatter.ADRAddendumFrontmatter
     - scieasy.qa.schemas.frontmatter.ArchitectureFrontmatter
     - scieasy.qa.audit.frontmatter_lint.lint_file
+    - scieasy.qa.audit.architecture_drift.check
     - scieasy.qa.governance.gate_record.GateRecord
     - scieasy.qa.governance.gate_record.GateStage
     - scieasy.qa.governance.gate_record.CheckEvidence
@@ -78,6 +82,7 @@ governs:
     - docs/architecture/ARCHITECTURE.md
     - src/scieasy/qa/schemas/frontmatter.py
     - src/scieasy/qa/audit/frontmatter_lint.py
+    - src/scieasy/qa/audit/architecture_drift.py
     - src/scieasy/qa/audit/loaders.py
     - src/scieasy/qa/governance/gate_record.py
     - src/scieasy/qa/governance/sentrux_gate.py
@@ -115,6 +120,7 @@ tests:
   - tests/qa/test_gate_record_ci.py
   - tests/qa/test_sentrux_gate.py
   - tests/qa/test_audit_frontmatter_lint.py
+  - tests/qa/test_architecture_drift.py
   - tests/qa/test_issue_link.py
   - tests/qa/test_docs_landing.py
   - tests/qa/test_persona_policy.py
@@ -233,6 +239,26 @@ Acceptance Scenarios:
    fails.
 3. Given an architecture document whose H1 does not match the frontmatter title,
    when lint runs, then it fails.
+
+### User Story 2b - Architecture document code truth is audited (Priority: P1)
+
+As a maintainer, I need `docs/architecture/ARCHITECTURE.md` to be accurate when
+it names repository modules, classes, functions, methods, or signatures.
+
+Independent Test: Modify architecture-doc fixtures with stale function names,
+wrong method signatures, missing modules, stale class names, and intentionally
+non-normative examples.
+
+Acceptance Scenarios:
+
+1. Given an architecture document that references an existing module path and
+   function signature, when architecture drift audit runs, then it passes.
+2. Given an architecture document that changes an actual function signature to
+   the wrong parameter list, when architecture drift audit runs, then it fails.
+3. Given an architecture document that names a missing repository class or
+   function in backticks or a code block, when audit runs, then it fails.
+4. Given an illustrative example explicitly marked non-normative, when audit
+   runs, then it is skipped.
 
 ### User Story 3 - Existing ADR-042 guards remain hard-fail (Priority: P1)
 
@@ -393,6 +419,16 @@ Acceptance Scenarios:
   `docs/architecture/ARCHITECTURE.md` with an architecture frontmatter schema,
   include it in repo-wide checks, and fail when architecture metadata or H1
   structure is invalid.
+- FR-002b: The implementation MUST add architecture drift checks for
+  `docs/architecture/ARCHITECTURE.md` that validate code blocks, referenced
+  repository module paths, class names, function names, method names, and
+  signatures against generated code facts.
+- FR-002c: Architecture examples are normative by default. The checker MAY skip
+  examples only when the surrounding prose or fence metadata explicitly marks
+  the example as non-normative, illustrative, or pseudocode.
+- FR-002d: Architecture drift findings MUST be included in full audit and MUST
+  block CI when `docs/architecture/ARCHITECTURE.md` changes unless classified as
+  known debt during the technical-debt phase.
 - FR-003: The implementation MUST define a Pydantic-backed `GateRecord` schema
   stored as JSON under `.workflow/records/`.
 - FR-004: Gate record validation MUST call or consume the existing ADR-042
@@ -531,6 +567,8 @@ applicable changes rather than silently treating evidence as complete.
 | `src/scieasy/qa/governance/weakened_ci_check.py` | use | Existing ADR-042 CI weakening guard |
 | `src/scieasy/qa/schemas/frontmatter.py` | modify | Add standalone ADR addendum frontmatter schema support |
 | `src/scieasy/qa/audit/frontmatter_lint.py` | modify | Accept and validate `ADR-NNN-addendumM.md` and `docs/architecture/ARCHITECTURE.md` |
+| `src/scieasy/qa/audit/architecture_drift.py` | create | Validate architecture code blocks, symbols, module paths, and signatures against repository facts |
+| `src/scieasy/qa/audit/full_audit.py` | modify | Include architecture drift as a child audit report |
 | `src/scieasy/qa/audit/loaders.py` | modify | Load addendum and architecture frontmatter for audit/facts tools |
 | `src/scieasy/qa/governance/__init__.py` | modify | Export gate-record public contracts |
 | `.workflow/gate.py` | delete | Remove obsolete local-only gate state machine |
@@ -546,6 +584,7 @@ applicable changes rather than silently treating evidence as complete.
 | `tests/qa/test_gate_record_ci.py` | create | PR body, issue closing, diff matching, technical-debt phase tests |
 | `tests/qa/test_sentrux_gate.py` | create | Free-tier Sentrux evidence tests |
 | `tests/qa/test_audit_frontmatter_lint.py` | modify | Add standalone ADR addendum lint cases |
+| `tests/qa/test_architecture_drift.py` | create | Architecture code truthfulness and skip-marker tests |
 | `tests/qa/test_issue_link.py` | use/complete if missing | Existing issue-link guard coverage |
 | `tests/qa/test_docs_landing.py` | use/complete if missing | Existing docs-landing guard coverage |
 | `tests/qa/test_persona_policy.py` | use/complete if missing | Existing persona-policy guard coverage |

--- a/docs/specs/adr-042-gate-record-sentrux-workflow.md
+++ b/docs/specs/adr-042-gate-record-sentrux-workflow.md
@@ -16,6 +16,7 @@ related_specs:
 scope:
   in:
     - Standalone ADR addendum frontmatter and lint support.
+    - Architecture document frontmatter and lint support for `docs/architecture/ARCHITECTURE.md`.
     - Committed gate record schema and validator.
     - Orchestration of ADR-042 custom hard-fail guards already defined for issue linkage, docs landing, persona policy, governance protection, and CI weakening.
     - Human bypass guard integration and contributor-facing bypass procedure.
@@ -50,6 +51,7 @@ governs:
     - scieasy.qa.governance.weakened_ci_check
   contracts:
     - scieasy.qa.schemas.frontmatter.ADRAddendumFrontmatter
+    - scieasy.qa.schemas.frontmatter.ArchitectureFrontmatter
     - scieasy.qa.audit.frontmatter_lint.lint_file
     - scieasy.qa.governance.gate_record.GateRecord
     - scieasy.qa.governance.gate_record.GateStage
@@ -73,6 +75,7 @@ governs:
   files:
     - docs/specs/adr-042-gate-record-sentrux-workflow.md
     - docs/adr/ADR-042-addendum1.md
+    - docs/architecture/ARCHITECTURE.md
     - src/scieasy/qa/schemas/frontmatter.py
     - src/scieasy/qa/audit/frontmatter_lint.py
     - src/scieasy/qa/audit/loaders.py
@@ -211,6 +214,25 @@ Acceptance Scenarios:
    then it fails.
 3. Given an addendum without `## 1. Decision Summary` or
    `### 1.1 Problems Addressed`, when lint runs, then it fails.
+
+### User Story 2a - Architecture document frontmatter is audited (Priority: P1)
+
+As a maintainer, I need the top-level architecture document to participate in
+ADR-042 frontmatter audit so architecture metadata cannot drift outside the
+quality gate.
+
+Independent Test: Run `frontmatter_lint.lint_file` against
+`docs/architecture/ARCHITECTURE.md` and fixtures with invalid `doc_type`,
+missing owner, missing governed ADRs, and wrong H1.
+
+Acceptance Scenarios:
+
+1. Given `docs/architecture/ARCHITECTURE.md` with `doc_type: architecture`,
+   when frontmatter lint runs, then it passes architecture metadata validation.
+2. Given an architecture document without an owner, when lint runs, then it
+   fails.
+3. Given an architecture document whose H1 does not match the frontmatter title,
+   when lint runs, then it fails.
 
 ### User Story 3 - Existing ADR-042 guards remain hard-fail (Priority: P1)
 
@@ -367,6 +389,10 @@ Acceptance Scenarios:
 - FR-002: `frontmatter_lint` MUST validate addendum filenames, H1 titles,
   `## 1. Decision Summary`, `### 1.1 Problems Addressed`, and detailed-section
   references.
+- FR-002a: `frontmatter_lint` MUST validate
+  `docs/architecture/ARCHITECTURE.md` with an architecture frontmatter schema,
+  include it in repo-wide checks, and fail when architecture metadata or H1
+  structure is invalid.
 - FR-003: The implementation MUST define a Pydantic-backed `GateRecord` schema
   stored as JSON under `.workflow/records/`.
 - FR-004: Gate record validation MUST call or consume the existing ADR-042
@@ -504,8 +530,8 @@ applicable changes rather than silently treating evidence as complete.
 | `src/scieasy/qa/governance/mod_guard.py` | use | Existing ADR-042 governance modification guard |
 | `src/scieasy/qa/governance/weakened_ci_check.py` | use | Existing ADR-042 CI weakening guard |
 | `src/scieasy/qa/schemas/frontmatter.py` | modify | Add standalone ADR addendum frontmatter schema support |
-| `src/scieasy/qa/audit/frontmatter_lint.py` | modify | Accept and validate `ADR-NNN-addendumM.md` |
-| `src/scieasy/qa/audit/loaders.py` | modify | Load addendum frontmatter for audit/facts tools |
+| `src/scieasy/qa/audit/frontmatter_lint.py` | modify | Accept and validate `ADR-NNN-addendumM.md` and `docs/architecture/ARCHITECTURE.md` |
+| `src/scieasy/qa/audit/loaders.py` | modify | Load addendum and architecture frontmatter for audit/facts tools |
 | `src/scieasy/qa/governance/__init__.py` | modify | Export gate-record public contracts |
 | `.workflow/gate.py` | delete | Remove obsolete local-only gate state machine |
 | `.workflow/gate-record.schema.json` | create | JSON Schema mirror for committed gate records |

--- a/docs/specs/adr-042-gate-record-sentrux-workflow.md
+++ b/docs/specs/adr-042-gate-record-sentrux-workflow.md
@@ -1,0 +1,715 @@
+---
+spec_id: adr-042-gate-record-sentrux-workflow
+title: "ADR-042 Gate Record And Sentrux Workflow Implementation Specification"
+status: Draft
+feature_branch: docs/adr-042-addendum
+created: 2026-05-20
+input: "Owner-approved ADR-042 Addendum 1: implement CI-reviewed gate records, required issue-closing PRs, QA full audit evidence, and Sentrux free-tier architecture checks."
+owners:
+  - "@jiazhenz026"
+related_adrs:
+  - 42
+related_specs:
+  - adr-042-ai-governance-tools
+  - adr-042-consistency-tools
+  - adr-042-code-quality-tools
+scope:
+  in:
+    - Standalone ADR addendum frontmatter and lint support.
+    - Committed gate record schema and validator.
+    - Orchestration of ADR-042 custom hard-fail guards already defined for issue linkage, docs landing, persona policy, governance protection, and CI weakening.
+    - Human bypass guard integration and contributor-facing bypass procedure.
+    - Administrator override label consistency and provenance checks.
+    - Mandatory changed-test-file enforcement for implementation-category tasks.
+    - Six-stage gate workflow from ADR-042 Addendum 1.
+    - Sentrux free-tier evidence collection and CI verification.
+    - ADR-042 QA full audit evidence and technical-debt classification.
+    - Local pre-commit, commit-msg, pre-push, and PR-create interception.
+    - GitHub Actions workflow-gate updates.
+  out:
+    - Requiring Sentrux Pro or Pro-only diagnostics.
+    - Replacing normal CI, branch protection, owner review, or GitHub issue tracking.
+    - Replacing ADR-042 custom guard semantics with new gate-record-only checks.
+    - Automatic application of GitHub labels or administrator approvals.
+governs:
+  modules:
+    - scieasy.qa.governance
+    - scieasy.qa.schemas.frontmatter
+    - scieasy.qa.audit.frontmatter_lint
+    - scieasy.qa.governance.gate_record
+    - scieasy.qa.governance.sentrux_gate
+    - scieasy.qa.governance.issue_link
+    - scieasy.qa.governance.docs_landing
+    - scieasy.qa.governance.persona_policy
+    - scieasy.qa.governance.human_bypass_guard
+    - scieasy.qa.governance.core_change_guard
+    - scieasy.qa.governance.pr_merge_guard
+    - scieasy.qa.governance.mod_guard
+    - scieasy.qa.governance.weakened_ci_check
+  contracts:
+    - scieasy.qa.schemas.frontmatter.ADRAddendumFrontmatter
+    - scieasy.qa.audit.frontmatter_lint.lint_file
+    - scieasy.qa.governance.gate_record.GateRecord
+    - scieasy.qa.governance.gate_record.GateStage
+    - scieasy.qa.governance.gate_record.CheckEvidence
+    - scieasy.qa.governance.gate_record.SentruxEvidence
+    - scieasy.qa.governance.gate_record.FullAuditEvidence
+    - scieasy.qa.governance.gate_record.validate_gate_record
+    - scieasy.qa.governance.gate_record.check_pre_commit
+    - scieasy.qa.governance.gate_record.check_commit_msg
+    - scieasy.qa.governance.gate_record.check_pr
+    - scieasy.qa.governance.sentrux_gate.parse_sentrux_result
+    - scieasy.qa.governance.sentrux_gate.verify_free_tier_claims
+    - scieasy.qa.governance.issue_link.resolve_or_create
+    - scieasy.qa.governance.docs_landing.check
+    - scieasy.qa.governance.persona_policy.check
+    - scieasy.qa.governance.human_bypass_guard.check
+    - scieasy.qa.governance.core_change_guard.check
+    - scieasy.qa.governance.pr_merge_guard.check
+    - scieasy.qa.governance.mod_guard.check
+    - scieasy.qa.governance.weakened_ci_check.verify_no_weakening
+  files:
+    - docs/specs/adr-042-gate-record-sentrux-workflow.md
+    - docs/adr/ADR-042-addendum1.md
+    - src/scieasy/qa/schemas/frontmatter.py
+    - src/scieasy/qa/audit/frontmatter_lint.py
+    - src/scieasy/qa/audit/loaders.py
+    - src/scieasy/qa/governance/gate_record.py
+    - src/scieasy/qa/governance/sentrux_gate.py
+    - src/scieasy/qa/governance/issue_link.py
+    - src/scieasy/qa/governance/docs_landing.py
+    - src/scieasy/qa/governance/persona_policy.py
+    - src/scieasy/qa/governance/human_bypass_guard.py
+    - src/scieasy/qa/governance/core_change_guard.py
+    - src/scieasy/qa/governance/pr_merge_guard.py
+    - src/scieasy/qa/governance/mod_guard.py
+    - src/scieasy/qa/governance/weakened_ci_check.py
+    - src/scieasy/qa/governance/__init__.py
+    - tests/qa/test_gate_record.py
+    - tests/qa/test_gate_record_hooks.py
+    - tests/qa/test_gate_record_ci.py
+    - tests/qa/test_sentrux_gate.py
+    - tests/qa/test_audit_frontmatter_lint.py
+    - tests/qa/test_issue_link.py
+    - tests/qa/test_docs_landing.py
+    - tests/qa/test_persona_policy.py
+    - tests/qa/test_human_bypass_guard.py
+    - tests/qa/test_core_change_guard.py
+    - tests/qa/test_pr_merge_guard.py
+    - .workflow/records/.gitkeep
+    - .workflow/gate-record.schema.json
+    - .pre-commit-config.yaml
+    - .github/workflows/workflow-gate.yml
+    - scripts/hooks/check-gate-before-pr.sh
+    - scripts/hooks/check-gate-before-push.sh
+    - docs/contributing/workflows/human-bypass.md
+tests:
+  - tests/qa/test_gate_record.py
+  - tests/qa/test_gate_record_hooks.py
+  - tests/qa/test_gate_record_ci.py
+  - tests/qa/test_sentrux_gate.py
+  - tests/qa/test_audit_frontmatter_lint.py
+  - tests/qa/test_issue_link.py
+  - tests/qa/test_docs_landing.py
+  - tests/qa/test_persona_policy.py
+  - tests/qa/test_human_bypass_guard.py
+  - tests/qa/test_core_change_guard.py
+  - tests/qa/test_pr_merge_guard.py
+acceptance_source: adr
+language_source: en
+---
+
+# ADR-042 Gate Record And Sentrux Workflow Implementation Specification
+
+## 1. Change Summary
+
+This spec implements ADR-042 Addendum 1. The implementation first teaches
+ADR-042 tooling to understand standalone addendum files such as
+`docs/adr/ADR-042-addendum1.md`. It then replaces the ADR-042 local-only gate
+model with committed gate records that CI validates against the pull request
+diff.
+
+The gate record is an evidence container and orchestration surface. It does not
+replace ADR-042 custom guards. Existing ADR-042 guards such as `issue_link`,
+`docs_landing`, `persona_policy`, `human_bypass_guard`,
+`governance_mod_guard`, and `weakened_ci_check` remain the normative hard-fail
+tools for their domains. The gate record records their inputs and results, and
+CI re-runs or verifies those guards where possible.
+
+The spec also makes Sentrux free-tier architecture evidence and ADR-042 QA full
+audit evidence part of the gate.
+
+The resulting workflow has six stages:
+
+1. Scope And Issue.
+2. Plan.
+3. Implement.
+4. Update Docs.
+5. Test And Checks.
+6. Commit And Submit PR.
+
+The implementation must keep Sentrux free-tier limits explicit. Gate records
+may claim only checks the installed tool actually executed. PRs must close every
+issue listed in the gate record unless the record and PR body include an
+owner-approved rationale for a non-closing follow-up reference.
+
+The override label vocabulary is fixed by ADR-042 and ADR-042 Addendum 1:
+`human-authored`, `admin-approved:ai-override`,
+`admin-approved:core-change`, and `admin-approved:merge`. Implementation code,
+CI, specs, and contributor docs must use these exact strings.
+
+## 2. User Scenarios & Testing
+
+### User Story 1 - Gate records are committed and CI-verifiable (Priority: P1)
+
+As a maintainer, I need every AI-authored PR to include a committed gate record
+that CI can compare with the PR diff.
+
+Independent Test: Validate gate-record fixtures for a matching PR diff, missing
+record, branch mismatch, unplanned file, denied path, and missing amendment.
+
+Acceptance Scenarios:
+
+1. Given a valid gate record and matching changed files, when CI validation
+   runs, then the gate passes.
+2. Given changed files outside `scope.include`, when CI validation runs, then
+   the gate fails.
+3. Given a governance file change with `governance_touch=false`, when CI
+   validation runs, then the gate fails.
+
+### User Story 2 - Standalone ADR addenda pass frontmatter lint (Priority: P1)
+
+As a maintainer, I need accepted ADR addenda to live in separate files while
+still being validated by ADR-042 frontmatter and first-section rules.
+
+Independent Test: Run `frontmatter_lint.lint_file` against
+`docs/adr/ADR-042-addendum1.md` and fixtures with invalid addendum filenames,
+missing addendum numbers, wrong H1 titles, and unresolved problem sections.
+
+Acceptance Scenarios:
+
+1. Given `docs/adr/ADR-042-addendum1.md` with `adr: 42` and `addendum: 1`,
+   when frontmatter lint runs, then it passes the addendum filename rule.
+2. Given `docs/adr/ADR-042-addendum2.md` without `addendum: 2`, when lint runs,
+   then it fails.
+3. Given an addendum without `## 1. Decision Summary` or
+   `### 1.1 Problems Addressed`, when lint runs, then it fails.
+
+### User Story 3 - Existing ADR-042 guards remain hard-fail (Priority: P1)
+
+As a maintainer, I need the committed gate workflow to reuse ADR-042's existing
+custom tools instead of redefining their policy in a parallel implementation.
+
+Independent Test: Run gate-record validation with mocked or fixture outputs
+from `issue_link`, `docs_landing`, `persona_policy`, `mod_guard`, and
+`weakened_ci_check`.
+
+Acceptance Scenarios:
+
+1. Given `docs_landing.check` reports missing changelog or N/A rationale, when
+   gate validation runs, then the gate fails.
+2. Given `issue_link.resolve_or_create` cannot resolve an issue, when gate
+   validation runs, then the gate fails.
+3. Given `persona_policy.check` reports an unsupported persona or runtime
+   policy, when gate validation runs, then the gate fails.
+4. Given `mod_guard.check` or `weakened_ci_check.verify_no_weakening` reports a
+   governance weakening, when CI validation runs, then the gate fails.
+
+### User Story 4 - PRs close the issues they deliver (Priority: P1)
+
+As a maintainer, I need completed work to close its issue so zombie issues do
+not accumulate.
+
+Independent Test: Validate PR-body fixtures with `Closes #N`, `Fixes #N`,
+`Resolves #N`, plain references, multiple issues, and owner-approved follow-up
+rationales.
+
+Acceptance Scenarios:
+
+1. Given a gate record listing issue `#1262`, when the PR body includes
+   `Closes #1262`, then issue-closing validation passes.
+2. Given the same record and a PR body that says `Refs #1262`, then validation
+   fails.
+3. Given multiple gate issues, when the PR body closes only one, then
+   validation fails unless the non-closed issue has an owner-approved follow-up
+   rationale in both the record and PR body.
+
+### User Story 5 - Sentrux free-tier evidence is honest and repeatable (Priority: P1)
+
+As a maintainer, I need architecture gate evidence that reflects the currently
+available free-tier Sentrux tool, not unavailable Pro diagnostics.
+
+Independent Test: Validate Sentrux evidence fixtures with pass/fail status,
+`rules_checked`, `total_rules_defined`, `mode=free-tier`, and forbidden
+Pro-only claims.
+
+Acceptance Scenarios:
+
+1. Given a source change and Sentrux free-tier pass evidence, when gate
+   validation runs, then Sentrux validation passes.
+2. Given a source change with missing Sentrux evidence, when gate validation
+   runs, then validation fails.
+3. Given evidence claiming Pro-only diagnostics, when validation runs, then it
+   fails even if `check_rules` passed.
+
+### User Story 6 - QA full audit evidence is present before PR readiness (Priority: P1)
+
+As a maintainer, I need ADR-042 full audit evidence after docs are updated so
+frontmatter, drift, facts, signatures, and closure problems are visible before
+review.
+
+Independent Test: Validate records with full-audit pass, known-debt findings,
+missing full-audit output, and unclassified failures.
+
+Acceptance Scenarios:
+
+1. Given a gate record with full-audit output and no blocking findings, when CI
+   validation runs, then full-audit evidence passes.
+2. Given known findings classified under the technical-debt handling phase,
+   when CI validation runs, then evidence is accepted but reported.
+3. Given missing full-audit evidence, when CI validation runs, then validation
+   fails.
+
+### User Story 7 - Humans can use documented, reviewable bypasses (Priority: P1)
+
+As a human maintainer, I need a clear procedure for bypassing AI-only local
+hooks without bypassing repository quality checks or hiding the bypass from CI.
+
+Independent Test: Validate `human_bypass_guard` fixtures for administrator
+label provenance, invalid label actor, AI-authored commits with human-authored
+labels, and approved one-off override labels.
+
+Acceptance Scenarios:
+
+1. Given a PR with a maintainer-applied `human-authored` label and no AI
+   evidence, when CI runs, then AI-only gate checks are marked
+   `skipped-human` and repository quality checks still run.
+2. Given a PR with a `human-authored` label applied by an unauthorized actor,
+   when CI runs, then `human_bypass_guard` fails.
+3. Given a PR with AI-authored commits or `Assisted-by` trailers, when the PR
+   only has `human-authored`, then CI still requires normal AI gate evidence or
+   an explicit administrator override.
+
+### User Story 8 - Local hooks catch mistakes before CI (Priority: P2)
+
+As an AI agent or maintainer, I need local hooks to fail early before a bad PR
+is opened.
+
+Independent Test: Run hook fixtures for pre-commit, commit-msg, pre-push, and
+PR-create wrappers.
+
+Acceptance Scenarios:
+
+1. Given staged files outside scope, when pre-commit runs, then it fails.
+2. Given a commit message missing `Gate-Record`, when commit-msg runs, then it
+   fails.
+3. Given a PR-create command with missing docs landing or issue-closing
+   evidence, when the wrapper runs, then it fails.
+
+### User Story 9 - Implementation tasks include changed tests (Priority: P1)
+
+As a maintainer, I need feature, bugfix, hotfix, refactor, and implementation
+maintenance work to include test changes, not only claims that existing tests
+were run.
+
+Independent Test: Validate PR-diff fixtures for implementation-category tasks
+with source changes and no test changes, source changes with added tests, docs
+tasks with no tests, and owner-approved human-authored bypasses.
+
+Acceptance Scenarios:
+
+1. Given a feature task that changes `src/` and no `tests/` or package test
+   files, when CI gate validation runs, then it fails.
+2. Given a bugfix task that changes source and adds a regression test, when CI
+   gate validation runs, then it passes the changed-test-file requirement.
+3. Given a docs task with no implementation files changed, when CI gate
+   validation runs, then the changed-test-file requirement is not applicable.
+
+### User Story 10 - Override labels are consistent (Priority: P1)
+
+As a maintainer, I need bypass and administrator approval labels to use one
+fixed vocabulary across docs, code, tests, and CI.
+
+Independent Test: Validate label fixtures for `human-authored`,
+`admin-approved:ai-override`, `admin-approved:core-change`,
+`admin-approved:merge`, misspelled labels, and unauthorized label actors.
+
+Acceptance Scenarios:
+
+1. Given a PR with `admin-approved:core-change` applied by an authorized
+   maintainer, when protected core validation runs, then the label is accepted.
+2. Given a PR with `admin-approved:corechange`, when validation runs, then the
+   label is ignored and the protected change fails.
+3. Given a PR with `admin-approved:merge` applied by an unauthorized actor, when
+   merge guard validation runs, then it fails.
+
+## 3. Functional Requirements
+
+- FR-001: The implementation MUST add `ADRAddendumFrontmatter` or equivalent
+  support for standalone ADR addendum files named `ADR-NNN-addendumM.md`.
+- FR-002: `frontmatter_lint` MUST validate addendum filenames, H1 titles,
+  `## 1. Decision Summary`, `### 1.1 Problems Addressed`, and detailed-section
+  references.
+- FR-003: The implementation MUST define a Pydantic-backed `GateRecord` schema
+  stored as JSON under `.workflow/records/`.
+- FR-004: Gate record validation MUST call or consume the existing ADR-042
+  `issue_link.resolve_or_create`, `docs_landing.check`, `persona_policy.check`,
+  `human_bypass_guard.check`, `mod_guard.check`, and
+  `weakened_ci_check.verify_no_weakening` contracts where their domains apply.
+- FR-005: Failures from those existing ADR-042 guards MUST be hard-fail gate
+  findings. The gate-record implementation MUST NOT downgrade them to advisory
+  findings.
+- FR-006: Gate records MUST include stage data for Scope And Issue, Plan,
+  Implement, Update Docs, Test And Checks, and Commit And Submit PR.
+- FR-007: Scope validation MUST compare staged files locally and PR changed
+  files in CI against `scope.include`, `scope.exclude`, and amendments.
+- FR-008: Gate records MUST include issue numbers and URLs before implementation
+  is committable.
+- FR-009: PR validation MUST require GitHub closing keywords for every gate
+  issue, unless an owner-approved follow-up rationale is present.
+- FR-010: Gate records MUST include docs landing evidence before Test And Checks.
+- FR-011: Gate records MUST include ADR-042 full audit evidence when
+  `python -m scieasy.qa.audit.full_audit` is available.
+- FR-012: During the technical-debt phase, full-audit findings MAY be accepted
+  only when classified as known debt in the gate record.
+- FR-013: Sentrux evidence MUST be required for source, package, workflow,
+  architecture, governance, and `.sentrux/rules.toml` changes.
+- FR-014: Sentrux evidence MUST declare `mode="free-tier"` and
+  `pro_required=false`.
+- FR-015: Sentrux validation MUST reject records that claim Pro-only diagnostics
+  or unchecked rules as completed.
+- FR-016: CI MUST re-run gate validation from repository state and PR metadata;
+  local evidence is not authoritative.
+- FR-017: Commit-message validation MUST require `Gate-Record`, `Task-Kind`,
+  `Issue`, and `Assisted-by` trailers for AI-authored commits.
+- FR-018: Existing `.workflow/gate.py` MAY remain during migration but MUST NOT
+  be treated as sufficient unless it emits the committed gate record.
+- FR-019: The implementation MUST add a human-facing bypass procedure under
+  `docs/contributing/workflows/human-bypass.md`.
+- FR-020: Human bypass documentation MUST state that human maintainers may skip
+  all local hooks, list the recommended human check set, explain how to request
+  the `human-authored` label, and state that final code quality is decided by PR
+  review and CI.
+- FR-021: The implementation MUST use these exact override labels:
+  `human-authored`, `admin-approved:ai-override`,
+  `admin-approved:core-change`, and `admin-approved:merge`.
+- FR-022: `human_bypass_guard`, `core_change_guard`, and `pr_merge_guard` MUST
+  validate label provenance and MUST reject misspelled, missing, or
+  unauthorized labels.
+- FR-023: Implementation-category tasks that change implementation files MUST
+  add or modify at least one test file in the same PR.
+- FR-024: Changed-test-file enforcement MUST apply to feature, bugfix, hotfix,
+  refactor, and maintenance tasks that touch source, package, frontend,
+  workflow, gate, or governance implementation files.
+
+## 4. Edge Cases
+
+- EC-001: Documentation-only PRs may mark Sentrux N/A unless they modify
+  architecture or governance rules.
+- EC-002: Hotfix batches may list multiple issues; the PR must close each fixed
+  issue.
+- EC-003: A non-closed follow-up issue must be recorded as follow-up in both the
+  gate record and PR body with owner-approved rationale.
+- EC-004: Sentrux MCP may be unavailable locally; the gate record must state the
+  fallback and CI must run CLI validation where the CLI is configured.
+- EC-005: Full audit may return known technical debt during rollout; the record
+  must classify it instead of omitting the audit.
+- EC-006: A PR that changes gate, CI, Sentrux, or governance rules must set
+  `governance_touch=true` and pass weakening checks.
+- EC-007: Human-authored PR bypass semantics still follow ADR-042 Section 9;
+  repository quality checks still run.
+- EC-008: If an existing ADR-042 guard has not yet been implemented, the gate
+  implementation must record that as a tracked implementation gap instead of
+  silently replacing the guard with weaker bespoke logic.
+- EC-009: Human maintainers may use `git commit --no-verify` or equivalent
+  skip-all local behavior. The PR still needs the administrator-applied
+  `human-authored` label or another approved administrator override for AI-only
+  CI bypass semantics.
+- EC-010: Running an existing test suite is not enough for implementation
+  tasks. The PR diff must include a changed test file.
+- EC-011: Docs-only and planning-only tasks are exempt from changed-test-file
+  enforcement unless they also touch implementation files.
+
+## 5. Implementation Plan
+
+### 5.1 Technical Approach
+
+Implement gate records as repository-visible JSON files validated by Pydantic
+models in `scieasy.qa.governance.gate_record`. The module exposes local hook
+entry points and CI validation entry points that share the same schema and
+scope-checking logic.
+
+`gate_record` is an orchestrator. It delegates domain-specific policy to the
+ADR-042 custom tools already designed for that purpose:
+
+| Domain | Existing tool | Gate behavior |
+|---|---|---|
+| Issue linkage | `issue_link.resolve_or_create` | Hard-fail when issue linkage is missing or invalid |
+| Docs landing | `docs_landing.check` | Hard-fail when docs/changelog/checklist evidence or N/A rationale is missing |
+| Persona/runtime policy | `persona_policy.check` | Hard-fail when persona, runtime config, root policy, or skill pointers are invalid |
+| Human bypass provenance | `human_bypass_guard.check` | Hard-fail invalid `human-authored` or administrator override provenance |
+| Protected core changes | `core_change_guard.check` | Hard-fail protected core changes without `admin-approved:core-change` or equivalent administrator review |
+| Merge automation | `pr_merge_guard.check` | Hard-fail AI merge automation without `admin-approved:merge` |
+| Governance modification | `mod_guard.check` | Hard-fail unauthorized governance changes |
+| CI/test weakening | `weakened_ci_check.verify_no_weakening` | Hard-fail weakened checks, thresholds, or exemptions |
+
+If one of these tools is not implemented when this spec is implemented, the PR
+must either implement that tool according to its existing ADR-042 spec or record
+a tracked implementation issue. The gate must not replace it with a weaker
+parallel check.
+
+Add `scieasy.qa.governance.sentrux_gate` for narrow Sentrux evidence parsing and
+free-tier claim validation. This module does not implement Sentrux; it validates
+evidence produced by Sentrux MCP or CLI and rejects Pro-only claims.
+
+CI validates gate records in `.github/workflows/workflow-gate.yml` after
+checkout. The workflow also runs full audit and Sentrux free-tier checks where
+available. If a check cannot be installed or run, the job must fail for
+applicable changes rather than silently treating evidence as complete.
+
+### 5.2 Affected Files
+
+| File | Action | Purpose |
+|---|---|---|
+| `src/scieasy/qa/governance/gate_record.py` | create | Gate record schema, local checks, commit-message checks, PR validation |
+| `src/scieasy/qa/governance/sentrux_gate.py` | create | Sentrux free-tier evidence parsing and validation |
+| `src/scieasy/qa/governance/issue_link.py` | use/complete if missing | Existing ADR-042 issue-link hard-fail guard |
+| `src/scieasy/qa/governance/docs_landing.py` | use/complete if missing | Existing ADR-042 docs/changelog/checklist hard-fail guard |
+| `src/scieasy/qa/governance/persona_policy.py` | use/complete if missing | Existing ADR-042 persona/runtime hard-fail guard |
+| `src/scieasy/qa/governance/human_bypass_guard.py` | use/complete if missing | Existing ADR-042 human bypass provenance guard |
+| `src/scieasy/qa/governance/core_change_guard.py` | use/complete if missing | Existing ADR-042 protected core change guard |
+| `src/scieasy/qa/governance/pr_merge_guard.py` | use/complete if missing | Existing ADR-042 AI merge guard |
+| `src/scieasy/qa/governance/mod_guard.py` | use | Existing ADR-042 governance modification guard |
+| `src/scieasy/qa/governance/weakened_ci_check.py` | use | Existing ADR-042 CI weakening guard |
+| `src/scieasy/qa/schemas/frontmatter.py` | modify | Add standalone ADR addendum frontmatter schema support |
+| `src/scieasy/qa/audit/frontmatter_lint.py` | modify | Accept and validate `ADR-NNN-addendumM.md` |
+| `src/scieasy/qa/audit/loaders.py` | modify | Load addendum frontmatter for audit/facts tools |
+| `src/scieasy/qa/governance/__init__.py` | modify | Export gate-record public contracts |
+| `.workflow/gate-record.schema.json` | create | JSON Schema mirror for committed gate records |
+| `.workflow/records/.gitkeep` | create | Keep committed gate-record directory present |
+| `.pre-commit-config.yaml` | modify | Add gate-record pre-commit and commit-msg hooks |
+| `scripts/hooks/check-gate-before-push.sh` | modify | Block push when gate record is incomplete |
+| `scripts/hooks/check-gate-before-pr.sh` | modify | Block PR creation when final gate evidence is incomplete |
+| `.github/workflows/workflow-gate.yml` | modify | Validate gate record, closing issues, full audit, Sentrux, and weakening checks |
+| `tests/qa/test_gate_record.py` | create | Schema and scope validation tests |
+| `tests/qa/test_gate_record_hooks.py` | create | Pre-commit and commit-msg behavior tests |
+| `tests/qa/test_gate_record_ci.py` | create | PR body, issue closing, diff matching, technical-debt phase tests |
+| `tests/qa/test_sentrux_gate.py` | create | Free-tier Sentrux evidence tests |
+| `tests/qa/test_audit_frontmatter_lint.py` | modify | Add standalone ADR addendum lint cases |
+| `tests/qa/test_issue_link.py` | use/complete if missing | Existing issue-link guard coverage |
+| `tests/qa/test_docs_landing.py` | use/complete if missing | Existing docs-landing guard coverage |
+| `tests/qa/test_persona_policy.py` | use/complete if missing | Existing persona-policy guard coverage |
+| `tests/qa/test_human_bypass_guard.py` | use/complete if missing | Existing human-bypass provenance coverage |
+| `tests/qa/test_core_change_guard.py` | use/complete if missing | Existing protected-core approval coverage |
+| `tests/qa/test_pr_merge_guard.py` | use/complete if missing | Existing AI merge guard coverage |
+| `docs/contributing/workflows/human-bypass.md` | create | Step-by-step human bypass procedure |
+
+### 5.3 Module Contracts
+
+`GateRecord` fields:
+
+- `schema_version`;
+- `record_path`;
+- `task_id`;
+- `task_kind`;
+- `branch`;
+- `owner_directive`;
+- `issues`;
+- `scope`;
+- `governance_touch`;
+- `planned_files`;
+- `changed_test_paths`;
+- `admin_labels`;
+- `amendments`;
+- `docs_landing`;
+- `required_checks`;
+- `check_results`;
+- `sentrux`;
+- `full_audit`;
+- `commit`;
+- `pull_request`.
+
+`CheckEvidence` fields:
+
+- `name`;
+- `command_or_tool`;
+- `status`;
+- `exit_code`;
+- `timestamp`;
+- `output_path`;
+- `summary`;
+
+`SentruxEvidence` fields:
+
+- `mode`;
+- `command_or_tool`;
+- `status`;
+- `rules_checked`;
+- `total_rules_defined`;
+- `quality_signal`;
+- `thresholds`;
+- `pro_required`;
+- `output_path`;
+
+`FullAuditEvidence` fields:
+
+- `command`;
+- `status`;
+- `exit_code`;
+- `output_path`;
+- `blocks_merge`;
+- `known_debt`;
+- `unclassified_failures`;
+
+### 5.4 Hook Configuration
+
+`.pre-commit-config.yaml` must add:
+
+- `scieasy-gate-record-pre-commit`: runs
+  `python -m scieasy.qa.governance.gate_record pre-commit --staged`.
+- `scieasy-gate-record-commit-msg`: runs
+  `python -m scieasy.qa.governance.gate_record commit-msg`.
+
+The pre-commit hook checks staged files, gate record existence, scope,
+governance touch, changed-test-file requirements for implementation-category
+tasks, docs landing presence, Sentrux evidence applicability, and QA full audit
+evidence presence.
+
+The commit-msg hook checks `Gate-Record`, `Task-Kind`, `Issue`, and
+`Assisted-by` trailers.
+
+`scripts/hooks/check-gate-before-push.sh` must check that the gate record has
+completed Step 5 before allowing `git push` from AI-governed branches.
+
+`scripts/hooks/check-gate-before-pr.sh` must check that Step 6 evidence is
+ready, including closing issue text and gate record path.
+
+### 5.5 CI Configuration
+
+`.github/workflows/workflow-gate.yml` must add or replace steps with:
+
+1. Discover gate records changed in the PR.
+2. Validate exactly one primary gate record for AI-authored task branches unless
+   the PR is an approved human-authored bypass.
+3. Fetch PR changed files, PR body, labels, label actor provenance, and review
+   approval metadata.
+4. Run:
+
+```bash
+python -m scieasy.qa.governance.gate_record ci \
+  --gate-record .workflow/records/<record>.json \
+  --base origin/${{ github.base_ref }} \
+  --head HEAD \
+  --pr-body "$PR_BODY"
+```
+
+5. Run full audit and upload/report the output:
+
+```bash
+python -m scieasy.qa.audit.full_audit \
+  --repo-root . \
+  --format json \
+  --output docs/audit/full-audit-latest.json
+```
+
+6. Run Sentrux free-tier checks for applicable changes:
+
+```bash
+sentrux scan .
+sentrux check .
+```
+
+7. Fail if Sentrux is applicable and the CLI is unavailable, unless the owner
+   explicitly marks the PR as part of the tool-install bootstrap issue.
+8. Fail if PR body does not close every gate-record issue.
+9. Fail if full audit evidence is missing, or if unclassified full-audit
+   failures remain after the technical-debt handling phase.
+10. Fail if an implementation-category task changes implementation files
+    without changed test files.
+11. Fail if override labels are misspelled, missing, or applied by unauthorized
+    actors. The only valid override labels are `human-authored`,
+    `admin-approved:ai-override`, `admin-approved:core-change`, and
+    `admin-approved:merge`.
+
+### 5.6 Implementation Sequence
+
+1. Add standalone ADR addendum frontmatter and lint support.
+2. Add `GateRecord`, evidence models, and fixture tests.
+3. Wire existing ADR-042 hard-fail guards into gate-record validation:
+   `issue_link`, `docs_landing`, `persona_policy`, `human_bypass_guard`,
+   `core_change_guard`, `pr_merge_guard`, `mod_guard`, and
+   `weakened_ci_check`.
+4. Add scope and PR-body validation, including issue-closing enforcement.
+5. Add changed-test-file enforcement for implementation-category tasks.
+6. Add override-label vocabulary and provenance tests.
+7. Add Sentrux evidence validation.
+8. Add full-audit evidence validation with known-debt classification support.
+9. Add CLI subcommands for `pre-commit`, `commit-msg`, and `ci`.
+10. Wire `.pre-commit-config.yaml` hooks.
+11. Update shell wrappers for push and PR creation.
+12. Update GitHub Actions workflow-gate job.
+13. Add `docs/contributing/workflows/human-bypass.md`.
+14. Add migration documentation in gate-record command help and PR template text
+   if needed.
+
+### 5.7 Verification Plan
+
+Run:
+
+```bash
+pytest tests/qa/test_gate_record.py
+pytest tests/qa/test_gate_record_hooks.py
+pytest tests/qa/test_gate_record_ci.py
+pytest tests/qa/test_sentrux_gate.py
+pytest tests/qa/test_audit_frontmatter_lint.py
+pytest tests/qa/test_issue_link.py
+pytest tests/qa/test_docs_landing.py
+pytest tests/qa/test_persona_policy.py
+pytest tests/qa/test_human_bypass_guard.py
+pytest tests/qa/test_core_change_guard.py
+pytest tests/qa/test_pr_merge_guard.py
+ruff check src/scieasy/qa/governance tests/qa/test_gate_record*.py tests/qa/test_sentrux_gate.py
+ruff format --check src/scieasy/qa/governance tests/qa/test_gate_record*.py tests/qa/test_sentrux_gate.py
+python -m scieasy.qa.audit.full_audit --repo-root . --format json --output docs/audit/full-audit-latest.json
+```
+
+When Sentrux is available locally, also run:
+
+```bash
+sentrux scan .
+sentrux check .
+```
+
+## 6. Risks And Rollback
+
+| Risk | Mitigation |
+|---|---|
+| CI cannot install Sentrux free CLI reliably | Treat installation as part of the first implementation PR and fail applicable checks rather than silently passing missing evidence |
+| Full audit has known existing findings | Require evidence and classification during the technical-debt phase; hard-fail unclassified findings after baseline acceptance |
+| Gate records become stale boilerplate | CI compares records against PR diff and fails mismatches |
+| Agents forget to close issues | CI checks PR body closing keywords against gate-record issues |
+| Human maintainers bypass all hooks with `--no-verify` | Document that this is allowed for humans and make PR review plus CI the final quality decision |
+| Existing `.workflow/gate.py` conflicts with the new model | Keep it as legacy helper only until it emits committed gate records |
+
+Rollback is limited to disabling the new CI gate job while preserving normal
+CI, branch protection, and owner review. Rollback must not remove the gate
+record files from already-open PRs; those remain audit artifacts.
+
+## 7. Success Criteria
+
+- SC-001: A valid AI-authored PR with a committed gate record passes local hook
+  fixtures and CI gate validation.
+- SC-002: A PR without a gate record fails CI.
+- SC-003: A PR that references but does not close its gate issue fails CI.
+- SC-004: A PR with source changes and missing Sentrux evidence fails CI.
+- SC-005: A PR with missing QA full audit evidence fails CI.
+- SC-006: Sentrux Pro-only claims are rejected.
+- SC-007: Known full-audit technical debt can be reported without suppressing
+  missing-evidence failures.
+
+## 8. Assumptions
+
+- Sentrux free-tier CLI or MCP is available to the implementation environment.
+- Sentrux Pro is unavailable and not required.
+- ADR-042 Addendum 1 is the governing source for this workflow.
+- Human-authored bypass semantics remain governed by ADR-042 Section 9.

--- a/docs/specs/adr-042-gate-record-sentrux-workflow.md
+++ b/docs/specs/adr-042-gate-record-sentrux-workflow.md
@@ -27,6 +27,7 @@ scope:
     - Local pre-commit, commit-msg, pre-push, and PR-create interception.
     - GitHub Actions workflow-gate updates.
     - `.gitignore` handling for generated gate/audit artifacts and any explicit migration away from conflict-prone tracked workflow files.
+    - Removal of obsolete `.workflow/gate.py` and replacement of current hook references with the gate-record CLI.
   out:
     - Requiring Sentrux Pro or Pro-only diagnostics.
     - Replacing normal CI, branch protection, owner review, or GitHub issue tracking.
@@ -163,7 +164,9 @@ CI, specs, and contributor docs must use these exact strings.
 The implementation must also replace the legacy CI gate check. The old
 `.workflow/active` local-state lookup in `.github/workflows/workflow-gate.yml`
 must not remain as a parallel source of authority after committed gate records
-are implemented.
+are implemented. The old `.workflow/gate.py` command is obsolete and must be
+deleted from the repository; current hooks and contributor instructions must
+call `python -m scieasy.qa.governance.gate_record` instead.
 
 Generated or local workflow artifacts that cause recurring branch conflicts
 must be ignored where they are not canonical repository documentation. If an
@@ -396,8 +399,8 @@ Acceptance Scenarios:
   local evidence is not authoritative.
 - FR-017: Commit-message validation MUST require `Gate-Record`, `Task-Kind`,
   `Issue`, and `Assisted-by` trailers for AI-authored commits.
-- FR-018: Existing `.workflow/gate.py` MAY remain during migration but MUST NOT
-  be treated as sufficient unless it emits the committed gate record.
+- FR-018: Existing `.workflow/gate.py` MUST be deleted. No current hook, CI
+  workflow, or agent instruction may call it after this implementation.
 - FR-019: The implementation MUST add a human-facing bypass procedure under
   `docs/contributing/workflows/human-bypass.md`.
 - FR-020: Human bypass documentation MUST state that human maintainers may skip
@@ -415,6 +418,11 @@ Acceptance Scenarios:
 - FR-024: Changed-test-file enforcement MUST apply to feature, bugfix, hotfix,
   refactor, and maintenance tasks that touch source, package, frontend,
   workflow, gate, or governance implementation files.
+- FR-025: `gate_record` MUST expose the AI-facing CLI commands `start`, `plan`,
+  `amend`, `docs`, `check`, `sentrux`, `finalize`, `pre-commit`,
+  `commit-msg`, and `ci`.
+- FR-026: The push and PR hook wrappers MUST call the gate-record CLI and MUST
+  NOT inspect `.workflow/active` or call `.workflow/gate.py`.
 
 ## 4. Edge Cases
 
@@ -499,6 +507,7 @@ applicable changes rather than silently treating evidence as complete.
 | `src/scieasy/qa/audit/frontmatter_lint.py` | modify | Accept and validate `ADR-NNN-addendumM.md` |
 | `src/scieasy/qa/audit/loaders.py` | modify | Load addendum frontmatter for audit/facts tools |
 | `src/scieasy/qa/governance/__init__.py` | modify | Export gate-record public contracts |
+| `.workflow/gate.py` | delete | Remove obsolete local-only gate state machine |
 | `.workflow/gate-record.schema.json` | create | JSON Schema mirror for committed gate records |
 | `.workflow/records/.gitkeep` | create | Keep committed gate-record directory present |
 | `.gitignore` | modify | Ignore generated gate/audit artifacts and document tracked-file migration requirements |
@@ -660,16 +669,18 @@ sentrux check .
 6. Add override-label vocabulary and provenance tests.
 7. Add Sentrux evidence validation.
 8. Add full-audit evidence validation with known-debt classification support.
-9. Add CLI subcommands for `pre-commit`, `commit-msg`, and `ci`.
-10. Wire `.pre-commit-config.yaml` hooks.
-11. Update `.gitignore` for generated gate/audit artifacts and explicitly
+9. Add CLI subcommands for `start`, `plan`, `amend`, `docs`, `check`,
+   `sentrux`, `finalize`, `pre-commit`, `commit-msg`, and `ci`.
+10. Delete `.workflow/gate.py` and remove all current hook/CI references to it.
+11. Wire `.pre-commit-config.yaml` hooks.
+12. Update `.gitignore` for generated gate/audit artifacts and explicitly
     migrate any tracked canonical conflict-prone file before treating it as
     ignored.
-12. Update shell wrappers for push and PR creation.
-13. Replace the legacy GitHub Actions workflow-gate job with gate-record
+13. Update shell wrappers for push and PR creation.
+14. Replace the legacy GitHub Actions workflow-gate job with gate-record
     validation.
-14. Add `docs/contributing/workflows/human-bypass.md`.
-15. Add migration documentation in gate-record command help and PR template text
+15. Add `docs/contributing/workflows/human-bypass.md`.
+16. Add migration documentation in gate-record command help and PR template text
    if needed.
 
 ### 5.7 Verification Plan
@@ -709,7 +720,7 @@ sentrux check .
 | Gate records become stale boilerplate | CI compares records against PR diff and fails mismatches |
 | Agents forget to close issues | CI checks PR body closing keywords against gate-record issues |
 | Human maintainers bypass all hooks with `--no-verify` | Document that this is allowed for humans and make PR review plus CI the final quality decision |
-| Existing `.workflow/gate.py` conflicts with the new model | Keep it as legacy helper only until it emits committed gate records; remove old `.workflow/active` CI lookup |
+| Existing `.workflow/gate.py` conflicts with the new model | Delete `.workflow/gate.py`; current hooks and CI must call `gate_record` instead |
 | Conflict-prone generated artifacts create repeated merge conflicts | Ignore generated gate/audit artifacts; migrate already tracked canonical files explicitly before relying on ignore rules |
 
 Rollback is limited to disabling the new CI gate job while preserving normal


### PR DESCRIPTION
## Summary
- add `docs/adr/ADR-042-addendum1.md` as the accepted addendum for CI-reviewed gate records, Sentrux free-tier checks, QA full audit evidence, override-label consistency, and mandatory changed-test enforcement
- add the implementation spec covering modules, hooks, CI configuration, and existing ADR-042 hard-fail guard integration
- add the human bypass workflow doc with the exact override-label vocabulary

## Local verification
- `python -m scieasy.qa.audit.full_audit --repo-root . --format json --output <temp>` -> failed on existing/baseline missing `docs/facts/generated.yaml`
- `python -m scieasy.qa.audit.frontmatter_lint docs/adr/ADR-042-addendum1.md docs/specs/adr-042-gate-record-sentrux-workflow.md docs/contributing/workflows/human-bypass.md` -> failed because current `frontmatter_lint` does not yet support standalone ADR addendum frontmatter; this is specified as implementation work in the new spec

## Follow-up implementation
After this docs PR, ADR-042 Addendum 1 implementation will be dispatched under agent-manager with separate tracks for frontmatter/addendum support, gate record schema/validator, Sentrux evidence, hard-fail guard orchestration, hooks/CI, and tests.

Closes #1264