### PR TITLE
fix(#888): stream Zarr axis iteration

### DIFF
--- a/.workflow/records/888-axis-iter-zarr-lazy.json
+++ b/.workflow/records/888-axis-iter-zarr-lazy.json
@@ -1,0 +1,201 @@
+{
+  "admin_labels": [],
+  "amendments": [
+    {
+      "approved_by": null,
+      "exclude": [],
+      "include": [],
+      "reason": "Implementation completed within the originally planned file scope."
+    }
+  ],
+  "branch": "fix/888-axis-iter-zarr-lazy",
+  "changed_test_paths": [
+    "tests/utils/test_axis_iter.py"
+  ],
+  "check_results": [
+    {
+      "command_or_tool": "PYTHONPATH=src ruff check .",
+      "exit_code": 0,
+      "name": "ruff",
+      "output_path": "All checks passed",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "PYTHONPATH=src ruff format --check .",
+      "exit_code": 0,
+      "name": "format",
+      "output_path": "662 files already formatted",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "PYTHONPATH=src pytest tests/utils/test_axis_iter.py -q --no-cov",
+      "exit_code": 0,
+      "name": "pytest",
+      "output_path": "16 passed",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "PYTHONPATH=src pytest tests/utils/test_axis_iter.py -q",
+      "exit_code": 1,
+      "name": "pytest-coverage-gated-target",
+      "output_path": "16 assertions passed; pytest failed only because repo-wide coverage total 6.12% is below fail-under=70 for narrow test invocation",
+      "status": "fail",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "sentrux check .",
+      "exit_code": 1,
+      "name": "sentrux-cli",
+      "output_path": "sentrux CLI not found on PATH; used Sentrux MCP check_rules instead",
+      "status": "skipped",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "PYTHONPATH=src;packages/scistudio-blocks-imaging/src pytest packages/scistudio-blocks-imaging/tests -q --no-cov",
+      "exit_code": 1,
+      "name": "imaging-package-tests",
+      "output_path": "335 passed, 9 skipped, 43 failed; failures are broad existing imaging package expectations around _data/unpersisted serialization, not isolated to this axis_iter change",
+      "status": "fail",
+      "summary": {},
+      "timestamp": null
+    }
+  ],
+  "commit": {
+    "gate_record_path": ".workflow/records/888-axis-iter-zarr-lazy.json",
+    "shas": [
+      "0a0f05156c47c6aedb84e67c0f622272227dabd3"
+    ],
+    "trailers": {}
+  },
+  "docs_landing": {
+    "changelog": {
+      "not_applicable": true,
+      "rationale": "No changelog entry; targeted bug fix for issue #888 is documented by PR and gate record without release-note surface."
+    },
+    "checklist": {
+      "not_applicable": true,
+      "rationale": "No separate checklist; scoped bug fix is covered by issue #888 acceptance criteria and regression test evidence."
+    },
+    "docs": {}
+  },
+  "full_audit": {
+    "blocks_merge": true,
+    "command": "PYTHONPATH=src python -m scistudio.qa.audit.full_audit --repo-root . --format json --output TEMP/scistudio-888-full-audit.json",
+    "exit_code": 0,
+    "known_debt": [],
+    "output_path": "C:\\Users\\jiazh\\AppData\\Local\\Temp\\scistudio-888-full-audit.json",
+    "status": "pass",
+    "summary": {},
+    "unclassified_failures": []
+  },
+  "governance_touch": false,
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 888,
+      "url": "https://github.com/zjzcpj/SciStudio/issues/888"
+    }
+  ],
+  "owner_directive": "Implement lazy Zarr-backed iterate_over_axes without full source/output materialization; scope limited to src/scistudio/utils/axis_iter.py, tests/utils/test_axis_iter.py, and gate record.",
+  "planned_files": [
+    "src/scistudio/utils/axis_iter.py",
+    "tests/utils/test_axis_iter.py",
+    ".workflow/records/888-axis-iter-zarr-lazy.json"
+  ],
+  "pull_request": {
+    "body_closes_issues": [
+      888
+    ],
+    "number": 1436,
+    "url": "https://github.com/zjzcpj/SciStudio/pull/1436"
+  },
+  "record_path": ".workflow/records/888-axis-iter-zarr-lazy.json",
+  "required_checks": [
+    "ruff",
+    "format",
+    "pytest",
+    "full_audit",
+    "sentrux"
+  ],
+  "schema_version": "1",
+  "scope": {
+    "exclude": [
+      "src/scistudio/engine/scheduler.py",
+      "src/scistudio/engine/resources.py",
+      "src/scistudio/api/runtime.py",
+      "src/scistudio/blocks/load_data.py",
+      "src/scistudio/blocks/save_data.py",
+      "packages/scistudio-blocks-imaging/**",
+      "frontend/**"
+    ],
+    "include": [
+      "src/scistudio/utils/axis_iter.py",
+      "tests/utils/test_axis_iter.py",
+      ".workflow/records/888-axis-iter-zarr-lazy.json"
+    ]
+  },
+  "sentrux": {
+    "command_or_tool": "mcp__sentrux__.scan; mcp__sentrux__.check_rules; mcp__sentrux__.health",
+    "mode": "free-tier",
+    "name": "sentrux.free_tier",
+    "output_path": "check_rules pass=true; rules_checked=3; total_rules_defined=15; health quality_signal=4441; pro_required=false",
+    "pro_required": false,
+    "quality_signal": 4441.0,
+    "rules_checked": 3,
+    "status": "pass",
+    "summary": {},
+    "thresholds": {
+      "pro_required": "false"
+    },
+    "total_rules_defined": 15
+  },
+  "stages": [
+    {
+      "completed_at": null,
+      "stage": "scope_and_issue",
+      "status": "done",
+      "summary": null
+    },
+    {
+      "completed_at": null,
+      "stage": "plan",
+      "status": "done",
+      "summary": null
+    },
+    {
+      "completed_at": null,
+      "stage": "implement",
+      "status": "done",
+      "summary": null
+    },
+    {
+      "completed_at": null,
+      "stage": "update_docs",
+      "status": "done",
+      "summary": null
+    },
+    {
+      "completed_at": null,
+      "stage": "test_and_checks",
+      "status": "done",
+      "summary": null
+    },
+    {
+      "completed_at": null,
+      "stage": "commit_and_submit_pr",
+      "status": "done",
+      "summary": null
+    }
+  ],
+  "task_id": "888-axis-iter-zarr-lazy",
+  "task_kind": "bugfix"
+}

--- a/.workflow/records/888-axis-iter-zarr-lazy.json
+++ b/.workflow/records/888-axis-iter-zarr-lazy.json
@@ -84,7 +84,10 @@
       "not_applicable": true,
       "rationale": "No separate checklist; scoped bug fix is covered by issue #888 acceptance criteria and regression test evidence."
     },
-    "docs": {}
+    "docs": {
+      "not_applicable": true,
+      "rationale": "No documentation change; issue #888 states existing docs are the source of truth and this PR only brings code into compliance with that contract."
+    }
   },
   "full_audit": {
     "blocks_merge": true,

--- a/src/scistudio/utils/axis_iter.py
+++ b/src/scistudio/utils/axis_iter.py
@@ -148,8 +148,18 @@ def iterate_over_axes(
     extra_sizes: list[int] = [source.shape[source.axes.index(a)] for a in extra_axes]
     operates_axes_in_order: list[str] = [a for a in source.axes if a in operates_on_fs]
 
+    if _is_zarr_backed(source):
+        return _iterate_over_axes_zarr(
+            source,
+            operates_on_fs,
+            func,
+            extra_axes,
+            extra_sizes,
+            operates_axes_in_order,
+        )
+
     # 4. Materialise source data once. Per ADR-027 D4 this is the
-    # Phase 10 Level 1 path; lazy Zarr partial-reads are deferred.
+    # fallback path for in-memory and non-Zarr sources.
     source_data = source.to_memory()
     source_arr = np.asarray(source_data)
 
@@ -233,6 +243,135 @@ def iterate_over_axes(
         )
 
     return _build_result(source, result_full)
+
+
+def _is_zarr_backed(source: Array) -> bool:
+    ref = getattr(source, "storage_ref", None)
+    return ref is not None and ref.backend == "zarr"
+
+
+def _iterate_over_axes_zarr(
+    source: Array,
+    operates_on_fs: frozenset[str],
+    func: SliceFn,
+    extra_axes: list[str],
+    extra_sizes: list[int],
+    operates_axes_in_order: list[str],
+) -> Array:
+    """Zarr-backed path that reads and writes one iteration slice at a time."""
+    if not extra_axes:
+        slice_data = np.asarray(source.sel().to_memory())
+        result_slice = func(slice_data, {})
+        result_arr = np.asarray(result_slice)
+        if result_arr.ndim != len(operates_axes_in_order):
+            raise BroadcastError(
+                f"iterate_over_axes: func must return arrays with "
+                f"{len(operates_axes_in_order)} dimensions (len(operates_on)), "
+                f"but got an array with {result_arr.ndim} dimensions."
+            )
+        return _build_result(source, result_arr)
+
+    writer: Any = None
+    zarr_path: str | None = None
+    first_slice_shape: tuple[int, ...] | None = None
+    first_slice_dtype: Any = None
+
+    for extra_idx in product(*(range(s) for s in extra_sizes)):
+        coord: dict[str, int] = dict(zip(extra_axes, extra_idx, strict=True))
+
+        slice_obj = source.sel(**coord)
+        slice_data = np.asarray(slice_obj.to_memory())
+        result_slice = func(slice_data, coord)
+        result_arr = np.asarray(result_slice)
+
+        if first_slice_shape is None:
+            if result_arr.ndim != len(operates_axes_in_order):
+                raise BroadcastError(
+                    f"iterate_over_axes: func must return arrays with "
+                    f"{len(operates_axes_in_order)} dimensions "
+                    f"(len(operates_on)), but got an array with "
+                    f"{result_arr.ndim} dimensions at coord {coord}."
+                )
+            first_slice_shape = result_arr.shape
+            first_slice_dtype = result_arr.dtype
+            zarr_path, writer = _open_zarr_result_writer(
+                source,
+                tuple(extra_sizes) + first_slice_shape,
+                first_slice_dtype,
+                tuple(1 for _ in extra_sizes) + first_slice_shape,
+            )
+        elif result_arr.shape != first_slice_shape:
+            raise BroadcastError(
+                f"iterate_over_axes: slice outputs must all have the same "
+                f"shape. First was {first_slice_shape}, but got "
+                f"{result_arr.shape} at coord {coord}."
+            )
+
+        assert writer is not None
+        writer[extra_idx] = result_arr
+
+    if writer is None:
+        operates_shape = tuple(source.shape[source.axes.index(a)] for a in operates_axes_in_order)  # type: ignore[index]
+        zarr_path, writer = _open_zarr_result_writer(
+            source,
+            tuple(extra_sizes) + operates_shape,
+            np.dtype(source.dtype),
+            tuple(1 for _ in extra_sizes) + operates_shape,
+        )
+
+    assert zarr_path is not None
+    assert first_slice_dtype is not None or writer.dtype is not None
+    return _build_result_from_zarr(source, zarr_path, tuple(writer.shape), writer.dtype)
+
+
+def _open_zarr_result_writer(
+    source: Array,
+    shape: tuple[int, ...],
+    dtype: Any,
+    chunks: tuple[int, ...],
+) -> tuple[str, Any]:
+    import tempfile
+    import uuid
+    from pathlib import Path
+
+    import zarr
+
+    from scistudio.core.storage.flush_context import get_output_dir
+
+    output_dir = get_output_dir()
+    if output_dir is None:
+        output_dir = tempfile.mkdtemp(prefix="scistudio_axis_iter_")
+    zarr_path = str(Path(output_dir) / f"{uuid.uuid4()}.zarr")
+    writer = zarr.open_array(
+        zarr_path,
+        mode="w",
+        shape=shape,
+        chunks=chunks,
+        dtype=dtype,
+    )
+    return zarr_path, writer
+
+
+def _build_result_from_zarr(source: Array, zarr_path: str, shape: tuple[int, ...], dtype: Any) -> Array:
+    from scistudio.core.storage.ref import StorageReference
+
+    new_framework = source._framework.derive()  # type: ignore[attr-defined]
+    ref = StorageReference(
+        backend="zarr",
+        path=zarr_path,
+        metadata={"shape": list(shape), "dtype": str(np.dtype(dtype))},
+    )
+
+    return type(source)(
+        axes=list(source.axes),
+        shape=shape,
+        dtype=np.dtype(dtype),
+        chunk_shape=source.chunk_shape,
+        framework=new_framework,
+        meta=source._meta,  # type: ignore[attr-defined]
+        user=dict(source._user),  # type: ignore[attr-defined]
+        storage_ref=ref,
+    )
 
 
 def _build_result(source: Array, data: np.ndarray) -> Array:

--- a/tests/utils/test_axis_iter.py
+++ b/tests/utils/test_axis_iter.py
@@ -18,6 +18,7 @@ import pytest
 from pydantic import BaseModel, ConfigDict
 
 from scistudio.core.meta import FrameworkMeta
+from scistudio.core.storage.ref import StorageReference
 from scistudio.core.types.array import Array
 from scistudio.utils.axis_iter import iterate_over_axes
 from scistudio.utils.broadcast import BroadcastError
@@ -58,6 +59,32 @@ def _make_array(
     )
     arr._data = data  # type: ignore[attr-defined]
     return arr
+
+
+def _make_zarr_array(tmp_path: Any, axes: list[str], data: np.ndarray, *, chunks: tuple[int, ...]) -> Array:
+    zarr = pytest.importorskip("zarr")
+
+    zarr_path = tmp_path / "source.zarr"
+    writer = zarr.open_array(
+        str(zarr_path),
+        mode="w",
+        shape=data.shape,
+        chunks=chunks,
+        dtype=data.dtype,
+    )
+    writer[:] = data
+    ref = StorageReference(
+        backend="zarr",
+        path=str(zarr_path),
+        metadata={"shape": list(data.shape), "dtype": str(data.dtype)},
+    )
+    return Array(
+        axes=axes,
+        shape=data.shape,
+        dtype=data.dtype,
+        chunk_shape=chunks,
+        storage_ref=ref,
+    )
 
 
 class _SubclassArray(Array):
@@ -198,6 +225,48 @@ def test_iterate_over_axes_coord_dict_correct() -> None:
 
     expected = [{"t": t, "c": c} for t in range(2) for c in range(3)]
     assert coords_seen == expected
+
+
+def test_iterate_over_axes_zarr_reads_per_slice_without_source_to_memory(
+    tmp_path: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Zarr-backed sources use partial reads instead of full materialisation."""
+    data = np.arange(2 * 3 * 4 * 5, dtype=np.float32).reshape(2, 3, 4, 5)
+    src = _make_zarr_array(tmp_path, ["t", "z", "y", "x"], data, chunks=(1, 1, 4, 5))
+
+    def fail_source_to_memory() -> np.ndarray:
+        raise AssertionError("source.to_memory() must not be called for Zarr-backed iterate_over_axes")
+
+    monkeypatch.setattr(src, "to_memory", fail_source_to_memory)
+
+    from scistudio.core.storage.zarr_backend import ZarrBackend
+
+    original_slice = ZarrBackend.slice
+    slice_calls: list[tuple[Any, ...]] = []
+
+    def spy_slice(self: ZarrBackend, ref: StorageReference, *args: Any) -> Any:
+        slice_calls.append(args)
+        return original_slice(self, ref, *args)
+
+    monkeypatch.setattr(ZarrBackend, "slice", spy_slice)
+
+    seen_coords: list[dict[str, int]] = []
+
+    def double(slice_data: np.ndarray, coord: dict[str, int]) -> np.ndarray:
+        seen_coords.append(dict(coord))
+        assert slice_data.shape == (4, 5)
+        return slice_data * 2
+
+    result = iterate_over_axes(src, {"y", "x"}, double)
+
+    assert seen_coords == [{"t": t, "z": z} for t in range(2) for z in range(3)]
+    assert len(slice_calls) == 6
+    assert all(call[0] in {0, 1} and call[1] in {0, 1, 2} for call in slice_calls)
+    assert all(call[2:] == (slice(None), slice(None)) for call in slice_calls)
+    assert result.storage_ref is not None
+    assert result.storage_ref.backend == "zarr"
+    np.testing.assert_array_equal(np.asarray(result), data * 2)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds a Zarr-backed lazy path for `iterate_over_axes` that reads each coordinate through `source.sel(...)` instead of materializing the source with `source.to_memory()`.
- Streams Zarr-path outputs into a result Zarr array after the first slice determines output shape/dtype, avoiding full `np.empty(extra_sizes + first_slice_shape)` output allocation.
- Preserves the existing eager fallback for in-memory and non-Zarr sources.

## Tests / checks

- `PYTHONPATH=src ruff check .` passed
- `PYTHONPATH=src ruff format --check .` passed
- `PYTHONPATH=src pytest tests/utils/test_axis_iter.py -q --no-cov` passed: 16 passed
- `PYTHONPATH=src python -m scistudio.qa.audit.full_audit --repo-root . --format json --output %TEMP%\scistudio-888-full-audit.json` passed
- Sentrux MCP free-tier check passed: 3/15 rules checked, `pro_required=false`

Diagnostic notes:
- `PYTHONPATH=src pytest tests/utils/test_axis_iter.py -q` fails only because a narrow run reports total repo coverage 6.12%, below `fail-under=70`; the axis_iter assertions pass.
- `PYTHONPATH=src;packages/scistudio-blocks-imaging/src pytest packages/scistudio-blocks-imaging/tests -q --no-cov` currently reports 335 passed, 9 skipped, 43 failed. Failures are broad existing imaging package expectations around `_data`/unpersisted serialization, not isolated to this `axis_iter` change.
- `sentrux` CLI is not installed on PATH in this environment; used Sentrux MCP evidence instead.

## Gate / governance

Gate record: `.workflow/records/888-axis-iter-zarr-lazy.json`

This PR changes protected `src/scistudio/utils/**`; it needs the `admin-approved:core-change` label before the CI workflow gate can be considered ready.

Closes #888
