### PR TITLE
[codex] stabilize AI workflow refresh hotfix

### DIFF
--- a/.workflow/records/1484-hotfix-workflow-refresh-restore.json
+++ b/.workflow/records/1484-hotfix-workflow-refresh-restore.json
@@ -1,0 +1,255 @@
+{
+  "admin_labels": [],
+  "amendments": [
+    {
+      "approved_by": null,
+      "exclude": [],
+      "include": [
+        ".workflow/records/**"
+      ],
+      "reason": "Include committed gate-record evidence required by ADR-042 gated workflow."
+    },
+    {
+      "approved_by": null,
+      "exclude": [],
+      "include": [
+        "docs/audit/1484-full-audit.json"
+      ],
+      "reason": "Include ADR-042 full audit evidence artifact required before PR submission."
+    }
+  ],
+  "branch": "hotfix/20260522-owner-guided",
+  "changed_test_paths": [],
+  "check_results": [
+    {
+      "command_or_tool": "PYTHONPATH=src pytest tests/ai/test_mcp_tools_workflow.py tests/ai/agent/mcp/test_tools_workflow_surface.py tests/integration/test_race_agent_write.py tests/integration/test_race_autosave.py tests/integration/test_race_multi_session.py tests/integration/test_race_lineage_restore.py tests/api/test_workflow_changed_event_schema.py tests/ai/test_windows_executable_resolution.py -q --no-cov",
+      "exit_code": 0,
+      "name": "pytest mcp agent and race hotfix suite",
+      "output_path": "43 passed",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "PYTHONPATH=src pytest tests/api/test_workflow_version_vector.py tests/api/test_file_version_vector.py tests/api/routes/test_workflow_watcher_fallback.py tests/api/test_workflow_watcher.py tests/contract/test_adr045_version_vector_contract.py tests/integration/test_race_external_editor.py tests/integration/test_race_agent_write.py tests/integration/test_race_lineage_restore.py tests/api/test_workflow_changed_event_schema.py -q --no-cov",
+      "exit_code": 0,
+      "name": "pytest ADR-045 workflow version matrix",
+      "output_path": "36 passed",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "PYTHONPATH=src pytest tests/core/test_git_engine.py tests/api/test_git_endpoints.py tests/api/test_workflows.py::test_get_workflow_malformed_yaml_returns_debuggable_422 -q --no-cov",
+      "exit_code": 0,
+      "name": "pytest git restore and malformed yaml",
+      "output_path": "91 passed",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "npm test -- --run src/hooks/__tests__/useWebSocket.versionVector.test.ts src/store/__tests__/workflowSlice.versionVector.test.ts src/store/__tests__/tabSlice.versionVector.test.ts",
+      "exit_code": 0,
+      "name": "frontend version-vector tests",
+      "output_path": "3 files passed, 20 tests passed",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "PYTHONPATH=src ruff check src/scistudio/core/versioning/_history_ops.py src/scistudio/api/routes/workflows.py tests/core/test_git_engine.py tests/api/test_git_endpoints.py tests/api/test_workflows.py",
+      "exit_code": 0,
+      "name": "ruff check",
+      "output_path": "All checks passed",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "PYTHONPATH=src ruff format --check src/scistudio/core/versioning/_history_ops.py src/scistudio/api/routes/workflows.py tests/core/test_git_engine.py tests/api/test_git_endpoints.py tests/api/test_workflows.py",
+      "exit_code": 0,
+      "name": "ruff format check",
+      "output_path": "5 files already formatted",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "git diff --check",
+      "exit_code": 0,
+      "name": "git diff whitespace",
+      "output_path": "no whitespace errors",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "PYTHONPATH=src ruff check src/scistudio/api/runtime/__init__.py src/scistudio/api/routes/workflows.py src/scistudio/ai/agent/mcp/tools_workflow/write.py",
+      "exit_code": 0,
+      "name": "ruff targeted hotfix files",
+      "output_path": "All checks passed",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "PYTHONPATH=src pytest tests/api/test_workflow_version_vector.py tests/api/test_file_version_vector.py tests/api/routes/test_workflow_watcher_fallback.py tests/api/test_workflow_watcher.py tests/contract/test_adr045_version_vector_contract.py tests/integration/test_race_agent_write.py tests/ai/test_mcp_tools_workflow.py -q --no-cov",
+      "exit_code": 0,
+      "name": "targeted workflow refresh regression tests",
+      "output_path": "49 passed; 1 deprecation warning",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json --out .tmp-semantic-dup-1485-local.md --json-out .tmp-semantic-dup-1485-local.json",
+      "exit_code": 0,
+      "name": "semantic duplication ratchet",
+      "output_path": "clusters=92 duplicate_loc=5266 duplicate_pct=14.61 max_cluster_size=10",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    }
+  ],
+  "commit": {
+    "gate_record_path": ".workflow/records/1484-hotfix-workflow-refresh-restore.json",
+    "shas": [
+      "b41e51fce883fb3f45f09e61de5ebca55f00c182"
+    ],
+    "trailers": {}
+  },
+  "docs_landing": {
+    "changelog": {
+      "not_applicable": true,
+      "rationale": "Hotfix behavior is covered by PR summary and ADR-039 restore semantics update; no product changelog file is maintained for this owner-guided hotfix."
+    },
+    "checklist": {
+      "not_applicable": true,
+      "rationale": "No standalone planning checklist was used; scope and checks are captured in this gate record."
+    },
+    "docs": {
+      "not_applicable": true,
+      "rationale": "Docs impact is limited to ADR-039 restore semantics, which is updated in docs/adr/ADR-039.md; malformed YAML UX is intentionally surfaced through existing log notifications per owner decision."
+    }
+  },
+  "full_audit": {
+    "blocks_merge": false,
+    "command": "PYTHONPATH=src python -m scistudio.qa.audit.full_audit --repo-root . --format json --output docs/audit/1484-full-audit.json",
+    "exit_code": 0,
+    "known_debt": [],
+    "output_path": "docs/audit/1484-full-audit.json",
+    "status": "pass",
+    "summary": {},
+    "unclassified_failures": []
+  },
+  "governance_touch": false,
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1484,
+      "url": "https://github.com/zjzcpj/SciStudio/issues/1484"
+    }
+  ],
+  "owner_directive": "Owner-guided hotfix for Codex MCP startup, workflow refresh/version-vector regressions, git restore semantics, and malformed YAML UX.",
+  "persona": "implementer",
+  "planned_files": [
+    "src/scistudio/ai/agent/terminal.py",
+    "src/scistudio/ai/agent/mcp/tools_workflow/write.py",
+    "src/scistudio/api/runtime/__init__.py",
+    "src/scistudio/api/routes/workflow_watcher.py",
+    "src/scistudio/api/routes/workflows.py",
+    "src/scistudio/core/versioning/_history_ops.py",
+    "tests/ai/test_mcp_tools_workflow.py",
+    "tests/ai/test_windows_executable_resolution.py",
+    "tests/api/test_file_version_vector.py",
+    "tests/api/test_git_endpoints.py",
+    "tests/api/test_workflow_version_vector.py",
+    "tests/api/test_workflows.py",
+    "tests/core/test_git_engine.py",
+    "tests/integration/test_race_agent_write.py"
+  ],
+  "pull_request": {
+    "body_closes_issues": [
+      1484
+    ],
+    "number": null,
+    "url": "https://github.com/zjzcpj/SciStudio/pull/1485"
+  },
+  "record_path": ".workflow/records/1484-hotfix-workflow-refresh-restore.json",
+  "required_checks": [
+    "pytest targeted backend",
+    "pytest ADR-045 race matrix",
+    "frontend npm version-vector tests",
+    "ruff check",
+    "ruff format --check",
+    "git diff --check"
+  ],
+  "schema_version": "1",
+  "scope": {
+    "exclude": [
+      "frontend/src/api/static/**"
+    ],
+    "include": [
+      "src/scistudio/ai/agent/**",
+      "src/scistudio/api/**",
+      "src/scistudio/core/versioning/**",
+      "tests/**",
+      "docs/adr/ADR-039.md"
+    ]
+  },
+  "sentrux": {
+    "command_or_tool": "sentrux check .",
+    "mode": "free-tier",
+    "name": "sentrux.free_tier",
+    "output_path": "Sentrux CLI not installed in this local environment; CI/workflow gate remains authoritative.",
+    "pro_required": false,
+    "quality_signal": null,
+    "rules_checked": null,
+    "status": "skipped",
+    "summary": {},
+    "thresholds": {},
+    "total_rules_defined": null
+  },
+  "stages": [
+    {
+      "completed_at": null,
+      "stage": "scope_and_issue",
+      "status": "done",
+      "summary": null
+    },
+    {
+      "completed_at": null,
+      "stage": "plan",
+      "status": "done",
+      "summary": null
+    },
+    {
+      "completed_at": null,
+      "stage": "implement",
+      "status": "done",
+      "summary": null
+    },
+    {
+      "completed_at": null,
+      "stage": "update_docs",
+      "status": "done",
+      "summary": null
+    },
+    {
+      "completed_at": null,
+      "stage": "test_and_checks",
+      "status": "done",
+      "summary": null
+    },
+    {
+      "completed_at": null,
+      "stage": "commit_and_submit_pr",
+      "status": "done",
+      "summary": null
+    }
+  ],
+  "task_id": "1484-hotfix-workflow-refresh-restore",
+  "task_kind": "hotfix"
+}

--- a/docs/adr/ADR-039.md
+++ b/docs/adr/ADR-039.md
@@ -461,7 +461,7 @@ Filter state lives in `gitSlice` so the dropdown choice persists across panel re
 
 #### 3.6 Restore semantics
 
-"Restore this version" defaults to **`git checkout <sha> -- <files>`** restoring listed files to the working tree without changing HEAD. This is the safer mode: user can keep editing, see what the old version looked like, decide whether to commit.
+"Restore this version" defaults to **`git restore --source=<sha> --worktree -- <files>`** restoring listed files to the working tree without changing HEAD or staging the restored content. If the target commit does not contain a listed file, the working tree is restored to that commit's state by deleting the file. This is the safer mode: user can keep editing, see what the old version looked like, decide whether to commit.
 
 Optional "Hard restore (move HEAD)" advanced action does `git reset --hard <sha>` — gated behind a confirmation dialog explaining the consequences. v1 surfaces the soft restore prominently; hard restore is deferred or hidden until user feedback shows demand.
 
@@ -812,7 +812,7 @@ Treat the rows below as authoritative until the next promotion of ADR-039. The o
 
 Lines 463 cancellation: the paragraph "If the working tree is dirty during restore, SciStudio auto-stashes (`git stash push -m "auto-stash before restore"`) first, restores, and prompts: 'Your unsaved changes are stashed. Apply them? [Apply now / Keep stashed / Discard]'" is **superseded** by:
 
-> If the working tree is dirty during restore, SciStudio auto-commits the dirty content first via `git_engine.commit(prefix="auto", message=f"pre-restore @ {iso_ts} (target={short_sha})")`. The new commit lands on the current branch as a recoverable point; the subsequent `git checkout <commit_sha> -- <files>` overlays the historical content as dirty changes the user can keep or revert. The response payload no longer carries `stash_id`; it carries `auto_commit_sha` (string when an auto-commit was made, otherwise null/absent).
+> If the working tree is dirty during restore, SciStudio auto-commits the dirty content first via `git_engine.commit(prefix="auto", message=f"pre-restore @ {iso_ts} (target={short_sha})")`. The new commit lands on the current branch as a recoverable point; the subsequent `git restore --source=<commit_sha> --worktree -- <files>` overlays the historical content as working-tree changes the user can keep or revert. If the target commit does not contain a listed file, the overlay deletes that file from the working tree. The response payload no longer carries `stash_id`; it carries `auto_commit_sha` (string when an auto-commit was made, otherwise null/absent).
 
 The hotfix #997 skip-if-unchanged short-circuit (`_files_unchanged_vs_commit`) is **retained** — it correctly prevents creating empty pre-restore commits when the target files already match the working tree.
 

--- a/docs/audit/1484-full-audit.json
+++ b/docs/audit/1484-full-audit.json
@@ -1,0 +1,349 @@
+{
+  "tool": "full_audit",
+  "status": "pass",
+  "generated_at": "1970-01-01T00:00:00Z",
+  "source_sha": "9a89105d0bdbddcd8d0610b71acace21637cbf9bbe64b20839b73d0f2a2ffa8d",
+  "findings": [],
+  "summary": {
+    "implemented_children": [
+      "generate_facts",
+      "frontmatter_lint",
+      "fact_drift",
+      "doc_drift",
+      "closure",
+      "signature_drift",
+      "architecture_drift",
+      "vulture"
+    ],
+    "deferred_children": [
+      "semantic_dup"
+    ]
+  },
+  "child_reports": [
+    {
+      "tool": "generate_facts",
+      "status": "pass",
+      "generated_at": "1970-01-01T00:00:00Z",
+      "source_sha": "9a89105d0bdbddcd8d0610b71acace21637cbf9bbe64b20839b73d0f2a2ffa8d",
+      "findings": [],
+      "summary": {
+        "facts_path": "docs/facts/generated.yaml",
+        "generated_in_memory": true,
+        "total_facts": 2585,
+        "facts_by_kind": {
+          "expected-signature": 188,
+          "symbol": 2397
+        },
+        "facts_by_source": {
+          "docs/adr/ADR-001.md": 9,
+          "docs/adr/ADR-002.md": 4,
+          "docs/adr/ADR-003.md": 2,
+          "docs/adr/ADR-004.md": 7,
+          "docs/adr/ADR-005.md": 4,
+          "docs/adr/ADR-006.md": 2,
+          "docs/adr/ADR-007.md": 2,
+          "docs/adr/ADR-008.md": 2,
+          "docs/adr/ADR-009.md": 4,
+          "docs/adr/ADR-011.md": 5,
+          "docs/adr/ADR-012.md": 2,
+          "docs/adr/ADR-013.md": 1,
+          "docs/adr/ADR-014.md": 2,
+          "docs/adr/ADR-015.md": 3,
+          "docs/adr/ADR-017.md": 10,
+          "docs/adr/ADR-018.md": 18,
+          "docs/adr/ADR-019.md": 43,
+          "docs/adr/ADR-020.md": 16,
+          "docs/adr/ADR-021.md": 8,
+          "docs/specs/adr-041-codeblock-v2.md": 12,
+          "docs/specs/adr-042-consistency-tools.md": 13,
+          "docs/specs/adr-043-io-format-capability-registry.md": 19,
+          "griffe": 2397
+        },
+        "facts_by_confidence": {
+          "generated": 2397,
+          "normative": 188
+        },
+        "facts_by_stability": {
+          "stable": 188,
+          "unknown": 2397
+        },
+        "symbol_facts": 2397,
+        "symbols_by_kind": {
+          "attribute": 1313,
+          "class": 260,
+          "function": 606,
+          "module": 218
+        },
+        "top_symbol_packages": {
+          "scistudio.blocks": 747,
+          "scistudio.qa": 504,
+          "scistudio.api": 470,
+          "scistudio.core": 345,
+          "scistudio.engine": 201,
+          "scistudio.workflow": 58,
+          "scistudio.cli": 27,
+          "scistudio.utils": 26,
+          "scistudio.agent_provisioning": 9,
+          "scistudio.testing": 9,
+          "scistudio.ai": 1
+        }
+      },
+      "child_reports": []
+    },
+    {
+      "tool": "frontmatter_lint",
+      "status": "pass",
+      "generated_at": "2026-05-23T03:02:58.370335Z",
+      "source_sha": "",
+      "findings": [],
+      "summary": {
+        "repo_root": "C:/Users/jiazh/Desktop/workspace/SciStudio-hotfix-20260522",
+        "findings": 0
+      },
+      "child_reports": []
+    },
+    {
+      "tool": "fact_drift",
+      "status": "pass",
+      "generated_at": "2026-05-23T03:02:59.586522Z",
+      "source_sha": "9a89105d0bdbddcd8d0610b71acace21637cbf9bbe64b20839b73d0f2a2ffa8d",
+      "findings": [],
+      "summary": {
+        "docs_checked": 220,
+        "substitutions_checked": 0
+      },
+      "child_reports": []
+    },
+    {
+      "tool": "doc_drift",
+      "status": "pass",
+      "generated_at": "2026-05-23T03:03:01.772655Z",
+      "source_sha": "9a89105d0bdbddcd8d0610b71acace21637cbf9bbe64b20839b73d0f2a2ffa8d",
+      "findings": [],
+      "summary": {
+        "governed_docs_checked": 71,
+        "modules_checked": 180,
+        "contracts_checked": 385,
+        "files_checked": 505,
+        "adr_spec_alignment_findings": 0,
+        "active_specs_checked": 6,
+        "adr_spec_links_checked": 6
+      },
+      "child_reports": []
+    },
+    {
+      "tool": "closure",
+      "status": "pass",
+      "generated_at": "2026-05-23T03:03:03.542256Z",
+      "source_sha": "9a89105d0bdbddcd8d0610b71acace21637cbf9bbe64b20839b73d0f2a2ffa8d",
+      "findings": [],
+      "summary": {
+        "governed_docs_checked": 71,
+        "governed_modules": 85,
+        "governed_contracts": 222,
+        "symbols_checked": 2397,
+        "maintainer_rules": 1,
+        "maintainer_covered_symbols": 21
+      },
+      "child_reports": []
+    },
+    {
+      "tool": "signature_drift",
+      "status": "pass",
+      "generated_at": "2026-05-23T03:03:03.545536Z",
+      "source_sha": "9a89105d0bdbddcd8d0610b71acace21637cbf9bbe64b20839b73d0f2a2ffa8d",
+      "findings": [],
+      "summary": {
+        "expected_signatures_checked": 188,
+        "expected_model_fields_checked": 0,
+        "expected_cli_commands_checked": 0,
+        "symbols_available": 2397,
+        "cli_facts_available": 0
+      },
+      "child_reports": []
+    },
+    {
+      "tool": "architecture_drift",
+      "status": "pass",
+      "generated_at": "2026-05-23T03:03:03.562779Z",
+      "source_sha": "9a89105d0bdbddcd8d0610b71acace21637cbf9bbe64b20839b73d0f2a2ffa8d",
+      "findings": [],
+      "summary": {
+        "architecture_path": "C:/Users/jiazh/Desktop/workspace/SciStudio-hotfix-20260522/docs/architecture/ARCHITECTURE.md",
+        "symbols_available": 2397,
+        "fences_checked": 6,
+        "fences_skipped": 1,
+        "references_checked": 0
+      },
+      "child_reports": []
+    },
+    {
+      "tool": "vulture",
+      "status": "pass",
+      "generated_at": "2026-05-23T03:03:04.215813Z",
+      "source_sha": "",
+      "findings": [
+        {
+          "rule_id": "vulture.dead-code",
+          "severity": "warning",
+          "file": "src/scistudio/blocks/io/loaders/load_data.py",
+          "message": "unused variable 'od' (100% confidence)",
+          "id": "vulture.dead-code",
+          "tool": null,
+          "finding_class": "vulture",
+          "path": "src/scistudio/blocks/io/loaders/load_data.py",
+          "line": 214,
+          "symbol": null,
+          "subject": null,
+          "expected": null,
+          "actual": null,
+          "drift_class": null,
+          "remediation": null,
+          "evidence": {
+            "confidence": 100
+          },
+          "suggested_fix": null,
+          "git_evidence": null,
+          "related_findings": []
+        },
+        {
+          "rule_id": "vulture.dead-code",
+          "severity": "warning",
+          "file": "src/scistudio/blocks/io/loaders/load_data.py",
+          "message": "unused variable 'od' (100% confidence)",
+          "id": "vulture.dead-code",
+          "tool": null,
+          "finding_class": "vulture",
+          "path": "src/scistudio/blocks/io/loaders/load_data.py",
+          "line": 215,
+          "symbol": null,
+          "subject": null,
+          "expected": null,
+          "actual": null,
+          "drift_class": null,
+          "remediation": null,
+          "evidence": {
+            "confidence": 100
+          },
+          "suggested_fix": null,
+          "git_evidence": null,
+          "related_findings": []
+        },
+        {
+          "rule_id": "vulture.dead-code",
+          "severity": "warning",
+          "file": "src/scistudio/core/metadata_store.py",
+          "message": "unused variable 'existing_paths' (100% confidence)",
+          "id": "vulture.dead-code",
+          "tool": null,
+          "finding_class": "vulture",
+          "path": "src/scistudio/core/metadata_store.py",
+          "line": 405,
+          "symbol": null,
+          "subject": null,
+          "expected": null,
+          "actual": null,
+          "drift_class": null,
+          "remediation": null,
+          "evidence": {
+            "confidence": 100
+          },
+          "suggested_fix": null,
+          "git_evidence": null,
+          "related_findings": []
+        },
+        {
+          "rule_id": "vulture.dead-code",
+          "severity": "warning",
+          "file": "src/scistudio/core/units.py",
+          "message": "unused variable 'source_type' (100% confidence)",
+          "id": "vulture.dead-code",
+          "tool": null,
+          "finding_class": "vulture",
+          "path": "src/scistudio/core/units.py",
+          "line": 187,
+          "symbol": null,
+          "subject": null,
+          "expected": null,
+          "actual": null,
+          "drift_class": null,
+          "remediation": null,
+          "evidence": {
+            "confidence": 100
+          },
+          "suggested_fix": null,
+          "git_evidence": null,
+          "related_findings": []
+        },
+        {
+          "rule_id": "vulture.dead-code",
+          "severity": "warning",
+          "file": "src/scistudio/engine/checkpoint.py",
+          "message": "unused variable 'fallback_type_name' (100% confidence)",
+          "id": "vulture.dead-code",
+          "tool": null,
+          "finding_class": "vulture",
+          "path": "src/scistudio/engine/checkpoint.py",
+          "line": 185,
+          "symbol": null,
+          "subject": null,
+          "expected": null,
+          "actual": null,
+          "drift_class": null,
+          "remediation": null,
+          "evidence": {
+            "confidence": 100
+          },
+          "suggested_fix": null,
+          "git_evidence": null,
+          "related_findings": []
+        },
+        {
+          "rule_id": "vulture.dead-code",
+          "severity": "warning",
+          "file": "src/scistudio/utils/logging.py",
+          "message": "unused variable 'json_output' (100% confidence)",
+          "id": "vulture.dead-code",
+          "tool": null,
+          "finding_class": "vulture",
+          "path": "src/scistudio/utils/logging.py",
+          "line": 6,
+          "symbol": null,
+          "subject": null,
+          "expected": null,
+          "actual": null,
+          "drift_class": null,
+          "remediation": null,
+          "evidence": {
+            "confidence": 100
+          },
+          "suggested_fix": null,
+          "git_evidence": null,
+          "related_findings": []
+        }
+      ],
+      "summary": {
+        "pyproject_config_honored": {
+          "ignore_decorators": [
+            "@app.*",
+            "@router.*",
+            "@pytest.fixture"
+          ],
+          "ignore_names": [],
+          "exclude": [
+            "src/scistudio/api/static/**"
+          ]
+        },
+        "paths": [
+          "src/scistudio"
+        ],
+        "min_confidence": 80,
+        "targets_resolved": 1,
+        "allowlist": "vulture_allowlist.py",
+        "total_findings": 6,
+        "vulture_available": true
+      },
+      "child_reports": []
+    }
+  ]
+}

--- a/src/scistudio/ai/agent/mcp/tools_workflow/write.py
+++ b/src/scistudio/ai/agent/mcp/tools_workflow/write.py
@@ -8,8 +8,11 @@ umbrella #1427). No behavior change.
 
 from __future__ import annotations
 
+import contextlib
 import json
 import logging
+from pathlib import Path
+from typing import Any
 
 import yaml as yaml_module
 from filelock import FileLock, Timeout
@@ -32,6 +35,7 @@ from scistudio.ai.agent.mcp.tools_workflow._models import (
     RunWorkflowResult,
     WriteWorkflowResult,
 )
+from scistudio.engine.events import WORKFLOW_CHANGED, EngineEvent
 
 logger = logging.getLogger(__name__)
 
@@ -80,9 +84,26 @@ async def write_workflow(
 
     p = _resolve_project_path(path)
     lock_path = str(p) + ".lock"
+    version_context = _workflow_change_context()
+    version: int | None = None
     try:
         with FileLock(lock_path, timeout=_LOCK_TIMEOUT_SECONDS):
             old = p.read_text(encoding="utf-8") if p.exists() else ""
+            existed = p.exists()
+            if version_context is not None:
+                _, runtime = version_context
+                version = runtime.bump_workflow_version(p.stem)
+                mark_entity_write = getattr(runtime, "mark_entity_first_party_write", None)
+                if mark_entity_write is not None:
+                    with contextlib.suppress(TypeError):
+                        mark_entity_write(
+                            "workflow",
+                            p.stem,
+                            version,
+                            path=p,
+                            kind="modified" if existed else "created",
+                            pending=True,
+                        )
             bytes_written = _atomic_write_text(p, yaml)
             summary = _diff_summary(old, yaml)
     except Timeout as exc:
@@ -90,8 +111,77 @@ async def write_workflow(
             f"write_workflow: could not acquire lock for {p} within {_LOCK_TIMEOUT_SECONDS}s (someone else is editing?)"
         ) from exc
 
+    await _emit_agent_workflow_changed(
+        workflow_id=p.stem,
+        path=p,
+        kind="modified" if existed else "created",
+        version=version,
+        version_context=version_context,
+    )
     logger.info("write_workflow: wrote %s (%s)", p, summary)
     return WriteWorkflowResult(path=str(p), bytes_written=bytes_written, diff_summary=summary)
+
+
+def _workflow_change_context() -> tuple[Any, Any] | None:
+    context = _get_workflow_runtime()
+    event_bus = getattr(context, "event_bus", None)
+    runtime = getattr(event_bus, "runtime", context)
+    if event_bus is None or not all(
+        hasattr(runtime, name)
+        for name in (
+            "bump_workflow_version",
+            "mark_workflow_first_party_write",
+            "versioned_change_payload",
+        )
+    ):
+        return None
+    return event_bus, runtime
+
+
+async def _emit_agent_workflow_changed(
+    *,
+    workflow_id: str,
+    path: Any,
+    kind: str,
+    version: int | None = None,
+    version_context: tuple[Any, Any] | None = None,
+) -> None:
+    """Emit ADR-045 versioned workflow change events for MCP writes."""
+    if version_context is None:
+        version_context = _workflow_change_context()
+    if version_context is None:
+        return
+    event_bus, runtime = version_context
+
+    resolved = Path(path)
+    if version is None:
+        version = runtime.bump_workflow_version(workflow_id)
+    runtime.mark_workflow_first_party_write(workflow_id, version, path=resolved, kind=kind)
+    try:
+        from scistudio.api.routes.workflow_watcher import mark_self_write
+
+        mark_self_write(resolved)
+    except Exception:
+        logger.debug("workflow_watcher: mark_self_write failed for %s", resolved, exc_info=True)
+
+    project_dir = getattr(runtime, "project_dir", None)
+    relative_path = str(resolved).replace("\\", "/")
+    if project_dir is not None:
+        with contextlib.suppress(ValueError):
+            relative_path = str(resolved.resolve().relative_to(Path(project_dir).resolve())).replace("\\", "/")
+
+    payload = runtime.versioned_change_payload(
+        entity_class="workflow",
+        entity_id=workflow_id,
+        version=version,
+        source="agent",
+        source_id=None,
+        kind=kind,
+        workflow_id=workflow_id,
+        path=relative_path,
+        changed_by="mcp.write_workflow",
+    )
+    await event_bus.emit(EngineEvent(event_type=WORKFLOW_CHANGED, data=payload))
 
 
 # ---------------------------------------------------------------------------

--- a/src/scistudio/ai/agent/terminal.py
+++ b/src/scistudio/ai/agent/terminal.py
@@ -55,6 +55,7 @@ macOS notes (verified separately by user):
 from __future__ import annotations
 
 import contextlib
+import json
 import logging
 import os
 import shutil
@@ -553,7 +554,7 @@ def spawn_codex(
     """Spawn ``codex`` inside a PTY, anchored at ``project_dir``.
 
     Argv:
-        ``["codex"]`` plus
+        ``["codex", "-c", "mcp_servers.scistudio...."]`` plus
         ``--dangerously-bypass-approvals-and-sandbox`` when
         ``dangerous``.
 
@@ -562,9 +563,10 @@ def spawn_codex(
     ``.codex/config.toml`` plus ``~/.codex/config.toml``. ADR-040 §3.7
     auto-provisions ``<project>/.codex/config.toml`` with the SciStudio MCP
     server entry; the user's ``scistudio install --target codex`` populates
-    the user-scope ``~/.codex/config.toml`` as a fallback. Both paths
-    converge on the same ``[mcp_servers.scistudio]`` block rendered by
-    ``scistudio.cli.install._render_codex_block``.
+    the user-scope ``~/.codex/config.toml`` as a fallback. The embedded GUI
+    path also injects the same ``mcp_servers.scistudio`` values via Codex
+    ``-c`` overrides so stale user config or project-scope loading drift
+    cannot select the wrong bridge.
 
     Codex also does not accept ``--append-system-prompt``; the SciStudio
     skill is picked up via the project-scope ``.agents/skills/scistudio/``
@@ -581,7 +583,10 @@ def spawn_codex(
     if _spawn_argv is not None:
         argv = list(_spawn_argv)
     else:
-        argv = [resolve_windows_executable("codex") or "codex"]
+        argv = [
+            resolve_windows_executable("codex") or "codex",
+            *_codex_mcp_config_overrides(project_dir),
+        ]
         if dangerous:
             argv.append("--dangerously-bypass-approvals-and-sandbox")
 
@@ -593,3 +598,40 @@ def spawn_codex(
         cleanup_paths=[],
         extra_env=extra_env,
     )
+
+
+def _codex_mcp_config_overrides(project_dir: Path) -> list[str]:
+    """Render Codex ``-c`` overrides for the SciStudio MCP server.
+
+    Codex project-scope config loading has changed across 2026 CLI builds,
+    and stale user-scope config can point at the wrong Python interpreter.
+    The embedded SciStudio chat owns the process spawn, so pass the current
+    project MCP entry explicitly just like ``spawn_claude`` passes
+    ``--mcp-config``.
+    """
+    from scistudio.cli.install import MCP_SERVER_NAME, _mcp_entry_payload
+
+    entry = _mcp_entry_payload(project_dir)
+    command = entry["command"]
+    args = entry["args"]
+    env = entry.get("env")
+
+    if not isinstance(command, str):
+        raise TypeError("Codex MCP command must be a string")
+    if not isinstance(args, list) or not all(isinstance(arg, str) for arg in args):
+        raise TypeError("Codex MCP args must be a list of strings")
+    if not isinstance(env, dict) or not all(
+        isinstance(key, str) and isinstance(value, str) for key, value in env.items()
+    ):
+        raise TypeError("Codex MCP env must be a string map")
+
+    env_literal = "{" + ",".join(f"{key}={json.dumps(value)}" for key, value in env.items()) + "}"
+    prefix = f"mcp_servers.{MCP_SERVER_NAME}"
+    return [
+        "-c",
+        f"{prefix}.command={json.dumps(command)}",
+        "-c",
+        f"{prefix}.args={json.dumps(args)}",
+        "-c",
+        f"{prefix}.env={env_literal}",
+    ]

--- a/src/scistudio/api/routes/workflow_watcher.py
+++ b/src/scistudio/api/routes/workflow_watcher.py
@@ -316,14 +316,18 @@ class _WorkflowFileHandler(FileSystemEventHandler):
                 disk_mtime = int(path.stat().st_mtime_ns)
             except OSError:
                 disk_mtime = 0
-            cached_version = self._runtime.current_workflow_version(workflow_id)
-            if disk_mtime and disk_mtime <= cached_version:
+            cached_disk_version = self._runtime.current_entity_disk_version(
+                _WORKFLOW_ENTITY_CLASS,
+                workflow_id,
+                path=path,
+            )
+            if disk_mtime and disk_mtime <= cached_disk_version:
                 logger.debug(
                     "workflow_watcher: skipping delayed-echo workflow event %s %s (disk %d <= cached %d)",
                     kind,
                     path,
                     disk_mtime,
-                    cached_version,
+                    cached_disk_version,
                 )
                 return
             version = self._runtime.bump_workflow_version(workflow_id)
@@ -442,14 +446,18 @@ class _ProjectFileHandler(_WorkflowFileHandler):
                 disk_mtime = int(path.stat().st_mtime_ns)
             except OSError:
                 disk_mtime = 0
-            cached_version = self._runtime.current_entity_version(FILE_ENTITY_CLASS, entity_id, path=path)
-            if disk_mtime and disk_mtime <= cached_version:
+            cached_disk_version = self._runtime.current_entity_disk_version(
+                FILE_ENTITY_CLASS,
+                entity_id,
+                path=path,
+            )
+            if disk_mtime and disk_mtime <= cached_disk_version:
                 logger.debug(
                     "workflow_watcher: skipping delayed-echo file event %s %s (disk %d <= cached %d)",
                     kind,
                     path,
                     disk_mtime,
-                    cached_version,
+                    cached_disk_version,
                 )
                 return
             version = self._runtime.bump_entity_version(FILE_ENTITY_CLASS, entity_id, path=path)

--- a/src/scistudio/api/routes/workflows.py
+++ b/src/scistudio/api/routes/workflows.py
@@ -2,16 +2,19 @@
 
 from __future__ import annotations
 
+import contextlib
 import logging
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Annotated, Any
 
+import yaml
 from fastapi import APIRouter, Depends, HTTPException, Request, UploadFile
 from pydantic import BaseModel, Field
 
 from scistudio.api.deps import get_runtime
-from scistudio.api.runtime import WORKFLOW_ENTITY_CLASS, ApiRuntime
+from scistudio.api.routes import workflow_watcher
+from scistudio.api.runtime import WORKFLOW_ENTITY_CLASS, ApiRuntime, WorkflowRun
 from scistudio.api.schemas import (
     CancelPropagationResponse,
     ExecuteFromRequest,
@@ -29,6 +32,28 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/workflows", tags=["workflows"])
 RuntimeDep = Annotated[ApiRuntime, Depends(get_runtime)]
 _API_SOURCES = {"canvas", "agent", "gitRestore", "import", "external"}
+
+
+def _yaml_error_detail(workflow_id: str, exc: yaml.YAMLError) -> dict[str, Any]:
+    mark = getattr(exc, "problem_mark", None)
+    problem = getattr(exc, "problem", None)
+    location = ""
+    if mark is not None:
+        location = f" at line {int(mark.line) + 1}, column {int(mark.column) + 1}"
+    problem_text = f": {problem}" if problem else ""
+    detail: dict[str, Any] = {
+        "message": f"Workflow '{workflow_id}' on disk is not valid YAML{location}{problem_text}.",
+        "error": str(exc),
+    }
+    if mark is not None:
+        detail["line"] = int(mark.line) + 1
+        detail["column"] = int(mark.column) + 1
+    if problem:
+        detail["problem"] = str(problem)
+    context = getattr(exc, "context", None)
+    if context:
+        detail["context"] = str(context)
+    return detail
 
 
 class VersionedWorkflowResponse(BaseModel):
@@ -51,26 +76,19 @@ class VersionedWorkflowResponse(BaseModel):
 
 
 def _mark_self_write(path: Path) -> None:
-    """ADR-034 Phase 2: tell the FS watcher this YAML write was canvas-originated.
-
-    Suppresses the next ``workflow.changed`` event for ``(path, mtime, size)``
-    so the watcher does not echo the canvas's own save back at the canvas.
-    Silent no-op when the watcher singleton has not been installed (e.g. in
-    pure-route unit tests).
-    """
-    try:
-        from scistudio.api.routes.workflow_watcher import mark_self_write as _mark
-
-        _mark(path)
-    except Exception:
-        # Watcher failures must not affect the user-facing save response.
-        import logging
-
-        logging.getLogger(__name__).debug("workflow_watcher: mark_self_write failed for %s", path, exc_info=True)
+    with contextlib.suppress(Exception):
+        workflow_watcher.mark_self_write(path)
 
 
 def _now_iso() -> str:
     return datetime.now(tz=UTC).isoformat()
+
+
+def _get_run_or_404(runtime: ApiRuntime, workflow_id: str) -> WorkflowRun:
+    try:
+        return runtime.get_run(workflow_id)
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
 
 
 def _request_source_id(request: Request, body: Any | None = None) -> str | None:
@@ -329,6 +347,8 @@ async def get_workflow(workflow_id: str, runtime: RuntimeDep) -> VersionedWorkfl
                 "errors": exc.errors(),
             },
         ) from exc
+    except yaml.YAMLError as exc:
+        raise HTTPException(status_code=422, detail=_yaml_error_detail(workflow_id, exc)) from exc
     except RuntimeError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     return _workflow_response(definition, state_version=runtime.current_workflow_version(definition.id))
@@ -428,22 +448,14 @@ async def execute_workflow(workflow_id: str, runtime: RuntimeDep) -> WorkflowExe
 
 @router.post("/{workflow_id}/pause", response_model=WorkflowExecutionResponse)
 async def pause_workflow(workflow_id: str, runtime: RuntimeDep) -> WorkflowExecutionResponse:
-    """Pause a running workflow."""
-    try:
-        run = runtime.get_run(workflow_id)
-    except KeyError as exc:
-        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    run = _get_run_or_404(runtime, workflow_id)
     await run.scheduler.pause()
     return WorkflowExecutionResponse(workflow_id=workflow_id, status="paused", message="Pause requested.")
 
 
 @router.post("/{workflow_id}/resume", response_model=WorkflowExecutionResponse)
 async def resume_workflow(workflow_id: str, runtime: RuntimeDep) -> WorkflowExecutionResponse:
-    """Resume a paused workflow."""
-    try:
-        run = runtime.get_run(workflow_id)
-    except KeyError as exc:
-        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    run = _get_run_or_404(runtime, workflow_id)
     await run.scheduler.resume()
     return WorkflowExecutionResponse(workflow_id=workflow_id, status="running", message="Workflow resumed.")
 
@@ -451,10 +463,7 @@ async def resume_workflow(workflow_id: str, runtime: RuntimeDep) -> WorkflowExec
 @router.post("/{workflow_id}/cancel", response_model=CancelPropagationResponse)
 async def cancel_workflow(workflow_id: str, runtime: RuntimeDep) -> CancelPropagationResponse:
     """Cancel an entire workflow."""
-    try:
-        run = runtime.get_run(workflow_id)
-    except KeyError as exc:
-        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    run = _get_run_or_404(runtime, workflow_id)
 
     await run.scheduler.cancel_workflow()
     block_states = run.scheduler.block_states()
@@ -474,10 +483,7 @@ async def cancel_block(
     runtime: RuntimeDep,
 ) -> CancelPropagationResponse:
     """Cancel a single block within a workflow."""
-    try:
-        run = runtime.get_run(workflow_id)
-    except KeyError as exc:
-        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    run = _get_run_or_404(runtime, workflow_id)
 
     await run.scheduler.cancel_block(block_id)
     block_states = run.scheduler.block_states()

--- a/src/scistudio/api/runtime/__init__.py
+++ b/src/scistudio/api/runtime/__init__.py
@@ -203,6 +203,7 @@ class ApiRuntime:
         # subprocess can discover it.
         self._mcp_port: int | None = None
         self._entity_versions: dict[tuple[str, str], int] = {}
+        self._entity_disk_versions: dict[tuple[str, str], int] = {}
         self._first_party_entity_writes: dict[tuple[str, str], FirstPartyEntityWrite] = {}
         self._version_lock = threading.RLock()
         # ADR-039 §5.2: the in-memory ``_workflow_revisions`` counter and its
@@ -276,51 +277,55 @@ class ApiRuntime:
         """Initialize ADR-045 version state from the active project's disk state."""
         workflows_dir = project_dir / "workflows"
         seeded: dict[tuple[str, str], int] = {}
+        disk_versions: dict[tuple[str, str], int] = {}
         if workflows_dir.is_dir():
             for pattern in ("*.yaml", "*.yml"):
                 for path in workflows_dir.glob(pattern):
                     try:
-                        disk_version = path.stat().st_mtime_ns
+                        disk_version = int(path.stat().st_mtime_ns)
                     except OSError:
                         continue
                     key = (WORKFLOW_ENTITY_CLASS, path.stem)
-                    seeded[key] = max(seeded.get(key, 0), int(disk_version))
+                    seeded[key] = max(seeded.get(key, 0), 1)
+                    disk_versions[key] = max(disk_versions.get(key, 0), disk_version)
         with self._version_lock:
             self._entity_versions = seeded
+            self._entity_disk_versions = disk_versions
             self._first_party_entity_writes.clear()
 
-    def current_entity_version(
-        self,
-        entity_class: str,
-        entity_id: str,
-        *,
-        path: Path | None = None,
-    ) -> int:
-        """Return the current server-owned version for ``(entity_class, entity_id)``."""
+    def current_entity_version(self, entity_class: str, entity_id: str, *, path: Path | None = None) -> int:
         key = self._version_key(entity_class, entity_id)
         with self._version_lock:
-            current = self._entity_versions.get(key)
-            if current is None:
-                current = self._initial_version_from_path(path)
-                self._entity_versions[key] = current
-            return current
+            return self._entity_version_locked(key, path=path, bump=False, disk=False)
 
-    def bump_entity_version(
-        self,
-        entity_class: str,
-        entity_id: str,
-        *,
-        path: Path | None = None,
-    ) -> int:
-        """Advance and return the next monotonic version for an entity."""
+    def bump_entity_version(self, entity_class: str, entity_id: str, *, path: Path | None = None) -> int:
         key = self._version_key(entity_class, entity_id)
         with self._version_lock:
-            current = self._entity_versions.get(key)
-            if current is None:
-                current = self._initial_version_from_path(path)
-            version = int(current) + 1
-            self._entity_versions[key] = version
-            return version
+            return self._entity_version_locked(key, path=path, bump=True, disk=False)
+
+    def current_entity_disk_version(self, entity_class: str, entity_id: str, *, path: Path | None = None) -> int:
+        key = self._version_key(entity_class, entity_id)
+        with self._version_lock:
+            return self._entity_version_locked(key, path=path, bump=False, disk=True)
+
+    def _entity_version_locked(
+        self,
+        key: tuple[str, str],
+        *,
+        path: Path | None,
+        bump: bool,
+        disk: bool,
+    ) -> int:
+        target = self._entity_disk_versions if disk else self._entity_versions
+        current = target.get(key)
+        if current is None:
+            current = self._disk_version_from_path(path) if disk else self._initial_version_from_path(path)
+        elif bump:
+            current = int(current) + 1
+        target[key] = current
+        if not disk and path is not None and (bump or key not in self._entity_disk_versions):
+            self._entity_disk_versions[key] = self._disk_version_from_path(path)
+        return current
 
     def current_workflow_version(self, workflow_id: str) -> int:
         return self.current_entity_version(
@@ -344,6 +349,15 @@ class ApiRuntime:
             return normalized, None, None, False
         return normalized, int(stat.st_mtime_ns), int(stat.st_size), True
 
+    def _signature_for_entity_write(
+        self, path: Path | None, *, pending: bool
+    ) -> tuple[str | None, int | None, int | None, bool | None]:
+        if path is None:
+            return None, None, None, None
+        if pending:
+            return str(path.resolve()), None, None, None
+        return self._first_party_write_signature(path)
+
     def mark_entity_first_party_write(
         self,
         entity_class: str,
@@ -356,14 +370,7 @@ class ApiRuntime:
     ) -> None:
         """Record an exact write-site signature so watcher fallback can suppress echoes."""
         key = self._version_key(entity_class, entity_id)
-        path_key: str | None = None
-        mtime_ns: int | None = None
-        size: int | None = None
-        exists: bool | None = None
-        if path is not None:
-            path_key = str(path.resolve())
-            if not pending:
-                path_key, mtime_ns, size, exists = self._first_party_write_signature(path)
+        path_key, mtime_ns, size, exists = self._signature_for_entity_write(path, pending=pending)
         with self._version_lock:
             self._first_party_entity_writes[key] = FirstPartyEntityWrite(
                 version=int(version),
@@ -374,6 +381,8 @@ class ApiRuntime:
                 exists=exists,
                 kind=kind,
             )
+            if mtime_ns is not None:
+                self._entity_disk_versions[key] = mtime_ns
 
     def mark_workflow_first_party_write(
         self,
@@ -385,6 +394,29 @@ class ApiRuntime:
     ) -> None:
         self.mark_entity_first_party_write(WORKFLOW_ENTITY_CLASS, workflow_id, version, path=path, kind=kind)
 
+    def _active_first_party_entity_write(
+        self, key: tuple[str, str], version: int | None
+    ) -> FirstPartyEntityWrite | None:
+        entry = self._first_party_entity_writes.get(key)
+        if entry is None:
+            return None
+        if time.monotonic() - entry.seen_at > _FIRST_PARTY_WRITE_SUPPRESSION_SECONDS:
+            self._first_party_entity_writes.pop(key, None)
+            return None
+        if version is not None and int(version) != entry.version:
+            return None
+        return entry
+
+    def _entity_write_path_matches(self, entry: FirstPartyEntityWrite, path: Path, kind: str | None) -> bool:
+        path_key, mtime_ns, size, exists = self._first_party_write_signature(path)
+        if entry.path != path_key:
+            return False
+        if entry.exists is None:
+            return True
+        if entry.exists is False:
+            return exists is False and entry.kind == "deleted" and kind == "deleted"
+        return exists is True and entry.mtime_ns == mtime_ns and entry.size == size
+
     def is_recent_first_party_entity_write(
         self,
         entity_class: str,
@@ -394,35 +426,12 @@ class ApiRuntime:
         path: Path | None = None,
         kind: str | None = None,
     ) -> bool:
-        key = self._version_key(entity_class, entity_id)
-        now = time.monotonic()
+        key = (str(entity_class), str(entity_id))
         with self._version_lock:
-            entry = self._first_party_entity_writes.get(key)
-            if entry is None:
-                return False
-            if now - entry.seen_at > _FIRST_PARTY_WRITE_SUPPRESSION_SECONDS:
-                self._first_party_entity_writes.pop(key, None)
-                return False
-            if version is not None and int(version) != entry.version:
-                return False
+            entry = self._active_first_party_entity_write(key, version)
             if path is None:
-                return version is not None
-            path_key, mtime_ns, size, exists = self._first_party_write_signature(path)
-            if entry.path != path_key:
-                return False
-            if entry.exists is None:
-                # Pending in-flight write: the writer marked the signature
-                # before completing the rename, so we know any event for
-                # this exact path during the suppression window is our own
-                # echo. On Linux, ``os.replace(tmp, target)`` surfaces as a
-                # FileMovedEvent which maps to kind="created"; on Windows
-                # it is typically kind="modified". Don't enforce kind match
-                # in pending mode — the path match plus the short 2s window
-                # are sufficient.
-                return True
-            if entry.exists is False:
-                return exists is False and entry.kind == "deleted" and kind == "deleted"
-            return exists is True and entry.mtime_ns == mtime_ns and entry.size == size
+                return entry is not None and version is not None
+            return entry is not None and self._entity_write_path_matches(entry, path, kind)
 
     def is_recent_workflow_first_party_write(
         self,
@@ -474,6 +483,15 @@ class ApiRuntime:
 
     @staticmethod
     def _initial_version_from_path(path: Path | None) -> int:
+        if path is None:
+            return 0
+        try:
+            return 1 if path.exists() else 0
+        except OSError:
+            return 0
+
+    @staticmethod
+    def _disk_version_from_path(path: Path | None) -> int:
         if path is None:
             return 0
         try:

--- a/src/scistudio/core/versioning/_history_ops.py
+++ b/src/scistudio/core/versioning/_history_ops.py
@@ -154,7 +154,7 @@ def _restore(engine: GitEngine, commit_sha: str, *, files: list[str] | None = No
 
     Hotfix #997: when every target file's content at ``commit_sha``
     is byte-identical to its current working-tree content, restore
-    is a no-op — skip the actual ``git checkout``. Pre-fix, clicking
+    is a no-op — skip the actual ``git restore``. Pre-fix, clicking
     "Restore this run's workflow" on a run whose recorded commit
     happened to match the current working tree still triggered an
     auto-handler against a tree that was dirty in *any* file (even
@@ -168,17 +168,21 @@ def _restore(engine: GitEngine, commit_sha: str, *, files: list[str] | None = No
             all_unchanged = _files_unchanged_vs_commit(engine, commit_sha, files)
         except GitError:
             # If we can't compare (commit doesn't exist, etc.) let
-            # the subsequent checkout produce the real error message.
+            # the subsequent restore produce the real error message.
             all_unchanged = False
         if all_unchanged:
             logger.debug(
-                "restore: %s @ %s already matches working tree; skipping checkout",
+                "restore: %s @ %s already matches working tree; skipping restore",
                 files,
                 commit_sha[:7],
             )
             return
 
-    args = ["checkout", commit_sha, "--"]
+    # Use `git restore --worktree` instead of `git checkout <sha> --`
+    # so soft restore updates the working tree without staging the
+    # restored content. If the source commit lacks a tracked path, git
+    # restores the working tree by deleting that file.
+    args = ["restore", f"--source={commit_sha}", "--worktree", "--"]
     if files:
         args.extend(files)
     else:
@@ -203,5 +207,5 @@ def _files_unchanged_vs_commit(engine: GitEngine, commit_sha: str, files: list[s
     if proc.returncode == 1:
         return False
     # Any other return code: treat as unable-to-determine; let the
-    # caller fall through to the normal checkout path.
+    # caller fall through to the normal restore path.
     raise GitError(proc.returncode, proc.stderr or "", diff_args)

--- a/tests/ai/test_mcp_tools_workflow.py
+++ b/tests/ai/test_mcp_tools_workflow.py
@@ -21,6 +21,7 @@ import pytest
 from scistudio.ai.agent.mcp import _context, tools_workflow
 from scistudio.blocks.registry import BlockRegistry
 from scistudio.core.types.registry import TypeRegistry
+from scistudio.engine.events import WORKFLOW_CHANGED
 
 # --- Stub MCPContext -------------------------------------------------------
 
@@ -47,6 +48,106 @@ class _StubRuntime:
 class _StubRun:
     task: Any = None
     scheduler: Any = None
+
+
+class _StubEventBus:
+    def __init__(self) -> None:
+        self.events: list[Any] = []
+
+    async def emit(self, event: Any) -> None:
+        self.events.append(event)
+
+
+class _VersionedStubRuntime(_StubRuntime):
+    def __init__(self, project_dir: Path) -> None:
+        super().__init__(_project_dir=project_dir)
+        self.event_bus = _StubEventBus()
+        self.event_bus.runtime = self
+        self._versions: dict[str, int] = {}
+        self.first_party_writes: list[dict[str, Any]] = []
+        self.pending_first_party_writes: list[dict[str, Any]] = []
+
+    def bump_workflow_version(self, workflow_id: str) -> int:
+        version = self._versions.get(workflow_id, 0) + 1
+        self._versions[workflow_id] = version
+        return version
+
+    def mark_workflow_first_party_write(
+        self,
+        workflow_id: str,
+        version: int,
+        *,
+        path: Path | None = None,
+        kind: str | None = None,
+    ) -> None:
+        self.first_party_writes.append(
+            {
+                "workflow_id": workflow_id,
+                "version": version,
+                "path": path,
+                "kind": kind,
+            }
+        )
+
+    def mark_entity_first_party_write(
+        self,
+        entity_class: str,
+        entity_id: str,
+        version: int,
+        *,
+        path: Path | None = None,
+        kind: str | None = None,
+        pending: bool = False,
+    ) -> None:
+        if pending:
+            self.pending_first_party_writes.append(
+                {
+                    "entity_class": entity_class,
+                    "entity_id": entity_id,
+                    "version": version,
+                    "path": path,
+                    "kind": kind,
+                    "pending": pending,
+                }
+            )
+
+    def versioned_change_payload(
+        self,
+        *,
+        entity_class: str,
+        entity_id: str,
+        version: int,
+        source: str,
+        source_id: str | None,
+        kind: str,
+        **extra: Any,
+    ) -> dict[str, Any]:
+        return {
+            "entity_class": entity_class,
+            "entity_id": entity_id,
+            "version": version,
+            "source": source,
+            "source_id": source_id,
+            "kind": kind,
+            **extra,
+        }
+
+
+class _RuntimeAdapterStub(_StubRuntime):
+    """Matches the API lifespan adapter shape used by the MCP context."""
+
+    def __init__(self, runtime: _VersionedStubRuntime) -> None:
+        super().__init__(
+            block_registry=runtime.block_registry,
+            type_registry=runtime.type_registry,
+            workflow_runs=runtime.workflow_runs,
+            _project_dir=runtime.project_dir,
+        )
+        self.event_bus = runtime.event_bus
+        self._runtime = runtime
+
+    def start_workflow(self, workflow_id: str) -> dict[str, Any]:
+        return self._runtime.start_workflow(workflow_id)
 
 
 @pytest.fixture
@@ -165,6 +266,88 @@ def test_write_workflow_creates_file(ctx: _StubRuntime, tmp_path: Path) -> None:
     assert "lines" in result.diff_summary
     # ADR-040 §3.2: write-class envelope must carry next_step.
     assert result.next_step and "validate_workflow" in result.next_step
+
+
+def test_write_workflow_emits_agent_versioned_change_event(tmp_path: Path) -> None:
+    runtime = _VersionedStubRuntime(tmp_path)
+    _context.set_context(runtime)
+    try:
+        target = tmp_path / "workflows" / "agent_edit.yaml"
+        result = _run(tools_workflow.write_workflow(str(target), _WF_YAML))
+    finally:
+        _context.set_context(None)
+
+    assert target.exists()
+    assert result.bytes_written > 0
+    assert runtime.pending_first_party_writes == [
+        {
+            "entity_class": "workflow",
+            "entity_id": "agent_edit",
+            "version": 1,
+            "path": target,
+            "kind": "created",
+            "pending": True,
+        }
+    ]
+    assert runtime.first_party_writes == [
+        {
+            "workflow_id": "agent_edit",
+            "version": 1,
+            "path": target,
+            "kind": "created",
+        }
+    ]
+    assert len(runtime.event_bus.events) == 1
+    event = runtime.event_bus.events[0]
+    assert event.event_type == WORKFLOW_CHANGED
+    assert event.data["entity_class"] == "workflow"
+    assert event.data["entity_id"] == "agent_edit"
+    assert event.data["workflow_id"] == "agent_edit"
+    assert event.data["version"] == 1
+    assert event.data["source"] == "agent"
+    assert event.data["source_id"] is None
+    assert event.data["kind"] == "created"
+    assert event.data["path"] == "workflows/agent_edit.yaml"
+    assert event.data["changed_by"] == "mcp.write_workflow"
+
+
+def test_write_workflow_emits_versioned_event_through_runtime_adapter(tmp_path: Path) -> None:
+    runtime = _VersionedStubRuntime(tmp_path)
+    adapter = _RuntimeAdapterStub(runtime)
+    _context.set_context(adapter)
+    try:
+        target = tmp_path / "workflows" / "agent_adapter_edit.yaml"
+        result = _run(tools_workflow.write_workflow(str(target), _WF_YAML))
+    finally:
+        _context.set_context(None)
+
+    assert target.exists()
+    assert result.bytes_written > 0
+    assert runtime.pending_first_party_writes == [
+        {
+            "entity_class": "workflow",
+            "entity_id": "agent_adapter_edit",
+            "version": 1,
+            "path": target,
+            "kind": "created",
+            "pending": True,
+        }
+    ]
+    assert runtime.first_party_writes == [
+        {
+            "workflow_id": "agent_adapter_edit",
+            "version": 1,
+            "path": target,
+            "kind": "created",
+        }
+    ]
+    assert len(runtime.event_bus.events) == 1
+    event = runtime.event_bus.events[0]
+    assert event.event_type == WORKFLOW_CHANGED
+    assert event.data["entity_id"] == "agent_adapter_edit"
+    assert event.data["version"] == 1
+    assert event.data["source"] == "agent"
+    assert event.data["path"] == "workflows/agent_adapter_edit.yaml"
 
 
 def test_write_workflow_rejects_unparseable_yaml(ctx: _StubRuntime, tmp_path: Path) -> None:

--- a/tests/ai/test_windows_executable_resolution.py
+++ b/tests/ai/test_windows_executable_resolution.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import subprocess
 import sys
 from pathlib import Path
@@ -66,10 +67,12 @@ def test_spawn_codex_uses_cmd_when_windows_which_finds_bare_wrapper(
 
     terminal.spawn_codex(project_dir=tmp_path, dangerous=True)
 
-    assert spawned["argv"] == [
-        "C:/Users/dev/AppData/Roaming/npm/codex.cmd",
-        "--dangerously-bypass-approvals-and-sandbox",
-    ]
+    argv = spawned["argv"]
+    assert argv[0] == "C:/Users/dev/AppData/Roaming/npm/codex.cmd"
+    assert "--dangerously-bypass-approvals-and-sandbox" in argv
+    assert any(arg.startswith("mcp_servers.scistudio.command=") for arg in argv)
+    assert any(arg == 'mcp_servers.scistudio.args=["-m", "scistudio", "mcp-bridge"]' for arg in argv)
+    assert any(arg.startswith("mcp_servers.scistudio.env={SCISTUDIO_PROJECT_DIR=") for arg in argv)
 
 
 def test_spawn_claude_uses_cmd_when_windows_which_finds_bare_wrapper(
@@ -119,3 +122,33 @@ def test_spawn_argv_seam_bypasses_windows_resolution(monkeypatch: Any, tmp_path:
     terminal.spawn_codex(project_dir=tmp_path, dangerous=True, _spawn_argv=[sys.executable, "-c", "pass"])
 
     assert spawned["argv"] == [sys.executable, "-c", "pass"]
+
+
+def test_spawn_codex_injects_project_mcp_config_overrides(monkeypatch: Any, tmp_path: Path) -> None:
+    """Embedded Codex tabs must not depend on project/global config discovery."""
+    spawned: dict[str, Any] = {}
+
+    class FakePtyProcess:
+        def __init__(self, argv: list[str], *args: Any, **kwargs: Any) -> None:
+            spawned["argv"] = argv
+            spawned["args"] = args
+            spawned["kwargs"] = kwargs
+
+    monkeypatch.setattr(terminal, "PtyProcess", FakePtyProcess)
+    monkeypatch.setattr(terminal, "resolve_windows_executable", lambda name: name)
+
+    terminal.spawn_codex(project_dir=tmp_path, dangerous=False)
+
+    argv = spawned["argv"]
+    assert argv[:7] == [
+        "codex",
+        "-c",
+        f"mcp_servers.scistudio.command={json.dumps(sys.executable)}",
+        "-c",
+        'mcp_servers.scistudio.args=["-m", "scistudio", "mcp-bridge"]',
+        "-c",
+        f"mcp_servers.scistudio.env={{SCISTUDIO_PROJECT_DIR={json.dumps(str(tmp_path))}}}",
+    ]
+    assert f"mcp_servers.scistudio.command={json.dumps(sys.executable)}" in argv
+    assert 'mcp_servers.scistudio.args=["-m", "scistudio", "mcp-bridge"]' in argv
+    assert f"SCISTUDIO_PROJECT_DIR={json.dumps(str(tmp_path))}" in argv[-1]

--- a/tests/api/test_file_version_vector.py
+++ b/tests/api/test_file_version_vector.py
@@ -11,6 +11,8 @@ from scistudio.api.runtime import FILE_ENTITY_CLASS, ApiRuntime
 from scistudio.engine.events import EngineEvent
 from tests.api.helpers import wait_for_condition
 
+JS_MAX_SAFE_INTEGER = 9_007_199_254_740_991
+
 
 def _open(client: TestClient, project_path: Path) -> str:
     response = client.post(
@@ -40,6 +42,7 @@ def test_file_get_returns_state_version_without_version_field(
     assert body["content"] == "# hello\n"
     assert "version" not in body
     assert isinstance(body["state_version"], int)
+    assert body["state_version"] <= JS_MAX_SAFE_INTEGER
     assert body["entity_class"] == FILE_ENTITY_CLASS
     assert body["entity_id"] == "notes.md"
     assert body["source"] is None

--- a/tests/api/test_git_endpoints.py
+++ b/tests/api/test_git_endpoints.py
@@ -193,6 +193,35 @@ def test_restore_endpoint_auto_commits_dirty_tree(client: TestClient, opened_pro
     assert target.read_text(encoding="utf-8") == "A"
 
 
+def test_restore_endpoint_to_commit_missing_file_deletes_after_auto_commit(
+    client: TestClient, opened_project: Path, runtime
+) -> None:
+    """Restoring a file to a commit that did not contain it means the
+    file is deleted in the working tree, not a post-auto-commit failure.
+    """
+    _drain(client)
+    sha_without_file = client.get("/api/git/log", params={"limit": 1}).json()[0]["sha"]
+    target = opened_project / "workflows" / "added-later.yaml"
+    target.write_text("workflow:\n  id: added-later\n  nodes: []\n  edges: []\n", encoding="utf-8")
+    client.post("/api/git/commit", json={"message": "add workflow"})
+
+    target.write_text("workflow:\n  id: added-later\n  nodes: [{id: dirty}]\n  edges: []\n", encoding="utf-8")
+    assert client.get("/api/git/status").json()["dirty"] is True
+    captured = _subscribe_workflow_changed(runtime)
+
+    resp = client.post(
+        "/api/git/restore",
+        json={"commit_sha": sha_without_file, "files": ["workflows/added-later.yaml"]},
+    )
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["auto_commit_sha"]
+    assert not target.exists()
+    event = next(ev for ev in captured if ev.data["path"] == "workflows/added-later.yaml")
+    assert event.data["kind"] == "deleted"
+
+
 def test_restore_endpoint_clean_tree_no_auto_commit(client: TestClient, opened_project: Path) -> None:
     """A clean working tree at restore time produces ``auto_commit_sha=null``
     and no new commit on HEAD.
@@ -228,7 +257,7 @@ def test_restore_skips_when_file_unchanged(client: TestClient, opened_project: P
     dirty tree before invoking ``engine.restore``, so the no-op
     measure is now: when the working tree is CLEAN and the target
     matches HEAD's content, the restore creates no new commit (no
-    auto-commit because clean, no checkout because unchanged). This
+    auto-commit because clean, no restore because unchanged). This
     test pins that contract.
     """
     _drain(client)

--- a/tests/api/test_workflow_version_vector.py
+++ b/tests/api/test_workflow_version_vector.py
@@ -10,6 +10,8 @@ from scistudio.api.runtime import ApiRuntime
 from scistudio.engine.events import WORKFLOW_CHANGED, EngineEvent
 from tests.api.helpers import build_linear_workflow, wait_for_condition
 
+JS_MAX_SAFE_INTEGER = 9_007_199_254_740_991
+
 
 def test_workflow_responses_return_monotonic_state_versions(
     client: TestClient,
@@ -24,6 +26,7 @@ def test_workflow_responses_return_monotonic_state_versions(
     assert created_body["entity_id"] == "versioned-flow"
     assert created_body["version"] == "1.0.0"
     assert isinstance(created_body["state_version"], int)
+    assert created_body["state_version"] <= JS_MAX_SAFE_INTEGER
     assert created_body["workflow_version"] == "1.0.0"
     assert created_body["source"] == "canvas"
     assert created_body["kind"] == "created"
@@ -42,6 +45,7 @@ def test_workflow_responses_return_monotonic_state_versions(
     updated_body = updated.json()
     assert updated_body["version"] == "1.0.0"
     assert updated_body["state_version"] == created_body["state_version"] + 1
+    assert updated_body["state_version"] <= JS_MAX_SAFE_INTEGER
     assert updated_body["kind"] == "modified"
 
 

--- a/tests/api/test_workflows.py
+++ b/tests/api/test_workflows.py
@@ -44,6 +44,24 @@ def test_workflow_crud_round_trips_yaml_layout(client: TestClient, opened_projec
     assert not workflow_file.exists()
 
 
+def test_get_workflow_malformed_yaml_returns_debuggable_422(client: TestClient, opened_project: Path) -> None:
+    workflow_file = opened_project / "workflows" / "broken.yaml"
+    workflow_file.write_text(
+        "workflow:\n  id: broken\n  nodes:\n  - id: load\n    block_type: load_data\n   - id: bad_indent\n",
+        encoding="utf-8",
+    )
+
+    resp = client.get("/api/workflows/broken")
+
+    assert resp.status_code == 422
+    detail = resp.json()["detail"]
+    assert detail["message"].startswith("Workflow 'broken' on disk is not valid YAML at line ")
+    assert "expected <block end>" in detail["message"]
+    assert "error" in detail
+    assert "line" in detail
+    assert "column" in detail
+
+
 def test_workflow_execute_and_execute_from_reuses_cached_outputs(
     client: TestClient,
     runtime: ApiRuntime,

--- a/tests/core/test_git_engine.py
+++ b/tests/core/test_git_engine.py
@@ -287,13 +287,30 @@ def test_restore_round_trip(tmp_path: Path) -> None:
     assert head_sha == sha_b
 
 
+def test_restore_to_commit_missing_file_deletes_worktree_file(tmp_path: Path) -> None:
+    engine = _init_engine(tmp_path)
+    sha_without_file = engine.head_state().commit_sha
+    target = tmp_path / "workflows" / "new.yaml"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("workflow:\n  id: new\n  nodes: []\n", encoding="utf-8")
+    sha_with_file = engine.commit("add workflow")
+
+    engine.restore(sha_without_file, files=["workflows/new.yaml"])
+
+    assert not target.exists()
+    assert engine.head_state().commit_sha == sha_with_file
+    status = engine.status()
+    assert "workflows/new.yaml" in status["modified"]
+    assert "workflows/new.yaml" not in status["staged"]
+
+
 def test_restore_does_not_auto_handle_dirty_tree(tmp_path: Path) -> None:
     """ADR-039 Addendum 1 (#1354): the engine.restore method is now a
     pure soft restore — it does NOT auto-stash or auto-commit a dirty
     tree. The auto-commit responsibility lives at the route layer
     (``scistudio.api.routes.git::restore``). This test pins the engine
     contract: ``restore`` against a dirty tree either succeeds without
-    creating a new commit (if git allows the checkout) or raises the
+    creating a new commit (if git allows the restore) or raises the
     raw ``GitError`` (which the route layer catches AFTER it has
     already auto-committed).
     """

--- a/tests/integration/test_race_agent_write.py
+++ b/tests/integration/test_race_agent_write.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 
+import yaml
 from fastapi.testclient import TestClient
 
+from scistudio.ai.agent.mcp import tools_workflow
 from tests.api.helpers import build_linear_workflow
 
 
@@ -44,3 +47,41 @@ def test_agent_workflow_write_is_remote_source_tagged_for_conflict_detection(
     fetched = client.get("/api/workflows/agent-write-race")
     assert fetched.status_code == 200, fetched.text
     assert fetched.json()["state_version"] == body["state_version"]
+
+
+def test_mcp_write_workflow_pushes_agent_workflow_changed_before_watcher_echo(
+    client: TestClient,
+    opened_project: Path,
+) -> None:
+    workflow_id = "mcp-agent-write-race"
+    workflow_yaml = yaml.safe_dump(
+        {
+            "workflow": {
+                "id": workflow_id,
+                "version": "1.0.0",
+                "description": "MCP agent write",
+                "nodes": [],
+                "edges": [],
+            }
+        },
+        sort_keys=False,
+    )
+
+    with client.websocket_connect("/ws") as websocket:
+        result = asyncio.run(tools_workflow.write_workflow(f"workflows/{workflow_id}.yaml", workflow_yaml))
+        event = websocket.receive_json()
+
+    assert result.bytes_written > 0
+    assert event["type"] == "workflow.changed"
+    assert event["workflow_id"] == workflow_id
+    data = event["data"]
+    assert data["entity_id"] == workflow_id
+    assert data["workflow_id"] == workflow_id
+    assert data["source"] == "agent"
+    assert data["source_id"] is None
+    assert data["changed_by"] == "mcp.write_workflow"
+    assert data["kind"] == "created"
+
+    fetched = client.get(f"/api/workflows/{workflow_id}")
+    assert fetched.status_code == 200, fetched.text
+    assert fetched.json()["state_version"] == data["version"]


### PR DESCRIPTION
## Summary

Closes #1484.

This owner-guided hotfix stabilizes the embedded AI workflow edit path and the downstream workflow refresh/restore behavior:

- injects the SciStudio MCP server config directly into Codex startup so embedded AI Chat can launch the `scistudio` MCP server consistently
- emits versioned `workflow.changed` events for MCP `write_workflow` and preserves first-party write signatures around atomic writes
- changes ADR-045 public state versions to safe monotonic counters instead of filesystem `mtime_ns` values that exceed JavaScript safe integer range
- keeps watcher disk mtimes as an internal guard so external edits still reconcile correctly
- changes soft restore to `git restore --source=<sha> --worktree -- <files>`, including deleting files absent from the target commit without staging the restore result
- returns debuggable `422` details for malformed workflow YAML instead of surfacing a backend 500

Related: #1401, #1322, #1394.

## Root Cause

The hotfix covered three connected failure modes:

1. Codex was not reliably consuming the generated SciStudio MCP config, so its MCP handshake failed while Claude Code remained healthy.
2. ADR-045 used filesystem mtimes as public state versions; those values exceed JavaScript safe integer precision and could make the frontend reject fresh events as stale.
3. Git restore used `git checkout <sha> -- <files>`, which staged restored content and failed when the target commit did not contain the workflow file instead of restoring the working tree to that deletion state.

## Validation

- `PYTHONPATH=src pytest tests/ai/test_mcp_tools_workflow.py tests/ai/agent/mcp/test_tools_workflow_surface.py tests/integration/test_race_agent_write.py tests/integration/test_race_autosave.py tests/integration/test_race_multi_session.py tests/integration/test_race_lineage_restore.py tests/api/test_workflow_changed_event_schema.py tests/ai/test_windows_executable_resolution.py -q --no-cov` — 43 passed
- `PYTHONPATH=src pytest tests/api/test_workflow_version_vector.py tests/api/test_file_version_vector.py tests/api/routes/test_workflow_watcher_fallback.py tests/api/test_workflow_watcher.py tests/contract/test_adr045_version_vector_contract.py tests/integration/test_race_external_editor.py tests/integration/test_race_agent_write.py tests/integration/test_race_lineage_restore.py tests/api/test_workflow_changed_event_schema.py -q --no-cov` — 36 passed
- `PYTHONPATH=src pytest tests/core/test_git_engine.py tests/api/test_git_endpoints.py tests/api/test_workflows.py::test_get_workflow_malformed_yaml_returns_debuggable_422 -q --no-cov` — 91 passed
- `npm test -- --run src/hooks/__tests__/useWebSocket.versionVector.test.ts src/store/__tests__/workflowSlice.versionVector.test.ts src/store/__tests__/tabSlice.versionVector.test.ts` — 3 files / 20 tests passed
- `ruff check` — pass
- `ruff format --check` — pass
- `git diff --check` — pass
- `PYTHONPATH=src python -m scistudio.qa.audit.full_audit --repo-root . --format json --output docs/audit/1484-full-audit.json` — pass
- `PYTHONPATH=src python -m scistudio.qa.governance.gate_record pre-push` — pass

## Gate Evidence

- `.workflow/records/1484-hotfix-workflow-refresh-restore.json`
- `docs/audit/1484-full-audit.json`

## Notes

Sentrux CLI was not installed in the local environment, so the gate record marks local Sentrux as skipped; CI/workflow gate remains authoritative for that check.