### PR TITLE
fix(#841): resolve Windows npm shim executables

### DIFF
--- a/.workflow/records/841-windows-npm-shim-resolution.json
+++ b/.workflow/records/841-windows-npm-shim-resolution.json
@@ -14,10 +14,10 @@
   ],
   "check_results": [
     {
-      "command_or_tool": "PYTHONPATH=src python -m pytest tests/ai/test_terminal.py tests/ai/test_windows_executable_resolution.py --no-cov",
+      "command_or_tool": "PYTHONPATH=src python -m pytest tests/ai/test_terminal.py tests/ai/test_windows_executable_resolution.py tests/api/test_provider_discovery.py --no-cov",
       "exit_code": 0,
       "name": "pytest-targeted",
-      "output_path": "11 passed, 1 skipped in 9.09s",
+      "output_path": "17 passed, 1 skipped in 12.45s",
       "status": "pass",
       "summary": {},
       "timestamp": null
@@ -68,10 +68,10 @@
   },
   "full_audit": {
     "blocks_merge": false,
-    "command": "PYTHONPATH=src python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .workflow/records/841-full-audit.json",
+    "command": "PYTHONPATH=src python -m scistudio.qa.audit.full_audit --repo-root . --format json --output C:\\Users\\jiazh\\AppData\\Local\\Temp\\scistudio-841-full-audit.json",
     "exit_code": 0,
     "known_debt": [],
-    "output_path": "full_audit pass; findings=0; implemented_children=generate_facts,frontmatter_lint,fact_drift,doc_drift,closure,signature_drift,architecture_drift,vulture; semantic_dup deferred by tool",
+    "output_path": "full_audit pass; findings=0; output=C:\\Users\\jiazh\\AppData\\Local\\Temp\\scistudio-841-full-audit.json",
     "status": "pass",
     "summary": {},
     "unclassified_failures": []
@@ -145,10 +145,10 @@
     ]
   },
   "sentrux": {
-    "command_or_tool": "mcp__sentrux__.scan/session_start/rescan/check_rules/session_end",
+    "command_or_tool": "mcp__sentrux__.scan/session_start/check_rules/session_end",
     "mode": "free-tier",
     "name": "sentrux.free_tier",
-    "output_path": "scan files=1161 quality_signal=4441; check_rules pass rules_checked=3 total_rules_defined=15 violation_count=0; session_end pass signal_delta=0",
+    "output_path": "scan files=1163 import_edges=2656 quality_signal=4441; check_rules pass rules_checked=3 total_rules_defined=15 violation_count=0; session_end pass signal_delta=0",
     "pro_required": false,
     "quality_signal": 4441.0,
     "rules_checked": 3,

--- a/.workflow/records/841-windows-npm-shim-resolution.json
+++ b/.workflow/records/841-windows-npm-shim-resolution.json
@@ -41,7 +41,13 @@
       "timestamp": null
     }
   ],
-  "commit": null,
+  "commit": {
+    "gate_record_path": ".workflow/records/841-windows-npm-shim-resolution.json",
+    "shas": [
+      "4b5c6c9137ced752bc456a2c821f1d4c1e75e089"
+    ],
+    "trailers": {}
+  },
   "docs_landing": {
     "changelog": {},
     "checklist": {},
@@ -78,7 +84,13 @@
     "tests/ai/test_windows_executable_resolution.py",
     ".workflow/records/841-windows-npm-shim-resolution.json"
   ],
-  "pull_request": null,
+  "pull_request": {
+    "body_closes_issues": [
+      841
+    ],
+    "number": null,
+    "url": "https://github.com/zjzcpj/SciStudio/pull/1434"
+  },
   "record_path": ".workflow/records/841-windows-npm-shim-resolution.json",
   "required_checks": [
     "ruff",
@@ -172,7 +184,7 @@
     {
       "completed_at": null,
       "stage": "commit_and_submit_pr",
-      "status": "pending",
+      "status": "done",
       "summary": null
     }
   ],

--- a/.workflow/records/841-windows-npm-shim-resolution.json
+++ b/.workflow/records/841-windows-npm-shim-resolution.json
@@ -1,0 +1,181 @@
+{
+  "admin_labels": [],
+  "amendments": [
+    {
+      "approved_by": null,
+      "exclude": [],
+      "include": [],
+      "reason": "Implementation completed within the planned issue #841 scope; no scope expansion."
+    }
+  ],
+  "branch": "fix/issue-841-windows-npm-shims",
+  "changed_test_paths": [
+    "tests/ai/test_windows_executable_resolution.py"
+  ],
+  "check_results": [
+    {
+      "command_or_tool": "PYTHONPATH=src python -m pytest tests/ai/test_terminal.py tests/ai/test_windows_executable_resolution.py --no-cov",
+      "exit_code": 0,
+      "name": "pytest-targeted",
+      "output_path": "11 passed, 1 skipped in 9.09s",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "PYTHONPATH=src python -m ruff check src/scistudio/api/routes/ai.py src/scistudio/ai/agent/terminal.py tests/ai/test_windows_executable_resolution.py",
+      "exit_code": 0,
+      "name": "ruff",
+      "output_path": "All checks passed",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "PYTHONPATH=src python -m ruff format --check src/scistudio/api/routes/ai.py src/scistudio/ai/agent/terminal.py tests/ai/test_windows_executable_resolution.py",
+      "exit_code": 0,
+      "name": "format",
+      "output_path": "3 files already formatted",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    }
+  ],
+  "commit": null,
+  "docs_landing": {
+    "changelog": {},
+    "checklist": {},
+    "docs": {},
+    "product-docs": {
+      "not_applicable": true,
+      "rationale": "Implementation-only Windows executable resolution bug fix for existing AI CLI behavior; no public workflow, schema, API response shape, ADR, or spec text changed."
+    }
+  },
+  "full_audit": {
+    "blocks_merge": false,
+    "command": "PYTHONPATH=src python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .workflow/records/841-full-audit.json",
+    "exit_code": 0,
+    "known_debt": [],
+    "output_path": "full_audit pass; findings=0; implemented_children=generate_facts,frontmatter_lint,fact_drift,doc_drift,closure,signature_drift,architecture_drift,vulture; semantic_dup deferred by tool",
+    "status": "pass",
+    "summary": {},
+    "unclassified_failures": []
+  },
+  "governance_touch": true,
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 841,
+      "url": "https://github.com/zjzcpj/SciStudio/issues/841"
+    }
+  ],
+  "owner_directive": "Implement Windows-safe npm shim executable resolution for Codex/Claude status and PTY spawn; close #841.",
+  "planned_files": [
+    "src/scistudio/api/routes/ai.py",
+    "src/scistudio/ai/agent/terminal.py",
+    "tests/ai/test_terminal.py",
+    "tests/ai/test_windows_executable_resolution.py",
+    ".workflow/records/841-windows-npm-shim-resolution.json"
+  ],
+  "pull_request": null,
+  "record_path": ".workflow/records/841-windows-npm-shim-resolution.json",
+  "required_checks": [
+    "ruff",
+    "format",
+    "pytest-targeted",
+    "full_audit",
+    "sentrux"
+  ],
+  "schema_version": "1",
+  "scope": {
+    "exclude": [
+      "frontend/src/App.tsx",
+      "frontend/src/components/nodes/BlockNode.tsx",
+      "frontend/src/components/DataPreview.tsx",
+      "frontend/src/components/BottomPanel.tsx",
+      "frontend/src/components/Lineage/RunDetail.tsx",
+      "frontend/src/lib/api.ts",
+      "frontend/src/components/Git/ConflictMarkerDecoration.ts",
+      "src/scistudio/api/runtime.py",
+      "src/scistudio/ai/agent/mcp/tools_workflow.py",
+      "src/scistudio/ai/agent/mcp/tools_inspection.py",
+      "src/scistudio/api/routes/ai_pty.py",
+      "src/scistudio/api/routes/workflow_watcher.py",
+      "src/scistudio/cli/install.py",
+      "src/scistudio/api/routes/git.py",
+      "src/scistudio/qa/governance/gate_record.py",
+      "src/scistudio/qa/audit/architecture_drift.py",
+      "src/scistudio/core/types/registry.py",
+      "src/scistudio/blocks/io/savers/save_data.py",
+      "src/scistudio/blocks/io/loaders/load_data.py",
+      "src/scistudio/blocks/code/code_block.py",
+      "src/scistudio/blocks/ai/ai_block.py",
+      "src/scistudio/core/lineage/store.py",
+      "src/scistudio/engine/scheduler.py",
+      "src/scistudio/blocks/registry.py",
+      "src/scistudio/core/versioning/git_engine.py"
+    ],
+    "include": [
+      "src/scistudio/api/routes/ai.py",
+      "src/scistudio/ai/agent/terminal.py",
+      "tests/ai/**",
+      ".workflow/records/**"
+    ]
+  },
+  "sentrux": {
+    "command_or_tool": "mcp__sentrux__.scan/session_start/rescan/check_rules/session_end",
+    "mode": "free-tier",
+    "name": "sentrux.free_tier",
+    "output_path": "scan files=1161 quality_signal=4441; check_rules pass rules_checked=3 total_rules_defined=15 violation_count=0; session_end pass signal_delta=0",
+    "pro_required": false,
+    "quality_signal": 4441.0,
+    "rules_checked": 3,
+    "status": "pass",
+    "summary": {},
+    "thresholds": {
+      "pro_required": "false"
+    },
+    "total_rules_defined": 15
+  },
+  "stages": [
+    {
+      "completed_at": null,
+      "stage": "scope_and_issue",
+      "status": "done",
+      "summary": null
+    },
+    {
+      "completed_at": null,
+      "stage": "plan",
+      "status": "done",
+      "summary": null
+    },
+    {
+      "completed_at": null,
+      "stage": "implement",
+      "status": "done",
+      "summary": null
+    },
+    {
+      "completed_at": null,
+      "stage": "update_docs",
+      "status": "done",
+      "summary": null
+    },
+    {
+      "completed_at": null,
+      "stage": "test_and_checks",
+      "status": "done",
+      "summary": null
+    },
+    {
+      "completed_at": null,
+      "stage": "commit_and_submit_pr",
+      "status": "pending",
+      "summary": null
+    }
+  ],
+  "task_id": "841-windows-npm-shim-resolution",
+  "task_kind": "bugfix"
+}

--- a/.workflow/records/841-windows-npm-shim-resolution.json
+++ b/.workflow/records/841-windows-npm-shim-resolution.json
@@ -49,9 +49,18 @@
     "trailers": {}
   },
   "docs_landing": {
-    "changelog": {},
-    "checklist": {},
-    "docs": {},
+    "changelog": {
+      "not_applicable": true,
+      "rationale": "N/A for scoped internal bug fix; repository changelog is not maintained for this issue-level backend fix."
+    },
+    "checklist": {
+      "not_applicable": true,
+      "rationale": "N/A; no planning checklist artifact is required for this narrow issue #841 implementation."
+    },
+    "docs": {
+      "not_applicable": true,
+      "rationale": "Implementation-only Windows executable resolution bug fix; no user-facing docs, API schema docs, ADR, or spec text changed."
+    },
     "product-docs": {
       "not_applicable": true,
       "rationale": "Implementation-only Windows executable resolution bug fix for existing AI CLI behavior; no public workflow, schema, API response shape, ADR, or spec text changed."

--- a/src/scistudio/ai/agent/terminal.py
+++ b/src/scistudio/ai/agent/terminal.py
@@ -63,7 +63,7 @@ import sys
 import tempfile
 import threading
 import time
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from pathlib import Path
 from typing import Any
 
@@ -75,7 +75,7 @@ __all__ = ["PtyProcess", "resolve_windows_executable", "spawn_claude", "spawn_co
 _WINDOWS_EXECUTABLE_SUFFIXES = (".cmd", ".bat", ".exe")
 
 
-def resolve_windows_executable(name: str) -> str | None:
+def resolve_windows_executable(name: str, *, which: Callable[[str], str | None] | None = None) -> str | None:
     """Resolve an agent CLI to a concrete Windows executable when needed.
 
     npm global installs on Windows commonly place both ``codex`` (a Unix
@@ -84,13 +84,14 @@ def resolve_windows_executable(name: str) -> str | None:
     spawn path cannot execute it reliably. Prefer extensioned Windows
     launchers while preserving normal ``shutil.which`` behavior elsewhere.
     """
-    resolved = shutil.which(name)
+    which = shutil.which if which is None else which
+    resolved = which(name)
     if sys.platform != "win32":
         return resolved
 
     extensioned: list[str] = []
     for suffix in _WINDOWS_EXECUTABLE_SUFFIXES:
-        candidate = shutil.which(name + suffix)
+        candidate = which(name + suffix)
         if candidate:
             extensioned.append(candidate)
 

--- a/src/scistudio/ai/agent/terminal.py
+++ b/src/scistudio/ai/agent/terminal.py
@@ -57,6 +57,7 @@ from __future__ import annotations
 import contextlib
 import logging
 import os
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -69,7 +70,35 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 # Public re-exports for the route layer.
-__all__ = ["PtyProcess", "spawn_claude", "spawn_codex"]
+__all__ = ["PtyProcess", "resolve_windows_executable", "spawn_claude", "spawn_codex"]
+
+_WINDOWS_EXECUTABLE_SUFFIXES = (".cmd", ".bat", ".exe")
+
+
+def resolve_windows_executable(name: str) -> str | None:
+    """Resolve an agent CLI to a concrete Windows executable when needed.
+
+    npm global installs on Windows commonly place both ``codex`` (a Unix
+    shell wrapper) and ``codex.cmd`` on PATH. Python 3.12.0 can return the
+    bare wrapper from :func:`shutil.which`, and pywinpty's CreateProcess
+    spawn path cannot execute it reliably. Prefer extensioned Windows
+    launchers while preserving normal ``shutil.which`` behavior elsewhere.
+    """
+    resolved = shutil.which(name)
+    if sys.platform != "win32":
+        return resolved
+
+    extensioned: list[str] = []
+    for suffix in _WINDOWS_EXECUTABLE_SUFFIXES:
+        candidate = shutil.which(name + suffix)
+        if candidate:
+            extensioned.append(candidate)
+
+    if extensioned:
+        if resolved and Path(resolved).suffix.lower() in _WINDOWS_EXECUTABLE_SUFFIXES:
+            return resolved
+        return extensioned[0]
+    return resolved
 
 
 class PtyProcess:
@@ -490,8 +519,9 @@ def spawn_claude(
     if _spawn_argv is not None:
         argv = list(_spawn_argv)
     else:
+        claude_binary = resolve_windows_executable("claude") or "claude"
         argv = [
-            "claude",
+            claude_binary,
             "--append-system-prompt",
             f"@{prompt_path}",
             "--mcp-config",
@@ -550,7 +580,7 @@ def spawn_codex(
     if _spawn_argv is not None:
         argv = list(_spawn_argv)
     else:
-        argv = ["codex"]
+        argv = [resolve_windows_executable("codex") or "codex"]
         if dangerous:
             argv.append("--dangerously-bypass-approvals-and-sandbox")
 

--- a/src/scistudio/api/routes/ai.py
+++ b/src/scistudio/api/routes/ai.py
@@ -12,13 +12,14 @@ PTY-tab embedded agent now replaces end-to-end.
 from __future__ import annotations
 
 import logging
-import shutil
 import subprocess
 import sys
 from pathlib import Path
 from typing import Any
 
 from fastapi import APIRouter
+
+from scistudio.ai.agent.terminal import resolve_windows_executable
 
 logger = logging.getLogger(__name__)
 
@@ -88,7 +89,7 @@ def _binary_status(name: str) -> tuple[bool, str | None]:
     completes within 2 s with non-empty stdout.  Version is the trimmed
     stdout.
     """
-    binary = shutil.which(name)
+    binary = resolve_windows_executable(name)
     if not binary:
         return False, None
     try:

--- a/src/scistudio/api/routes/ai.py
+++ b/src/scistudio/api/routes/ai.py
@@ -12,6 +12,7 @@ PTY-tab embedded agent now replaces end-to-end.
 from __future__ import annotations
 
 import logging
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -89,7 +90,7 @@ def _binary_status(name: str) -> tuple[bool, str | None]:
     completes within 2 s with non-empty stdout.  Version is the trimmed
     stdout.
     """
-    binary = resolve_windows_executable(name)
+    binary = resolve_windows_executable(name, which=shutil.which)
     if not binary:
         return False, None
     try:

--- a/tests/ai/test_windows_executable_resolution.py
+++ b/tests/ai/test_windows_executable_resolution.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+from scistudio.ai.agent import terminal
+from scistudio.api.routes import ai as ai_route
+
+
+def _npm_shim_which(name: str) -> str | None:
+    shims = {
+        "codex": "C:/Users/dev/AppData/Roaming/npm/codex",
+        "codex.cmd": "C:/Users/dev/AppData/Roaming/npm/codex.cmd",
+        "claude": "C:/Users/dev/AppData/Roaming/npm/claude",
+        "claude.cmd": "C:/Users/dev/AppData/Roaming/npm/claude.cmd",
+    }
+    return shims.get(name.lower())
+
+
+def test_resolve_windows_executable_prefers_cmd_over_bare_npm_wrapper(monkeypatch: Any) -> None:
+    monkeypatch.setattr(terminal.sys, "platform", "win32")
+    monkeypatch.setattr(terminal.shutil, "which", _npm_shim_which)
+
+    assert terminal.resolve_windows_executable("codex") == "C:/Users/dev/AppData/Roaming/npm/codex.cmd"
+
+
+def test_resolve_windows_executable_preserves_non_windows_which(monkeypatch: Any) -> None:
+    monkeypatch.setattr(terminal.sys, "platform", "linux")
+    monkeypatch.setattr(terminal.shutil, "which", lambda name: f"/usr/bin/{name}")
+
+    assert terminal.resolve_windows_executable("codex") == "/usr/bin/codex"
+
+
+def test_binary_status_uses_cmd_when_windows_which_finds_bare_wrapper(monkeypatch: Any) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(argv: list[str], **_: Any) -> subprocess.CompletedProcess[str]:
+        calls.append(argv)
+        return subprocess.CompletedProcess(argv, 0, stdout="codex 0.1.0\n", stderr="")
+
+    monkeypatch.setattr(terminal.sys, "platform", "win32")
+    monkeypatch.setattr(terminal.shutil, "which", _npm_shim_which)
+    monkeypatch.setattr(ai_route.subprocess, "run", fake_run)
+
+    assert ai_route._binary_status("codex") == (True, "codex 0.1.0")
+    assert calls == [["C:/Users/dev/AppData/Roaming/npm/codex.cmd", "--version"]]
+
+
+def test_spawn_codex_uses_cmd_when_windows_which_finds_bare_wrapper(
+    monkeypatch: Any,
+    tmp_path: Path,
+) -> None:
+    spawned: dict[str, Any] = {}
+
+    class FakePtyProcess:
+        def __init__(self, argv: list[str], *args: Any, **kwargs: Any) -> None:
+            spawned["argv"] = argv
+            spawned["args"] = args
+            spawned["kwargs"] = kwargs
+
+    monkeypatch.setattr(terminal.sys, "platform", "win32")
+    monkeypatch.setattr(terminal.shutil, "which", _npm_shim_which)
+    monkeypatch.setattr(terminal, "PtyProcess", FakePtyProcess)
+
+    terminal.spawn_codex(project_dir=tmp_path, dangerous=True)
+
+    assert spawned["argv"] == [
+        "C:/Users/dev/AppData/Roaming/npm/codex.cmd",
+        "--dangerously-bypass-approvals-and-sandbox",
+    ]
+
+
+def test_spawn_claude_uses_cmd_when_windows_which_finds_bare_wrapper(
+    monkeypatch: Any,
+    tmp_path: Path,
+) -> None:
+    spawned: dict[str, Any] = {}
+    prompt_path = tmp_path / "prompt.md"
+    mcp_config = tmp_path / ".scistudio" / "mcp.json"
+
+    class FakePtyProcess:
+        def __init__(self, argv: list[str], *args: Any, **kwargs: Any) -> None:
+            spawned["argv"] = argv
+            spawned["args"] = args
+            spawned["kwargs"] = kwargs
+
+    monkeypatch.setattr(terminal.sys, "platform", "win32")
+    monkeypatch.setattr(terminal.shutil, "which", _npm_shim_which)
+    monkeypatch.setattr(terminal, "PtyProcess", FakePtyProcess)
+    monkeypatch.setattr(terminal, "_write_system_prompt_tempfile", lambda project_dir: prompt_path)
+    monkeypatch.setattr(terminal, "_ensure_mcp_config", lambda project_dir: mcp_config)
+
+    terminal.spawn_claude(project_dir=tmp_path, dangerous=False)
+
+    assert spawned["argv"] == [
+        "C:/Users/dev/AppData/Roaming/npm/claude.cmd",
+        "--append-system-prompt",
+        f"@{prompt_path}",
+        "--mcp-config",
+        str(mcp_config),
+    ]
+
+
+def test_spawn_argv_seam_bypasses_windows_resolution(monkeypatch: Any, tmp_path: Path) -> None:
+    spawned: dict[str, Any] = {}
+
+    class FakePtyProcess:
+        def __init__(self, argv: list[str], *args: Any, **kwargs: Any) -> None:
+            spawned["argv"] = argv
+            spawned["args"] = args
+            spawned["kwargs"] = kwargs
+
+    monkeypatch.setattr(terminal.sys, "platform", "win32")
+    monkeypatch.setattr(terminal.shutil, "which", _npm_shim_which)
+    monkeypatch.setattr(terminal, "PtyProcess", FakePtyProcess)
+
+    terminal.spawn_codex(project_dir=tmp_path, dangerous=True, _spawn_argv=[sys.executable, "-c", "pass"])
+
+    assert spawned["argv"] == [sys.executable, "-c", "pass"]


### PR DESCRIPTION
## Summary
- Adds a shared Windows executable resolver for agent CLIs that prefers concrete `.cmd`, `.bat`, and `.exe` launchers over extensionless npm wrappers.
- Uses the resolver for AI provider status probes and Codex/Claude PTY spawn argv construction while preserving `_spawn_argv` test overrides.
- Adds regression coverage for the Python 3.12.0 Windows npm shim behavior.

## Tests
- `PYTHONPATH=src python -m pytest tests/ai/test_terminal.py tests/ai/test_windows_executable_resolution.py --no-cov`
- `PYTHONPATH=src python -m ruff check src/scistudio/api/routes/ai.py src/scistudio/ai/agent/terminal.py tests/ai/test_windows_executable_resolution.py`
- `PYTHONPATH=src python -m ruff format --check src/scistudio/api/routes/ai.py src/scistudio/ai/agent/terminal.py tests/ai/test_windows_executable_resolution.py`
- `PYTHONPATH=src python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .workflow/records/841-full-audit.json` (pass; summarized in gate record)
- Sentrux MCP free-tier: pass, 3/15 rules checked, quality signal stable at 4441

Gate record: .workflow/records/841-windows-npm-shim-resolution.json

Closes #841