### PR TITLE
fix(#709): stage configured imaging app inputs

### DIFF
--- a/.workflow/records/709-imaging-variadic-inputs.json
+++ b/.workflow/records/709-imaging-variadic-inputs.json
@@ -49,11 +49,17 @@
     "trailers": {}
   },
   "docs_landing": {
-    "changelog": {},
-    "checklist": {},
+    "changelog": {
+      "not_applicable": true,
+      "rationale": "No release-facing changelog entry is required for this narrow internal bugfix before release packaging; behavior is tracked by issue #709 and PR #1439."
+    },
+    "checklist": {
+      "not_applicable": true,
+      "rationale": "No manager dispatch or multi-agent checklist is required for this single-implementer scoped bugfix; gate record is the checklist evidence."
+    },
     "docs": {
       "not_applicable": true,
-      "rationale": "No user-facing contract docs changed; bugfix is covered by issue #709 and package regression tests."
+      "rationale": "No user-facing documentation contract changed; issue #709 and package regression tests document the bugfix behavior."
     }
   },
   "full_audit": {

--- a/.workflow/records/709-imaging-variadic-inputs.json
+++ b/.workflow/records/709-imaging-variadic-inputs.json
@@ -1,0 +1,159 @@
+{
+  "admin_labels": [],
+  "amendments": [
+    {
+      "approved_by": null,
+      "exclude": [],
+      "include": [],
+      "reason": "Implementation completed within original scoped files; marking implement stage after code and regression test edits."
+    }
+  ],
+  "branch": "fix/709-imaging-variadic-inputs",
+  "changed_test_paths": [
+    "packages/scistudio-blocks-imaging/tests/test_interactive_blocks.py"
+  ],
+  "check_results": [
+    {
+      "command_or_tool": "PYTHONPATH=src;packages/scistudio-blocks-imaging/src python -m ruff check packages/scistudio-blocks-imaging/src/scistudio_blocks_imaging/interactive packages/scistudio-blocks-imaging/tests/test_interactive_blocks.py",
+      "exit_code": 0,
+      "name": "ruff",
+      "output_path": "All checks passed",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "PYTHONPATH=src;packages/scistudio-blocks-imaging/src python -m ruff format --check packages/scistudio-blocks-imaging/src/scistudio_blocks_imaging/interactive packages/scistudio-blocks-imaging/tests/test_interactive_blocks.py",
+      "exit_code": 0,
+      "name": "format",
+      "output_path": "4 files already formatted",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "PYTHONPATH=src;packages/scistudio-blocks-imaging/src python -m pytest packages/scistudio-blocks-imaging/tests/test_interactive_blocks.py --no-cov -q",
+      "exit_code": 0,
+      "name": "pytest",
+      "output_path": "9 passed in 9.04s",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    }
+  ],
+  "commit": null,
+  "docs_landing": {
+    "changelog": {},
+    "checklist": {},
+    "docs": {
+      "not_applicable": true,
+      "rationale": "No user-facing contract docs changed; bugfix is covered by issue #709 and package regression tests."
+    }
+  },
+  "full_audit": {
+    "blocks_merge": true,
+    "command": "PYTHONPATH=src;packages/scistudio-blocks-imaging/src python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .workflow/records/709-imaging-variadic-inputs-full-audit.json",
+    "exit_code": 0,
+    "known_debt": [],
+    "output_path": "status pass; findings=0; local output file not committed because .workflow/records must contain only gate records",
+    "status": "pass",
+    "summary": {},
+    "unclassified_failures": []
+  },
+  "governance_touch": false,
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 709,
+      "url": "https://github.com/zjzcpj/SciStudio/issues/709"
+    }
+  ],
+  "owner_directive": "Implement GitHub issue #709: Fiji/Napari interactive imaging blocks must stage effective configured input ports, including user-added Artifact ports, without touching forbidden core/frontend paths.",
+  "planned_files": [
+    "packages/scistudio-blocks-imaging/src/scistudio_blocks_imaging/interactive/__init__.py",
+    "packages/scistudio-blocks-imaging/src/scistudio_blocks_imaging/interactive/fiji_block.py",
+    "packages/scistudio-blocks-imaging/src/scistudio_blocks_imaging/interactive/napari_block.py"
+  ],
+  "pull_request": null,
+  "record_path": ".workflow/records/709-imaging-variadic-inputs.json",
+  "required_checks": [
+    "ruff",
+    "format",
+    "pytest",
+    "full_audit",
+    "sentrux"
+  ],
+  "schema_version": "1",
+  "scope": {
+    "exclude": [
+      "src/scistudio/blocks/ai/ai_block.py",
+      "src/scistudio/blocks/code/code_block.py",
+      "src/scistudio/blocks/io/loaders/load_data.py",
+      "src/scistudio/blocks/io/savers/save_data.py",
+      "src/scistudio/blocks/registry.py",
+      "src/scistudio/engine/scheduler.py",
+      "src/scistudio/api/runtime.py"
+    ],
+    "include": [
+      "packages/scistudio-blocks-imaging/src/scistudio_blocks_imaging/interactive/**",
+      "packages/scistudio-blocks-imaging/tests/test_interactive_blocks.py",
+      ".workflow/records/**"
+    ]
+  },
+  "sentrux": {
+    "command_or_tool": "mcp__sentrux__.scan; mcp__sentrux__.check_rules; mcp__sentrux__.health",
+    "mode": "free-tier",
+    "name": "sentrux.free_tier",
+    "output_path": "check_rules pass=true rules_checked=3 total_rules_defined=15; quality_signal=4441; pro_required=false",
+    "pro_required": false,
+    "quality_signal": 4441.0,
+    "rules_checked": 3,
+    "status": "pass",
+    "summary": {},
+    "thresholds": {
+      "pro_required": "false"
+    },
+    "total_rules_defined": 15
+  },
+  "stages": [
+    {
+      "completed_at": null,
+      "stage": "scope_and_issue",
+      "status": "done",
+      "summary": null
+    },
+    {
+      "completed_at": null,
+      "stage": "plan",
+      "status": "done",
+      "summary": null
+    },
+    {
+      "completed_at": null,
+      "stage": "implement",
+      "status": "done",
+      "summary": null
+    },
+    {
+      "completed_at": null,
+      "stage": "update_docs",
+      "status": "done",
+      "summary": null
+    },
+    {
+      "completed_at": null,
+      "stage": "test_and_checks",
+      "status": "done",
+      "summary": null
+    },
+    {
+      "completed_at": null,
+      "stage": "commit_and_submit_pr",
+      "status": "pending",
+      "summary": null
+    }
+  ],
+  "task_id": "709-imaging-variadic-inputs",
+  "task_kind": "bugfix"
+}

--- a/.workflow/records/709-imaging-variadic-inputs.json
+++ b/.workflow/records/709-imaging-variadic-inputs.json
@@ -41,7 +41,13 @@
       "timestamp": null
     }
   ],
-  "commit": null,
+  "commit": {
+    "gate_record_path": ".workflow/records/709-imaging-variadic-inputs.json",
+    "shas": [
+      "11c74a408ac9ba69b09740632f304f0b88aec067"
+    ],
+    "trailers": {}
+  },
   "docs_landing": {
     "changelog": {},
     "checklist": {},
@@ -75,7 +81,13 @@
     "packages/scistudio-blocks-imaging/src/scistudio_blocks_imaging/interactive/fiji_block.py",
     "packages/scistudio-blocks-imaging/src/scistudio_blocks_imaging/interactive/napari_block.py"
   ],
-  "pull_request": null,
+  "pull_request": {
+    "body_closes_issues": [
+      709
+    ],
+    "number": null,
+    "url": "https://github.com/zjzcpj/SciStudio/pull/1439"
+  },
   "record_path": ".workflow/records/709-imaging-variadic-inputs.json",
   "required_checks": [
     "ruff",
@@ -150,7 +162,7 @@
     {
       "completed_at": null,
       "stage": "commit_and_submit_pr",
-      "status": "pending",
+      "status": "done",
       "summary": null
     }
   ],

--- a/packages/scistudio-blocks-imaging/src/scistudio_blocks_imaging/interactive/__init__.py
+++ b/packages/scistudio-blocks-imaging/src/scistudio_blocks_imaging/interactive/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import logging
 import platform
+import shutil
 import subprocess
 import tempfile
 from collections.abc import Mapping
@@ -16,7 +17,9 @@ from scistudio.blocks.app.app_block import AppBlock, _PopenProcessAdapter
 from scistudio.blocks.app.bridge import FileExchangeBridge
 from scistudio.blocks.app.watcher import FileWatcher, ProcessExitedWithoutOutputError
 from scistudio.blocks.base.config import BlockConfig
+from scistudio.blocks.base.ports import InputPort, ports_from_config_dicts
 from scistudio.blocks.base.state import BlockState
+from scistudio.core.types.artifact import Artifact
 from scistudio.core.types.collection import Collection
 from scistudio_blocks_imaging.types import Image
 
@@ -86,6 +89,139 @@ def _prepare_image_exchange(
     }
     (exchange_dir / "manifest.json").write_text(json.dumps(manifest, indent=2, default=str), encoding="utf-8")
     return paths
+
+
+def _effective_input_ports(block: AppBlock, config: BlockConfig) -> list[InputPort]:
+    configured_ports = config.get("input_ports")
+    if type(block).variadic_inputs and configured_ports and isinstance(configured_ports, list):
+        return ports_from_config_dicts(configured_ports, "input")  # type: ignore[return-value]
+    return list(type(block).input_ports)
+
+
+def _prepare_configured_input_exchange(
+    block: AppBlock,
+    inputs: Mapping[str, Collection | Image | Artifact],
+    exchange_dir: Path,
+    *,
+    tool_name: str,
+    config: BlockConfig,
+) -> list[Path]:
+    """Stage every effective input port for Fiji/Napari exchange."""
+    input_dir = exchange_dir / "inputs"
+    input_dir.mkdir(exist_ok=True)
+    staged_image_paths: list[Path] = []
+    manifest_inputs: dict[str, Any] = {}
+
+    for port in _effective_input_ports(block, config):
+        if port.name not in inputs:
+            if port.required and port.default is None:
+                raise ValueError(f"{type(block).__name__}: missing required input port {port.name!r}")
+            continue
+        value = inputs[port.name]
+        items = list(value) if isinstance(value, Collection) else [value]
+        item_entries: list[dict[str, Any]] = []
+        for index, item in enumerate(items):
+            if isinstance(item, Image):
+                image_path = _stage_image_input(
+                    item,
+                    input_dir,
+                    port_name=port.name,
+                    index=index,
+                    legacy_flat_layout=port.name == "image",
+                )
+                staged_image_paths.append(image_path)
+                item_entries.append(
+                    {
+                        "type": "Image",
+                        "path": str(image_path),
+                        "extension": image_path.suffix,
+                        "format": "tiff",
+                    }
+                )
+                continue
+            if isinstance(item, Artifact):
+                artifact_path = _stage_artifact_input(item, input_dir / port.name, index=index)
+                item_entries.append(
+                    {
+                        "type": "Artifact",
+                        "path": str(artifact_path),
+                        "extension": artifact_path.suffix,
+                        "format": "file",
+                    }
+                )
+                continue
+            raise NotImplementedError(
+                f"{type(block).__name__}: input port {port.name!r} item {index} has unsupported type "
+                f"{type(item).__name__}; interactive imaging exchange supports Image and Artifact inputs"
+            )
+
+        manifest_inputs[port.name] = {
+            "type": "collection"
+            if isinstance(value, Collection)
+            else (item_entries[0]["type"] if item_entries else "empty"),
+            "item_type": _collection_item_type_name(value) if isinstance(value, Collection) else None,
+            "items": item_entries,
+        }
+
+    manifest = {
+        "tool": tool_name,
+        "input_files": [str(path) for path in staged_image_paths],
+        "inputs": manifest_inputs,
+        "output_dir": str(exchange_dir / "outputs"),
+        "config": dict(config.params),
+    }
+    (exchange_dir / "manifest.json").write_text(json.dumps(manifest, indent=2, default=str), encoding="utf-8")
+    return staged_image_paths
+
+
+def _stage_image_input(
+    image: Image,
+    input_dir: Path,
+    *,
+    port_name: str,
+    index: int,
+    legacy_flat_layout: bool,
+) -> Path:
+    import numpy as np
+    import tifffile
+
+    if legacy_flat_layout:
+        path = input_dir / f"image_{index:04d}.tif"
+    else:
+        port_dir = input_dir / port_name
+        port_dir.mkdir(exist_ok=True)
+        path = port_dir / f"{port_name}_{index:04d}.tif"
+    if image.storage_ref is None and getattr(image, "_data", None) is not None:
+        data = np.asarray(image._data)  # type: ignore[attr-defined]
+    else:
+        data = np.asarray(image.to_memory())
+    tifffile.imwrite(str(path), data, metadata={"axes": "".join(image.axes).upper()})
+    return path
+
+
+def _stage_artifact_input(artifact: Artifact, port_dir: Path, *, index: int) -> Path:
+    source = artifact.file_path
+    if source is None:
+        raise ValueError("Artifact input cannot be staged because file_path is None")
+    source = Path(source)
+    if not source.is_file():
+        raise ValueError(f"Artifact input cannot be staged because file_path does not exist: {source}")
+    port_dir.mkdir(parents=True, exist_ok=True)
+    target = port_dir / source.name
+    if target.exists():
+        target = port_dir / f"{source.stem}_{index:04d}{source.suffix}"
+    shutil.copy2(source, target)
+    return target
+
+
+def _collection_item_type_name(value: Collection) -> str:
+    item_type = getattr(value, "item_type", None)
+    if item_type is not None:
+        return item_type.__name__
+    names = {type(item).__name__ for item in value}
+    if len(names) == 1:
+        return next(iter(names))
+    return "mixed" if names else "unknown"
 
 
 def _resolve_command(

--- a/packages/scistudio-blocks-imaging/src/scistudio_blocks_imaging/interactive/fiji_block.py
+++ b/packages/scistudio-blocks-imaging/src/scistudio_blocks_imaging/interactive/fiji_block.py
@@ -10,8 +10,7 @@ from scistudio.blocks.base.ports import InputPort, OutputPort
 from scistudio.blocks.base.state import ExecutionMode
 from scistudio.core.types.collection import Collection
 from scistudio_blocks_imaging.interactive import (
-    _input_images,
-    _prepare_image_exchange,
+    _prepare_configured_input_exchange,
     _resolve_command,
     _resolve_exchange_dir,
     _run_external_app,
@@ -62,9 +61,14 @@ class FijiBlock(AppBlock):
     }
 
     def run(self, inputs: dict[str, Collection], config: BlockConfig) -> dict[str, Collection]:
-        images = _input_images(inputs, "image", "FijiBlock")
         exchange_dir = _resolve_exchange_dir(config, prefix="scistudio_fiji_")
-        staged_paths = _prepare_image_exchange(images, exchange_dir, tool_name=self.type_name, config=config)
+        staged_paths = _prepare_configured_input_exchange(
+            self,
+            inputs,
+            exchange_dir,
+            tool_name=self.type_name,
+            config=config,
+        )
 
         extra_args: list[str] = []
         macro_path = config.get("macro_path")

--- a/packages/scistudio-blocks-imaging/src/scistudio_blocks_imaging/interactive/napari_block.py
+++ b/packages/scistudio-blocks-imaging/src/scistudio_blocks_imaging/interactive/napari_block.py
@@ -10,8 +10,7 @@ from scistudio.blocks.base.ports import InputPort, OutputPort
 from scistudio.blocks.base.state import ExecutionMode
 from scistudio.core.types.collection import Collection
 from scistudio_blocks_imaging.interactive import (
-    _input_images,
-    _prepare_image_exchange,
+    _prepare_configured_input_exchange,
     _resolve_command,
     _resolve_exchange_dir,
     _run_external_app,
@@ -50,9 +49,14 @@ class NapariBlock(AppBlock):
     }
 
     def run(self, inputs: dict[str, Collection], config: BlockConfig) -> dict[str, Collection]:
-        images = _input_images(inputs, "image", "NapariBlock")
         exchange_dir = _resolve_exchange_dir(config, prefix="scistudio_napari_")
-        staged_paths = _prepare_image_exchange(images, exchange_dir, tool_name=self.type_name, config=config)
+        staged_paths = _prepare_configured_input_exchange(
+            self,
+            inputs,
+            exchange_dir,
+            tool_name=self.type_name,
+            config=config,
+        )
         command = _resolve_command(config, app_command=self.app_command, override_key="napari_path")
         # Issue #680: broaden watcher patterns with each declared extension.
         patterns = list(self.output_patterns)

--- a/packages/scistudio-blocks-imaging/tests/test_interactive_blocks.py
+++ b/packages/scistudio-blocks-imaging/tests/test_interactive_blocks.py
@@ -10,10 +10,13 @@ no ports are declared).
 
 from __future__ import annotations
 
+import json
 import sys
 from pathlib import Path
+from types import MethodType
 
 import numpy as np
+import pytest
 from scistudio_blocks_imaging.interactive.fiji_block import FijiBlock
 from scistudio_blocks_imaging.interactive.napari_block import NapariBlock
 from scistudio_blocks_imaging.types import Image
@@ -31,6 +34,12 @@ def _make_image(arr: np.ndarray, axes: list[str] | None = None) -> Image:
 
 
 def _make_running(block: object) -> object:
+    if not hasattr(block, "transition"):
+
+        def _transition(self: object, state: BlockState) -> None:
+            self.state = state  # type: ignore[attr-defined]
+
+        block.transition = MethodType(_transition, block)  # type: ignore[attr-defined]
     block.transition(BlockState.READY)  # type: ignore[attr-defined]
     block.transition(BlockState.RUNNING)  # type: ignore[attr-defined]
     return block
@@ -262,3 +271,125 @@ shutil.copyfile(tiff_path, out / "result.tif")
     assert result["images"][0].file_path is not None
     assert result["images"][0].file_path.suffix.lower() == ".tif"
     assert result["tables"][0].file_path.suffix.lower() == ".csv"
+
+
+def test_fiji_block_stages_configured_artifact_input_port(tmp_path: Path) -> None:
+    script = _write_fake_tool(
+        tmp_path,
+        """
+from pathlib import Path
+import shutil
+import sys
+
+tiff_path = Path(sys.argv[-1])
+exchange = tiff_path.parent.parent
+roi = exchange / "inputs" / "roi_zip" / "cells.roi.zip"
+assert roi.is_file(), f"ROI input was not staged: {roi}"
+out = exchange / "outputs"
+out.mkdir(exist_ok=True)
+shutil.copyfile(tiff_path, out / "image_with_roi.tif")
+""".strip(),
+    )
+    roi_source = tmp_path / "cells.roi.zip"
+    roi_source.write_bytes(b"roi")
+    exchange_dir = tmp_path / "exchange"
+    block = _make_running(FijiBlock())
+    image = _make_image(np.arange(16, dtype=np.uint8).reshape(4, 4))
+
+    result = block.run(
+        {
+            "image": Collection(items=[image], item_type=Image),
+            "roi_zip": Collection(items=[Artifact(file_path=roi_source)], item_type=Artifact),
+        },
+        BlockConfig(
+            params={
+                "app_command": [sys.executable, str(script)],
+                "exchange_dir": str(exchange_dir),
+                "watch_timeout": 5,
+                "input_ports": [
+                    {"name": "image", "types": ["Image"]},
+                    {"name": "roi_zip", "types": ["Artifact"]},
+                ],
+            }
+        ),
+    )
+
+    staged_roi = exchange_dir / "inputs" / "roi_zip" / "cells.roi.zip"
+    manifest = json.loads((exchange_dir / "manifest.json").read_text(encoding="utf-8"))
+    assert staged_roi.read_bytes() == b"roi"
+    assert "image" in result
+    assert manifest["inputs"]["image"]["items"][0]["path"] == str(exchange_dir / "inputs" / "image_0000.tif")
+    assert manifest["inputs"]["roi_zip"]["items"][0]["path"] == str(staged_roi)
+    assert manifest["input_files"] == [str(exchange_dir / "inputs" / "image_0000.tif")]
+
+
+def test_napari_block_stages_configured_artifact_input_port(tmp_path: Path) -> None:
+    script = _write_fake_tool(
+        tmp_path,
+        """
+from pathlib import Path
+import shutil
+import sys
+
+tiff_path = Path(sys.argv[-1])
+exchange = tiff_path.parent.parent
+roi = exchange / "inputs" / "roi_zip" / "cells.roi.zip"
+assert roi.is_file(), f"ROI input was not staged: {roi}"
+out = exchange / "outputs"
+out.mkdir(exist_ok=True)
+shutil.copyfile(tiff_path, out / "napari_layer.tif")
+""".strip(),
+    )
+    roi_source = tmp_path / "cells.roi.zip"
+    roi_source.write_bytes(b"roi")
+    exchange_dir = tmp_path / "exchange"
+    block = _make_running(NapariBlock())
+    image = _make_image(np.arange(25, dtype=np.uint8).reshape(5, 5))
+
+    result = block.run(
+        {
+            "image": Collection(items=[image], item_type=Image),
+            "roi_zip": Collection(items=[Artifact(file_path=roi_source)], item_type=Artifact),
+        },
+        BlockConfig(
+            params={
+                "app_command": [sys.executable, str(script)],
+                "exchange_dir": str(exchange_dir),
+                "watch_timeout": 5,
+                "input_ports": [
+                    {"name": "image", "types": ["Image"]},
+                    {"name": "roi_zip", "types": ["Artifact"]},
+                ],
+            }
+        ),
+    )
+
+    staged_roi = exchange_dir / "inputs" / "roi_zip" / "cells.roi.zip"
+    manifest = json.loads((exchange_dir / "manifest.json").read_text(encoding="utf-8"))
+    assert staged_roi.read_bytes() == b"roi"
+    assert "image" in result
+    assert manifest["inputs"]["image"]["items"][0]["path"] == str(exchange_dir / "inputs" / "image_0000.tif")
+    assert manifest["inputs"]["roi_zip"]["items"][0]["path"] == str(staged_roi)
+    assert manifest["input_files"] == [str(exchange_dir / "inputs" / "image_0000.tif")]
+
+
+def test_fiji_block_rejects_unsupported_configured_input_type(tmp_path: Path) -> None:
+    block = _make_running(FijiBlock())
+    image = _make_image(np.arange(16, dtype=np.uint8).reshape(4, 4))
+
+    with pytest.raises(NotImplementedError, match="unsupported type int"):
+        block.run(
+            {
+                "image": Collection(items=[image], item_type=Image),
+                "threshold": 3,
+            },
+            BlockConfig(
+                params={
+                    "exchange_dir": str(tmp_path / "exchange"),
+                    "input_ports": [
+                        {"name": "image", "types": ["Image"]},
+                        {"name": "threshold", "types": ["DataObject"]},
+                    ],
+                }
+            ),
+        )


### PR DESCRIPTION
Summary:
- Stage Fiji/Napari inputs by effective configured input port instead of only the hard-coded image port.
- Preserve default image TIFF staging and launch args while copying Artifact inputs under inputs/<port_name>/ with source filenames.
- Add Fiji/Napari roi_zip regression coverage plus an unsupported-input negative test.

Tests:
- PYTHONPATH=src;packages/scistudio-blocks-imaging/src python -m ruff check packages/scistudio-blocks-imaging/src/scistudio_blocks_imaging/interactive packages/scistudio-blocks-imaging/tests/test_interactive_blocks.py
- PYTHONPATH=src;packages/scistudio-blocks-imaging/src python -m ruff format --check packages/scistudio-blocks-imaging/src/scistudio_blocks_imaging/interactive packages/scistudio-blocks-imaging/tests/test_interactive_blocks.py
- PYTHONPATH=src;packages/scistudio-blocks-imaging/src python -m pytest packages/scistudio-blocks-imaging/tests/test_interactive_blocks.py --no-cov -q
- PYTHONPATH=src;packages/scistudio-blocks-imaging/src python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .workflow/records/709-imaging-variadic-inputs-full-audit.json
- mcp__sentrux__.rescan; mcp__sentrux__.check_rules

Gate record: .workflow/records/709-imaging-variadic-inputs.json

Closes #709