### PR TITLE
test(#1449): add scheduler state-machine contract table

### DIFF
--- a/.workflow/records/1376-scheduler-state-machine-contract.json
+++ b/.workflow/records/1376-scheduler-state-machine-contract.json
@@ -92,8 +92,8 @@
     {
       "close_in_pr": true,
       "followup_rationale": null,
-      "number": 1376,
-      "url": null
+      "number": 1449,
+      "url": "https://github.com/zjzcpj/SciStudio/issues/1449"
     }
   ],
   "owner_directive": "Add complete scheduler state-machine table coverage before god-file refactors; tests only, do not modify product code.",
@@ -102,7 +102,9 @@
     ".workflow/records/1376-scheduler-state-machine-contract.json"
   ],
   "pull_request": {
-    "body_closes_issues": [],
+    "body_closes_issues": [
+      1449
+    ],
     "number": 1448,
     "url": "https://github.com/zjzcpj/SciStudio/pull/1448"
   },

--- a/.workflow/records/1376-scheduler-state-machine-contract.json
+++ b/.workflow/records/1376-scheduler-state-machine-contract.json
@@ -73,8 +73,14 @@
       "not_applicable": true,
       "rationale": "test-only-contract-coverage-no-user-visible-product-change"
     },
-    "checklist": {},
-    "docs": {}
+    "checklist": {
+      "not_applicable": true,
+      "rationale": "single-PR-test-only-change-no-manager-dispatch-checklist"
+    },
+    "docs": {
+      "not_applicable": true,
+      "rationale": "test-only-contract-coverage-no-public-contract-text-change"
+    }
   },
   "full_audit": {
     "blocks_merge": false,

--- a/.workflow/records/1376-scheduler-state-machine-contract.json
+++ b/.workflow/records/1376-scheduler-state-machine-contract.json
@@ -1,0 +1,181 @@
+{
+  "admin_labels": [],
+  "amendments": [
+    {
+      "approved_by": null,
+      "exclude": [],
+      "include": [
+        "docs/audit/2026-05-22-1376-scheduler-state-machine-contract-full-audit.json"
+      ],
+      "reason": "Commit full_audit JSON evidence generated for this test-only PR."
+    }
+  ],
+  "branch": "test/issue-1376-scheduler-state-machine-contract",
+  "changed_test_paths": [
+    "tests/engine/test_scheduler_state_machine_contract.py"
+  ],
+  "check_results": [
+    {
+      "command_or_tool": "PYTHONPATH=src pytest tests/engine/test_scheduler.py tests/engine/test_scheduler_concurrency.py tests/engine/test_scheduler_rerun_cancel.py tests/engine/test_scheduler_terminal_data.py tests/engine/test_scheduler_interactive.py -q --no-cov",
+      "exit_code": 0,
+      "name": "pytest-neighbor-scheduler",
+      "output_path": "68 passed",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "ruff check tests/engine/test_scheduler_state_machine_contract.py",
+      "exit_code": 0,
+      "name": "ruff",
+      "output_path": "All checks passed",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "PYTHONPATH=src pytest tests/engine/test_scheduler_state_machine_contract.py -q --no-cov",
+      "exit_code": 0,
+      "name": "pytest-new-contract",
+      "output_path": "24 passed, 6 strict xfail (#1376 known cancel_block drift)",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "ruff format --check tests/engine/test_scheduler_state_machine_contract.py",
+      "exit_code": 0,
+      "name": "format",
+      "output_path": "1 file already formatted",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "git diff --check",
+      "exit_code": 0,
+      "name": "git-diff-check",
+      "output_path": "pass",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    }
+  ],
+  "commit": {
+    "gate_record_path": ".workflow/records/1376-scheduler-state-machine-contract.json",
+    "shas": [
+      "0b3f5a81f11e220b62d1aa711afd7fe5f35348aa"
+    ],
+    "trailers": {}
+  },
+  "docs_landing": {
+    "changelog": {},
+    "checklist": {},
+    "docs": {},
+    "public-docs": {
+      "not_applicable": true,
+      "rationale": "test-only-scheduler-contract-coverage-no-user-facing-behavior-change"
+    }
+  },
+  "full_audit": {
+    "blocks_merge": false,
+    "command": "PYTHONPATH=src python -m scistudio.qa.audit.full_audit --repo-root . --format json --output docs/audit/2026-05-22-1376-scheduler-state-machine-contract-full-audit.json",
+    "exit_code": 0,
+    "known_debt": [],
+    "output_path": "docs/audit/2026-05-22-1376-scheduler-state-machine-contract-full-audit.json",
+    "status": "pass",
+    "summary": {},
+    "unclassified_failures": []
+  },
+  "governance_touch": false,
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1376,
+      "url": null
+    }
+  ],
+  "owner_directive": "Add complete scheduler state-machine table coverage before god-file refactors; tests only, do not modify product code.",
+  "planned_files": [
+    "tests/engine/test_scheduler_state_machine_contract.py",
+    ".workflow/records/1376-scheduler-state-machine-contract.json"
+  ],
+  "pull_request": {
+    "body_closes_issues": [],
+    "number": 1448,
+    "url": "https://github.com/zjzcpj/SciStudio/pull/1448"
+  },
+  "record_path": ".workflow/records/1376-scheduler-state-machine-contract.json",
+  "required_checks": [
+    "ruff",
+    "format",
+    "pytest",
+    "full_audit",
+    "sentrux"
+  ],
+  "schema_version": "1",
+  "scope": {
+    "exclude": [
+      "src/**",
+      "frontend/**"
+    ],
+    "include": [
+      "tests/engine/test_scheduler_state_machine_contract.py",
+      ".workflow/records/1376-scheduler-state-machine-contract.json"
+    ]
+  },
+  "sentrux": {
+    "command_or_tool": "Get-Command sentrux",
+    "mode": "free-tier",
+    "name": "sentrux.free_tier",
+    "output_path": "Sentrux CLI unavailable in local environment; test-only PR touches tests plus committed gate/audit evidence. Workflow gate treats missing/skipped Sentrux as advisory after ADR-042 Addendum 3.",
+    "pro_required": false,
+    "quality_signal": null,
+    "rules_checked": null,
+    "status": "skipped",
+    "summary": {},
+    "thresholds": {},
+    "total_rules_defined": null
+  },
+  "stages": [
+    {
+      "completed_at": null,
+      "stage": "scope_and_issue",
+      "status": "done",
+      "summary": null
+    },
+    {
+      "completed_at": null,
+      "stage": "plan",
+      "status": "done",
+      "summary": null
+    },
+    {
+      "completed_at": null,
+      "stage": "implement",
+      "status": "done",
+      "summary": null
+    },
+    {
+      "completed_at": null,
+      "stage": "update_docs",
+      "status": "done",
+      "summary": null
+    },
+    {
+      "completed_at": null,
+      "stage": "test_and_checks",
+      "status": "done",
+      "summary": null
+    },
+    {
+      "completed_at": null,
+      "stage": "commit_and_submit_pr",
+      "status": "done",
+      "summary": null
+    }
+  ],
+  "task_id": "1376-scheduler-state-machine-contract",
+  "task_kind": "bugfix"
+}

--- a/.workflow/records/1376-scheduler-state-machine-contract.json
+++ b/.workflow/records/1376-scheduler-state-machine-contract.json
@@ -64,7 +64,7 @@
   "commit": {
     "gate_record_path": ".workflow/records/1376-scheduler-state-machine-contract.json",
     "shas": [
-      "f83bad4bd9661846d3b1a20fb1501d233259ab97"
+      "9957f720f5456f82627706029c45deb66146484b"
     ],
     "trailers": {}
   },

--- a/.workflow/records/1376-scheduler-state-machine-contract.json
+++ b/.workflow/records/1376-scheduler-state-machine-contract.json
@@ -69,13 +69,12 @@
     "trailers": {}
   },
   "docs_landing": {
-    "changelog": {},
-    "checklist": {},
-    "docs": {},
-    "public-docs": {
+    "changelog": {
       "not_applicable": true,
-      "rationale": "test-only-scheduler-contract-coverage-no-user-facing-behavior-change"
-    }
+      "rationale": "test-only-contract-coverage-no-user-visible-product-change"
+    },
+    "checklist": {},
+    "docs": {}
   },
   "full_audit": {
     "blocks_merge": false,

--- a/.workflow/records/1376-scheduler-state-machine-contract.json
+++ b/.workflow/records/1376-scheduler-state-machine-contract.json
@@ -64,7 +64,7 @@
   "commit": {
     "gate_record_path": ".workflow/records/1376-scheduler-state-machine-contract.json",
     "shas": [
-      "0b3f5a81f11e220b62d1aa711afd7fe5f35348aa"
+      "f83bad4bd9661846d3b1a20fb1501d233259ab97"
     ],
     "trailers": {}
   },

--- a/docs/audit/2026-05-22-1376-scheduler-state-machine-contract-full-audit.json
+++ b/docs/audit/2026-05-22-1376-scheduler-state-machine-contract-full-audit.json
@@ -1,0 +1,347 @@
+{
+  "tool": "full_audit",
+  "status": "pass",
+  "generated_at": "1970-01-01T00:00:00Z",
+  "source_sha": "574890e582a138b087184eae087b58985832308c3e1dc98c12cf9f07f2769c20",
+  "findings": [],
+  "summary": {
+    "implemented_children": [
+      "generate_facts",
+      "frontmatter_lint",
+      "fact_drift",
+      "doc_drift",
+      "closure",
+      "signature_drift",
+      "architecture_drift",
+      "vulture"
+    ],
+    "deferred_children": [
+      "semantic_dup"
+    ]
+  },
+  "child_reports": [
+    {
+      "tool": "generate_facts",
+      "status": "pass",
+      "generated_at": "1970-01-01T00:00:00Z",
+      "source_sha": "574890e582a138b087184eae087b58985832308c3e1dc98c12cf9f07f2769c20",
+      "findings": [],
+      "summary": {
+        "facts_path": "docs/facts/generated.yaml",
+        "generated_in_memory": true,
+        "total_facts": 2464,
+        "facts_by_kind": {
+          "expected-signature": 157,
+          "symbol": 2307
+        },
+        "facts_by_source": {
+          "docs/adr/ADR-001.md": 9,
+          "docs/adr/ADR-002.md": 4,
+          "docs/adr/ADR-003.md": 2,
+          "docs/adr/ADR-004.md": 7,
+          "docs/adr/ADR-005.md": 4,
+          "docs/adr/ADR-006.md": 2,
+          "docs/adr/ADR-007.md": 2,
+          "docs/adr/ADR-008.md": 2,
+          "docs/adr/ADR-009.md": 4,
+          "docs/adr/ADR-011.md": 5,
+          "docs/adr/ADR-012.md": 2,
+          "docs/adr/ADR-013.md": 1,
+          "docs/adr/ADR-014.md": 2,
+          "docs/adr/ADR-015.md": 3,
+          "docs/adr/ADR-017.md": 10,
+          "docs/adr/ADR-018.md": 18,
+          "docs/adr/ADR-019.md": 43,
+          "docs/adr/ADR-020.md": 16,
+          "docs/adr/ADR-021.md": 8,
+          "docs/specs/adr-042-consistency-tools.md": 13,
+          "griffe": 2307
+        },
+        "facts_by_confidence": {
+          "generated": 2307,
+          "normative": 157
+        },
+        "facts_by_stability": {
+          "stable": 157,
+          "unknown": 2307
+        },
+        "symbol_facts": 2307,
+        "symbols_by_kind": {
+          "attribute": 1212,
+          "class": 255,
+          "function": 636,
+          "module": 204
+        },
+        "top_symbol_packages": {
+          "scistudio.blocks": 752,
+          "scistudio.qa": 485,
+          "scistudio.api": 407,
+          "scistudio.core": 336,
+          "scistudio.engine": 197,
+          "scistudio.workflow": 58,
+          "scistudio.cli": 27,
+          "scistudio.utils": 26,
+          "scistudio.agent_provisioning": 9,
+          "scistudio.testing": 9,
+          "scistudio.ai": 1
+        }
+      },
+      "child_reports": []
+    },
+    {
+      "tool": "frontmatter_lint",
+      "status": "pass",
+      "generated_at": "2026-05-22T19:24:43.640623Z",
+      "source_sha": "",
+      "findings": [],
+      "summary": {
+        "repo_root": "C:/Users/jiazh/Desktop/workspace/SciStudio-test-1376-scheduler-contract",
+        "findings": 0
+      },
+      "child_reports": []
+    },
+    {
+      "tool": "fact_drift",
+      "status": "pass",
+      "generated_at": "2026-05-22T19:24:45.473130Z",
+      "source_sha": "574890e582a138b087184eae087b58985832308c3e1dc98c12cf9f07f2769c20",
+      "findings": [],
+      "summary": {
+        "docs_checked": 191,
+        "substitutions_checked": 0
+      },
+      "child_reports": []
+    },
+    {
+      "tool": "doc_drift",
+      "status": "pass",
+      "generated_at": "2026-05-22T19:24:45.728184Z",
+      "source_sha": "574890e582a138b087184eae087b58985832308c3e1dc98c12cf9f07f2769c20",
+      "findings": [],
+      "summary": {
+        "governed_docs_checked": 65,
+        "modules_checked": 157,
+        "contracts_checked": 315,
+        "files_checked": 410,
+        "adr_spec_alignment_findings": 0,
+        "active_specs_checked": 1,
+        "adr_spec_links_checked": 1
+      },
+      "child_reports": []
+    },
+    {
+      "tool": "closure",
+      "status": "pass",
+      "generated_at": "2026-05-22T19:24:45.986515Z",
+      "source_sha": "574890e582a138b087184eae087b58985832308c3e1dc98c12cf9f07f2769c20",
+      "findings": [],
+      "summary": {
+        "governed_docs_checked": 65,
+        "governed_modules": 85,
+        "governed_contracts": 202,
+        "symbols_checked": 2307,
+        "maintainer_rules": 1,
+        "maintainer_covered_symbols": 21
+      },
+      "child_reports": []
+    },
+    {
+      "tool": "signature_drift",
+      "status": "pass",
+      "generated_at": "2026-05-22T19:24:45.988631Z",
+      "source_sha": "574890e582a138b087184eae087b58985832308c3e1dc98c12cf9f07f2769c20",
+      "findings": [],
+      "summary": {
+        "expected_signatures_checked": 157,
+        "expected_model_fields_checked": 0,
+        "expected_cli_commands_checked": 0,
+        "symbols_available": 2307,
+        "cli_facts_available": 0
+      },
+      "child_reports": []
+    },
+    {
+      "tool": "architecture_drift",
+      "status": "pass",
+      "generated_at": "2026-05-22T19:24:45.996862Z",
+      "source_sha": "574890e582a138b087184eae087b58985832308c3e1dc98c12cf9f07f2769c20",
+      "findings": [],
+      "summary": {
+        "architecture_path": "C:/Users/jiazh/Desktop/workspace/SciStudio-test-1376-scheduler-contract/docs/architecture/ARCHITECTURE.md",
+        "symbols_available": 2307,
+        "fences_checked": 6,
+        "fences_skipped": 1,
+        "references_checked": 0
+      },
+      "child_reports": []
+    },
+    {
+      "tool": "vulture",
+      "status": "pass",
+      "generated_at": "2026-05-22T19:24:46.658910Z",
+      "source_sha": "",
+      "findings": [
+        {
+          "rule_id": "vulture.dead-code",
+          "severity": "warning",
+          "file": "src/scistudio/blocks/io/loaders/load_data.py",
+          "message": "unused variable 'od' (100% confidence)",
+          "id": "vulture.dead-code",
+          "tool": null,
+          "finding_class": "vulture",
+          "path": "src/scistudio/blocks/io/loaders/load_data.py",
+          "line": 631,
+          "symbol": null,
+          "subject": null,
+          "expected": null,
+          "actual": null,
+          "drift_class": null,
+          "remediation": null,
+          "evidence": {
+            "confidence": 100
+          },
+          "suggested_fix": null,
+          "git_evidence": null,
+          "related_findings": []
+        },
+        {
+          "rule_id": "vulture.dead-code",
+          "severity": "warning",
+          "file": "src/scistudio/blocks/io/loaders/load_data.py",
+          "message": "unused variable 'od' (100% confidence)",
+          "id": "vulture.dead-code",
+          "tool": null,
+          "finding_class": "vulture",
+          "path": "src/scistudio/blocks/io/loaders/load_data.py",
+          "line": 632,
+          "symbol": null,
+          "subject": null,
+          "expected": null,
+          "actual": null,
+          "drift_class": null,
+          "remediation": null,
+          "evidence": {
+            "confidence": 100
+          },
+          "suggested_fix": null,
+          "git_evidence": null,
+          "related_findings": []
+        },
+        {
+          "rule_id": "vulture.dead-code",
+          "severity": "warning",
+          "file": "src/scistudio/core/metadata_store.py",
+          "message": "unused variable 'existing_paths' (100% confidence)",
+          "id": "vulture.dead-code",
+          "tool": null,
+          "finding_class": "vulture",
+          "path": "src/scistudio/core/metadata_store.py",
+          "line": 405,
+          "symbol": null,
+          "subject": null,
+          "expected": null,
+          "actual": null,
+          "drift_class": null,
+          "remediation": null,
+          "evidence": {
+            "confidence": 100
+          },
+          "suggested_fix": null,
+          "git_evidence": null,
+          "related_findings": []
+        },
+        {
+          "rule_id": "vulture.dead-code",
+          "severity": "warning",
+          "file": "src/scistudio/core/units.py",
+          "message": "unused variable 'source_type' (100% confidence)",
+          "id": "vulture.dead-code",
+          "tool": null,
+          "finding_class": "vulture",
+          "path": "src/scistudio/core/units.py",
+          "line": 187,
+          "symbol": null,
+          "subject": null,
+          "expected": null,
+          "actual": null,
+          "drift_class": null,
+          "remediation": null,
+          "evidence": {
+            "confidence": 100
+          },
+          "suggested_fix": null,
+          "git_evidence": null,
+          "related_findings": []
+        },
+        {
+          "rule_id": "vulture.dead-code",
+          "severity": "warning",
+          "file": "src/scistudio/engine/checkpoint.py",
+          "message": "unused variable 'fallback_type_name' (100% confidence)",
+          "id": "vulture.dead-code",
+          "tool": null,
+          "finding_class": "vulture",
+          "path": "src/scistudio/engine/checkpoint.py",
+          "line": 185,
+          "symbol": null,
+          "subject": null,
+          "expected": null,
+          "actual": null,
+          "drift_class": null,
+          "remediation": null,
+          "evidence": {
+            "confidence": 100
+          },
+          "suggested_fix": null,
+          "git_evidence": null,
+          "related_findings": []
+        },
+        {
+          "rule_id": "vulture.dead-code",
+          "severity": "warning",
+          "file": "src/scistudio/utils/logging.py",
+          "message": "unused variable 'json_output' (100% confidence)",
+          "id": "vulture.dead-code",
+          "tool": null,
+          "finding_class": "vulture",
+          "path": "src/scistudio/utils/logging.py",
+          "line": 6,
+          "symbol": null,
+          "subject": null,
+          "expected": null,
+          "actual": null,
+          "drift_class": null,
+          "remediation": null,
+          "evidence": {
+            "confidence": 100
+          },
+          "suggested_fix": null,
+          "git_evidence": null,
+          "related_findings": []
+        }
+      ],
+      "summary": {
+        "pyproject_config_honored": {
+          "ignore_decorators": [
+            "@app.*",
+            "@router.*",
+            "@pytest.fixture"
+          ],
+          "ignore_names": [],
+          "exclude": [
+            "src/scistudio/api/static/**"
+          ]
+        },
+        "paths": [
+          "src/scistudio"
+        ],
+        "min_confidence": 80,
+        "targets_resolved": 1,
+        "allowlist": "vulture_allowlist.py",
+        "total_findings": 6,
+        "vulture_available": true
+      },
+      "child_reports": []
+    }
+  ]
+}

--- a/tests/engine/test_scheduler_state_machine_contract.py
+++ b/tests/engine/test_scheduler_state_machine_contract.py
@@ -1,0 +1,371 @@
+"""Executable scheduler state-machine contract.
+
+The architecture state table is small enough to keep as a table-driven test:
+
+* ``cancel_block`` may only produce ``CANCELLED`` from ``RUNNING``/``PAUSED``.
+* ``cancel_workflow`` cancels active blocks and skips not-yet-started blocks.
+* ``PROCESS_EXITED`` only turns ``RUNNING`` into ``ERROR``.
+* Scheduler-owned readiness transitions must emit ``BLOCK_READY`` exactly once.
+
+Rows marked ``xfail`` are known drift from issue #1376. They stay visible here
+so the suite describes the full desired contract without requiring product-code
+changes in this test-only PR.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from scistudio.blocks.base.state import BlockState
+from scistudio.engine.events import (
+    BLOCK_CANCELLED,
+    BLOCK_DONE,
+    BLOCK_ERROR,
+    BLOCK_READY,
+    BLOCK_RUNNING,
+    BLOCK_SKIPPED,
+    CANCEL_BLOCK_REQUEST,
+    CANCEL_WORKFLOW_REQUEST,
+    PROCESS_EXITED,
+    EngineEvent,
+    EventBus,
+)
+from scistudio.engine.scheduler import DAGScheduler
+from scistudio.workflow.definition import EdgeDef, NodeDef, WorkflowDefinition
+
+TERMINAL_STATES = {
+    BlockState.DONE,
+    BlockState.ERROR,
+    BlockState.CANCELLED,
+    BlockState.SKIPPED,
+}
+
+
+@dataclass(frozen=True)
+class EventCapture:
+    """Lifecycle events emitted during one scheduler operation."""
+
+    event_type: str
+    block_id: str | None
+
+
+def _workflow() -> WorkflowDefinition:
+    """Three-node chain: A -> B -> C."""
+    return WorkflowDefinition(
+        id="state-machine-contract",
+        nodes=[
+            NodeDef(id="A", block_type="type.a", config={"role": "root"}),
+            NodeDef(id="B", block_type="type.b", config={"role": "middle"}),
+            NodeDef(id="C", block_type="type.c", config={"role": "leaf"}),
+        ],
+        edges=[
+            EdgeDef(source="A:out", target="B:in"),
+            EdgeDef(source="B:out", target="C:in"),
+        ],
+    )
+
+
+def _make_scheduler() -> tuple[DAGScheduler, EventBus]:
+    """Build a scheduler with mocked dependencies and deterministic runner."""
+    bus = EventBus()
+    resource_manager = MagicMock()
+    resource_manager.can_dispatch.return_value = True
+    process_registry = MagicMock()
+    process_registry.get_handle.return_value = None
+    runner = AsyncMock()
+    runner.run.return_value = {"out": "ok"}
+    scheduler = DAGScheduler(
+        workflow=_workflow(),
+        event_bus=bus,
+        resource_manager=resource_manager,
+        process_registry=process_registry,
+        runner=runner,
+    )
+    return scheduler, bus
+
+
+def _capture_lifecycle(bus: EventBus) -> list[EventCapture]:
+    """Capture scheduler lifecycle events relevant to the state table."""
+    seen: list[EventCapture] = []
+
+    def _append(event: EngineEvent) -> None:
+        seen.append(EventCapture(event_type=event.event_type, block_id=event.block_id))
+
+    for event_type in (
+        BLOCK_READY,
+        BLOCK_RUNNING,
+        BLOCK_DONE,
+        BLOCK_ERROR,
+        BLOCK_CANCELLED,
+        BLOCK_SKIPPED,
+    ):
+        bus.subscribe(event_type, _append)
+    return seen
+
+
+def _event_pairs(seen: list[EventCapture]) -> list[tuple[str, str | None]]:
+    """Return the captured event stream as comparable tuples."""
+    return [(event.event_type, event.block_id) for event in seen]
+
+
+def _block_events(seen: list[EventCapture], block_id: str) -> list[str]:
+    """Return lifecycle event names observed for one block."""
+    return [event.event_type for event in seen if event.block_id == block_id]
+
+
+def _state_map(
+    *,
+    a: BlockState = BlockState.DONE,
+    b: BlockState,
+    c: BlockState = BlockState.IDLE,
+) -> dict[str, BlockState]:
+    """Compact state setup for the A -> B -> C workflow."""
+    return {"A": a, "B": b, "C": c}
+
+
+async def _emit(
+    bus: EventBus, event_type: str, block_id: str | None = None, data: dict[str, Any] | None = None
+) -> None:
+    await bus.emit(EngineEvent(event_type=event_type, block_id=block_id, data=data or {}))
+
+
+@pytest.mark.parametrize(
+    ("initial", "expected_b", "expected_c", "expected_events"),
+    [
+        pytest.param(
+            BlockState.IDLE,
+            BlockState.IDLE,
+            BlockState.IDLE,
+            [],
+            marks=pytest.mark.xfail(reason="#1376: cancel_block currently cancels IDLE blocks", strict=True),
+            id="IDLE-noop",
+        ),
+        pytest.param(
+            BlockState.READY,
+            BlockState.READY,
+            BlockState.IDLE,
+            [],
+            marks=pytest.mark.xfail(reason="#1376: cancel_block currently cancels READY blocks", strict=True),
+            id="READY-noop",
+        ),
+        pytest.param(
+            BlockState.RUNNING,
+            BlockState.CANCELLED,
+            BlockState.SKIPPED,
+            [(BLOCK_CANCELLED, "B"), (BLOCK_SKIPPED, "C")],
+            id="RUNNING-cancelled",
+        ),
+        pytest.param(
+            BlockState.PAUSED,
+            BlockState.CANCELLED,
+            BlockState.SKIPPED,
+            [(BLOCK_CANCELLED, "B"), (BLOCK_SKIPPED, "C")],
+            id="PAUSED-cancelled",
+        ),
+        pytest.param(
+            BlockState.DONE,
+            BlockState.DONE,
+            BlockState.IDLE,
+            [],
+            marks=pytest.mark.xfail(reason="#1376: cancel_block currently cancels DONE blocks", strict=True),
+            id="DONE-noop",
+        ),
+        pytest.param(
+            BlockState.ERROR,
+            BlockState.ERROR,
+            BlockState.IDLE,
+            [],
+            marks=pytest.mark.xfail(reason="#1376: cancel_block currently cancels ERROR blocks", strict=True),
+            id="ERROR-noop",
+        ),
+        pytest.param(
+            BlockState.CANCELLED,
+            BlockState.CANCELLED,
+            BlockState.IDLE,
+            [],
+            marks=pytest.mark.xfail(reason="#1376: cancel_block currently re-emits CANCELLED", strict=True),
+            id="CANCELLED-noop",
+        ),
+        pytest.param(
+            BlockState.SKIPPED,
+            BlockState.SKIPPED,
+            BlockState.IDLE,
+            [],
+            marks=pytest.mark.xfail(reason="#1376: cancel_block currently cancels SKIPPED blocks", strict=True),
+            id="SKIPPED-noop",
+        ),
+    ],
+)
+def test_cancel_block_state_table(
+    initial: BlockState,
+    expected_b: BlockState,
+    expected_c: BlockState,
+    expected_events: list[tuple[str, str]],
+) -> None:
+    """``cancel_block`` follows the architecture state table for all states."""
+    scheduler, bus = _make_scheduler()
+    seen = _capture_lifecycle(bus)
+    scheduler._block_states.update(_state_map(b=initial))
+    scheduler._block_outputs["A"] = {"out": "done"}
+
+    asyncio.run(_emit(bus, CANCEL_BLOCK_REQUEST, block_id="B"))
+
+    assert scheduler._block_states["B"] == expected_b
+    assert scheduler._block_states["C"] == expected_c
+    assert [(event.event_type, event.block_id) for event in seen] == expected_events
+
+
+@pytest.mark.parametrize(
+    ("initial", "expected_b", "expected_events"),
+    [
+        (BlockState.IDLE, BlockState.SKIPPED, [(BLOCK_SKIPPED, "B")]),
+        (BlockState.READY, BlockState.SKIPPED, [(BLOCK_SKIPPED, "B")]),
+        (BlockState.RUNNING, BlockState.CANCELLED, [(BLOCK_CANCELLED, "B")]),
+        (BlockState.PAUSED, BlockState.CANCELLED, [(BLOCK_CANCELLED, "B")]),
+        (BlockState.DONE, BlockState.DONE, []),
+        (BlockState.ERROR, BlockState.ERROR, []),
+        (BlockState.CANCELLED, BlockState.CANCELLED, []),
+        (BlockState.SKIPPED, BlockState.SKIPPED, []),
+    ],
+    ids=lambda value: value.name if isinstance(value, BlockState) else None,
+)
+def test_cancel_workflow_state_table(
+    initial: BlockState,
+    expected_b: BlockState,
+    expected_events: list[tuple[str, str]],
+) -> None:
+    """``cancel_workflow`` cancels active states and skips not-yet-started states."""
+    scheduler, bus = _make_scheduler()
+    seen = _capture_lifecycle(bus)
+    scheduler._block_states.update(_state_map(b=initial, c=BlockState.DONE))
+    scheduler._block_outputs["A"] = {"out": "done"}
+    if initial == BlockState.DONE:
+        scheduler._block_outputs["B"] = {"out": "done"}
+
+    asyncio.run(_emit(bus, CANCEL_WORKFLOW_REQUEST))
+
+    assert scheduler._block_states["B"] == expected_b
+    assert scheduler._block_states["C"] == BlockState.DONE
+    assert [(event.event_type, event.block_id) for event in seen] == expected_events
+
+
+@pytest.mark.parametrize(
+    ("initial", "expected", "expected_events"),
+    [
+        (BlockState.IDLE, BlockState.IDLE, []),
+        (BlockState.READY, BlockState.READY, []),
+        (BlockState.RUNNING, BlockState.ERROR, [(BLOCK_ERROR, "B")]),
+        (BlockState.PAUSED, BlockState.PAUSED, []),
+        (BlockState.DONE, BlockState.DONE, []),
+        (BlockState.ERROR, BlockState.ERROR, []),
+        (BlockState.CANCELLED, BlockState.CANCELLED, []),
+        (BlockState.SKIPPED, BlockState.SKIPPED, []),
+    ],
+    ids=lambda value: value.name if isinstance(value, BlockState) else None,
+)
+def test_process_exited_state_table(
+    initial: BlockState,
+    expected: BlockState,
+    expected_events: list[tuple[str, str]],
+) -> None:
+    """Unexpected process exit is only meaningful for ``RUNNING`` blocks."""
+    scheduler, bus = _make_scheduler()
+    seen = _capture_lifecycle(bus)
+    scheduler._block_states.update(_state_map(b=initial, c=BlockState.DONE))
+    scheduler._block_outputs["A"] = {"out": "done"}
+
+    asyncio.run(
+        _emit(
+            bus,
+            PROCESS_EXITED,
+            block_id="B",
+            data={"exit_info": {"exit_code": -9, "signal_number": 9}},
+        )
+    )
+
+    assert scheduler._block_states["B"] == expected
+    assert scheduler._block_states["C"] == BlockState.DONE
+    assert [(event.event_type, event.block_id) for event in seen] == expected_events
+
+
+@pytest.mark.parametrize("terminal_state", sorted(TERMINAL_STATES, key=lambda state: state.value))
+def test_reset_block_terminal_to_idle_then_ready_contract(terminal_state: BlockState) -> None:
+    """Resetting a terminal block re-enters the scheduler via ``IDLE -> READY``."""
+    scheduler, bus = _make_scheduler()
+    seen = _capture_lifecycle(bus)
+    scheduler._dispatch = AsyncMock()
+    scheduler._block_states.update(_state_map(b=terminal_state))
+    scheduler._block_outputs["A"] = {"out": "done"}
+    if terminal_state == BlockState.SKIPPED:
+        scheduler.skip_reasons["B"] = "upstream A test"
+    else:
+        scheduler._block_outputs["B"] = {"out": "stale"}
+
+    asyncio.run(scheduler.reset_block("B"))
+
+    assert scheduler._block_states["B"] == BlockState.READY
+    assert scheduler._block_states["C"] == BlockState.IDLE
+    assert "B" not in scheduler._block_outputs
+    assert "B" not in scheduler.skip_reasons
+    assert [(event.event_type, event.block_id) for event in seen] == [(BLOCK_READY, "B")]
+
+
+def test_execute_happy_path_emits_ready_running_done_once_per_block() -> None:
+    """Normal execution emits each block's lifecycle triple exactly once.
+
+    The EventBus invokes scheduler-internal subscribers before the test capture
+    subscriber for ``BLOCK_DONE``. Successor ``BLOCK_READY`` events can therefore
+    be captured before the predecessor ``BLOCK_DONE`` capture. That callback
+    ordering is not part of the public contract; the public contract is the
+    per-block lifecycle sequence and exact event cardinality.
+    """
+    scheduler, bus = _make_scheduler()
+    seen = _capture_lifecycle(bus)
+
+    asyncio.run(scheduler.execute())
+
+    assert scheduler._block_states == {
+        "A": BlockState.DONE,
+        "B": BlockState.DONE,
+        "C": BlockState.DONE,
+    }
+    assert _event_pairs(seen).count((BLOCK_READY, "A")) == 1
+    assert _event_pairs(seen).count((BLOCK_READY, "B")) == 1
+    assert _event_pairs(seen).count((BLOCK_READY, "C")) == 1
+    assert _block_events(seen, "A") == [BLOCK_READY, BLOCK_RUNNING, BLOCK_DONE]
+    assert _block_events(seen, "B") == [BLOCK_READY, BLOCK_RUNNING, BLOCK_DONE]
+    assert _block_events(seen, "C") == [BLOCK_READY, BLOCK_RUNNING, BLOCK_DONE]
+
+
+def test_runner_error_emits_error_and_downstream_skip_once() -> None:
+    """A failed block emits one ``BLOCK_ERROR`` and skips each downstream block once.
+
+    As with the happy path, EventBus callback order can capture the downstream
+    skip before the failed block's error capture. The state-machine contract is
+    exact cardinality and per-block lifecycle order.
+    """
+    scheduler, bus = _make_scheduler()
+    seen = _capture_lifecycle(bus)
+
+    async def _run(block: Any, inputs: dict[str, Any], config: dict[str, Any], **kwargs: Any) -> dict[str, Any]:
+        if block.id == "B":
+            raise RuntimeError("B failed")
+        return {"out": "ok"}
+
+    scheduler._runner.run.side_effect = _run
+
+    asyncio.run(scheduler.execute())
+
+    assert scheduler._block_states == {
+        "A": BlockState.DONE,
+        "B": BlockState.ERROR,
+        "C": BlockState.SKIPPED,
+    }
+    assert _block_events(seen, "A") == [BLOCK_READY, BLOCK_RUNNING, BLOCK_DONE]
+    assert _block_events(seen, "B") == [BLOCK_READY, BLOCK_RUNNING, BLOCK_ERROR]
+    assert _block_events(seen, "C") == [BLOCK_SKIPPED]


### PR DESCRIPTION
## Summary

Adds a centralized, table-driven executable scheduler state-machine contract before the backend god-file refactor work moves scheduler-adjacent code around.

This is intentionally test-only:

- Adds `tests/engine/test_scheduler_state_machine_contract.py`.
- Covers `cancel_block`, `cancel_workflow`, `PROCESS_EXITED`, terminal `reset_block`, happy-path lifecycle events, and error/skip events.
- Keeps product code untouched.
- Records full-audit evidence in `docs/audit/2026-05-22-1376-scheduler-state-machine-contract-full-audit.json` and gate evidence in `.workflow/records/1376-scheduler-state-machine-contract.json`.

## Known drift

Six `cancel_block` rows are marked `strict xfail` for #1376 because current `DAGScheduler._on_cancel_block()` still transitions non-active states to `CANCELLED` / re-emits `BLOCK_CANCELLED`. This PR makes the drift explicit and keeps the rest of the state table green, but it does **not** fix the implementation.

Closes #1449
Refs #1376

## Validation

- `PYTHONPATH=src pytest tests/engine/test_scheduler_state_machine_contract.py -q --no-cov` -> 24 passed, 6 strict xfail
- `PYTHONPATH=src pytest tests/engine/test_scheduler.py tests/engine/test_scheduler_concurrency.py tests/engine/test_scheduler_rerun_cancel.py tests/engine/test_scheduler_terminal_data.py tests/engine/test_scheduler_interactive.py -q --no-cov` -> 68 passed
- `ruff check tests/engine/test_scheduler_state_machine_contract.py` -> pass
- `ruff format --check tests/engine/test_scheduler_state_machine_contract.py` -> pass
- `PYTHONPATH=src python -m scistudio.qa.audit.full_audit --repo-root . --format json --output docs/audit/2026-05-22-1376-scheduler-state-machine-contract-full-audit.json` -> pass
- `git diff --check` -> pass
- `python -m scistudio.qa.governance.gate_record pre-commit --staged` -> pass before commit
- `python -m scistudio.qa.governance.gate_record pre-push` -> pass

## Gate note

Local Sentrux CLI was unavailable (`Get-Command sentrux` returned no command). The gate record records Sentrux as skipped/advisory per ADR-042 Addendum 3.