### PR TITLE
fix(#1330): engine auto-wrap bare DataObject into length-one Collection

### DIFF
--- a/.workflow/records/1330-engine-collection-wrap.json
+++ b/.workflow/records/1330-engine-collection-wrap.json
@@ -48,7 +48,13 @@
       "timestamp": null
     }
   ],
-  "commit": null,
+  "commit": {
+    "gate_record_path": ".workflow/records/1330-engine-collection-wrap.json",
+    "shas": [
+      "a4724d7af4e04452e26dcebb05fad05414d8401e"
+    ],
+    "trailers": {}
+  },
   "docs_landing": {
     "adr": {
       "not_applicable": true,
@@ -98,7 +104,11 @@
     "tests/engine/test_collection_wrap.py",
     ".workflow/records/1330-engine-collection-wrap.json"
   ],
-  "pull_request": null,
+  "pull_request": {
+    "body_closes_issues": [],
+    "number": null,
+    "url": null
+  },
   "record_path": ".workflow/records/1330-engine-collection-wrap.json",
   "required_checks": [
     "pytest:tests/engine/test_collection_wrap.py",
@@ -165,7 +175,7 @@
     {
       "completed_at": null,
       "stage": "commit_and_submit_pr",
-      "status": "pending",
+      "status": "done",
       "summary": null
     }
   ],

--- a/.workflow/records/1330-engine-collection-wrap.json
+++ b/.workflow/records/1330-engine-collection-wrap.json
@@ -51,7 +51,7 @@
   "commit": {
     "gate_record_path": ".workflow/records/1330-engine-collection-wrap.json",
     "shas": [
-      "a4724d7af4e04452e26dcebb05fad05414d8401e"
+      "3080156dd4946b082098b4e4fabf144d7fab905e"
     ],
     "trailers": {}
   },
@@ -105,9 +105,11 @@
     ".workflow/records/1330-engine-collection-wrap.json"
   ],
   "pull_request": {
-    "body_closes_issues": [],
-    "number": null,
-    "url": null
+    "body_closes_issues": [
+      1330
+    ],
+    "number": 1338,
+    "url": "https://github.com/zjzcpj/SciStudio/pull/1338"
   },
   "record_path": ".workflow/records/1330-engine-collection-wrap.json",
   "required_checks": [

--- a/.workflow/records/1330-engine-collection-wrap.json
+++ b/.workflow/records/1330-engine-collection-wrap.json
@@ -72,7 +72,10 @@
       "not_applicable": true,
       "rationale": "manager-owned checklist at docs/planning/arch-drift-checklist.md is updated by manager, not implementer (per dispatch prompt scope: out of scope)"
     },
-    "docs": {},
+    "docs": {
+      "not_applicable": true,
+      "rationale": "Engine-internal boundary enforcement (worker.py + scheduler.py); no public-facing user docs are affected. The ADR-020 + ARCHITECTURE.md contract description is unchanged and already covers this behavior."
+    },
     "spec": {
       "not_applicable": true,
       "rationale": "no public contract or schema change"
@@ -94,7 +97,7 @@
       "close_in_pr": true,
       "followup_rationale": null,
       "number": 1330,
-      "url": null
+      "url": "https://github.com/zjzcpj/SciStudio/issues/1330"
     }
   ],
   "owner_directive": "Implement engine-side auto-wrap of bare DataObject into length-one Collection at output boundary; ADR-020 \u00a73 contract enforcement; do not touch the six existing manual wraps.",

--- a/.workflow/records/1330-engine-collection-wrap.json
+++ b/.workflow/records/1330-engine-collection-wrap.json
@@ -1,0 +1,174 @@
+{
+  "admin_labels": [],
+  "amendments": [
+    {
+      "approved_by": "owner",
+      "exclude": [],
+      "include": [],
+      "reason": "no scope change; verifying implementation matches initial plan; governance_touch=true because .workflow/records/ is governance-protected"
+    }
+  ],
+  "branch": "fix/issue-1330-engine-collection-wrap",
+  "changed_test_paths": [],
+  "check_results": [
+    {
+      "command_or_tool": "python -m pytest tests/engine/test_collection_wrap.py --no-cov --timeout=60",
+      "exit_code": 0,
+      "name": "pytest:tests/engine/test_collection_wrap.py",
+      "output_path": null,
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "python -m pytest tests/engine/test_scheduler.py --no-cov --timeout=60",
+      "exit_code": 0,
+      "name": "pytest:tests/engine/test_scheduler.py",
+      "output_path": null,
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "python -m ruff check src/scistudio/engine/ tests/engine/test_collection_wrap.py",
+      "exit_code": 0,
+      "name": "ruff-check",
+      "output_path": null,
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "python -m ruff format --check src/scistudio/engine/ tests/engine/test_collection_wrap.py",
+      "exit_code": 0,
+      "name": "ruff-format",
+      "output_path": null,
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    }
+  ],
+  "commit": null,
+  "docs_landing": {
+    "adr": {
+      "not_applicable": true,
+      "rationale": "ADR-020 \u00a73 contract text already matches the implementation; only the engine-side enforcement gap closes \u2014 no ADR change needed"
+    },
+    "architecture-doc": {
+      "not_applicable": true,
+      "rationale": "docs/architecture/ARCHITECTURE.md lines 1120-1130 already describe the Collection transport contract; out of scope per owner directive 2026-05-21"
+    },
+    "changelog": {
+      "not_applicable": true,
+      "rationale": "internal engine boundary enforcement; no user-facing API or behaviour change \u2014 blocks that already self-wrap continue to work; blocks that returned bare DataObject now silently wrap (the contract was implicit before)"
+    },
+    "checklist": {
+      "not_applicable": true,
+      "rationale": "manager-owned checklist at docs/planning/arch-drift-checklist.md is updated by manager, not implementer (per dispatch prompt scope: out of scope)"
+    },
+    "docs": {},
+    "spec": {
+      "not_applicable": true,
+      "rationale": "no public contract or schema change"
+    }
+  },
+  "full_audit": {
+    "blocks_merge": false,
+    "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output docs/audit/full-audit-latest.json",
+    "exit_code": 0,
+    "known_debt": [],
+    "output_path": "docs/audit/full-audit-latest.json",
+    "status": "pass",
+    "summary": {},
+    "unclassified_failures": []
+  },
+  "governance_touch": true,
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1330,
+      "url": null
+    }
+  ],
+  "owner_directive": "Implement engine-side auto-wrap of bare DataObject into length-one Collection at output boundary; ADR-020 \u00a73 contract enforcement; do not touch the six existing manual wraps.",
+  "planned_files": [
+    "src/scistudio/engine/runners/worker.py",
+    "src/scistudio/engine/scheduler.py",
+    "tests/engine/test_collection_wrap.py",
+    ".workflow/records/1330-engine-collection-wrap.json"
+  ],
+  "pull_request": null,
+  "record_path": ".workflow/records/1330-engine-collection-wrap.json",
+  "required_checks": [
+    "pytest:tests/engine/test_collection_wrap.py",
+    "pytest:tests/engine/test_scheduler.py",
+    "ruff-check",
+    "ruff-format",
+    "full-audit",
+    "sentrux"
+  ],
+  "schema_version": "1",
+  "scope": {
+    "exclude": [],
+    "include": [
+      "src/scistudio/engine/runners/worker.py",
+      "src/scistudio/engine/scheduler.py",
+      "tests/engine/test_collection_wrap.py",
+      ".workflow/records/1330-engine-collection-wrap.json"
+    ]
+  },
+  "sentrux": {
+    "command_or_tool": "sentrux",
+    "mode": "free-tier",
+    "name": "sentrux.free_tier",
+    "output_path": null,
+    "pro_required": false,
+    "quality_signal": 4125.0,
+    "rules_checked": 3,
+    "status": "pass",
+    "summary": {},
+    "thresholds": {},
+    "total_rules_defined": 15
+  },
+  "stages": [
+    {
+      "completed_at": null,
+      "stage": "scope_and_issue",
+      "status": "done",
+      "summary": null
+    },
+    {
+      "completed_at": null,
+      "stage": "plan",
+      "status": "done",
+      "summary": null
+    },
+    {
+      "completed_at": null,
+      "stage": "implement",
+      "status": "done",
+      "summary": null
+    },
+    {
+      "completed_at": null,
+      "stage": "update_docs",
+      "status": "done",
+      "summary": null
+    },
+    {
+      "completed_at": null,
+      "stage": "test_and_checks",
+      "status": "done",
+      "summary": null
+    },
+    {
+      "completed_at": null,
+      "stage": "commit_and_submit_pr",
+      "status": "pending",
+      "summary": null
+    }
+  ],
+  "task_id": "1330-engine-collection-wrap",
+  "task_kind": "feature"
+}

--- a/src/scistudio/engine/runners/worker.py
+++ b/src/scistudio/engine/runners/worker.py
@@ -91,6 +91,81 @@ def reconstruct_inputs(payload: dict[str, Any]) -> dict[str, Any]:
     return result
 
 
+def _normalize_outputs(
+    outputs: dict[str, Any],
+    output_ports: list[Any],
+) -> dict[str, Any]:
+    """Normalize block outputs to satisfy the ADR-020 §3 transport contract.
+
+    ADR-020 §3 makes a hard contract claim: every value crossing a block
+    boundary is represented as a :class:`Collection`. A single item is a
+    length-one Collection; a multi-file or multi-object input is a longer
+    Collection. The engine, not the block, is responsible for honouring
+    that contract — block authors who follow the docs and return a bare
+    :class:`DataObject` on a port with ``is_collection=True`` would
+    otherwise silently produce a wire-format mismatch at the downstream
+    port (#1330).
+
+    For each ``(port_name, value)`` pair:
+
+    1. Look up the matching :class:`OutputPort` by name. If the port name
+       is not declared (e.g. sentinels like ``__scistudio_env__``), leave
+       the value unchanged.
+    2. If ``port.is_collection=True`` and ``value`` is a bare
+       :class:`DataObject` (not already a :class:`Collection`), wrap it as
+       ``Collection([value], item_type=type(value))``. The ``type(value)``
+       strategy matches the precedent in
+       :mod:`scistudio.blocks.ai.ai_block` (``ai_block.py:532``) and is
+       stable under Add6's ``port_accepts_type`` check.
+    3. For all other shapes (already-wrapped Collection, non-Collection
+       port, scalar/dict/None, wire-format dict from a serialised payload),
+       leave the value untouched.
+
+    The helper is idempotent: calling it twice on the same dict yields
+    the same result. It is safe to invoke on both raw-Python outputs
+    (subprocess pre-``serialise_outputs``) and wire-format dicts
+    (in-process post-runner), because plain ``dict`` values never satisfy
+    the ``isinstance(value, DataObject)`` guard.
+
+    Parameters
+    ----------
+    outputs:
+        Mapping of port names to output values. Mutated in-place.
+    output_ports:
+        Effective output ports for the block (typically obtained via
+        :meth:`Block.get_effective_output_ports`).
+
+    Returns
+    -------
+    dict[str, Any]
+        The same ``outputs`` dict, mutated in-place and returned for
+        chainability.
+    """
+    from scistudio.core.types.base import DataObject
+    from scistudio.core.types.collection import Collection
+
+    port_map = {port.name: port for port in output_ports}
+
+    for port_name, value in list(outputs.items()):
+        port = port_map.get(port_name)
+        if port is None:
+            # Unknown port name (e.g. ``__scistudio_env__`` sentinel) —
+            # leave it alone.
+            continue
+        if not getattr(port, "is_collection", False):
+            continue
+        if isinstance(value, Collection):
+            continue
+        if not isinstance(value, DataObject):
+            # Bare scalar / dict / None / wire-format payload — the
+            # contract only covers DataObject values. ``serialise_outputs``
+            # already handles non-DataObject pass-through.
+            continue
+        outputs[port_name] = Collection([value], item_type=type(value))
+
+    return outputs
+
+
 def serialise_outputs(outputs: dict[str, Any], output_dir: str) -> dict[str, Any]:
     """Serialize block outputs to JSON-compatible wire format.
 
@@ -283,6 +358,19 @@ def main() -> None:
 
         # Execute.
         outputs = block.run(inputs, block_config)
+
+        # #1330: enforce ADR-020 §3 transport contract — wrap bare
+        # DataObject values on ``is_collection=True`` ports into length-one
+        # Collections at the engine boundary. Idempotent and a no-op for
+        # blocks that already self-wrap (six concrete blocks in
+        # blocks/process|code|app|ai). Skipped when ``run`` returned a
+        # non-dict (handled below by the ``_result`` fallback).
+        if isinstance(outputs, dict):
+            try:
+                effective_output_ports = block.get_effective_output_ports()
+            except AttributeError:
+                effective_output_ports = list(getattr(type(block), "output_ports", []))
+            _normalize_outputs(outputs, effective_output_ports)
 
         # #681: capture the block's terminal state if it transitioned to a
         # non-DONE terminal state (CANCELLED / ERROR / SKIPPED) from inside

--- a/src/scistudio/engine/scheduler.py
+++ b/src/scistudio/engine/scheduler.py
@@ -473,6 +473,22 @@ class DAGScheduler:
                 if isinstance(env_candidate, dict):
                     env_payload = env_candidate
 
+            # #1330: ADR-020 §3 contract enforcement at the in-process
+            # boundary. Subprocess execution already normalises inside
+            # ``worker.py`` before ``serialise_outputs``; this second call
+            # site is a belt-and-suspenders no-op for the wire-format
+            # dict path and a meaningful wrap for any future runner that
+            # returns raw Python DataObjects directly (e.g. in-process
+            # path or partial outputs from BlockTerminalStateReportedError).
+            if isinstance(result, dict):
+                from scistudio.engine.runners.worker import _normalize_outputs
+
+                try:
+                    effective_output_ports = block.get_effective_output_ports()
+                except AttributeError:
+                    effective_output_ports = list(getattr(type(block), "output_ports", []))
+                _normalize_outputs(result, effective_output_ports)
+
             self._block_outputs[node_id] = result
             # ADR-038 §5.2: persist DataObject identity to the unified
             # ``data_objects`` table via :class:`LineageStore`. The

--- a/tests/engine/test_collection_wrap.py
+++ b/tests/engine/test_collection_wrap.py
@@ -1,0 +1,153 @@
+"""Tests for engine-side Collection wrap normalization (#1330).
+
+ADR-020 §3 requires every value crossing a block boundary to be a
+:class:`Collection`. The engine — not the block — is responsible for
+honouring that contract. ``_normalize_outputs`` in
+:mod:`scistudio.engine.runners.worker` performs the wrap at the output
+boundary.
+
+These tests exercise the helper directly (unit-level) since the wrap
+logic is independent of the runner protocol. The two call sites
+(worker subprocess pre-``serialise_outputs`` and scheduler in-process
+pre-``_block_outputs`` storage) both delegate to this helper.
+"""
+
+from __future__ import annotations
+
+from scistudio.blocks.base.ports import OutputPort
+from scistudio.core.types.array import Array
+from scistudio.core.types.collection import Collection
+from scistudio.engine.runners.worker import _normalize_outputs
+
+
+def _make_array() -> Array:
+    """Return a bare :class:`Array` with deterministic axes/shape."""
+    return Array(axes=["y", "x"], shape=(4, 4), dtype="uint8")
+
+
+class TestEngineWrapsBareDataObject:
+    """Bare DataObject on an ``is_collection=True`` port is auto-wrapped."""
+
+    def test_engine_wraps_bare_dataobject_on_is_collection_port(self) -> None:
+        """Block returns ``{"out": bare_array}`` for an ``is_collection`` port;
+        the post-normalize value is ``Collection([bare_array], item_type=Array)``.
+
+        This is the core ADR-020 §3 contract enforcement gap from #1330.
+        """
+        bare = _make_array()
+        ports = [
+            OutputPort(name="out", accepted_types=[Array], is_collection=True),
+        ]
+        outputs: dict = {"out": bare}
+
+        _normalize_outputs(outputs, ports)
+
+        wrapped = outputs["out"]
+        assert isinstance(wrapped, Collection)
+        assert len(wrapped) == 1
+        assert wrapped[0] is bare
+        # item_type=type(value) per #1330 spec — matches ai_block.py:532
+        # precedent. Subclass narrowing is stable under Add6.
+        assert wrapped.item_type is Array
+
+
+class TestEngineDoesNotDoubleWrap:
+    """Existing Collection passes through unchanged (identity preserved)."""
+
+    def test_engine_does_not_double_wrap_existing_collection(self) -> None:
+        """Block returns ``{"out": Collection([a, b])}``; post-normalize value
+        is the SAME Collection instance (identity check) with ``len=2``.
+
+        This guards the six existing manual self-wraps in concrete blocks
+        (merge.py / split.py / code_block.py / process_block.py /
+        app_block.py / ai_block.py) — engine normalization must be a no-op
+        when the block already wrapped.
+        """
+        a, b = _make_array(), _make_array()
+        original = Collection([a, b], item_type=Array)
+        ports = [
+            OutputPort(name="out", accepted_types=[Array], is_collection=True),
+        ]
+        outputs: dict = {"out": original}
+
+        _normalize_outputs(outputs, ports)
+
+        assert outputs["out"] is original
+        assert len(outputs["out"]) == 2
+
+
+class TestEngineLeavesNonCollectionPortAlone:
+    """Bare DataObject on an ``is_collection=False`` port is NOT wrapped."""
+
+    def test_engine_leaves_bare_alone_on_non_collection_port(self) -> None:
+        """Block returns ``{"out": bare_array}`` for an ``is_collection=False``
+        port; post-normalize value is the same bare object (no wrap).
+
+        ADR-020 §3 only mandates Collection-as-transport on Collection
+        ports. Scalar / single-item ports keep their bare-DataObject
+        wire format.
+        """
+        bare = _make_array()
+        ports = [
+            OutputPort(name="out", accepted_types=[Array], is_collection=False),
+        ]
+        outputs: dict = {"out": bare}
+
+        _normalize_outputs(outputs, ports)
+
+        assert outputs["out"] is bare
+        assert not isinstance(outputs["out"], Collection)
+
+
+class TestEngineNormalizeEdgeCases:
+    """Defensive coverage: unknown port, sentinel keys, non-DataObject values."""
+
+    def test_unknown_port_name_is_left_alone(self) -> None:
+        """Sentinel-style keys like ``__scistudio_env__`` (no matching port)
+        must not be touched. ADR-038 §5.2 lifts that sentinel into event
+        data downstream; corrupting it here would break lineage.
+        """
+        ports = [
+            OutputPort(name="out", accepted_types=[Array], is_collection=True),
+        ]
+        env_payload = {"python_version": "3.11.0"}
+        outputs: dict = {"__scistudio_env__": env_payload}
+
+        _normalize_outputs(outputs, ports)
+
+        assert outputs["__scistudio_env__"] is env_payload
+
+    def test_non_dataobject_value_on_collection_port_is_left_alone(self) -> None:
+        """Wire-format dicts and scalars are not DataObject instances and
+        must NOT be wrapped (would corrupt them into Collections of dicts).
+        ``serialise_outputs`` already pass-through-serialises plain values.
+        """
+        wire_format = {"backend": "zarr", "path": "/data/x.zarr"}
+        ports = [
+            OutputPort(name="out", accepted_types=[Array], is_collection=True),
+        ]
+        outputs: dict = {"out": wire_format, "count": 5}
+
+        _normalize_outputs(outputs, ports)
+
+        assert outputs["out"] is wire_format
+        assert outputs["count"] == 5
+
+    def test_idempotent_on_second_call(self) -> None:
+        """Calling ``_normalize_outputs`` twice on the same dict is a no-op
+        on the second call (Collection input passes through unchanged).
+        """
+        bare = _make_array()
+        ports = [
+            OutputPort(name="out", accepted_types=[Array], is_collection=True),
+        ]
+        outputs: dict = {"out": bare}
+
+        _normalize_outputs(outputs, ports)
+        first_pass = outputs["out"]
+        _normalize_outputs(outputs, ports)
+        second_pass = outputs["out"]
+
+        assert first_pass is second_pass
+        assert isinstance(second_pass, Collection)
+        assert len(second_pass) == 1


### PR DESCRIPTION
## Summary

Closes #1330. Implements engine-side auto-wrap of bare `DataObject` into length-one `Collection` at the output boundary, closing the ADR-020 §3 transport contract gap.

ADR-020 §3 mandates Collection-as-transport at every block boundary, but the engine did not enforce. Blocks self-wrapped (six manual sites), and any new block author who followed the docs and returned a bare `DataObject` for a port with `is_collection=True` silently produced a wire-format mismatch at the downstream port.

## Change

New helper in `src/scistudio/engine/runners/worker.py`:

```python
def _normalize_outputs(outputs, output_ports):
    for port_name, value in list(outputs.items()):
        port = port_map.get(port_name)
        if port is None or not port.is_collection:
            continue
        if isinstance(value, Collection) or not isinstance(value, DataObject):
            continue
        outputs[port_name] = Collection([value], item_type=type(value))
    return outputs
```

Two call sites:

1. **Subprocess** — `worker.py` between `block.run()` and `serialise_outputs(...)`, so wire-format payloads carry the correct Collection envelope.
2. **In-process** — `scheduler.py::_run_and_finalize` before `_block_outputs[node_id] = result`. Belt-and-suspenders no-op for the wire-format path; meaningful wrap for any future runner returning raw Python DataObjects directly (e.g. partial outputs from `BlockTerminalStateReportedError`).

## Why `item_type=type(value)` is stable

Matches the precedent in `src/scistudio/blocks/ai/ai_block.py:532`. Per #1330:

- All values reaching this path are `DataObject` subclasses (already passed `IOBlock`/`ProcessBlock`/`CodeBlock` schema checks).
- ADR-020-Add6's `port_accepts_type` checks `issubclass(item.item_type, port.accepted_types)`, so subclass-narrowed `item_type` (e.g. `SRSImage` wrapped on a port declaring `Image`) passes downstream checks.

Non-DataObject values (scalars, dicts, wire-format payloads, `__scistudio_env__` sentinel) are left untouched — `serialise_outputs` already handles plain-value pass-through.

## Tests

`tests/engine/test_collection_wrap.py` (6 tests, all pass):

- `test_engine_wraps_bare_dataobject_on_is_collection_port` — bare `Array` on `is_collection=True` port becomes `Collection([arr], item_type=Array)`.
- `test_engine_does_not_double_wrap_existing_collection` — existing `Collection` passes through with identity preserved.
- `test_engine_leaves_bare_alone_on_non_collection_port` — bare `Array` on `is_collection=False` port is unchanged.
- `test_unknown_port_name_is_left_alone` — `__scistudio_env__` sentinel and other unknown keys are not touched.
- `test_non_dataobject_value_on_collection_port_is_left_alone` — wire-format dicts and scalars are not corrupted.
- `test_idempotent_on_second_call` — second normalize pass is a no-op (identity preserved).

```
tests\engine\test_collection_wrap.py ......                              [100%]
============================== 6 passed in 0.21s ==============================
```

Regression check on `tests/engine/test_scheduler.py` (45 tests) and the broader engine suite (66 tests across worker, local_runner, scheduler_concurrency, scheduler_terminal_data, scheduler_rerun_cancel) — all pass.

## Out of scope (deferred per #1330 spec)

- Removing the six existing manual `Collection([result], item_type=X)` wraps in concrete blocks (`merge.py`, `split.py`, `code_block.py`, `process_block.py`, `app_block.py`, `ai_block.py`). Leave them as explicit intent; follow-up cleanup PR after engine wrap soaks.
- ADR-020 text revision — the §3 contract claim already matches the implementation.
- `ARCHITECTURE.md` lines 1120-1130 already describe the contract.

## Risk

Low. Additive only. The six existing self-wraps continue to work (engine sees `Collection`, no-ops). Plugin authors who follow ADR-020 §3 docs gain a working contract. AI-generated blocks gain a safety net against the "forgot to wrap" footgun.

## Gate record

`.workflow/records/1330-engine-collection-wrap.json`

Closes #1330
