### PR TITLE
fix(#1332): TypeRegistry filesystem scan for project/user types/ dirs

### DIFF
--- a/.workflow/records/1332-types-scan.json
+++ b/.workflow/records/1332-types-scan.json
@@ -89,7 +89,12 @@
     "src/scistudio/api/runtime.py",
     "tests/core/test_type_registry_scan_dirs.py"
   ],
-  "pull_request": null,
+  "pull_request": {
+    "number": 1339,
+    "url": "https://github.com/zjzcpj/SciStudio/pull/1339",
+    "base": "umbrella/arch-drift-and-collection-wrap",
+    "head": "fix/issue-1332-types-scan"
+  },
   "record_path": ".workflow/records/1332-types-scan.json",
   "required_checks": [
     "ruff,format,pytest,sentrux"

--- a/.workflow/records/1332-types-scan.json
+++ b/.workflow/records/1332-types-scan.json
@@ -94,9 +94,7 @@
   ],
   "pull_request": {
     "number": 1339,
-    "url": "https://github.com/zjzcpj/SciStudio/pull/1339",
-    "base": "umbrella/arch-drift-and-collection-wrap",
-    "head": "fix/issue-1332-types-scan"
+    "url": "https://github.com/zjzcpj/SciStudio/pull/1339"
   },
   "record_path": ".workflow/records/1332-types-scan.json",
   "required_checks": [

--- a/.workflow/records/1332-types-scan.json
+++ b/.workflow/records/1332-types-scan.json
@@ -1,0 +1,151 @@
+{
+  "admin_labels": [],
+  "amendments": [],
+  "branch": "fix/issue-1332-types-scan",
+  "changed_test_paths": [
+    "tests/core/test_type_registry_scan_dirs.py"
+  ],
+  "check_results": [
+    {
+      "command_or_tool": "python -m pytest tests/core/test_type_registry_scan_dirs.py --timeout=60 --no-cov",
+      "exit_code": 0,
+      "name": "pytest-scan-dirs",
+      "output_path": "10 passed, 1 warning in 2.79s",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "python -m pytest tests/core/ --timeout=60 --no-cov",
+      "exit_code": 0,
+      "name": "pytest-core-regression",
+      "output_path": "564 passed, 2 skipped, 20 warnings in 10.87s",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "python -m ruff check src/scistudio/core/types/registry.py src/scistudio/api/runtime.py tests/core/test_type_registry_scan_dirs.py",
+      "exit_code": 0,
+      "name": "ruff-check",
+      "output_path": "All checks passed!",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "python -m ruff format --check src/scistudio/core/types/registry.py src/scistudio/api/runtime.py tests/core/test_type_registry_scan_dirs.py",
+      "exit_code": 0,
+      "name": "ruff-format",
+      "output_path": "3 files already formatted",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    }
+  ],
+  "commit": null,
+  "docs_landing": {
+    "adr": {
+      "not_applicable": true,
+      "rationale": "no new ADR \u2014 this is an impl-catches-up-to-existing-doc patch under issue #1332; no architectural decision is being made."
+    },
+    "architecture": {
+      "not_applicable": true,
+      "rationale": "ARCHITECTURE.md sections 10 + 10.5 already commit to project/types and ~/.scistudio/types scan paths; this PR catches the impl up to the existing doc commitment. Owner directive 2026-05-21 forbids editing ARCHITECTURE.md."
+    },
+    "changelog": {
+      "not_applicable": true,
+      "rationale": "no functional user-visible behavior added; the scan-dir paths were promised by ARCHITECTURE.md and were silently absent. CHANGELOG follow-up may be added by the umbrella PR if owner requires."
+    },
+    "checklist": {},
+    "docs": {},
+    "spec": {
+      "not_applicable": true,
+      "rationale": "no spec touched; TypeRegistry.add_scan_dir mirrors BlockRegistry.add_scan_dir which is already part of the registry contract."
+    }
+  },
+  "full_audit": null,
+  "governance_touch": true,
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1332,
+      "url": null
+    }
+  ],
+  "owner_directive": "Implement TypeRegistry add_scan_dir + wire project/user types directories. Catch impl up to ARCHITECTURE.md sections 10 + 10.5. Do NOT touch ARCHITECTURE.md (final commitment per owner).",
+  "planned_files": [
+    "src/scistudio/core/types/registry.py",
+    "src/scistudio/api/runtime.py",
+    "tests/core/test_type_registry_scan_dirs.py"
+  ],
+  "pull_request": null,
+  "record_path": ".workflow/records/1332-types-scan.json",
+  "required_checks": [
+    "ruff,format,pytest,sentrux"
+  ],
+  "schema_version": "1",
+  "scope": {
+    "exclude": [],
+    "include": [
+      "src/scistudio/core/types/registry.py",
+      "src/scistudio/api/runtime.py",
+      "tests/core/test_type_registry_scan_dirs.py",
+      ".workflow/records/1332-types-scan.json"
+    ]
+  },
+  "sentrux": {
+    "command_or_tool": "sentrux check",
+    "mode": "free-tier",
+    "name": "sentrux.free_tier",
+    "output_path": "{\"files\":1075,\"import_edges\":2598,\"lines\":276362,\"quality_signal\":4124,\"rules_checked\":3,\"violation_count\":0,\"source\":\"mcp__plugin_sentrux_sentrux__{scan,check_rules}\"}",
+    "pro_required": false,
+    "quality_signal": null,
+    "rules_checked": null,
+    "status": "pass",
+    "summary": {},
+    "thresholds": {},
+    "total_rules_defined": null
+  },
+  "stages": [
+    {
+      "completed_at": null,
+      "stage": "scope_and_issue",
+      "status": "done",
+      "summary": null
+    },
+    {
+      "completed_at": null,
+      "stage": "plan",
+      "status": "done",
+      "summary": null
+    },
+    {
+      "completed_at": null,
+      "stage": "implement",
+      "status": "pending",
+      "summary": null
+    },
+    {
+      "completed_at": null,
+      "stage": "update_docs",
+      "status": "done",
+      "summary": null
+    },
+    {
+      "completed_at": null,
+      "stage": "test_and_checks",
+      "status": "done",
+      "summary": null
+    },
+    {
+      "completed_at": null,
+      "stage": "commit_and_submit_pr",
+      "status": "pending",
+      "summary": null
+    }
+  ],
+  "task_id": "1332-types-scan",
+  "task_kind": "feature"
+}

--- a/.workflow/records/1332-types-scan.json
+++ b/.workflow/records/1332-types-scan.json
@@ -64,7 +64,16 @@
       "rationale": "no spec touched; TypeRegistry.add_scan_dir mirrors BlockRegistry.add_scan_dir which is already part of the registry contract."
     }
   },
-  "full_audit": null,
+  "full_audit": {
+    "blocks_merge": false,
+    "command": "python -m scistudio.qa.audit.full_audit --format json --output /tmp/full-audit-1332.json",
+    "exit_code": 0,
+    "known_debt": [],
+    "output_path": "C:/Users/jiazh/AppData/Local/Temp/full-audit-1332.json",
+    "status": "pass",
+    "summary": {},
+    "unclassified_failures": []
+  },
   "governance_touch": true,
   "issues": [
     {
@@ -124,7 +133,7 @@
     {
       "completed_at": null,
       "stage": "implement",
-      "status": "pending",
+      "status": "done",
       "summary": null
     },
     {
@@ -142,7 +151,7 @@
     {
       "completed_at": null,
       "stage": "commit_and_submit_pr",
-      "status": "pending",
+      "status": "done",
       "summary": null
     }
   ],

--- a/.workflow/records/1332-types-scan.json
+++ b/.workflow/records/1332-types-scan.json
@@ -58,7 +58,10 @@
       "rationale": "no functional user-visible behavior added; the scan-dir paths were promised by ARCHITECTURE.md and were silently absent. CHANGELOG follow-up may be added by the umbrella PR if owner requires."
     },
     "checklist": {},
-    "docs": {},
+    "docs": {
+      "not_applicable": true,
+      "rationale": "Impl catches the existing ARCHITECTURE.md §10 + §10.5 commitment up to runtime behavior; the doc text already describes the intended scan paths. No new user-facing docs needed — the existing ARCHITECTURE description is now backed by impl."
+    },
     "spec": {
       "not_applicable": true,
       "rationale": "no spec touched; TypeRegistry.add_scan_dir mirrors BlockRegistry.add_scan_dir which is already part of the registry contract."
@@ -80,7 +83,7 @@
       "close_in_pr": true,
       "followup_rationale": null,
       "number": 1332,
-      "url": null
+      "url": "https://github.com/zjzcpj/SciStudio/issues/1332"
     }
   ],
   "owner_directive": "Implement TypeRegistry add_scan_dir + wire project/user types directories. Catch impl up to ARCHITECTURE.md sections 10 + 10.5. Do NOT touch ARCHITECTURE.md (final commitment per owner).",

--- a/.workflow/records/1332-types-scan.json
+++ b/.workflow/records/1332-types-scan.json
@@ -57,7 +57,10 @@
       "not_applicable": true,
       "rationale": "no functional user-visible behavior added; the scan-dir paths were promised by ARCHITECTURE.md and were silently absent. CHANGELOG follow-up may be added by the umbrella PR if owner requires."
     },
-    "checklist": {},
+    "checklist": {
+      "not_applicable": true,
+      "rationale": "manager-owned checklist at docs/planning/arch-drift-checklist.md is updated by manager, not implementer (per dispatch prompt scope: out of scope for this sub-PR)"
+    },
     "docs": {
       "not_applicable": true,
       "rationale": "Impl catches the existing ARCHITECTURE.md §10 + §10.5 commitment up to runtime behavior; the doc text already describes the intended scan paths. No new user-facing docs needed — the existing ARCHITECTURE description is now backed by impl."
@@ -111,17 +114,17 @@
     ]
   },
   "sentrux": {
-    "command_or_tool": "sentrux check",
+    "command_or_tool": "sentrux",
     "mode": "free-tier",
     "name": "sentrux.free_tier",
-    "output_path": "{\"files\":1075,\"import_edges\":2598,\"lines\":276362,\"quality_signal\":4124,\"rules_checked\":3,\"violation_count\":0,\"source\":\"mcp__plugin_sentrux_sentrux__{scan,check_rules}\"}",
+    "output_path": null,
     "pro_required": false,
-    "quality_signal": null,
-    "rules_checked": null,
+    "quality_signal": 4124,
+    "rules_checked": 3,
     "status": "pass",
     "summary": {},
-    "thresholds": {},
-    "total_rules_defined": null
+    "thresholds": {"complexity": "70"},
+    "total_rules_defined": 15
   },
   "stages": [
     {

--- a/src/scistudio/api/runtime.py
+++ b/src/scistudio/api/runtime.py
@@ -432,7 +432,7 @@ class ApiRuntime:
         include_monorepo = os.environ.get("SCISTUDIO_DEV") == "1"
         if include_monorepo:
             logger.info("SCISTUDIO_DEV=1: monorepo package scan enabled")
-        self.type_registry.scan_all(include_monorepo=include_monorepo)
+        self.refresh_type_registry()
         self.refresh_block_registry()
 
     def _bind_event_logging(self) -> None:
@@ -488,6 +488,23 @@ class ApiRuntime:
             registry.add_scan_dir(Path.home() / ".scistudio" / "blocks")
         registry.scan(include_monorepo=os.environ.get("SCISTUDIO_DEV") == "1")
         self.block_registry = registry
+
+    def refresh_type_registry(self) -> None:
+        """Re-scan the TypeRegistry with the current active project's types dir.
+
+        Issue #1332 / ARCHITECTURE.md §10 + §10.5: mirrors
+        :meth:`refresh_block_registry` so a project switch picks up
+        ``<project>/types`` drop-in :class:`DataObject` subclasses and the
+        user-wide ``~/.scistudio/types`` dir. Always rebuilds from scratch
+        so a switch from project A to project B does not leak project A's
+        types into project B.
+        """
+        registry = TypeRegistry()
+        if self.active_project is not None:
+            registry.add_scan_dir(Path(self.active_project.path) / "types")
+        registry.add_scan_dir(Path.home() / ".scistudio" / "types")
+        registry.scan_all(include_monorepo=os.environ.get("SCISTUDIO_DEV") == "1")
+        self.type_registry = registry
 
     def _init_lineage_store(self, project_path: Path) -> None:
         """Open the unified ADR-038 lineage store for the active project.
@@ -773,6 +790,10 @@ class ApiRuntime:
         self._save_known_projects()
         self.active_project = candidate
         self.data_catalog = {}
+        # Issue #1332 / ARCHITECTURE.md §10 + §10.5: rescan TypeRegistry so
+        # the project's ``types/`` drop-in DataObject subclasses register,
+        # mirroring the block-registry refresh below.
+        self.refresh_type_registry()
         self.refresh_block_registry()
         self._init_metadata_store(Path(candidate.path))
         # ADR-038 §3.1: open the unified lineage store alongside the legacy

--- a/src/scistudio/core/types/registry.py
+++ b/src/scistudio/core/types/registry.py
@@ -39,6 +39,7 @@ from __future__ import annotations
 
 import importlib
 import importlib.metadata
+import importlib.util
 import logging
 import sys
 from dataclasses import dataclass
@@ -80,6 +81,32 @@ class TypeRegistry:
 
     def __init__(self) -> None:
         self._registry: dict[str, TypeSpec] = {}
+        # Issue #1332 / ARCHITECTURE.md §10 + §10.5: filesystem scan dirs for
+        # project-local (``<project>/types``) and user-wide
+        # (``~/.scistudio/types``) custom DataObject subclasses. Mirrors
+        # :attr:`BlockRegistry._scan_dirs`. Populated via :meth:`add_scan_dir`
+        # and consumed by :meth:`scan_all` (after entry-points / monorepo).
+        self._scan_dirs: list[Path] = []
+
+    def add_scan_dir(self, directory: str | Path) -> None:
+        """Add a directory to the filesystem scan path (issue #1332).
+
+        Mirrors :meth:`BlockRegistry.add_scan_dir`. Each registered
+        directory is walked by :meth:`scan_all` after the entry-point and
+        monorepo passes; any top-level :class:`DataObject` subclass
+        defined in a ``.py`` file under *directory* is registered.
+
+        ``directory`` may be a :class:`pathlib.Path` or a string. The
+        path is stored as-is (not eagerly resolved) so a not-yet-created
+        ``<project>/types`` or ``~/.scistudio/types`` dir is silently
+        skipped at scan time rather than raising at registration time.
+
+        ARCHITECTURE.md §10 (project layout) and §10.5 (user-wide
+        extension paths) document the two intended call sites; runtime
+        wiring in :class:`scistudio.api.runtime.ApiRuntime` issues these
+        calls before invoking :meth:`scan_all`.
+        """
+        self._scan_dirs.append(Path(directory))
 
     def register(self, name: str, spec: TypeSpec) -> None:
         """Register *spec* under *name*."""
@@ -424,11 +451,106 @@ class TypeRegistry:
                 logger.info("Registered external type '%s' from entry-point '%s'", cls.__name__, ep.name)
 
     def scan_all(self, *, include_monorepo: bool = False) -> None:
-        """Register built-in types and then scan entry-points for external types."""
+        """Register built-in types and then scan entry-points for external types.
+
+        Issue #1332 / ARCHITECTURE.md §10 + §10.5: after the entry-point and
+        monorepo passes, this also walks every directory registered via
+        :meth:`add_scan_dir` and registers any drop-in :class:`DataObject`
+        subclass found in a ``.py`` file there. Entry-point and monorepo
+        registrations win on duplicates (this matches
+        :meth:`BlockRegistry.scan`'s ordering).
+        """
         self.scan_builtins()
         self._scan_entrypoint_types()
         if include_monorepo:
             self._scan_monorepo_types()
+        self._scan_filesystem_dirs()
+
+    def _scan_filesystem_dirs(self) -> None:
+        """Walk each registered scan directory and register drop-in types.
+
+        Issue #1332 / ARCHITECTURE.md §10 + §10.5. Mirrors
+        :meth:`BlockRegistry._scan_tier1` for the type-registration path.
+
+        For each registered directory (see :meth:`add_scan_dir`):
+
+        - Silently skip if the directory does not exist (the
+          ``<project>/types`` dir is created on project init but a
+          freshly-cloned project or a user without ``~/.scistudio/types``
+          must not crash registry startup).
+        - Import every ``.py`` file via
+          :func:`importlib.util.spec_from_file_location`. Files whose
+          names start with ``_`` are skipped (private / dunder modules).
+        - Any top-level :class:`DataObject` subclass that is defined in
+          the loaded module (not merely re-exported from another module)
+          is registered under its ``__name__`` via
+          :meth:`register_class`. Names already in the registry (from
+          built-ins, entry-points, or monorepo passes) are left alone —
+          plugin and built-in registrations win on duplicates.
+        - Import failures and Meta-validation failures are logged as
+          warnings; the offending file is skipped and scanning
+          continues. A single broken drop-in must never kill the
+          registry.
+        """
+        if not self._scan_dirs:
+            return
+
+        from scistudio.core.types.base import DataObject
+
+        for scan_dir in self._scan_dirs:
+            if not scan_dir.is_dir():
+                logger.debug("TypeRegistry: scan dir %s does not exist; skipping", scan_dir)
+                continue
+            for py_file in scan_dir.glob("*.py"):
+                if py_file.name.startswith("_"):
+                    continue
+                try:
+                    mtime = py_file.stat().st_mtime
+                    mod_name = f"_scistudio_type_dropin_{py_file.stem}_{int(mtime)}"
+                    spec = importlib.util.spec_from_file_location(mod_name, py_file)
+                    if spec is None or spec.loader is None:
+                        continue
+                    module = importlib.util.module_from_spec(spec)
+                    spec.loader.exec_module(module)
+                except Exception:
+                    logger.warning(
+                        "TypeRegistry: failed to import type drop-in from %s",
+                        py_file,
+                        exc_info=True,
+                    )
+                    continue
+
+                for attr_name in dir(module):
+                    obj = getattr(module, attr_name, None)
+                    if not (
+                        isinstance(obj, type)
+                        and issubclass(obj, DataObject)
+                        and obj is not DataObject
+                        # Skip re-exports — only register classes actually
+                        # defined in this drop-in file. Matches the #706
+                        # guard in :meth:`BlockRegistry._scan_tier1`.
+                        and getattr(obj, "__module__", None) == module.__name__
+                    ):
+                        continue
+                    if obj.__name__ in self._registry:
+                        # Built-ins / entry-points / monorepo plugins win
+                        # on duplicates; the drop-in path is the last
+                        # tier and must not silently shadow them.
+                        continue
+                    try:
+                        self.register_class(obj)
+                        logger.info(
+                            "TypeRegistry: registered drop-in type %r from %s",
+                            obj.__name__,
+                            py_file,
+                        )
+                    except Exception:
+                        logger.warning(
+                            "TypeRegistry: failed to register drop-in type %r from %s",
+                            obj.__name__,
+                            py_file,
+                            exc_info=True,
+                        )
 
     def _scan_monorepo_types(self) -> None:
         """Development fallback for plugin type discovery in the monorepo.

--- a/tests/core/test_type_registry_scan_dirs.py
+++ b/tests/core/test_type_registry_scan_dirs.py
@@ -1,0 +1,310 @@
+"""Tests for :meth:`TypeRegistry.add_scan_dir` (issue #1332).
+
+ARCHITECTURE.md §10 + §10.5 commit the runtime to discovering local custom
+:class:`DataObject` subclasses from two filesystem locations:
+
+- ``<project>/types/`` — project-local drop-in types
+- ``~/.scistudio/types/`` — user-wide drop-in types shared across projects
+
+Issue #1332 (P1, audit P1-3): the documentation claim was previously
+implemented for :class:`BlockRegistry` only (``add_scan_dir`` + project +
+user-wide wiring in :class:`ApiRuntime`); :class:`TypeRegistry` had only
+built-ins + ``scistudio.types`` entry-points + optional monorepo. This
+test module exercises the new :meth:`TypeRegistry.add_scan_dir` path and
+the :meth:`ApiRuntime.refresh_type_registry` wiring that catches the impl
+up to the doc commitment.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+from scistudio.core.types.registry import TypeRegistry
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_module(directory: Path, filename: str, body: str) -> Path:
+    """Write *body* to ``directory/filename`` and return the path."""
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / filename
+    path.write_text(dedent(body), encoding="utf-8")
+    return path
+
+
+_GOOD_MODULE = """
+from scistudio.core.types.base import DataObject
+
+
+class CustomDropInType(DataObject):
+    \"\"\"Drop-in DataObject subclass used by the scan-dir tests.\"\"\"
+"""
+
+
+_TWO_TYPES_MODULE = """
+from scistudio.core.types.base import DataObject
+
+
+class FirstDropInType(DataObject):
+    \"\"\"First drop-in DataObject.\"\"\"
+
+
+class SecondDropInType(DataObject):
+    \"\"\"Second drop-in DataObject.\"\"\"
+"""
+
+
+_BROKEN_MODULE = """
+this is not valid python
+"""
+
+
+_NOT_A_DATAOBJECT_MODULE = """
+class NotADataObject:
+    \"\"\"Plain class — must not be registered.\"\"\"
+"""
+
+
+# ---------------------------------------------------------------------------
+# Direct TypeRegistry tests
+# ---------------------------------------------------------------------------
+
+
+class TestAddScanDir:
+    """``TypeRegistry.add_scan_dir`` + ``scan_all`` discover drop-in types."""
+
+    def test_add_scan_dir_picks_up_drop_in_type(self, tmp_path: Path) -> None:
+        """A DataObject subclass in a scanned dir is registered by scan_all."""
+        scan_dir = tmp_path / "types"
+        _write_module(scan_dir, "custom_type.py", _GOOD_MODULE)
+
+        registry = TypeRegistry()
+        registry.add_scan_dir(scan_dir)
+        registry.scan_all()
+
+        assert "CustomDropInType" in registry.all_types()
+        # Sanity: built-ins still register (the new path must not displace them).
+        assert "DataObject" in registry.all_types()
+        assert "Array" in registry.all_types()
+
+    def test_multiple_drop_in_types_per_file_register(self, tmp_path: Path) -> None:
+        """A single drop-in file declaring two types registers both."""
+        scan_dir = tmp_path / "types"
+        _write_module(scan_dir, "two_types.py", _TWO_TYPES_MODULE)
+
+        registry = TypeRegistry()
+        registry.add_scan_dir(scan_dir)
+        registry.scan_all()
+
+        assert "FirstDropInType" in registry.all_types()
+        assert "SecondDropInType" in registry.all_types()
+
+    def test_nonexistent_scan_dir_is_skipped_silently(
+        self,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A registered scan dir that does not exist must not raise."""
+        missing = tmp_path / "does_not_exist"
+        registry = TypeRegistry()
+        registry.add_scan_dir(missing)
+
+        with caplog.at_level(logging.DEBUG, logger="scistudio.core.types.registry"):
+            registry.scan_all()  # must not raise
+
+        # Built-ins still register and only the missing dir was a no-op.
+        assert "DataObject" in registry.all_types()
+
+    def test_underscore_prefixed_files_are_ignored(self, tmp_path: Path) -> None:
+        """Drop-in files starting with ``_`` are skipped (private modules)."""
+        scan_dir = tmp_path / "types"
+        _write_module(scan_dir, "_private.py", _GOOD_MODULE)
+
+        registry = TypeRegistry()
+        registry.add_scan_dir(scan_dir)
+        registry.scan_all()
+
+        assert "CustomDropInType" not in registry.all_types()
+
+    def test_import_error_warns_and_continues(
+        self,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A broken drop-in logs a warning but does not crash scan_all.
+
+        A second valid file in the same dir must still register.
+        """
+        scan_dir = tmp_path / "types"
+        _write_module(scan_dir, "broken.py", _BROKEN_MODULE)
+        _write_module(scan_dir, "good.py", _GOOD_MODULE)
+
+        registry = TypeRegistry()
+        registry.add_scan_dir(scan_dir)
+        with caplog.at_level(logging.WARNING, logger="scistudio.core.types.registry"):
+            registry.scan_all()
+
+        assert "CustomDropInType" in registry.all_types()
+        warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+        assert any("broken.py" in (r.getMessage()) for r in warnings)
+
+    def test_non_dataobject_classes_not_registered(self, tmp_path: Path) -> None:
+        """Plain classes that are not DataObject subclasses must not register."""
+        scan_dir = tmp_path / "types"
+        _write_module(scan_dir, "plain.py", _NOT_A_DATAOBJECT_MODULE)
+
+        registry = TypeRegistry()
+        registry.add_scan_dir(scan_dir)
+        registry.scan_all()
+
+        assert "NotADataObject" not in registry.all_types()
+
+    def test_drop_in_does_not_override_builtin(self, tmp_path: Path) -> None:
+        """A drop-in cannot shadow built-ins — built-ins are registered first.
+
+        We write a file that re-declares a class named ``DataObject`` (a
+        DataObject subclass shadowing the builtin name). The drop-in pass
+        must NOT replace the canonical builtin entry.
+        """
+        scan_dir = tmp_path / "types"
+        _write_module(
+            scan_dir,
+            "shadowing.py",
+            """
+            from scistudio.core.types.base import DataObject as _RealDO
+
+
+            class DataObject(_RealDO):  # noqa: D401 - intentional shadow
+                \"\"\"Drop-in that tries to shadow the canonical DataObject.\"\"\"
+            """,
+        )
+
+        registry = TypeRegistry()
+        registry.add_scan_dir(scan_dir)
+        registry.scan_all()
+
+        # The built-in DataObject is the registered class, not the
+        # shadow defined under ``_scistudio_type_dropin_*``.
+        spec = registry.all_types()["DataObject"]
+        assert spec.module_path == "scistudio.core.types.base"
+
+
+# ---------------------------------------------------------------------------
+# ApiRuntime wiring tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def fake_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Redirect ``Path.home()`` (in the runtime module) to a per-test dir.
+
+    The :class:`ApiRuntime` writes its registry under ``~/.scistudio``;
+    this fixture isolates that side effect from the developer's real home.
+    """
+    fake = tmp_path / "home"
+    fake.mkdir()
+
+    from scistudio.api import runtime as runtime_module
+
+    monkeypatch.setattr(runtime_module.Path, "home", classmethod(lambda cls: fake))
+    return fake
+
+
+class TestRuntimeWiring:
+    """``ApiRuntime.refresh_type_registry`` wires both scan dirs."""
+
+    def test_user_wide_types_dir_is_scanned_on_refresh(
+        self,
+        fake_home: Path,
+    ) -> None:
+        """``~/.scistudio/types`` drops in get picked up via refresh_type_registry."""
+        from scistudio.api.runtime import ApiRuntime
+
+        runtime = ApiRuntime()
+        user_types_dir = fake_home / ".scistudio" / "types"
+        _write_module(user_types_dir, "user_type.py", _GOOD_MODULE)
+
+        runtime.refresh_type_registry()
+
+        assert "CustomDropInType" in runtime.type_registry.all_types()
+
+    def test_project_local_types_dir_is_scanned_on_open(
+        self,
+        fake_home: Path,
+        tmp_path: Path,
+    ) -> None:
+        """Opening a project picks up ``<project>/types`` drop-ins.
+
+        Issue #1332: :meth:`ApiRuntime.open_project` must call
+        :meth:`refresh_type_registry` so the project's ``types/`` dir is
+        scanned. Without that wiring this test would fail because the
+        scan would happen at startup (when ``active_project is None``)
+        and never re-run.
+        """
+        from scistudio.api.runtime import ApiRuntime
+
+        parent = tmp_path / "workspace"
+        parent.mkdir()
+        runtime = ApiRuntime()
+        project = runtime.create_project(name="Demo", description="", parent_path=str(parent))
+        project_path = Path(project.path)
+        _write_module(project_path / "types", "project_type.py", _GOOD_MODULE)
+
+        # Open the project — refresh_type_registry must fire.
+        runtime.open_project(str(project_path))
+
+        assert "CustomDropInType" in runtime.type_registry.all_types()
+
+    def test_switching_projects_does_not_leak_types(
+        self,
+        fake_home: Path,
+        tmp_path: Path,
+    ) -> None:
+        """Switching from project A to project B does not retain A's types."""
+        from scistudio.api.runtime import ApiRuntime
+
+        parent = tmp_path / "workspace"
+        parent.mkdir()
+        runtime = ApiRuntime()
+        project_a = runtime.create_project(name="Proj-A", description="", parent_path=str(parent))
+        project_b = runtime.create_project(name="Proj-B", description="", parent_path=str(parent))
+        a_path = Path(project_a.path)
+        b_path = Path(project_b.path)
+
+        _write_module(
+            a_path / "types",
+            "first.py",
+            """
+            from scistudio.core.types.base import DataObject
+
+
+            class FirstDropInType(DataObject):
+                pass
+            """,
+        )
+        _write_module(
+            b_path / "types",
+            "second.py",
+            """
+            from scistudio.core.types.base import DataObject
+
+
+            class SecondDropInType(DataObject):
+                pass
+            """,
+        )
+
+        runtime.open_project(str(a_path))
+        assert "FirstDropInType" in runtime.type_registry.all_types()
+
+        runtime.open_project(str(b_path))
+        types = runtime.type_registry.all_types()
+        assert "SecondDropInType" in types
+        # A's type must not leak into B.
+        assert "FirstDropInType" not in types


### PR DESCRIPTION
Closes #1332.

## Summary

Implements `TypeRegistry.add_scan_dir(...)` filesystem scan for project-local `<project>/types/` and user-wide `~/.scistudio/types/` directories. This catches the impl up to the existing `ARCHITECTURE.md` §10 + §10.5 commitment — the doc has promised these two scan paths for some time, but `TypeRegistry` only loaded built-ins, `scistudio.types` entry-points, and (under `SCISTUDIO_DEV=1`) the monorepo `packages/*` source tree.

This PR mirrors the existing `BlockRegistry.add_scan_dir` / `BlockRegistry._scan_tier1` pattern so the two registries behave identically with respect to drop-in discovery, duplicate-resolution ordering (built-ins → entry-points → monorepo → drop-ins), and error tolerance.

## What changed

- `src/scistudio/core/types/registry.py`
  - New `add_scan_dir(directory)` method storing `Path` in `self._scan_dirs`.
  - New `_scan_filesystem_dirs()` helper consumed from `scan_all()` after the entry-point and monorepo passes.
  - Drop-in files imported via `importlib.util.spec_from_file_location` with a mtime-stamped module name to avoid `sys.modules` collisions.
  - Underscore-prefixed files skipped (private/dunder modules).
  - Re-exports skipped via `obj.__module__ == module.__name__` guard (matches `BlockRegistry`'s #706 fix).
  - Built-ins/entry-points/monorepo plugins WIN on duplicate names — drop-ins cannot shadow canonical types.
  - Missing directories silently skipped (debug log only); single broken drop-in file logs a warning and continues without crashing `scan_all()`.

- `src/scistudio/api/runtime.py`
  - New `refresh_type_registry()` method (parallels `refresh_block_registry()`) that rebuilds the registry from scratch with `<project>/types` + `~/.scistudio/types` wired before `scan_all()`.
  - `_configure_static_registries` and `open_project` now call both refreshers so a project switch picks up new drop-ins (and discards the prior project's).

- `tests/core/test_type_registry_scan_dirs.py` (new, 10 tests, all passing)
  - Direct `TypeRegistry` tests: drop-in discovery, multi-class files, missing dir, underscore skip, import-error warn-and-continue, non-DataObject rejection, no-shadow-builtin guarantee.
  - `ApiRuntime` integration tests: user-wide dir picked up on refresh, project-local dir picked up on `open_project`, no leak when switching projects A→B.

## Why no doc edit

`ARCHITECTURE.md` §10 + §10.5 already documents the two scan paths — this PR is the impl catch-up to that existing commitment. Owner directive 2026-05-21: do not weaken the final doc commitment by editing it.

## Tests

```
pytest tests/core/test_type_registry_scan_dirs.py    10 passed
pytest tests/core/                                  564 passed, 2 skipped
ruff check (scope files)                            All checks passed
ruff format --check (scope files)                   already formatted
sentrux scan + check_rules                          0 violations
```

## Out-of-scope

- `docs/architecture/ARCHITECTURE.md` (owner directive — do not touch)
- `src/scistudio/engine/` (Track A territory — PR #1338)
- `src/scistudio/blocks/registry.py` (read-only reference; only mirrored, never modified)

Gate record: `.workflow/records/1332-types-scan.json` (all 6 stages done, full audit + sentrux clean).