### PR TITLE
feat(#1268): support ADR addendum frontmatter

### DIFF
--- a/docs/planning/adr-042-addendum1-implementation-checklist.md
+++ b/docs/planning/adr-042-addendum1-implementation-checklist.md
@@ -26,12 +26,12 @@ Sub-issue: #1268
 - [x] Add `ADRAddendumFrontmatter` and loader support for standalone `ADR-NNN-addendumM.md` files. [ADR-042 Addendum 1 Section 3; Spec User Story 2] Result: `python -m scieasy.qa.audit.frontmatter_lint docs/adr/ADR-042-addendum1.md` passed with `PYTHONPATH=src`.
 - [x] Update `frontmatter_lint` filename/H1/Decision Summary checks for addenda without weakening ordinary ADR checks. [Spec FR-001..FR-003] Result: `pytest tests/qa/test_audit_frontmatter_lint.py --timeout=60 --no-cov` passed 15 tests with `PYTHONPATH=src`.
 - [x] Add or update tests in `tests/qa/test_audit_frontmatter_lint.py` for valid and invalid addenda. Result: valid addendum, malformed filename, mismatched addendum number, missing addendum number, wrong H1, unresolved detail section, and loader selection cases covered.
-- [ ] Add `ArchitectureFrontmatter` and include `docs/architecture/ARCHITECTURE.md` in repo-wide `frontmatter_lint` checks. [Spec User Story 2a; FR-002a]
-- [ ] Validate architecture document H1 against frontmatter title and reject missing owner/governed ADR metadata.
+- [x] Add `ArchitectureFrontmatter` and include `docs/architecture/ARCHITECTURE.md` in repo-wide `frontmatter_lint` checks. [Spec User Story 2a; FR-002a] Result: `PYTHONPATH=src python -m scieasy.qa.audit.frontmatter_lint docs/architecture/ARCHITECTURE.md` passed; repo-wide command now includes architecture but still reports pre-existing non-Track-A ADR/spec frontmatter debt.
+- [x] Validate architecture document H1 against frontmatter title and reject missing owner/governed ADR metadata. Result: architecture tests cover valid metadata, invalid `doc_type`, missing owner, wrong H1, repo `ARCHITECTURE.md`, and repo-wide `check()` inclusion.
 
 ### Verification
 
-- [!] `pytest tests/qa/test_audit_frontmatter_lint.py --timeout=60` Result: test assertions passed, but the repository global coverage fail-under rejected this targeted run at 9%; rerun with `PYTHONPATH=src` and `--no-cov` passed 15 tests.
+- [!] `pytest tests/qa/test_audit_frontmatter_lint.py --timeout=60` Result: test assertions passed, but the repository global coverage fail-under rejected this targeted run at 9%; rerun with `PYTHONPATH=src` and `--no-cov` passed 21 tests.
 
 ## Track B - Gate Record Core
 

--- a/docs/planning/adr-042-addendum1-implementation-checklist.md
+++ b/docs/planning/adr-042-addendum1-implementation-checklist.md
@@ -23,13 +23,13 @@ Sub-issue: #1268
 
 ### Phase 2 Implementation (Owner: I-A)
 
-- [ ] Add `ADRAddendumFrontmatter` and loader support for standalone `ADR-NNN-addendumM.md` files. [ADR-042 Addendum 1 Section 3; Spec User Story 2]
-- [ ] Update `frontmatter_lint` filename/H1/Decision Summary checks for addenda without weakening ordinary ADR checks. [Spec FR-001..FR-003]
-- [ ] Add or update tests in `tests/qa/test_audit_frontmatter_lint.py` for valid and invalid addenda.
+- [x] Add `ADRAddendumFrontmatter` and loader support for standalone `ADR-NNN-addendumM.md` files. [ADR-042 Addendum 1 Section 3; Spec User Story 2] Result: `python -m scieasy.qa.audit.frontmatter_lint docs/adr/ADR-042-addendum1.md` passed with `PYTHONPATH=src`.
+- [x] Update `frontmatter_lint` filename/H1/Decision Summary checks for addenda without weakening ordinary ADR checks. [Spec FR-001..FR-003] Result: `pytest tests/qa/test_audit_frontmatter_lint.py --timeout=60 --no-cov` passed 15 tests with `PYTHONPATH=src`.
+- [x] Add or update tests in `tests/qa/test_audit_frontmatter_lint.py` for valid and invalid addenda. Result: valid addendum, malformed filename, mismatched addendum number, missing addendum number, wrong H1, unresolved detail section, and loader selection cases covered.
 
 ### Verification
 
-- [ ] `pytest tests/qa/test_audit_frontmatter_lint.py --timeout=60`
+- [!] `pytest tests/qa/test_audit_frontmatter_lint.py --timeout=60` Result: test assertions passed, but the repository global coverage fail-under rejected this targeted run at 9%; rerun with `PYTHONPATH=src` and `--no-cov` passed 15 tests.
 
 ## Track B - Gate Record Core
 

--- a/src/scieasy/qa/audit/_util.py
+++ b/src/scieasy/qa/audit/_util.py
@@ -9,7 +9,7 @@ from typing import Any
 import yaml
 from pydantic import ValidationError
 
-from scieasy.qa.schemas.frontmatter import ADRFrontmatter, SpecFrontmatter
+from scieasy.qa.schemas.frontmatter import ADRFrontmatter, ArchitectureFrontmatter, SpecFrontmatter
 from scieasy.qa.schemas.maintainers import Maintainers
 from scieasy.qa.schemas.report import Finding, Severity
 
@@ -281,6 +281,30 @@ def load_spec_frontmatter(path: Path) -> tuple[SpecFrontmatter | None, str, list
                     file=normalise_path(path),
                     line=1,
                     message=f"Spec frontmatter validation failed: {exc}",
+                )
+            ],
+        )
+
+
+def load_architecture_frontmatter(path: Path) -> tuple[ArchitectureFrontmatter | None, str, list[Finding]]:
+    """Load and validate architecture document frontmatter."""
+
+    data, body, findings = parse_yaml_frontmatter(path)
+    if data is None:
+        return None, body, findings
+    try:
+        return ArchitectureFrontmatter.model_validate(data), body, []
+    except ValidationError as exc:
+        return (
+            None,
+            body,
+            [
+                Finding(
+                    rule_id="frontmatter.validation",
+                    severity=Severity.ERROR,
+                    file=normalise_path(path),
+                    line=1,
+                    message=f"Architecture frontmatter validation failed: {exc}",
                 )
             ],
         )

--- a/src/scieasy/qa/audit/frontmatter_lint.py
+++ b/src/scieasy/qa/audit/frontmatter_lint.py
@@ -6,17 +6,30 @@ import argparse
 import re
 from pathlib import Path
 
-from scieasy.qa.audit._util import load_adr_frontmatter, load_spec_frontmatter, normalise_path
-from scieasy.qa.schemas.frontmatter import ADRFrontmatter
+from pydantic import ValidationError
+
+from scieasy.qa.audit._util import (
+    _apply_governance_amendments,
+    load_adr_frontmatter,
+    load_spec_frontmatter,
+    normalise_path,
+    parse_yaml_frontmatter,
+)
+from scieasy.qa.schemas.frontmatter import ADRAddendumFrontmatter, ADRFrontmatter
 from scieasy.qa.schemas.report import AuditReport, AuditStatus, Finding, Severity
 
 _HEADING_RE = re.compile(r"^(#{1,6})\s+(.+?)\s*$")
 _DETAIL_SECTION_RE = re.compile(r"\bSection\s+(\d+(?:\.\d+)*)\b", re.IGNORECASE)
+_ADR_ADDENDUM_RE = re.compile(r"^ADR-\d{3}-addendum")
 
 
 def _is_adr(path: Path) -> bool:
     parts = [part.lower() for part in path.parts]
     return "docs" in parts and "adr" in parts and path.name.startswith("ADR-")
+
+
+def _is_adr_addendum(path: Path) -> bool:
+    return _ADR_ADDENDUM_RE.match(path.name) is not None
 
 
 def _is_spec(path: Path) -> bool:
@@ -59,7 +72,45 @@ def _section_numbers(headings: list[tuple[int, str, int]]) -> set[str]:
     return numbers
 
 
-def _check_adr_filename(path: Path, fm: ADRFrontmatter) -> list[Finding]:
+def _load_adr_addendum_frontmatter(path: Path) -> tuple[ADRAddendumFrontmatter | None, str, list[Finding]]:
+    data, body, findings = parse_yaml_frontmatter(path)
+    if data is None:
+        return None, body, findings
+    data, amendment_findings = _apply_governance_amendments(data, body, path=path)
+    if amendment_findings:
+        return None, body, amendment_findings
+    try:
+        return ADRAddendumFrontmatter.model_validate(data), body, []
+    except ValidationError as exc:
+        return (
+            None,
+            body,
+            [
+                Finding(
+                    rule_id="frontmatter.validation",
+                    severity=Severity.ERROR,
+                    file=normalise_path(path),
+                    line=1,
+                    message=f"ADR addendum frontmatter validation failed: {exc}",
+                )
+            ],
+        )
+
+
+def _check_adr_filename(path: Path, fm: ADRFrontmatter | ADRAddendumFrontmatter) -> list[Finding]:
+    if isinstance(fm, ADRAddendumFrontmatter):
+        expected = f"ADR-{fm.adr:03d}-addendum{fm.addendum}.md"
+        if path.name != expected:
+            return [
+                _finding(
+                    path,
+                    "frontmatter.adr-addendum-filename",
+                    f"ADR addendum filename must be {expected} for adr={fm.adr} addendum={fm.addendum}",
+                    line=1,
+                )
+            ]
+        return []
+
     expected = f"ADR-{fm.adr:03d}.md"
     if path.name != expected:
         return [
@@ -73,11 +124,14 @@ def _check_adr_filename(path: Path, fm: ADRFrontmatter) -> list[Finding]:
     return []
 
 
-def _check_adr_body(path: Path, fm: ADRFrontmatter, body: str) -> list[Finding]:
+def _check_adr_body(path: Path, fm: ADRFrontmatter | ADRAddendumFrontmatter, body: str) -> list[Finding]:
     headings = _headings(body)
     findings: list[Finding] = []
 
-    expected_h1 = f"ADR-{fm.adr:03d}: {fm.title}"
+    if isinstance(fm, ADRAddendumFrontmatter):
+        expected_h1 = f"ADR-{fm.adr:03d} Addendum {fm.addendum}: {fm.title}"
+    else:
+        expected_h1 = f"ADR-{fm.adr:03d}: {fm.title}"
     if not headings or headings[0][0] != 1:
         findings.append(_finding(path, "frontmatter.adr-h1", "ADR body must start with an H1 title"))
     elif headings[0][1] != expected_h1:
@@ -167,7 +221,11 @@ def lint_file(path: Path) -> list[Finding]:
         return [_finding(path, "frontmatter.file-missing", "file does not exist", line=1)]
 
     if _is_adr(path):
-        adr_fm, body, findings = load_adr_frontmatter(path)
+        adr_fm: ADRFrontmatter | ADRAddendumFrontmatter | None
+        if _is_adr_addendum(path):
+            adr_fm, body, findings = _load_adr_addendum_frontmatter(path)
+        else:
+            adr_fm, body, findings = load_adr_frontmatter(path)
         if adr_fm is None:
             return findings
         return findings + _check_adr_filename(path, adr_fm) + _check_adr_body(path, adr_fm, body)

--- a/src/scieasy/qa/audit/frontmatter_lint.py
+++ b/src/scieasy/qa/audit/frontmatter_lint.py
@@ -11,11 +11,12 @@ from pydantic import ValidationError
 from scieasy.qa.audit._util import (
     _apply_governance_amendments,
     load_adr_frontmatter,
+    load_architecture_frontmatter,
     load_spec_frontmatter,
     normalise_path,
     parse_yaml_frontmatter,
 )
-from scieasy.qa.schemas.frontmatter import ADRAddendumFrontmatter, ADRFrontmatter
+from scieasy.qa.schemas.frontmatter import ADRAddendumFrontmatter, ADRFrontmatter, ArchitectureFrontmatter
 from scieasy.qa.schemas.report import AuditReport, AuditStatus, Finding, Severity
 
 _HEADING_RE = re.compile(r"^(#{1,6})\s+(.+?)\s*$")
@@ -35,6 +36,11 @@ def _is_adr_addendum(path: Path) -> bool:
 def _is_spec(path: Path) -> bool:
     parts = [part.lower() for part in path.parts]
     return "docs" in parts and "specs" in parts
+
+
+def _is_architecture(path: Path) -> bool:
+    parts = [part.lower() for part in path.parts]
+    return "docs" in parts and "architecture" in parts and path.name == "ARCHITECTURE.md"
 
 
 def _finding(path: Path, rule_id: str, message: str, *, line: int | None = None) -> Finding:
@@ -214,8 +220,25 @@ def _check_spec_body(path: Path, body: str) -> list[Finding]:
     ]
 
 
+def _check_architecture_body(path: Path, fm: ArchitectureFrontmatter, body: str) -> list[Finding]:
+    headings = _headings(body)
+    expected_h1 = fm.title
+    if not headings or headings[0][0] != 1:
+        return [_finding(path, "frontmatter.architecture-h1", "architecture body must start with an H1 title")]
+    if headings[0][1] != expected_h1:
+        return [
+            _finding(
+                path,
+                "frontmatter.architecture-h1",
+                f"architecture H1 must be '# {expected_h1}'",
+                line=headings[0][2],
+            )
+        ]
+    return []
+
+
 def lint_file(path: Path) -> list[Finding]:
-    """Validate one ADR/spec file's frontmatter and required first section."""
+    """Validate one ADR/spec/architecture file's frontmatter and required first section."""
 
     if not path.exists():
         return [_finding(path, "frontmatter.file-missing", "file does not exist", line=1)]
@@ -236,19 +259,25 @@ def lint_file(path: Path) -> list[Finding]:
             return findings
         return findings + _check_spec_body(path, body)
 
+    if _is_architecture(path):
+        architecture_fm, body, findings = load_architecture_frontmatter(path)
+        if architecture_fm is None:
+            return findings
+        return findings + _check_architecture_body(path, architecture_fm, body)
+
     return [
         Finding(
             rule_id="frontmatter.unknown-kind",
             severity=Severity.WARNING,
             file=normalise_path(path),
             line=1,
-            message="not an ADR/spec target for frontmatter lint",
+            message="not an ADR/spec/architecture target for frontmatter lint",
         )
     ]
 
 
 def check(repo_root: Path | None = None) -> list[Finding]:
-    """Validate all ADR and spec Markdown files under ``repo_root``."""
+    """Validate all ADR, spec, and architecture Markdown files under ``repo_root``."""
 
     root = Path(repo_root or Path.cwd())
     findings: list[Finding] = []
@@ -256,6 +285,7 @@ def check(repo_root: Path | None = None) -> list[Finding]:
         findings.extend(lint_file(path))
     for path in sorted((root / "docs" / "specs").glob("*.md")):
         findings.extend(lint_file(path))
+    findings.extend(lint_file(root / "docs" / "architecture" / "ARCHITECTURE.md"))
     return findings
 
 
@@ -277,7 +307,7 @@ def lint_paths(paths: list[Path], *, repo_root: Path | None = None) -> AuditRepo
 
 
 def check_report(repo_root: Path | None = None) -> AuditReport:
-    """Validate all ADR and spec Markdown files under ``repo_root`` as an audit report."""
+    """Validate all ADR, spec, and architecture Markdown files under ``repo_root`` as an audit report."""
 
     root = Path(repo_root or Path.cwd())
     findings = check(root)
@@ -294,7 +324,7 @@ def main(argv: list[str] | None = None) -> int:
     """CLI entry point for ADR/spec frontmatter validation."""
 
     parser = argparse.ArgumentParser(description="Validate ADR-042 frontmatter and document structure")
-    parser.add_argument("paths", nargs="*", type=Path, help="ADR/spec files to validate")
+    parser.add_argument("paths", nargs="*", type=Path, help="ADR/spec/architecture files to validate")
     parser.add_argument("--repo-root", type=Path, default=Path.cwd())
     parser.add_argument("--format", choices=["text", "json"], default="text")
     args = parser.parse_args(argv)

--- a/src/scieasy/qa/audit/loaders.py
+++ b/src/scieasy/qa/audit/loaders.py
@@ -9,9 +9,15 @@ from pydantic import ValidationError
 
 from scieasy.qa.audit._util import _apply_governance_amendments, parse_yaml_frontmatter
 from scieasy.qa.audit._util import load_adr_frontmatter as _load_adr_frontmatter
+from scieasy.qa.audit._util import load_architecture_frontmatter as _load_architecture_frontmatter
 from scieasy.qa.audit._util import load_maintainers as _load_maintainers
 from scieasy.qa.audit._util import load_spec_frontmatter as _load_spec_frontmatter
-from scieasy.qa.schemas.frontmatter import ADRAddendumFrontmatter, ADRFrontmatter, SpecFrontmatter
+from scieasy.qa.schemas.frontmatter import (
+    ADRAddendumFrontmatter,
+    ADRFrontmatter,
+    ArchitectureFrontmatter,
+    SpecFrontmatter,
+)
 from scieasy.qa.schemas.maintainers import Maintainers
 
 _ADR_ADDENDUM_RE = re.compile(r"^ADR-\d{3}-addendum")
@@ -54,6 +60,15 @@ def load_spec_frontmatter(path: Path) -> SpecFrontmatter:
     frontmatter, _body, findings = _load_spec_frontmatter(path)
     if frontmatter is None:
         raise ValueError(f"invalid spec frontmatter in {path}: {findings}")
+    return frontmatter
+
+
+def load_architecture_frontmatter(path: Path) -> ArchitectureFrontmatter:
+    """Load and validate architecture document frontmatter, raising on invalid input."""
+
+    frontmatter, _body, findings = _load_architecture_frontmatter(path)
+    if frontmatter is None:
+        raise ValueError(f"invalid architecture frontmatter in {path}: {findings}")
     return frontmatter
 
 

--- a/src/scieasy/qa/audit/loaders.py
+++ b/src/scieasy/qa/audit/loaders.py
@@ -2,22 +2,50 @@
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
+from pydantic import ValidationError
+
+from scieasy.qa.audit._util import _apply_governance_amendments, parse_yaml_frontmatter
 from scieasy.qa.audit._util import load_adr_frontmatter as _load_adr_frontmatter
 from scieasy.qa.audit._util import load_maintainers as _load_maintainers
 from scieasy.qa.audit._util import load_spec_frontmatter as _load_spec_frontmatter
-from scieasy.qa.schemas.frontmatter import ADRFrontmatter, SpecFrontmatter
+from scieasy.qa.schemas.frontmatter import ADRAddendumFrontmatter, ADRFrontmatter, SpecFrontmatter
 from scieasy.qa.schemas.maintainers import Maintainers
 
+_ADR_ADDENDUM_RE = re.compile(r"^ADR-\d{3}-addendum")
 
-def load_adr_frontmatter(path: Path) -> ADRFrontmatter:
-    """Load and validate ADR frontmatter, raising on invalid input."""
+
+def _is_adr_addendum(path: Path) -> bool:
+    return _ADR_ADDENDUM_RE.match(path.name) is not None
+
+
+def load_adr_frontmatter(path: Path) -> ADRFrontmatter | ADRAddendumFrontmatter:
+    """Load and validate ADR or standalone ADR addendum frontmatter."""
+
+    if _is_adr_addendum(path):
+        return load_adr_addendum_frontmatter(path)
 
     frontmatter, _body, findings = _load_adr_frontmatter(path)
     if frontmatter is None:
         raise ValueError(f"invalid ADR frontmatter in {path}: {findings}")
     return frontmatter
+
+
+def load_adr_addendum_frontmatter(path: Path) -> ADRAddendumFrontmatter:
+    """Load and validate standalone ADR addendum frontmatter."""
+
+    data, body, findings = parse_yaml_frontmatter(path)
+    if data is None:
+        raise ValueError(f"invalid ADR addendum frontmatter in {path}: {findings}")
+    data, amendment_findings = _apply_governance_amendments(data, body, path=path)
+    if amendment_findings:
+        raise ValueError(f"invalid ADR addendum frontmatter in {path}: {amendment_findings}")
+    try:
+        return ADRAddendumFrontmatter.model_validate(data)
+    except ValidationError as exc:
+        raise ValueError(f"invalid ADR addendum frontmatter in {path}: {exc}") from exc
 
 
 def load_spec_frontmatter(path: Path) -> SpecFrontmatter:

--- a/src/scieasy/qa/schemas/frontmatter.py
+++ b/src/scieasy/qa/schemas/frontmatter.py
@@ -128,6 +128,43 @@ class ADRAddendumFrontmatter(ADRFrontmatter):
     addendum: int = Field(gt=0)
 
 
+class ArchitectureFrontmatter(BaseModel):
+    """Architecture document frontmatter contract for repo-wide frontmatter lint."""
+
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+
+    doc_type: Literal["architecture"]
+    title: str = Field(min_length=4, max_length=160)
+    status: Literal["living"]
+    owner: str = Field(min_length=1)
+    last_updated: date
+    governed_by: list[str] = Field(min_length=1)
+    related_adrs: list[int]
+    summary: str = Field(min_length=8, max_length=400)
+
+    @field_validator("owner")
+    @classmethod
+    def _owner_non_empty(cls, value: str) -> str:
+        if not value:
+            raise ValueError("architecture owner must be non-empty")
+        return value
+
+    @field_validator("governed_by")
+    @classmethod
+    def _governed_by_entries(cls, values: list[str]) -> list[str]:
+        cleaned: list[str] = []
+        seen: set[str] = set()
+        for raw in values:
+            value = raw.strip()
+            if not value:
+                raise ValueError("governed_by entries must be non-empty strings")
+            if value in seen:
+                raise ValueError(f"duplicate governed_by entry: {value}")
+            seen.add(value)
+            cleaned.append(value)
+        return cleaned
+
+
 class SpecScope(BaseModel):
     """SpecKit-compatible scope record."""
 

--- a/src/scieasy/qa/schemas/frontmatter.py
+++ b/src/scieasy/qa/schemas/frontmatter.py
@@ -115,11 +115,17 @@ class ADRFrontmatter(BaseModel):
     @model_validator(mode="after")
     def _implementation_expectations(self) -> ADRFrontmatter:
         if self.is_code_implementation:
-            if self.tracking_issue is None:
+            if getattr(self, "addendum", None) is None and self.tracking_issue is None:
                 raise ValueError("is_code_implementation=true requires tracking_issue")
             if not self.tests:
                 raise ValueError("is_code_implementation=true requires tests")
         return self
+
+
+class ADRAddendumFrontmatter(ADRFrontmatter):
+    """Standalone ADR addendum frontmatter contract from ADR-042 Addendum 1."""
+
+    addendum: int = Field(gt=0)
 
 
 class SpecScope(BaseModel):

--- a/tests/qa/test_audit_frontmatter_lint.py
+++ b/tests/qa/test_audit_frontmatter_lint.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from pathlib import Path
 
 from scieasy.qa.audit.frontmatter_lint import lint_file, lint_paths
+from scieasy.qa.audit.loaders import load_adr_frontmatter
+from scieasy.qa.schemas.frontmatter import ADRAddendumFrontmatter
 from scieasy.qa.schemas.report import AuditStatus, Severity
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -64,6 +66,61 @@ translations: []
 """
 
 
+def _valid_addendum(number: int = 42, addendum: int = 1) -> str:
+    return f"""---
+adr: {number}
+addendum: {addendum}
+title: "CI-Reviewed Gate Records And Sentrux Free-Tier Checks"
+status: Accepted
+date_created: 2026-05-20
+date_accepted: 2026-05-20
+date_superseded: null
+supersedes: []
+superseded_by: null
+related: [{number}]
+closes_issues: []
+tracking_issue: null
+is_code_implementation: true
+governs:
+  modules:
+    - scieasy.qa.governance
+  contracts:
+    - scieasy.qa.governance.gate_record.GateRecord
+  entry_points: []
+  files:
+    - docs/adr/ADR-{number:03d}-addendum{addendum}.md
+  excludes: []
+tests:
+  - tests/qa/test_gate_record.py
+agent_editable: false
+assisted_by:
+  - "Codex:gpt-5"
+phase: planning
+tags: [qa, ci]
+owner: "@owner"
+co_authors: ["@codex"]
+language_source: en
+translations: []
+---
+
+# ADR-{number:03d} Addendum {addendum}: CI-Reviewed Gate Records And Sentrux Free-Tier Checks
+
+## 1. Decision Summary
+
+| Decision | Change | Enforcement target | Detailed section |
+|---|---|---|---|
+| D1. Addendum support | Validate standalone addenda | Frontmatter lint | Section 2 |
+
+### 1.1 Problems Addressed
+
+| Problem | Risk | Decision | Detailed section |
+|---|---|---|---|
+| Addenda fail ADR filename checks | Locked ADRs cannot receive compliant updates | Add addendum-specific schema selection | Section 2 |
+
+## 2. Addendum Details
+"""
+
+
 def test_valid_adr_frontmatter_and_structure_pass(tmp_path: Path) -> None:
     path = _write(tmp_path / "docs" / "adr" / "ADR-123.md", _valid_adr())
 
@@ -104,6 +161,76 @@ def test_adr_detail_section_references_must_resolve(tmp_path: Path) -> None:
     path = _write(
         tmp_path / "docs" / "adr" / "ADR-123.md",
         _valid_adr().replace("Section 2", "Section 9"),
+    )
+
+    findings = lint_file(path)
+
+    assert any(f.rule_id == "frontmatter.adr-detail-section" for f in findings)
+
+
+def test_valid_adr_addendum_frontmatter_and_structure_pass(tmp_path: Path) -> None:
+    path = _write(tmp_path / "docs" / "adr" / "ADR-042-addendum1.md", _valid_addendum())
+
+    assert lint_file(path) == []
+
+
+def test_adr_addendum_filename_must_match_number_and_addendum(tmp_path: Path) -> None:
+    path = _write(tmp_path / "docs" / "adr" / "ADR-042-addendum2.md", _valid_addendum())
+
+    findings = lint_file(path)
+
+    assert any(f.rule_id == "frontmatter.adr-addendum-filename" for f in findings)
+
+
+def test_adr_addendum_malformed_filename_fails_filename_rule(tmp_path: Path) -> None:
+    path = _write(tmp_path / "docs" / "adr" / "ADR-042-addendum-one.md", _valid_addendum())
+
+    findings = lint_file(path)
+
+    assert any(f.rule_id == "frontmatter.adr-addendum-filename" for f in findings)
+
+
+def test_adr_addendum_requires_addendum_number(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path / "docs" / "adr" / "ADR-042-addendum1.md",
+        _valid_addendum().replace("addendum: 1\n", ""),
+    )
+
+    findings = lint_file(path)
+
+    assert findings[0].severity is Severity.ERROR
+    assert findings[0].rule_id == "frontmatter.validation"
+    assert "addendum" in findings[0].message
+
+
+def test_adr_addendum_loader_selects_addendum_schema(tmp_path: Path) -> None:
+    path = _write(tmp_path / "docs" / "adr" / "ADR-042-addendum1.md", _valid_addendum())
+
+    frontmatter = load_adr_frontmatter(path)
+
+    assert isinstance(frontmatter, ADRAddendumFrontmatter)
+    assert frontmatter.adr == 42
+    assert frontmatter.addendum == 1
+
+
+def test_adr_addendum_h1_must_match_title_and_number(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path / "docs" / "adr" / "ADR-042-addendum1.md",
+        _valid_addendum().replace(
+            "# ADR-042 Addendum 1: CI-Reviewed Gate Records And Sentrux Free-Tier Checks",
+            "# ADR-042: CI-Reviewed Gate Records And Sentrux Free-Tier Checks",
+        ),
+    )
+
+    findings = lint_file(path)
+
+    assert any(f.rule_id == "frontmatter.adr-h1" for f in findings)
+
+
+def test_adr_addendum_detail_section_references_must_resolve(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path / "docs" / "adr" / "ADR-042-addendum1.md",
+        _valid_addendum().replace("Section 2", "Section 9"),
     )
 
     findings = lint_file(path)
@@ -192,6 +319,7 @@ language_source: en
 def test_adr042_governance_documents_pass_frontmatter_lint() -> None:
     paths = [
         REPO_ROOT / "docs" / "adr" / "ADR-042.md",
+        REPO_ROOT / "docs" / "adr" / "ADR-042-addendum1.md",
         REPO_ROOT / "docs" / "specs" / "adr-042-consistency-tools.md",
     ]
 

--- a/tests/qa/test_audit_frontmatter_lint.py
+++ b/tests/qa/test_audit_frontmatter_lint.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from scieasy.qa.audit.frontmatter_lint import lint_file, lint_paths
-from scieasy.qa.audit.loaders import load_adr_frontmatter
-from scieasy.qa.schemas.frontmatter import ADRAddendumFrontmatter
+from scieasy.qa.audit.frontmatter_lint import check, lint_file, lint_paths
+from scieasy.qa.audit.loaders import load_adr_frontmatter, load_architecture_frontmatter
+from scieasy.qa.schemas.frontmatter import ADRAddendumFrontmatter, ArchitectureFrontmatter
 from scieasy.qa.schemas.report import AuditStatus, Severity
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -121,6 +121,28 @@ translations: []
 """
 
 
+def _valid_architecture() -> str:
+    return """---
+doc_type: architecture
+title: "SciEasy Architecture Document"
+status: living
+owner: "@owner"
+last_updated: 2026-05-19
+governed_by:
+  - ADR-042
+  - ADR-043
+related_adrs:
+  - 42
+  - 43
+summary: "Stable architecture overview for SciEasy runtime and governance layers."
+---
+
+# SciEasy Architecture Document
+
+## 1. Problem statement
+"""
+
+
 def test_valid_adr_frontmatter_and_structure_pass(tmp_path: Path) -> None:
     path = _write(tmp_path / "docs" / "adr" / "ADR-123.md", _valid_adr())
 
@@ -211,6 +233,59 @@ def test_adr_addendum_loader_selects_addendum_schema(tmp_path: Path) -> None:
     assert isinstance(frontmatter, ADRAddendumFrontmatter)
     assert frontmatter.adr == 42
     assert frontmatter.addendum == 1
+
+
+def test_valid_architecture_frontmatter_and_h1_pass(tmp_path: Path) -> None:
+    path = _write(tmp_path / "docs" / "architecture" / "ARCHITECTURE.md", _valid_architecture())
+
+    assert lint_file(path) == []
+    frontmatter = load_architecture_frontmatter(path)
+    assert isinstance(frontmatter, ArchitectureFrontmatter)
+
+
+def test_architecture_frontmatter_rejects_invalid_doc_type(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path / "docs" / "architecture" / "ARCHITECTURE.md",
+        _valid_architecture().replace("doc_type: architecture", "doc_type: guide"),
+    )
+
+    findings = lint_file(path)
+
+    assert findings[0].severity is Severity.ERROR
+    assert findings[0].rule_id == "frontmatter.validation"
+    assert "doc_type" in findings[0].message
+
+
+def test_architecture_frontmatter_requires_owner(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path / "docs" / "architecture" / "ARCHITECTURE.md",
+        _valid_architecture().replace('owner: "@owner"\n', ""),
+    )
+
+    findings = lint_file(path)
+
+    assert findings[0].severity is Severity.ERROR
+    assert findings[0].rule_id == "frontmatter.validation"
+    assert "owner" in findings[0].message
+
+
+def test_architecture_h1_must_match_title(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path / "docs" / "architecture" / "ARCHITECTURE.md",
+        _valid_architecture().replace("# SciEasy Architecture Document", "# Wrong Architecture Title"),
+    )
+
+    findings = lint_file(path)
+
+    assert any(f.rule_id == "frontmatter.architecture-h1" for f in findings)
+
+
+def test_frontmatter_check_includes_architecture_doc(tmp_path: Path) -> None:
+    _write(tmp_path / "docs" / "architecture" / "ARCHITECTURE.md", _valid_architecture())
+
+    findings = check(tmp_path)
+
+    assert findings == []
 
 
 def test_adr_addendum_h1_must_match_title_and_number(tmp_path: Path) -> None:
@@ -325,3 +400,9 @@ def test_adr042_governance_documents_pass_frontmatter_lint() -> None:
 
     for path in paths:
         assert lint_file(path) == []
+
+
+def test_repo_architecture_document_passes_frontmatter_lint() -> None:
+    path = REPO_ROOT / "docs" / "architecture" / "ARCHITECTURE.md"
+
+    assert lint_file(path) == []


### PR DESCRIPTION
## Summary
- Adds `ADRAddendumFrontmatter` for standalone ADR addendum files such as `ADR-042-addendum1.md`.
- Updates frontmatter lint selection and public ADR loader support for addendum files while preserving ordinary ADR checks.
- Adds Track A tests for valid addenda, filename/addendum mismatches, missing addendum numbers, wrong H1, unresolved section references, and loader selection.
- Updates only Track A checklist rows with verification results.

## Verification
- `PYTHONPATH=src pytest tests/qa/test_audit_frontmatter_lint.py --timeout=60 --no-cov` -> 15 passed.
- `ruff check src/scieasy/qa/schemas/frontmatter.py src/scieasy/qa/audit/frontmatter_lint.py src/scieasy/qa/audit/loaders.py tests/qa/test_audit_frontmatter_lint.py` -> passed.
- `ruff format --check src/scieasy/qa/schemas/frontmatter.py src/scieasy/qa/audit/frontmatter_lint.py src/scieasy/qa/audit/loaders.py tests/qa/test_audit_frontmatter_lint.py` -> passed.
- `PYTHONPATH=src python -m scieasy.qa.audit.frontmatter_lint docs/adr/ADR-042-addendum1.md` -> passed.

## Notes
- The mandatory bare targeted command `pytest tests/qa/test_audit_frontmatter_lint.py --timeout=60` had all assertions pass but exited non-zero because the repository global coverage fail-under checks the whole package for this single-file run.

Closes #1268