### PR TITLE
fix(#891): require bundled SPA in release wheels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,7 +240,9 @@ jobs:
       - name: Build wheel with required frontend bundle
         env:
           SCISTUDIO_REQUIRE_FRONTEND_BUILD: "1"
-        run: python -m build --wheel
+        run: |
+          # setup.py invokes npm ci and npm run build before collecting wheel package data.
+          python -m build --wheel
       - name: Inspect wheel SPA contents
         run: |
           python - <<'PY'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,12 +237,17 @@ jobs:
           cache-dependency-path: "frontend/package-lock.json"
       - name: Install build frontend
         run: python -m pip install --upgrade pip build
+      - name: Build frontend for packaging
+        working-directory: frontend
+        run: npm ci && npm run build
+      - name: Copy build output to Python package
+        run: |
+          rm -rf src/scistudio/api/static
+          cp -r frontend/dist/ src/scistudio/api/static/
       - name: Build wheel with required frontend bundle
         env:
           SCISTUDIO_REQUIRE_FRONTEND_BUILD: "1"
-        run: |
-          # setup.py invokes npm ci and npm run build before collecting wheel package data.
-          python -m build --wheel
+        run: python -m build --wheel
       - name: Inspect wheel SPA contents
         run: |
           python - <<'PY'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,23 +222,75 @@ jobs:
           fi
           echo "frontend/dist is up to date."
 
-  build-frontend-release:
-    name: Build Frontend for Release
+  wheel-release-smoke:
+    name: Wheel Release Smoke
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v')
     steps:
       - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
       - uses: actions/setup-node@v6
         with:
           node-version: "20"
           cache: "npm"
           cache-dependency-path: "frontend/package-lock.json"
-      - name: Build frontend for packaging
-        working-directory: frontend
-        run: npm ci && npm run build
-      - name: Copy build output to Python package
-        run: cp -r frontend/dist/ src/scistudio/api/static/
-      - uses: actions/upload-artifact@v7
+      - name: Install build frontend
+        run: python -m pip install --upgrade pip build
+      - name: Build wheel with required frontend bundle
+        env:
+          SCISTUDIO_REQUIRE_FRONTEND_BUILD: "1"
+        run: python -m build --wheel
+      - name: Inspect wheel SPA contents
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+          from zipfile import ZipFile
+
+          wheels = list(Path("dist").glob("*.whl"))
+          if len(wheels) != 1:
+              raise SystemExit(f"expected exactly one wheel, found {wheels}")
+
+          with ZipFile(wheels[0]) as wheel:
+              names = set(wheel.namelist())
+
+          index = "scistudio/api/static/index.html"
+          js_assets = [
+              name
+              for name in names
+              if name.startswith("scistudio/api/static/assets/") and name.endswith(".js")
+          ]
+          if index not in names:
+              raise SystemExit(f"missing {index} in {wheels[0]}")
+          if not js_assets:
+              raise SystemExit(f"missing JS asset under scistudio/api/static/assets/ in {wheels[0]}")
+          print(f"{wheels[0]} contains {index} and {len(js_assets)} JS asset(s)")
+          PY
+      - name: Install wheel and smoke-test GUI root
+        run: |
+          python -m venv .venv-wheel-smoke
+          . .venv-wheel-smoke/bin/activate
+          python -m pip install --upgrade pip
+          python -m pip install dist/*.whl
+          python - <<'PY'
+          from fastapi.testclient import TestClient
+
+          from scistudio.api.app import create_app
+
+          with TestClient(create_app()) as client:
+              response = client.get("/", follow_redirects=False)
+
+          if response.is_redirect or response.headers.get("location") == "/docs":
+              raise SystemExit("GET / redirected to /docs instead of serving the GUI")
+          if response.status_code != 200:
+              raise SystemExit(f"GET / returned {response.status_code}")
+          if "<html" not in response.text.lower() or "/assets/" not in response.text:
+              raise SystemExit("GET / did not return bundled GUI HTML")
+          print("GET / served bundled GUI HTML")
+          PY
+      - name: Upload verified wheel
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: actions/upload-artifact@v7
         with:
-          name: frontend-static
-          path: src/scistudio/api/static/
+          name: scistudio-wheel
+          path: dist/*.whl

--- a/.workflow/records/891-require-frontend-wheel.json
+++ b/.workflow/records/891-require-frontend-wheel.json
@@ -67,11 +67,17 @@
     "trailers": {}
   },
   "docs_landing": {
-    "changelog": {},
-    "checklist": {},
+    "changelog": {
+      "not_applicable": true,
+      "rationale": "No changelog entry required for issue #891 because this is a pre-release packaging/CI guardrail fix with behavior captured by the issue, PR, tests, and release wheel smoke."
+    },
+    "checklist": {
+      "not_applicable": true,
+      "rationale": "No separate checklist required for issue #891 because acceptance criteria are tracked directly in the issue and validated by the gate record plus CI Wheel Release Smoke."
+    },
     "docs": {
       "not_applicable": true,
-      "rationale": "Packaging/CI regression is covered by issue #891, setup.py behavior, CI wheel smoke, and tests; no user-facing doc contract changed"
+      "rationale": "Packaging/CI regression is covered by issue #891, setup.py behavior, CI wheel smoke, and tests; no user-facing doc contract changed."
     }
   },
   "full_audit": {

--- a/.workflow/records/891-require-frontend-wheel.json
+++ b/.workflow/records/891-require-frontend-wheel.json
@@ -96,7 +96,7 @@
       "close_in_pr": true,
       "followup_rationale": null,
       "number": 891,
-      "url": null
+      "url": "https://github.com/zjzcpj/SciStudio/issues/891"
     }
   ],
   "owner_directive": "Implement issue #891: require verified bundled SPA for release-mode wheel builds while preserving SCISTUDIO_SKIP_FRONTEND_BUILD developer escape hatch.",

--- a/.workflow/records/891-require-frontend-wheel.json
+++ b/.workflow/records/891-require-frontend-wheel.json
@@ -1,0 +1,195 @@
+{
+  "admin_labels": [],
+  "amendments": [
+    {
+      "approved_by": null,
+      "exclude": [],
+      "include": [],
+      "reason": "Owner-assigned scope includes .github/workflows/ci.yml to add release wheel verification for issue #891; mark governance_touch for workflow CI change."
+    }
+  ],
+  "branch": "fix/891-require-frontend-wheel",
+  "changed_test_paths": [
+    "tests/packaging/test_wheel_spa.py"
+  ],
+  "check_results": [
+    {
+      "command_or_tool": "PYTHONPATH=src pytest tests/packaging/test_wheel_spa.py --no-cov --timeout=60",
+      "exit_code": 0,
+      "name": "pytest-packaging-spa",
+      "output_path": "7 passed in 0.51s",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "ruff check setup.py tests/packaging/test_wheel_spa.py",
+      "exit_code": 0,
+      "name": "ruff",
+      "output_path": "All checks passed",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "ruff format --check setup.py tests/packaging/test_wheel_spa.py",
+      "exit_code": 0,
+      "name": "format",
+      "output_path": "2 files already formatted",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "python -c import yaml...safe_load(.github/workflows/ci.yml)",
+      "exit_code": 0,
+      "name": "yaml-parse",
+      "output_path": "workflow YAML parsed; wheel-release-smoke job present",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "SCISTUDIO_REQUIRE_FRONTEND_BUILD=1 python -m build --wheel; inspect wheel; install wheel; TestClient GET /",
+      "exit_code": 0,
+      "name": "wheel-build-require-spa",
+      "output_path": "wheel contains scistudio/api/static/index.html and JS assets; installed wheel GET / returned 200 text/html GUI HTML",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    }
+  ],
+  "commit": null,
+  "docs_landing": {
+    "changelog": {},
+    "checklist": {},
+    "docs": {
+      "not_applicable": true,
+      "rationale": "Packaging/CI regression is covered by issue #891, setup.py behavior, CI wheel smoke, and tests; no user-facing doc contract changed"
+    }
+  },
+  "full_audit": {
+    "blocks_merge": false,
+    "command": "PYTHONPATH=src python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit-891.json",
+    "exit_code": 0,
+    "known_debt": [],
+    "output_path": ".audit/full-audit-891.json",
+    "status": "pass",
+    "summary": {},
+    "unclassified_failures": []
+  },
+  "governance_touch": true,
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 891,
+      "url": null
+    }
+  ],
+  "owner_directive": "Implement issue #891: require verified bundled SPA for release-mode wheel builds while preserving SCISTUDIO_SKIP_FRONTEND_BUILD developer escape hatch.",
+  "planned_files": [
+    "setup.py",
+    ".github/workflows/ci.yml",
+    "tests/packaging/test_wheel_spa.py"
+  ],
+  "pull_request": null,
+  "record_path": ".workflow/records/891-require-frontend-wheel.json",
+  "required_checks": [
+    "ruff",
+    "format",
+    "pytest-packaging-spa",
+    "wheel-build-require-spa",
+    "full_audit",
+    "sentrux"
+  ],
+  "schema_version": "1",
+  "scope": {
+    "exclude": [
+      "frontend/src/App.tsx",
+      "frontend/src/components/nodes/BlockNode.tsx",
+      "frontend/src/components/DataPreview.tsx",
+      "frontend/src/components/BottomPanel.tsx",
+      "frontend/src/components/Lineage/RunDetail.tsx",
+      "frontend/src/lib/api.ts",
+      "frontend/src/components/Git/ConflictMarkerDecoration.ts",
+      "src/scistudio/api/runtime.py",
+      "src/scistudio/ai/agent/mcp/tools_workflow.py",
+      "src/scistudio/ai/agent/mcp/tools_inspection.py",
+      "src/scistudio/api/routes/ai_pty.py",
+      "src/scistudio/api/routes/workflow_watcher.py",
+      "src/scistudio/cli/install.py",
+      "src/scistudio/api/routes/git.py",
+      "src/scistudio/qa/governance/gate_record.py",
+      "src/scistudio/qa/audit/architecture_drift.py",
+      "src/scistudio/core/types/registry.py",
+      "src/scistudio/blocks/io/savers/save_data.py",
+      "src/scistudio/blocks/io/loaders/load_data.py",
+      "src/scistudio/blocks/code/code_block.py",
+      "src/scistudio/blocks/ai/ai_block.py",
+      "src/scistudio/core/lineage/store.py",
+      "src/scistudio/engine/scheduler.py",
+      "src/scistudio/blocks/registry.py",
+      "src/scistudio/core/versioning/git_engine.py"
+    ],
+    "include": [
+      "setup.py",
+      ".github/workflows/ci.yml",
+      "tests/packaging/**",
+      ".workflow/records/**"
+    ]
+  },
+  "sentrux": {
+    "command_or_tool": "mcp__sentrux__.scan+mcp__sentrux__.check_rules",
+    "mode": "free-tier",
+    "name": "sentrux.free_tier",
+    "output_path": "scan quality_signal=4441; check_rules pass=true violation_count=0; session_end baseline unavailable because MCP exposes no session_start tool in this session",
+    "pro_required": false,
+    "quality_signal": 4441.0,
+    "rules_checked": 3,
+    "status": "pass",
+    "summary": {},
+    "thresholds": {},
+    "total_rules_defined": 15
+  },
+  "stages": [
+    {
+      "completed_at": null,
+      "stage": "scope_and_issue",
+      "status": "done",
+      "summary": null
+    },
+    {
+      "completed_at": null,
+      "stage": "plan",
+      "status": "done",
+      "summary": null
+    },
+    {
+      "completed_at": null,
+      "stage": "implement",
+      "status": "done",
+      "summary": null
+    },
+    {
+      "completed_at": null,
+      "stage": "update_docs",
+      "status": "done",
+      "summary": null
+    },
+    {
+      "completed_at": null,
+      "stage": "test_and_checks",
+      "status": "done",
+      "summary": null
+    },
+    {
+      "completed_at": null,
+      "stage": "commit_and_submit_pr",
+      "status": "pending",
+      "summary": null
+    }
+  ],
+  "task_id": "891-require-frontend-wheel",
+  "task_kind": "bugfix"
+}

--- a/.workflow/records/891-require-frontend-wheel.json
+++ b/.workflow/records/891-require-frontend-wheel.json
@@ -59,7 +59,13 @@
       "timestamp": null
     }
   ],
-  "commit": null,
+  "commit": {
+    "gate_record_path": ".workflow/records/891-require-frontend-wheel.json",
+    "shas": [
+      "309d18f3bf9c2c84515980bf1e70ffe6613938f9"
+    ],
+    "trailers": {}
+  },
   "docs_landing": {
     "changelog": {},
     "checklist": {},
@@ -93,7 +99,13 @@
     ".github/workflows/ci.yml",
     "tests/packaging/test_wheel_spa.py"
   ],
-  "pull_request": null,
+  "pull_request": {
+    "body_closes_issues": [
+      891
+    ],
+    "number": null,
+    "url": "https://github.com/zjzcpj/SciStudio/pull/1437"
+  },
   "record_path": ".workflow/records/891-require-frontend-wheel.json",
   "required_checks": [
     "ruff",
@@ -186,7 +198,7 @@
     {
       "completed_at": null,
       "stage": "commit_and_submit_pr",
-      "status": "pending",
+      "status": "done",
       "summary": null
     }
   ],

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,8 @@ Flow
 Whenever setuptools runs the ``build_py`` command (which happens during
 wheel building, source installs, and editable installs), we:
 
-1. Check whether ``src/scistudio/api/static/index.html`` already exists.
+1. Check whether ``src/scistudio/api/static/`` already contains a complete
+   SPA bundle: ``index.html``, ``assets/``, and at least one JavaScript asset.
    If yes, we assume a previous invocation (or a pre-built sdist) already
    populated it and skip the build. This keeps offline / no-Node installs
    working as long as the static dir was pre-populated.
@@ -29,6 +30,7 @@ running this hook.
 
 from __future__ import annotations
 
+import os
 import shutil
 import subprocess
 import sys
@@ -47,8 +49,17 @@ def _log(msg: str) -> None:
     print(f"[scistudio-build] {msg}", file=sys.stderr)
 
 
+def _is_complete_spa_bundle(static_dir: Path) -> bool:
+    assets_dir = static_dir / "assets"
+    return (
+        (static_dir / "index.html").is_file()
+        and assets_dir.is_dir()
+        and any(path.is_file() for path in assets_dir.rglob("*.js"))
+    )
+
+
 def _has_prebuilt_spa() -> bool:
-    return (_PACKAGED_STATIC / "index.html").is_file()
+    return _is_complete_spa_bundle(_PACKAGED_STATIC)
 
 
 def _npm_available() -> bool:
@@ -56,17 +67,23 @@ def _npm_available() -> bool:
     return shutil.which("npm") is not None
 
 
-def _run_frontend_build() -> None:
+def _run_frontend_build(*, required: bool = False) -> None:
     if not _FRONTEND_DIR.is_dir():
-        _log(f"no frontend/ directory at {_FRONTEND_DIR}; skipping SPA build")
+        msg = f"no frontend/ directory at {_FRONTEND_DIR}; skipping SPA build"
+        if required:
+            raise RuntimeError(msg)
+        _log(msg)
         return
 
     if not _npm_available():
-        _log(
+        msg = (
             "npm not found on PATH; skipping SPA build. Install Node.js to "
             "bundle the SPA, or set SCISTUDIO_SKIP_FRONTEND_BUILD=1 to silence "
             "this warning. The runtime will redirect GET / to /docs."
         )
+        if required:
+            raise RuntimeError(msg)
+        _log(msg)
         return
 
     _log("running `npm ci` in frontend/")
@@ -74,8 +91,11 @@ def _run_frontend_build() -> None:
     _log("running `npm run build` in frontend/")
     subprocess.check_call(["npm", "run", "build"], cwd=_FRONTEND_DIR, shell=sys.platform == "win32")
 
-    if not (_FRONTEND_DIST / "index.html").is_file():
-        raise RuntimeError(f"frontend build did not produce {_FRONTEND_DIST / 'index.html'}")
+    if not _is_complete_spa_bundle(_FRONTEND_DIST):
+        raise RuntimeError(
+            "frontend build did not produce a complete SPA bundle "
+            f"(expected index.html, assets/, and at least one JS asset under {_FRONTEND_DIST})"
+        )
 
     if _PACKAGED_STATIC.exists():
         shutil.rmtree(_PACKAGED_STATIC)
@@ -87,18 +107,21 @@ class build_py(_build_py):  # noqa: N801 - setuptools command name must stay low
     """Extend ``build_py`` to bundle the frontend SPA before collecting package data."""
 
     def run(self) -> None:
-        import os
-
         if os.environ.get("SCISTUDIO_SKIP_FRONTEND_BUILD") == "1":
             _log("SCISTUDIO_SKIP_FRONTEND_BUILD=1 set; skipping SPA build")
         elif _has_prebuilt_spa():
             _log(f"found pre-built SPA at {_PACKAGED_STATIC}; skipping rebuild")
         else:
+            required = os.environ.get("SCISTUDIO_REQUIRE_FRONTEND_BUILD") == "1"
             try:
-                _run_frontend_build()
+                _run_frontend_build(required=required)
             except subprocess.CalledProcessError as exc:
+                if required:
+                    raise RuntimeError(f"frontend build failed with exit {exc.returncode}") from exc
                 _log(f"frontend build failed with exit {exc.returncode}; continuing without SPA")
             except Exception as exc:  # pragma: no cover - defensive
+                if required:
+                    raise
                 _log(f"unexpected error bundling frontend SPA: {exc!r}; continuing without SPA")
         super().run()
 

--- a/tests/packaging/test_wheel_spa.py
+++ b/tests/packaging/test_wheel_spa.py
@@ -10,7 +10,9 @@ from types import ModuleType
 from unittest.mock import Mock
 
 import pytest
-from setuptools import Distribution
+
+setuptools = pytest.importorskip("setuptools")
+Distribution = setuptools.Distribution
 
 
 def _load_setup_module(monkeypatch: pytest.MonkeyPatch) -> ModuleType:

--- a/tests/packaging/test_wheel_spa.py
+++ b/tests/packaging/test_wheel_spa.py
@@ -1,0 +1,146 @@
+"""Regression coverage for wheel SPA bundling (#891)."""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import Mock
+
+import pytest
+from setuptools import Distribution
+
+
+def _load_setup_module(monkeypatch: pytest.MonkeyPatch) -> ModuleType:
+    monkeypatch.setattr("setuptools.setup", Mock())
+    module_path = Path(__file__).resolve().parents[2] / "setup.py"
+    spec = importlib.util.spec_from_file_location("scistudio_test_setup", module_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_spa(root: Path, *, with_assets: bool = True, with_js: bool = True) -> None:
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "index.html").write_text("<!doctype html><html><body>SciStudio</body></html>", encoding="utf-8")
+    if with_assets:
+        assets = root / "assets"
+        assets.mkdir()
+        if with_js:
+            (assets / "index.js").write_text("console.log('scistudio')", encoding="utf-8")
+
+
+def test_has_prebuilt_spa_requires_index_assets_and_js(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    setup_module = _load_setup_module(monkeypatch)
+    static_dir = tmp_path / "static"
+    monkeypatch.setattr(setup_module, "_PACKAGED_STATIC", static_dir)
+
+    assert setup_module._has_prebuilt_spa() is False
+
+    (static_dir / "index.html").parent.mkdir(parents=True)
+    (static_dir / "index.html").write_text("<html></html>", encoding="utf-8")
+    assert setup_module._has_prebuilt_spa() is False
+
+    (static_dir / "assets").mkdir()
+    assert setup_module._has_prebuilt_spa() is False
+
+    (static_dir / "assets" / "style.css").write_text("body{}", encoding="utf-8")
+    assert setup_module._has_prebuilt_spa() is False
+
+    (static_dir / "assets" / "main.js").write_text("console.log('ok')", encoding="utf-8")
+    assert setup_module._has_prebuilt_spa() is True
+
+
+def test_required_frontend_build_fails_when_npm_is_missing(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    setup_module = _load_setup_module(monkeypatch)
+    frontend_dir = tmp_path / "frontend"
+    frontend_dir.mkdir()
+    monkeypatch.setattr(setup_module, "_FRONTEND_DIR", frontend_dir)
+    monkeypatch.setattr(setup_module, "_npm_available", lambda: False)
+
+    with pytest.raises(RuntimeError, match="npm not found"):
+        setup_module._run_frontend_build(required=True)
+
+
+def test_optional_frontend_build_allows_missing_npm(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    setup_module = _load_setup_module(monkeypatch)
+    frontend_dir = tmp_path / "frontend"
+    frontend_dir.mkdir()
+    monkeypatch.setattr(setup_module, "_FRONTEND_DIR", frontend_dir)
+    monkeypatch.setattr(setup_module, "_npm_available", lambda: False)
+
+    setup_module._run_frontend_build(required=False)
+
+
+def test_required_frontend_build_rejects_partial_dist(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    setup_module = _load_setup_module(monkeypatch)
+    frontend_dir = tmp_path / "frontend"
+    dist_dir = frontend_dir / "dist"
+    frontend_dir.mkdir()
+    dist_dir.mkdir()
+    (dist_dir / "index.html").write_text("<html></html>", encoding="utf-8")
+    monkeypatch.setattr(setup_module, "_FRONTEND_DIR", frontend_dir)
+    monkeypatch.setattr(setup_module, "_FRONTEND_DIST", dist_dir)
+    monkeypatch.setattr(setup_module, "_npm_available", lambda: True)
+    monkeypatch.setattr(setup_module.subprocess, "check_call", Mock())
+
+    with pytest.raises(RuntimeError, match="complete SPA bundle"):
+        setup_module._run_frontend_build(required=True)
+
+
+def test_required_frontend_build_copies_complete_dist(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    setup_module = _load_setup_module(monkeypatch)
+    frontend_dir = tmp_path / "frontend"
+    dist_dir = frontend_dir / "dist"
+    packaged_static = tmp_path / "package" / "static"
+    frontend_dir.mkdir()
+    _write_spa(dist_dir)
+    monkeypatch.setattr(setup_module, "_FRONTEND_DIR", frontend_dir)
+    monkeypatch.setattr(setup_module, "_FRONTEND_DIST", dist_dir)
+    monkeypatch.setattr(setup_module, "_PACKAGED_STATIC", packaged_static)
+    monkeypatch.setattr(setup_module, "_npm_available", lambda: True)
+    check_call = Mock()
+    monkeypatch.setattr(setup_module.subprocess, "check_call", check_call)
+
+    setup_module._run_frontend_build(required=True)
+
+    assert (packaged_static / "index.html").is_file()
+    assert (packaged_static / "assets" / "index.js").is_file()
+    assert check_call.call_args_list[0].args[0] == ["npm", "ci"]
+    assert check_call.call_args_list[1].args[0] == ["npm", "run", "build"]
+
+
+def test_required_frontend_build_raises_on_npm_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    setup_module = _load_setup_module(monkeypatch)
+    command = setup_module.build_py(Distribution())
+    monkeypatch.setattr(setup_module, "_has_prebuilt_spa", lambda: False)
+    monkeypatch.setattr(setup_module, "_run_frontend_build", Mock(side_effect=subprocess.CalledProcessError(1, "npm")))
+    monkeypatch.setattr(setup_module._build_py, "run", Mock())
+    monkeypatch.setenv("SCISTUDIO_REQUIRE_FRONTEND_BUILD", "1")
+
+    with pytest.raises(RuntimeError, match="frontend build failed with exit 1"):
+        command.run()
+
+
+def test_skip_frontend_build_overrides_required_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+    setup_module = _load_setup_module(monkeypatch)
+    command = setup_module.build_py(Distribution())
+    run_frontend_build = Mock()
+    base_run = Mock()
+    monkeypatch.setattr(setup_module, "_has_prebuilt_spa", lambda: False)
+    monkeypatch.setattr(setup_module, "_run_frontend_build", run_frontend_build)
+    monkeypatch.setattr(setup_module._build_py, "run", base_run)
+    monkeypatch.setenv("SCISTUDIO_REQUIRE_FRONTEND_BUILD", "1")
+    monkeypatch.setenv("SCISTUDIO_SKIP_FRONTEND_BUILD", "1")
+
+    command.run()
+
+    run_frontend_build.assert_not_called()
+    base_run.assert_called_once_with()


### PR DESCRIPTION
## Summary

- require complete SPA bundles for prebuilt wheel assets: `index.html`, `assets/`, and at least one JS asset
- add `SCISTUDIO_REQUIRE_FRONTEND_BUILD=1` release hard-fail behavior while preserving `SCISTUDIO_SKIP_FRONTEND_BUILD=1`
- replace the tag-only frontend-static artifact job with a wheel smoke that builds, inspects, installs, and verifies the GUI root

## Tests

- `PYTHONPATH=src pytest tests/packaging/test_wheel_spa.py --no-cov --timeout=60`
- `ruff check setup.py tests/packaging/test_wheel_spa.py`
- `ruff format --check setup.py tests/packaging/test_wheel_spa.py`
- YAML parse of `.github/workflows/ci.yml`
- `SCISTUDIO_REQUIRE_FRONTEND_BUILD=1 python -m build --wheel`, wheel content inspection, installed-wheel `GET /` smoke
- `PYTHONPATH=src python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit-891.json`
- Sentrux MCP free-tier scan/check_rules: pass, 3/15 rules checked

Gate record: `.workflow/records/891-require-frontend-wheel.json`

Closes #891
