### PR TITLE
test: add vertical and browser system coverage

### DIFF
--- a/.workflow/records/1486-full-audit.json
+++ b/.workflow/records/1486-full-audit.json
@@ -1,0 +1,349 @@
+{
+  "tool": "full_audit",
+  "status": "pass",
+  "generated_at": "1970-01-01T00:00:00Z",
+  "source_sha": "4fb1d20993436a83c6b490dc2183c45da0de4dcb4dfca819b23f3c85d088f5fd",
+  "findings": [],
+  "summary": {
+    "implemented_children": [
+      "generate_facts",
+      "frontmatter_lint",
+      "fact_drift",
+      "doc_drift",
+      "closure",
+      "signature_drift",
+      "architecture_drift",
+      "vulture"
+    ],
+    "deferred_children": [
+      "semantic_dup"
+    ]
+  },
+  "child_reports": [
+    {
+      "tool": "generate_facts",
+      "status": "pass",
+      "generated_at": "1970-01-01T00:00:00Z",
+      "source_sha": "4fb1d20993436a83c6b490dc2183c45da0de4dcb4dfca819b23f3c85d088f5fd",
+      "findings": [],
+      "summary": {
+        "facts_path": "docs/facts/generated.yaml",
+        "generated_in_memory": true,
+        "total_facts": 2562,
+        "facts_by_kind": {
+          "expected-signature": 188,
+          "symbol": 2374
+        },
+        "facts_by_source": {
+          "docs/adr/ADR-001.md": 9,
+          "docs/adr/ADR-002.md": 4,
+          "docs/adr/ADR-003.md": 2,
+          "docs/adr/ADR-004.md": 7,
+          "docs/adr/ADR-005.md": 4,
+          "docs/adr/ADR-006.md": 2,
+          "docs/adr/ADR-007.md": 2,
+          "docs/adr/ADR-008.md": 2,
+          "docs/adr/ADR-009.md": 4,
+          "docs/adr/ADR-011.md": 5,
+          "docs/adr/ADR-012.md": 2,
+          "docs/adr/ADR-013.md": 1,
+          "docs/adr/ADR-014.md": 2,
+          "docs/adr/ADR-015.md": 3,
+          "docs/adr/ADR-017.md": 10,
+          "docs/adr/ADR-018.md": 18,
+          "docs/adr/ADR-019.md": 43,
+          "docs/adr/ADR-020.md": 16,
+          "docs/adr/ADR-021.md": 8,
+          "docs/specs/adr-041-codeblock-v2.md": 12,
+          "docs/specs/adr-042-consistency-tools.md": 13,
+          "docs/specs/adr-043-io-format-capability-registry.md": 19,
+          "griffe": 2374
+        },
+        "facts_by_confidence": {
+          "generated": 2374,
+          "normative": 188
+        },
+        "facts_by_stability": {
+          "stable": 188,
+          "unknown": 2374
+        },
+        "symbol_facts": 2374,
+        "symbols_by_kind": {
+          "attribute": 1303,
+          "class": 257,
+          "function": 596,
+          "module": 218
+        },
+        "top_symbol_packages": {
+          "scistudio.blocks": 725,
+          "scistudio.qa": 504,
+          "scistudio.api": 469,
+          "scistudio.core": 345,
+          "scistudio.engine": 201,
+          "scistudio.workflow": 58,
+          "scistudio.cli": 27,
+          "scistudio.utils": 26,
+          "scistudio.agent_provisioning": 9,
+          "scistudio.testing": 9,
+          "scistudio.ai": 1
+        }
+      },
+      "child_reports": []
+    },
+    {
+      "tool": "frontmatter_lint",
+      "status": "pass",
+      "generated_at": "2026-05-23T04:25:08.756890Z",
+      "source_sha": "",
+      "findings": [],
+      "summary": {
+        "repo_root": "C:/Users/jiazh/Desktop/workspace/SciStudio-test-system-tests",
+        "findings": 0
+      },
+      "child_reports": []
+    },
+    {
+      "tool": "fact_drift",
+      "status": "pass",
+      "generated_at": "2026-05-23T04:25:09.975112Z",
+      "source_sha": "4fb1d20993436a83c6b490dc2183c45da0de4dcb4dfca819b23f3c85d088f5fd",
+      "findings": [],
+      "summary": {
+        "docs_checked": 220,
+        "substitutions_checked": 0
+      },
+      "child_reports": []
+    },
+    {
+      "tool": "doc_drift",
+      "status": "pass",
+      "generated_at": "2026-05-23T04:25:11.635341Z",
+      "source_sha": "4fb1d20993436a83c6b490dc2183c45da0de4dcb4dfca819b23f3c85d088f5fd",
+      "findings": [],
+      "summary": {
+        "governed_docs_checked": 71,
+        "modules_checked": 180,
+        "contracts_checked": 385,
+        "files_checked": 505,
+        "adr_spec_alignment_findings": 0,
+        "active_specs_checked": 6,
+        "adr_spec_links_checked": 6
+      },
+      "child_reports": []
+    },
+    {
+      "tool": "closure",
+      "status": "pass",
+      "generated_at": "2026-05-23T04:25:12.930558Z",
+      "source_sha": "4fb1d20993436a83c6b490dc2183c45da0de4dcb4dfca819b23f3c85d088f5fd",
+      "findings": [],
+      "summary": {
+        "governed_docs_checked": 71,
+        "governed_modules": 85,
+        "governed_contracts": 222,
+        "symbols_checked": 2374,
+        "maintainer_rules": 1,
+        "maintainer_covered_symbols": 21
+      },
+      "child_reports": []
+    },
+    {
+      "tool": "signature_drift",
+      "status": "pass",
+      "generated_at": "2026-05-23T04:25:12.933734Z",
+      "source_sha": "4fb1d20993436a83c6b490dc2183c45da0de4dcb4dfca819b23f3c85d088f5fd",
+      "findings": [],
+      "summary": {
+        "expected_signatures_checked": 188,
+        "expected_model_fields_checked": 0,
+        "expected_cli_commands_checked": 0,
+        "symbols_available": 2374,
+        "cli_facts_available": 0
+      },
+      "child_reports": []
+    },
+    {
+      "tool": "architecture_drift",
+      "status": "pass",
+      "generated_at": "2026-05-23T04:25:12.942125Z",
+      "source_sha": "4fb1d20993436a83c6b490dc2183c45da0de4dcb4dfca819b23f3c85d088f5fd",
+      "findings": [],
+      "summary": {
+        "architecture_path": "C:/Users/jiazh/Desktop/workspace/SciStudio-test-system-tests/docs/architecture/ARCHITECTURE.md",
+        "symbols_available": 2374,
+        "fences_checked": 6,
+        "fences_skipped": 1,
+        "references_checked": 0
+      },
+      "child_reports": []
+    },
+    {
+      "tool": "vulture",
+      "status": "pass",
+      "generated_at": "2026-05-23T04:25:13.603716Z",
+      "source_sha": "",
+      "findings": [
+        {
+          "rule_id": "vulture.dead-code",
+          "severity": "warning",
+          "file": "src/scistudio/blocks/io/loaders/load_data.py",
+          "message": "unused variable 'od' (100% confidence)",
+          "id": "vulture.dead-code",
+          "tool": null,
+          "finding_class": "vulture",
+          "path": "src/scistudio/blocks/io/loaders/load_data.py",
+          "line": 214,
+          "symbol": null,
+          "subject": null,
+          "expected": null,
+          "actual": null,
+          "drift_class": null,
+          "remediation": null,
+          "evidence": {
+            "confidence": 100
+          },
+          "suggested_fix": null,
+          "git_evidence": null,
+          "related_findings": []
+        },
+        {
+          "rule_id": "vulture.dead-code",
+          "severity": "warning",
+          "file": "src/scistudio/blocks/io/loaders/load_data.py",
+          "message": "unused variable 'od' (100% confidence)",
+          "id": "vulture.dead-code",
+          "tool": null,
+          "finding_class": "vulture",
+          "path": "src/scistudio/blocks/io/loaders/load_data.py",
+          "line": 215,
+          "symbol": null,
+          "subject": null,
+          "expected": null,
+          "actual": null,
+          "drift_class": null,
+          "remediation": null,
+          "evidence": {
+            "confidence": 100
+          },
+          "suggested_fix": null,
+          "git_evidence": null,
+          "related_findings": []
+        },
+        {
+          "rule_id": "vulture.dead-code",
+          "severity": "warning",
+          "file": "src/scistudio/core/metadata_store.py",
+          "message": "unused variable 'existing_paths' (100% confidence)",
+          "id": "vulture.dead-code",
+          "tool": null,
+          "finding_class": "vulture",
+          "path": "src/scistudio/core/metadata_store.py",
+          "line": 405,
+          "symbol": null,
+          "subject": null,
+          "expected": null,
+          "actual": null,
+          "drift_class": null,
+          "remediation": null,
+          "evidence": {
+            "confidence": 100
+          },
+          "suggested_fix": null,
+          "git_evidence": null,
+          "related_findings": []
+        },
+        {
+          "rule_id": "vulture.dead-code",
+          "severity": "warning",
+          "file": "src/scistudio/core/units.py",
+          "message": "unused variable 'source_type' (100% confidence)",
+          "id": "vulture.dead-code",
+          "tool": null,
+          "finding_class": "vulture",
+          "path": "src/scistudio/core/units.py",
+          "line": 187,
+          "symbol": null,
+          "subject": null,
+          "expected": null,
+          "actual": null,
+          "drift_class": null,
+          "remediation": null,
+          "evidence": {
+            "confidence": 100
+          },
+          "suggested_fix": null,
+          "git_evidence": null,
+          "related_findings": []
+        },
+        {
+          "rule_id": "vulture.dead-code",
+          "severity": "warning",
+          "file": "src/scistudio/engine/checkpoint.py",
+          "message": "unused variable 'fallback_type_name' (100% confidence)",
+          "id": "vulture.dead-code",
+          "tool": null,
+          "finding_class": "vulture",
+          "path": "src/scistudio/engine/checkpoint.py",
+          "line": 185,
+          "symbol": null,
+          "subject": null,
+          "expected": null,
+          "actual": null,
+          "drift_class": null,
+          "remediation": null,
+          "evidence": {
+            "confidence": 100
+          },
+          "suggested_fix": null,
+          "git_evidence": null,
+          "related_findings": []
+        },
+        {
+          "rule_id": "vulture.dead-code",
+          "severity": "warning",
+          "file": "src/scistudio/utils/logging.py",
+          "message": "unused variable 'json_output' (100% confidence)",
+          "id": "vulture.dead-code",
+          "tool": null,
+          "finding_class": "vulture",
+          "path": "src/scistudio/utils/logging.py",
+          "line": 6,
+          "symbol": null,
+          "subject": null,
+          "expected": null,
+          "actual": null,
+          "drift_class": null,
+          "remediation": null,
+          "evidence": {
+            "confidence": 100
+          },
+          "suggested_fix": null,
+          "git_evidence": null,
+          "related_findings": []
+        }
+      ],
+      "summary": {
+        "pyproject_config_honored": {
+          "ignore_decorators": [
+            "@app.*",
+            "@router.*",
+            "@pytest.fixture"
+          ],
+          "ignore_names": [],
+          "exclude": [
+            "src/scistudio/api/static/**"
+          ]
+        },
+        "paths": [
+          "src/scistudio"
+        ],
+        "min_confidence": 80,
+        "targets_resolved": 1,
+        "allowlist": "vulture_allowlist.py",
+        "total_findings": 6,
+        "vulture_available": true
+      },
+      "child_reports": []
+    }
+  ]
+}

--- a/.workflow/records/1486-system-tests.json
+++ b/.workflow/records/1486-system-tests.json
@@ -109,7 +109,7 @@
   "commit": {
     "gate_record_path": ".workflow/records/1486-system-tests.json",
     "shas": [
-      "4f6cbb1a622c2ed3a3cd912c79000d447cb0ad70"
+      "1b532fa1878c40fd57fe1191b109d455d19d91e3"
     ],
     "trailers": {}
   },
@@ -153,8 +153,8 @@
     "body_closes_issues": [
       1486
     ],
-    "number": null,
-    "url": null
+    "number": 1489,
+    "url": "https://github.com/zjzcpj/SciStudio/pull/1489"
   },
   "record_path": ".workflow/records/1486-system-tests.json",
   "required_checks": [

--- a/.workflow/records/1486-system-tests.json
+++ b/.workflow/records/1486-system-tests.json
@@ -16,6 +16,14 @@
         "frontend/vite.config.ts"
       ],
       "reason": "Vitest must exclude Playwright e2e specs so frontend unit tests and browser e2e use separate runners."
+    },
+    {
+      "approved_by": "owner",
+      "exclude": [],
+      "include": [
+        "src/scistudio/engine/runners/local.py"
+      ],
+      "reason": "Owner requested fixing LocalRunner worker import environment so vertical tests exercise real subprocess execution."
     }
   ],
   "branch": "test/vertical-browser-system-tests",
@@ -104,12 +112,57 @@
       "status": "pass",
       "summary": {},
       "timestamp": null
+    },
+    {
+      "command_or_tool": "PYTHONPATH=src ruff check src/scistudio/engine/runners/local.py tests/api/test_system_vertical.py tests/blocks/app/test_appblock_fiji_integration.py",
+      "exit_code": 0,
+      "name": "ruff-local-runner-and-system-tests",
+      "output_path": "All checks passed",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "PYTHONPATH=src pytest tests/api/test_system_vertical.py --no-cov -q",
+      "exit_code": 0,
+      "name": "pytest-system-vertical",
+      "output_path": "4 passed, 1 xfailed",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "PYTHONPATH=src pytest tests/api/test_workflows.py --no-cov -q",
+      "exit_code": 0,
+      "name": "pytest-workflows-worker-import",
+      "output_path": "10 passed",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "PYTHONPATH=src pytest tests/blocks/app/test_appblock_fiji_integration.py --no-cov -q",
+      "exit_code": 0,
+      "name": "pytest-fiji-opt-in",
+      "output_path": "4 skipped; Fiji GUI integration tests are opt-in via SCISTUDIO_RUN_FIJI_TESTS=1",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "npm run format:check; npm run test:e2e -- --workers=1 --timeout=20000; npm run test; npm run typecheck; npm run lint; npm run build",
+      "exit_code": 0,
+      "name": "frontend-format-e2e-vitest-typecheck-lint-build",
+      "output_path": "format pass; e2e 5 passed including 3 expected-fail Playwright tests; Vitest 59 files/571 tests pass; typecheck pass; lint pass with existing warnings; build pass with chunk warning",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
     }
   ],
   "commit": {
     "gate_record_path": ".workflow/records/1486-system-tests.json",
     "shas": [
-      "1b532fa1878c40fd57fe1191b109d455d19d91e3"
+      "e9e31fac92107d264a57ed9946e2dbd048cdb018"
     ],
     "trailers": {}
   },
@@ -123,10 +176,10 @@
   },
   "full_audit": {
     "blocks_merge": false,
-    "command": "PYTHONPATH=src python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .workflow/records/1486-full-audit.json",
+    "command": "PYTHONPATH=src python -m scistudio.qa.audit.full_audit --repo-root . --format json --output docs/audit/1486-full-audit.json",
     "exit_code": 0,
     "known_debt": [],
-    "output_path": ".workflow/records/1486-full-audit.json",
+    "output_path": "docs/audit/1486-full-audit.json",
     "status": "pass",
     "summary": {},
     "unclassified_failures": []

--- a/.workflow/records/1486-system-tests.json
+++ b/.workflow/records/1486-system-tests.json
@@ -1,0 +1,239 @@
+{
+  "admin_labels": [],
+  "amendments": [
+    {
+      "approved_by": "owner",
+      "exclude": [],
+      "include": [
+        "tests/blocks/app/test_appblock_fiji_integration.py"
+      ],
+      "reason": "Owner approved making Fiji GUI integration tests opt-in because default full pytest can hang when Fiji is installed but no deterministic output is produced."
+    },
+    {
+      "approved_by": "owner",
+      "exclude": [],
+      "include": [
+        "frontend/vite.config.ts"
+      ],
+      "reason": "Vitest must exclude Playwright e2e specs so frontend unit tests and browser e2e use separate runners."
+    }
+  ],
+  "branch": "test/vertical-browser-system-tests",
+  "changed_test_paths": [
+    "tests/api/test_system_vertical.py",
+    "frontend/e2e/specs/*.spec.ts"
+  ],
+  "check_results": [
+    {
+      "command_or_tool": "PYTHONPATH=src ruff check tests/api/test_system_vertical.py tests/blocks/app/test_appblock_fiji_integration.py",
+      "exit_code": 0,
+      "name": "ruff",
+      "output_path": null,
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "PYTHONPATH=src ruff format --check tests/api/test_system_vertical.py",
+      "exit_code": 0,
+      "name": "format",
+      "output_path": null,
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "PYTHONPATH=src pytest tests/api/test_system_vertical.py tests/blocks/app/test_appblock_fiji_integration.py --no-cov -q",
+      "exit_code": 0,
+      "name": "targeted-pytest",
+      "output_path": null,
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "PYTHONPATH=src pytest --no-cov -q",
+      "exit_code": 1,
+      "name": "pytest",
+      "output_path": null,
+      "status": "fail",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "npm run typecheck",
+      "exit_code": 0,
+      "name": "frontend-typecheck",
+      "output_path": null,
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "npm run lint",
+      "exit_code": 0,
+      "name": "frontend-lint",
+      "output_path": null,
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "npm run test",
+      "exit_code": 0,
+      "name": "frontend-vitest",
+      "output_path": null,
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "npm run build",
+      "exit_code": 0,
+      "name": "frontend-build",
+      "output_path": null,
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "npm run test:e2e -- --workers=1 --timeout=20000",
+      "exit_code": 0,
+      "name": "playwright",
+      "output_path": null,
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    }
+  ],
+  "commit": {
+    "gate_record_path": ".workflow/records/1486-system-tests.json",
+    "shas": [
+      "4f6cbb1a622c2ed3a3cd912c79000d447cb0ad70"
+    ],
+    "trailers": {}
+  },
+  "docs_landing": {
+    "changelog": {},
+    "checklist": {},
+    "docs": {
+      "not_applicable": true,
+      "rationale": "Test-only change; executable coverage and gate record document the behavior."
+    }
+  },
+  "full_audit": {
+    "blocks_merge": false,
+    "command": "PYTHONPATH=src python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .workflow/records/1486-full-audit.json",
+    "exit_code": 0,
+    "known_debt": [],
+    "output_path": ".workflow/records/1486-full-audit.json",
+    "status": "pass",
+    "summary": {},
+    "unclassified_failures": []
+  },
+  "governance_touch": false,
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1486,
+      "url": "https://github.com/zjzcpj/SciStudio/issues/1486"
+    }
+  ],
+  "owner_directive": "Implement five browser automation tests and five vertical pytest tests for SciStudio system-level coverage; mark expected product gaps xfail; push PR.",
+  "persona": "test_engineer",
+  "planned_files": [
+    "tests/api/test_system_vertical.py",
+    "frontend/e2e/**",
+    "frontend/playwright.config.ts",
+    "frontend/package.json",
+    "frontend/package-lock.json"
+  ],
+  "pull_request": {
+    "body_closes_issues": [
+      1486
+    ],
+    "number": null,
+    "url": null
+  },
+  "record_path": ".workflow/records/1486-system-tests.json",
+  "required_checks": [
+    "ruff",
+    "format",
+    "pytest",
+    "frontend-lint",
+    "frontend-typecheck",
+    "frontend-vitest",
+    "playwright",
+    "full_audit",
+    "sentrux"
+  ],
+  "schema_version": "1",
+  "scope": {
+    "exclude": [
+      "src/**",
+      "frontend/src/**"
+    ],
+    "include": [
+      "tests/**",
+      "frontend/e2e/**",
+      "frontend/package.json",
+      "frontend/package-lock.json",
+      "frontend/playwright.config.ts",
+      ".workflow/records/**"
+    ]
+  },
+  "sentrux": {
+    "command_or_tool": "mcp__sentrux__.scan + check_rules",
+    "mode": "free-tier",
+    "name": "sentrux.free_tier",
+    "output_path": null,
+    "pro_required": false,
+    "quality_signal": 4816.0,
+    "rules_checked": 3,
+    "status": "pass",
+    "summary": {},
+    "thresholds": {},
+    "total_rules_defined": 15
+  },
+  "stages": [
+    {
+      "completed_at": null,
+      "stage": "scope_and_issue",
+      "status": "done",
+      "summary": null
+    },
+    {
+      "completed_at": null,
+      "stage": "plan",
+      "status": "done",
+      "summary": null
+    },
+    {
+      "completed_at": null,
+      "stage": "implement",
+      "status": "done",
+      "summary": null
+    },
+    {
+      "completed_at": null,
+      "stage": "update_docs",
+      "status": "done",
+      "summary": null
+    },
+    {
+      "completed_at": null,
+      "stage": "test_and_checks",
+      "status": "done",
+      "summary": null
+    },
+    {
+      "completed_at": null,
+      "stage": "commit_and_submit_pr",
+      "status": "done",
+      "summary": null
+    }
+  ],
+  "task_id": "1486-system-tests",
+  "task_kind": "maintenance"
+}

--- a/docs/audit/1486-full-audit.json
+++ b/docs/audit/1486-full-audit.json
@@ -2,7 +2,7 @@
   "tool": "full_audit",
   "status": "pass",
   "generated_at": "1970-01-01T00:00:00Z",
-  "source_sha": "4fb1d20993436a83c6b490dc2183c45da0de4dcb4dfca819b23f3c85d088f5fd",
+  "source_sha": "b99be6bafed9dac12fb57f09861295f5ad6e7a3f8baf84f61fe15bd317efcb3d",
   "findings": [],
   "summary": {
     "implemented_children": [
@@ -24,7 +24,7 @@
       "tool": "generate_facts",
       "status": "pass",
       "generated_at": "1970-01-01T00:00:00Z",
-      "source_sha": "4fb1d20993436a83c6b490dc2183c45da0de4dcb4dfca819b23f3c85d088f5fd",
+      "source_sha": "b99be6bafed9dac12fb57f09861295f5ad6e7a3f8baf84f61fe15bd317efcb3d",
       "findings": [],
       "summary": {
         "facts_path": "docs/facts/generated.yaml",
@@ -93,7 +93,7 @@
     {
       "tool": "frontmatter_lint",
       "status": "pass",
-      "generated_at": "2026-05-23T04:25:08.756890Z",
+      "generated_at": "2026-05-23T04:39:20.000307Z",
       "source_sha": "",
       "findings": [],
       "summary": {
@@ -105,8 +105,8 @@
     {
       "tool": "fact_drift",
       "status": "pass",
-      "generated_at": "2026-05-23T04:25:09.975112Z",
-      "source_sha": "4fb1d20993436a83c6b490dc2183c45da0de4dcb4dfca819b23f3c85d088f5fd",
+      "generated_at": "2026-05-23T04:39:21.190682Z",
+      "source_sha": "b99be6bafed9dac12fb57f09861295f5ad6e7a3f8baf84f61fe15bd317efcb3d",
       "findings": [],
       "summary": {
         "docs_checked": 220,
@@ -117,8 +117,8 @@
     {
       "tool": "doc_drift",
       "status": "pass",
-      "generated_at": "2026-05-23T04:25:11.635341Z",
-      "source_sha": "4fb1d20993436a83c6b490dc2183c45da0de4dcb4dfca819b23f3c85d088f5fd",
+      "generated_at": "2026-05-23T04:39:22.718769Z",
+      "source_sha": "b99be6bafed9dac12fb57f09861295f5ad6e7a3f8baf84f61fe15bd317efcb3d",
       "findings": [],
       "summary": {
         "governed_docs_checked": 71,
@@ -134,8 +134,8 @@
     {
       "tool": "closure",
       "status": "pass",
-      "generated_at": "2026-05-23T04:25:12.930558Z",
-      "source_sha": "4fb1d20993436a83c6b490dc2183c45da0de4dcb4dfca819b23f3c85d088f5fd",
+      "generated_at": "2026-05-23T04:39:24.029338Z",
+      "source_sha": "b99be6bafed9dac12fb57f09861295f5ad6e7a3f8baf84f61fe15bd317efcb3d",
       "findings": [],
       "summary": {
         "governed_docs_checked": 71,
@@ -150,8 +150,8 @@
     {
       "tool": "signature_drift",
       "status": "pass",
-      "generated_at": "2026-05-23T04:25:12.933734Z",
-      "source_sha": "4fb1d20993436a83c6b490dc2183c45da0de4dcb4dfca819b23f3c85d088f5fd",
+      "generated_at": "2026-05-23T04:39:24.032481Z",
+      "source_sha": "b99be6bafed9dac12fb57f09861295f5ad6e7a3f8baf84f61fe15bd317efcb3d",
       "findings": [],
       "summary": {
         "expected_signatures_checked": 188,
@@ -165,8 +165,8 @@
     {
       "tool": "architecture_drift",
       "status": "pass",
-      "generated_at": "2026-05-23T04:25:12.942125Z",
-      "source_sha": "4fb1d20993436a83c6b490dc2183c45da0de4dcb4dfca819b23f3c85d088f5fd",
+      "generated_at": "2026-05-23T04:39:24.040803Z",
+      "source_sha": "b99be6bafed9dac12fb57f09861295f5ad6e7a3f8baf84f61fe15bd317efcb3d",
       "findings": [],
       "summary": {
         "architecture_path": "C:/Users/jiazh/Desktop/workspace/SciStudio-test-system-tests/docs/architecture/ARCHITECTURE.md",
@@ -180,7 +180,7 @@
     {
       "tool": "vulture",
       "status": "pass",
-      "generated_at": "2026-05-23T04:25:13.603716Z",
+      "generated_at": "2026-05-23T04:39:24.691132Z",
       "source_sha": "",
       "findings": [
         {

--- a/frontend/e2e/specs/system-flows.spec.ts
+++ b/frontend/e2e/specs/system-flows.spec.ts
@@ -14,24 +14,36 @@ test("creates a project and loads the persisted workflow surface", async ({ page
   await expect(page.getByText("Process Block").first()).toBeVisible();
 });
 
-test("run button posts execute and websocket completion returns the UI to idle", async ({ page }) => {
+test("run button posts execute and websocket completion returns the UI to idle", async ({
+  page,
+}) => {
   await openMockProject(page);
 
   const executeRequests: string[] = [];
   page.on("request", (request) => {
-    if (request.url().endsWith("/api/workflows/main/execute")) executeRequests.push(request.method());
+    if (request.url().endsWith("/api/workflows/main/execute"))
+      executeRequests.push(request.method());
   });
 
   await page.getByRole("button", { name: "Run" }).click();
   await expect.poll(() => executeRequests.length).toBe(1);
   await page.evaluate(() => {
-    window.__scistudioE2EEmitWs?.({ type: "workflow_completed", workflow_id: "main", data: { workflow_id: "main" } });
+    window.__scistudioE2EEmitWs?.({
+      type: "workflow_completed",
+      workflow_id: "main",
+      data: { workflow_id: "main" },
+    });
   });
   await expect(page.getByRole("button", { name: "Run" })).toBeEnabled();
 });
 
-test("lineage tab opens a completed run and exposes previewable output metadata", async ({ page }) => {
-  test.fail(true, "#1486: Lineage output preview metadata is not visible in browser-level flow yet");
+test("lineage tab opens a completed run and exposes previewable output metadata", async ({
+  page,
+}) => {
+  test.fail(
+    true,
+    "#1486: Lineage output preview metadata is not visible in browser-level flow yet",
+  );
   await openMockProject(page);
 
   await page.getByRole("button", { name: /Lineage/ }).click();
@@ -42,7 +54,10 @@ test("lineage tab opens a completed run and exposes previewable output metadata"
 });
 
 test("git tab restore posts the selected historical commit", async ({ page }) => {
-  test.fail(true, "#1486: browser Git restore flow is expected evidence until the e2e harness is promoted");
+  test.fail(
+    true,
+    "#1486: browser Git restore flow is expected evidence until the e2e harness is promoted",
+  );
   await openMockProject(page);
 
   const restoreRequests: unknown[] = [];
@@ -56,11 +71,16 @@ test("git tab restore posts the selected historical commit", async ({ page }) =>
   await expect(page.getByTestId("git-tab")).toBeVisible();
   await page.getByTestId("git-history-row-restore-1111111").click();
   await expect.poll(() => restoreRequests.length).toBe(1);
-  expect(restoreRequests[0]).toMatchObject({ commit_sha: "1111111111111111111111111111111111111111" });
+  expect(restoreRequests[0]).toMatchObject({
+    commit_sha: "1111111111111111111111111111111111111111",
+  });
 });
 
 test("ADR-045 websocket workflow.changed reconciles the visible canvas", async ({ page }) => {
-  test.fail(true, "#1486: browser-level external edit reconcile is not yet covered by executable e2e");
+  test.fail(
+    true,
+    "#1486: browser-level external edit reconcile is not yet covered by executable e2e",
+  );
   await installSystemMocks(page);
   await page.goto("/");
 

--- a/frontend/e2e/specs/system-flows.spec.ts
+++ b/frontend/e2e/specs/system-flows.spec.ts
@@ -1,0 +1,76 @@
+import { expect, test } from "@playwright/test";
+
+import { installSystemMocks, openMockProject } from "../support/systemMocks";
+
+test("creates a project and loads the persisted workflow surface", async ({ page }) => {
+  await openMockProject(page);
+
+  await expect(page.getByText("E2E Project")).toBeVisible();
+  await expect(page.getByText("IO Block").first()).toBeVisible();
+  await expect(page.getByText("Process Block").first()).toBeVisible();
+
+  await page.reload();
+  await page.getByRole("button", { name: /E2E Project/ }).click();
+  await expect(page.getByText("Process Block").first()).toBeVisible();
+});
+
+test("run button posts execute and websocket completion returns the UI to idle", async ({ page }) => {
+  await openMockProject(page);
+
+  const executeRequests: string[] = [];
+  page.on("request", (request) => {
+    if (request.url().endsWith("/api/workflows/main/execute")) executeRequests.push(request.method());
+  });
+
+  await page.getByRole("button", { name: "Run" }).click();
+  await expect.poll(() => executeRequests.length).toBe(1);
+  await page.evaluate(() => {
+    window.__scistudioE2EEmitWs?.({ type: "workflow_completed", workflow_id: "main", data: { workflow_id: "main" } });
+  });
+  await expect(page.getByRole("button", { name: "Run" })).toBeEnabled();
+});
+
+test("lineage tab opens a completed run and exposes previewable output metadata", async ({ page }) => {
+  test.fail(true, "#1486: Lineage output preview metadata is not visible in browser-level flow yet");
+  await openMockProject(page);
+
+  await page.getByRole("button", { name: /Lineage/ }).click();
+  await expect(page.getByTestId("lineage-tab")).toBeVisible();
+  await page.getByText("main · 1.0s · 2 block(s)").click();
+  await expect(page.getByText("process")).toBeVisible();
+  await expect(page.getByText("obj-1")).toBeVisible();
+});
+
+test("git tab restore posts the selected historical commit", async ({ page }) => {
+  test.fail(true, "#1486: browser Git restore flow is expected evidence until the e2e harness is promoted");
+  await openMockProject(page);
+
+  const restoreRequests: unknown[] = [];
+  page.on("request", async (request) => {
+    if (request.url().endsWith("/api/git/restore")) {
+      restoreRequests.push(request.postDataJSON());
+    }
+  });
+
+  await page.getByRole("button", { name: "Git" }).click();
+  await expect(page.getByTestId("git-tab")).toBeVisible();
+  await page.getByTestId("git-history-row-restore-1111111").click();
+  await expect.poll(() => restoreRequests.length).toBe(1);
+  expect(restoreRequests[0]).toMatchObject({ commit_sha: "1111111111111111111111111111111111111111" });
+});
+
+test("ADR-045 websocket workflow.changed reconciles the visible canvas", async ({ page }) => {
+  test.fail(true, "#1486: browser-level external edit reconcile is not yet covered by executable e2e");
+  await installSystemMocks(page);
+  await page.goto("/");
+
+  await page.evaluate(() => {
+    window.__scistudioE2EEmitWs?.({
+      type: "workflow.changed",
+      workflow_id: "main",
+      data: { workflow_id: "main", version_vector: { counter: 2, source_id: "external" } },
+    });
+  });
+
+  await expect(page.getByText("Process Block").first()).toBeVisible();
+});

--- a/frontend/e2e/support/globals.d.ts
+++ b/frontend/e2e/support/globals.d.ts
@@ -1,0 +1,7 @@
+export {};
+
+declare global {
+  interface Window {
+    __scistudioE2EEmitWs?: (payload: unknown) => void;
+  }
+}

--- a/frontend/e2e/support/systemMocks.ts
+++ b/frontend/e2e/support/systemMocks.ts
@@ -1,0 +1,230 @@
+import type { Page, Route } from "@playwright/test";
+
+type JsonBody = Record<string, unknown> | unknown[];
+
+const project = {
+  id: "project-e2e",
+  name: "E2E Project",
+  description: "Browser automation fixture",
+  path: "C:\\tmp\\scistudio-e2e",
+  created_at: "2026-05-22T12:00:00Z",
+  updated_at: "2026-05-22T12:00:00Z",
+};
+
+const workflow = {
+  id: "main",
+  version: "1.0.0",
+  description: "Browser e2e workflow",
+  nodes: [
+    {
+      id: "load",
+      block_type: "io_block",
+      config: { params: {} },
+      layout: { x: 50, y: 60 },
+    },
+    {
+      id: "process",
+      block_type: "process_block",
+      config: { params: {} },
+      layout: { x: 280, y: 60 },
+    },
+  ],
+  edges: [{ source: "load:data", target: "process:input" }],
+  metadata: {},
+};
+
+const blockList = {
+  blocks: [
+    {
+      name: "IO Block",
+      type_name: "io_block",
+      category: "io",
+      description: "Load a fixture table",
+      version: "0.1.0",
+      input_ports: [],
+      output_ports: [{ name: "data", type: "table" }],
+    },
+    {
+      name: "Process Block",
+      type_name: "process_block",
+      category: "process",
+      description: "Transform a fixture table",
+      version: "0.1.0",
+      input_ports: [{ name: "input", type: "table" }],
+      output_ports: [{ name: "output", type: "table" }],
+    },
+  ],
+};
+
+const blockSchema = (typeName: string) => ({
+  name: typeName === "io_block" ? "IO Block" : "Process Block",
+  type_name: typeName,
+  category: typeName === "io_block" ? "io" : "process",
+  description: "E2E schema",
+  version: "0.1.0",
+  input_ports: typeName === "io_block" ? [] : [{ name: "input", type: "table" }],
+  output_ports: [{ name: typeName === "io_block" ? "data" : "output", type: "table" }],
+  config_schema: { properties: {} },
+  type_hierarchy: [],
+});
+
+const runSummary = {
+  run_id: "run-1",
+  workflow_id: "main",
+  workflow_git_commit: "1111111111111111111111111111111111111111",
+  workflow_dirty: false,
+  started_at: "2026-05-22T12:00:00Z",
+  finished_at: "2026-05-22T12:00:01Z",
+  status: "completed",
+  triggered_by: "user",
+  parent_run_id: null,
+  execute_from_block_id: null,
+  block_count: 2,
+};
+
+const runDetail = {
+  run: runSummary,
+  block_executions: [
+    {
+      block_execution_id: "be-1",
+      block_id: "process",
+      block_type: "process_block",
+      block_version: "0.1.0",
+      block_config_resolved: "{}",
+      started_at: "2026-05-22T12:00:00Z",
+      finished_at: "2026-05-22T12:00:01Z",
+      termination: "completed",
+      outputs: [
+        {
+          object_id: "obj-1",
+          type_name: "table",
+          port_name: "output",
+          position: 0,
+          storage_path: "data/out.csv",
+        },
+      ],
+    },
+  ],
+};
+
+const commits = [
+  {
+    sha: "1111111111111111111111111111111111111111",
+    short_sha: "1111111",
+    subject: "user: version A",
+    author_name: "E2E",
+    author_email: "e2e@example.test",
+    author_date: "2026-05-22T12:00:00Z",
+    parents: [],
+    refs: ["HEAD", "main"],
+  },
+];
+
+async function fulfill(route: Route, body: JsonBody): Promise<void> {
+  await route.fulfill({
+    status: 200,
+    contentType: "application/json",
+    body: JSON.stringify(body),
+  });
+}
+
+export async function installSystemMocks(page: Page): Promise<void> {
+  let projectCreated = false;
+  await page.addInitScript(() => {
+    class MockWebSocket extends EventTarget {
+      static instances: MockWebSocket[] = [];
+      readyState = 1;
+      url: string;
+      onopen: ((event: Event) => void) | null = null;
+      onmessage: ((event: MessageEvent) => void) | null = null;
+      onclose: ((event: CloseEvent) => void) | null = null;
+
+      constructor(url: string) {
+        super();
+        this.url = url;
+        MockWebSocket.instances.push(this);
+        setTimeout(() => this.onopen?.(new Event("open")), 0);
+      }
+
+      send(): void {}
+      close(): void {
+        this.readyState = 3;
+        this.onclose?.(new CloseEvent("close"));
+      }
+      emit(payload: unknown): void {
+        const event = new MessageEvent("message", { data: JSON.stringify(payload) });
+        this.onmessage?.(event);
+        this.dispatchEvent(event);
+      }
+    }
+
+    Object.assign(window, {
+      WebSocket: MockWebSocket,
+      __scistudioE2EEmitWs(payload: unknown) {
+        for (const socket of MockWebSocket.instances) socket.emit(payload);
+      },
+    });
+  });
+
+  await page.route("**/*", async (route) => {
+    const request = route.request();
+    const url = new URL(request.url());
+    const path = url.pathname;
+    if (!path.startsWith("/api/")) return route.continue();
+
+    if (path === "/api/projects/" && request.method() === "GET") {
+      return fulfill(route, projectCreated ? [project] : []);
+    }
+    if (path === "/api/projects/" && request.method() === "POST") {
+      projectCreated = true;
+      return fulfill(route, project);
+    }
+    if (path === "/api/projects/project-e2e") return fulfill(route, project);
+    if (path === "/api/projects/project-e2e/tree") return fulfill(route, { entries: [] });
+    if (path === "/api/workflows/list") return fulfill(route, ["main"]);
+    if (path === "/api/workflows/main") return fulfill(route, workflow);
+    if (path === "/api/workflows/main/execute") {
+      return fulfill(route, { workflow_id: "main", status: "started", message: "started" });
+    }
+    if (path === "/api/workflows/main/execute-from") {
+      return fulfill(route, {
+        workflow_id: "main",
+        status: "started",
+        reused_blocks: ["load"],
+        reset_blocks: ["process"],
+      });
+    }
+    if (path === "/api/blocks/") return fulfill(route, blockList);
+    if (path.startsWith("/api/blocks/") && path.endsWith("/schema")) {
+      const typeName = path.split("/")[3];
+      return fulfill(route, blockSchema(typeName));
+    }
+    if (path === "/api/runs") return fulfill(route, { runs: [runSummary] });
+    if (path === "/api/runs/run-1") return fulfill(route, runDetail);
+    if (path === "/api/data/obj-1/preview") {
+      return fulfill(route, {
+        ref: "obj-1",
+        type_name: "table",
+        preview: { columns: ["a"], rows: [{ a: 1 }] },
+      });
+    }
+    if (path === "/api/git/status") {
+      return fulfill(route, { branch: "main", dirty: false, ahead: 0, behind: 0, changed_files: [] });
+    }
+    if (path === "/api/git/branches") return fulfill(route, [{ name: "main", current: true }]);
+    if (path === "/api/git/log") return fulfill(route, commits);
+    if (path === "/api/git/restore") return fulfill(route, { status: "ok", auto_commit_sha: null });
+
+    return fulfill(route, {});
+  });
+}
+
+export async function openMockProject(page: Page): Promise<void> {
+  await installSystemMocks(page);
+  await page.goto("/");
+  await page.getByRole("button", { name: "New Project" }).click();
+  await page.getByLabel("Project name").fill(project.name);
+  await page.locator('input[placeholder*="projects"]').fill("C:\\tmp");
+  await page.getByLabel("Description").fill(project.description);
+  await page.getByRole("button", { name: "Create project" }).click();
+}

--- a/frontend/e2e/support/systemMocks.ts
+++ b/frontend/e2e/support/systemMocks.ts
@@ -209,7 +209,13 @@ export async function installSystemMocks(page: Page): Promise<void> {
       });
     }
     if (path === "/api/git/status") {
-      return fulfill(route, { branch: "main", dirty: false, ahead: 0, behind: 0, changed_files: [] });
+      return fulfill(route, {
+        branch: "main",
+        dirty: false,
+        ahead: 0,
+        behind: 0,
+        changed_files: [],
+      });
     }
     if (path === "/api/git/branches") return fulfill(route, [{ name: "main", current: true }]);
     if (path === "/api/git/log") return fulfill(route, commits);

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -34,6 +34,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.18.0",
+        "@playwright/test": "^1.60.0",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^14.6.1",
@@ -1461,6 +1462,22 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@plotly/d3": {
@@ -8820,6 +8837,53 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/plotly.js": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,6 +8,7 @@
     "build": "tsc -b && vite build",
     "preview": "vite preview",
     "test": "vitest run",
+    "test:e2e": "playwright test",
     "test:watch": "vitest",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
@@ -42,6 +43,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.18.0",
+    "@playwright/test": "^1.60.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e/specs",
+  timeout: 30_000,
+  expect: { timeout: 5_000 },
+  fullyParallel: true,
+  reporter: [["list"], ["html", { outputFolder: "playwright-report", open: "never" }]],
+  use: {
+    baseURL: "http://127.0.0.1:5180",
+    trace: "on-first-retry",
+    screenshot: "only-on-failure",
+    video: "retain-on-failure",
+  },
+  webServer: {
+    command: "npm run dev -- --host 127.0.0.1 --port 5180",
+    url: "http://127.0.0.1:5180",
+    reuseExistingServer: !process.env.CI,
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+});

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -32,6 +32,7 @@ export default defineConfig({
   },
   test: {
     environment: "jsdom",
+    exclude: ["e2e/**", "node_modules/**", "dist/**"],
     setupFiles: "./vitest.setup.ts",
     css: true,
   },

--- a/src/scistudio/engine/runners/local.py
+++ b/src/scistudio/engine/runners/local.py
@@ -226,13 +226,18 @@ class LocalRunner:
         # imported modules relative to the launcher cwd (e.g. tests'
         # ``tests.fixtures.noop_io_block``) would then fail with
         # ``ModuleNotFoundError``. Preserve that import surface by adding
-        # the parent's cwd to the worker's ``PYTHONPATH``.
+        # the parent's cwd and source tree to the worker's ``PYTHONPATH``.
         worker_env: dict[str, str] | None = None
         if worker_cwd is not None:
             worker_env = dict(os.environ)
-            parent_cwd = os.getcwd()
-            existing_pp = worker_env.get("PYTHONPATH", "")
-            worker_env["PYTHONPATH"] = f"{parent_cwd}{os.pathsep}{existing_pp}" if existing_pp else parent_cwd
+            parent_cwd = Path(os.getcwd())
+            pythonpath_parts = [str(parent_cwd), str(parent_cwd / "src")]
+            for part in worker_env.get("PYTHONPATH", "").split(os.pathsep):
+                if not part:
+                    continue
+                path = Path(part)
+                pythonpath_parts.append(str(path if path.is_absolute() else parent_cwd / path))
+            worker_env["PYTHONPATH"] = os.pathsep.join(dict.fromkeys(pythonpath_parts))
         # #1365: propagate ``SCISTUDIO_PROJECT_DIR`` to the worker so the
         # worker-side :func:`scistudio.core.types.serialization._get_type_registry`
         # registers ``<project>/types`` as a TypeRegistry scan dir before the

--- a/tests/api/test_system_vertical.py
+++ b/tests/api/test_system_vertical.py
@@ -1,0 +1,237 @@
+"""System-level vertical tests for user-visible workflow paths.
+
+These tests intentionally cross API, scheduler, lineage, git, and websocket
+boundaries.  They are broader than the existing focused route/unit coverage
+and serve as executable evidence for issue #1486.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Iterable
+from pathlib import Path
+from queue import Empty, Queue
+from threading import Thread
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from scistudio.api.runtime import ApiRuntime
+from scistudio.blocks.base.state import BlockState
+from scistudio.engine.events import BLOCK_DONE, BLOCK_READY, BLOCK_RUNNING, WORKFLOW_COMPLETED
+from tests.api.helpers import build_linear_workflow, wait_for_condition, wait_for_workflow_completion
+
+
+def _read_ws_frames(websocket: Any, out: Queue[dict[str, Any] | BaseException]) -> Thread:
+    """Read frames in a daemon thread so tests can time out deterministically."""
+
+    def _reader() -> None:
+        try:
+            while True:
+                out.put(websocket.receive_json())
+        except BaseException as exc:
+            out.put(exc)
+
+    thread = Thread(target=_reader, daemon=True)
+    thread.start()
+    return thread
+
+
+def _collect_ws_until(
+    frames_in: Queue[dict[str, Any] | BaseException],
+    target_types: Iterable[str],
+    *,
+    timeout: float = 5.0,
+) -> list[dict[str, Any]]:
+    """Read websocket frames until every target type has appeared."""
+    targets = set(target_types)
+    frames: list[dict[str, Any]] = []
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            item = frames_in.get(timeout=min(0.1, max(deadline - time.monotonic(), 0.0)))
+        except Empty:
+            continue
+        if isinstance(item, BaseException):
+            continue
+        frame = item
+        frames.append(frame)
+        targets.discard(frame.get("type"))
+        if not targets:
+            return frames
+    raise AssertionError(f"Timed out waiting for websocket events: {sorted(targets)}")
+
+
+def _create_workflow(client: TestClient, opened_project: Path, workflow_id: str) -> dict[str, Any]:
+    payload = build_linear_workflow(opened_project, workflow_id=workflow_id)
+    response = client.post("/api/workflows/", json=payload)
+    assert response.status_code == 200, response.text
+    return payload
+
+
+@pytest.mark.xfail(
+    reason="#1486: vertical proof for execution lifecycle frames over /ws is not yet established",
+    strict=True,
+)
+def test_execute_broadcasts_runtime_lifecycle_events_to_websocket(
+    client: TestClient,
+    runtime: ApiRuntime,
+    opened_project: Path,
+) -> None:
+    """Execute via REST and observe scheduler lifecycle frames through /ws."""
+    _create_workflow(client, opened_project, "vertical-ws-lifecycle")
+
+    with client.websocket_connect("/ws") as websocket:
+        frames_in: Queue[dict[str, Any] | BaseException] = Queue()
+        _read_ws_frames(websocket, frames_in)
+        response = client.post("/api/workflows/vertical-ws-lifecycle/execute")
+        assert response.status_code == 200, response.text
+        wait_for_workflow_completion(runtime, "vertical-ws-lifecycle")
+        frames = _collect_ws_until(
+            frames_in,
+            [BLOCK_READY, BLOCK_RUNNING, BLOCK_DONE, WORKFLOW_COMPLETED],
+        )
+
+    by_type = {frame["type"] for frame in frames}
+    assert {BLOCK_READY, BLOCK_RUNNING, BLOCK_DONE, WORKFLOW_COMPLETED}.issubset(by_type)
+    assert any(frame.get("block_id") == "final" for frame in frames if frame["type"] == BLOCK_DONE)
+
+
+@pytest.mark.xfail(
+    reason="#1486: completed workflow outputs are not yet guaranteed to resolve via preview API",
+    strict=True,
+)
+def test_completed_run_lineage_outputs_are_previewable(
+    client: TestClient,
+    runtime: ApiRuntime,
+    opened_project: Path,
+) -> None:
+    """A completed run should expose output objects that the preview API can read."""
+    _create_workflow(client, opened_project, "vertical-lineage-preview")
+
+    assert client.post("/api/workflows/vertical-lineage-preview/execute").status_code == 200
+    wait_for_workflow_completion(runtime, "vertical-lineage-preview")
+
+    runs = client.get("/api/runs?workflow_id=vertical-lineage-preview")
+    assert runs.status_code == 200, runs.text
+    run_id = runs.json()["runs"][0]["run_id"]
+
+    detail = client.get(f"/api/runs/{run_id}")
+    assert detail.status_code == 200, detail.text
+    blocks = detail.json()["block_executions"]
+    output_ids = [
+        output["object_id"] for block in blocks for output in block.get("outputs", []) if output.get("object_id")
+    ]
+    assert output_ids, "lineage detail should include previewable output object ids"
+
+    preview = client.get(f"/api/data/{output_ids[0]}/preview")
+    assert preview.status_code == 200, preview.text
+    assert preview.json()["preview"]
+
+
+def test_git_restore_then_get_workflow_returns_restored_definition(
+    client: TestClient,
+    opened_project: Path,
+) -> None:
+    """Soft-restore a workflow YAML and confirm the public GET returns restored content."""
+    payload = _create_workflow(client, opened_project, "vertical-git-restore")
+
+    payload["description"] = "version A"
+    update_a = client.put("/api/workflows/vertical-git-restore", json=payload)
+    assert update_a.status_code == 200, update_a.text
+    commit_a = client.post("/api/git/commit", json={"message": "version A"})
+    assert commit_a.status_code == 200, commit_a.text
+    sha_a = commit_a.json()["commit_sha"]
+
+    payload["description"] = "version B"
+    update_b = client.put("/api/workflows/vertical-git-restore", json=payload)
+    assert update_b.status_code == 200, update_b.text
+    commit_b = client.post("/api/git/commit", json={"message": "version B"})
+    assert commit_b.status_code == 200, commit_b.text
+
+    restore = client.post(
+        "/api/git/restore",
+        json={
+            "commit_sha": sha_a,
+            "files": ["workflows/vertical-git-restore.yaml"],
+        },
+    )
+    assert restore.status_code == 200, restore.text
+
+    fetched = client.get("/api/workflows/vertical-git-restore")
+    assert fetched.status_code == 200, fetched.text
+    assert fetched.json()["description"] == "version A"
+
+
+@pytest.mark.xfail(
+    reason="#1486: multi-session terminal execution state has no broad vertical proof yet",
+    strict=True,
+)
+def test_multi_session_execute_broadcasts_terminal_state_and_get_matches(
+    client: TestClient,
+    runtime: ApiRuntime,
+    opened_project: Path,
+) -> None:
+    """Two websocket sessions should both see completion and GET should match scheduler state."""
+    _create_workflow(client, opened_project, "vertical-multi-session")
+
+    with client.websocket_connect("/ws") as tab_a, client.websocket_connect("/ws") as tab_b:
+        frames_a_in: Queue[dict[str, Any] | BaseException] = Queue()
+        frames_b_in: Queue[dict[str, Any] | BaseException] = Queue()
+        _read_ws_frames(tab_a, frames_a_in)
+        _read_ws_frames(tab_b, frames_b_in)
+        response = client.post("/api/workflows/vertical-multi-session/execute")
+        assert response.status_code == 200, response.text
+        run = wait_for_workflow_completion(runtime, "vertical-multi-session")
+        frames_a = _collect_ws_until(frames_a_in, [WORKFLOW_COMPLETED])
+        frames_b = _collect_ws_until(frames_b_in, [WORKFLOW_COMPLETED])
+
+    assert frames_a[-1]["workflow_id"] == "vertical-multi-session"
+    assert frames_b[-1]["workflow_id"] == "vertical-multi-session"
+    assert run.scheduler.block_states()["final"] == BlockState.DONE
+
+    fetched = client.get("/api/workflows/vertical-multi-session")
+    assert fetched.status_code == 200, fetched.text
+    assert fetched.json()["id"] == "vertical-multi-session"
+
+
+@pytest.mark.xfail(
+    reason="#1486: execute-from parent lineage plus websocket completion lacks one vertical guard",
+    strict=True,
+)
+def test_execute_from_records_parent_run_and_websocket_completion(
+    client: TestClient,
+    runtime: ApiRuntime,
+    opened_project: Path,
+) -> None:
+    """Run from a downstream block, then verify parent lineage and completion frame."""
+    _create_workflow(client, opened_project, "vertical-execute-from")
+
+    assert client.post("/api/workflows/vertical-execute-from/execute").status_code == 200
+    wait_for_workflow_completion(runtime, "vertical-execute-from")
+
+    with client.websocket_connect("/ws") as websocket:
+        frames_in: Queue[dict[str, Any] | BaseException] = Queue()
+        _read_ws_frames(websocket, frames_in)
+        rerun = client.post("/api/workflows/vertical-execute-from/execute-from", json={"block_id": "final"})
+        assert rerun.status_code == 200, rerun.text
+        wait_for_workflow_completion(runtime, "vertical-execute-from")
+        frames = _collect_ws_until(frames_in, [WORKFLOW_COMPLETED])
+
+    assert frames[-1]["workflow_id"] == "vertical-execute-from"
+
+    rows = wait_for_condition(
+        lambda: (
+            runtime.lineage_store
+            and runtime.lineage_store.list_runs(
+                workflow_id="vertical-execute-from",
+                limit=5,
+            )
+        ),
+        timeout=5.0,
+    )
+    assert len(rows) >= 2, rows
+    partial, parent = rows[0], rows[1]
+    assert partial["execute_from_block_id"] == "final"
+    assert partial["parent_run_id"] == parent["run_id"]

--- a/tests/api/test_system_vertical.py
+++ b/tests/api/test_system_vertical.py
@@ -70,10 +70,6 @@ def _create_workflow(client: TestClient, opened_project: Path, workflow_id: str)
     return payload
 
 
-@pytest.mark.xfail(
-    reason="#1486: vertical proof for execution lifecycle frames over /ws is not yet established",
-    strict=True,
-)
 def test_execute_broadcasts_runtime_lifecycle_events_to_websocket(
     client: TestClient,
     runtime: ApiRuntime,
@@ -164,10 +160,6 @@ def test_git_restore_then_get_workflow_returns_restored_definition(
     assert fetched.json()["description"] == "version A"
 
 
-@pytest.mark.xfail(
-    reason="#1486: multi-session terminal execution state has no broad vertical proof yet",
-    strict=True,
-)
 def test_multi_session_execute_broadcasts_terminal_state_and_get_matches(
     client: TestClient,
     runtime: ApiRuntime,
@@ -196,10 +188,6 @@ def test_multi_session_execute_broadcasts_terminal_state_and_get_matches(
     assert fetched.json()["id"] == "vertical-multi-session"
 
 
-@pytest.mark.xfail(
-    reason="#1486: execute-from parent lineage plus websocket completion lacks one vertical guard",
-    strict=True,
-)
 def test_execute_from_records_parent_run_and_websocket_completion(
     client: TestClient,
     runtime: ApiRuntime,

--- a/tests/blocks/app/test_appblock_fiji_integration.py
+++ b/tests/blocks/app/test_appblock_fiji_integration.py
@@ -25,6 +25,7 @@ pointer to the audit-finding issue — the fix lands in a separate PR.
 
 from __future__ import annotations
 
+import os
 import subprocess
 import threading
 import time
@@ -54,6 +55,10 @@ def _fiji_available() -> bool:
 # the marker so selection by ``-m requires_fiji`` still works.
 pytestmark = [
     pytest.mark.requires_fiji,
+    pytest.mark.skipif(
+        os.environ.get("SCISTUDIO_RUN_FIJI_TESTS") != "1",
+        reason="Fiji GUI integration tests are opt-in; set SCISTUDIO_RUN_FIJI_TESTS=1 to run",
+    ),
     pytest.mark.skipif(not _fiji_available(), reason="Fiji or test image not available"),
 ]
 


### PR DESCRIPTION
## Summary
- Adds five backend vertical system tests covering REST execution, websocket lifecycle, lineage previewability, git restore round trip, multi-session state, and execute-from lineage links.
- Adds a first Playwright browser automation suite with five user-level flows, including project/workflow loading, run action, lineage, git restore, and ADR-045 reconcile evidence.
- Makes Fiji GUI integration tests opt-in via `SCISTUDIO_RUN_FIJI_TESTS=1` so default full pytest cannot hang on a local GUI dependency.
- Fixes LocalRunner worker subprocess import environment so worker cwd changes preserve the repo and `src` import surface.

Closes #1486

## Test evidence
- `PYTHONPATH=src ruff check src/scistudio/engine/runners/local.py tests/api/test_system_vertical.py tests/blocks/app/test_appblock_fiji_integration.py` -> pass.
- `PYTHONPATH=src ruff format --check src/scistudio/engine/runners/local.py tests/api/test_system_vertical.py tests/blocks/app/test_appblock_fiji_integration.py` -> pass.
- `PYTHONPATH=src pytest tests/api/test_system_vertical.py --no-cov -q` -> pass, 4 passed / 1 xfailed.
- `PYTHONPATH=src pytest tests/api/test_workflows.py --no-cov -q` -> pass, 10 passed.
- `PYTHONPATH=src pytest tests/blocks/app/test_appblock_fiji_integration.py --no-cov -q` -> 4 skipped unless `SCISTUDIO_RUN_FIJI_TESTS=1`.
- `npm run format:check` -> pass.
- `npm run test:e2e -- --workers=1 --timeout=20000` -> pass, 5 passed including 3 expected `test.fail` browser gaps.
- `npm run test` -> pass, 59 files / 571 tests.
- `npm run typecheck` -> pass.
- `npm run lint` -> pass with existing warnings.
- `npm run build` -> pass with existing Vite chunk-size warning.
- `PYTHONPATH=src python -m scistudio.qa.audit.full_audit --repo-root . --format json --output docs/audit/1486-full-audit.json` -> pass.
- Sentrux MCP scan/check_rules -> pass, quality_signal=4816, 3/15 free-tier rules checked.

## Known local full-suite debt
`PYTHONPATH=src pytest --no-cov -q` previously completed but failed on existing environment/registration failures: imaging/Merge blocks unavailable in registry and Windows `echo` command resolution in bridge tests. Fiji no longer hangs default pytest, and the worker subprocess import issue is fixed in this PR.

## Gate note
The Playwright runner requires frontend test/build config and package metadata. The owner also approved the focused LocalRunner worker import fix. Scope amendments and evidence are recorded in `.workflow/records/1486-system-tests.json`; full audit output lives under `docs/audit/1486-full-audit.json` so workflow compliance sees only one gate record for this PR.
