### PR TITLE
test(#1384): add CodeBlock format e2e matrix

### DIFF
--- a/.workflow/records/1384-codeblock-e2e.json
+++ b/.workflow/records/1384-codeblock-e2e.json
@@ -114,7 +114,13 @@
       "timestamp": null
     }
   ],
-  "commit": null,
+  "commit": {
+    "gate_record_path": ".workflow/records/1384-codeblock-e2e.json",
+    "shas": [
+      "ee7b7124e7759f99ff92abae417f835f9a17ef96"
+    ],
+    "trailers": {}
+  },
   "docs_landing": {
     "adr": {
       "not_applicable": true,
@@ -164,7 +170,13 @@
     "tests/api/test_blocks.py",
     "docs/audit/2026-05-22-1384-codeblock-e2e-full-audit.json"
   ],
-  "pull_request": null,
+  "pull_request": {
+    "body_closes_issues": [
+      1384
+    ],
+    "number": 1403,
+    "url": "https://github.com/zjzcpj/SciStudio/pull/1403"
+  },
   "record_path": ".workflow/records/1384-codeblock-e2e.json",
   "required_checks": [
     "frontend-e2e-list",
@@ -235,7 +247,7 @@
     {
       "completed_at": null,
       "stage": "commit_and_submit_pr",
-      "status": "pending",
+      "status": "done",
       "summary": null
     }
   ],

--- a/.workflow/records/1384-codeblock-e2e.json
+++ b/.workflow/records/1384-codeblock-e2e.json
@@ -1,0 +1,244 @@
+{
+  "admin_labels": [],
+  "amendments": [
+    {
+      "approved_by": null,
+      "exclude": [],
+      "include": [
+        "src/scistudio/blocks/registry.py",
+        "tests/api/test_blocks.py"
+      ],
+      "reason": "CodeBlock format E2E exposed that the concrete code_block runtime is not registered, preventing every Load-Code-Save scenario from reaching the format backend."
+    },
+    {
+      "approved_by": null,
+      "exclude": [],
+      "include": [
+        "frontend/e2e/support/scistudio.ts"
+      ],
+      "reason": "CodeBlock notebook and shell E2E needed support-helper timeout and backend-aligned runtime detection after registry execution reached real format backends."
+    },
+    {
+      "approved_by": null,
+      "exclude": [],
+      "include": [
+        "docs/audit/2026-05-22-1384-codeblock-e2e-full-audit.json"
+      ],
+      "reason": "Add committed ADR-042 full audit report required by PR readiness preflight."
+    }
+  ],
+  "branch": "track/issue-1384-codeblock-e2e",
+  "changed_test_paths": [
+    "tests/api/test_blocks.py"
+  ],
+  "check_results": [
+    {
+      "command_or_tool": "cd frontend; npm run test:e2e -- --list",
+      "exit_code": 0,
+      "name": "frontend-e2e-list",
+      "output_path": "Listed 37 Playwright tests, including 8 CodeBlock format cases.",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "cd frontend; SCISTUDIO_E2E_BACKEND_PORT=8138 SCISTUDIO_E2E_FRONTEND_PORT=5208 npm run test:e2e -- --grep @codeblock",
+      "exit_code": 0,
+      "name": "frontend-e2e-codeblock",
+      "output_path": "8 passed: .py, .ipynb, .R, .Rmd, .qmd, .sh, .m, .mlx Load-Code-Save matrix.",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "PYTHONPATH=src pytest tests/api/test_blocks.py::test_code_block_builtin_schema_is_registered -q --no-cov",
+      "exit_code": 0,
+      "name": "pytest-codeblock-schema",
+      "output_path": "1 passed.",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "ruff check src/scistudio/blocks/registry.py tests/api/test_blocks.py",
+      "exit_code": 0,
+      "name": "ruff-check",
+      "output_path": "All checks passed; ruff cache write warning only.",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "ruff format --check src/scistudio/blocks/registry.py tests/api/test_blocks.py",
+      "exit_code": 0,
+      "name": "ruff-format-check",
+      "output_path": "2 files already formatted.",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "cd frontend; npm run build",
+      "exit_code": 0,
+      "name": "npm-build",
+      "output_path": "tsc -b and vite build passed; existing large chunk warning emitted.",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "git diff --check",
+      "exit_code": 0,
+      "name": "git-diff-check",
+      "output_path": "No whitespace errors.",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "sentrux MCP/CLI unavailable in this session",
+      "exit_code": 0,
+      "name": "sentrux-skipped",
+      "output_path": "Sentrux unavailable locally; recorded skipped evidence.",
+      "status": "skipped",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "PYTHONPATH=src python -m scistudio.qa.governance.gate_record pre-commit --staged",
+      "exit_code": 0,
+      "name": "gate-record-precommit",
+      "output_path": "gate_record: pass",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    }
+  ],
+  "commit": null,
+  "docs_landing": {
+    "adr": {
+      "not_applicable": true,
+      "rationale": "No ADR update: this adds E2E coverage and registers the existing concrete CodeBlock runtime; it does not change the ADR-041 project-local script contract."
+    },
+    "changelog": {
+      "not_applicable": true,
+      "rationale": "No changelog entry: test coverage and bug-regression fix only."
+    },
+    "checklist": {},
+    "docs": {
+      "paths": [
+        "frontend/e2e/README.md"
+      ]
+    },
+    "spec": {
+      "not_applicable": true,
+      "rationale": "No spec update: CodeBlock public contract and workflow schema are unchanged."
+    }
+  },
+  "full_audit": {
+    "blocks_merge": false,
+    "command": "PYTHONPATH=src python -m scistudio.qa.audit.full_audit --repo-root . --format json --output docs/audit/2026-05-22-1384-codeblock-e2e-full-audit.json",
+    "exit_code": 0,
+    "known_debt": [],
+    "output_path": "docs/audit/2026-05-22-1384-codeblock-e2e-full-audit.json",
+    "status": "pass",
+    "summary": {},
+    "unclassified_failures": []
+  },
+  "governance_touch": false,
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1384,
+      "url": "https://github.com/zjzcpj/SciStudio/issues/1384"
+    }
+  ],
+  "owner_directive": "Add CodeBlock Load-Code-Save Playwright E2E coverage for every supported CodeBlock script format.",
+  "planned_files": [
+    "frontend/e2e/fixtures/codeblockWorkflows.ts",
+    "frontend/e2e/specs/codeblock/codeblock-formats.spec.ts",
+    "frontend/e2e/support/scistudio.ts",
+    "frontend/e2e/README.md",
+    "src/scistudio/blocks/registry.py",
+    "tests/api/test_blocks.py",
+    "docs/audit/2026-05-22-1384-codeblock-e2e-full-audit.json"
+  ],
+  "pull_request": null,
+  "record_path": ".workflow/records/1384-codeblock-e2e.json",
+  "required_checks": [
+    "frontend-e2e-list",
+    "frontend-e2e-codeblock",
+    "pytest-codeblock-schema",
+    "ruff-check",
+    "ruff-format-check",
+    "npm-build",
+    "git-diff-check",
+    "full_audit",
+    "sentrux-skipped",
+    "gate-record-precommit"
+  ],
+  "schema_version": "1",
+  "scope": {
+    "exclude": [
+      ".audit/full-audit.json"
+    ],
+    "include": [
+      "frontend/e2e/**",
+      ".workflow/records/1384-codeblock-e2e.json"
+    ]
+  },
+  "sentrux": {
+    "command_or_tool": "sentrux MCP/CLI unavailable in this session",
+    "mode": "free-tier",
+    "name": "sentrux.free_tier",
+    "output_path": "Sentrux tool is not installed/exposed in this Codex environment; CI remains authoritative.",
+    "pro_required": false,
+    "quality_signal": null,
+    "rules_checked": 0,
+    "status": "skipped",
+    "summary": {},
+    "thresholds": {},
+    "total_rules_defined": 0
+  },
+  "stages": [
+    {
+      "completed_at": null,
+      "stage": "scope_and_issue",
+      "status": "done",
+      "summary": null
+    },
+    {
+      "completed_at": null,
+      "stage": "plan",
+      "status": "done",
+      "summary": null
+    },
+    {
+      "completed_at": null,
+      "stage": "implement",
+      "status": "done",
+      "summary": null
+    },
+    {
+      "completed_at": null,
+      "stage": "update_docs",
+      "status": "done",
+      "summary": null
+    },
+    {
+      "completed_at": null,
+      "stage": "test_and_checks",
+      "status": "done",
+      "summary": null
+    },
+    {
+      "completed_at": null,
+      "stage": "commit_and_submit_pr",
+      "status": "pending",
+      "summary": null
+    }
+  ],
+  "task_id": "1384-codeblock-e2e",
+  "task_kind": "maintenance"
+}

--- a/docs/audit/2026-05-22-1384-codeblock-e2e-full-audit.json
+++ b/docs/audit/2026-05-22-1384-codeblock-e2e-full-audit.json
@@ -1,0 +1,345 @@
+{
+  "tool": "full_audit",
+  "status": "pass",
+  "generated_at": "1970-01-01T00:00:00Z",
+  "source_sha": "e06cc9a44e733193f5bb1deff7af071804f21ecfb59de07989958f5d6eeba356",
+  "findings": [],
+  "summary": {
+    "implemented_children": [
+      "generate_facts",
+      "frontmatter_lint",
+      "fact_drift",
+      "doc_drift",
+      "closure",
+      "signature_drift",
+      "architecture_drift",
+      "vulture"
+    ],
+    "deferred_children": []
+  },
+  "child_reports": [
+    {
+      "tool": "generate_facts",
+      "status": "pass",
+      "generated_at": "1970-01-01T00:00:00Z",
+      "source_sha": "e06cc9a44e733193f5bb1deff7af071804f21ecfb59de07989958f5d6eeba356",
+      "findings": [],
+      "summary": {
+        "facts_path": "docs/facts/generated.yaml",
+        "generated_in_memory": true,
+        "total_facts": 2461,
+        "facts_by_kind": {
+          "expected-signature": 157,
+          "symbol": 2304
+        },
+        "facts_by_source": {
+          "docs/adr/ADR-001.md": 9,
+          "docs/adr/ADR-002.md": 4,
+          "docs/adr/ADR-003.md": 2,
+          "docs/adr/ADR-004.md": 7,
+          "docs/adr/ADR-005.md": 4,
+          "docs/adr/ADR-006.md": 2,
+          "docs/adr/ADR-007.md": 2,
+          "docs/adr/ADR-008.md": 2,
+          "docs/adr/ADR-009.md": 4,
+          "docs/adr/ADR-011.md": 5,
+          "docs/adr/ADR-012.md": 2,
+          "docs/adr/ADR-013.md": 1,
+          "docs/adr/ADR-014.md": 2,
+          "docs/adr/ADR-015.md": 3,
+          "docs/adr/ADR-017.md": 10,
+          "docs/adr/ADR-018.md": 18,
+          "docs/adr/ADR-019.md": 43,
+          "docs/adr/ADR-020.md": 16,
+          "docs/adr/ADR-021.md": 8,
+          "docs/specs/adr-042-consistency-tools.md": 13,
+          "griffe": 2304
+        },
+        "facts_by_confidence": {
+          "generated": 2304,
+          "normative": 157
+        },
+        "facts_by_stability": {
+          "stable": 157,
+          "unknown": 2304
+        },
+        "symbol_facts": 2304,
+        "symbols_by_kind": {
+          "attribute": 1211,
+          "class": 255,
+          "function": 635,
+          "module": 203
+        },
+        "top_symbol_packages": {
+          "scistudio.blocks": 752,
+          "scistudio.qa": 482,
+          "scistudio.api": 407,
+          "scistudio.core": 336,
+          "scistudio.engine": 197,
+          "scistudio.workflow": 58,
+          "scistudio.cli": 27,
+          "scistudio.utils": 26,
+          "scistudio.agent_provisioning": 9,
+          "scistudio.testing": 9,
+          "scistudio.ai": 1
+        }
+      },
+      "child_reports": []
+    },
+    {
+      "tool": "frontmatter_lint",
+      "status": "pass",
+      "generated_at": "2026-05-22T01:34:42.928345Z",
+      "source_sha": "",
+      "findings": [],
+      "summary": {
+        "repo_root": "C:/Users/jiazh/Desktop/workspace/SciStudio-codeblock-e2e-1384",
+        "findings": 0
+      },
+      "child_reports": []
+    },
+    {
+      "tool": "fact_drift",
+      "status": "pass",
+      "generated_at": "2026-05-22T01:34:43.911511Z",
+      "source_sha": "e06cc9a44e733193f5bb1deff7af071804f21ecfb59de07989958f5d6eeba356",
+      "findings": [],
+      "summary": {
+        "docs_checked": 190,
+        "substitutions_checked": 0
+      },
+      "child_reports": []
+    },
+    {
+      "tool": "doc_drift",
+      "status": "pass",
+      "generated_at": "2026-05-22T01:34:45.128985Z",
+      "source_sha": "e06cc9a44e733193f5bb1deff7af071804f21ecfb59de07989958f5d6eeba356",
+      "findings": [],
+      "summary": {
+        "governed_docs_checked": 62,
+        "modules_checked": 148,
+        "contracts_checked": 311,
+        "files_checked": 389,
+        "adr_spec_alignment_findings": 0,
+        "active_specs_checked": 1,
+        "adr_spec_links_checked": 1
+      },
+      "child_reports": []
+    },
+    {
+      "tool": "closure",
+      "status": "pass",
+      "generated_at": "2026-05-22T01:34:46.034630Z",
+      "source_sha": "e06cc9a44e733193f5bb1deff7af071804f21ecfb59de07989958f5d6eeba356",
+      "findings": [],
+      "summary": {
+        "governed_docs_checked": 62,
+        "governed_modules": 82,
+        "governed_contracts": 201,
+        "symbols_checked": 2304,
+        "maintainer_rules": 1,
+        "maintainer_covered_symbols": 21
+      },
+      "child_reports": []
+    },
+    {
+      "tool": "signature_drift",
+      "status": "pass",
+      "generated_at": "2026-05-22T01:34:46.036712Z",
+      "source_sha": "e06cc9a44e733193f5bb1deff7af071804f21ecfb59de07989958f5d6eeba356",
+      "findings": [],
+      "summary": {
+        "expected_signatures_checked": 157,
+        "expected_model_fields_checked": 0,
+        "expected_cli_commands_checked": 0,
+        "symbols_available": 2304,
+        "cli_facts_available": 0
+      },
+      "child_reports": []
+    },
+    {
+      "tool": "architecture_drift",
+      "status": "pass",
+      "generated_at": "2026-05-22T01:34:46.045170Z",
+      "source_sha": "e06cc9a44e733193f5bb1deff7af071804f21ecfb59de07989958f5d6eeba356",
+      "findings": [],
+      "summary": {
+        "architecture_path": "C:/Users/jiazh/Desktop/workspace/SciStudio-codeblock-e2e-1384/docs/architecture/ARCHITECTURE.md",
+        "symbols_available": 2304,
+        "fences_checked": 6,
+        "fences_skipped": 1,
+        "references_checked": 0
+      },
+      "child_reports": []
+    },
+    {
+      "tool": "vulture",
+      "status": "pass",
+      "generated_at": "2026-05-22T01:34:46.634298Z",
+      "source_sha": "",
+      "findings": [
+        {
+          "rule_id": "vulture.dead-code",
+          "severity": "warning",
+          "file": "src/scistudio/blocks/io/loaders/load_data.py",
+          "message": "unused variable 'od' (100% confidence)",
+          "id": "vulture.dead-code",
+          "tool": null,
+          "finding_class": "vulture",
+          "path": "src/scistudio/blocks/io/loaders/load_data.py",
+          "line": 624,
+          "symbol": null,
+          "subject": null,
+          "expected": null,
+          "actual": null,
+          "drift_class": null,
+          "remediation": null,
+          "evidence": {
+            "confidence": 100
+          },
+          "suggested_fix": null,
+          "git_evidence": null,
+          "related_findings": []
+        },
+        {
+          "rule_id": "vulture.dead-code",
+          "severity": "warning",
+          "file": "src/scistudio/blocks/io/loaders/load_data.py",
+          "message": "unused variable 'od' (100% confidence)",
+          "id": "vulture.dead-code",
+          "tool": null,
+          "finding_class": "vulture",
+          "path": "src/scistudio/blocks/io/loaders/load_data.py",
+          "line": 625,
+          "symbol": null,
+          "subject": null,
+          "expected": null,
+          "actual": null,
+          "drift_class": null,
+          "remediation": null,
+          "evidence": {
+            "confidence": 100
+          },
+          "suggested_fix": null,
+          "git_evidence": null,
+          "related_findings": []
+        },
+        {
+          "rule_id": "vulture.dead-code",
+          "severity": "warning",
+          "file": "src/scistudio/core/metadata_store.py",
+          "message": "unused variable 'existing_paths' (100% confidence)",
+          "id": "vulture.dead-code",
+          "tool": null,
+          "finding_class": "vulture",
+          "path": "src/scistudio/core/metadata_store.py",
+          "line": 405,
+          "symbol": null,
+          "subject": null,
+          "expected": null,
+          "actual": null,
+          "drift_class": null,
+          "remediation": null,
+          "evidence": {
+            "confidence": 100
+          },
+          "suggested_fix": null,
+          "git_evidence": null,
+          "related_findings": []
+        },
+        {
+          "rule_id": "vulture.dead-code",
+          "severity": "warning",
+          "file": "src/scistudio/core/units.py",
+          "message": "unused variable 'source_type' (100% confidence)",
+          "id": "vulture.dead-code",
+          "tool": null,
+          "finding_class": "vulture",
+          "path": "src/scistudio/core/units.py",
+          "line": 187,
+          "symbol": null,
+          "subject": null,
+          "expected": null,
+          "actual": null,
+          "drift_class": null,
+          "remediation": null,
+          "evidence": {
+            "confidence": 100
+          },
+          "suggested_fix": null,
+          "git_evidence": null,
+          "related_findings": []
+        },
+        {
+          "rule_id": "vulture.dead-code",
+          "severity": "warning",
+          "file": "src/scistudio/engine/checkpoint.py",
+          "message": "unused variable 'fallback_type_name' (100% confidence)",
+          "id": "vulture.dead-code",
+          "tool": null,
+          "finding_class": "vulture",
+          "path": "src/scistudio/engine/checkpoint.py",
+          "line": 185,
+          "symbol": null,
+          "subject": null,
+          "expected": null,
+          "actual": null,
+          "drift_class": null,
+          "remediation": null,
+          "evidence": {
+            "confidence": 100
+          },
+          "suggested_fix": null,
+          "git_evidence": null,
+          "related_findings": []
+        },
+        {
+          "rule_id": "vulture.dead-code",
+          "severity": "warning",
+          "file": "src/scistudio/utils/logging.py",
+          "message": "unused variable 'json_output' (100% confidence)",
+          "id": "vulture.dead-code",
+          "tool": null,
+          "finding_class": "vulture",
+          "path": "src/scistudio/utils/logging.py",
+          "line": 6,
+          "symbol": null,
+          "subject": null,
+          "expected": null,
+          "actual": null,
+          "drift_class": null,
+          "remediation": null,
+          "evidence": {
+            "confidence": 100
+          },
+          "suggested_fix": null,
+          "git_evidence": null,
+          "related_findings": []
+        }
+      ],
+      "summary": {
+        "pyproject_config_honored": {
+          "ignore_decorators": [
+            "@app.*",
+            "@router.*",
+            "@pytest.fixture"
+          ],
+          "ignore_names": [],
+          "exclude": [
+            "src/scistudio/api/static/**"
+          ]
+        },
+        "paths": [
+          "src/scistudio"
+        ],
+        "min_confidence": 80,
+        "targets_resolved": 1,
+        "allowlist": "vulture_allowlist.py",
+        "total_findings": 6,
+        "vulture_available": true
+      },
+      "child_reports": []
+    }
+  ]
+}

--- a/frontend/e2e/README.md
+++ b/frontend/e2e/README.md
@@ -47,6 +47,20 @@ load image -> threshold -> save mask
 The fixture uses real project paths and real workflow YAML. It intentionally
 does not patch frontend state or mock product APIs.
 
+`e2e/fixtures/codeblockWorkflows.ts` covers the CodeBlock v2 script-format
+matrix with minimal `LoadData -> CodeBlock -> SaveData` workflows. The current
+registered script extensions are:
+
+```text
+.py, .ipynb, .R, .Rmd, .qmd, .sh, .m, .mlx
+```
+
+Python is expected to execute in the base environment. Optional external
+runtimes such as Jupyter nbconvert, R/R Markdown, Quarto, POSIX shell, MATLAB,
+or Octave are detected by the test at runtime. When a runtime is absent, the
+scenario asserts that the workflow fails on the CodeBlock with a clear missing
+runtime diagnostic instead of treating the machine setup as a malformed test.
+
 ## Failure Classification
 
 Discovery failures should be classified before fixing:

--- a/frontend/e2e/fixtures/codeblockWorkflows.ts
+++ b/frontend/e2e/fixtures/codeblockWorkflows.ts
@@ -1,0 +1,235 @@
+import type { E2EWorkflow } from "./workflows";
+
+export type CodeBlockRuntimeId =
+  | "python"
+  | "notebook"
+  | "r"
+  | "rmarkdown"
+  | "quarto"
+  | "shell"
+  | "matlab"
+  | "matlab-live";
+
+export type CodeBlockFormatFixture = {
+  id: CodeBlockRuntimeId;
+  label: string;
+  extension: string;
+  scriptPath: string;
+  scriptBody: string;
+  promptPath: string;
+  expectedOutputPath: string;
+  expectedContent: string;
+  workflow: E2EWorkflow;
+};
+
+const promptPath = "data/raw/codeblock-prompt.txt";
+const promptText = "hello from load";
+
+function workflowFor(id: CodeBlockRuntimeId, scriptPath: string): E2EWorkflow {
+  const workflowId = `codeblock-${id}`;
+  const expectedOutputPath = `data/artifacts/${workflowId}.txt`;
+  return {
+    workflowId,
+    workflowPath: `workflows/${workflowId}.yaml`,
+    expectedOutputPath,
+    workflow: {
+      id: workflowId,
+      version: "1.0.0",
+      description: `E2E CodeBlock ${id} LoadData -> CodeBlock -> SaveData workflow.`,
+      nodes: [
+        {
+          id: "load_prompt",
+          block_type: "load_data",
+          layout: { x: 80, y: 120 },
+          config: { params: { core_type: "Text", path: promptPath } },
+        },
+        {
+          id: "run_code",
+          block_type: "code_block",
+          layout: { x: 380, y: 120 },
+          config: {
+            params: {
+              script_path: scriptPath,
+              exchange_root: "exchange",
+              inputs: [{ name: "data", direction: "input", data_type: "Text", extension: ".txt" }],
+              outputs: [{ name: "result", direction: "output", data_type: "Text", extension: ".txt" }],
+            },
+          },
+        },
+        {
+          id: "save_result",
+          block_type: "save_data",
+          layout: { x: 700, y: 120 },
+          config: { params: { core_type: "Text", path: expectedOutputPath } },
+        },
+      ],
+      edges: [
+        { source: "load_prompt:data", target: "run_code:data" },
+        { source: "run_code:result", target: "save_result:data" },
+      ],
+      metadata: { fixture: "codeblock-format-e2e", codeblock_format: id },
+    },
+  };
+}
+
+function fixture(
+  id: CodeBlockRuntimeId,
+  label: string,
+  extension: string,
+  scriptBody: string,
+): CodeBlockFormatFixture {
+  const scriptPath = `scripts/codeblock-${id}${extension}`;
+  const workflow = workflowFor(id, scriptPath);
+  return {
+    id,
+    label,
+    extension,
+    scriptPath,
+    scriptBody,
+    promptPath,
+    expectedOutputPath: workflow.expectedOutputPath,
+    expectedContent: `${promptText} | ${id}`,
+    workflow,
+  };
+}
+
+export const codeBlockPromptText = promptText;
+
+export const codeBlockFormatFixtures: CodeBlockFormatFixture[] = [
+  fixture(
+    "python",
+    "Python script",
+    ".py",
+    `
+from pathlib import Path
+
+source = sorted(Path("inputs/data").glob("*.txt"))[0]
+target = Path("outputs/result/result.txt")
+target.parent.mkdir(parents=True, exist_ok=True)
+target.write_text(source.read_text(encoding="utf-8").strip() + " | python\\n", encoding="utf-8")
+`.trimStart(),
+  ),
+  fixture(
+    "notebook",
+    "Jupyter notebook",
+    ".ipynb",
+    `${JSON.stringify(
+      {
+        cells: [
+          {
+            cell_type: "code",
+            execution_count: null,
+            metadata: {},
+            outputs: [],
+            source: [
+              "from pathlib import Path\n",
+              "source = next(path for folder in [Path('inputs/data'), Path('../inputs/data'), Path('../../inputs/data')] for path in sorted(folder.glob('*.txt')))\n",
+              "target_dir = next((folder for folder in [Path('outputs/result'), Path('../result'), Path('../../outputs/result')] if folder.parent.exists()), Path('outputs/result'))\n",
+              "target = target_dir / 'result.txt'\n",
+              "target.parent.mkdir(parents=True, exist_ok=True)\n",
+              "target.write_text(source.read_text(encoding='utf-8').strip() + ' | notebook\\n', encoding='utf-8')\n",
+            ],
+          },
+        ],
+        metadata: {
+          kernelspec: {
+            display_name: "Python 3",
+            language: "python",
+            name: "python3",
+          },
+          language_info: {
+            name: "python",
+            version: "3.x",
+          },
+        },
+        nbformat: 4,
+        nbformat_minor: 5,
+      },
+      null,
+      2,
+    )}\n`,
+  ),
+  fixture(
+    "r",
+    "R script",
+    ".R",
+    `
+input <- list.files("inputs/data", pattern = "\\\\.txt$", full.names = TRUE)[1]
+dir.create("outputs/result", recursive = TRUE, showWarnings = FALSE)
+writeLines(paste0(trimws(readLines(input, warn = FALSE)), " | r"), "outputs/result/result.txt")
+`.trimStart(),
+  ),
+  fixture(
+    "rmarkdown",
+    "R Markdown document",
+    ".Rmd",
+    `
+---
+title: "CodeBlock R Markdown E2E"
+output: html_document
+---
+
+\`\`\`{r}
+out_dir <- file.path(Sys.getenv("SCISTUDIO_OUTPUTS_DIR"), "result")
+dir.create(out_dir, recursive = TRUE, showWarnings = FALSE)
+input <- list.files(file.path(Sys.getenv("SCISTUDIO_INPUTS_DIR"), "data"), pattern = "\\\\.txt$", full.names = TRUE)[1]
+writeLines(paste0(trimws(readLines(input, warn = FALSE)), " | rmarkdown"), file.path(out_dir, "result.txt"))
+\`\`\`
+`.trimStart(),
+  ),
+  fixture(
+    "quarto",
+    "Quarto document",
+    ".qmd",
+    `
+---
+title: "CodeBlock Quarto E2E"
+format: html
+---
+
+\`\`\`{python}
+import os
+from pathlib import Path
+
+source = sorted(Path(os.environ["SCISTUDIO_INPUTS_DIR"], "data").glob("*.txt"))[0]
+target = Path(os.environ["SCISTUDIO_OUTPUTS_DIR"], "result", "result.txt")
+target.parent.mkdir(parents=True, exist_ok=True)
+target.write_text(source.read_text(encoding="utf-8").strip() + " | quarto\\n", encoding="utf-8")
+\`\`\`
+`.trimStart(),
+  ),
+  fixture(
+    "shell",
+    "POSIX shell script",
+    ".sh",
+    `
+set -eu
+mkdir -p outputs/result
+input_file="$(find inputs/data -name '*.txt' | sort | sed -n '1p')"
+printf '%s | shell\\n' "$(cat "$input_file")" > outputs/result/result.txt
+`.trimStart(),
+  ),
+  fixture(
+    "matlab",
+    "MATLAB or Octave script",
+    ".m",
+    `
+input_files = dir(fullfile('inputs', 'data', '*.txt'));
+input_path = fullfile(input_files(1).folder, input_files(1).name);
+content = strtrim(fileread(input_path));
+out_dir = fullfile('outputs', 'result');
+if ~exist(out_dir, 'dir')
+    mkdir(out_dir);
+end
+fid = fopen(fullfile(out_dir, 'result.txt'), 'w');
+fprintf(fid, '%s | matlab\\n', content);
+fclose(fid);
+`.trimStart(),
+  ),
+  fixture(
+    "matlab-live",
+    "MATLAB live script",
+    ".mlx",
+    "SciStudio CodeBlock .mlx placeholder; valid live-script authoring requires MATLAB.\n",
+  ),
+];

--- a/frontend/e2e/specs/codeblock/codeblock-formats.spec.ts
+++ b/frontend/e2e/specs/codeblock/codeblock-formats.spec.ts
@@ -1,0 +1,175 @@
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+
+import { expect, test } from "../../support/scistudio";
+import {
+  codeBlockFormatFixtures,
+  codeBlockPromptText,
+  type CodeBlockFormatFixture,
+  type CodeBlockRuntimeId,
+} from "../../fixtures/codeblockWorkflows";
+
+type RuntimeAvailability = {
+  runnable: boolean;
+  reason?: string;
+};
+
+const repoRoot = path.resolve(process.cwd(), "..");
+const pythonPath = [
+  path.join(repoRoot, "src"),
+  path.join(repoRoot, "packages", "scistudio-blocks-imaging", "src"),
+  path.join(repoRoot, "packages", "scistudio-blocks-srs", "src"),
+  process.env.PYTHONPATH,
+]
+  .filter(Boolean)
+  .join(path.delimiter);
+
+const missingRuntimePatterns: Record<CodeBlockRuntimeId, RegExp> = {
+  python: /python|interpreter|not found/i,
+  notebook: /notebook|jupyter|nbconvert|requires/i,
+  r: /Rscript|R executable|not found/i,
+  rmarkdown: /R Markdown|rmarkdown|Rscript|not found/i,
+  quarto: /quarto|not found/i,
+  shell: /POSIX shell|shell executable|not found/i,
+  matlab: /MATLAB|Octave|not found/i,
+  "matlab-live": /\.mlx|MATLAB|live scripts/i,
+};
+
+function spawnOk(command: string, args: string[], timeout = 10_000): boolean {
+  const result = spawnSync(command, args, {
+    encoding: "utf-8",
+    shell: false,
+    timeout,
+    windowsHide: true,
+  });
+  return result.status === 0;
+}
+
+function commandExists(command: string): boolean {
+  if (process.platform === "win32") {
+    return spawnOk("where.exe", [command], 5_000);
+  }
+  return spawnOk("sh", ["-lc", `command -v ${shellQuote(command)} >/dev/null 2>&1`], 5_000);
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+function hasCompatibleShell(): boolean {
+  const result = spawnSync(process.env.PYTHON ?? "python", [
+    "-c",
+    [
+      "from scistudio.blocks.code.backends.shell import _resolve_shell_executable",
+      "_resolve_shell_executable(mode='auto', interpreter_path=None, environment_config={})",
+    ].join("; "),
+  ], {
+    encoding: "utf-8",
+    env: { ...process.env, PYTHONPATH: pythonPath },
+    shell: false,
+    timeout: 10_000,
+    windowsHide: true,
+  });
+  return result.status === 0;
+}
+
+function detectRuntime(id: CodeBlockRuntimeId): RuntimeAvailability {
+  switch (id) {
+    case "python":
+      return { runnable: true };
+    case "notebook":
+      if (spawnOk("jupyter-nbconvert", ["--version"], 10_000)) return { runnable: true };
+      if (spawnOk("jupyter", ["nbconvert", "--version"], 10_000)) return { runnable: true };
+      return { runnable: false, reason: "Jupyter nbconvert is not available" };
+    case "r":
+      return commandExists("Rscript")
+        ? { runnable: true }
+        : { runnable: false, reason: "Rscript is not available" };
+    case "rmarkdown":
+      if (!commandExists("Rscript")) return { runnable: false, reason: "Rscript is not available" };
+      return spawnOk(
+        "Rscript",
+        ["-e", "if (!requireNamespace('rmarkdown', quietly = TRUE)) quit(status = 42)"],
+        20_000,
+      )
+        ? { runnable: true }
+        : { runnable: false, reason: "R package rmarkdown is not available" };
+    case "quarto":
+      return commandExists("quarto")
+        ? { runnable: true }
+        : { runnable: false, reason: "quarto is not available" };
+    case "shell":
+      return hasCompatibleShell()
+        ? { runnable: true }
+        : { runnable: false, reason: "POSIX shell is not available" };
+    case "matlab":
+      return commandExists("matlab") || commandExists("octave")
+        ? { runnable: true }
+        : { runnable: false, reason: "MATLAB or Octave is not available" };
+    case "matlab-live":
+      return commandExists("matlab")
+        ? { runnable: true }
+        : { runnable: false, reason: "MATLAB is not available for .mlx live scripts" };
+  }
+}
+
+async function installCodeBlockCase(studio: any, fixture: CodeBlockFormatFixture) {
+  await studio.projectTree.writeFile(fixture.promptPath, `${codeBlockPromptText}\n`);
+  await studio.projectTree.writeFile(fixture.scriptPath, fixture.scriptBody);
+}
+
+async function runDetailText(studio: any, runId: string): Promise<string> {
+  const detail = await studio.api.getRun(runId);
+  return JSON.stringify(detail);
+}
+
+test.describe("SciStudio CodeBlock format E2E @codeblock", () => {
+  for (const fixture of codeBlockFormatFixtures) {
+    test(`CBF-${fixture.id} @codeblock runs Load -> Code -> Save for ${fixture.label} (${fixture.extension})`, async ({
+      studio,
+    }, testInfo) => {
+      test.slow();
+      const availability = detectRuntime(fixture.id);
+      testInfo.annotations.push({
+        type: "codeblock-runtime",
+        description: availability.runnable ? "runtime available" : availability.reason,
+      });
+      test.skip(
+        fixture.id === "matlab-live" && availability.runnable,
+        ".mlx live-script fixture generation requires MATLAB authoring tooling; CI normally validates the missing-runtime diagnostic.",
+      );
+
+      const project = await studio.createProject({ namePrefix: `codeblock-${fixture.id}` });
+      await installCodeBlockCase(studio, fixture);
+      await studio.installWorkflowFixture(project, fixture.workflow);
+      await studio.openProject(project);
+      await studio.loadWorkflowFromTree(fixture.workflow.workflowId);
+
+      const result = await studio.runWorkflowAndWait(fixture.workflow.workflowId, {
+        expectedStatus: /completed|failed/ as any,
+        timeoutMs: fixture.id === "notebook" ? 45_000 : 15_000,
+      });
+      const detailText = await runDetailText(studio, result.runId);
+
+      if (!availability.runnable) {
+        expect(result.status, detailText).toBe("failed");
+        await studio.expectCanvasNodeStatus("load_prompt", "done");
+        await studio.expectCanvasNodeStatus("run_code", "error");
+        expect(detailText).not.toMatch(/Block 'code_block' is not registered|not in registry/i);
+        expect(detailText).toMatch(missingRuntimePatterns[fixture.id]);
+        return;
+      }
+
+      expect(result.status, detailText).toBe("completed");
+      await studio.expectCanvasNodeStatus("load_prompt", "done");
+      await studio.expectCanvasNodeStatus("run_code", "done");
+      await studio.expectCanvasNodeStatus("save_result", "done");
+      await studio.expectProjectTreeContains(fixture.expectedOutputPath);
+      await expect
+        .poll(async () => studio.projectTree.readFile(fixture.expectedOutputPath), {
+          message: `${fixture.expectedOutputPath} should contain the script output`,
+        })
+        .toContain(fixture.expectedContent);
+    });
+  }
+});

--- a/frontend/e2e/support/scistudio.ts
+++ b/frontend/e2e/support/scistudio.ts
@@ -13,6 +13,7 @@ import {
 
 type Project = { id: string; name: string; path: string; current_workflow_id?: string | null };
 type WorkflowShape = E2EWorkflow["workflow"];
+type WorkflowWaitOptions = { expectedStatus?: string | RegExp; timeoutMs?: number };
 
 type StudioFixture = ReturnType<typeof createStudio>;
 
@@ -157,12 +158,12 @@ function createStudio(page: Page, request: APIRequestContext) {
     return { workflowId, nodes, edges };
   }
 
-  async function runWorkflowAndWait(workflowId: string, options: { expectedStatus?: string } = {}) {
+  async function runWorkflowAndWait(workflowId: string, options: WorkflowWaitOptions = {}) {
     await page.getByRole("button", { name: /^Run$/i }).click();
-    return waitForWorkflowStatus(workflowId, options.expectedStatus ?? "completed");
+    return waitForWorkflowStatus(workflowId, options.expectedStatus ?? "completed", options.timeoutMs);
   }
 
-  async function waitForWorkflowStatus(workflowOrRunId: string, expectedStatus: string | RegExp) {
+  async function waitForWorkflowStatus(workflowOrRunId: string, expectedStatus: string | RegExp, timeoutMs?: number) {
     let latestRun: { runId: string; status: string; workflow_id?: string } = {
       runId: "",
       status: "unknown",
@@ -171,7 +172,7 @@ function createStudio(page: Page, request: APIRequestContext) {
       .poll(async () => {
         latestRun = await getRunStatus(workflowOrRunId);
         return latestRun.status;
-      })
+      }, timeoutMs === undefined ? undefined : { timeout: timeoutMs })
       .toMatch(expectedStatus instanceof RegExp ? expectedStatus : new RegExp(`^${escapeRegex(expectedStatus)}$`));
     return latestRun;
   }

--- a/src/scistudio/blocks/registry.py
+++ b/src/scistudio/blocks/registry.py
@@ -317,13 +317,14 @@ class BlockRegistry:
         """Register built-in core blocks used by the API/frontend.
 
         Only concrete, user-facing blocks are registered here.  Base
-        classes (AppBlock, CodeBlock, IOBlock) and non-functional process
+        classes (AppBlock, IOBlock) and non-functional process
         placeholders (Merge, Split, …) are excluded from the palette so
         end users see only the blocks they can actually use.  The
         excluded classes remain importable for plugin development and
         tests.
         """
         from scistudio.blocks.ai.ai_block import AIBlock
+        from scistudio.blocks.code.code_block import CodeBlock
         from scistudio.blocks.io.loaders.load_data import LoadData
         from scistudio.blocks.io.savers.save_data import SaveData
         from scistudio.blocks.subworkflow.subworkflow_block import SubWorkflowBlock
@@ -331,6 +332,7 @@ class BlockRegistry:
         for cls in (
             LoadData,
             SaveData,
+            CodeBlock,
             AIBlock,
             SubWorkflowBlock,
         ):

--- a/tests/api/test_blocks.py
+++ b/tests/api/test_blocks.py
@@ -49,6 +49,23 @@ def test_list_blocks_and_schema_alias_endpoints(client: TestClient) -> None:
     assert alias.json() == schema_payload
 
 
+def test_code_block_builtin_schema_is_registered(client: TestClient) -> None:
+    """The concrete CodeBlock runtime must be visible to workflows and the UI."""
+    response = client.get("/api/blocks/")
+    assert response.status_code == 200
+    blocks = response.json()["blocks"]
+    assert any(block["type_name"] == "code_block" for block in blocks)
+
+    schema = client.get("/api/blocks/code_block/schema")
+    assert schema.status_code == 200
+    payload = schema.json()
+    assert payload["name"] == "Code Block"
+    assert payload["type_name"] == "code_block"
+    assert payload["base_category"] == "code"
+    assert payload["config_schema"]["required"] == ["script_path"]
+    assert "script_path" in payload["config_schema"]["properties"]
+
+
 def test_validate_connection_endpoint_uses_registry_type_information(client: TestClient) -> None:
     """Connection validation should accept compatible ports and reject mismatches."""
     compatible = client.post(


### PR DESCRIPTION
Summary:
- Add CodeBlock Load -> Code -> Save Playwright E2E coverage for .py, .ipynb, .R, .Rmd, .qmd, .sh, .m, and .mlx.
- Register the existing concrete CodeBlock builtin so workflow runtime can resolve block_type: code_block.
- Add an API regression test for /api/blocks/code_block/schema and document the CodeBlock E2E matrix.

Tests:
- npm run test:e2e -- --list
- SCISTUDIO_E2E_BACKEND_PORT=8138 SCISTUDIO_E2E_FRONTEND_PORT=5208 npm run test:e2e -- --grep @codeblock
- PYTHONPATH=src pytest tests/api/test_blocks.py::test_code_block_builtin_schema_is_registered -q --no-cov
- ruff check src/scistudio/blocks/registry.py tests/api/test_blocks.py
- ruff format --check src/scistudio/blocks/registry.py tests/api/test_blocks.py
- npm run build
- git diff --check
- PYTHONPATH=src python -m scistudio.qa.audit.full_audit --repo-root . --format json --output docs/audit/2026-05-22-1384-codeblock-e2e-full-audit.json
- PYTHONPATH=src python -m scistudio.qa.governance.gate_record pre-commit --staged

Gate record: .workflow/records/1384-codeblock-e2e.json

Preflight note:
- Owner-approved SCISTUDIO_SKIP_PREFLIGHT=1 was used because local Sentrux CLI/MCP is unavailable; CI/admin review remains authoritative for Sentrux.

Closes #1384