### PR TITLE
docs(#1357): ADR-044 — SubWorkflowBlock authoring-only with inline flattening at load

### DIFF
--- a/.workflow/records/1357-adr-044-subworkflow.json
+++ b/.workflow/records/1357-adr-044-subworkflow.json
@@ -1,0 +1,131 @@
+{
+  "admin_labels": [],
+  "amendments": [],
+  "branch": "docs/issue-1357/adr-044-subworkflow-spec",
+  "changed_test_paths": [],
+  "check_results": [
+    {
+      "command_or_tool": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output docs/audit/full-audit-latest.json",
+      "exit_code": 0,
+      "name": "full_audit",
+      "output_path": "docs/audit/full-audit-latest.json",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "python -m scistudio.qa.audit.full_audit (child: frontmatter_lint)",
+      "exit_code": 0,
+      "name": "frontmatter_lint",
+      "output_path": "docs/audit/full-audit-latest.json",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    }
+  ],
+  "commit": null,
+  "docs_landing": {
+    "changelog": {
+      "not_applicable": true,
+      "rationale": "docs-only ADR + spec authoring; no user-visible behavior change; implementation tracked separately"
+    },
+    "checklist": {},
+    "docs": {
+      "paths": [
+        "docs/adr/ADR-044.md",
+        "docs/specs/adr-044-subworkflow-block.md",
+        "docs/architecture/ARCHITECTURE.md"
+      ]
+    },
+    "tests": {
+      "not_applicable": true,
+      "rationale": "docs-only; tests listed in spec for implementation PR"
+    }
+  },
+  "full_audit": null,
+  "governance_touch": true,
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1357,
+      "url": null
+    }
+  ],
+  "owner_directive": "Authoring-only SubWorkflowBlock; inline flattening at load; ref-only; no kind discriminator; cycle detection; delete stub; close #890 in impl PR; reproducibility via lineage snapshot + git",
+  "planned_files": [
+    "docs/adr/ADR-044.md",
+    "docs/specs/adr-044-subworkflow-block.md",
+    "docs/architecture/ARCHITECTURE.md"
+  ],
+  "pull_request": null,
+  "record_path": ".workflow/records/1357-adr-044-subworkflow.json",
+  "required_checks": [
+    "frontmatter_lint",
+    "full_audit",
+    "sentrux"
+  ],
+  "schema_version": "1",
+  "scope": {
+    "exclude": [],
+    "include": [
+      "docs/adr/ADR-044.md",
+      "docs/specs/adr-044-subworkflow-block.md",
+      "docs/architecture/ARCHITECTURE.md",
+      ".workflow/records/1357-adr-044-subworkflow.json"
+    ]
+  },
+  "sentrux": {
+    "command_or_tool": "sentrux.exe check .",
+    "mode": "free-tier",
+    "name": "sentrux.free_tier",
+    "output_path": "11/11 rules pass; Quality=4126; docs-only diff (ADR-044 + spec + ARCHITECTURE.md \u00a75.4.7); no source files changed",
+    "pro_required": false,
+    "quality_signal": 4126.0,
+    "rules_checked": 11,
+    "status": "pass",
+    "summary": {},
+    "thresholds": {},
+    "total_rules_defined": 11
+  },
+  "stages": [
+    {
+      "completed_at": null,
+      "stage": "scope_and_issue",
+      "status": "done",
+      "summary": null
+    },
+    {
+      "completed_at": null,
+      "stage": "plan",
+      "status": "done",
+      "summary": null
+    },
+    {
+      "completed_at": null,
+      "stage": "implement",
+      "status": "pending",
+      "summary": null
+    },
+    {
+      "completed_at": null,
+      "stage": "update_docs",
+      "status": "done",
+      "summary": null
+    },
+    {
+      "completed_at": null,
+      "stage": "test_and_checks",
+      "status": "done",
+      "summary": null
+    },
+    {
+      "completed_at": null,
+      "stage": "commit_and_submit_pr",
+      "status": "pending",
+      "summary": null
+    }
+  ],
+  "task_id": "1357-adr-044-subworkflow",
+  "task_kind": "docs"
+}

--- a/.workflow/records/1357-adr-044-subworkflow.json
+++ b/.workflow/records/1357-adr-044-subworkflow.json
@@ -1,6 +1,13 @@
 {
   "admin_labels": [],
-  "amendments": [],
+  "amendments": [
+    {
+      "approved_by": null,
+      "exclude": [],
+      "include": [],
+      "reason": "Docs-only task \u2014 no scope changes during implementation; recording amend to mark implement stage as done"
+    }
+  ],
   "branch": "docs/issue-1357/adr-044-subworkflow-spec",
   "changed_test_paths": [],
   "check_results": [
@@ -42,7 +49,16 @@
       "rationale": "docs-only; tests listed in spec for implementation PR"
     }
   },
-  "full_audit": null,
+  "full_audit": {
+    "blocks_merge": false,
+    "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output docs/audit/full-audit-latest.json",
+    "exit_code": 0,
+    "known_debt": [],
+    "output_path": "docs/audit/full-audit-latest.json",
+    "status": "pass",
+    "summary": {},
+    "unclassified_failures": []
+  },
   "governance_touch": true,
   "issues": [
     {
@@ -104,7 +120,7 @@
     {
       "completed_at": null,
       "stage": "implement",
-      "status": "pending",
+      "status": "done",
       "summary": null
     },
     {

--- a/.workflow/records/1357-adr-044-subworkflow.json
+++ b/.workflow/records/1357-adr-044-subworkflow.json
@@ -30,7 +30,13 @@
       "timestamp": null
     }
   ],
-  "commit": null,
+  "commit": {
+    "gate_record_path": ".workflow/records/1357-adr-044-subworkflow.json",
+    "shas": [
+      "59d8f8fb"
+    ],
+    "trailers": {}
+  },
   "docs_landing": {
     "changelog": {
       "not_applicable": true,
@@ -74,7 +80,13 @@
     "docs/specs/adr-044-subworkflow-block.md",
     "docs/architecture/ARCHITECTURE.md"
   ],
-  "pull_request": null,
+  "pull_request": {
+    "body_closes_issues": [
+      1357
+    ],
+    "number": 1359,
+    "url": "https://github.com/zjzcpj/SciStudio/pull/1359"
+  },
   "record_path": ".workflow/records/1357-adr-044-subworkflow.json",
   "required_checks": [
     "frontmatter_lint",
@@ -138,7 +150,7 @@
     {
       "completed_at": null,
       "stage": "commit_and_submit_pr",
-      "status": "pending",
+      "status": "done",
       "summary": null
     }
   ],

--- a/docs/adr/ADR-044.md
+++ b/docs/adr/ADR-044.md
@@ -1,0 +1,401 @@
+---
+adr: 44
+title: "SubWorkflowBlock As Authoring-Only Container With Inline Flattening At Load"
+status: Accepted
+date_created: 2026-05-21
+date_accepted: 2026-05-21
+date_superseded: null
+
+supersedes: []
+superseded_by: null
+related: [17, 18, 22, 28, 38, 42]
+closes_issues: []
+tracking_issue: 1357
+
+is_code_implementation: false
+governs:
+  modules:
+    - scistudio.workflow
+    - scistudio.blocks.subworkflow
+    - scistudio.api.runtime
+    - scistudio.core.lineage
+  contracts:
+    - scistudio.blocks.subworkflow.subworkflow_block.SubWorkflowBlock
+    - scistudio.workflow.definition.WorkflowDefinition
+  entry_points: []
+  files:
+    - src/scistudio/blocks/subworkflow/subworkflow_block.py
+    - src/scistudio/workflow/definition.py
+    - src/scistudio/workflow/schema.py
+    - src/scistudio/workflow/validator.py
+    - src/scistudio/api/runtime.py
+    - src/scistudio/core/lineage/recorder.py
+    - docs/architecture/ARCHITECTURE.md
+    - docs/specs/adr-044-subworkflow-block.md
+  excludes:
+    - src/scistudio/engine/scheduler.py
+    - src/scistudio/engine/runners/**
+
+tests: []
+agent_editable: false
+assisted_by:
+  - "claude:opus-4-7"
+phase: planning
+tags:
+  - subworkflow
+  - authoring-only
+  - runtime
+  - parser
+  - lineage
+owner: "@jiazhenz026"
+co_authors: []
+language_source: en
+translations: []
+---
+
+# ADR-044: SubWorkflowBlock As Authoring-Only Container With Inline Flattening At Load
+
+## 1. Decision Summary
+
+SciStudio adopts an authoring-only model for `SubWorkflowBlock`. A
+`SubWorkflowBlock` node in a workflow YAML is an editor-time and parser-time
+concept that references an external subworkflow file. The engine's scheduler
+never observes a `SubWorkflowBlock` at runtime. At workflow load time (both
+editor open and run start), a parser-layer **inline flattener** rewrites every
+`SubWorkflowBlock` reference into a prefixed copy of the referenced
+subworkflow's blocks and edges. The scheduler always receives a single flat
+DAG.
+
+This decision deletes the existing `SubWorkflowBlock` runtime stub (sequential
+executor, injected `_scheduler_factory`, injected `_cleanup_callback`) and
+removes the entire nested-execution surface that issue
+[#890](https://github.com/zjzcpj/SciStudio/issues/890) was tracking. The
+implementation PR closes #890.
+
+### 1.1 Problems Addressed
+
+| Problem | Risk | ADR response | Detailed section |
+|---|---|---|---|
+| Long workflows tangle the canvas; no readable collapse mechanism for sub-pipelines. | Users abandon workflows mid-build or refuse to use SciStudio for non-trivial pipelines. | Introduce `SubWorkflowBlock` as an authoring-time container that visually collapses a sub-pipeline without engaging nested runtime execution. | Section 3 |
+| Nested runtime execution of subworkflows imposes a large engineering surface (grandchild subprocesses, cancellation propagation, parent/child lineage, resource accounting) tracked by #890. | Implementation cost is high; failure modes are subtle; the design is the largest blocker to completing `SubWorkflowBlock` as a product feature. | Resolve nested execution at the parser layer via inline flattening at load. The scheduler always receives a flat DAG and never knows `SubWorkflowBlock` existed. | Section 4 |
+| Embedding a copy of the subworkflow content per reference introduces version-skew and refresh UI complexity. | Two conflicting semantics (frozen copies versus implicit re-runs against new content); users misunderstand which version executed; ad-hoc UI for "refresh from source" duplicates git's role. | Use ref-only references. Edits to the source propagate on next load. Per-run reproducibility is captured by the existing lineage YAML snapshot, not by tool-managed freeze. | Section 5 |
+| Discriminating subworkflow files via a `kind` field adds schema migration cost and forks standalone-run semantics. | Discriminator becomes a redundancy and a tripwire; users hit a "this file can only be referenced, not run" mode that contradicts the design intent. | Omit `kind`. Cycle detection (canonical-path DFS) is the actual safety guarantee; any workflow file may be referenced and any may be run standalone. | Section 6 |
+| Reference cycles (`A → B → A`, including renamed copies of the parent) can produce infinite recursion at flatten time. | Editor hang, stack overflow on workflow open, or silent corruption of the flattened workflow. | Detect cycles by canonical-path DFS during flattening; raise `CyclicSubworkflowError` with the full reference chain. | Section 7 |
+| Existing `SubWorkflowBlock` stub injects engine-side machinery (`_scheduler_factory`, `_cleanup_callback`) that is moot under the authoring-only design. | Dead code in `blocks/`; accidental dependencies on stub behavior; #890 stays open and confuses future readers. | Delete the stub. The post-ADR class is a thin authoring-time shell with dynamic-ports derivation only. The implementation PR closes #890. | Section 8 |
+
+## 2. Scope
+
+### 2.1 In Scope
+
+- Authoring-layer model for `SubWorkflowBlock`: disk schema, canvas
+  representation, double-click tab navigation, dynamic port adaptation.
+- Parser-layer inline flattening at workflow load time, executed at both
+  editor open and run start.
+- Cycle detection during flattening.
+- Lineage snapshot semantics: the `workflow_yaml_snapshot` recorded with
+  every run is the flattened YAML, not the original referenced YAML.
+- External-file load: copying chosen external files into
+  `<project>/subworkflows/` for project portability.
+- Removal of the existing `SubWorkflowBlock` runtime stub and closure of
+  issue #890 by the implementation PR.
+
+### 2.2 Out Of Scope
+
+- Reproducibility freeze or version pinning of subworkflow references.
+  Reproducibility is provided by (a) the per-run flattened lineage snapshot
+  and (b) user-managed git branches or tags. SciStudio does not embed
+  version control for subworkflow references.
+- Cross-project subworkflow catalog or shared library. Each project's
+  `subworkflows/` directory is local.
+- Subworkflow template parameters (parameterising a subworkflow with config
+  inputs distinct from ports). Future ADR or spec if user demand emerges.
+- Streaming intermediate states of inlined inner blocks back to a
+  "subworkflow node" view in the UI. The flattened DAG executes normally;
+  UI filtering by group prefix is a frontend concern outside this ADR.
+- Automatic rename or move refactoring of subworkflow files with reference
+  updates. Broken refs are surfaced as load-time errors; users handle
+  rename manually.
+
+## 3. Authoring-Time Container
+
+`SubWorkflowBlock` is a node type that exists for three purposes:
+
+1. **Canvas readability** — a single node represents a sub-pipeline that
+   would otherwise crowd the parent canvas with many blocks and edges.
+2. **Tab navigation** — double-click opens the referenced subworkflow file
+   in its own editor tab; the user edits the inner DAG in that tab.
+3. **Port surface** — the node exposes a set of ports derived from the
+   referenced subworkflow's `exposed_ports` declaration, so the parent can
+   connect to the sub-pipeline as if it were a single block.
+
+The container has no `run()`-time behaviour. By the time the scheduler runs,
+the parser has already replaced it with its inner blocks. See §4.
+
+## 4. Inline Flattening At Load
+
+The workflow parser layer (`scistudio.workflow.definition`) gains a function:
+
+```python
+WorkflowDefinition.flatten_subworkflows(self) -> WorkflowDefinition
+```
+
+It is pure: a new `WorkflowDefinition` whose blocks/edges contain no
+`SubWorkflowBlock` nodes is returned. The function is invoked at exactly two
+call sites:
+
+| Call site | Caller | Purpose |
+|---|---|---|
+| Editor open | `ApiRuntime.load_workflow` | UI needs the flattened port surface for each `SubWorkflowBlock` (to render ports, validate edges, surface dangling edges). |
+| Run start | `ApiRuntime.start_workflow` (before scheduler dispatch) | Scheduler consumes a flat DAG; the flattened YAML is captured in `RunRecord.workflow_yaml_snapshot`. |
+
+Both sites call the same function. The result is identical at both sites
+because flattening is pure over on-disk YAML inputs.
+
+For each `SubWorkflowBlock` node `sw` in a workflow:
+
+1. Resolve `sw.config.ref.path` to a canonical absolute file path.
+2. Refuse if the canonical path is already on the DFS visiting stack
+   (cycle — §7).
+3. Load the referenced workflow YAML and recursively flatten it
+   (depth-first). Nested subworkflows flatten in one pass.
+4. Rewrite every inner block id by prefixing with `sw.id + "__"` (e.g.
+   `load` → `sw1__load`).
+5. Rewrite inner edges to use the prefixed ids.
+6. Rewrite every parent edge that touched `sw` by translating
+   `sw.<exposed_port>` to the inner `block.port` that `exposed_ports`
+   pointed at (with the prefix applied).
+7. Replace `sw` in the parent's block list with the (now prefixed) inner
+   block list.
+
+The downstream consumers — validator, scheduler, runners, lineage recorder
+— see a normal flat workflow. None of them know about `SubWorkflowBlock`.
+
+## 5. Ref-Only References And Reproducibility
+
+A `SubWorkflowBlock` node stores **only a reference** to an external
+subworkflow file in `config.ref.path`. It does not embed a copy of the
+subworkflow's content.
+
+Consequence: editing the referenced subworkflow file affects every workflow
+that references it, on the next load. This is the explicit user-facing
+semantic, modeled on Python `import` rather than on git submodule pinning.
+
+Reproducibility of past runs is provided not by freezing references but by
+the existing lineage snapshot mechanism (ADR-038):
+
+- `RunRecord.workflow_yaml_snapshot` is populated with the **flattened**
+  YAML at run start. This snapshot fully captures the inner subworkflow
+  content as it existed at the moment of execution.
+- A past run can be reconstructed even if the subworkflow file is later
+  edited, moved, or deleted, because the snapshot is the post-flattening
+  flat workflow.
+
+Reproducibility of future edits (the user wants to "freeze" the current
+state of a subworkflow against future modifications) is provided by git:
+the user creates a branch or tag at the desired commit. SciStudio does not
+embed version control for subworkflow references because building it in
+would duplicate git's role and add UI surface area that science users
+would not consistently maintain.
+
+The freeze-and-refresh model (embedding copies plus a "refresh from
+source" UI) was considered during design discussion 2026-05-21 and
+rejected for this reason.
+
+## 6. No `kind` Discriminator
+
+Workflow YAML files do not gain a `kind: workflow | subworkflow` field. Any
+workflow file is potentially referenceable by a `SubWorkflowBlock` and any
+workflow file is potentially runnable standalone.
+
+A subworkflow's identity as "designed to be referenced by a parent" is
+conveyed by the optional top-level `exposed_ports` section in its YAML.
+Files with no `exposed_ports` are still referenceable but expose zero ports
+to the parent (rendered as a node with no port handles, legal but not
+useful). Files with `exposed_ports` are regular workflows that also happen
+to be useful as subworkflows.
+
+This avoids three sources of friction:
+
+- A discriminator that would need migration across existing workflow files.
+- A second runnability rule (subworkflow files would otherwise need a
+  special "can be run standalone" exception).
+- Redundancy with cycle detection (§7), which already provides the misuse
+  safety net.
+
+The user could in principle copy a main workflow file, rename it, edit it
+to add `exposed_ports`, and reference it. Cycle detection catches the case
+where the copy retained its original references that loop back to the
+original parent. No additional schema discriminator is needed to prevent
+this.
+
+## 7. Cycle Detection
+
+During inline flattening (§4), the recursive descent maintains a
+`visiting: set[Path]` of canonicalised absolute file paths. Before recursing
+into a referenced file, the flattener checks set membership:
+
+- Already in `visiting` → raise `CyclicSubworkflowError(path_chain)`.
+- Not in `visiting` → add, recurse, remove on return.
+
+`CyclicSubworkflowError` includes the full chain
+(`a.wf.yaml → b.swf.yaml → c.swf.yaml → a.wf.yaml`) so users can locate the
+offending reference.
+
+Paths are canonicalised via `Path.resolve(strict=True)` before set
+membership check. This handles symbolic links, `..` segments, and
+case-insensitive filesystems (Windows). Two refs that resolve to the same
+inode are the same path.
+
+A subtler edge case: a user copies `main.wf.yaml` to
+`external.swf.yaml`, adds an `exposed_ports` section to the copy, and
+references `external.swf.yaml` from `main.wf.yaml`. If `external.swf.yaml`
+retains the original references that loop back to `main.wf.yaml`, the
+cycle detector catches it on the second visit. If the user manually
+rewrites the copy to remove the back-reference, that is not a cycle and
+the flattener has no opinion: the result is two independent workflows that
+happen to share content.
+
+## 8. Removal Of The Existing Stub
+
+The current `SubWorkflowBlock` implementation
+([subworkflow_block.py](../../src/scistudio/blocks/subworkflow/subworkflow_block.py))
+is a stub with engine-side injection points that this ADR makes moot:
+
+- `SubWorkflowBlock._scheduler_factory: ClassVar` and all engine-side
+  injection of it.
+- `SubWorkflowBlock._cleanup_callback: ClassVar` and all engine-side
+  injection of it.
+- `SubWorkflowBlock._run_with_scheduler` method.
+- `SubWorkflowBlock._sequential_execute` helper.
+- `SubWorkflowBlock.input_mapping` / `output_mapping` ClassVars.
+- Existing tests in `tests/blocks/test_subworkflow.py` that assert on the
+  sequential executor, scheduler factory injection, and cleanup callback
+  semantics.
+
+The implementation PR deletes these and replaces them with the
+authoring-only class: a thin shell whose only behavior is dynamic port
+derivation from the referenced subworkflow's `exposed_ports`. The
+implementation PR closes #890 with the rationale that the issue's premise
+(nested execution wiring) is rejected by this ADR.
+
+## 9. Verification And Tooling Impact
+
+### 9.1 Validator
+
+The workflow validator (`scistudio.workflow.validator`) is extended to
+check, after flattening:
+
+- Every `SubWorkflowBlock` node had `config.ref.path` set.
+- Every `config.ref.path` resolved to a readable file.
+- Each referenced file's `exposed_ports.internal` references resolved to
+  blocks and ports that exist in that file.
+- The flattened workflow is a valid acyclic DAG with all edges connecting
+  existing ports (normal validation, unchanged).
+
+### 9.2 Lineage
+
+`RunRecord.workflow_yaml_snapshot`
+([record.py:35](../../src/scistudio/core/lineage/record.py#L35)) is
+populated with the flattened YAML (per §5). `BlockExecutionRecord.block_id`
+carries the prefixed flat id (e.g. `sw1__peak_pick`). No new schema
+fields. No `parent_run_id` usage; there is no parent/child run hierarchy
+under this ADR.
+
+### 9.3 Frontmatter And Audit
+
+The new ADR-044 and the matching spec
+(`docs/specs/adr-044-subworkflow-block.md`) must pass:
+
+- Frontmatter lint (ADR-042 schema for both ADR and spec).
+- ADR-042 QA full audit.
+- Sentrux applicability check on the touched files (the implementation PR
+  will trigger this; the docs-only PR for this ADR + spec records
+  applicability in the gate record).
+
+### 9.4 ARCHITECTURE.md
+
+ARCHITECTURE.md §5.4.7 (SubWorkflowBlock) is updated to:
+
+- Describe the authoring-only model.
+- Mark the implementation as planned (this ADR is `Accepted` but
+  `phase: planning`; the runtime change has not landed).
+- Cross-reference ADR-044 and the spec.
+
+## 10. Consequences
+
+### 10.1 Positive
+
+- The #890 problem set is dissolved, not solved. Nested execution surface
+  is removed entirely.
+- Lineage retains full reproducibility for past runs (snapshot is
+  flattened YAML).
+- The downstream consumers (scheduler, runners, validator) do not need to
+  learn a new node type.
+- Editing a subworkflow file and observing the change in every dependent
+  workflow on next load is a familiar mental model (Python `import`).
+- Standalone execution of a subworkflow file requires no special case.
+
+### 10.2 Negative
+
+- Editing the referenced subworkflow can silently break parent edges
+  (e.g. by removing an `exposed_ports` entry). Mitigated by the
+  editor surfacing dangling edges on next load and the validator
+  rejecting them at run start.
+- Future-state reproducibility is delegated to git. Users who do not use
+  git tags or branches to mark "publishable" states will experience
+  drift between past runs (which are snapshotted) and re-runs of the
+  same workflow (which use the current source).
+- Cross-project subworkflow sharing is out of scope; teams that want
+  shared libraries must use manual file copies or git submodules until a
+  future ADR addresses it.
+
+### 10.3 Migration
+
+The existing `SubWorkflowBlock` stub has no production usage — its tests
+exercise only the sequential executor and scheduler-factory injection,
+both deleted by this ADR. No production workflow YAML files in the
+repository contain `SubWorkflowBlock` nodes (verified at ADR-draft time;
+the implementation PR re-verifies). No on-disk migration is required.
+
+If a developer has a workflow with a stub `SubWorkflowBlock` in a feature
+branch, the migration is mechanical: extract the `child_blocks` into a new
+subworkflow file with an `exposed_ports` section, and replace the
+`SubWorkflowBlock`'s config with `config.ref.path` pointing at the new
+file.
+
+## 11. Alternatives Considered
+
+### 11.1 Implement Nested Runtime Execution (Issue #890 As Stated)
+
+Build out the engine-side machinery #890 describes: scheduler factory
+injection, nested subprocess hierarchy, cancellation propagation, parent
+/child lineage linkage, grandchild process registry, resource accounting
+across nesting levels. Rejected because the entire engineering surface
+exists only to support a UX requirement (visual collapse) that does not
+require nested execution.
+
+### 11.2 Embedded Copies With Refresh-From-Source
+
+Each `SubWorkflowBlock` embeds a deep copy of the subworkflow blocks into
+the parent workflow YAML, plus a `source_ref` book-mark and a
+`content_hash` field. Edits to the source surface as "source updated;
+refresh?" prompts. Rejected during owner discussion 2026-05-21: the
+freeze-by-default semantics duplicate git's role, the refresh UI is a
+maintenance burden, and the per-run lineage snapshot already provides the
+reproducibility property that copy-and-freeze was meant to deliver.
+
+### 11.3 `kind: subworkflow` Discriminator
+
+Workflow YAML files gain a `kind: workflow | subworkflow` field; only
+`kind: subworkflow` files can be referenced. Rejected because cycle
+detection (§7) is the actual safety guarantee, the discriminator adds
+schema migration cost, and it complicates standalone-run semantics (§6).
+
+### 11.4 New MCP Tools For Subworkflow Authoring
+
+Introduce `create_subworkflow`, `list_subworkflows`,
+`reference_subworkflow_from` MCP tools so AI agents have first-class
+subworkflow primitives. Rejected because a subworkflow file is a regular
+workflow file with an `exposed_ports` section; the existing
+`write_workflow` and project-file listing endpoints already cover every
+use case.

--- a/docs/adr/ADR-044.md
+++ b/docs/adr/ADR-044.md
@@ -60,11 +60,17 @@ translations: []
 SciStudio adopts an authoring-only model for `SubWorkflowBlock`. A
 `SubWorkflowBlock` node in a workflow YAML is an editor-time and parser-time
 concept that references an external subworkflow file. The engine's scheduler
-never observes a `SubWorkflowBlock` at runtime. At workflow load time (both
-editor open and run start), a parser-layer **inline flattener** rewrites every
-`SubWorkflowBlock` reference into a prefixed copy of the referenced
-subworkflow's blocks and edges. The scheduler always receives a single flat
-DAG.
+never observes a `SubWorkflowBlock` at runtime. At run start
+(`ApiRuntime.start_workflow`), a parser-layer **inline flattener** rewrites
+every `SubWorkflowBlock` reference into a prefixed copy of the referenced
+subworkflow's blocks and edges before scheduler dispatch. The scheduler always
+receives a single flat DAG. The editor sees the authored graph (with
+`SubWorkflowBlock` nodes intact); per-node port handles and dangling-edge
+detection use the existing dynamic-ports mechanism on
+`SubWorkflowBlock.get_effective_*_ports`, not whole-graph flattening — this
+preserves the round-trip invariant that opening and saving a workflow
+without edits leaves the on-disk YAML byte-for-byte identical (Codex P1
+on PR #1359).
 
 This decision deletes the existing `SubWorkflowBlock` runtime stub (sequential
 executor, injected `_scheduler_factory`, injected `_cleanup_callback`) and
@@ -113,8 +119,12 @@ implementation PR closes #890.
   "subworkflow node" view in the UI. The flattened DAG executes normally;
   UI filtering by group prefix is a frontend concern outside this ADR.
 - Automatic rename or move refactoring of subworkflow files with reference
-  updates. Broken refs are surfaced as load-time errors; users handle
-  rename manually.
+  updates. Broken refs are surfaced as `SubWorkflowBroken` placeholder nodes
+  at editor load (the editor continues to render the rest of the workflow)
+  and as a validator-level error at `start_workflow`; users repair via the
+  editor's "locate file…" affordance on the placeholder. Renaming or moving
+  the referenced file is the user's responsibility (Codex P2 on PR #1359
+  reconciliation: this clause now matches spec §2 User Story 6 and FR-010).
 
 ## 3. Authoring-Time Container
 
@@ -131,7 +141,7 @@ implementation PR closes #890.
 The container has no `run()`-time behaviour. By the time the scheduler runs,
 the parser has already replaced it with its inner blocks. See §4.
 
-## 4. Inline Flattening At Load
+## 4. Inline Flattening Before Dispatch
 
 The workflow parser layer (`scistudio.workflow.definition`) gains a function:
 
@@ -140,16 +150,26 @@ WorkflowDefinition.flatten_subworkflows(self) -> WorkflowDefinition
 ```
 
 It is pure: a new `WorkflowDefinition` whose blocks/edges contain no
-`SubWorkflowBlock` nodes is returned. The function is invoked at exactly two
-call sites:
+`SubWorkflowBlock` nodes is returned. The function is invoked at **exactly
+one** call site:
 
 | Call site | Caller | Purpose |
 |---|---|---|
-| Editor open | `ApiRuntime.load_workflow` | UI needs the flattened port surface for each `SubWorkflowBlock` (to render ports, validate edges, surface dangling edges). |
 | Run start | `ApiRuntime.start_workflow` (before scheduler dispatch) | Scheduler consumes a flat DAG; the flattened YAML is captured in `RunRecord.workflow_yaml_snapshot`. |
 
-Both sites call the same function. The result is identical at both sites
-because flattening is pure over on-disk YAML inputs.
+`ApiRuntime.load_workflow` deliberately does **not** call the flattener; it
+returns the authored graph (with `SubWorkflowBlock` nodes intact) so that
+saving from the editor preserves the on-disk YAML byte-for-byte
+(rationale: Codex P1 on PR #1359 — flattening at the editor fetch path
+would let a save overwrite each `SubWorkflowBlock` container with its
+inlined contents, destroying authored intent).
+
+The editor still needs per-node visibility into each `SubWorkflowBlock`'s
+port surface (to render handles and surface dangling edges). That data
+comes from the existing dynamic-ports mechanism — see
+`SubWorkflowBlock.get_effective_input_ports` /
+`get_effective_output_ports`, which read the referenced subworkflow's
+`exposed_ports` at the per-node level without flattening the parent graph.
 
 For each `SubWorkflowBlock` node `sw` in a workflow:
 

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -887,12 +887,16 @@ tracks the gap, and the stub is not used by any production workflow YAML.
 
 **Planned state (ADR-044, accepted 2026-05-21).** `SubWorkflowBlock` becomes
 an authoring-only container. A node in a workflow YAML carries only a
-reference to an external subworkflow file (`config.ref.path`). At workflow
-load time (both editor open and run start), a parser-layer flattener
+reference to an external subworkflow file (`config.ref.path`). At run start
+(`ApiRuntime.start_workflow`), a parser-layer flattener
 (`WorkflowDefinition.flatten_subworkflows`) replaces every `SubWorkflowBlock`
-node with a prefixed copy of the referenced subworkflow's blocks and edges.
-The scheduler always receives a flat DAG and never observes a
-`SubWorkflowBlock` at runtime. The lineage record's
+node with a prefixed copy of the referenced subworkflow's blocks and edges
+before scheduler dispatch. The editor sees the authored graph (with
+`SubWorkflowBlock` containers intact) so that subsequent saves preserve the
+on-disk YAML; per-node port handles and dangling-edge detection in the
+editor use the existing dynamic-ports mechanism on `SubWorkflowBlock`, not
+whole-graph flattening. The scheduler always receives a flat DAG and never
+observes a `SubWorkflowBlock` at runtime. The lineage record's
 `workflow_yaml_snapshot` captures the flattened YAML, so reproducibility of
 past runs is preserved automatically. Per-reference reproducibility against
 future edits is delegated to git (branches or tags), not embedded in the

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -875,12 +875,37 @@ schema.
 
 #### 5.4.7 SubWorkflowBlock
 
-`SubWorkflowBlock` lets a workflow be reused as a single block inside another
-workflow. It is the composition mechanism for reusable sub-pipelines and
-hierarchical workflows.
+`SubWorkflowBlock` lets a workflow be referenced as a single node inside
+another workflow. It is the canvas-readability mechanism for collapsing
+sub-pipelines.
 
-Important class attributes include ports that map parent workflow values into
-child workflow inputs and child outputs back to the parent node.
+**Current state.** The class in
+`src/scistudio/blocks/subworkflow/subworkflow_block.py` is a runtime stub: it
+executes child blocks via an in-process sequential executor with engine-side
+`_scheduler_factory` and `_cleanup_callback` injection points. Issue #890
+tracks the gap, and the stub is not used by any production workflow YAML.
+
+**Planned state (ADR-044, accepted 2026-05-21).** `SubWorkflowBlock` becomes
+an authoring-only container. A node in a workflow YAML carries only a
+reference to an external subworkflow file (`config.ref.path`). At workflow
+load time (both editor open and run start), a parser-layer flattener
+(`WorkflowDefinition.flatten_subworkflows`) replaces every `SubWorkflowBlock`
+node with a prefixed copy of the referenced subworkflow's blocks and edges.
+The scheduler always receives a flat DAG and never observes a
+`SubWorkflowBlock` at runtime. The lineage record's
+`workflow_yaml_snapshot` captures the flattened YAML, so reproducibility of
+past runs is preserved automatically. Per-reference reproducibility against
+future edits is delegated to git (branches or tags), not embedded in the
+tool.
+
+The planned state deletes the existing scheduler-injection scaffold and
+closes issue #890 via the implementation PR. The post-ADR class is a thin
+authoring-time shell with dynamic port derivation from the referenced
+subworkflow's `exposed_ports`, and double-click on the canvas node opens
+the referenced file in its own editor tab.
+
+See ADR-044 (`docs/adr/ADR-044.md`) and the implementation spec
+(`docs/specs/adr-044-subworkflow-block.md`) for the full contract.
 
 ### 5.5 Port System
 

--- a/docs/specs/adr-044-subworkflow-block.md
+++ b/docs/specs/adr-044-subworkflow-block.md
@@ -82,9 +82,16 @@ The core requirements are:
 - A pure `WorkflowDefinition.flatten_subworkflows` function replaces every
   `SubWorkflowBlock` node with its referenced subworkflow's inner blocks
   and edges, using `<sw_id>__` id prefixes.
-- Both the editor-open path (`ApiRuntime.load_workflow`) and the run-start
-  path (`ApiRuntime.start_workflow`) call this function. The run-start path
-  captures the flattened YAML as the per-run lineage snapshot.
+- `ApiRuntime.start_workflow` is the single call site for this function;
+  it runs the flattener immediately before scheduler dispatch and writes
+  the result to `RunRecord.workflow_yaml_snapshot`.
+- `ApiRuntime.load_workflow` returns the authored graph unchanged.
+  Flattening is run-time-only so that saving from the editor preserves
+  every `SubWorkflowBlock` container in the on-disk YAML. The editor
+  resolves each `SubWorkflowBlock` node's port surface via the dynamic-
+  ports mechanism (FR-004) — a per-node lookup into the referenced
+  subworkflow's `exposed_ports`, not whole-graph flattening (rationale:
+  Codex P1 on PR #1359).
 - `SubWorkflowBlock` retains only dynamic-port derivation from the referenced
   subworkflow's `exposed_ports`. The existing scheduler-injection scaffold
   (`_scheduler_factory`, `_cleanup_callback`, `_sequential_execute`) is
@@ -284,11 +291,16 @@ Acceptance Scenarios:
 - **FR-001:** `WorkflowDefinition.flatten_subworkflows(self) -> WorkflowDefinition`
   exists as a pure function that returns a new definition whose blocks/edges
   contain no `SubWorkflowBlock` nodes.
-- **FR-002:** `ApiRuntime.load_workflow` calls `flatten_subworkflows` before
-  returning the definition; the returned definition is the editor's view.
-- **FR-003:** `ApiRuntime.start_workflow` calls `flatten_subworkflows` before
-  scheduler dispatch and writes the flattened YAML to
-  `RunRecord.workflow_yaml_snapshot`.
+- **FR-002:** `ApiRuntime.load_workflow` returns the authored workflow
+  definition with every `SubWorkflowBlock` node intact. It does **not**
+  invoke `flatten_subworkflows`; the editor consumes the authored graph
+  so that subsequent saves preserve each `SubWorkflowBlock` container
+  byte-for-byte in the on-disk YAML. The editor obtains each node's port
+  surface via FR-004 (dynamic ports), not by flattening.
+- **FR-003:** `ApiRuntime.start_workflow` calls `flatten_subworkflows`
+  before scheduler dispatch and writes the flattened YAML to
+  `RunRecord.workflow_yaml_snapshot`. This is the sole call site for the
+  flattener.
 - **FR-004:** `SubWorkflowBlock.get_effective_input_ports` and
   `get_effective_output_ports` derive the port set from the referenced
   subworkflow's `exposed_ports`, with port `accepted_types` inherited from
@@ -349,7 +361,10 @@ Acceptance Scenarios:
 
 - A pure parser-layer flattener (`WorkflowDefinition.flatten_subworkflows`)
   is the single boundary between authoring-layer concepts and runtime
-  concepts. It is invoked at two sites only: editor open and run start.
+  concepts. It is invoked at exactly one site:
+  `ApiRuntime.start_workflow`, immediately before scheduler dispatch.
+  `ApiRuntime.load_workflow` returns the authored graph unchanged so the
+  editor never sees the flattened form (preserves the save round-trip).
 - The flattener is purely functional over on-disk YAML inputs (no
   randomness, no caller-supplied context). The same YAML inputs always
   produce the same flat DAG. This is required so the lineage snapshot
@@ -378,7 +393,7 @@ Acceptance Scenarios:
 | `src/scistudio/workflow/schema.py` | modify | Add optional top-level `exposed_ports` field for workflow YAML schema. |
 | `src/scistudio/workflow/validator.py` | modify | Validate `SubWorkflowBroken` placeholders fail at run start; validate post-flatten DAG. |
 | `src/scistudio/workflow/serializer.py` | modify | Ensure `exposed_ports` round-trips through serialise/deserialise. |
-| `src/scistudio/api/runtime.py` | modify | Call `flatten_subworkflows` in `load_workflow` and `start_workflow`. |
+| `src/scistudio/api/runtime.py` | modify | Call `flatten_subworkflows` in `start_workflow` only. `load_workflow` returns the authored graph unchanged. |
 | `src/scistudio/core/lineage/recorder.py` | modify | Ensure the flattened YAML is what reaches `workflow_yaml_snapshot`. |
 | `src/scistudio/engine/runners/**` | modify | Remove `_scheduler_factory` injection of `SubWorkflowBlock`. |
 | `src/scistudio/engine/scheduler.py` | modify | Remove any path that recognises `SubWorkflowBlock` (none should remain after flattening). |
@@ -394,7 +409,7 @@ Acceptance Scenarios:
 | ID | Title | Story | Files | Depends on | Verification |
 |---|---|---|---|---|---|
 | T-001 | Implement `flatten_subworkflows` with cycle detection | US 2, US 4 | `workflow/definition.py`, `workflow/schema.py` | — | `tests/workflow/test_flatten_subworkflows.py` |
-| T-002 | Wire flatten into `ApiRuntime.load_workflow` | US 1, US 3 | `api/runtime.py` | T-001 | unit + manual editor open |
+| T-002 | Confirm `ApiRuntime.load_workflow` returns the authored graph unchanged; wire per-`SubWorkflowBlock` dynamic-ports resolution + dangling-edge detection via FR-004 | US 1, US 3, US 6 | `api/runtime.py`, `blocks/subworkflow/subworkflow_block.py` | T-001 | unit + manual editor open |
 | T-003 | Wire flatten into `ApiRuntime.start_workflow` + lineage snapshot | US 2, US 3 | `api/runtime.py`, `core/lineage/recorder.py` | T-001 | `tests/integration/test_subworkflow_lineage.py` |
 | T-004 | Rewrite `SubWorkflowBlock` as authoring-only with dynamic ports | US 1 | `blocks/subworkflow/subworkflow_block.py`, `tests/blocks/test_subworkflow.py` | T-001 | unit |
 | T-005 | Validator updates for broken-ref placeholders | US 6 | `workflow/validator.py` | T-001 | unit |

--- a/docs/specs/adr-044-subworkflow-block.md
+++ b/docs/specs/adr-044-subworkflow-block.md
@@ -1,0 +1,500 @@
+---
+spec_id: adr-044-subworkflow-block
+title: "ADR-044 SubWorkflowBlock Authoring-Only Container Implementation Specification"
+status: Draft
+feature_branch: docs/issue-1357/adr-044-subworkflow-spec
+created: 2026-05-21
+input: "Owner directive 2026-05-21 to make SubWorkflowBlock an authoring/UI-only concept with engine-side inline flattening at load, eliminating the nested-execution surface tracked by issue #890."
+owners:
+  - "@jiazhenz026"
+related_adrs:
+  - 44
+  - 17
+  - 18
+  - 22
+  - 28
+  - 38
+  - 42
+related_specs: []
+scope:
+  in:
+    - Disk-format contract for SubWorkflowBlock references (config.ref.path) and subworkflow files (top-level exposed_ports section).
+    - Engine-side inline flattening of subworkflow references at workflow load time (editor open and run start).
+    - Dynamic port adaptation for SubWorkflowBlock derived from referenced subworkflow's exposed_ports.
+    - Cycle detection via canonical-path DFS during inline flattening.
+    - Lineage snapshot semantics — workflow_yaml_snapshot must contain the flattened YAML.
+    - External-file load behaviour — copy into project/subworkflows/ on import.
+    - Removal of the existing SubWorkflowBlock stub (sequential executor, _scheduler_factory, _cleanup_callback) and closure of issue #890 by the implementation PR.
+    - Frontend UI behaviour for SubWorkflowBlock nodes — dynamic port rendering, double-click tab switch, dangling edge surfacing, SubWorkflowBroken placeholder.
+    - MCP / AI agent integration — no new tools; reuse write_workflow.
+  out:
+    - Reproducibility freeze or version pinning of referenced subworkflows. Reproducibility is provided by the per-run flattened lineage snapshot and user-managed git branches/tags.
+    - Cross-project subworkflow catalog or shared library.
+    - Subworkflow template parameters distinct from ports. Future spec if needed.
+    - Streaming intermediate states of inlined inner blocks back to a "subworkflow node" view in the UI.
+    - Automatic rename refactoring of subworkflow files with reference rewriting.
+governs:
+  modules:
+    - scistudio.workflow
+    - scistudio.blocks.subworkflow
+    - scistudio.api.runtime
+    - scistudio.core.lineage
+    - frontend.src.components.nodes
+  contracts:
+    - scistudio.blocks.subworkflow.subworkflow_block.SubWorkflowBlock
+    - scistudio.workflow.definition.WorkflowDefinition.flatten_subworkflows
+    - scistudio.workflow.schema
+    - scistudio.api.runtime.ApiRuntime.load_workflow
+    - scistudio.api.runtime.ApiRuntime.start_workflow
+  files:
+    - src/scistudio/blocks/subworkflow/subworkflow_block.py
+    - src/scistudio/workflow/definition.py
+    - src/scistudio/workflow/schema.py
+    - src/scistudio/workflow/validator.py
+    - src/scistudio/workflow/serializer.py
+    - src/scistudio/api/runtime.py
+    - src/scistudio/core/lineage/recorder.py
+    - tests/blocks/test_subworkflow.py
+    - tests/workflow/test_flatten_subworkflows.py
+    - tests/integration/test_subworkflow_lineage.py
+    - frontend/src/components/nodes/SubWorkflowNode.tsx
+    - frontend/src/components/nodes/BlockNode.tsx
+    - docs/architecture/ARCHITECTURE.md
+tests:
+  - tests/blocks/test_subworkflow.py
+  - tests/workflow/test_flatten_subworkflows.py
+  - tests/integration/test_subworkflow_lineage.py
+acceptance_source: adr
+language_source: en
+---
+
+# ADR-044 SubWorkflowBlock Authoring-Only Container Implementation Specification
+
+## 1. Change Summary
+
+This spec translates ADR-044 into implementation requirements. The change is
+to make `SubWorkflowBlock` an authoring-only concept and have the engine
+inline-flatten subworkflow references at workflow load time. The scheduler,
+runners, validator, and lineage recorder always see a flat DAG.
+
+The core requirements are:
+
+- A pure `WorkflowDefinition.flatten_subworkflows` function replaces every
+  `SubWorkflowBlock` node with its referenced subworkflow's inner blocks
+  and edges, using `<sw_id>__` id prefixes.
+- Both the editor-open path (`ApiRuntime.load_workflow`) and the run-start
+  path (`ApiRuntime.start_workflow`) call this function. The run-start path
+  captures the flattened YAML as the per-run lineage snapshot.
+- `SubWorkflowBlock` retains only dynamic-port derivation from the referenced
+  subworkflow's `exposed_ports`. The existing scheduler-injection scaffold
+  (`_scheduler_factory`, `_cleanup_callback`, `_sequential_execute`) is
+  deleted.
+- Cycle detection during flattening uses canonical-path DFS; symbolic links,
+  `..` segments, and case-insensitive filesystems all canonicalise.
+- The implementation PR closes issue #890 because nested execution is
+  rejected by ADR-044.
+
+This spec comes from owner directive 2026-05-21 and is acceptance-sourced
+from ADR-044.
+
+## 2. User Scenarios & Testing
+
+### User Story 1 - Collapse a sub-pipeline for canvas readability (Priority: P1)
+
+As a workflow author with a long pipeline, I need to factor a logical sub-section
+into a separate subworkflow file and reference it as a single node on the main
+canvas.
+
+Why this priority: ADR-044 §3 — the core user-visible problem the ADR
+addresses.
+
+Independent Test: Create a main workflow file and a subworkflow file with an
+`exposed_ports` section; drop a `SubWorkflowBlock` in the main file with
+`config.ref.path` pointing at the subworkflow; verify the canvas shows one
+node with the exposed ports.
+
+Acceptance Scenarios:
+
+1. Given a subworkflow file with `exposed_ports` declaring `raw_in` and
+   `report`, when the user drops a `SubWorkflowBlock` and sets
+   `config.ref.path`, then the node renders with `raw_in` as an input handle
+   and `report` as an output handle.
+2. Given two referenced subworkflows, when the user connects them on the main
+   canvas via their exposed port names, then the edges persist in the parent
+   workflow YAML using the `<sw_id>.<exposed_port>` form.
+3. Given the user double-clicks a `SubWorkflowBlock` node, when the action
+   fires, then the editor opens the referenced subworkflow file in a new tab
+   (or switches focus to its existing tab).
+
+### User Story 2 - Engine runs the flattened DAG (Priority: P1)
+
+As a workflow runtime, I need subworkflow references inlined at load time so
+the scheduler always sees a flat DAG.
+
+Why this priority: ADR-044 §4 — the architectural decision that eliminates
+the #890 surface.
+
+Independent Test: Submit a workflow containing one `SubWorkflowBlock` to
+`start_workflow`; assert that the dispatched DAG contains the inner blocks
+with prefixed ids and that the `SubWorkflowBlock` node is absent.
+
+Acceptance Scenarios:
+
+1. Given a workflow with one `SubWorkflowBlock` `sw1` containing inner blocks
+   `load`, `peak_pick`, `qc_report`, when `start_workflow` is invoked, then
+   the dispatched DAG contains exactly `sw1__load`, `sw1__peak_pick`, and
+   `sw1__qc_report` (plus other top-level blocks) and no `SubWorkflowBlock`
+   nodes.
+2. Given nested subworkflows (`sw1` contains `sw2` which contains `load`),
+   when flattening runs, then the resulting flat block id is
+   `sw1__sw2__load` and the DAG is flat.
+3. Given a workflow run completes, when the `RunRecord` row is examined,
+   then `workflow_yaml_snapshot` equals the flattened YAML and
+   `block_executions` contains rows with the prefixed ids; no
+   `parent_run_id` is set.
+
+### User Story 3 - Edits to a referenced subworkflow propagate on next load (Priority: P1)
+
+As a workflow author, I need changes to a subworkflow file to take effect in
+every workflow that references it on next load, similar to Python `import`.
+
+Why this priority: ADR-044 §5 — establishes the explicit ref-only semantic
+and rejects the freeze-and-refresh UI.
+
+Independent Test: Edit the `exposed_ports` of a subworkflow file; reopen a
+parent that references it; verify the parent shows the new port surface and
+flags dangling edges where prior connections no longer match.
+
+Acceptance Scenarios:
+
+1. Given a subworkflow with output port `report`, when the parent references
+   it and then the subworkflow renames `report` to `summary`, then reopening
+   the parent shows the parent's edge to `report` as dangling and the
+   `SubWorkflowBlock` node exposes `summary` instead.
+2. Given a subworkflow is edited to add a new exposed port, when the parent
+   is reopened, then the `SubWorkflowBlock` node shows the new port available
+   for connection.
+3. Given a run completed before the subworkflow edit, when the lineage
+   snapshot for that run is read, then it contains the pre-edit flattened
+   YAML and the run can be reconstructed without depending on the current
+   state of the subworkflow file.
+
+### User Story 4 - Cycle detection catches reference loops (Priority: P1)
+
+As a workflow loader, I need to detect cyclic subworkflow references and fail
+with a clear error chain.
+
+Why this priority: ADR-044 §7 — without cycle detection, recursion can hang
+the editor or overflow the stack.
+
+Independent Test: Construct files `a.wf.yaml` and `b.swf.yaml` that reference
+each other; assert load raises `CyclicSubworkflowError` with the chain.
+
+Acceptance Scenarios:
+
+1. Given `a.wf.yaml` references `b.swf.yaml` and `b.swf.yaml` references back
+   to `a.wf.yaml`, when either is opened, then load raises
+   `CyclicSubworkflowError` with chain
+   `a.wf.yaml → b.swf.yaml → a.wf.yaml`.
+2. Given a symbolic link `alias.swf.yaml` points at `a.wf.yaml` and `a.wf.yaml`
+   references `alias.swf.yaml`, when load runs, then cycle detection fires
+   because both paths canonicalise to the same inode.
+3. Given a user copies `main.wf.yaml` to `external.swf.yaml`, manually
+   rewrites the copy to remove its back-references, and references
+   `external.swf.yaml` from `main.wf.yaml`, when load runs, then no cycle is
+   detected and load succeeds with the inlined content.
+
+### User Story 5 - External subworkflow files import into the project (Priority: P2)
+
+As an author with a subworkflow file outside the current project, I need the
+file copied into `<project>/subworkflows/` on import so the resulting
+workflow is portable.
+
+Why this priority: ADR-044 §2.1 — convenience and portability. Users could
+manually copy files; the auto-import removes the friction.
+
+Independent Test: Open a `SubWorkflowBlock`, pick an external `.swf.yaml`;
+verify the file appears in `<project>/subworkflows/` with a project-relative
+`config.ref.path` recorded in the parent.
+
+Acceptance Scenarios:
+
+1. Given the user selects an external `.swf.yaml` via the file picker, when
+   the picker confirms, then the file is copied into
+   `<project>/subworkflows/` with the original filename (or a numeric suffix
+   on collision) and `config.ref.path` is set to the project-relative path.
+2. Given the same external file is picked twice in two `SubWorkflowBlock`
+   nodes, when both imports complete, then the project contains two copies
+   with distinct names and each parent reference points to its own copy.
+3. Given the project directory is copied to another machine, when the parent
+   workflow is opened there, then references resolve against the copied
+   subworkflow files in the project (no dependency on the original external
+   path).
+
+### User Story 6 - Broken refs surface as red placeholder nodes (Priority: P2)
+
+As an author whose referenced subworkflow file was deleted or moved, I need
+the main workflow to still open with a clearly marked broken node so I can
+repair it without losing the rest of the workflow.
+
+Why this priority: ADR-044 §10 — graceful degradation; a hard-fail on missing
+ref would punish users for filesystem-level events.
+
+Independent Test: Delete the file at `config.ref.path`; reopen the parent;
+observe a `SubWorkflowBroken` placeholder node and the rest of the canvas
+renders normally.
+
+Acceptance Scenarios:
+
+1. Given a `SubWorkflowBlock` whose `config.ref.path` does not resolve to a
+   readable file, when the workflow opens in the editor, then the canvas
+   shows a `SubWorkflowBroken` placeholder node (red style) and all other
+   blocks render normally.
+2. Given the user clicks the broken placeholder, when the action fires, then
+   a "locate file…" dialog appears allowing the user to repoint
+   `config.ref.path`.
+3. Given a workflow run is attempted with an unresolved ref, when
+   `start_workflow` runs, then the validator rejects the workflow before
+   dispatch with a clear missing-file error.
+
+### Edge Cases
+
+- A `SubWorkflowBlock` whose `config.ref.path` points at a file with no
+  `exposed_ports` section (or an empty section) resolves to a node with
+  zero ports. Legal but no edges can connect; the validator does not fail
+  unless edges reference non-existent ports.
+- A subworkflow file referenced by multiple `SubWorkflowBlock` nodes in the
+  same parent produces independent prefixed copies in the flat DAG; runtime
+  state is independent between copies.
+- A subworkflow may reference more subworkflows; flattening handles
+  arbitrary nesting depth in one pass. Prefix chains compose
+  (`sw1__sw2__load`).
+- A subworkflow file may be opened in its own editor tab and executed
+  standalone via the normal run path. The `exposed_ports` section is
+  ignored during standalone execution; the blocks list runs as a normal DAG
+  with user-supplied initial inputs.
+- An edge in the parent references `sw.<port>` for a port that is not in
+  the referenced subworkflow's `exposed_ports` becomes a dangling edge
+  after flattening. The validator rejects it at run start.
+
+## 3. Requirements
+
+### Functional Requirements
+
+- **FR-001:** `WorkflowDefinition.flatten_subworkflows(self) -> WorkflowDefinition`
+  exists as a pure function that returns a new definition whose blocks/edges
+  contain no `SubWorkflowBlock` nodes.
+- **FR-002:** `ApiRuntime.load_workflow` calls `flatten_subworkflows` before
+  returning the definition; the returned definition is the editor's view.
+- **FR-003:** `ApiRuntime.start_workflow` calls `flatten_subworkflows` before
+  scheduler dispatch and writes the flattened YAML to
+  `RunRecord.workflow_yaml_snapshot`.
+- **FR-004:** `SubWorkflowBlock.get_effective_input_ports` and
+  `get_effective_output_ports` derive the port set from the referenced
+  subworkflow's `exposed_ports`, with port `accepted_types` inherited from
+  the inner block port at `exposed_ports.<direction>[].internal`.
+- **FR-005:** Inline flattening prefixes inner block ids with `<sw_id>__`
+  and rewrites all inner edges to use prefixed ids.
+- **FR-006:** Inline flattening rewrites parent edges that reference
+  `<sw_id>.<exposed_port>` to the prefixed
+  `<sw_id>__<internal_block>.<internal_port>`.
+- **FR-007:** Inline flattening detects reference cycles via canonical-path
+  DFS (paths canonicalised by `Path.resolve(strict=True)`) and raises
+  `CyclicSubworkflowError` with the full reference chain.
+- **FR-008:** A workflow file with no `exposed_ports` section is legal and
+  referenceable; it exposes zero ports to the parent.
+- **FR-009:** A workflow file with `exposed_ports` may also be executed
+  standalone via the normal run path; `exposed_ports` is ignored at
+  standalone run time.
+- **FR-010:** Broken refs produce `SubWorkflowBroken` placeholder nodes
+  during editor load; other blocks load normally; the validator fails at
+  `start_workflow` if any broken-ref placeholder remains.
+- **FR-011:** External-file load copies the chosen file into
+  `<project>/subworkflows/` (numeric suffix on filename collision) and
+  records `config.ref.path` as a project-relative path.
+- **FR-012:** The existing `SubWorkflowBlock` stub is deleted:
+  `_scheduler_factory`, `_cleanup_callback`, `_run_with_scheduler`,
+  `_sequential_execute`, `input_mapping` and `output_mapping` ClassVars,
+  and all engine-side injection of these symbols.
+- **FR-013:** The implementation PR closes issue #890 with the rationale
+  that ADR-044 rejects nested execution.
+
+### Key Entities
+
+- **SubWorkflowBlock** — Authoring-time container class in
+  `scistudio.blocks.subworkflow.subworkflow_block`. Carries
+  `config.ref.path` and derives ports dynamically from the referenced
+  subworkflow's `exposed_ports`. Has no `run()`-time behaviour after
+  flattening removes it. Relationships: referenced by zero or more parent
+  workflow YAML files; references exactly one subworkflow file via
+  `config.ref.path`.
+- **WorkflowDefinition** — Existing in-memory workflow representation in
+  `scistudio.workflow.definition`. Gains `flatten_subworkflows()` and is
+  the contract object passed to scheduler dispatch. Attributes: blocks,
+  edges, exposed_ports (when the workflow is itself a subworkflow source).
+- **exposed_ports** — Top-level YAML section in a referenceable subworkflow
+  file. Has `inputs: [{name, internal}]` and `outputs: [{name, internal}]`
+  arrays, where `internal` is `<block_id>.<port>` referencing a block and
+  port that must exist in the same file's `blocks` list.
+- **SubWorkflowBroken** — Placeholder block type emitted by the parser when
+  `config.ref.path` does not resolve. Carries the unresolved path string
+  for the editor to display.
+- **CyclicSubworkflowError** — Exception type raised during inline
+  flattening when canonical-path DFS detects a cycle. Carries the full
+  reference chain as a list of `Path` objects.
+
+## 4. Implementation Plan
+
+### 4.1 Technical Approach
+
+- A pure parser-layer flattener (`WorkflowDefinition.flatten_subworkflows`)
+  is the single boundary between authoring-layer concepts and runtime
+  concepts. It is invoked at two sites only: editor open and run start.
+- The flattener is purely functional over on-disk YAML inputs (no
+  randomness, no caller-supplied context). The same YAML inputs always
+  produce the same flat DAG. This is required so the lineage snapshot
+  taken at run start exactly matches the structure that runs.
+- `SubWorkflowBlock` retains only its YAML schema identity, the
+  `config.ref.path` config field, and `get_effective_*_ports` methods.
+  The dynamic-ports mechanism is identical to `CodeBlock`'s existing
+  pattern (ADR-028 Addendum 1 D5).
+- Lineage schema (ADR-038) is unchanged. Only the input to
+  `workflow_yaml_snapshot` changes: it is the flattened YAML rather than
+  the on-disk YAML for runs that contain `SubWorkflowBlock` nodes.
+- Validator is extended to recognise `SubWorkflowBroken` placeholders and
+  fail on them at `start_workflow`. Other validation rules operate on the
+  post-flatten DAG and are unchanged.
+- Frontend renders `SubWorkflowBlock` nodes with handles derived from the
+  effective ports endpoint. Double-click invokes the existing tab-open
+  action. `SubWorkflowBroken` placeholders render in the broken-ref style
+  with a "locate file…" affordance.
+
+### 4.2 Affected Files
+
+| File | Action | Rationale |
+|---|---|---|
+| `src/scistudio/blocks/subworkflow/subworkflow_block.py` | modify | Delete stub; add `get_effective_input_ports` / `get_effective_output_ports`; keep `config.ref.path` schema. |
+| `src/scistudio/workflow/definition.py` | modify | Add `flatten_subworkflows`, cycle detection, prefix logic, edge rewriting. |
+| `src/scistudio/workflow/schema.py` | modify | Add optional top-level `exposed_ports` field for workflow YAML schema. |
+| `src/scistudio/workflow/validator.py` | modify | Validate `SubWorkflowBroken` placeholders fail at run start; validate post-flatten DAG. |
+| `src/scistudio/workflow/serializer.py` | modify | Ensure `exposed_ports` round-trips through serialise/deserialise. |
+| `src/scistudio/api/runtime.py` | modify | Call `flatten_subworkflows` in `load_workflow` and `start_workflow`. |
+| `src/scistudio/core/lineage/recorder.py` | modify | Ensure the flattened YAML is what reaches `workflow_yaml_snapshot`. |
+| `src/scistudio/engine/runners/**` | modify | Remove `_scheduler_factory` injection of `SubWorkflowBlock`. |
+| `src/scistudio/engine/scheduler.py` | modify | Remove any path that recognises `SubWorkflowBlock` (none should remain after flattening). |
+| `tests/blocks/test_subworkflow.py` | modify | Rewrite: drop stub-behavior tests; add port-derivation tests. |
+| `tests/workflow/test_flatten_subworkflows.py` | create | Cycle detection, id prefixing, nested flattening, broken ref placeholder. |
+| `tests/integration/test_subworkflow_lineage.py` | create | End-to-end run with `SubWorkflowBlock`; verify snapshot contains flattened YAML and `block_executions` rows. |
+| `frontend/src/components/nodes/SubWorkflowNode.tsx` | create | Render `SubWorkflowBlock` with dynamic port handles, double-click tab open, broken-ref state. |
+| `frontend/src/components/nodes/BlockNode.tsx` | modify | Route `SubWorkflowBlock` and `SubWorkflowBroken` types to the new component. |
+| `docs/architecture/ARCHITECTURE.md` | modify | Update §5.4.7 to describe the authoring-only model; cross-reference ADR-044. |
+
+### 4.3 Implementation Sequence
+
+| ID | Title | Story | Files | Depends on | Verification |
+|---|---|---|---|---|---|
+| T-001 | Implement `flatten_subworkflows` with cycle detection | US 2, US 4 | `workflow/definition.py`, `workflow/schema.py` | — | `tests/workflow/test_flatten_subworkflows.py` |
+| T-002 | Wire flatten into `ApiRuntime.load_workflow` | US 1, US 3 | `api/runtime.py` | T-001 | unit + manual editor open |
+| T-003 | Wire flatten into `ApiRuntime.start_workflow` + lineage snapshot | US 2, US 3 | `api/runtime.py`, `core/lineage/recorder.py` | T-001 | `tests/integration/test_subworkflow_lineage.py` |
+| T-004 | Rewrite `SubWorkflowBlock` as authoring-only with dynamic ports | US 1 | `blocks/subworkflow/subworkflow_block.py`, `tests/blocks/test_subworkflow.py` | T-001 | unit |
+| T-005 | Validator updates for broken-ref placeholders | US 6 | `workflow/validator.py` | T-001 | unit |
+| T-006 | External-file load → copy-to-project | US 5 | `api/runtime.py`, frontend file picker | T-002 | manual + unit |
+| T-007 | Frontend `SubWorkflowNode` + dynamic ports + double-click + broken placeholder | US 1, US 6 | `frontend/src/components/nodes/SubWorkflowNode.tsx`, `BlockNode.tsx` | T-002 | Chrome smoke test |
+| T-008 | Delete stub: `_scheduler_factory`, `_cleanup_callback`, sequential executor, engine-side injection | FR-012 | `blocks/subworkflow/**`, `engine/runners/**`, `engine/scheduler.py` | T-004 | full audit |
+| T-009 | Update ARCHITECTURE.md §5.4.7 | docs | `docs/architecture/ARCHITECTURE.md` | T-008 | frontmatter lint + doc drift |
+| T-010 | Close #890 in implementation PR | FR-013 | PR body only | T-008 | PR closing keyword |
+
+### 4.4 Verification Plan
+
+- Unit tests under `tests/workflow/test_flatten_subworkflows.py` and
+  `tests/blocks/test_subworkflow.py` cover cycle detection, id prefixing,
+  port derivation, broken-ref handling.
+- Integration test `tests/integration/test_subworkflow_lineage.py` covers
+  end-to-end run + lineage snapshot equality with the flattened YAML.
+- Frontend Chrome smoke test (per memory rule "Mandatory Chrome smoke test
+  for all UI agents") covers `SubWorkflowNode` rendering, double-click tab
+  open, dynamic port handle rendering, broken-ref placeholder.
+- `ruff check .`, `ruff format --check .`, `pytest` on relevant directories.
+- ADR-042 QA full audit on the implementation PR.
+- Frontmatter lint on this spec and ADR-044.
+- Sentrux applicability check on the touched source paths.
+
+### 4.5 Risks And Rollback
+
+- **Risk:** A subworkflow edit silently breaks parent edges. **Mitigation:**
+  Editor surfaces dangling edges on next load; validator rejects them at
+  run start. **Rollback:** None required; the rejection mechanism is the
+  rollback signal.
+- **Risk:** The flattener performance for deeply nested subworkflows is
+  poor. **Mitigation:** Each file read is cached within a single flatten
+  invocation (mtime+hash); typical workflows have ≤ 100 inner blocks and
+  ≤ 3 nesting levels per Assumption A-004. **Rollback:** Add caching
+  across invocations if profiling shows hotspots; the public contract is
+  unchanged.
+- **Risk:** Symbolic-link or `..`-segment edge cases on Windows cause
+  cycle detection to miss a cycle. **Mitigation:** Test fixtures exercise
+  symlinks (where the platform supports them), `..` segments, and
+  case-insensitive paths; `Path.resolve(strict=True)` is the canonical
+  form. **Rollback:** None; the test fixtures guard the implementation.
+- **Risk:** Deleting `_scheduler_factory` / `_cleanup_callback` breaks
+  some other downstream consumer outside `subworkflow/`. **Mitigation:**
+  Grep for both symbol names across the codebase during T-008; engine
+  reviewers verify no remaining consumers. **Rollback:** Revert T-008
+  alone; the rest of the cascade does not require deletion.
+- **Risk:** External-file load misses an edge case where the chosen file
+  has the same name as an existing project subworkflow but different
+  content. **Mitigation:** Numeric suffix on name collision and a visible
+  confirmation in the file picker that the new name was chosen.
+  **Rollback:** None; users can rename manually.
+
+## 5. Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001:** Zero `SubWorkflowBlock` nodes reach the scheduler. Measured
+  by assertion in scheduler dispatch and by integration test inspecting
+  the dispatched DAG.
+- **SC-002:** For 100% of runs of workflows that contain `SubWorkflowBlock`
+  nodes pre-flatten, `RunRecord.workflow_yaml_snapshot` equals the
+  flattened YAML. Measured by integration test.
+- **SC-003:** Direct cycles (A→A), 2-cycles (A→B→A), and 3-cycles
+  (A→B→C→A) are all detected and produce `CyclicSubworkflowError` with
+  the correct chain. Measured by parametrized test fixtures.
+- **SC-004:** Issue #890 closed by the implementation PR with the
+  `Closes #890` keyword in the PR body. Measured by GitHub state.
+- **SC-005:** `_scheduler_factory`, `_cleanup_callback`,
+  `_run_with_scheduler`, `_sequential_execute`, `input_mapping`, and
+  `output_mapping` symbols are absent from
+  `src/scistudio/blocks/subworkflow/**` and from any engine-side injection
+  site. Measured by `grep` in CI.
+- **SC-006:** `docs/architecture/ARCHITECTURE.md` §5.4.7 describes the
+  authoring-only model and cross-references ADR-044. Measured by manual
+  review and doc-drift audit.
+- **SC-007:** Dropping a `SubWorkflowBlock` on the canvas, setting
+  `config.ref.path`, and connecting an edge to/from one of its exposed
+  ports persists correctly in the parent workflow YAML and renders
+  correctly on reload. Measured by Chrome smoke test.
+
+## 6. Assumptions
+
+- **A-001 (existing-system):** The dynamic-ports mechanism established by
+  `CodeBlock` (ADR-028 Addendum 1 D5) — specifically
+  `get_effective_input_ports` and `get_effective_output_ports` — covers
+  `SubWorkflowBlock`'s port-adaptation needs without further base-class
+  changes.
+- **A-002 (existing-system):** ADR-038 lineage schema is unchanged by this
+  work; only the content of `workflow_yaml_snapshot` changes for runs
+  containing `SubWorkflowBlock` nodes pre-flatten.
+- **A-003 (owner):** The frontend tab system can open any workflow YAML
+  file in its own tab (user confirmed 2026-05-21: "tab 系统早就有了").
+- **A-004 (inferred):** Realistic workflows have ≤ 100 inner blocks across
+  all nesting levels and ≤ 3 levels of nesting. The flattener is expected
+  to complete in tens of milliseconds for such workflows; if profiling
+  later shows hotspots, caching across invocations is the planned
+  mitigation (§4.5).
+- **A-005 (existing-system):** No production workflow YAML files in the
+  repository currently contain `SubWorkflowBlock` nodes; the implementation
+  PR re-verifies this before deleting the stub.
+- **A-006 (adr):** Per ADR-044 §6, no `kind: workflow | subworkflow`
+  discriminator is introduced. Any workflow file may be referenced and any
+  may be run standalone.


### PR DESCRIPTION
## Summary

Owner-directed redesign of `SubWorkflowBlock` as an authoring-only canvas container. The engine never executes a `SubWorkflowBlock` at runtime; the workflow parser inline-flattens subworkflow references at workflow load (both editor open and run start) so the scheduler always receives a flat DAG. This obviates the nested-execution surface tracked by #890 and lets the implementation PR delete the existing stub.

This PR lands the ADR + spec + ARCHITECTURE.md note. Implementation is out of scope and will be tracked separately.

## What changed

- **`docs/adr/ADR-044.md`** — Accepted decision record (Problems Addressed table; sections cover authoring container, inline flattening at load, ref-only references and reproducibility split between lineage snapshot + git, no `kind` discriminator, cycle detection, removal of existing stub, verification/tooling impact, consequences, alternatives considered).
- **`docs/specs/adr-044-subworkflow-block.md`** — SpecKit-structured implementation spec (6 user stories, 13 functional requirements, key entities, implementation plan with task table, success criteria, assumptions).
- **`docs/architecture/ARCHITECTURE.md` §5.4.7** — Updated to describe the current stub state and the planned authoring-only model, cross-referenced to ADR-044 and the spec.
- **`.workflow/records/1357-adr-044-subworkflow.json`** — Committed gate record.

## Owner directive (2026-05-21)

- Authoring-only model; no nested runtime execution.
- Ref-only references (not embedded copies); edits to source propagate on next load.
- No `kind: subworkflow` discriminator. Any workflow file may be referenced; cycle detection by canonical-path DFS is the safety guarantee.
- Delete existing `SubWorkflowBlock` stub; close #890 in the implementation PR.
- Reproducibility: per-run lineage `workflow_yaml_snapshot` captures the flattened YAML (ADR-038); future-state freezes are delegated to git (branches/tags), not embedded in the tool.

## Checks

- `python -m scistudio.qa.audit.full_audit` — **pass** (all 8 child reports pass; frontmatter lint clean).
- `sentrux check .` — **pass** (11/11 rules; Quality=4126).
- `gate_record pre-push` — **pass**.

## Out of scope

- Implementation of the flattener, `SubWorkflowBlock` rewrite, frontend updates. Tracked separately; implementation PR closes #890.
- Reproducibility freeze / version pinning of references.
- Cross-project subworkflow catalog or shared library.

## Gate record

Gate record: `.workflow/records/1357-adr-044-subworkflow.json`

Closes #1357