### PR TITLE
test: add runtime architecture contract suite

### DIFF
--- a/.workflow/records/1455-runtime-contract-tests.json
+++ b/.workflow/records/1455-runtime-contract-tests.json
@@ -12,7 +12,10 @@
   ],
   "branch": "test/contract-surfaces-2-5",
   "changed_test_paths": [
-    "tests/contracts"
+    "tests/contracts/test_block_schema_contract.py",
+    "tests/contracts/test_eventbus_lifecycle_contract.py",
+    "tests/contracts/test_io_capability_contract.py",
+    "tests/contracts/test_lineage_run_recipe_contract.py"
   ],
   "check_results": [
     {
@@ -20,6 +23,15 @@
       "exit_code": 0,
       "name": "ruff",
       "output_path": "All checks passed",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "PYTHONPATH=src python -m ruff format --check tests\\\\contracts",
+      "exit_code": 0,
+      "name": "format",
+      "output_path": "4 files already formatted",
       "status": "pass",
       "summary": {},
       "timestamp": null
@@ -49,7 +61,16 @@
       "rationale": "test-only contract suite; issues #1452 and #1454 carry tracking context"
     }
   },
-  "full_audit": null,
+  "full_audit": {
+    "blocks_merge": false,
+    "command": "PYTHONPATH=src python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/1455-full-audit.json",
+    "exit_code": 0,
+    "known_debt": [],
+    "output_path": ".audit/1455-full-audit.json",
+    "status": "pass",
+    "summary": {},
+    "unclassified_failures": []
+  },
   "governance_touch": false,
   "issues": [
     {
@@ -72,7 +93,10 @@
   },
   "record_path": ".workflow/records/1455-runtime-contract-tests.json",
   "required_checks": [
-    "ruff,pytest"
+    "ruff",
+    "format",
+    "pytest",
+    "full_audit"
   ],
   "schema_version": "1",
   "scope": {

--- a/.workflow/records/1455-runtime-contract-tests.json
+++ b/.workflow/records/1455-runtime-contract-tests.json
@@ -1,0 +1,117 @@
+{
+  "admin_labels": [],
+  "amendments": [
+    {
+      "approved_by": null,
+      "exclude": [],
+      "include": [
+        ".workflow/records/1455-runtime-contract-tests.json"
+      ],
+      "reason": "Committed gate-record evidence is required for AI-authored work; source/docs/frontend remain out of scope."
+    }
+  ],
+  "branch": "test/contract-surfaces-2-5",
+  "changed_test_paths": [
+    "tests/contracts"
+  ],
+  "check_results": [
+    {
+      "command_or_tool": "PYTHONPATH=src python -m ruff check tests\\\\contracts",
+      "exit_code": 0,
+      "name": "ruff",
+      "output_path": "All checks passed",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "PYTHONPATH=src python -m pytest tests\\\\contracts --no-cov --timeout=60",
+      "exit_code": 0,
+      "name": "pytest",
+      "output_path": "20 passed, 8 xfailed; xfails tracked by #1454",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    }
+  ],
+  "commit": null,
+  "docs_landing": {
+    "changelog": {},
+    "checklist": {},
+    "docs": {
+      "not_applicable": true,
+      "rationale": "test-only contract suite; issues #1452 and #1454 carry tracking context"
+    }
+  },
+  "full_audit": null,
+  "governance_touch": false,
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1455,
+      "url": "https://github.com/zjzcpj/SciStudio/issues/1455"
+    }
+  ],
+  "owner_directive": "Add test-only architecture contract tests for runtime surfaces 2-5; no product code changes; xfails tracked by #1454.",
+  "planned_files": [
+    "tests/contracts/**"
+  ],
+  "pull_request": null,
+  "record_path": ".workflow/records/1455-runtime-contract-tests.json",
+  "required_checks": [
+    "ruff,pytest"
+  ],
+  "schema_version": "1",
+  "scope": {
+    "exclude": [
+      "src/**",
+      "frontend/**",
+      "docs/**"
+    ],
+    "include": [
+      "tests/contracts/**"
+    ]
+  },
+  "sentrux": null,
+  "stages": [
+    {
+      "completed_at": null,
+      "stage": "scope_and_issue",
+      "status": "done",
+      "summary": null
+    },
+    {
+      "completed_at": null,
+      "stage": "plan",
+      "status": "done",
+      "summary": null
+    },
+    {
+      "completed_at": null,
+      "stage": "implement",
+      "status": "done",
+      "summary": null
+    },
+    {
+      "completed_at": null,
+      "stage": "update_docs",
+      "status": "done",
+      "summary": null
+    },
+    {
+      "completed_at": null,
+      "stage": "test_and_checks",
+      "status": "done",
+      "summary": null
+    },
+    {
+      "completed_at": null,
+      "stage": "commit_and_submit_pr",
+      "status": "pending",
+      "summary": null
+    }
+  ],
+  "task_id": "1455-runtime-contract-tests",
+  "task_kind": "maintenance"
+}

--- a/.workflow/records/1455-runtime-contract-tests.json
+++ b/.workflow/records/1455-runtime-contract-tests.json
@@ -34,7 +34,13 @@
       "timestamp": null
     }
   ],
-  "commit": null,
+  "commit": {
+    "gate_record_path": ".workflow/records/1455-runtime-contract-tests.json",
+    "shas": [
+      "e9274aa82a1aa1aad0bda3980c4e355128ebd423"
+    ],
+    "trailers": {}
+  },
   "docs_landing": {
     "changelog": {},
     "checklist": {},
@@ -57,7 +63,13 @@
   "planned_files": [
     "tests/contracts/**"
   ],
-  "pull_request": null,
+  "pull_request": {
+    "body_closes_issues": [
+      1455
+    ],
+    "number": null,
+    "url": "https://github.com/zjzcpj/SciStudio/pull/1456"
+  },
   "record_path": ".workflow/records/1455-runtime-contract-tests.json",
   "required_checks": [
     "ruff,pytest"
@@ -108,7 +120,7 @@
     {
       "completed_at": null,
       "stage": "commit_and_submit_pr",
-      "status": "pending",
+      "status": "done",
       "summary": null
     }
   ],

--- a/.workflow/records/1455-runtime-contract-tests.json
+++ b/.workflow/records/1455-runtime-contract-tests.json
@@ -49,7 +49,7 @@
   "commit": {
     "gate_record_path": ".workflow/records/1455-runtime-contract-tests.json",
     "shas": [
-      "e9274aa82a1aa1aad0bda3980c4e355128ebd423"
+      "098486226637bb27bd03926751b649a8820b6610"
     ],
     "trailers": {}
   },

--- a/.workflow/records/1455-runtime-contract-tests.json
+++ b/.workflow/records/1455-runtime-contract-tests.json
@@ -49,13 +49,19 @@
   "commit": {
     "gate_record_path": ".workflow/records/1455-runtime-contract-tests.json",
     "shas": [
-      "098486226637bb27bd03926751b649a8820b6610"
+      "484b389ce168a28d5ec3d4b3b9df099fc50264a9"
     ],
     "trailers": {}
   },
   "docs_landing": {
-    "changelog": {},
-    "checklist": {},
+    "changelog": {
+      "not_applicable": true,
+      "rationale": "test-only contract suite; no user-facing product behavior change"
+    },
+    "checklist": {
+      "not_applicable": true,
+      "rationale": "single-scope PR tracked by #1455 plus xfail ledger #1454; no manager checklist required"
+    },
     "docs": {
       "not_applicable": true,
       "rationale": "test-only contract suite; issues #1452 and #1454 carry tracking context"

--- a/tests/contracts/test_block_schema_contract.py
+++ b/tests/contracts/test_block_schema_contract.py
@@ -1,0 +1,170 @@
+"""Contract tests for block registry/schema single-source API payloads.
+
+Issues #1452/#1454, slice 3: the backend block registry is the source of truth for
+palette, schema, connection validation, and MCP-facing schema helpers.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from scistudio.ai.agent.mcp import _context, tools_workflow
+from scistudio.api.app import create_app
+
+IDENTITY_FIELDS = ("name", "type_name", "base_category", "source", "package_name")
+SCHEMA_CONTRACT_FIELDS = {
+    "ports",
+    "config_schema",
+    "type_hierarchy",
+    "format_capabilities",
+    "source",
+    "package_name",
+    "base_category",
+}
+
+
+@pytest.fixture()
+def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
+    """Create an API client with isolated user state for contract tests."""
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+
+    from scistudio.api import runtime as runtime_module
+
+    monkeypatch.setattr(runtime_module.Path, "home", classmethod(lambda cls: fake_home))
+
+    app = create_app()
+    with TestClient(app) as test_client:
+        yield test_client
+
+
+def _palette_by_type(client: TestClient) -> dict[str, dict[str, Any]]:
+    response = client.get("/api/blocks/")
+    assert response.status_code == 200
+    return {block["type_name"]: block for block in response.json()["blocks"]}
+
+
+def _schema(client: TestClient, type_name: str) -> dict[str, Any]:
+    response = client.get(f"/api/blocks/{type_name}/schema")
+    assert response.status_code == 200
+    return response.json()
+
+
+def _representative_type_names(palette: dict[str, dict[str, Any]]) -> list[str]:
+    representatives: list[str] = []
+
+    for candidate in ("load_data", "ai.agent", "subworkflow_block", "noop", "process_block"):
+        if candidate in palette:
+            representatives.append(candidate)
+            break
+    else:
+        pytest.fail("Expected at least one representative built-in block in /api/blocks/.")
+
+    if "code_block" in palette:
+        representatives.append("code_block")
+
+    plugin_or_imaging = next(
+        (
+            type_name
+            for type_name, block in palette.items()
+            if block.get("package_name") == "scistudio-blocks-imaging" or type_name.startswith("imaging.")
+        ),
+        None,
+    )
+    if plugin_or_imaging is not None:
+        representatives.append(plugin_or_imaging)
+
+    return representatives
+
+
+def test_palette_items_and_schema_identity_fields_match_for_representative_blocks(client: TestClient) -> None:
+    """Palette summaries and schema payloads must agree on registry identity."""
+    palette = _palette_by_type(client)
+
+    for type_name in _representative_type_names(palette):
+        palette_item = palette[type_name]
+        schema_payload = _schema(client, type_name)
+
+        for field in IDENTITY_FIELDS:
+            assert schema_payload[field] == palette_item[field], (
+                f"{type_name} has mismatched {field!r}: "
+                f"palette={palette_item[field]!r}, schema={schema_payload[field]!r}"
+            )
+
+
+@pytest.mark.xfail(
+    reason="#1454: schema payloads do not yet expose the desired unified ports envelope.",
+    strict=False,
+)
+def test_schema_payload_exposes_stable_contract_fields(client: TestClient) -> None:
+    """Block schemas should expose one stable API contract envelope."""
+    type_name = _representative_type_names(_palette_by_type(client))[0]
+    schema_payload = _schema(client, type_name)
+
+    missing = SCHEMA_CONTRACT_FIELDS.difference(schema_payload)
+    assert not missing, f"{type_name} schema missing contract fields: {sorted(missing)}"
+    assert {"input", "output"}.issubset(schema_payload["ports"])
+    assert isinstance(schema_payload["config_schema"], dict)
+    assert isinstance(schema_payload["type_hierarchy"], list)
+    assert isinstance(schema_payload["format_capabilities"], list)
+
+
+def test_connection_validation_uses_backend_registry_type_information(client: TestClient) -> None:
+    """Connection validation should need only block/port identifiers from the client."""
+    palette = _palette_by_type(client)
+    if not {"load_data", "save_data"}.issubset(palette):
+        pytest.skip("load_data/save_data are unavailable in this registry.")
+
+    source_schema = _schema(client, "load_data")
+    target_schema = _schema(client, "save_data")
+    source_port = source_schema["output_ports"][0]["name"]
+    target_port = target_schema["input_ports"][0]["name"]
+
+    response = client.post(
+        "/api/blocks/validate-connection",
+        json={
+            "source_block": "load_data",
+            "source_port": source_port,
+            "target_block": "save_data",
+            "target_port": target_port,
+        },
+    )
+    assert response.status_code == 200
+    assert response.json()["compatible"] is True
+
+    missing_port = client.post(
+        "/api/blocks/validate-connection",
+        json={
+            "source_block": "load_data",
+            "source_port": "__frontend_only_fake_port__",
+            "target_block": "save_data",
+            "target_port": target_port,
+        },
+    )
+    assert missing_port.status_code == 404
+
+
+@pytest.mark.xfail(
+    reason="#1454: MCP get_block_schema is not yet API-equivalent for identity and schema fields.",
+    strict=False,
+)
+def test_mcp_and_api_schema_payloads_share_block_registry_source_of_truth(client: TestClient) -> None:
+    """MCP workflow helpers and HTTP schema payloads should expose equivalent contracts."""
+    type_name = _representative_type_names(_palette_by_type(client))[0]
+    api_schema = _schema(client, type_name)
+
+    _context.set_context(client.app.state.runtime)
+    try:
+        mcp_schema = asyncio.run(tools_workflow.get_block_schema(type_name)).model_dump()
+    finally:
+        _context.set_context(None)
+
+    assert mcp_schema["type_name"] == api_schema["type_name"]
+    assert mcp_schema["config_schema"] == api_schema["config_schema"]
+    assert mcp_schema["ports"] == api_schema["ports"]

--- a/tests/contracts/test_eventbus_lifecycle_contract.py
+++ b/tests/contracts/test_eventbus_lifecycle_contract.py
@@ -194,11 +194,7 @@ def test_public_lifecycle_events_carry_consistent_workflow_id_and_block_type(
 
     asyncio.run(scheduler.execute())
 
-    matching = [
-        event
-        for event in seen
-        if event.event_type == event_type and event.block_id == block_id
-    ]
+    matching = [event for event in seen if event.event_type == event_type and event.block_id == block_id]
     assert len(matching) == 1
     event = matching[0]
     _assert_public_identity(event, block_id=block_id)
@@ -221,21 +217,15 @@ def test_public_lifecycle_events_carry_consistent_workflow_id_and_block_type(
             BLOCK_CANCELLED,
             "A",
             "contract.type.A",
-            lambda scheduler: scheduler._block_states.update(
-                {"A": BlockState.RUNNING, "B": BlockState.IDLE}
-            ),
-            lambda scheduler, bus: bus.emit(
-                EngineEvent(event_type=CANCEL_BLOCK_REQUEST, block_id="A")
-            ),
+            lambda scheduler: scheduler._block_states.update({"A": BlockState.RUNNING, "B": BlockState.IDLE}),
+            lambda scheduler, bus: bus.emit(EngineEvent(event_type=CANCEL_BLOCK_REQUEST, block_id="A")),
         ),
         (
             "workflow-cancel-skips-idle",
             BLOCK_SKIPPED,
             "B",
             "contract.type.B",
-            lambda scheduler: scheduler._block_states.update(
-                {"A": BlockState.DONE, "B": BlockState.IDLE}
-            ),
+            lambda scheduler: scheduler._block_states.update({"A": BlockState.DONE, "B": BlockState.IDLE}),
             lambda scheduler, bus: bus.emit(EngineEvent(event_type=CANCEL_WORKFLOW_REQUEST)),
         ),
     ],
@@ -265,11 +255,7 @@ def test_error_cancel_skip_terminal_events_have_downstream_payload_shape(
 
     asyncio.run(trigger(scheduler, bus))
 
-    events = [
-        event
-        for event in seen
-        if event.event_type == terminal_event and event.block_id == block_id
-    ]
+    events = [event for event in seen if event.event_type == terminal_event and event.block_id == block_id]
     assert len(events) == 1
     event = events[0]
     _assert_terminal_payload(event, block_id=block_id, block_type=block_type)

--- a/tests/contracts/test_eventbus_lifecycle_contract.py
+++ b/tests/contracts/test_eventbus_lifecycle_contract.py
@@ -1,0 +1,306 @@
+"""Contract tests for EventBus lifecycle payloads.
+
+This slice covers the public runtime events consumed by API/WebSocket/lineage
+layers. Rows marked xfail document desired #1454 contract drift without
+changing product code in this test-only worker task.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from scistudio.blocks.base.state import BlockState
+from scistudio.engine.events import (
+    BLOCK_CANCELLED,
+    BLOCK_DONE,
+    BLOCK_ERROR,
+    BLOCK_READY,
+    BLOCK_RUNNING,
+    BLOCK_SKIPPED,
+    CANCEL_BLOCK_REQUEST,
+    CANCEL_WORKFLOW_REQUEST,
+    EngineEvent,
+    EventBus,
+)
+from scistudio.engine.scheduler import DAGScheduler
+from scistudio.workflow.definition import EdgeDef, NodeDef, WorkflowDefinition
+
+WORKFLOW_ID = "eventbus-lifecycle-contract"
+
+
+def _workflow() -> WorkflowDefinition:
+    return WorkflowDefinition(
+        id=WORKFLOW_ID,
+        nodes=[
+            NodeDef(id="A", block_type="contract.type.A", config={"alpha": 1}),
+            NodeDef(id="B", block_type="contract.type.B", config={"beta": 2}),
+        ],
+        edges=[EdgeDef(source="A:out", target="B:in")],
+    )
+
+
+def _make_scheduler(
+    *,
+    bus: EventBus | None = None,
+    runner: Any | None = None,
+) -> tuple[DAGScheduler, EventBus]:
+    event_bus = bus or EventBus()
+    resource_manager = MagicMock()
+    resource_manager.can_dispatch.return_value = True
+    process_registry = MagicMock()
+    process_registry.get_handle.return_value = None
+    scheduler_runner = runner or AsyncMock()
+    scheduler_runner.run.return_value = {"out": "ok"}
+
+    scheduler = DAGScheduler(
+        workflow=_workflow(),
+        event_bus=event_bus,
+        resource_manager=resource_manager,
+        process_registry=process_registry,
+        runner=scheduler_runner,
+        registry=None,
+        checkpoint_manager=None,
+    )
+    return scheduler, event_bus
+
+
+def _capture(
+    bus: EventBus,
+    event_types: tuple[str, ...] = (
+        BLOCK_READY,
+        BLOCK_RUNNING,
+        BLOCK_DONE,
+        BLOCK_ERROR,
+        BLOCK_CANCELLED,
+        BLOCK_SKIPPED,
+    ),
+) -> list[EngineEvent]:
+    seen: list[EngineEvent] = []
+    for event_type in event_types:
+        bus.subscribe(event_type, seen.append)
+    return seen
+
+
+def _event_pairs(events: list[EngineEvent]) -> list[tuple[str, str | None]]:
+    return [(event.event_type, event.block_id) for event in events]
+
+
+def _assert_public_identity(
+    event: EngineEvent,
+    *,
+    block_id: str,
+    workflow_id: str = WORKFLOW_ID,
+) -> None:
+    assert event.block_id == block_id
+    assert event.data["workflow_id"] == workflow_id
+
+
+def _assert_terminal_payload(
+    event: EngineEvent,
+    *,
+    block_id: str,
+    block_type: str,
+) -> None:
+    _assert_public_identity(event, block_id=block_id)
+    assert event.data["block_type"] == block_type
+    assert "block_version" in event.data
+    assert isinstance(event.data["config"], dict)
+    assert isinstance(event.data["inputs"], dict)
+    assert isinstance(event.data["input_object_ids"], dict)
+    assert isinstance(event.data["output_object_ids"], dict)
+
+
+def test_linear_workflow_emits_ready_running_done_with_public_identity() -> None:
+    """A small linear run exposes stable lifecycle identity to subscribers."""
+    bus = EventBus()
+    seen = _capture(bus)
+    scheduler, _ = _make_scheduler(bus=bus)
+
+    asyncio.run(scheduler.execute())
+
+    assert _event_pairs(seen) == [
+        (BLOCK_READY, "A"),
+        (BLOCK_RUNNING, "A"),
+        (BLOCK_DONE, "A"),
+        (BLOCK_READY, "B"),
+        (BLOCK_RUNNING, "B"),
+        (BLOCK_DONE, "B"),
+    ]
+    for event in seen:
+        _assert_public_identity(event, block_id=event.block_id or "")
+
+
+@pytest.mark.parametrize(
+    ("event_type", "block_id", "expected_block_type"),
+    [
+        pytest.param(
+            BLOCK_READY,
+            "A",
+            "contract.type.A",
+            marks=pytest.mark.xfail(
+                reason="#1454: BLOCK_READY should carry block_type for downstream lifecycle consumers",
+                strict=False,
+            ),
+            id="ready-block-type",
+        ),
+        pytest.param(
+            BLOCK_RUNNING,
+            "A",
+            "contract.type.A",
+            marks=pytest.mark.xfail(
+                reason="#1454: BLOCK_RUNNING should carry block_type for downstream lifecycle consumers",
+                strict=False,
+            ),
+            id="running-block-type",
+        ),
+        pytest.param(BLOCK_DONE, "A", "contract.type.A", id="done-block-type"),
+        pytest.param(
+            BLOCK_READY,
+            "B",
+            "contract.type.B",
+            marks=pytest.mark.xfail(
+                reason="#1454: BLOCK_READY should carry block_type for downstream lifecycle consumers",
+                strict=False,
+            ),
+            id="downstream-ready-block-type",
+        ),
+        pytest.param(
+            BLOCK_RUNNING,
+            "B",
+            "contract.type.B",
+            marks=pytest.mark.xfail(
+                reason="#1454: BLOCK_RUNNING should carry block_type for downstream lifecycle consumers",
+                strict=False,
+            ),
+            id="downstream-running-block-type",
+        ),
+        pytest.param(BLOCK_DONE, "B", "contract.type.B", id="downstream-done-block-type"),
+    ],
+)
+def test_public_lifecycle_events_carry_consistent_workflow_id_and_block_type(
+    event_type: str,
+    block_id: str,
+    expected_block_type: str,
+) -> None:
+    """Public lifecycle events should carry workflow_id and block_type."""
+    bus = EventBus()
+    seen = _capture(bus)
+    scheduler, _ = _make_scheduler(bus=bus)
+
+    asyncio.run(scheduler.execute())
+
+    matching = [
+        event
+        for event in seen
+        if event.event_type == event_type and event.block_id == block_id
+    ]
+    assert len(matching) == 1
+    event = matching[0]
+    _assert_public_identity(event, block_id=block_id)
+    assert event.data["block_type"] == expected_block_type
+
+
+@pytest.mark.parametrize(
+    ("scenario", "terminal_event", "block_id", "block_type", "configure", "trigger"),
+    [
+        (
+            "runner-error",
+            BLOCK_ERROR,
+            "A",
+            "contract.type.A",
+            lambda scheduler: None,
+            lambda scheduler, bus: scheduler.execute(),
+        ),
+        (
+            "cancel-running",
+            BLOCK_CANCELLED,
+            "A",
+            "contract.type.A",
+            lambda scheduler: scheduler._block_states.update(
+                {"A": BlockState.RUNNING, "B": BlockState.IDLE}
+            ),
+            lambda scheduler, bus: bus.emit(
+                EngineEvent(event_type=CANCEL_BLOCK_REQUEST, block_id="A")
+            ),
+        ),
+        (
+            "workflow-cancel-skips-idle",
+            BLOCK_SKIPPED,
+            "B",
+            "contract.type.B",
+            lambda scheduler: scheduler._block_states.update(
+                {"A": BlockState.DONE, "B": BlockState.IDLE}
+            ),
+            lambda scheduler, bus: bus.emit(EngineEvent(event_type=CANCEL_WORKFLOW_REQUEST)),
+        ),
+    ],
+    ids=lambda value: value if isinstance(value, str) else None,
+)
+def test_error_cancel_skip_terminal_events_have_downstream_payload_shape(
+    scenario: str,
+    terminal_event: str,
+    block_id: str,
+    block_type: str,
+    configure: Callable[[DAGScheduler], None],
+    trigger: Callable[[DAGScheduler, EventBus], Any],
+) -> None:
+    """Terminal events expose the payload shape API/WS/lineage layers need."""
+    bus = EventBus()
+    seen = _capture(bus, (BLOCK_ERROR, BLOCK_CANCELLED, BLOCK_SKIPPED))
+    runner = AsyncMock()
+
+    async def _run(block: Any, inputs: dict[str, Any], config: dict[str, Any], **kwargs: Any) -> dict[str, Any]:
+        if scenario == "runner-error" and block.id == "A":
+            raise RuntimeError("contract boom")
+        return {"out": "ok"}
+
+    runner.run.side_effect = _run
+    scheduler, _ = _make_scheduler(bus=bus, runner=runner)
+    configure(scheduler)
+
+    asyncio.run(trigger(scheduler, bus))
+
+    events = [
+        event
+        for event in seen
+        if event.event_type == terminal_event and event.block_id == block_id
+    ]
+    assert len(events) == 1
+    event = events[0]
+    _assert_terminal_payload(event, block_id=block_id, block_type=block_type)
+    if terminal_event == BLOCK_ERROR:
+        assert event.data["error"]
+        assert event.data["error_summary"]
+
+
+def test_eventbus_subscriber_failure_does_not_block_later_subscribers() -> None:
+    """One failing subscriber is isolated from later EventBus subscribers."""
+    bus = EventBus()
+    calls: list[str] = []
+    received: list[EngineEvent] = []
+
+    def bad_subscriber(event: EngineEvent) -> None:
+        calls.append("bad")
+        raise RuntimeError("subscriber failed")
+
+    def later_subscriber(event: EngineEvent) -> None:
+        calls.append("later")
+        received.append(event)
+
+    bus.subscribe(BLOCK_DONE, bad_subscriber)
+    bus.subscribe(BLOCK_DONE, later_subscriber)
+
+    event = EngineEvent(
+        event_type=BLOCK_DONE,
+        block_id="A",
+        data={"workflow_id": WORKFLOW_ID, "block_type": "contract.type.A"},
+    )
+    asyncio.run(bus.emit(event))
+
+    assert calls == ["bad", "later"]
+    assert received == [event]

--- a/tests/contracts/test_io_capability_contract.py
+++ b/tests/contracts/test_io_capability_contract.py
@@ -25,11 +25,7 @@ def _core_io_registry() -> BlockRegistry:
 
 
 def _registered_capabilities() -> list[FormatCapability]:
-    return [
-        capability
-        for spec in _core_io_registry().all_specs().values()
-        for capability in spec.format_capabilities
-    ]
+    return [capability for spec in _core_io_registry().all_specs().values() for capability in spec.format_capabilities]
 
 
 def _capability_key(capability: FormatCapability) -> tuple[str, type[DataObject], str]:
@@ -76,12 +72,8 @@ def test_capability_ids_are_unique_and_defaults_do_not_overlap() -> None:
 
     assert duplicate_ids == []
 
-    defaults_by_type_format = [
-        _capability_key(capability) for capability in capabilities if capability.is_default
-    ]
-    duplicate_type_format_defaults = [
-        key for key, count in Counter(defaults_by_type_format).items() if count > 1
-    ]
+    defaults_by_type_format = [_capability_key(capability) for capability in capabilities if capability.is_default]
+    duplicate_type_format_defaults = [key for key, count in Counter(defaults_by_type_format).items() if count > 1]
     assert duplicate_type_format_defaults == []
 
     defaults_by_extension: list[tuple[str, type[DataObject], str]] = []
@@ -89,12 +81,9 @@ def test_capability_ids_are_unique_and_defaults_do_not_overlap() -> None:
         if not capability.is_default:
             continue
         defaults_by_extension.extend(
-            (capability.direction, capability.data_type, extension)
-            for extension in capability.extensions
+            (capability.direction, capability.data_type, extension) for extension in capability.extensions
         )
-    duplicate_extension_defaults = [
-        key for key, count in Counter(defaults_by_extension).items() if count > 1
-    ]
+    duplicate_extension_defaults = [key for key, count in Counter(defaults_by_extension).items() if count > 1]
     assert duplicate_extension_defaults == []
 
 

--- a/tests/contracts/test_io_capability_contract.py
+++ b/tests/contracts/test_io_capability_contract.py
@@ -1,0 +1,278 @@
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+from collections.abc import Iterable
+
+import pytest
+
+from scistudio.blocks.base.ports import InputPort, OutputPort
+from scistudio.blocks.io.capabilities import FormatCapability, MetadataFidelity
+from scistudio.blocks.io.loaders.load_data import LoadData
+from scistudio.blocks.io.savers.save_data import SaveData
+from scistudio.blocks.registry import BlockRegistry, BlockSpec, _spec_from_class
+from scistudio.core.types.base import DataObject
+from scistudio.core.types.dataframe import DataFrame
+from scistudio.core.types.text import Text
+from scistudio.workflow.definition import EdgeDef, NodeDef, WorkflowDefinition
+from scistudio.workflow.validator import validate_workflow
+
+
+def _core_io_registry() -> BlockRegistry:
+    registry = BlockRegistry()
+    registry._register_spec(_spec_from_class(LoadData, source="contract"))
+    registry._register_spec(_spec_from_class(SaveData, source="contract"))
+    return registry
+
+
+def _registered_capabilities() -> list[FormatCapability]:
+    return [
+        capability
+        for spec in _core_io_registry().all_specs().values()
+        for capability in spec.format_capabilities
+    ]
+
+
+def _capability_key(capability: FormatCapability) -> tuple[str, type[DataObject], str]:
+    return (capability.direction, capability.data_type, capability.format_id)
+
+
+def _direction_index(
+    capabilities: Iterable[FormatCapability],
+) -> dict[str | None, dict[str, list[FormatCapability]]]:
+    groups: dict[str | None, dict[str, list[FormatCapability]]] = defaultdict(lambda: defaultdict(list))
+    for capability in capabilities:
+        groups[capability.roundtrip_group][capability.direction].append(capability)
+    return groups
+
+
+def test_registered_io_capabilities_expose_stable_replay_fields() -> None:
+    capabilities = _registered_capabilities()
+
+    assert capabilities
+    for capability in capabilities:
+        assert isinstance(capability.id, str) and capability.id.strip() == capability.id
+        assert capability.id.count(".") >= 2
+        assert capability.direction in {"load", "save"}
+        assert isinstance(capability.data_type, type)
+        assert issubclass(capability.data_type, DataObject)
+        assert isinstance(capability.format_id, str) and capability.format_id == capability.format_id.lower()
+        assert capability.extensions
+        assert all(extension.startswith(".") for extension in capability.extensions)
+        assert all(extension == extension.lower() for extension in capability.extensions)
+        assert len(capability.extensions) == len(set(capability.extensions))
+        assert isinstance(capability.label, str) and capability.label.strip() == capability.label
+        assert capability.block_type in {"LoadData", "SaveData"}
+        assert isinstance(capability.handler, str) and capability.handler.strip() == capability.handler
+        assert isinstance(capability.is_default, bool)
+        assert isinstance(capability.priority, int)
+        assert isinstance(capability.roundtrip_group, str) and capability.roundtrip_group
+        assert isinstance(capability.metadata_fidelity, MetadataFidelity)
+
+
+def test_capability_ids_are_unique_and_defaults_do_not_overlap() -> None:
+    capabilities = _registered_capabilities()
+    ids = [capability.id for capability in capabilities]
+    duplicate_ids = [identifier for identifier, count in Counter(ids).items() if count > 1]
+
+    assert duplicate_ids == []
+
+    defaults_by_type_format = [
+        _capability_key(capability) for capability in capabilities if capability.is_default
+    ]
+    duplicate_type_format_defaults = [
+        key for key, count in Counter(defaults_by_type_format).items() if count > 1
+    ]
+    assert duplicate_type_format_defaults == []
+
+    defaults_by_extension: list[tuple[str, type[DataObject], str]] = []
+    for capability in capabilities:
+        if not capability.is_default:
+            continue
+        defaults_by_extension.extend(
+            (capability.direction, capability.data_type, extension)
+            for extension in capability.extensions
+        )
+    duplicate_extension_defaults = [
+        key for key, count in Counter(defaults_by_extension).items() if count > 1
+    ]
+    assert duplicate_extension_defaults == []
+
+
+def test_paired_roundtrip_groups_have_compatible_load_and_save_contracts() -> None:
+    grouped = _direction_index(_registered_capabilities())
+
+    for group, by_direction in grouped.items():
+        loads = by_direction.get("load", [])
+        saves = by_direction.get("save", [])
+        if not loads or not saves:
+            continue
+        for load_capability in loads:
+            for save_capability in saves:
+                assert load_capability.data_type is save_capability.data_type, group
+                assert load_capability.format_id == save_capability.format_id, group
+                assert set(load_capability.extensions) & set(save_capability.extensions), group
+
+
+@pytest.mark.parametrize(
+    "roundtrip_group",
+    [
+        pytest.param(
+            "core.series.json",
+            marks=pytest.mark.xfail(
+                reason="#1454: current core IO declarations have save-only Series JSON roundtrip drift",
+                strict=False,
+            ),
+        ),
+        pytest.param(
+            "core.text.json",
+            marks=pytest.mark.xfail(
+                reason="#1454: current core IO declarations have save-only Text JSON roundtrip drift",
+                strict=False,
+            ),
+        ),
+    ],
+)
+def test_roundtrip_group_claims_have_registered_load_and_save_sides(roundtrip_group: str) -> None:
+    grouped = _direction_index(_registered_capabilities())
+    directions = set(grouped[roundtrip_group])
+
+    assert directions == {"load", "save"}
+
+
+def _registry_from_specs(*specs: BlockSpec) -> BlockRegistry:
+    registry = BlockRegistry()
+    for spec in specs:
+        registry._registry[spec.name] = spec
+        if spec.type_name:
+            registry._aliases[spec.type_name] = spec.name
+    return registry
+
+
+def _workflow_for_edge(
+    *,
+    source_spec: BlockSpec,
+    target_spec: BlockSpec,
+) -> WorkflowDefinition:
+    return WorkflowDefinition(
+        nodes=[
+            NodeDef(id="source", block_type=source_spec.name),
+            NodeDef(id="target", block_type=target_spec.name),
+        ],
+        edges=[EdgeDef(source="source:out", target="target:in")],
+    )
+
+
+def test_workflow_validation_rejects_hidden_format_conversion_on_ordinary_edges() -> None:
+    producer = BlockSpec(
+        name="contract_text_producer",
+        base_category="process",
+        output_ports=[OutputPort(name="out", accepted_types=[Text])],
+    )
+    consumer = BlockSpec(
+        name="contract_dataframe_consumer",
+        base_category="process",
+        input_ports=[InputPort(name="in", accepted_types=[DataFrame])],
+    )
+    registry = _registry_from_specs(producer, consumer)
+
+    errors = validate_workflow(
+        _workflow_for_edge(source_spec=producer, target_spec=consumer),
+        registry=registry,
+    )
+
+    assert any("source:out" in error and "target:in" in error for error in errors)
+
+
+def test_workflow_validation_accepts_type_compatible_canonical_zone_edges() -> None:
+    producer = BlockSpec(
+        name="contract_text_canonical_producer",
+        base_category="process",
+        output_ports=[OutputPort(name="out", accepted_types=[Text])],
+    )
+    consumer = BlockSpec(
+        name="contract_text_canonical_consumer",
+        base_category="process",
+        input_ports=[InputPort(name="in", accepted_types=[Text])],
+    )
+    registry = _registry_from_specs(producer, consumer)
+
+    errors = validate_workflow(
+        _workflow_for_edge(source_spec=producer, target_spec=consumer),
+        registry=registry,
+    )
+
+    assert [error for error in errors if "source:out" in error and "target:in" in error] == []
+
+
+def _boundary_registry() -> BlockRegistry:
+    text_loader = FormatCapability(
+        id="tests.contract.text.same.load",
+        direction="load",
+        data_type=Text,
+        format_id="same",
+        extensions=("same",),
+        label="Same Text",
+        block_type="ContractTextLoader",
+        handler="_load_same",
+    )
+    dataframe_loader = FormatCapability(
+        id="tests.contract.dataframe.same.load",
+        direction="load",
+        data_type=DataFrame,
+        format_id="same",
+        extensions=(".same",),
+        label="Same DataFrame",
+        block_type="ContractDataFrameLoader",
+        handler="_load_same",
+    )
+    registry = _registry_from_specs(
+        BlockSpec(
+            name="contract_app_boundary",
+            base_category="app",
+            variadic_outputs=True,
+        ),
+        BlockSpec(name="contract_text_loader", format_capabilities=[text_loader]),
+        BlockSpec(name="contract_dataframe_loader", format_capabilities=[dataframe_loader]),
+    )
+    return registry
+
+
+def _boundary_workflow(*, capability_id: str) -> WorkflowDefinition:
+    return WorkflowDefinition(
+        nodes=[
+            NodeDef(
+                id="boundary",
+                block_type="contract_app_boundary",
+                config={
+                    "params": {
+                        "output_ports": [
+                            {
+                                "name": "out",
+                                "types": ["Text"],
+                                "extension": "same",
+                                "capability_id": capability_id,
+                            }
+                        ]
+                    }
+                },
+            )
+        ],
+    )
+
+
+def test_boundary_validation_uses_capability_id_not_extension_hint_as_contract() -> None:
+    errors = validate_workflow(
+        _boundary_workflow(capability_id="tests.contract.dataframe.same.load"),
+        registry=_boundary_registry(),
+    )
+
+    assert any("capability_id='tests.contract.dataframe.same.load'" in error for error in errors)
+
+
+def test_boundary_validation_accepts_matching_capability_id_with_same_extension_hint() -> None:
+    errors = validate_workflow(
+        _boundary_workflow(capability_id="tests.contract.text.same.load"),
+        registry=_boundary_registry(),
+    )
+
+    assert [error for error in errors if "output port 'out'" in error] == []

--- a/tests/contracts/test_lineage_run_recipe_contract.py
+++ b/tests/contracts/test_lineage_run_recipe_contract.py
@@ -1,0 +1,291 @@
+"""Contract tests for the ADR-038 lineage run-recipe surface.
+
+The durable reproducibility contract is the normalized lineage recipe:
+``runs`` + ``block_executions`` + ``data_objects`` + ordered ``block_io``.
+Checkpoint files may support pause/resume, but they are not the durable
+historical run recipe.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import MagicMock
+
+from scistudio.core.lineage.record import RunRecord
+from scistudio.core.lineage.recorder import LineageRecorder
+from scistudio.core.lineage.store import LineageStore
+from scistudio.engine.events import (
+    BLOCK_CANCELLED,
+    BLOCK_DONE,
+    BLOCK_ERROR,
+    BLOCK_SKIPPED,
+    EngineEvent,
+    EventBus,
+)
+from scistudio.engine.scheduler import DAGScheduler
+from scistudio.workflow.definition import EdgeDef, NodeDef, WorkflowDefinition
+
+
+def _wire_object(object_id: str, *, type_name: str = "Image") -> dict[str, Any]:
+    return {
+        "backend": "zarr",
+        "path": f"/data/zarr/{object_id}.zarr",
+        "format": None,
+        "metadata": {
+            "type_chain": ["DataObject", type_name],
+            "framework": {
+                "object_id": object_id,
+                "derived_from": None,
+                "created_at": "2026-05-22T12:00:00+00:00",
+                "source": "",
+                "lineage_id": None,
+            },
+            "meta": None,
+            "user": {},
+        },
+    }
+
+
+def _seed_run(
+    store: LineageStore,
+    *,
+    run_id: str,
+    workflow_id: str = "wf-lineage-contract",
+    status: str = "running",
+    parent_run_id: str | None = None,
+) -> None:
+    store.insert_run(
+        RunRecord(
+            run_id=run_id,
+            workflow_id=workflow_id,
+            workflow_yaml_snapshot="nodes: []\n",
+            started_at="2026-05-22T12:00:00+00:00",
+            status=status,
+            environment_snapshot={"python": "contract-test"},
+            parent_run_id=parent_run_id,
+        )
+    )
+
+
+class _Runner:
+    def __init__(self, outputs_by_block: dict[str, dict[str, Any]]) -> None:
+        self.outputs_by_block = outputs_by_block
+
+    async def run(self, block: NodeDef, inputs: dict[str, Any], config: dict[str, Any]) -> dict[str, Any]:
+        return self.outputs_by_block[config["block_id"]]
+
+
+def _scheduler(
+    *,
+    workflow: WorkflowDefinition,
+    event_bus: EventBus,
+    recorder: LineageRecorder,
+    outputs_by_block: dict[str, dict[str, Any]],
+) -> DAGScheduler:
+    resource_manager = MagicMock()
+    resource_manager.can_dispatch.return_value = True
+
+    process_registry = MagicMock()
+    process_registry.get_handle.return_value = None
+
+    return DAGScheduler(
+        workflow=workflow,
+        event_bus=event_bus,
+        resource_manager=resource_manager,
+        process_registry=process_registry,
+        runner=_Runner(outputs_by_block),
+        lineage_recorder=recorder,
+    )
+
+
+def test_scheduler_run_records_four_table_recipe_and_relationships() -> None:
+    store = LineageStore(":memory:")
+    try:
+        run_id = "run-four-table-recipe"
+        _seed_run(store, run_id=run_id)
+        event_bus = EventBus()
+        recorder = LineageRecorder(event_bus, lineage_store=store, run_id=run_id)
+        workflow = WorkflowDefinition(
+            id="wf-lineage-contract",
+            nodes=[
+                NodeDef(id="load", block_type="loader", config={"path": "input.zarr"}),
+                NodeDef(id="measure", block_type="measure", config={"threshold": 0.7}),
+            ],
+            edges=[EdgeDef(source="load:out", target="measure:image")],
+        )
+        scheduler = _scheduler(
+            workflow=workflow,
+            event_bus=event_bus,
+            recorder=recorder,
+            outputs_by_block={
+                "load": {"out": _wire_object("obj-load")},
+                "measure": {"table": _wire_object("obj-measure", type_name="Table")},
+            },
+        )
+
+        asyncio.run(scheduler.execute())
+        recorder.finalize_run(status="completed")
+        recorder.dispose()
+
+        run = store.get_run(run_id)
+        assert run is not None
+        assert run["status"] == "completed"
+        assert run["workflow_yaml_snapshot"] == "nodes: []\n"
+        assert run["environment_snapshot"]
+
+        block_rows = store.list_block_executions(run_id)
+        assert [row["block_id"] for row in block_rows] == ["load", "measure"]
+        assert {row["termination"] for row in block_rows} == {"completed"}
+
+        load_exec = next(row for row in block_rows if row["block_id"] == "load")
+        measure_exec = next(row for row in block_rows if row["block_id"] == "measure")
+        assert store.get_data_object("obj-load")["produced_by_execution"] == load_exec["block_execution_id"]
+        assert store.get_data_object("obj-measure")["produced_by_execution"] == measure_exec["block_execution_id"]
+
+        load_edges = store.list_block_io(load_exec["block_execution_id"])
+        measure_edges = store.list_block_io(measure_exec["block_execution_id"])
+        assert [(edge["direction"], edge["port_name"], edge["object_id"]) for edge in load_edges] == [
+            ("output", "out", "obj-load")
+        ]
+        assert ("input", "image", "obj-load") in {
+            (edge["direction"], edge["port_name"], edge["object_id"]) for edge in measure_edges
+        }
+        assert ("output", "table", "obj-measure") in {
+            (edge["direction"], edge["port_name"], edge["object_id"]) for edge in measure_edges
+        }
+
+        joined_edges = store.list_block_io_with_objects(run_id)
+        assert {edge["object_id"] for edge in joined_edges} == {"obj-load", "obj-measure"}
+    finally:
+        store.close()
+
+
+def test_collection_output_records_ordered_item_level_block_io_positions() -> None:
+    store = LineageStore(":memory:")
+    try:
+        run_id = "run-collection-item-edges"
+        _seed_run(store, run_id=run_id)
+        event_bus = EventBus()
+        recorder = LineageRecorder(event_bus, lineage_store=store, run_id=run_id)
+        items = [_wire_object(f"collection-item-{position}") for position in range(3)]
+        workflow = WorkflowDefinition(
+            id="wf-lineage-contract",
+            nodes=[NodeDef(id="split", block_type="splitter")],
+            edges=[],
+        )
+        scheduler = _scheduler(
+            workflow=workflow,
+            event_bus=event_bus,
+            recorder=recorder,
+            outputs_by_block={
+                "split": {
+                    "images": {
+                        "_collection": True,
+                        "items": items,
+                        "item_type": "Image",
+                    }
+                }
+            },
+        )
+
+        asyncio.run(scheduler.execute())
+        recorder.dispose()
+
+        [block_row] = store.list_block_executions(run_id)
+        output_edges = [
+            edge
+            for edge in store.list_block_io(block_row["block_execution_id"])
+            if edge["direction"] == "output" and edge["port_name"] == "images"
+        ]
+        assert [(edge["position"], edge["object_id"]) for edge in output_edges] == [
+            (0, "collection-item-0"),
+            (1, "collection-item-1"),
+            (2, "collection-item-2"),
+        ]
+        assert store.get_data_object("images") is None
+    finally:
+        store.close()
+
+
+def test_terminal_events_distinguish_run_and_block_terminal_statuses() -> None:
+    store = LineageStore(":memory:")
+    try:
+        run_id = "run-terminal-statuses"
+        _seed_run(store, run_id=run_id)
+        event_bus = EventBus()
+        recorder = LineageRecorder(event_bus, lineage_store=store, run_id=run_id)
+
+        async def emit_terminal_events() -> None:
+            for event_type, block_id in [
+                (BLOCK_DONE, "done-block"),
+                (BLOCK_ERROR, "error-block"),
+                (BLOCK_CANCELLED, "cancelled-block"),
+                (BLOCK_SKIPPED, "skipped-block"),
+            ]:
+                recorder.record_start(block_id)
+                await event_bus.emit(
+                    EngineEvent(
+                        event_type=event_type,
+                        block_id=block_id,
+                        data={
+                            "workflow_id": "wf-lineage-contract",
+                            "block_type": "contract_block",
+                            "block_version": "1.2.3",
+                            "config": {"block_id": block_id},
+                            "error": "boom" if event_type == BLOCK_ERROR else "",
+                            "inputs": {},
+                            "input_object_ids": {},
+                            "outputs": {},
+                            "output_object_ids": {},
+                        },
+                    )
+                )
+
+        asyncio.run(emit_terminal_events())
+        assert {
+            row["block_id"]: row["termination"]
+            for row in store.list_block_executions(run_id)
+        } == {
+            "done-block": "completed",
+            "error-block": "error",
+            "cancelled-block": "cancelled",
+            "skipped-block": "skipped",
+        }
+
+        for status in ["completed", "failed", "cancelled"]:
+            recorder.finalize_run(status=status)
+            assert store.get_run(run_id)["status"] == status
+
+        recorder.dispose()
+    finally:
+        store.close()
+
+
+def test_rerun_parent_run_relationship_is_durable_in_runs_table() -> None:
+    store = LineageStore(":memory:")
+    try:
+        _seed_run(
+            store,
+            run_id="run-parent",
+            workflow_id="wf-lineage-contract",
+            status="completed",
+        )
+        _seed_run(
+            store,
+            run_id="run-child",
+            workflow_id="wf-lineage-contract",
+            parent_run_id="run-parent",
+        )
+
+        child = store.get_run("run-child")
+        assert child is not None
+        assert child["parent_run_id"] == "run-parent"
+
+        children = store.execute_query(
+            "SELECT run_id FROM runs WHERE parent_run_id = ? ORDER BY started_at",
+            ("run-parent",),
+        )
+        assert children == [("run-child",)]
+    finally:
+        store.close()

--- a/tests/contracts/test_lineage_run_recipe_contract.py
+++ b/tests/contracts/test_lineage_run_recipe_contract.py
@@ -243,10 +243,7 @@ def test_terminal_events_distinguish_run_and_block_terminal_statuses() -> None:
                 )
 
         asyncio.run(emit_terminal_events())
-        assert {
-            row["block_id"]: row["termination"]
-            for row in store.list_block_executions(run_id)
-        } == {
+        assert {row["block_id"]: row["termination"] for row in store.list_block_executions(run_id)} == {
             "done-block": "completed",
             "error-block": "error",
             "cancelled-block": "cancelled",


### PR DESCRIPTION
## Summary

- adds a test-only `tests/contracts/` suite for runtime architecture contract surfaces 2-5
- covers EventBus lifecycle payloads, block registry/schema consistency, IO capability boundaries, and lineage run recipe behavior
- marks expected current contract drift as xfail and points those xfails to the global ledger #1454

## Verification

```powershell
$env:PYTHONPATH='src'; python -m ruff check tests\contracts
$env:PYTHONPATH='src'; python -m pytest tests\contracts --no-cov --timeout=60
```

Results:

- `ruff`: pass
- `pytest tests\contracts`: `20 passed, 8 xfailed`

Related tracking:

- Runtime contract surfaces: #1452
- Global xfail ledger: #1454

Closes #1455