### PR TITLE
fix(#1316): whitelist workflow gate records

### DIFF
--- a/.workflow/records/1316-workflow-records-mod-guard-whitelist.json
+++ b/.workflow/records/1316-workflow-records-mod-guard-whitelist.json
@@ -1,0 +1,183 @@
+{
+  "admin_labels": [],
+  "amendments": [
+    {
+      "approved_by": null,
+      "exclude": [],
+      "include": [],
+      "reason": "Implementation completed within planned scope: .workflow/records whitelist plus regression tests and checklist."
+    }
+  ],
+  "branch": "codex/adr042-docgen-checklist",
+  "changed_test_paths": [
+    "tests/qa/test_governance_mod_guard.py"
+  ],
+  "check_results": [
+    {
+      "command_or_tool": "ruff check src/scieasy/qa/governance/mod_guard.py tests/qa/test_governance_mod_guard.py && ruff format --check src/scieasy/qa/governance/mod_guard.py tests/qa/test_governance_mod_guard.py",
+      "exit_code": 0,
+      "name": "ruff",
+      "output_path": "ruff check passed; ruff format --check passed",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "PYTHONPATH=src PYTEST_ADDOPTS=--no-cov pytest tests/qa/test_governance_mod_guard.py --timeout=60",
+      "exit_code": 0,
+      "name": "targeted-pytest",
+      "output_path": "8 passed",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "PYTHONPATH=src python -m scieasy.qa.audit.frontmatter_lint docs/adr/ADR-042.md docs/specs/adr-042-documentation-tools.md --format text",
+      "exit_code": 0,
+      "name": "frontmatter-lint",
+      "output_path": "passed: governing ADR/spec frontmatter check",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    }
+  ],
+  "commit": {
+    "gate_record_path": ".workflow/records/1316-workflow-records-mod-guard-whitelist.json",
+    "shas": [
+      "b9442064"
+    ],
+    "trailers": {}
+  },
+  "docs_landing": {
+    "adr": {
+      "not_applicable": true,
+      "rationale": "owner-authorized-narrow-guard-behavior-without-changing-adr-042-semantics"
+    },
+    "changelog": {
+      "not_applicable": true,
+      "rationale": "bugfix-and-tracking-checklist-no-user-facing-release-note"
+    },
+    "checklist": {
+      "paths": [
+        "docs/planning/adr-042-documentation-generation-checklist.md"
+      ]
+    },
+    "docs": {
+      "not_applicable": true,
+      "rationale": "implementation-linked-documentation-is-the-tracking-checklist-for-this-narrow-governance-fix"
+    },
+    "spec": {
+      "not_applicable": true,
+      "rationale": "owner-authorized-narrow-implementation-fix-covered-by-issue-1316"
+    }
+  },
+  "full_audit": {
+    "blocks_merge": true,
+    "command": "PYTHONPATH=src python -m scieasy.qa.audit.full_audit --repo-root . --format json --output %TEMP%\\scieasy-1316-full-audit.json --no-stale-check",
+    "exit_code": 1,
+    "known_debt": [
+      "pre-existing ADR/frontmatter/closure/signature/architecture drift baseline unrelated to .workflow/records whitelist and checklist"
+    ],
+    "output_path": "C:\\Users\\jiazh\\AppData\\Local\\Temp\\scieasy-1316-full-audit.json",
+    "status": "fail",
+    "summary": {},
+    "unclassified_failures": []
+  },
+  "governance_touch": true,
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1316,
+      "url": "https://github.com/zjzcpj/SciEasy/issues/1316"
+    }
+  ],
+  "owner_directive": "Whitelist only .workflow/records/** in governance modification guard so every agent can commit gate records without broad governance approval; keep all other protected files guarded. Also keep ADR-042 documentation-generation checklist tracking.",
+  "planned_files": [
+    "src/scieasy/qa/governance/mod_guard.py",
+    "tests/qa/test_governance_mod_guard.py",
+    "docs/planning/adr-042-documentation-generation-checklist.md",
+    ".workflow/records/1316-workflow-records-mod-guard-whitelist.json"
+  ],
+  "pull_request": {
+    "body_closes_issues": [
+      1316,
+      1314
+    ],
+    "number": 1317,
+    "url": "https://github.com/zjzcpj/SciEasy/pull/1317"
+  },
+  "record_path": ".workflow/records/1316-workflow-records-mod-guard-whitelist.json",
+  "required_checks": [
+    "ruff",
+    "targeted-pytest",
+    "frontmatter-lint",
+    "full-audit",
+    "sentrux"
+  ],
+  "schema_version": "1",
+  "scope": {
+    "exclude": [
+      "frontend/**"
+    ],
+    "include": [
+      "src/scieasy/qa/governance/mod_guard.py",
+      "tests/qa/test_governance_mod_guard.py",
+      "docs/planning/adr-042-documentation-generation-checklist.md",
+      ".workflow/records/1316-workflow-records-mod-guard-whitelist.json"
+    ]
+  },
+  "sentrux": {
+    "command_or_tool": "C:\\Users\\jiazh\\Desktop\\workspace\\SciEasy\\sentrux.exe check .",
+    "mode": "free-tier",
+    "name": "sentrux.free_tier",
+    "output_path": "sentrux check: 11 rules checked; Quality 4130; all rules pass",
+    "pro_required": false,
+    "quality_signal": 4130.0,
+    "rules_checked": 11,
+    "status": "pass",
+    "summary": {},
+    "thresholds": {},
+    "total_rules_defined": 11
+  },
+  "stages": [
+    {
+      "completed_at": null,
+      "stage": "scope_and_issue",
+      "status": "done",
+      "summary": null
+    },
+    {
+      "completed_at": null,
+      "stage": "plan",
+      "status": "done",
+      "summary": null
+    },
+    {
+      "completed_at": null,
+      "stage": "implement",
+      "status": "done",
+      "summary": null
+    },
+    {
+      "completed_at": null,
+      "stage": "update_docs",
+      "status": "done",
+      "summary": null
+    },
+    {
+      "completed_at": null,
+      "stage": "test_and_checks",
+      "status": "done",
+      "summary": null
+    },
+    {
+      "completed_at": null,
+      "stage": "commit_and_submit_pr",
+      "status": "done",
+      "summary": null
+    }
+  ],
+  "task_id": "1316-workflow-records-mod-guard-whitelist",
+  "task_kind": "bugfix"
+}

--- a/docs/planning/adr-042-documentation-generation-checklist.md
+++ b/docs/planning/adr-042-documentation-generation-checklist.md
@@ -1,0 +1,78 @@
+# ADR-042 Documentation Generation Tooling Checklist
+
+Tracking issue: #1314
+
+This checklist records the current rollout state for ADR-042 documentation
+generation and adjacent QA tooling. It is evidence-only tracking; the governing
+contracts remain `docs/adr/ADR-042.md`,
+`docs/specs/adr-042-documentation-tools.md`, and the related ADR-042 specs.
+
+## Conventions
+
+- `[x]` implemented and wired to at least one runnable workflow.
+- `[~]` implemented but not fully wired to the ADR-042 target pipeline.
+- `[ ]` specified by ADR-042/specs but not implemented in the repository.
+- Evidence paths name current implementation or the absence observed during the
+  2026-05-21 audit for #1314.
+
+## ADR-042 Generated Documentation Targets
+
+| Status | Target | ADR-042 source | Current evidence | Follow-up |
+|---|---|---|---|---|
+| [ ] | Python API reference at `docs/user/reference/api/` | `docs/adr/ADR-042.md` Section 6.3 | No `docs/user/` tree; no Sphinx config found. | Implement Sphinx/griffe-backed API reference generator. |
+| [ ] | Schema reference at `docs/user/reference/schemas/` | `docs/adr/ADR-042.md` Section 6.3 | No `src/scieasy/qa/docs/schema_reference.py`; no generated target. | Implement Pydantic schema reference generator. |
+| [ ] | CLI reference at `docs/user/reference/cli.md` | `docs/adr/ADR-042.md` Section 6.3 | No `src/scieasy/qa/docs/cli_reference.py`; no generated target. | Implement Typer command-tree reference generator. |
+| [ ] | Server API reference at `docs/user/reference/server-api.md` | `docs/adr/ADR-042.md` Section 6.3 | No `src/scieasy/qa/docs/openapi_reference.py`; no generated target. | Implement FastAPI OpenAPI reference generator. |
+| [ ] | Entry-point catalog at `docs/user/reference/entry-points.md` | `docs/adr/ADR-042.md` Section 6.3 | No `src/scieasy/qa/docs/entry_point_catalog.py`; no generated target. | Implement `importlib.metadata.entry_points()` catalog generator. |
+| [ ] | Block catalog at `docs/user/reference/blocks/` | `docs/adr/ADR-042.md` Section 6.3 | No `src/scieasy/qa/docs/block_catalog.py`; no generated target. | Implement block-registry catalog generator. |
+| [ ] | Runner catalog at `docs/user/reference/runners/` | `docs/adr/ADR-042.md` Section 6.3 | No `src/scieasy/qa/docs/runner_catalog.py`; no generated target. | Implement runner-registry catalog generator. |
+| [ ] | Tutorial gallery under `docs/user/tutorials/` and `docs/user/examples-gallery/` | `docs/adr/ADR-042.md` Section 6.3 | No `sphinx-gallery` wiring or generated gallery target found. | Decide rollout timing after Sphinx docs root exists. |
+| [ ] | LLM context file at `docs/user/llms.txt` | `docs/adr/ADR-042.md` Section 6.3 | No `src/scieasy/qa/docs/llms_txt.py`; no `docs/user/llms.txt`. | Implement deterministic `llms.txt` generator. |
+| [~] | Facts registry at `docs/facts/generated.yaml` | `docs/adr/ADR-042.md` Section 6.3 | `scripts/audit/generate_facts.py` and `scieasy.qa.audit.facts` exist; `docs/facts/generated.yaml` is absent in this checkout. | Decide whether generated facts should be committed or produced only as gate evidence. |
+
+## ADR-042 Documentation Tooling
+
+| Status | Tool | ADR/spec source | Current evidence | Follow-up |
+|---|---|---|---|---|
+| [x] | `frontmatter_lint` | `docs/specs/adr-042-documentation-tools.md` FR-001..FR-005 | `src/scieasy/qa/audit/frontmatter_lint.py`; `tests/qa/test_audit_frontmatter_lint.py`; included by `full_audit`. | None for current slice. |
+| [ ] | `doc_length_lint` | `docs/specs/adr-042-documentation-tools.md` FR-006..FR-007 | No `src/scieasy/qa/audit/doc_length_lint.py`; no `tests/qa/test_doc_length_lint.py`. | Implement report-only first, then hard-fail per ADR-042 rollout. |
+| [ ] | `auto_generated_lint` | `docs/specs/adr-042-documentation-tools.md` FR-008..FR-009 | No `src/scieasy/qa/audit/auto_generated_lint.py`; no generated-doc manifest. | Implement after at least one deterministic generated-doc target exists. |
+| [ ] | `skill_pointer_sync` | `docs/specs/adr-042-documentation-tools.md` FR-012 | No `src/scieasy/qa/audit/skill_pointer_sync.py`; no `tests/qa/test_skill_pointer_sync.py`. | Implement pointer parity checks for `.agents/`, `.claude/`, and `.codex/`. |
+| [ ] | Generated-doc manifest | `docs/specs/adr-042-documentation-tools.md` Section 4.5 | No `docs/user/reference/generated-docs.yaml`. | Add manifest schema with generator id, target path, inputs, and source hash. |
+| [ ] | Sphinx build with warnings as errors | `docs/adr/ADR-042.md` Sections 6.4..6.7 | No `docs/sphinx/conf.py`; no Sphinx dependencies in `pyproject.toml`; no docs-build CI job. | Add docs build only after generated references are deterministic. |
+| [ ] | ADR-042 generation pipeline order | `docs/adr/ADR-042.md` Section 6.5 | No pipeline currently runs facts -> references -> `llms.txt` -> Sphinx -> generated-doc lint -> drift checks. | Add a single documented command and CI job once missing generators land. |
+
+## Implemented Consistency Tools Relevant To Documentation
+
+| Status | Tool | Current evidence | Wiring state |
+|---|---|---|---|
+| [x] | `griffe_facts` | `src/scieasy/qa/audit/griffe_facts.py`; `tests/qa/test_griffe_facts.py`. | Used by `generate_facts`. |
+| [~] | `generate_facts` | `src/scieasy/qa/audit/facts.py`; `scripts/audit/generate_facts.py`; `tests/qa/test_generate_facts_cli.py`. | Runnable and used by `full_audit`; generated target is absent from the tree. |
+| [x] | `fact_drift` | `src/scieasy/qa/audit/fact_drift.py`; `tests/qa/test_audit_fact_drift.py`. | Included by `full_audit`. |
+| [x] | `doc_drift` | `src/scieasy/qa/audit/doc_drift.py`; `tests/qa/test_audit_doc_drift.py`. | Included by `full_audit`. |
+| [x] | `closure` | `src/scieasy/qa/audit/closure.py`; `tests/qa/test_audit_closure.py`. | Included by `full_audit`. |
+| [x] | `signature_drift` | `src/scieasy/qa/audit/signature_drift.py`; `tests/qa/test_audit_signature_drift.py`. | Included by `full_audit`. |
+| [x] | `architecture_drift` | `src/scieasy/qa/audit/architecture_drift.py`; `tests/qa/test_architecture_drift.py`. | Included by `full_audit` via ADR-042 Addendum 1 work. |
+| [x] | `full_audit` | `src/scieasy/qa/audit/full_audit.py`; `tests/qa/test_audit_full_audit.py`. | Runnable CLI; gate workflow validates recorded full-audit evidence. |
+
+## Adjacent ADR-042 Tooling Not Yet In Documentation Pipeline
+
+| Status | Tool family | Current evidence | Note |
+|---|---|---|---|
+| [x] | Gate records and PR workflow guards | `src/scieasy/qa/governance/gate_record.py`; `.github/workflows/workflow-gate.yml`; `.pre-commit-config.yaml`; `tests/qa/test_gate_record*.py`. | Implemented by ADR-042 Addendum 1, not a docs generator. |
+| [x] | Docs landing guard | `src/scieasy/qa/governance/docs_landing.py`; `tests/qa/test_docs_landing.py`; workflow-gate orchestration. | Enforces docs evidence in gate records. |
+| [ ] | `complete_artifacts`, `codemod_lint`, `trailer_lint`, `committer_enforce` | Listed in `docs/specs/adr-042-ai-governance-tools.md`; no corresponding modules found. | Track separately from documentation generation. |
+| [ ] | `code_score` and `test_quality` | Listed in `docs/specs/adr-042-code-quality-tools.md`; no `src/scieasy/qa/code_score/` or `src/scieasy/qa/test_quality/` found. | Track separately from documentation generation. |
+
+## Open Follow-Ups
+
+- [ ] Create an implementation issue for `doc_length_lint`,
+      `auto_generated_lint`, and generated-doc manifest rollout.
+- [ ] Create an implementation issue for `src/scieasy/qa/docs/**`
+      generators: `llms_txt`, `entry_point_catalog`, `cli_reference`,
+      `openapi_reference`, `schema_reference`, `block_catalog`, and
+      `runner_catalog`.
+- [ ] Create an implementation issue for Sphinx docs root and docs-build CI
+      once at least one generated reference target is deterministic.
+- [ ] Decide whether `docs/facts/generated.yaml` should be committed as
+      canonical generated evidence or kept out of tree and produced in gate/CI.

--- a/src/scieasy/qa/governance/mod_guard.py
+++ b/src/scieasy/qa/governance/mod_guard.py
@@ -29,6 +29,8 @@ PROTECTED_PATTERNS: tuple[str, ...] = (
     "tests/qa/**",
 )
 
+UNPROTECTED_PATTERNS: tuple[str, ...] = (".workflow/records/**",)
+
 
 def _run_git(repo_root: Path, args: list[str]) -> str:
     return subprocess.check_output(["git", *args], cwd=repo_root, text=True, stderr=subprocess.DEVNULL)
@@ -52,6 +54,8 @@ def _changed_files(repo_root: Path, *, base_ref: str, head_ref: str, staged: boo
 
 def _is_protected(path: str) -> bool:
     normalized = path.replace("\\", "/")
+    if any(fnmatch.fnmatchcase(normalized, pattern) for pattern in UNPROTECTED_PATTERNS):
+        return False
     return any(fnmatch.fnmatchcase(normalized, pattern) for pattern in PROTECTED_PATTERNS)
 
 

--- a/tests/qa/test_governance_mod_guard.py
+++ b/tests/qa/test_governance_mod_guard.py
@@ -4,6 +4,8 @@ import os
 import subprocess
 from pathlib import Path
 
+import pytest
+
 from scieasy.qa.governance import mod_guard
 from scieasy.qa.schemas.report import AuditStatus
 
@@ -53,6 +55,28 @@ def test_mod_guard_blocks_protected_staged_change_without_approval(tmp_path: Pat
     assert [finding.file for finding in report.findings] == [".pre-commit-config.yaml"]
 
 
+def test_mod_guard_allows_gate_record_without_approval(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    _write(repo, ".workflow/records/123-example.json", "{}\n")
+    _git(repo, "add", ".")
+
+    report = mod_guard.check(repo, staged=True)
+
+    assert report.status == AuditStatus.PASS
+    assert report.summary["changed_protected_files"] == []
+
+
+def test_mod_guard_still_blocks_non_record_workflow_change_without_approval(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    _write(repo, ".workflow/gate-record.schema.json", "{}\n")
+    _git(repo, "add", ".")
+
+    report = mod_guard.check(repo, staged=True)
+
+    assert report.status == AuditStatus.FAIL
+    assert [finding.file for finding in report.findings] == [".workflow/gate-record.schema.json"]
+
+
 def test_mod_guard_allows_protected_change_with_explicit_flag(tmp_path: Path) -> None:
     repo = _init_repo(tmp_path)
     _write(repo, "src/scieasy/qa/governance/mod_guard.py", "print('changed')\n")
@@ -64,7 +88,9 @@ def test_mod_guard_allows_protected_change_with_explicit_flag(tmp_path: Path) ->
     assert report.summary["changed_protected_files"] == ["src/scieasy/qa/governance/mod_guard.py"]
 
 
-def test_mod_guard_allows_protected_change_with_environment_override(tmp_path: Path, monkeypatch) -> None:
+def test_mod_guard_allows_protected_change_with_environment_override(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     repo = _init_repo(tmp_path)
     _write(repo, "tests/qa/test_example.py", "def test_example():\n    assert True\n")
     _git(repo, "add", ".")
@@ -76,7 +102,7 @@ def test_mod_guard_allows_protected_change_with_environment_override(tmp_path: P
     assert os.environ[mod_guard.APPROVAL_ENV] == "1"
 
 
-def test_mod_guard_accepts_adr042_local_bypass_labels(tmp_path: Path, monkeypatch) -> None:
+def test_mod_guard_accepts_adr042_local_bypass_labels(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     repo = _init_repo(tmp_path)
     _write(repo, ".pre-commit-config.yaml", "repos:\n  - repo: local\n")
     _git(repo, "add", ".")
@@ -88,7 +114,7 @@ def test_mod_guard_accepts_adr042_local_bypass_labels(tmp_path: Path, monkeypatc
     assert report.summary["bypassed"] is True
 
 
-def test_mod_guard_rejects_invalid_adr042_local_bypass_label(tmp_path: Path, monkeypatch) -> None:
+def test_mod_guard_rejects_invalid_adr042_local_bypass_label(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     repo = _init_repo(tmp_path)
     _write(repo, ".pre-commit-config.yaml", "repos:\n  - repo: local\n")
     _git(repo, "add", ".")


### PR DESCRIPTION
﻿## Summary
- whitelist only `.workflow/records/**` in `mod_guard` so agent gate records do not require broad governance-change approval
- keep all other `.workflow/**` paths protected with regression coverage
- add ADR-042 documentation-generation tooling rollout checklist

## Validation
- `ruff check src/scieasy/qa/governance/mod_guard.py tests/qa/test_governance_mod_guard.py`
- `ruff format --check src/scieasy/qa/governance/mod_guard.py tests/qa/test_governance_mod_guard.py`
- `PYTHONPATH=src PYTEST_ADDOPTS=--no-cov pytest tests/qa/test_governance_mod_guard.py --timeout=60` -> 8 passed
- `PYTHONPATH=src python -m scieasy.qa.audit.frontmatter_lint docs/adr/ADR-042.md docs/specs/adr-042-documentation-tools.md --format text`
- `C:\Users\jiazh\Desktop\workspace\SciEasy\sentrux.exe check .` -> 11 rules checked, Quality 4130, all pass
- `PYTHONPATH=src python -m scieasy.qa.audit.full_audit --repo-root . --format json --output %TEMP%\scieasy-1316-full-audit.json --no-stale-check` -> known pre-existing ADR/frontmatter/closure/signature/architecture drift baseline, recorded in gate record

Gate record: `.workflow/records/1316-workflow-records-mod-guard-whitelist.json`

Closes #1314
Closes #1316
