### PR TITLE
docs(#1466): add test engineer persona addendum

### DIFF
--- a/.workflow/records/1466-adr-042-test-engineer-persona.json
+++ b/.workflow/records/1466-adr-042-test-engineer-persona.json
@@ -1,0 +1,156 @@
+{
+  "admin_labels": [],
+  "amendments": [
+    {
+      "approved_by": null,
+      "exclude": [],
+      "include": [
+        "docs/audit/adr-042-addendum4-full-audit.json"
+      ],
+      "reason": "Record ADR-042 full audit evidence output for the addendum."
+    },
+    {
+      "approved_by": null,
+      "exclude": [],
+      "include": [
+        "docs/specs/adr-042-test-engineer-persona.md"
+      ],
+      "reason": "Add implementation spec requested by owner for the accepted test_engineer persona addendum."
+    },
+    {
+      "approved_by": null,
+      "exclude": [],
+      "include": [
+        "docs/specs/adr-042-test-engineer-persona.md",
+        "docs/audit/adr-042-addendum4-full-audit.json"
+      ],
+      "reason": "Ensure spec and full-audit evidence are included after repairing gate record JSON."
+    }
+  ],
+  "branch": "docs/issue-1466/adr-042-test-engineer-persona",
+  "changed_test_paths": [],
+  "check_results": [
+    {
+      "command_or_tool": "python -m scistudio.qa.governance.gate_record pre-commit --record .workflow/records/1466-adr-042-test-engineer-persona.json --staged",
+      "exit_code": 0,
+      "name": "gate_record_pre_commit",
+      "output_path": "gate_record: pass",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "git diff --check",
+      "exit_code": 0,
+      "name": "git_diff_check",
+      "output_path": "passed with CRLF warnings only",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "python -m scistudio.qa.audit.frontmatter_lint docs/adr/ADR-042-addendum4.md docs/specs/adr-042-test-engineer-persona.md --repo-root . --format text",
+      "exit_code": 0,
+      "name": "frontmatter_lint",
+      "output_path": "passed for accepted addendum and implementation spec",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    }
+  ],
+  "commit": null,
+  "docs_landing": {
+    "changelog": {},
+    "checklist": {},
+    "docs": {
+      "paths": [
+        "docs/adr/ADR-042-addendum4.md",
+        "docs/specs/adr-042-test-engineer-persona.md"
+      ]
+    },
+    "tests": {
+      "not_applicable": true,
+      "rationale": "docs-and-spec-only-pr-defers-implementation-tests-to-issue-1467"
+    }
+  },
+  "full_audit": {
+    "blocks_merge": false,
+    "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output docs/audit/adr-042-addendum4-full-audit.json",
+    "exit_code": 0,
+    "known_debt": [],
+    "output_path": "docs/audit/adr-042-addendum4-full-audit.json",
+    "status": "pass",
+    "summary": {},
+    "unclassified_failures": []
+  },
+  "governance_touch": true,
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1466,
+      "url": "https://github.com/zjzcpj/SciStudio/issues/1466"
+    }
+  ],
+  "owner_directive": "Write ADR-042 addendum for test_engineer persona; production code changes are not allowed for the persona by default; analyze gate workflow CLI and affected surfaces.",
+  "planned_files": [
+    "docs/adr/ADR-042-addendum4.md",
+    ".workflow/records/1466-adr-042-test-engineer-persona.json"
+  ],
+  "pull_request": null,
+  "record_path": ".workflow/records/1466-adr-042-test-engineer-persona.json",
+  "required_checks": [
+    "frontmatter_lint",
+    "full_audit",
+    "git_diff_check"
+  ],
+  "schema_version": "1",
+  "scope": {
+    "exclude": [],
+    "include": [
+      "docs/adr/ADR-042-addendum4.md",
+      ".workflow/records/1466-adr-042-test-engineer-persona.json"
+    ]
+  },
+  "sentrux": null,
+  "stages": [
+    {
+      "completed_at": null,
+      "stage": "scope_and_issue",
+      "status": "done",
+      "summary": null
+    },
+    {
+      "completed_at": null,
+      "stage": "plan",
+      "status": "done",
+      "summary": null
+    },
+    {
+      "completed_at": null,
+      "stage": "implement",
+      "status": "done",
+      "summary": null
+    },
+    {
+      "completed_at": null,
+      "stage": "update_docs",
+      "status": "done",
+      "summary": null
+    },
+    {
+      "completed_at": null,
+      "stage": "test_and_checks",
+      "status": "done",
+      "summary": null
+    },
+    {
+      "completed_at": null,
+      "stage": "commit_and_submit_pr",
+      "status": "pending",
+      "summary": null
+    }
+  ],
+  "task_id": "1466-adr-042-test-engineer-persona",
+  "task_kind": "docs"
+}

--- a/.workflow/records/1466-adr-042-test-engineer-persona.json
+++ b/.workflow/records/1466-adr-042-test-engineer-persona.json
@@ -46,19 +46,19 @@
       "timestamp": null
     },
     {
-      "command_or_tool": "git diff --check",
+      "command_or_tool": "python -m scistudio.qa.audit.frontmatter_lint docs/adr/ADR-042-addendum4.md docs/specs/adr-042-test-engineer-persona.md --repo-root . --format text",
       "exit_code": 0,
-      "name": "git_diff_check",
-      "output_path": "passed with CRLF warnings only",
+      "name": "frontmatter_lint",
+      "output_path": "passed for addendum and implementation spec after frontend allowlist narrowing",
       "status": "pass",
       "summary": {},
       "timestamp": null
     },
     {
-      "command_or_tool": "python -m scistudio.qa.audit.frontmatter_lint docs/adr/ADR-042-addendum4.md docs/specs/adr-042-test-engineer-persona.md --repo-root . --format text",
+      "command_or_tool": "git diff --check",
       "exit_code": 0,
-      "name": "frontmatter_lint",
-      "output_path": "passed for accepted addendum and implementation spec",
+      "name": "git_diff_check",
+      "output_path": "passed with CRLF warning for regenerated audit JSON only",
       "status": "pass",
       "summary": {},
       "timestamp": null

--- a/.workflow/records/1466-adr-042-test-engineer-persona.json
+++ b/.workflow/records/1466-adr-042-test-engineer-persona.json
@@ -58,7 +58,13 @@
       "timestamp": null
     }
   ],
-  "commit": null,
+  "commit": {
+    "gate_record_path": ".workflow/records/1466-adr-042-test-engineer-persona.json",
+    "shas": [
+      "2c58f86be6548cc3a9f2981419b5bcc25b9c584b"
+    ],
+    "trailers": {}
+  },
   "docs_landing": {
     "changelog": {},
     "checklist": {},
@@ -97,7 +103,13 @@
     "docs/adr/ADR-042-addendum4.md",
     ".workflow/records/1466-adr-042-test-engineer-persona.json"
   ],
-  "pull_request": null,
+  "pull_request": {
+    "body_closes_issues": [
+      1466
+    ],
+    "number": 1469,
+    "url": "https://github.com/zjzcpj/SciStudio/pull/1469"
+  },
   "record_path": ".workflow/records/1466-adr-042-test-engineer-persona.json",
   "required_checks": [
     "frontmatter_lint",
@@ -147,7 +159,7 @@
     {
       "completed_at": null,
       "stage": "commit_and_submit_pr",
-      "status": "pending",
+      "status": "done",
       "summary": null
     }
   ],

--- a/.workflow/records/1466-adr-042-test-engineer-persona.json
+++ b/.workflow/records/1466-adr-042-test-engineer-persona.json
@@ -1,5 +1,11 @@
 {
-  "admin_labels": [],
+  "admin_labels": [
+    {
+      "applied_at": "2026-05-22T19:08:48.337974-04:00",
+      "applied_by": "@jiazhenz026",
+      "name": "admin-approved:core-change"
+    }
+  ],
   "amendments": [
     {
       "approved_by": null,
@@ -66,8 +72,14 @@
     "trailers": {}
   },
   "docs_landing": {
-    "changelog": {},
-    "checklist": {},
+    "changelog": {
+      "not_applicable": true,
+      "rationale": "governance-decision-and-implementation-spec-only-no-user-facing-release-note"
+    },
+    "checklist": {
+      "not_applicable": true,
+      "rationale": "single-agent-governance-doc-change-no-manager-dispatch-checklist-required"
+    },
     "docs": {
       "paths": [
         "docs/adr/ADR-042-addendum4.md",

--- a/docs/adr/ADR-042-addendum4.md
+++ b/docs/adr/ADR-042-addendum4.md
@@ -1,0 +1,430 @@
+---
+adr: 42
+addendum: 4
+title: "Test Engineer AI Persona"
+status: Accepted
+date_created: 2026-05-22
+date_accepted: 2026-05-22
+date_superseded: null
+
+supersedes: []
+superseded_by: null
+related: [42]
+closes_issues: [1466]
+tracking_issue: 1467
+
+is_code_implementation: true
+governs:
+  modules:
+    - scistudio.qa.governance
+    - scistudio.qa.governance.gate_record
+  contracts:
+    - scistudio.qa.governance.persona_policy.check
+    - scistudio.qa.governance.gate_record.models.GateRecord
+    - scistudio.qa.governance.gate_record.cli.main
+    - scistudio.qa.governance.gate_record.validation.validate_gate_record
+  entry_points: []
+  files:
+    - docs/adr/ADR-042-addendum4.md
+    - docs/specs/adr-042-test-engineer-persona.md
+    - docs/adr/ADR-042.md
+    - docs/specs/adr-042-ai-governance-tools.md
+    - docs/ai-developer/rules.md
+    - docs/ai-developer/specific_rules/gated-workflow.md
+    - docs/ai-developer/specific_rules/agent-dispatch.md
+    - docs/ai-developer/templates/agent-dispatch-*.md
+    - docs/ai-developer/checklists/agent-manager-rules-review.md
+    - docs/ai-developer/skills/scistudio-e2e-test/SKILL.md
+    - src/scistudio/qa/governance/persona_policy.py
+    - src/scistudio/qa/governance/gate_record/**
+    - tests/qa/test_persona_policy.py
+    - tests/qa/test_gate_record.py
+    - tests/qa/test_gate_record_ci.py
+  excludes: []
+
+tests:
+  - tests/qa/test_persona_policy.py
+  - tests/qa/test_test_engineer_scope_guard.py
+  - tests/qa/test_gate_record.py
+  - tests/qa/test_gate_record_ci.py
+
+agent_editable: false
+assisted_by:
+  - "Codex:gpt-5"
+
+phase: planning
+tags: [qa, ai-governance, persona, testing, e2e, runtime-validation]
+owner: "@jiazhenz026"
+co_authors: ["@codex"]
+language_source: en
+translations: []
+---
+
+# ADR-042 Addendum 4: Test Engineer AI Persona
+
+## 1. Decision Summary
+
+This addendum proposes a fifth ADR-042 AI persona, `test_engineer`, for
+test architecture, test design, regression coverage, runtime validation, and
+end-to-end verification. The new persona is evidence-producing and
+coverage-building. It is not feature-owning.
+
+The `test_engineer` persona MUST NOT modify production code by default. When it
+finds a product defect, it records executable evidence, failing tests, runtime
+validation output, e2e evidence, and findings; production fixes remain owned by
+`implementer` unless the owner or manager explicitly amends scope and persona.
+
+| Decision | Change | Enforcement target | Detailed section |
+|---|---|---|---|
+| D1. Add `test_engineer` as a formal persona | ADR-042 Section 7.3 changes from four repository personas to five | Persona policy and AI developer rules | Section 3 |
+| D2. Keep test engineering separate from production fixes | The persona may write tests, fixtures, test utilities, validation scripts, e2e scenarios, and test reports, but not production runtime/API/frontend code by default | Gate scope, dispatch prompts, review | Section 4 |
+| D3. Update committed gate records to carry persona | Gate records must record `persona`; the CLI must accept `--persona` on `start` | `gate_record` CLI/schema/validation | Section 5 |
+| D4. Do not add a new task kind | `test_engineer` is a persona, not a task kind; existing task kinds remain sufficient | Gate CLI task-kind list | Section 5 |
+| D5. Add a test-engineering rule document and runtime skill pointers | Every supported runtime receives a `test-engineer` skill that points to canonical docs | `persona_policy` and `skill_pointer_sync` | Section 6 |
+| D6. Make runtime validation and e2e first-class test-engineer work | Scenario files, browser evidence, runtime probes, API/schema checks, and validation matrices are owned test artifacts | Dispatch and e2e docs | Section 7 |
+| D7. Add a persona-scoped test-engineer write guard | When `persona == test_engineer`, non-test and non-validation-evidence changes are blocked unless explicitly amended by the owner or manager | Local hooks and CI gate validation | Section 8 |
+
+### 1.1 Problems Addressed
+
+| Problem | Risk | Decision | Detailed section |
+|---|---|---|---|
+| Testing work is split between implementer, manager, and audit reviewer | Coverage gaps are noticed late, e2e evidence becomes manager-only, and test architecture lacks a clear owner | Add `test_engineer` as a dedicated persona | Section 3 |
+| Audit reviewers can identify missing tests but are read-only by default | Findings remain prose-only unless an implementer is separately assigned | Let test engineers add tests and validation artifacts while remaining outside production-code fixes | Section 4 |
+| Implementers can add tests but are biased toward proving their implementation | Tests may mirror implementation shape instead of testing the contract | Assign independent test design and test-layer ownership to `test_engineer` | Section 7 |
+| Manager agents coordinate e2e but should not be the testing specialist | PR readiness depends on one coordinator's manual testing discipline | Make runtime validation and e2e executable evidence a test-engineer responsibility | Section 7 |
+| Current committed gate-record CLI does not record persona | `persona_policy` cannot validate the selected persona from durable gate evidence | Add `persona` to `GateRecord` and `--persona` to `gate_record start` | Section 5 |
+| A test engineer could accidentally become an implementer | The agent may fix production code to make tests pass, weakening independence | Define a hard no-production-code default and escalation path | Section 4 |
+| Prompt-only boundaries are not enough to keep test engineers out of product code | A test engineer can accidentally stage runtime, API, or frontend behavior changes while chasing a failing test | Add a deterministic `test_engineer_scope_guard` hook and CI check | Section 8 |
+
+## 2. Scope
+
+This addendum changes the AI developer governance model. It does not implement
+the persona. Implementation is tracked by issue #1467.
+
+In scope:
+
+- adding the `test_engineer` persona to ADR-042 governance;
+- defining its authority, allowed artifacts, and stop conditions;
+- defining the gate workflow and CLI impact;
+- defining the expected docs, runtime skills, tests, and CI validation updates;
+- defining how test-engineer work interacts with runtime validation and e2e.
+
+Out of scope:
+
+- changing product runtime behavior;
+- fixing production defects found by a test engineer;
+- adding a new task kind;
+- changing branch protection, Sentrux semantics, full-audit semantics, or
+  administrator bypass labels;
+- making e2e mandatory for every PR.
+
+## 3. Persona Contract
+
+ADR-042 Section 7.3 is extended from four personas to five:
+
+| Persona | Use | Required skill | Root policy |
+|---|---|---|---|
+| `test_engineer` | Design test architecture and layers, design test cases, add tests and fixtures, run runtime validation, run e2e, report coverage and validation evidence | `test-engineer` | Must obey root `AGENTS.md`, gate scope, no-production-code default, test-quality rules, runtime validation evidence rules, and e2e evidence rules |
+
+The existing four personas remain unchanged:
+
+- `manager`
+- `implementer`
+- `adr_author`
+- `audit_reviewer`
+
+Every AI task still declares exactly one persona. If a task begins as
+`test_engineer` and later needs a production fix, the task must stop and either:
+
+1. hand the defect to an `implementer`, or
+2. receive an explicit owner or manager scope/persona amendment before any
+   production code is edited.
+
+The `test_engineer` persona is AI-runtime agnostic. Codex, Claude Code, Gemini,
+local CLI agents, and future agent runtimes use the same persona name and the
+same policy checks.
+
+## 4. Production-Code Boundary
+
+The `test_engineer` persona MUST NOT modify production code by default.
+
+For this addendum, production code means code or assets that implement product
+behavior for users or runtime execution, including:
+
+- `src/scistudio/**` except repository QA/governance/test-tooling modules
+  explicitly included in the gate scope;
+- `frontend/src/**` product components, hooks, runtime state, API clients, and
+  UI behavior;
+- package metadata or build configuration when the purpose is to change product
+  behavior;
+- workflow runtime, block registry, API routes, MCP tools, data model, lineage,
+  scheduler, plugin, or frontend production surfaces.
+
+Allowed default write surfaces for `test_engineer` include:
+
+- `tests/**`;
+- `frontend/**` test files, Playwright specs, Vitest tests, test fixtures, and
+  test support utilities;
+- `docs/ai-developer/e2e/**` scenario files and e2e verdicts;
+- `docs/audit/**` test reports and validation reports;
+- test-only fixtures, golden files, mocks, sample projects, and test data;
+- runtime validation scripts when they are test harnesses and do not change
+  product runtime behavior;
+- `src/scistudio/qa/**` only when the issue explicitly assigns QA/governance or
+  validation tooling changes.
+
+If a `test_engineer` discovers that production behavior is wrong, the expected
+output is a finding plus evidence, not a product fix. Acceptable evidence
+includes a failing test, a runtime validation transcript, API/schema mismatch,
+browser screenshot, Playwright trace, console/network log, or a concise
+reproduction note.
+
+## 5. Gate Workflow And CLI Impact
+
+Yes: the gate workflow CLI and schema must change if `test_engineer` is accepted
+as a formal persona.
+
+ADR-042 and Addendum 1 require agents to choose a persona, and `persona_policy`
+is supposed to verify that choice. The current committed gate-record CLI
+records `task_kind` but does not record `persona`. That means a durable
+committed gate record cannot currently prove whether work was performed as
+`manager`, `implementer`, `adr_author`, `audit_reviewer`, or the proposed
+`test_engineer`.
+
+The implementation must therefore update the committed gate workflow:
+
+| Surface | Required change | Reason |
+|---|---|---|
+| `GateRecord` schema | Add `persona: manager|implementer|adr_author|audit_reviewer|test_engineer` | Make persona durable PR evidence |
+| `gate_record start` CLI | Add required `--persona <persona>` | Ensure every gate record captures the chosen persona at stage 1 |
+| Gate validation | Reject missing or unsupported personas | Prevent unreviewable AI role drift |
+| `persona_policy.check` | Accept `test_engineer` and require `test-engineer` skill | Align code with ADR-042 Section 7.3 as amended |
+| PR/CI gate validation | Validate persona from committed gate record | Make CI, not chat, the enforcement boundary |
+| Gate examples and docs | Update all command examples to include `--persona` | Prevent agents from following stale procedures |
+
+No new task kind is required. `test_engineer` work can use existing task kinds:
+
+| Work shape | Task kind |
+|---|---|
+| Add or improve tests for an existing bug or regression issue | `bugfix` when the PR closes the bug with test evidence only, or `maintenance` when the work is coverage hardening |
+| Build or adjust test harness, validation tooling, or e2e infrastructure | `maintenance` |
+| Write test architecture docs or validation plan docs | `docs` |
+| Coordinate multiple test engineers or combine test/e2e evidence | `manager` |
+
+Commit trailers do not need a new mandatory `Persona:` trailer in this
+addendum. `Gate-Record`, `Task-Kind`, `Issue`, and `Assisted-by` remain the
+commit trailer set; persona is stored in the committed gate record. A future
+addendum may add a `Persona:` trailer if reviewers need faster commit-log
+filtering, but it is not required for correctness.
+
+## 6. Documentation, Skill, And Policy Impact
+
+Implementation of this addendum must update all persona lists and runtime
+pointers at equivalent fidelity.
+
+| Artifact | Required change |
+|---|---|
+| `docs/ai-developer/rules.md` | Add `test_engineer` to the required persona list and routing table |
+| `docs/ai-developer/specific_rules/gated-workflow.md` | Add `test_engineer` to persona selection and `gate_record start --persona` examples |
+| `docs/ai-developer/specific_rules/agent-dispatch.md` | Allow managers to dispatch `test_engineer`; require write sets to exclude production code by default |
+| `docs/ai-developer/specific_rules/test-engineering.md` | Create canonical rules for test architecture, test design, runtime validation, e2e, evidence, and production-code stop conditions |
+| `docs/ai-developer/personas/test-engineer.md` | Create the persona guide |
+| `docs/ai-developer/templates/agent-dispatch-prompt-template.md` | Add `test_engineer` as a non-audit dispatch persona and include production-code stop conditions |
+| `docs/ai-developer/templates/agent-dispatch-checklist-template.md` | Add test-engineer rows/status expectations and evidence fields where needed |
+| `docs/ai-developer/checklists/agent-manager-rules-review.md` | Register the new persona docs and skills |
+| `.agents/skills/test-engineer/SKILL.md` | Add runtime-neutral skill pointer |
+| `.codex/skills/test-engineer/SKILL.md` | Add Codex skill pointer |
+| `.claude/skills/test-engineer/SKILL.md` | Add Claude skill pointer |
+| `docs/ai-developer/skills/scistudio-e2e-test/SKILL.md` | Add `test_engineer` as a related persona |
+
+Skill files must stay pointer-only. They must not duplicate policy or create a
+runtime-specific rule that is absent from canonical docs.
+
+## 7. Test Engineering Work Model
+
+The `test_engineer` persona owns the test evidence path for a task. Typical
+outputs include:
+
+- test architecture and layer plans;
+- test matrices mapped to ADR/spec/issue requirements;
+- unit, contract, integration, frontend, runtime validation, and e2e tests;
+- fixtures, sample projects, golden files, mocks, and test helpers;
+- runtime validation scripts and reports;
+- e2e scenario files, screenshots, traces, console/network evidence, and
+  verdicts;
+- coverage gap analysis and risk classification;
+- failing tests that demonstrate a bug for implementer handoff.
+
+The expected testing layers are:
+
+| Layer | Purpose | Example evidence |
+|---|---|---|
+| Unit | Local behavior of a function, class, parser, or helper | Focused `pytest` or Vitest tests |
+| Contract | Stable API/schema/runtime boundary behavior | API schema assertions, block schema contracts, event/state-machine tests |
+| Integration | Multiple backend/frontend/runtime components interacting | Backend workflow execution tests, API plus engine tests |
+| Runtime validation | Real runtime behavior beyond static audit | run status probes, backend truth endpoints, artifact checks, lineage checks |
+| Frontend validation | UI behavior at component or browser-test level | Vitest, Playwright, DOM state, console/network evidence |
+| E2E | User-observable flow through the real app | scenario file, screenshots, trace, pass/fail verdict |
+| Regression | Reproduce a known issue and lock the fix path | failing-before/passing-after test or preserved failing evidence |
+
+Runtime validation is not a synonym for `full_audit`. ADR-042 full audit covers
+static governance, frontmatter, facts, signatures, closure, documentation drift,
+architecture drift, and related checks. Runtime validation must execute or
+observe the runtime behavior being claimed.
+
+## 8. Test Engineer Scope Guard
+
+Implementation of this addendum MUST add a persona-scoped deterministic guard
+named `test_engineer_scope_guard`.
+
+The guard runs whenever a gate record declares `persona == "test_engineer"`.
+It must run in local hook paths and CI gate validation. It may be implemented as
+a standalone audit module, a gate-record validation child, or both, but the
+public check name must remain stable so reports can cite it.
+
+The guard blocks changed files outside the test-engineer artifact allowlist.
+
+Allowed by default:
+
+- `tests/**`;
+- `frontend/**` test files and test support files, including `*.test.*`,
+  `*.spec.*`, Playwright specs, Vitest setup, fixtures, and mocks;
+- `frontend/e2e/**`;
+- `docs/ai-developer/e2e/**`;
+- `docs/audit/**` validation reports and test reports;
+- test fixtures, golden files, sample projects, and generated test evidence
+  under repository paths designated for tests or audit evidence;
+- `src/scistudio/qa/**` only when the gate record explicitly includes QA,
+  governance, or validation-tooling scope.
+
+Blocked by default:
+
+- product runtime code under `src/scistudio/**`;
+- frontend product code under `frontend/src/**` unless the path is a test file;
+- workflow runtime, block, API, MCP, data model, lineage, scheduler, plugin, or
+  product UI implementation files;
+- package/build/dependency changes whose purpose is product behavior rather
+  than test execution;
+- governance or CI changes unless the owner directive explicitly assigns test
+  governance/tooling work.
+
+Escape path:
+
+1. The test engineer stops before editing the blocked path.
+2. The manager or owner either assigns an `implementer` production-code fix or
+   amends the gate record with a specific allowed path and rationale.
+3. The amended gate must state why the change is test tooling rather than a
+   production fix, or must explicitly change persona/scope for production code.
+
+The guard must report findings with enough evidence for reviewers to see:
+
+- persona;
+- blocked path;
+- matched reason or missing allowlist match;
+- whether a gate amendment attempted to allow the path;
+- recommended handoff (`implementer` fix, manager amendment, or remove path).
+
+The initial implementation should add:
+
+- `src/scistudio/qa/governance/test_engineer_scope_guard.py`;
+- `tests/qa/test_test_engineer_scope_guard.py`;
+- integration in `gate_record pre-commit`, `pre-push`, `pr-ready`, and `ci`
+  validation paths, or an equivalent shared validator called from those paths.
+
+## 9. Verification Plan
+
+The implementation issue #1467 must verify this addendum with at least:
+
+- `tests/qa/test_persona_policy.py`: `test_engineer` is accepted, requires the
+  `test-engineer` skill, and unsupported personas still fail.
+- `tests/qa/test_test_engineer_scope_guard.py`: `test_engineer` changes to
+  production code are blocked, test/e2e/audit evidence paths are allowed, and
+  explicit amendments are reported correctly.
+- `tests/qa/test_gate_record.py`: gate records require and validate `persona`.
+- `tests/qa/test_gate_record_ci.py`: CI validation rejects missing or invalid
+  gate-record persona data and invokes the test-engineer scope guard.
+- Documentation checks for `docs/ai-developer/personas/test-engineer.md` and
+  `docs/ai-developer/specific_rules/test-engineering.md`.
+- Skill pointer checks across `.agents`, `.codex`, and `.claude`.
+- A targeted e2e-skill metadata check or documentation check confirming
+  `test_engineer` is a related persona for e2e work.
+- ADR-042 full audit after docs and code changes.
+
+Manual review must confirm that the new persona does not grant permission to
+modify production code by default.
+
+## 10. Implementation Sequence
+
+Implement #1467 in this order:
+
+1. Update `GateRecord` schema, CLI `start`, validators, and docs examples to
+   record `persona`.
+2. Update `persona_policy` and its tests for the five-persona set and
+   `test-engineer` skill mapping.
+3. Add `test_engineer_scope_guard` and integrate it with local and CI gate
+   validation.
+4. Add canonical test-engineer persona and test-engineering specific-rule docs.
+5. Add runtime skill pointers in `.agents`, `.codex`, and `.claude`.
+6. Update dispatch templates, checklist template, e2e skill metadata, and
+   manager rules review checklist.
+7. Run targeted QA tests.
+8. Run ADR-042 full audit and record gate evidence.
+
+This sequence intentionally updates gate/schema enforcement before adding broad
+dispatch usage so that the new persona is machine-checkable as soon as agents
+can select it.
+
+## 11. Consequences And Risks
+
+Positive consequences:
+
+- Testing becomes an owned engineering function rather than an afterthought of
+  implementation or audit.
+- Runtime validation and e2e evidence become normal test artifacts.
+- Implementers can receive higher-quality failing tests and reproduction
+  evidence before fixing production code.
+- Managers can dispatch testing work without blurring audit, implementation,
+  and coordination responsibilities.
+
+Risks:
+
+- Adding a fifth persona increases governance surface area.
+- A test engineer may need narrow test-tooling changes under `src/scistudio/qa`.
+  Gate scope must distinguish those changes from production fixes.
+- Dispatch prompts must be explicit enough to prevent accidental production
+  code edits.
+- Gate CLI/schema changes can temporarily break older records unless migration
+  behavior is defined.
+
+Migration guidance:
+
+- Existing gate records without `persona` may remain valid as historical
+  records if their schema version predates the implementation.
+- New gate records after implementation must include `persona`.
+- If the schema version changes, validation must document whether old records
+  are grandfathered, migrated, or rejected only for new PRs.
+
+## 12. Alternatives Considered
+
+| Alternative | Rejected because |
+|---|---|
+| Keep testing under `implementer` | Implementers should test their own changes, but independent test architecture, runtime validation, and e2e ownership need a separate route |
+| Keep testing under `audit_reviewer` | Audit reviewers are read-only by default; test engineers must be able to add tests and validation artifacts |
+| Keep e2e under `manager` only | Managers coordinate readiness but should not be the only persona allowed to produce e2e evidence |
+| Add a `test` task kind instead of a persona | The work type is role-specific; existing task kinds already express docs, maintenance, bugfix, and manager workflows |
+| Let test engineers fix production bugs | That collapses the independence boundary with `implementer` and makes tests less trustworthy as external evidence |
+| Rely on prompt instructions to block production changes | ADR-042 requires deterministic enforcement for AI failure modes; a hook/CI guard is needed |
+
+## 13. Out Of Scope
+
+This addendum does not:
+
+- implement #1467;
+- authorize test engineers to modify production code by default;
+- remove implementer responsibility to add tests for implementation-category
+  work;
+- make audit reviewers responsible for writing tests;
+- make managers responsible for detailed test architecture;
+- require e2e for every PR;
+- change Sentrux advisory semantics from Addendum 3;
+- change semantic-duplication gate semantics from Addendum 2.

--- a/docs/adr/ADR-042-addendum4.md
+++ b/docs/adr/ADR-042-addendum4.md
@@ -163,8 +163,12 @@ behavior for users or runtime execution, including:
 Allowed default write surfaces for `test_engineer` include:
 
 - `tests/**`;
-- `frontend/**` test files, Playwright specs, Vitest tests, test fixtures, and
-  test support utilities;
+- frontend test and e2e paths that match explicit test-only patterns:
+  `frontend/**/*.test.*`, `frontend/**/*.spec.*`, `frontend/**/__tests__/**`,
+  `frontend/**/__fixtures__/**`, `frontend/**/__mocks__/**`,
+  `frontend/e2e/**`, `frontend/tests/**`, `frontend/test/**`,
+  `frontend/playwright.config.*`, `frontend/vitest.config.*`, and
+  `frontend/vitest.setup.*`;
 - `docs/ai-developer/e2e/**` scenario files and e2e verdicts;
 - `docs/audit/**` test reports and validation reports;
 - test-only fixtures, golden files, mocks, sample projects, and test data;
@@ -287,9 +291,17 @@ The guard blocks changed files outside the test-engineer artifact allowlist.
 Allowed by default:
 
 - `tests/**`;
-- `frontend/**` test files and test support files, including `*.test.*`,
-  `*.spec.*`, Playwright specs, Vitest setup, fixtures, and mocks;
+- `frontend/**/*.test.*`;
+- `frontend/**/*.spec.*`;
+- `frontend/**/__tests__/**`;
+- `frontend/**/__fixtures__/**`;
+- `frontend/**/__mocks__/**`;
 - `frontend/e2e/**`;
+- `frontend/tests/**`;
+- `frontend/test/**`;
+- `frontend/playwright.config.*`;
+- `frontend/vitest.config.*`;
+- `frontend/vitest.setup.*`;
 - `docs/ai-developer/e2e/**`;
 - `docs/audit/**` validation reports and test reports;
 - test fixtures, golden files, sample projects, and generated test evidence
@@ -300,7 +312,9 @@ Allowed by default:
 Blocked by default:
 
 - product runtime code under `src/scistudio/**`;
-- frontend product code under `frontend/src/**` unless the path is a test file;
+- frontend product code under `frontend/src/**` unless the exact path also
+  matches one of the explicit frontend test-file or test-directory patterns
+  above; a repo-wide `frontend/**` allowlist is not permitted;
 - workflow runtime, block, API, MCP, data model, lineage, scheduler, plugin, or
   product UI implementation files;
 - package/build/dependency changes whose purpose is product behavior rather

--- a/docs/audit/adr-042-addendum4-full-audit.json
+++ b/docs/audit/adr-042-addendum4-full-audit.json
@@ -2,7 +2,7 @@
   "tool": "full_audit",
   "status": "pass",
   "generated_at": "1970-01-01T00:00:00Z",
-  "source_sha": "0a6fec2a3933fcb607f01b4d656e8f71659ca3aedf191123be60d54900c6e783",
+  "source_sha": "667df1e9596bb44156d6949c114a8f26500444ab940826501e0f7ffa7952380e",
   "findings": [],
   "summary": {
     "implemented_children": [
@@ -24,7 +24,7 @@
       "tool": "generate_facts",
       "status": "pass",
       "generated_at": "1970-01-01T00:00:00Z",
-      "source_sha": "0a6fec2a3933fcb607f01b4d656e8f71659ca3aedf191123be60d54900c6e783",
+      "source_sha": "667df1e9596bb44156d6949c114a8f26500444ab940826501e0f7ffa7952380e",
       "findings": [],
       "summary": {
         "facts_path": "docs/facts/generated.yaml",
@@ -93,7 +93,7 @@
     {
       "tool": "frontmatter_lint",
       "status": "pass",
-      "generated_at": "2026-05-22T23:01:39.703668Z",
+      "generated_at": "2026-05-22T23:18:39.992150Z",
       "source_sha": "",
       "findings": [],
       "summary": {
@@ -105,11 +105,11 @@
     {
       "tool": "fact_drift",
       "status": "pass",
-      "generated_at": "2026-05-22T23:01:40.819355Z",
-      "source_sha": "0a6fec2a3933fcb607f01b4d656e8f71659ca3aedf191123be60d54900c6e783",
+      "generated_at": "2026-05-22T23:18:41.127664Z",
+      "source_sha": "667df1e9596bb44156d6949c114a8f26500444ab940826501e0f7ffa7952380e",
       "findings": [],
       "summary": {
-        "docs_checked": 206,
+        "docs_checked": 207,
         "substitutions_checked": 0
       },
       "child_reports": []
@@ -117,28 +117,28 @@
     {
       "tool": "doc_drift",
       "status": "pass",
-      "generated_at": "2026-05-22T23:01:41.076980Z",
-      "source_sha": "0a6fec2a3933fcb607f01b4d656e8f71659ca3aedf191123be60d54900c6e783",
+      "generated_at": "2026-05-22T23:18:41.381816Z",
+      "source_sha": "667df1e9596bb44156d6949c114a8f26500444ab940826501e0f7ffa7952380e",
       "findings": [],
       "summary": {
-        "governed_docs_checked": 67,
-        "modules_checked": 176,
+        "governed_docs_checked": 68,
+        "modules_checked": 177,
         "contracts_checked": 374,
         "files_checked": 485,
         "adr_spec_alignment_findings": 0,
-        "active_specs_checked": 5,
-        "adr_spec_links_checked": 5
+        "active_specs_checked": 6,
+        "adr_spec_links_checked": 6
       },
       "child_reports": []
     },
     {
       "tool": "closure",
       "status": "pass",
-      "generated_at": "2026-05-22T23:01:41.338818Z",
-      "source_sha": "0a6fec2a3933fcb607f01b4d656e8f71659ca3aedf191123be60d54900c6e783",
+      "generated_at": "2026-05-22T23:18:41.651516Z",
+      "source_sha": "667df1e9596bb44156d6949c114a8f26500444ab940826501e0f7ffa7952380e",
       "findings": [],
       "summary": {
-        "governed_docs_checked": 67,
+        "governed_docs_checked": 68,
         "governed_modules": 84,
         "governed_contracts": 220,
         "symbols_checked": 2388,
@@ -150,8 +150,8 @@
     {
       "tool": "signature_drift",
       "status": "pass",
-      "generated_at": "2026-05-22T23:01:41.341708Z",
-      "source_sha": "0a6fec2a3933fcb607f01b4d656e8f71659ca3aedf191123be60d54900c6e783",
+      "generated_at": "2026-05-22T23:18:41.655149Z",
+      "source_sha": "667df1e9596bb44156d6949c114a8f26500444ab940826501e0f7ffa7952380e",
       "findings": [],
       "summary": {
         "expected_signatures_checked": 188,
@@ -165,8 +165,8 @@
     {
       "tool": "architecture_drift",
       "status": "pass",
-      "generated_at": "2026-05-22T23:01:41.349575Z",
-      "source_sha": "0a6fec2a3933fcb607f01b4d656e8f71659ca3aedf191123be60d54900c6e783",
+      "generated_at": "2026-05-22T23:18:41.665183Z",
+      "source_sha": "667df1e9596bb44156d6949c114a8f26500444ab940826501e0f7ffa7952380e",
       "findings": [],
       "summary": {
         "architecture_path": "C:/Users/jiazh/Desktop/workspace/SciStudio-adr042-test-engineer-persona/docs/architecture/ARCHITECTURE.md",
@@ -180,7 +180,7 @@
     {
       "tool": "vulture",
       "status": "pass",
-      "generated_at": "2026-05-22T23:01:41.927102Z",
+      "generated_at": "2026-05-22T23:18:42.352919Z",
       "source_sha": "",
       "findings": [
         {

--- a/docs/audit/adr-042-addendum4-full-audit.json
+++ b/docs/audit/adr-042-addendum4-full-audit.json
@@ -1,0 +1,349 @@
+{
+  "tool": "full_audit",
+  "status": "pass",
+  "generated_at": "1970-01-01T00:00:00Z",
+  "source_sha": "0a6fec2a3933fcb607f01b4d656e8f71659ca3aedf191123be60d54900c6e783",
+  "findings": [],
+  "summary": {
+    "implemented_children": [
+      "generate_facts",
+      "frontmatter_lint",
+      "fact_drift",
+      "doc_drift",
+      "closure",
+      "signature_drift",
+      "architecture_drift",
+      "vulture"
+    ],
+    "deferred_children": [
+      "semantic_dup"
+    ]
+  },
+  "child_reports": [
+    {
+      "tool": "generate_facts",
+      "status": "pass",
+      "generated_at": "1970-01-01T00:00:00Z",
+      "source_sha": "0a6fec2a3933fcb607f01b4d656e8f71659ca3aedf191123be60d54900c6e783",
+      "findings": [],
+      "summary": {
+        "facts_path": "docs/facts/generated.yaml",
+        "generated_in_memory": true,
+        "total_facts": 2576,
+        "facts_by_kind": {
+          "expected-signature": 188,
+          "symbol": 2388
+        },
+        "facts_by_source": {
+          "docs/adr/ADR-001.md": 9,
+          "docs/adr/ADR-002.md": 4,
+          "docs/adr/ADR-003.md": 2,
+          "docs/adr/ADR-004.md": 7,
+          "docs/adr/ADR-005.md": 4,
+          "docs/adr/ADR-006.md": 2,
+          "docs/adr/ADR-007.md": 2,
+          "docs/adr/ADR-008.md": 2,
+          "docs/adr/ADR-009.md": 4,
+          "docs/adr/ADR-011.md": 5,
+          "docs/adr/ADR-012.md": 2,
+          "docs/adr/ADR-013.md": 1,
+          "docs/adr/ADR-014.md": 2,
+          "docs/adr/ADR-015.md": 3,
+          "docs/adr/ADR-017.md": 10,
+          "docs/adr/ADR-018.md": 18,
+          "docs/adr/ADR-019.md": 43,
+          "docs/adr/ADR-020.md": 16,
+          "docs/adr/ADR-021.md": 8,
+          "docs/specs/adr-041-codeblock-v2.md": 12,
+          "docs/specs/adr-042-consistency-tools.md": 13,
+          "docs/specs/adr-043-io-format-capability-registry.md": 19,
+          "griffe": 2388
+        },
+        "facts_by_confidence": {
+          "generated": 2388,
+          "normative": 188
+        },
+        "facts_by_stability": {
+          "stable": 188,
+          "unknown": 2388
+        },
+        "symbol_facts": 2388,
+        "symbols_by_kind": {
+          "attribute": 1288,
+          "class": 260,
+          "function": 623,
+          "module": 217
+        },
+        "top_symbol_packages": {
+          "scistudio.blocks": 751,
+          "scistudio.qa": 491,
+          "scistudio.api": 469,
+          "scistudio.core": 346,
+          "scistudio.engine": 201,
+          "scistudio.workflow": 58,
+          "scistudio.cli": 27,
+          "scistudio.utils": 26,
+          "scistudio.agent_provisioning": 9,
+          "scistudio.testing": 9,
+          "scistudio.ai": 1
+        }
+      },
+      "child_reports": []
+    },
+    {
+      "tool": "frontmatter_lint",
+      "status": "pass",
+      "generated_at": "2026-05-22T23:01:39.703668Z",
+      "source_sha": "",
+      "findings": [],
+      "summary": {
+        "repo_root": "C:/Users/jiazh/Desktop/workspace/SciStudio-adr042-test-engineer-persona",
+        "findings": 0
+      },
+      "child_reports": []
+    },
+    {
+      "tool": "fact_drift",
+      "status": "pass",
+      "generated_at": "2026-05-22T23:01:40.819355Z",
+      "source_sha": "0a6fec2a3933fcb607f01b4d656e8f71659ca3aedf191123be60d54900c6e783",
+      "findings": [],
+      "summary": {
+        "docs_checked": 206,
+        "substitutions_checked": 0
+      },
+      "child_reports": []
+    },
+    {
+      "tool": "doc_drift",
+      "status": "pass",
+      "generated_at": "2026-05-22T23:01:41.076980Z",
+      "source_sha": "0a6fec2a3933fcb607f01b4d656e8f71659ca3aedf191123be60d54900c6e783",
+      "findings": [],
+      "summary": {
+        "governed_docs_checked": 67,
+        "modules_checked": 176,
+        "contracts_checked": 374,
+        "files_checked": 485,
+        "adr_spec_alignment_findings": 0,
+        "active_specs_checked": 5,
+        "adr_spec_links_checked": 5
+      },
+      "child_reports": []
+    },
+    {
+      "tool": "closure",
+      "status": "pass",
+      "generated_at": "2026-05-22T23:01:41.338818Z",
+      "source_sha": "0a6fec2a3933fcb607f01b4d656e8f71659ca3aedf191123be60d54900c6e783",
+      "findings": [],
+      "summary": {
+        "governed_docs_checked": 67,
+        "governed_modules": 84,
+        "governed_contracts": 220,
+        "symbols_checked": 2388,
+        "maintainer_rules": 1,
+        "maintainer_covered_symbols": 21
+      },
+      "child_reports": []
+    },
+    {
+      "tool": "signature_drift",
+      "status": "pass",
+      "generated_at": "2026-05-22T23:01:41.341708Z",
+      "source_sha": "0a6fec2a3933fcb607f01b4d656e8f71659ca3aedf191123be60d54900c6e783",
+      "findings": [],
+      "summary": {
+        "expected_signatures_checked": 188,
+        "expected_model_fields_checked": 0,
+        "expected_cli_commands_checked": 0,
+        "symbols_available": 2388,
+        "cli_facts_available": 0
+      },
+      "child_reports": []
+    },
+    {
+      "tool": "architecture_drift",
+      "status": "pass",
+      "generated_at": "2026-05-22T23:01:41.349575Z",
+      "source_sha": "0a6fec2a3933fcb607f01b4d656e8f71659ca3aedf191123be60d54900c6e783",
+      "findings": [],
+      "summary": {
+        "architecture_path": "C:/Users/jiazh/Desktop/workspace/SciStudio-adr042-test-engineer-persona/docs/architecture/ARCHITECTURE.md",
+        "symbols_available": 2388,
+        "fences_checked": 6,
+        "fences_skipped": 1,
+        "references_checked": 0
+      },
+      "child_reports": []
+    },
+    {
+      "tool": "vulture",
+      "status": "pass",
+      "generated_at": "2026-05-22T23:01:41.927102Z",
+      "source_sha": "",
+      "findings": [
+        {
+          "rule_id": "vulture.dead-code",
+          "severity": "warning",
+          "file": "src/scistudio/blocks/io/loaders/load_data.py",
+          "message": "unused variable 'od' (100% confidence)",
+          "id": "vulture.dead-code",
+          "tool": null,
+          "finding_class": "vulture",
+          "path": "src/scistudio/blocks/io/loaders/load_data.py",
+          "line": 214,
+          "symbol": null,
+          "subject": null,
+          "expected": null,
+          "actual": null,
+          "drift_class": null,
+          "remediation": null,
+          "evidence": {
+            "confidence": 100
+          },
+          "suggested_fix": null,
+          "git_evidence": null,
+          "related_findings": []
+        },
+        {
+          "rule_id": "vulture.dead-code",
+          "severity": "warning",
+          "file": "src/scistudio/blocks/io/loaders/load_data.py",
+          "message": "unused variable 'od' (100% confidence)",
+          "id": "vulture.dead-code",
+          "tool": null,
+          "finding_class": "vulture",
+          "path": "src/scistudio/blocks/io/loaders/load_data.py",
+          "line": 215,
+          "symbol": null,
+          "subject": null,
+          "expected": null,
+          "actual": null,
+          "drift_class": null,
+          "remediation": null,
+          "evidence": {
+            "confidence": 100
+          },
+          "suggested_fix": null,
+          "git_evidence": null,
+          "related_findings": []
+        },
+        {
+          "rule_id": "vulture.dead-code",
+          "severity": "warning",
+          "file": "src/scistudio/core/metadata_store.py",
+          "message": "unused variable 'existing_paths' (100% confidence)",
+          "id": "vulture.dead-code",
+          "tool": null,
+          "finding_class": "vulture",
+          "path": "src/scistudio/core/metadata_store.py",
+          "line": 405,
+          "symbol": null,
+          "subject": null,
+          "expected": null,
+          "actual": null,
+          "drift_class": null,
+          "remediation": null,
+          "evidence": {
+            "confidence": 100
+          },
+          "suggested_fix": null,
+          "git_evidence": null,
+          "related_findings": []
+        },
+        {
+          "rule_id": "vulture.dead-code",
+          "severity": "warning",
+          "file": "src/scistudio/core/units.py",
+          "message": "unused variable 'source_type' (100% confidence)",
+          "id": "vulture.dead-code",
+          "tool": null,
+          "finding_class": "vulture",
+          "path": "src/scistudio/core/units.py",
+          "line": 187,
+          "symbol": null,
+          "subject": null,
+          "expected": null,
+          "actual": null,
+          "drift_class": null,
+          "remediation": null,
+          "evidence": {
+            "confidence": 100
+          },
+          "suggested_fix": null,
+          "git_evidence": null,
+          "related_findings": []
+        },
+        {
+          "rule_id": "vulture.dead-code",
+          "severity": "warning",
+          "file": "src/scistudio/engine/checkpoint.py",
+          "message": "unused variable 'fallback_type_name' (100% confidence)",
+          "id": "vulture.dead-code",
+          "tool": null,
+          "finding_class": "vulture",
+          "path": "src/scistudio/engine/checkpoint.py",
+          "line": 185,
+          "symbol": null,
+          "subject": null,
+          "expected": null,
+          "actual": null,
+          "drift_class": null,
+          "remediation": null,
+          "evidence": {
+            "confidence": 100
+          },
+          "suggested_fix": null,
+          "git_evidence": null,
+          "related_findings": []
+        },
+        {
+          "rule_id": "vulture.dead-code",
+          "severity": "warning",
+          "file": "src/scistudio/utils/logging.py",
+          "message": "unused variable 'json_output' (100% confidence)",
+          "id": "vulture.dead-code",
+          "tool": null,
+          "finding_class": "vulture",
+          "path": "src/scistudio/utils/logging.py",
+          "line": 6,
+          "symbol": null,
+          "subject": null,
+          "expected": null,
+          "actual": null,
+          "drift_class": null,
+          "remediation": null,
+          "evidence": {
+            "confidence": 100
+          },
+          "suggested_fix": null,
+          "git_evidence": null,
+          "related_findings": []
+        }
+      ],
+      "summary": {
+        "pyproject_config_honored": {
+          "ignore_decorators": [
+            "@app.*",
+            "@router.*",
+            "@pytest.fixture"
+          ],
+          "ignore_names": [],
+          "exclude": [
+            "src/scistudio/api/static/**"
+          ]
+        },
+        "paths": [
+          "src/scistudio"
+        ],
+        "min_confidence": 80,
+        "targets_resolved": 1,
+        "allowlist": "vulture_allowlist.py",
+        "total_findings": 6,
+        "vulture_available": true
+      },
+      "child_reports": []
+    }
+  ]
+}

--- a/docs/specs/adr-042-test-engineer-persona.md
+++ b/docs/specs/adr-042-test-engineer-persona.md
@@ -1,0 +1,400 @@
+---
+spec_id: adr-042-test-engineer-persona
+title: "ADR-042 Test Engineer Persona Implementation Specification"
+status: Planned
+feature_branch: docs/issue-1466/adr-042-test-engineer-persona
+created: 2026-05-22
+input: "Owner-approved ADR-042 Addendum 4: add a test_engineer AI persona for test architecture, test design, test additions, runtime validation, and e2e evidence, with a hard no-production-code default and deterministic scope guard."
+owners:
+  - "@jiazhenz026"
+related_adrs:
+  - 42
+related_specs:
+  - adr-042-ai-governance-tools
+  - adr-042-gate-record-sentrux-workflow
+scope:
+  in:
+    - Add `test_engineer` to ADR-042 persona policy and durable gate-record evidence.
+    - Add a required `persona` field to new gate records and require `--persona` in `gate_record start`.
+    - Add a deterministic `test_engineer_scope_guard` that blocks non-test and non-validation-evidence changes for `test_engineer`.
+    - Add canonical test-engineer persona docs, test-engineering specific rules, and runtime skill pointers for supported runtimes.
+    - Update dispatch templates, manager checklist templates, e2e skill metadata, and AI developer routing docs.
+    - Add targeted QA tests for persona policy, gate record persona validation, and test-engineer scope guard behavior.
+  out:
+    - Modifying production runtime, API, frontend, block, scheduler, lineage, plugin, or MCP behavior to fix bugs found by test engineers.
+    - Adding a new task kind.
+    - Changing Sentrux advisory semantics, semantic-duplication semantics, or administrator bypass label names.
+    - Making e2e mandatory for every PR.
+governs:
+  modules:
+    - scistudio.qa.governance
+    - scistudio.qa.governance.gate_record
+  contracts:
+    - scistudio.qa.governance.persona_policy.check
+    - scistudio.qa.governance.test_engineer_scope_guard.check
+    - scistudio.qa.governance.gate_record.models.GateRecord
+    - scistudio.qa.governance.gate_record.cli.main
+    - scistudio.qa.governance.gate_record.validation.validate_gate_record
+  files:
+    - docs/specs/adr-042-test-engineer-persona.md
+    - docs/adr/ADR-042-addendum4.md
+    - docs/ai-developer/rules.md
+    - docs/ai-developer/specific_rules/gated-workflow.md
+    - docs/ai-developer/specific_rules/agent-dispatch.md
+    - docs/ai-developer/specific_rules/test-engineering.md
+    - docs/ai-developer/personas/test-engineer.md
+    - docs/ai-developer/templates/agent-dispatch-prompt-template.md
+    - docs/ai-developer/templates/agent-dispatch-checklist-template.md
+    - docs/ai-developer/checklists/agent-manager-rules-review.md
+    - docs/ai-developer/skills/scistudio-e2e-test/SKILL.md
+    - .agents/skills/test-engineer/SKILL.md
+    - .codex/skills/test-engineer/SKILL.md
+    - .claude/skills/test-engineer/SKILL.md
+    - src/scistudio/qa/governance/persona_policy.py
+    - src/scistudio/qa/governance/test_engineer_scope_guard.py
+    - src/scistudio/qa/governance/gate_record/**
+    - tests/qa/test_persona_policy.py
+    - tests/qa/test_test_engineer_scope_guard.py
+    - tests/qa/test_gate_record.py
+    - tests/qa/test_gate_record_ci.py
+tests:
+  - tests/qa/test_persona_policy.py
+  - tests/qa/test_test_engineer_scope_guard.py
+  - tests/qa/test_gate_record.py
+  - tests/qa/test_gate_record_ci.py
+acceptance_source: adr
+language_source: en
+---
+
+# ADR-042 Test Engineer Persona Implementation Specification
+
+## 1. Change Summary
+
+This spec implements ADR-042 Addendum 4. It adds `test_engineer` as a formal
+AI persona for test architecture, test-layer design, test-case design, test
+additions, runtime validation, and e2e evidence.
+
+The persona is deliberately not a production-code fixer. A `test_engineer`
+may create or update tests, fixtures, e2e scenarios, runtime validation
+harnesses, QA reports, and test evidence. It must not modify product runtime,
+API, frontend, block, scheduler, lineage, plugin, or MCP behavior by default.
+When a test engineer finds a product defect, the expected output is executable
+evidence and a handoff to `implementer`, unless the owner or manager explicitly
+amends scope and persona.
+
+The implementation must also close a current governance gap: committed gate
+records record `task_kind` but not `persona`. Since ADR-042 requires persona
+selection and `persona_policy` validation, new gate records must include a
+durable `persona` field, and `gate_record start` must require `--persona`.
+
+Finally, the implementation adds a deterministic
+`test_engineer_scope_guard`. Prompt-only instructions are insufficient for this
+boundary. When `persona == "test_engineer"`, local hooks and CI must block
+changed files outside the test/evidence allowlist unless an explicit owner or
+manager amendment authorizes the path.
+
+## 2. User Scenarios & Testing
+
+### User Story 1 - Gate records declare the test engineer persona (Priority: P1)
+
+As a maintainer, I need every new gate record to state the agent persona so CI
+can verify that `test_engineer` work is using the correct restrictions.
+
+Why this priority: Without durable persona evidence, `persona_policy` and the
+test-engineer scope guard cannot decide whether the PR should be treated as
+test-engineer work.
+
+Independent Test: Validate gate-record fixtures with missing persona, invalid
+persona, and `test_engineer` persona.
+
+Acceptance Scenarios:
+
+1. Given `gate_record start --persona test_engineer`, when the record is
+   written, then `persona` is stored in the committed JSON.
+2. Given a new gate record without `persona`, when validation runs, then it
+   fails for new-record schema validation.
+3. Given `persona: freeform_agent`, when validation runs, then it fails with
+   an unsupported-persona finding.
+
+### User Story 2 - Test engineers cannot modify production code by default (Priority: P1)
+
+As a repository owner, I need `test_engineer` changes to stay in test,
+validation, and evidence paths unless a manager or owner explicitly amends
+scope.
+
+Why this priority: The persona's value depends on independence from production
+fixes. If it can quietly change product code, it becomes another implementer
+and weakens test evidence.
+
+Independent Test: Run `test_engineer_scope_guard.check` against changed-file
+fixtures for test paths, e2e paths, audit evidence paths, product source paths,
+frontend product paths, QA tooling paths, and amended exceptions.
+
+Acceptance Scenarios:
+
+1. Given `persona: test_engineer` and changed `tests/engine/test_state.py`,
+   when the guard runs, then it passes.
+2. Given `persona: test_engineer` and changed
+   `src/scistudio/engine/scheduler.py`, when the guard runs, then it fails.
+3. Given `persona: test_engineer` and changed
+   `src/scistudio/qa/governance/test_engineer_scope_guard.py` with the path
+   explicitly included in the gate scope, when the guard runs, then it passes.
+4. Given `persona: implementer`, when the same product source path changes,
+   then `test_engineer_scope_guard` does not apply.
+
+### User Story 3 - Persona policy recognizes the fifth persona (Priority: P1)
+
+As an agent manager, I need runtime skill parity and persona validation to
+accept `test_engineer` across supported runtime roots.
+
+Why this priority: ADR-042 requires runtime-agnostic persona policy and skill
+pointers. A new persona is incomplete until `.agents`, `.codex`, and `.claude`
+can all load it at equivalent fidelity.
+
+Independent Test: Run `persona_policy.check` fixtures for `test_engineer`,
+missing test-engineer skill path, wrong required skill, and unsupported runtime
+root.
+
+Acceptance Scenarios:
+
+1. Given `persona: test_engineer` and skill `test-engineer`, when
+   `persona_policy` runs, then it passes.
+2. Given `persona: test_engineer` and skill `implementation-worker`, when
+   `persona_policy` runs, then it fails.
+3. Given `.agents`, `.codex`, and `.claude` test-engineer skills, when
+   skill-pointer checks run, then each points to canonical docs.
+
+### User Story 4 - Managers can dispatch test engineers safely (Priority: P2)
+
+As a manager agent, I need dispatch templates and checklists to express
+test-engineer scope, stop conditions, and evidence expectations.
+
+Why this priority: Test engineers will often be dispatched after specs, audits,
+or implementation PRs. Their prompt must make the production-code boundary and
+evidence outputs explicit.
+
+Independent Test: Review template updates and run documentation checks that
+validate persona references and canonical docs.
+
+Acceptance Scenarios:
+
+1. Given a non-audit dispatch prompt with `Persona: test_engineer`, when a
+   manager fills it, then it contains test/evidence write sets and production
+   code stop conditions.
+2. Given a manager checklist, when a test-engineer row is added, then evidence
+   fields can record tests, runtime validation, e2e reports, and blockers.
+
+### User Story 5 - Runtime validation and e2e are test-engineer evidence (Priority: P2)
+
+As a maintainer, I need runtime validation and e2e artifacts to be treated as
+test-engineer outputs, distinct from static full audit.
+
+Why this priority: ADR-042 full audit proves static governance consistency, not
+runtime behavior. Test engineers need a clear route for executable validation.
+
+Independent Test: Confirm e2e skill metadata includes `test_engineer` and that
+test-engineering docs distinguish static audit from runtime validation.
+
+Acceptance Scenarios:
+
+1. Given an e2e scenario under `docs/ai-developer/e2e/**`, when a test engineer
+   runs it, then the verdict and evidence are valid test artifacts.
+2. Given a runtime validation report under `docs/audit/**`, when the scope
+   guard runs, then the report path is allowed.
+
+### Edge Cases
+
+- A test engineer needs to add a helper under `src/scistudio/qa/**` for the
+  guard or validation tooling itself.
+- A test engineer finds a product bug and writes a failing test that now fails
+  CI until an implementer fixes it.
+- A historical gate record lacks `persona` because it predates this
+  implementation.
+- A frontend file under `frontend/src/**` is a test file, such as
+  `*.test.tsx`, while adjacent product files are blocked.
+- A manager intentionally changes persona from `test_engineer` to
+  `implementer` for a follow-up fix.
+
+## 3. Requirements
+
+### Functional Requirements
+
+- FR-001: `GateRecord` MUST include a `persona` field for new records.
+- FR-002: The accepted persona values MUST be `manager`, `implementer`,
+  `adr_author`, `audit_reviewer`, and `test_engineer`.
+- FR-003: `gate_record start` MUST require `--persona` and write it to the
+  committed record.
+- FR-004: Gate validation MUST reject unsupported persona values.
+- FR-005: The implementation MUST define whether historical records without
+  `persona` are grandfathered, migrated, or rejected only for new PRs.
+- FR-006: `persona_policy.check` MUST accept `test_engineer` only with the
+  required skill `test-engineer`.
+- FR-007: Runtime skill pointers for `.agents`, `.codex`, and `.claude` MUST
+  exist and point to canonical AI developer docs.
+- FR-008: `test_engineer_scope_guard.check` MUST run when
+  `persona == "test_engineer"`.
+- FR-009: `test_engineer_scope_guard.check` MUST not apply when persona is not
+  `test_engineer`.
+- FR-010: The scope guard MUST allow test files, fixtures, e2e scenarios,
+  runtime validation reports, audit evidence, and explicitly scoped QA tooling.
+- FR-011: The scope guard MUST block production source, frontend product code,
+  runtime/API/MCP/block/scheduler/lineage/plugin/UI implementation files, and
+  product-behavior build/package changes by default.
+- FR-012: The scope guard MUST report blocked path, persona, allowlist decision,
+  amendment state, and recommended handoff.
+- FR-013: Local `pre-commit`, local `pre-push`, local `pr-ready`, and CI gate
+  validation MUST invoke the guard or an equivalent shared validator.
+- FR-014: `docs/ai-developer/personas/test-engineer.md` MUST define allowed
+  work, prohibited production-code edits, evidence outputs, and stop
+  conditions.
+- FR-015: `docs/ai-developer/specific_rules/test-engineering.md` MUST define
+  test architecture, test-case design, runtime validation, e2e, evidence, and
+  handoff rules.
+- FR-016: Dispatch templates MUST support `test_engineer` and include the
+  no-production-code stop condition.
+- FR-017: The e2e skill metadata MUST include `test_engineer` as a related
+  persona.
+
+### Key Entities
+
+| Entity | Description | Attributes | Relationships |
+|---|---|---|---|
+| `Persona` | AI role declaration | name, required skill, canonical docs | Stored in `GateRecord`, checked by `persona_policy` |
+| `GateRecord` | Committed AI work evidence | task id, task kind, persona, branch, issues, scope, stages, checks | Read by local hooks and CI |
+| `TestEngineerScopeGuard` | Persona-scoped changed-file validator | persona, changed files, allowed patterns, blocked patterns, amendments | Runs from gate validation paths |
+| `AllowedTestArtifact` | Path class that a test engineer may edit by default | path, class, rationale | Used by scope guard |
+| `BlockedProductionSurface` | Product implementation path blocked for test engineers | path, matched rule, recommended handoff | Reported as findings |
+| `TestEngineerSkill` | Runtime skill pointer | runtime root, skill path, canonical doc links | Checked by persona policy and skill pointer sync |
+| `RuntimeValidationEvidence` | Runtime/e2e proof artifact | command, output path, verdict, logs/screenshots/traces | Recorded in gate checks, audit reports, or e2e scenario files |
+
+## 4. Implementation Plan
+
+### 4.1 Technical Approach
+
+Treat `test_engineer` as a normal ADR-042 persona plus an additional
+persona-scoped file guard.
+
+Gate-record schema and CLI changes make persona durable. Persona policy changes
+make the new role runtime-agnostic. The test-engineer scope guard enforces the
+no-production-code default at the same boundaries already used by ADR-042 gate
+validation: local pre-commit, pre-push, PR readiness, and CI.
+
+The guard should use explicit path classification rather than vague string
+matching. A small helper can classify paths as:
+
+- allowed test artifact;
+- allowed e2e artifact;
+- allowed audit or runtime validation evidence;
+- allowed explicitly scoped QA/governance tooling;
+- blocked production source;
+- blocked frontend product code;
+- blocked product build/package behavior;
+- unknown blocked path.
+
+### 4.2 Affected Files
+
+| File or glob | Action | Rationale |
+|---|---|---|
+| `src/scistudio/qa/governance/gate_record/models.py` | modify | Add `persona` to `GateRecord` |
+| `src/scistudio/qa/governance/gate_record/cli.py` | modify | Require `--persona` on `start` |
+| `src/scistudio/qa/governance/gate_record/stages.py` | modify | Persist persona during record creation |
+| `src/scistudio/qa/governance/gate_record/validation.py` | modify | Validate persona and invoke test-engineer scope guard |
+| `src/scistudio/qa/governance/persona_policy.py` | modify | Accept `test_engineer` and required skill mapping |
+| `src/scistudio/qa/governance/test_engineer_scope_guard.py` | create | Implement persona-scoped path guard |
+| `tests/qa/test_gate_record.py` | modify | Schema and CLI stage fixtures for persona |
+| `tests/qa/test_gate_record_ci.py` | modify | CI validation rejects missing/invalid persona and applies guard |
+| `tests/qa/test_persona_policy.py` | modify | Persona-policy fixtures for `test_engineer` |
+| `tests/qa/test_test_engineer_scope_guard.py` | create | Guard allow/block/amendment coverage |
+| `docs/ai-developer/personas/test-engineer.md` | create | Canonical persona guide |
+| `docs/ai-developer/specific_rules/test-engineering.md` | create | Canonical task rules |
+| `docs/ai-developer/rules.md` | modify | Persona list and routing table |
+| `docs/ai-developer/specific_rules/gated-workflow.md` | modify | Add `--persona` to gate CLI examples |
+| `docs/ai-developer/specific_rules/agent-dispatch.md` | modify | Add test-engineer dispatch and no-production-code rules |
+| `docs/ai-developer/templates/agent-dispatch-prompt-template.md` | modify | Allow `test_engineer` and add stop condition |
+| `docs/ai-developer/templates/agent-dispatch-checklist-template.md` | modify | Add test-engineer evidence expectations |
+| `docs/ai-developer/checklists/agent-manager-rules-review.md` | modify | Register docs and runtime skills |
+| `.agents/skills/test-engineer/SKILL.md` | create | Runtime-neutral pointer |
+| `.codex/skills/test-engineer/SKILL.md` | create | Codex pointer |
+| `.claude/skills/test-engineer/SKILL.md` | create | Claude pointer |
+| `docs/ai-developer/skills/scistudio-e2e-test/SKILL.md` | modify | Add related persona |
+
+### 4.3 Implementation Sequence
+
+1. Add `persona` to gate-record model fixtures and decide historical-record
+   compatibility.
+2. Add `--persona` to `gate_record start` and update all examples/tests.
+3. Update `persona_policy` and runtime skill mappings.
+4. Create `test_engineer_scope_guard` with path-classification unit tests.
+5. Invoke the guard from gate validation paths.
+6. Add canonical persona docs and test-engineering rules.
+7. Add runtime skill pointers.
+8. Update dispatch templates, manager checklist template, e2e metadata, and
+   manager rules review checklist.
+9. Run targeted QA tests and full audit.
+
+### 4.4 Verification Plan
+
+Run:
+
+```bash
+pytest tests/qa/test_persona_policy.py tests/qa/test_test_engineer_scope_guard.py tests/qa/test_gate_record.py tests/qa/test_gate_record_ci.py -q
+```
+
+Run docs/governance checks:
+
+```bash
+python -m scistudio.qa.audit.frontmatter_lint docs/adr/ADR-042-addendum4.md docs/specs/adr-042-test-engineer-persona.md --repo-root . --format text
+python -m scistudio.qa.audit.full_audit --repo-root . --format json --output docs/audit/adr-042-test-engineer-persona-implementation-full-audit.json
+```
+
+If frontend/e2e docs or test files are touched in implementation, also run the
+relevant frontend checks declared by the implementation gate record.
+
+### 4.5 Risks And Rollback
+
+Risks:
+
+- Requiring `persona` may break old gate-record fixtures or in-flight PRs.
+- Path classification can be too strict and block legitimate test tooling.
+- Path classification can be too loose and permit product changes.
+- Dispatch docs may drift from actual guard behavior.
+
+Rollback:
+
+- If the schema change disrupts historical records, grandfather records whose
+  schema version predates the implementation while requiring persona for new
+  records.
+- If the guard blocks legitimate test tooling, add explicit allowlist entries
+  through code and tests, not prompt-only exceptions.
+- If a production-code change is needed, change persona/scope through manager
+  workflow and assign an implementer.
+
+## 5. Success Criteria
+
+### Measurable Outcomes
+
+- SC-001: `gate_record start --persona test_engineer` creates a valid gate
+  record containing `persona: test_engineer`.
+- SC-002: New gate records missing `persona` fail validation.
+- SC-003: `persona_policy.check` accepts `test_engineer` with `test-engineer`
+  skill and rejects mismatched skills.
+- SC-004: `test_engineer_scope_guard` allows representative test, e2e, audit,
+  fixture, and explicitly scoped QA-tooling paths.
+- SC-005: `test_engineer_scope_guard` blocks representative product source,
+  frontend product, runtime/API/MCP/block/scheduler/lineage/plugin/UI paths.
+- SC-006: Gate validation invokes the guard in local and CI validation paths.
+- SC-007: Runtime skill pointers exist for `.agents`, `.codex`, and `.claude`.
+- SC-008: Canonical docs define the no-production-code default and handoff path.
+- SC-009: Targeted QA tests and ADR-042 full audit pass.
+
+## 6. Assumptions
+
+- The owner has accepted ADR-042 Addendum 4.
+- `test_engineer` is a persona, not a task kind.
+- Production fixes remain implementer-owned unless owner or manager explicitly
+  amends scope/persona.
+- Runtime validation and e2e evidence are test artifacts, while ADR-042 full
+  audit remains static governance evidence.
+- Supported runtime roots remain `.agents`, `.codex`, `.claude`, and `.gemini`
+  where present; this implementation must at least keep existing supported
+  repository roots at equivalent fidelity.

--- a/docs/specs/adr-042-test-engineer-persona.md
+++ b/docs/specs/adr-042-test-engineer-persona.md
@@ -28,35 +28,8 @@ scope:
 governs:
   modules:
     - scistudio.qa.governance
-    - scistudio.qa.governance.gate_record
-  contracts:
-    - scistudio.qa.governance.persona_policy.check
-    - scistudio.qa.governance.test_engineer_scope_guard.check
-    - scistudio.qa.governance.gate_record.models.GateRecord
-    - scistudio.qa.governance.gate_record.cli.main
-    - scistudio.qa.governance.gate_record.validation.validate_gate_record
-  files:
-    - docs/specs/adr-042-test-engineer-persona.md
-    - docs/adr/ADR-042-addendum4.md
-    - docs/ai-developer/rules.md
-    - docs/ai-developer/specific_rules/gated-workflow.md
-    - docs/ai-developer/specific_rules/agent-dispatch.md
-    - docs/ai-developer/specific_rules/test-engineering.md
-    - docs/ai-developer/personas/test-engineer.md
-    - docs/ai-developer/templates/agent-dispatch-prompt-template.md
-    - docs/ai-developer/templates/agent-dispatch-checklist-template.md
-    - docs/ai-developer/checklists/agent-manager-rules-review.md
-    - docs/ai-developer/skills/scistudio-e2e-test/SKILL.md
-    - .agents/skills/test-engineer/SKILL.md
-    - .codex/skills/test-engineer/SKILL.md
-    - .claude/skills/test-engineer/SKILL.md
-    - src/scistudio/qa/governance/persona_policy.py
-    - src/scistudio/qa/governance/test_engineer_scope_guard.py
-    - src/scistudio/qa/governance/gate_record/**
-    - tests/qa/test_persona_policy.py
-    - tests/qa/test_test_engineer_scope_guard.py
-    - tests/qa/test_gate_record.py
-    - tests/qa/test_gate_record_ci.py
+  contracts: []
+  files: []
 tests:
   - tests/qa/test_persona_policy.py
   - tests/qa/test_test_engineer_scope_guard.py
@@ -237,22 +210,29 @@ Acceptance Scenarios:
   `test_engineer`.
 - FR-010: The scope guard MUST allow test files, fixtures, e2e scenarios,
   runtime validation reports, audit evidence, and explicitly scoped QA tooling.
-- FR-011: The scope guard MUST block production source, frontend product code,
+- FR-011: Frontend allowlist matching MUST use explicit test and e2e patterns
+  such as `frontend/**/*.test.*`, `frontend/**/*.spec.*`,
+  `frontend/**/__tests__/**`, `frontend/**/__fixtures__/**`,
+  `frontend/**/__mocks__/**`, `frontend/e2e/**`, `frontend/tests/**`,
+  `frontend/test/**`, `frontend/playwright.config.*`,
+  `frontend/vitest.config.*`, and `frontend/vitest.setup.*`. It MUST NOT use
+  `frontend/**` as an allowlist entry.
+- FR-012: The scope guard MUST block production source, frontend product code,
   runtime/API/MCP/block/scheduler/lineage/plugin/UI implementation files, and
   product-behavior build/package changes by default.
-- FR-012: The scope guard MUST report blocked path, persona, allowlist decision,
+- FR-013: The scope guard MUST report blocked path, persona, allowlist decision,
   amendment state, and recommended handoff.
-- FR-013: Local `pre-commit`, local `pre-push`, local `pr-ready`, and CI gate
+- FR-014: Local `pre-commit`, local `pre-push`, local `pr-ready`, and CI gate
   validation MUST invoke the guard or an equivalent shared validator.
-- FR-014: `docs/ai-developer/personas/test-engineer.md` MUST define allowed
+- FR-015: `docs/ai-developer/personas/test-engineer.md` MUST define allowed
   work, prohibited production-code edits, evidence outputs, and stop
   conditions.
-- FR-015: `docs/ai-developer/specific_rules/test-engineering.md` MUST define
+- FR-016: `docs/ai-developer/specific_rules/test-engineering.md` MUST define
   test architecture, test-case design, runtime validation, e2e, evidence, and
   handoff rules.
-- FR-016: Dispatch templates MUST support `test_engineer` and include the
+- FR-017: Dispatch templates MUST support `test_engineer` and include the
   no-production-code stop condition.
-- FR-017: The e2e skill metadata MUST include `test_engineer` as a related
+- FR-018: The e2e skill metadata MUST include `test_engineer` as a related
   persona.
 
 ### Key Entities


### PR DESCRIPTION
## Summary
- Adds ADR-042 Addendum 4 accepting the `test_engineer` AI persona.
- Adds the concrete implementation spec for issue #1467, including gate schema/CLI, persona policy, runtime skill pointers, dispatch docs, e2e metadata, and scope-guard tests.
- Requires `test_engineer_scope_guard` so test-engineer PRs are blocked from non-test/non-validation-evidence changes unless explicitly amended.

## Validation
- `python -m scistudio.qa.audit.frontmatter_lint docs/adr/ADR-042-addendum4.md docs/specs/adr-042-test-engineer-persona.md --repo-root . --format text`
- `python -m scistudio.qa.audit.full_audit --repo-root . --format json --output docs/audit/adr-042-addendum4-full-audit.json`
- `git diff --cached --check`
- `python -m scistudio.qa.governance.gate_record pre-commit --record .workflow/records/1466-adr-042-test-engineer-persona.json --staged`

Gate record: `.workflow/records/1466-adr-042-test-engineer-persona.json`

Closes #1466
Refs #1467