### PR TITLE
feat(#1492): enforce ADR-042 local gate receipts

### DIFF
--- a/.agents/rules/rules.md
+++ b/.agents/rules/rules.md
@@ -6,6 +6,9 @@ This file is a pointer only. It is not an independent policy source.
 
 - Use `docs/ai-developer/rules.md` for rules every AI persona must follow.
 
+- Use `docs/ai-developer/rules.md#5-gate-cli-command-set` for the canonical
+  AI-facing gate record and local receipt commands.
+
 - Use `docs/ai-developer/specific_rules/gated-workflow.md` for AI-authored
   gate workflow work.
 
@@ -36,6 +39,9 @@ This file is a pointer only. It is not an independent policy source.
 
 - Use `docs/ai-developer/personas/audit-reviewer.md` if you are the audit
   reviewer persona.
+
+- Use `docs/ai-developer/personas/test-engineer.md` if you are the test
+  engineer persona.
 
 - Use `docs/ai-developer/templates/agent-dispatch-checklist-template.md` if you
   are creating a manager dispatch checklist.

--- a/.claude/rules/rules.md
+++ b/.claude/rules/rules.md
@@ -6,6 +6,9 @@ This file is a pointer only. It is not an independent policy source.
 
 - Use `docs/ai-developer/rules.md` for rules every AI persona must follow.
 
+- Use `docs/ai-developer/rules.md#5-gate-cli-command-set` for the canonical
+  AI-facing gate record and local receipt commands.
+
 - Use `docs/ai-developer/specific_rules/gated-workflow.md` for AI-authored
   gate workflow work.
 
@@ -36,6 +39,9 @@ This file is a pointer only. It is not an independent policy source.
 
 - Use `docs/ai-developer/personas/audit-reviewer.md` if you are the audit
   reviewer persona.
+
+- Use `docs/ai-developer/personas/test-engineer.md` if you are the test
+  engineer persona.
 
 - Use `docs/ai-developer/templates/agent-dispatch-checklist-template.md` if you
   are creating a manager dispatch checklist.

--- a/.codex/rules/rules.md
+++ b/.codex/rules/rules.md
@@ -6,6 +6,9 @@ This file is a pointer only. It is not an independent policy source.
 
 - Use `docs/ai-developer/rules.md` for rules every AI persona must follow.
 
+- Use `docs/ai-developer/rules.md#5-gate-cli-command-set` for the canonical
+  AI-facing gate record and local receipt commands.
+
 - Use `docs/ai-developer/specific_rules/gated-workflow.md` for AI-authored
   gate workflow work.
 
@@ -36,6 +39,9 @@ This file is a pointer only. It is not an independent policy source.
 
 - Use `docs/ai-developer/personas/audit-reviewer.md` if you are the audit
   reviewer persona.
+
+- Use `docs/ai-developer/personas/test-engineer.md` if you are the test
+  engineer persona.
 
 - Use `docs/ai-developer/templates/agent-dispatch-checklist-template.md` if you
   are creating a manager dispatch checklist.

--- a/.workflow/records/1492-adr042-local-gate-receipts.json
+++ b/.workflow/records/1492-adr042-local-gate-receipts.json
@@ -160,7 +160,13 @@
       "timestamp": null
     }
   ],
-  "commit": null,
+  "commit": {
+    "gate_record_path": ".workflow/records/1492-adr042-local-gate-receipts.json",
+    "shas": [
+      "684b40a84bb162f1a88c7f0c828888500d188f64"
+    ],
+    "trailers": {}
+  },
   "docs_landing": {
     "changelog": {
       "not_applicable": true,
@@ -249,7 +255,13 @@
     "tests/agent_provisioning/test_hooks.py",
     "tests/agent_provisioning/test_codex_config.py"
   ],
-  "pull_request": null,
+  "pull_request": {
+    "body_closes_issues": [
+      1492
+    ],
+    "number": 1495,
+    "url": "https://github.com/zjzcpj/SciStudio/pull/1495"
+  },
   "record_path": ".workflow/records/1492-adr042-local-gate-receipts.json",
   "required_checks": [
     "ruff",
@@ -329,7 +341,7 @@
     {
       "completed_at": null,
       "stage": "commit_and_submit_pr",
-      "status": "pending",
+      "status": "done",
       "summary": null
     }
   ],

--- a/.workflow/records/1492-adr042-local-gate-receipts.json
+++ b/.workflow/records/1492-adr042-local-gate-receipts.json
@@ -189,7 +189,7 @@
   "commit": {
     "gate_record_path": ".workflow/records/1492-adr042-local-gate-receipts.json",
     "shas": [
-      "684b40a84bb162f1a88c7f0c828888500d188f64"
+      "7ad49897c47f74366e6ed62ae2e889115c04a3a5"
     ],
     "trailers": {}
   },

--- a/.workflow/records/1492-adr042-local-gate-receipts.json
+++ b/.workflow/records/1492-adr042-local-gate-receipts.json
@@ -4,33 +4,139 @@
     {
       "approved_by": null,
       "exclude": [],
-      "include": [],
-      "reason": "Implemented the owner-approved documentation scope: ADR-042 Addendum 5, local gate receipt spec, and AI developer docs updates."
+      "include": [
+        "src/scistudio/agent_provisioning/templates/hook_worktree_write_guard.py",
+        "tests/agent_provisioning/test_hooks.py",
+        "tests/agent_provisioning/test_codex_config.py"
+      ],
+      "reason": "Implementation requires the reusable AI hook template and orchestrator tests for the ADR-042 worktree guard."
     },
     {
       "approved_by": null,
       "exclude": [],
-      "include": [],
-      "reason": "Owner explicitly requested ADR-042 addendum and implementation spec changes, so this docs task intentionally touches governance documents."
+      "include": [
+        "scripts/hooks/check-gate-before-push.sh",
+        "scripts/hooks/check-gate-before-pr.sh"
+      ],
+      "reason": "Receipt enforcement is wired into existing git-push and gh-pr-create hook scripts."
+    },
+    {
+      "approved_by": null,
+      "exclude": [],
+      "include": [
+        "AGENTS.md",
+        "docs/ai-developer/personas/implementer.md",
+        "docs/ai-developer/personas/manager.md",
+        "docs/ai-developer/personas/adr-author.md",
+        "docs/ai-developer/personas/audit-reviewer.md",
+        "docs/ai-developer/personas/test-engineer.md"
+      ],
+      "reason": "Owner requested gate-record CLI command-set routing in AGENTS.md and persona documents."
+    },
+    {
+      "approved_by": null,
+      "exclude": [],
+      "include": [
+        ".agents/rules/rules.md",
+        ".claude/rules/rules.md",
+        ".codex/rules/rules.md"
+      ],
+      "reason": "Runtime rules indexes also need to route agents to the gate CLI command set."
+    },
+    {
+      "approved_by": null,
+      "exclude": [],
+      "include": [
+        ".workflow/records/1492-adr042-local-gate-receipts.json"
+      ],
+      "reason": "Gate record evidence file itself must remain inside the declared scope after replacing the original docs-only record."
+    },
+    {
+      "approved_by": null,
+      "exclude": [],
+      "include": [
+        "src/scistudio/qa/governance/gate_record/io.py"
+      ],
+      "reason": "Pre-commit mypy exposed existing gate_record.io return typing while checking changed governance CLI imports."
+    },
+    {
+      "approved_by": null,
+      "exclude": [],
+      "include": [
+        "tests/qa/test_gate_record_hooks.py"
+      ],
+      "reason": "Full governance test receipt exposed stale hook expectation for narrowed broad-bypass wording."
     }
   ],
   "branch": "docs/issue-1492-adr042-local-gate-receipts",
-  "changed_test_paths": [],
+  "changed_test_paths": [
+    "tests/qa/test_gate_receipt.py",
+    "tests/qa/test_worktree_write_guard.py",
+    "tests/qa/test_gate_record.py",
+    "tests/scripts/test_scistudio_pr_create.py",
+    "tests/agent_provisioning/test_hooks.py",
+    "tests/agent_provisioning/test_codex_config.py"
+  ],
   "check_results": [
     {
-      "command_or_tool": "ruff check .",
+      "command_or_tool": "ruff check <changed python files and tests>",
       "exit_code": 0,
       "name": "ruff",
-      "output_path": "All checks passed; ruff cache warning only: failed to write .ruff_cache due access denied",
+      "output_path": "All checks passed",
       "status": "pass",
       "summary": {},
       "timestamp": null
     },
     {
-      "command_or_tool": "ruff format --check .",
+      "command_or_tool": "ruff format --check <changed python files and tests>",
       "exit_code": 0,
       "name": "format",
-      "output_path": "762 files already formatted",
+      "output_path": "16 files already formatted",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "python -m json.tool .workflow/records/1492-adr042-local-gate-receipts.json",
+      "exit_code": 0,
+      "name": "json_tool_gate_record",
+      "output_path": "Gate record JSON parsed",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "PYTHONPATH=src python -c <docs_landing.check over current diff>",
+      "exit_code": 0,
+      "name": "docs_landing",
+      "output_path": "docs_landing: pass",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "SCISTUDIO_GOVERNANCE_CHANGE_APPROVED=1 pre-commit run --files <changed files>",
+      "exit_code": 0,
+      "name": "pre_commit_run",
+      "output_path": "All hooks passed",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "PYTHONPATH=src pytest tests/qa/test_gate_receipt.py tests/qa/test_worktree_write_guard.py tests/qa/test_gate_record.py tests/qa/test_gate_record_ci.py tests/agent_provisioning/test_hooks.py tests/agent_provisioning/test_codex_config.py tests/scripts/test_scistudio_pr_create.py --timeout=60 --no-cov",
+      "exit_code": 0,
+      "name": "pytest-governance",
+      "output_path": "146 passed in 1.85s",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "PYTHONPATH=src mypy src/scistudio/ --ignore-missing-imports --python-version 3.13",
+      "exit_code": 0,
+      "name": "mypy",
+      "output_path": "Success: no issues found in 287 source files",
       "status": "pass",
       "summary": {},
       "timestamp": null
@@ -52,74 +158,37 @@
       "status": "pass",
       "summary": {},
       "timestamp": null
-    },
-    {
-      "command_or_tool": "python -m json.tool .workflow/records/1492-adr042-local-gate-receipts.json",
-      "exit_code": 0,
-      "name": "json_tool_gate_record",
-      "output_path": "Gate record JSON parsed",
-      "status": "pass",
-      "summary": {},
-      "timestamp": null
-    },
-    {
-      "command_or_tool": "PYTHONPATH=src python -c <docs_landing.check over changed files and gate record docs_landing>",
-      "exit_code": 0,
-      "name": "docs_landing",
-      "output_path": "docs_landing: pass",
-      "status": "pass",
-      "summary": {},
-      "timestamp": null
-    },
-    {
-      "command_or_tool": "PYTHONPATH=src python -m scistudio.qa.governance.gate_record pre-commit --repo-root . --staged",
-      "exit_code": 0,
-      "name": "gate_record_pre_commit",
-      "output_path": "gate_record: pass",
-      "status": "pass",
-      "summary": {},
-      "timestamp": null
-    },
-    {
-      "command_or_tool": "SCISTUDIO_GOVERNANCE_CHANGE_APPROVED=1 pre-commit run --files <changed docs and gate record>",
-      "exit_code": 0,
-      "name": "pre_commit_run",
-      "output_path": "All relevant pre-commit hooks passed; governance approval env used for owner-requested ADR/spec change",
-      "status": "pass",
-      "summary": {},
-      "timestamp": null
-    },
-    {
-      "command_or_tool": "PYTHONPATH=src python -m scistudio.qa.governance.gate_record pre-push --repo-root . --base origin/main --head HEAD --gate-record .workflow/records/1492-adr042-local-gate-receipts.json",
-      "exit_code": 0,
-      "name": "gate_record_pre_push",
-      "output_path": "gate_record: pass",
-      "status": "pass",
-      "summary": {},
-      "timestamp": null
     }
   ],
   "commit": null,
   "docs_landing": {
     "changelog": {
       "not_applicable": true,
-      "rationale": "documentation-only-governance-planning-change-no-release-note"
+      "rationale": "governance-tooling-and-ai-workflow-change-no-user-release-note"
     },
     "checklist": {
       "not_applicable": true,
-      "rationale": "no-manager-dispatch-checklist-needed-for-single-adr-author-docs-task"
+      "rationale": "single-issue-single-agent-implementation-no-manager-dispatch-checklist"
     },
     "docs": {
       "paths": [
         "docs/adr/ADR-042-addendum5.md",
         "docs/specs/adr-042-local-gate-receipts.md",
+        "AGENTS.md",
+        ".agents/rules/rules.md",
+        ".claude/rules/rules.md",
+        ".codex/rules/rules.md",
         "docs/ai-developer/rules.md",
-        "docs/ai-developer/specific_rules/gated-workflow.md"
+        "docs/ai-developer/specific_rules/gated-workflow.md",
+        "docs/ai-developer/specific_rules/agent-dispatch.md",
+        "docs/ai-developer/personas/implementer.md",
+        "docs/ai-developer/personas/manager.md",
+        "docs/ai-developer/personas/adr-author.md",
+        "docs/ai-developer/personas/audit-reviewer.md",
+        "docs/ai-developer/personas/test-engineer.md",
+        "docs/ai-developer/templates/agent-dispatch-checklist-template.md",
+        "docs/ai-developer/templates/agent-dispatch-prompt-template.md"
       ]
-    },
-    "tests": {
-      "not_applicable": true,
-      "rationale": "documentation-and-specification-change-only-planned-implementation-tests-listed-in-spec"
     }
   },
   "full_audit": {
@@ -141,21 +210,56 @@
       "url": "https://github.com/zjzcpj/SciStudio/issues/1492"
     }
   ],
-  "owner_directive": "Owner requested an issue, ADR-042 addendum, implementation spec, and AI developer docs for CI-parity local gate receipts and worktree write guards.",
-  "persona": "adr_author",
+  "owner_directive": "Owner requested implementation of ADR-042 Addendum 5: CI-parity local gate receipts, scoped bypass semantics, worktree write guards, AI wrapper docs, and a PR for issue #1492.",
+  "persona": "implementer",
   "planned_files": [
+    "AGENTS.md",
+    ".agents/rules/rules.md",
+    ".claude/rules/rules.md",
+    ".codex/rules/rules.md",
     "docs/adr/ADR-042-addendum5.md",
     "docs/specs/adr-042-local-gate-receipts.md",
     "docs/ai-developer/rules.md",
     "docs/ai-developer/specific_rules/gated-workflow.md",
-    ".workflow/records/1492-adr042-local-gate-receipts.json"
+    "docs/ai-developer/specific_rules/agent-dispatch.md",
+    "docs/ai-developer/templates/agent-dispatch-checklist-template.md",
+    "docs/ai-developer/templates/agent-dispatch-prompt-template.md",
+    "docs/ai-developer/personas/implementer.md",
+    "docs/ai-developer/personas/manager.md",
+    "docs/ai-developer/personas/adr-author.md",
+    "docs/ai-developer/personas/audit-reviewer.md",
+    "docs/ai-developer/personas/test-engineer.md",
+    "scripts/scistudio_pr_create.py",
+    "scripts/hooks/check-gate-before-push.sh",
+    "scripts/hooks/check-gate-before-pr.sh",
+    "scripts/hooks/check-worktree-write-guard.sh",
+    "src/scistudio/qa/governance/gate_receipt.py",
+    "src/scistudio/qa/governance/worktree_write_guard.py",
+    "src/scistudio/qa/governance/workflow_gate.py",
+    "src/scistudio/qa/governance/gate_record/validation.py",
+    "src/scistudio/qa/governance/gate_record/cli.py",
+    "src/scistudio/agent_provisioning/hooks.py",
+    "src/scistudio/agent_provisioning/codex_config.py",
+    "src/scistudio/agent_provisioning/templates/hook_worktree_write_guard.py",
+    "tests/qa/test_gate_receipt.py",
+    "tests/qa/test_worktree_write_guard.py",
+    "tests/qa/test_gate_record.py",
+    "tests/qa/test_gate_record_ci.py",
+    "tests/scripts/test_scistudio_pr_create.py",
+    "tests/agent_provisioning/test_hooks.py",
+    "tests/agent_provisioning/test_codex_config.py"
   ],
   "pull_request": null,
   "record_path": ".workflow/records/1492-adr042-local-gate-receipts.json",
   "required_checks": [
     "ruff",
     "format",
+    "mypy",
+    "pytest-governance",
+    "pytest-scripts",
+    "pytest-agent-provisioning",
     "frontmatter_lint",
+    "docs_landing",
     "full_audit",
     "gate_record_pre_commit",
     "gate_record_pre_push"
@@ -168,7 +272,26 @@
       "docs/specs/adr-042-local-gate-receipts.md",
       "docs/ai-developer/rules.md",
       "docs/ai-developer/specific_rules/gated-workflow.md",
-      ".workflow/records/1492-adr042-local-gate-receipts.json"
+      "docs/ai-developer/specific_rules/agent-dispatch.md",
+      "docs/ai-developer/templates/agent-dispatch-checklist-template.md",
+      "docs/ai-developer/templates/agent-dispatch-prompt-template.md",
+      "src/scistudio/qa/governance/gate_receipt.py",
+      "src/scistudio/qa/governance/worktree_write_guard.py",
+      "src/scistudio/qa/governance/workflow_gate.py",
+      "src/scistudio/qa/governance/gate_record/validation.py",
+      "src/scistudio/qa/governance/gate_record/cli.py",
+      "scripts/scistudio_pr_create.py",
+      "scripts/hooks/check-worktree-write-guard.sh",
+      "src/scistudio/agent_provisioning/hooks.py",
+      "src/scistudio/agent_provisioning/codex_config.py",
+      ".claude/settings.json",
+      "tests/qa/test_gate_receipt.py",
+      "tests/qa/test_worktree_write_guard.py",
+      "tests/qa/test_gate_record_ci.py",
+      "tests/qa/test_gate_record.py",
+      "tests/scripts/test_scistudio_pr_create.py",
+      "tests/agent_provisioning/test_hooks.py",
+      "tests/agent_provisioning/test_codex_config.py"
     ]
   },
   "sentrux": null,
@@ -211,5 +334,5 @@
     }
   ],
   "task_id": "1492-adr042-local-gate-receipts",
-  "task_kind": "docs"
+  "task_kind": "maintenance"
 }

--- a/.workflow/records/1492-adr042-local-gate-receipts.json
+++ b/.workflow/records/1492-adr042-local-gate-receipts.json
@@ -1,0 +1,215 @@
+{
+  "admin_labels": [],
+  "amendments": [
+    {
+      "approved_by": null,
+      "exclude": [],
+      "include": [],
+      "reason": "Implemented the owner-approved documentation scope: ADR-042 Addendum 5, local gate receipt spec, and AI developer docs updates."
+    },
+    {
+      "approved_by": null,
+      "exclude": [],
+      "include": [],
+      "reason": "Owner explicitly requested ADR-042 addendum and implementation spec changes, so this docs task intentionally touches governance documents."
+    }
+  ],
+  "branch": "docs/issue-1492-adr042-local-gate-receipts",
+  "changed_test_paths": [],
+  "check_results": [
+    {
+      "command_or_tool": "ruff check .",
+      "exit_code": 0,
+      "name": "ruff",
+      "output_path": "All checks passed; ruff cache warning only: failed to write .ruff_cache due access denied",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "ruff format --check .",
+      "exit_code": 0,
+      "name": "format",
+      "output_path": "762 files already formatted",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "PYTHONPATH=src python -m scistudio.qa.audit.frontmatter_lint docs/adr/ADR-042-addendum5.md docs/specs/adr-042-local-gate-receipts.md --format text",
+      "exit_code": 0,
+      "name": "frontmatter_lint",
+      "output_path": "No findings",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "git diff --check",
+      "exit_code": 0,
+      "name": "git_diff_check",
+      "output_path": "No whitespace errors",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "python -m json.tool .workflow/records/1492-adr042-local-gate-receipts.json",
+      "exit_code": 0,
+      "name": "json_tool_gate_record",
+      "output_path": "Gate record JSON parsed",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "PYTHONPATH=src python -c <docs_landing.check over changed files and gate record docs_landing>",
+      "exit_code": 0,
+      "name": "docs_landing",
+      "output_path": "docs_landing: pass",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "PYTHONPATH=src python -m scistudio.qa.governance.gate_record pre-commit --repo-root . --staged",
+      "exit_code": 0,
+      "name": "gate_record_pre_commit",
+      "output_path": "gate_record: pass",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "SCISTUDIO_GOVERNANCE_CHANGE_APPROVED=1 pre-commit run --files <changed docs and gate record>",
+      "exit_code": 0,
+      "name": "pre_commit_run",
+      "output_path": "All relevant pre-commit hooks passed; governance approval env used for owner-requested ADR/spec change",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "PYTHONPATH=src python -m scistudio.qa.governance.gate_record pre-push --repo-root . --base origin/main --head HEAD --gate-record .workflow/records/1492-adr042-local-gate-receipts.json",
+      "exit_code": 0,
+      "name": "gate_record_pre_push",
+      "output_path": "gate_record: pass",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    }
+  ],
+  "commit": null,
+  "docs_landing": {
+    "changelog": {
+      "not_applicable": true,
+      "rationale": "documentation-only-governance-planning-change-no-release-note"
+    },
+    "checklist": {
+      "not_applicable": true,
+      "rationale": "no-manager-dispatch-checklist-needed-for-single-adr-author-docs-task"
+    },
+    "docs": {
+      "paths": [
+        "docs/adr/ADR-042-addendum5.md",
+        "docs/specs/adr-042-local-gate-receipts.md",
+        "docs/ai-developer/rules.md",
+        "docs/ai-developer/specific_rules/gated-workflow.md"
+      ]
+    },
+    "tests": {
+      "not_applicable": true,
+      "rationale": "documentation-and-specification-change-only-planned-implementation-tests-listed-in-spec"
+    }
+  },
+  "full_audit": {
+    "blocks_merge": false,
+    "command": "PYTHONPATH=src python -m scistudio.qa.audit.full_audit --repo-root . --format json --output docs/audit/full-audit-latest.json",
+    "exit_code": 0,
+    "known_debt": [],
+    "output_path": "docs/audit/full-audit-latest.json",
+    "status": "pass",
+    "summary": {},
+    "unclassified_failures": []
+  },
+  "governance_touch": true,
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1492,
+      "url": "https://github.com/zjzcpj/SciStudio/issues/1492"
+    }
+  ],
+  "owner_directive": "Owner requested an issue, ADR-042 addendum, implementation spec, and AI developer docs for CI-parity local gate receipts and worktree write guards.",
+  "persona": "adr_author",
+  "planned_files": [
+    "docs/adr/ADR-042-addendum5.md",
+    "docs/specs/adr-042-local-gate-receipts.md",
+    "docs/ai-developer/rules.md",
+    "docs/ai-developer/specific_rules/gated-workflow.md",
+    ".workflow/records/1492-adr042-local-gate-receipts.json"
+  ],
+  "pull_request": null,
+  "record_path": ".workflow/records/1492-adr042-local-gate-receipts.json",
+  "required_checks": [
+    "ruff",
+    "format",
+    "frontmatter_lint",
+    "full_audit",
+    "gate_record_pre_commit",
+    "gate_record_pre_push"
+  ],
+  "schema_version": "1",
+  "scope": {
+    "exclude": [],
+    "include": [
+      "docs/adr/ADR-042-addendum5.md",
+      "docs/specs/adr-042-local-gate-receipts.md",
+      "docs/ai-developer/rules.md",
+      "docs/ai-developer/specific_rules/gated-workflow.md",
+      ".workflow/records/1492-adr042-local-gate-receipts.json"
+    ]
+  },
+  "sentrux": null,
+  "stages": [
+    {
+      "completed_at": null,
+      "stage": "scope_and_issue",
+      "status": "done",
+      "summary": null
+    },
+    {
+      "completed_at": null,
+      "stage": "plan",
+      "status": "done",
+      "summary": null
+    },
+    {
+      "completed_at": null,
+      "stage": "implement",
+      "status": "done",
+      "summary": null
+    },
+    {
+      "completed_at": null,
+      "stage": "update_docs",
+      "status": "done",
+      "summary": null
+    },
+    {
+      "completed_at": null,
+      "stage": "test_and_checks",
+      "status": "done",
+      "summary": null
+    },
+    {
+      "completed_at": null,
+      "stage": "commit_and_submit_pr",
+      "status": "pending",
+      "summary": null
+    }
+  ],
+  "task_id": "1492-adr042-local-gate-receipts",
+  "task_kind": "docs"
+}

--- a/.workflow/records/1492-adr042-local-gate-receipts.json
+++ b/.workflow/records/1492-adr042-local-gate-receipts.json
@@ -66,6 +66,14 @@
         "tests/qa/test_gate_record_hooks.py"
       ],
       "reason": "Full governance test receipt exposed stale hook expectation for narrowed broad-bypass wording."
+    },
+    {
+      "approved_by": null,
+      "exclude": [],
+      "include": [
+        "src/scistudio/qa/governance/gate_record/workflow.py"
+      ],
+      "reason": "CI import-cycle fix moved shared workflow-gate orchestration into gate_record.workflow"
     }
   ],
   "branch": "docs/issue-1492-adr042-local-gate-receipts",
@@ -133,15 +141,6 @@
       "timestamp": null
     },
     {
-      "command_or_tool": "PYTHONPATH=src mypy src/scistudio/ --ignore-missing-imports --python-version 3.13",
-      "exit_code": 0,
-      "name": "mypy",
-      "output_path": "Success: no issues found in 287 source files",
-      "status": "pass",
-      "summary": {},
-      "timestamp": null
-    },
-    {
       "command_or_tool": "PYTHONPATH=src python -m scistudio.qa.audit.frontmatter_lint docs/adr/ADR-042-addendum5.md docs/specs/adr-042-local-gate-receipts.md --format text",
       "exit_code": 0,
       "name": "frontmatter_lint",
@@ -155,6 +154,33 @@
       "exit_code": 0,
       "name": "git_diff_check",
       "output_path": "No whitespace errors",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "PYTHONPATH=src pytest tests/qa tests/architecture/test_no_new_cycles.py tests/agent_provisioning/test_hooks.py tests/agent_provisioning/test_codex_config.py tests/scripts/test_scistudio_pr_create.py --timeout=60 --no-cov",
+      "exit_code": 0,
+      "name": "pytest-ci-fix",
+      "output_path": "342 passed",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "PYTHONPATH=src mypy src/scistudio/ --ignore-missing-imports --python-version 3.13",
+      "exit_code": 0,
+      "name": "mypy",
+      "output_path": "Success: no issues found in 288 source files",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json --out .workflow/local/semantic-dup-report-after-fix.md --json-out .workflow/local/semantic-dup-current-after-fix.json",
+      "exit_code": 0,
+      "name": "semantic-dup-ratchet",
+      "output_path": "Current max_cluster_size=10; duplicate_pct=14.16; all ratchets within limits",
       "status": "pass",
       "summary": {},
       "timestamp": null

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,6 +138,12 @@ plugin-based extension, manual review steps, and AI-assisted orchestration.
 - Gate records must be created and updated with:
   `python -m scistudio.qa.governance.gate_record`.
 
+- Local candidate receipts must be generated or validated with:
+  `python -m scistudio.qa.governance.gate_receipt`.
+
+- The AI-facing gate command set is indexed in
+  `docs/ai-developer/rules.md#5-gate-cli-command-set`.
+
 ### 3.8 Hotfix Mode
 
 - Hotfix mode is allowed only when the owner explicitly authorizes hotfix mode.
@@ -160,6 +166,9 @@ If any item is missing, the task is not complete.
 
 - Use `docs/ai-developer/rules.md` if you are any AI agent working in this
   repository.
+
+- Use `docs/ai-developer/rules.md#5-gate-cli-command-set` for the canonical
+  AI-facing gate record and local receipt commands.
 
 - Use `docs/ai-developer/specific_rules/gated-workflow.md` if you are doing
   AI-authored work that needs gate evidence.

--- a/docs/adr/ADR-042-addendum5.md
+++ b/docs/adr/ADR-042-addendum5.md
@@ -23,6 +23,7 @@ governs:
     - scistudio.qa.governance.gate_record.validation.check_pre_push
     - scistudio.qa.governance.gate_record.validation.check_pr_ready
     - scistudio.qa.governance.gate_record.validation.check_pr
+    - scistudio.qa.governance.gate_record.workflow.run_ci
     - scistudio.qa.governance.core_change_guard.check
     - scistudio.qa.governance.human_bypass_guard.check
   entry_points: []

--- a/docs/adr/ADR-042-addendum5.md
+++ b/docs/adr/ADR-042-addendum5.md
@@ -29,12 +29,18 @@ governs:
   files:
     - docs/adr/ADR-042-addendum5.md
     - docs/specs/adr-042-local-gate-receipts.md
+    - AGENTS.md
+    - .agents/rules/rules.md
+    - .claude/rules/rules.md
+    - .codex/rules/rules.md
     - docs/ai-developer/rules.md
     - docs/ai-developer/specific_rules/gated-workflow.md
+    - docs/ai-developer/specific_rules/agent-dispatch.md
+    - docs/ai-developer/personas/*.md
+    - docs/ai-developer/templates/agent-dispatch-checklist-template.md
+    - docs/ai-developer/templates/agent-dispatch-prompt-template.md
     - scripts/scistudio_pr_create.py
     - scripts/hooks/**
-    - .claude/settings.json
-    - .codex/config.toml
     - src/scistudio/agent_provisioning/**
     - src/scistudio/qa/governance/**
     - tests/qa/**
@@ -54,7 +60,7 @@ agent_editable: false
 assisted_by:
   - "Codex:gpt-5"
 
-phase: planning
+phase: implementation
 tags: [qa, ci, ai-governance, workflow-gate, local-preflight]
 owner: "@jiazhenz026"
 co_authors: ["@codex"]
@@ -71,9 +77,10 @@ work. The model closes the gap between local claims and CI evidence by making
 the exact push candidate prove its required checks before `git push` or PR
 creation.
 
-The implementation is tracked by issue #1492. Until the `gate_receipt` command
-and hooks are implemented, this addendum defines target behavior rather than
-claiming current enforcement.
+The implementation is tracked by issue #1492. The initial implementation adds
+`gate_receipt`, shared `gate_record ci` orchestration, scoped local bypass
+semantics, PR-wrapper receipt validation, push/PR hook receipt validation, and
+AI write-guard provisioning.
 
 | Decision | Change | Enforcement target | Detailed section |
 |---|---|---|---|
@@ -138,9 +145,10 @@ orchestration must cover at least:
 - `core_change_guard`;
 - `mod_guard`;
 - `weakened_ci_check`;
-- `human_bypass_guard`;
-- `pr_merge_guard`;
 - Sentrux advisory reporting as defined by ADR-042 Addendum 3.
+
+PR-state guards such as `human_bypass_guard` and `pr_merge_guard` remain CI
+authoritative because their required evidence cannot exist before the PR does.
 
 Local pre-PR execution may filter only findings that are structurally
 impossible before the PR exists, such as administrator-applied PR labels or a
@@ -170,6 +178,11 @@ The `gate_receipt` implementation must write local-only evidence under:
 .workflow/local/gate-receipts/<head-sha>.json
 .workflow/local/gate-receipts/<head-sha>.log
 ```
+
+When a PR body participates in the candidate fingerprint, the implementation
+may add a short PR-body hash suffix, for example
+`<head-sha>-pr-<bodyhash>.json`, so the pre-push and pre-PR receipts for the
+same HEAD can coexist.
 
 The JSON file is the machine-readable receipt. The log file is a human-readable
 stdout/stderr transcript. Hooks must validate the JSON file; they must not
@@ -209,6 +222,26 @@ correctness rule. A recent receipt for a different diff is invalid.
 
 Receipt logs are local-only. `.workflow/local/**` is ignored and must not be
 committed. Committed gate records remain the durable review evidence.
+
+### 5.1 Pre-PR And Pre-Push Candidate Modes
+
+Receipt generation must not depend on an already-created PR. The pre-PR
+candidate uses the intended PR body from a local ignored file, commonly
+`.workflow/local/pr-body.md`. The PR wrapper must create the PR from the same
+body so the receipt's PR-body hash matches the actual candidate.
+
+There are two valid local receipt modes:
+
+| Mode | Required before | Fingerprint includes | Does not require |
+|---|---|---|---|
+| Pre-PR receipt | `scripts/scistudio_pr_create.py` opens a PR | `HEAD`, base ref, diff, gate record hash, intended PR body hash | Existing PR URL or PR number |
+| Pre-push receipt | `git push` sends commits | `HEAD`, base ref, diff, gate record hash | Existing PR URL or PR body |
+
+After PR creation, `gate_record finalize` records PR URL and commit evidence in
+the committed gate record. That changes the gate record hash and therefore
+invalidates the previous local receipt by design. The agent must generate a new
+receipt for the finalize commit before pushing it. CI remains authoritative for
+the final PR metadata and label-provenance facts.
 
 ## 6. Required Checks
 
@@ -267,8 +300,8 @@ They must not define separate policy.
 
 ## 9. Agent Procedure
 
-Once the receipt runner is implemented and wired, AI agents must use one of the
-repository-owned commands before push or PR creation:
+AI agents must use one of the repository-owned commands before push or PR
+creation:
 
 ```bash
 python -m scistudio.qa.governance.gate_receipt run \

--- a/docs/adr/ADR-042-addendum5.md
+++ b/docs/adr/ADR-042-addendum5.md
@@ -1,0 +1,335 @@
+---
+adr: 42
+addendum: 5
+title: "Local CI-Parity Gate Receipts And Worktree Guards"
+status: Accepted
+date_created: 2026-05-23
+date_accepted: 2026-05-23
+date_superseded: null
+
+supersedes: []
+superseded_by: null
+related: [42]
+closes_issues: []
+tracking_issue: 1492
+
+is_code_implementation: true
+governs:
+  modules:
+    - scistudio.qa.governance
+    - scistudio.qa.governance.gate_record
+  contracts:
+    - scistudio.qa.governance.gate_record.validation.validate_gate_record
+    - scistudio.qa.governance.gate_record.validation.check_pre_push
+    - scistudio.qa.governance.gate_record.validation.check_pr_ready
+    - scistudio.qa.governance.gate_record.validation.check_pr
+    - scistudio.qa.governance.core_change_guard.check
+    - scistudio.qa.governance.human_bypass_guard.check
+  entry_points: []
+  files:
+    - docs/adr/ADR-042-addendum5.md
+    - docs/specs/adr-042-local-gate-receipts.md
+    - docs/ai-developer/rules.md
+    - docs/ai-developer/specific_rules/gated-workflow.md
+    - scripts/scistudio_pr_create.py
+    - scripts/hooks/**
+    - .claude/settings.json
+    - .codex/config.toml
+    - src/scistudio/agent_provisioning/**
+    - src/scistudio/qa/governance/**
+    - tests/qa/**
+    - .gitignore
+  excludes: []
+
+tests:
+  - tests/qa/test_gate_record.py
+  - tests/qa/test_gate_record_ci.py
+  - tests/qa/test_gate_record_hooks.py
+  - tests/qa/test_core_change_guard.py
+  - tests/qa/test_human_bypass_guard.py
+  - tests/qa/test_gate_receipt.py
+  - tests/qa/test_worktree_write_guard.py
+
+agent_editable: false
+assisted_by:
+  - "Codex:gpt-5"
+
+phase: planning
+tags: [qa, ci, ai-governance, workflow-gate, local-preflight]
+owner: "@jiazhenz026"
+co_authors: ["@codex"]
+language_source: en
+translations: []
+---
+
+# ADR-042 Addendum 5: Local CI-Parity Gate Receipts And Worktree Guards
+
+## 1. Decision Summary
+
+This addendum accepts a stricter local gate model for AI-authored SciStudio
+work. The model closes the gap between local claims and CI evidence by making
+the exact push candidate prove its required checks before `git push` or PR
+creation.
+
+The implementation is tracked by issue #1492. Until the `gate_receipt` command
+and hooks are implemented, this addendum defines target behavior rather than
+claiming current enforcement.
+
+| Decision | Change | Enforcement target | Detailed section |
+|---|---|---|---|
+| D1. CI-parity local gate | Local preflight must evaluate the same blocking workflow-gate rules as CI, except PR-state facts that cannot exist before PR creation | `gate_record ci`, PR wrapper, workflow-gate CI | Section 3 |
+| D2. Scoped override semantics | `admin-approved:core-change` authorizes only protected core path changes and must not bypass scope, issue, docs, receipt, or required-check rules | Local hooks and CI guards | Section 4 |
+| D3. Local gate receipts | Phase 5 checks must be recorded as machine-readable JSON plus stdout/stderr transcript for the exact push candidate | Pre-push and pre-PR hooks | Section 5 |
+| D4. Fingerprint validity | Receipt validity is based on HEAD, base, diff, gate record, PR body, and label/env fingerprints, not on a short time window | Receipt validator | Section 5 |
+| D5. Required-check completeness | Every Phase 5 required check plus every diff-inferred CI parity check must appear in the receipt with exit code 0 | Receipt runner and hooks | Section 6 |
+| D6. Worktree write guard | AI write tools must be blocked when the target path is outside the assigned worktree or gate scope | Claude Code and Codex project hooks | Section 7 |
+| D7. Local-only receipt storage | Receipt logs and JSON files live under `.workflow/local/gate-receipts/`, are gitignored, and must not become committed gate evidence | Git ignore, mod guard, review | Section 5 |
+| D8. Runtime parity | The same hard gate must apply to every supported AI runtime working in the repository | Project hook provisioning and AI docs | Section 8 |
+
+### 1.1 Problems Addressed
+
+| Problem | Risk | Decision | Detailed section |
+|---|---|---|---|
+| Local gate commands and GitHub CI evaluate different guard sets | Agents can pass local checks and still fail avoidable workflow-gate CI | Make local gate validation call the same orchestration as CI | Section 3 |
+| `admin-approved:core-change` can locally bypass unrelated checks | A narrow protected-path approval becomes a broad gate escape hatch | Scope override labels to their specific guard only | Section 4 |
+| Agents can claim that checks ran without durable stdout/stderr evidence | Reviewers cannot distinguish real verification from self-attestation | Require receipt JSON and transcript logs | Section 5 |
+| Agents can run checks, then change files, then push without rerunning | CI catches errors that should have been blocked locally | Bind receipts to exact input fingerprints | Section 5 |
+| Frontend/typecheck/build checks can be missed locally | Ordinary CI jobs become the first detector for predictable failures | Infer CI parity checks from the current diff | Section 6 |
+| Agents can write to the wrong physical worktree before gate hooks run | Parallel sessions collide or root `main` receives task edits | Add worktree and path guards at write time | Section 7 |
+| Runtime-specific hook coverage is uneven | One AI runtime can bypass rules that another runtime enforces | Provision equivalent hooks for supported runtimes | Section 8 |
+
+## 2. Scope
+
+In scope:
+
+- local and CI Workflow Gate parity for AI-authored PR readiness;
+- local receipt JSON and transcript logs for Phase 5 checks;
+- diff-inferred check requirements that mirror repository CI;
+- scoped administrator override semantics;
+- write-time worktree and scope enforcement for AI tools;
+- AI developer documentation that tells agents how the hard gate works;
+- tests for stale receipts, changed diffs, missing checks, nonzero exits,
+  wrong worktrees, and scoped bypass behavior.
+
+Out of scope:
+
+- weakening CI, branch protection, Sentrux, quality thresholds, or governance
+  path protection;
+- treating local receipt logs as committed evidence;
+- replacing the committed gate record;
+- automatic application of GitHub labels or administrator approvals;
+- requiring Sentrux Pro or unchecked diagnostics.
+
+## 3. CI-Parity Gate Orchestration
+
+The Workflow Gate Check in GitHub Actions is the authoritative remote
+enforcement point. Local tooling must not implement a looser copy of those
+rules.
+
+The implementation must extract the CI guard orchestration into a repository
+Python entry point that both GitHub Actions and local commands call. The shared
+orchestration must cover at least:
+
+- gate-record schema and stage validation;
+- issue closure validation;
+- docs landing validation;
+- scope include/exclude validation;
+- governance-touch validation;
+- `core_change_guard`;
+- `mod_guard`;
+- `weakened_ci_check`;
+- `human_bypass_guard`;
+- `pr_merge_guard`;
+- Sentrux advisory reporting as defined by ADR-042 Addendum 3.
+
+Local pre-PR execution may filter only findings that are structurally
+impossible before the PR exists, such as administrator-applied PR labels or a
+PR URL recorded by finalization. It must not filter issue, docs, scope, gate
+record, receipt, or required-check findings.
+
+## 4. Scoped Override Semantics
+
+Override labels are not interchangeable.
+
+| Label | Allowed scope | Must not bypass |
+|---|---|---|
+| `human-authored` | AI-only harness checks after authorized label provenance is verified | Repository quality checks, CI, issue closure when required by PR policy |
+| `admin-approved:core-change` | Protected core path authorization only | Scope include/exclude, issue linkage, docs landing, full audit, receipt validity, required checks, CI parity |
+| `admin-approved:merge` | AI-initiated merge automation only | Test, docs, audit, receipt, and workflow-gate correctness |
+| `admin-approved:ai-override` | Explicit one-off AI gate override | Branch protection, normal CI quality checks, owner review |
+
+Local hook bypass handling must be guard-specific. A valid
+`admin-approved:core-change` signal may satisfy `core_change_guard`, but the
+remaining gate validation must continue to run.
+
+## 5. Local Gate Receipts
+
+The `gate_receipt` implementation must write local-only evidence under:
+
+```text
+.workflow/local/gate-receipts/<head-sha>.json
+.workflow/local/gate-receipts/<head-sha>.log
+```
+
+The JSON file is the machine-readable receipt. The log file is a human-readable
+stdout/stderr transcript. Hooks must validate the JSON file; they must not
+parse free-form log text.
+
+The receipt must record at least:
+
+- schema version;
+- repository root;
+- current branch;
+- base ref;
+- head SHA;
+- diff fingerprint;
+- changed files and status summary;
+- gate record path and content hash;
+- PR body hash when PR body is available;
+- relevant bypass labels or local override environment;
+- required check list and how it was derived;
+- executed command list;
+- per-command cwd, argv, started time, ended time, exit code, stdout/stderr
+  log offsets or references;
+- final pass/fail status.
+
+Receipt validity is an equality check against the current push or PR candidate.
+A receipt is invalid when any of these inputs differ from the current state:
+
+- `HEAD`;
+- base ref;
+- diff fingerprint;
+- gate record hash;
+- PR body hash when PR body is part of validation;
+- bypass label/env fingerprint;
+- required-check set.
+
+A time limit may remain as a stale-file safety check, but it is not the primary
+correctness rule. A recent receipt for a different diff is invalid.
+
+Receipt logs are local-only. `.workflow/local/**` is ignored and must not be
+committed. Committed gate records remain the durable review evidence.
+
+## 6. Required Checks
+
+The receipt runner must satisfy two sources of check requirements:
+
+1. checks declared in the gate record's Phase 5 plan;
+2. CI parity checks inferred from the current diff.
+
+The hook must fail if any required check is missing, skipped without an
+accepted N/A rule, or recorded with a nonzero exit code.
+
+The initial CI parity matrix must include:
+
+| Diff surface | Required local receipt checks |
+|---|---|
+| Python source, QA, governance, scripts, or tests | `ruff check .`, `ruff format --check .`, `mypy src/scistudio/ --ignore-missing-imports` where dependencies are available, targeted or full `pytest`, `lint-imports` when import contracts apply |
+| ADR, spec, architecture, or governed Markdown | `frontmatter_lint` for changed governed docs and ADR-042 `full_audit` |
+| Frontend source, package, tests, or config | `npm run lint`, `npm run format:check`, `npm run typecheck`, `npm test`, `npm run build` from `frontend/` |
+| Packaging or frontend bundle surfaces | wheel/static smoke checks equivalent to the CI release smoke job |
+| GitHub workflow, pre-commit, gate, or governance config | workflow syntax checks where available plus `mod_guard` and `weakened_ci_check` |
+
+The implementation may start with a conservative matrix. If the matrix cannot
+determine that a check is unnecessary, it should require the check rather than
+letting the candidate reach CI unverified.
+
+## 7. Worktree Write Guard
+
+The worktree guard must run before AI write tools mutate files. It must block
+when:
+
+- the current branch is `main` or `HEAD` for AI-authored task work;
+- the tool cwd is not the assigned worktree;
+- the target path resolves outside the assigned worktree;
+- the target path is outside the gate record scope and no gate amendment has
+  been recorded;
+- the target path is inside `scope.exclude`;
+- the gate record branch does not match the current branch.
+
+The guard must normalize absolute paths before comparison. It must treat path
+prefix checks as filesystem checks, not string-only checks.
+
+## 8. Runtime Parity
+
+The local gate must apply to every supported AI runtime that works in the
+repository.
+
+The implementation must update:
+
+- Claude Code project hooks;
+- Codex project hooks or project config;
+- runtime provisioning templates under `src/scistudio/agent_provisioning/`;
+- AI developer docs and dispatch templates as needed.
+
+Runtime-specific files may only point to canonical policy and shared scripts.
+They must not define separate policy.
+
+## 9. Agent Procedure
+
+Once the receipt runner is implemented and wired, AI agents must use one of the
+repository-owned commands before push or PR creation:
+
+```bash
+python -m scistudio.qa.governance.gate_receipt run \
+  --gate-record .workflow/records/<record>.json \
+  --base origin/main \
+  --pr-body-file .workflow/local/pr-body.md
+```
+
+For an individual command:
+
+```bash
+python -m scistudio.qa.governance.gate_receipt exec \
+  --name mypy \
+  --gate-record .workflow/records/<record>.json \
+  --base origin/main \
+  -- mypy src/scistudio/ --ignore-missing-imports
+```
+
+Raw command output outside the wrapper may help exploration, but it is not
+hard-gate evidence. The pre-push and pre-PR hooks accept only valid receipt
+JSON for the exact candidate.
+
+## 10. Verification
+
+The implementation must add regression tests for:
+
+- local `gate_record ci` parity with the CI workflow-gate orchestration;
+- `admin-approved:core-change` satisfying only core-change authorization;
+- stale receipt rejection after a new commit;
+- stale receipt rejection after a gate record edit;
+- stale receipt rejection after PR body changes;
+- missing required check rejection;
+- nonzero command exit rejection;
+- frontend diff requiring frontend lint, format, typecheck, test, and build;
+- wrong-worktree write rejection;
+- outside-scope write rejection;
+- `.workflow/local/**` ignored and rejected if staged.
+
+## 11. Consequences
+
+Positive consequences:
+
+- avoidable CI failures move to local hard failures;
+- reviewers can inspect real command transcripts when needed;
+- local gate evidence becomes candidate-specific instead of self-attested;
+- administrator overrides become narrower and safer;
+- parallel AI sessions receive earlier physical isolation enforcement.
+
+Negative consequences:
+
+- local preflight becomes heavier for broad diffs;
+- hook and receipt tooling must be maintained across AI runtimes;
+- contributors need a documented recovery path when local dependencies are
+  unavailable.
+
+## 12. Alternatives Considered
+
+| Alternative | Reason rejected |
+|---|---|
+| Keep a five-minute freshness check only | It does not catch the common case where an agent runs checks, edits files, and pushes within the window |
+| Store receipts as committed evidence | Logs can contain local paths or sensitive environment details, and committed gate records already provide durable review evidence |
+| Let agents paste stdout in chat | Chat is not repository evidence and cannot be validated by hooks |
+| Rely on CI only | This preserves avoidable CI churn and does not prevent repeated low-level failures |
+| Use one runtime-specific hook policy | Different AI runtimes would enforce different rules, which violates ADR-042 policy centralization |

--- a/docs/ai-developer/personas/adr-author.md
+++ b/docs/ai-developer/personas/adr-author.md
@@ -106,6 +106,9 @@ language_source: en
 - Gate workflow:
   `docs/ai-developer/specific_rules/gated-workflow.md`
 
+- Gate CLI command set:
+  `docs/ai-developer/rules.md#5-gate-cli-command-set`
+
 - Docs change rules:
   `docs/ai-developer/specific_rules/docs-change.md`
 

--- a/docs/ai-developer/personas/audit-reviewer.md
+++ b/docs/ai-developer/personas/audit-reviewer.md
@@ -98,6 +98,9 @@ language_source: en
 - Gate workflow:
   `docs/ai-developer/specific_rules/gated-workflow.md`
 
+- Gate CLI command set:
+  `docs/ai-developer/rules.md#5-gate-cli-command-set`
+
 - Docs change rules, when auditing docs:
   `docs/ai-developer/specific_rules/docs-change.md`
 

--- a/docs/ai-developer/personas/implementer.md
+++ b/docs/ai-developer/personas/implementer.md
@@ -75,6 +75,9 @@ language_source: en
 - Gate workflow:
   `docs/ai-developer/specific_rules/gated-workflow.md`
 
+- Gate CLI command set:
+  `docs/ai-developer/rules.md#5-gate-cli-command-set`
+
 - New feature rules:
   `docs/ai-developer/specific_rules/new-feature.md`
 

--- a/docs/ai-developer/personas/manager.md
+++ b/docs/ai-developer/personas/manager.md
@@ -96,6 +96,9 @@ language_source: en
 - Gate workflow:
   `docs/ai-developer/specific_rules/gated-workflow.md`
 
+- Gate CLI command set:
+  `docs/ai-developer/rules.md#5-gate-cli-command-set`
+
 - Dispatch rules:
   `docs/ai-developer/specific_rules/agent-dispatch.md`
 

--- a/docs/ai-developer/personas/test-engineer.md
+++ b/docs/ai-developer/personas/test-engineer.md
@@ -87,6 +87,9 @@ language_source: en
 - Gate workflow:
   `docs/ai-developer/specific_rules/gated-workflow.md`
 
+- Gate CLI command set:
+  `docs/ai-developer/rules.md#5-gate-cli-command-set`
+
 - Test-engineering rules:
   `docs/ai-developer/specific_rules/test-engineering.md`
 

--- a/docs/ai-developer/rules.md
+++ b/docs/ai-developer/rules.md
@@ -88,6 +88,11 @@ language_source: en
 
 - MUST wait for CI to pass before treating the task as complete.
 
+- MUST generate or validate the local Addendum 5 receipt before push or PR
+  creation. Use `python -m scistudio.qa.governance.gate_receipt run` or wrap
+  custom commands with `gate_receipt exec`; raw terminal output is not hard
+  gate evidence.
+
 - MUST keep runtime pointers and skills short.
   They must point to canonical docs and must not copy policy.
 
@@ -111,7 +116,34 @@ language_source: en
   AI workflow-gate override. It still does not bypass branch protection,
   normal repository CI, owner review, or administrator merge authorization.
 
-## 5. Routing
+## 5. Gate CLI Command Set
+
+All AI-authored work uses these repository-owned commands. The detailed
+procedure and examples live in
+`docs/ai-developer/specific_rules/gated-workflow.md`; this section is the
+quick command index every persona should route back to.
+
+| Need | Command |
+|---|---|
+| Start committed gate record | `python -m scistudio.qa.governance.gate_record start ...` |
+| Record plan | `python -m scistudio.qa.governance.gate_record plan --record <record> ...` |
+| Amend scope before new paths are edited | `python -m scistudio.qa.governance.gate_record amend --record <record> --reason <reason> --include <path>` |
+| Record docs landing or N/A | `python -m scistudio.qa.governance.gate_record docs --record <record> --updated <path>` |
+| Record a check in the committed gate record | `python -m scistudio.qa.governance.gate_record check --record <record> --name <name> --command <cmd> --status pass --exit-code 0` |
+| Record Sentrux evidence | `python -m scistudio.qa.governance.gate_record sentrux --record <record> --status pass|fail|skipped` |
+| Validate staged scope | `python -m scistudio.qa.governance.gate_record pre-commit --staged` |
+| Validate commit message trailers | `python -m scistudio.qa.governance.gate_record commit-msg <commit-msg-file>` |
+| Validate branch diff before push | `python -m scistudio.qa.governance.gate_record pre-push --base <base-ref> --head HEAD` |
+| Validate shared local/CI workflow gate | `python -m scistudio.qa.governance.gate_record ci --gate-record <record> --base <base-ref> --head HEAD --pr-body <body>` |
+| Generate exact-candidate local receipt | `python -m scistudio.qa.governance.gate_receipt run --gate-record <record> --base <base-ref> --pr-body-file .workflow/local/pr-body.md` |
+| Record one custom command in the receipt | `python -m scistudio.qa.governance.gate_receipt exec --name <name> --gate-record <record> --base <base-ref> -- <command>` |
+| Validate receipt freshness/completeness | `python -m scistudio.qa.governance.gate_receipt validate --gate-record <record> --base <base-ref> --pr-body-file .workflow/local/pr-body.md` |
+| Finalize commit and PR evidence | `python -m scistudio.qa.governance.gate_record finalize --record <record> --commit <sha> --pr <url> --closes "#<issue>"` |
+
+`admin-approved:core-change` is not a broad bypass for these commands. It only
+answers protected-core authorization where that guard applies.
+
+## 6. Routing
 
 Task-specific rules MUST include `docs/ai-developer/specific_rules/gated-workflow.md`
 unless the owner explicitly authorizes hotfix mode.
@@ -119,6 +151,7 @@ unless the owner explicitly authorizes hotfix mode.
 | Need | Read |
 |---|---|
 | Gate execution | `docs/ai-developer/specific_rules/gated-workflow.md` |
+| Gate CLI command index | `docs/ai-developer/rules.md#5-gate-cli-command-set` |
 | New feature | `docs/ai-developer/specific_rules/new-feature.md` |
 | Bug fix | `docs/ai-developer/specific_rules/bug-fix.md` |
 | Hotfix | `docs/ai-developer/specific_rules/hotfix.md` |

--- a/docs/ai-developer/rules.md
+++ b/docs/ai-developer/rules.md
@@ -95,7 +95,9 @@ language_source: en
 
 - `admin-approved:ai-override` authorizes a one-off AI gate override.
 
-- `admin-approved:core-change` authorizes protected core path changes.
+- `admin-approved:core-change` authorizes protected core path changes only.
+  It does not bypass scope, issue linkage, docs landing, full-audit evidence,
+  local receipt validation, required checks, or CI parity checks.
 
 - `admin-approved:merge` authorizes approved merge automation.
 
@@ -104,6 +106,10 @@ language_source: en
 
 - CI must validate label provenance.
   Chat authorization alone is not enough for final PR readiness.
+
+- `admin-approved:ai-override` is the only accepted label for a one-off broad
+  AI workflow-gate override. It still does not bypass branch protection,
+  normal repository CI, owner review, or administrator merge authorization.
 
 ## 5. Routing
 

--- a/docs/ai-developer/specific_rules/agent-dispatch.md
+++ b/docs/ai-developer/specific_rules/agent-dispatch.md
@@ -138,7 +138,9 @@ language_source: en
   label for the current manager task.
 
 - MAY pass the authorized bypass label to local gate hook commands.
-  This only helps local checks; CI still decides final readiness.
+  Only `human-authored` and `admin-approved:ai-override` are broad local
+  bypasses. `admin-approved:core-change` is narrow and must not bypass scope,
+  docs, issue, receipt, or required-check validation.
 
 - MUST record the bypass label, reason, and owner authorization in the
   checklist when any bypass label is used.
@@ -157,6 +159,16 @@ python -m scistudio.qa.governance.gate_record pre-push \
   --bypass-label human-authored|admin-approved:ai-override|admin-approved:core-change|admin-approved:merge
 ```
 
+After integration, the manager must require a valid receipt for the exact
+candidate:
+
+```bash
+python -m scistudio.qa.governance.gate_receipt validate \
+  --gate-record .workflow/records/<record>.json \
+  --base origin/main \
+  --pr-body-file .workflow/local/pr-body.md
+```
+
 ## 7. Verification Rules
 
 - MUST run the checks declared in the manager gate record after integration.
@@ -167,6 +179,10 @@ python -m scistudio.qa.governance.gate_record pre-push \
 
 - MUST record each agent-owned test, docs update, and PR or commit evidence in
   the manager checklist or gate record.
+
+- MUST check whether AI workflow docs or dispatch templates need updates when
+  the work changes wrapper, hook, gate-record, receipt, CI, or AI-runtime
+  behavior.
 
 - MUST wait for CI to pass before calling the coordinated task complete.
 

--- a/docs/ai-developer/specific_rules/gated-workflow.md
+++ b/docs/ai-developer/specific_rules/gated-workflow.md
@@ -40,6 +40,9 @@ self-attestation are not gate evidence.
 AI agents must use the repository-owned gate-record CLI to create, update, and
 validate the committed gate record. The CLI may expose additional convenience
 aliases, but the commands below are the normative AI-facing interface.
+The quick command index is also routed from
+`docs/ai-developer/rules.md#5-gate-cli-command-set`, `AGENTS.md`, and each
+persona guide so all AI runtimes land on the same command set.
 
 Start a gate record:
 
@@ -48,6 +51,7 @@ python -m scistudio.qa.governance.gate_record start \
   --task-kind feature|bugfix|hotfix|refactor|docs|maintenance|manager \
   --persona manager|implementer|adr_author|audit_reviewer|test_engineer \
   --issue <number> \
+  --slug <task-slug> \
   --branch <branch> \
   --owner-directive "<owner instruction>" \
   --include <path-or-glob> \
@@ -61,9 +65,11 @@ Record the plan:
 python -m scistudio.qa.governance.gate_record plan \
   --record .workflow/records/<issue>-<task-slug>.json \
   --files <path-or-glob> \
-  --docs <path-or-na> \
-  --tests <path-or-na> \
-  --checks ruff,format,pytest,full_audit,sentrux
+  --tests <test-path> \
+  --checks ruff \
+  --checks format \
+  --checks pytest \
+  --checks full_audit
 ```
 
 Amend scope:
@@ -135,7 +141,7 @@ python -m scistudio.qa.governance.gate_record ci \
   --gate-record .workflow/records/<issue>-<task-slug>.json \
   --base <base-ref> \
   --head <head-ref> \
-  --pr-body <path-or-text>
+  --pr-body "<body-text>"
 ```
 
 ADR-042 Addendum 5 defines an additional local receipt gate for exact push or
@@ -409,9 +415,9 @@ For Sentrux, the record must store free-tier mode, `rules_checked`,
 `total_rules_defined` when reported, pass/fail status, relevant thresholds from
 `.sentrux/rules.toml`, and `pro_required: false`.
 
-When ADR-042 Addendum 5 receipt tooling is available, Step 5 is not complete
-until the receipt runner has recorded every required check for the exact
-candidate. The required set is the union of:
+ADR-042 Addendum 5 receipt tooling is active. Step 5 is not complete until the
+receipt runner has recorded every required check for the exact candidate. The
+required set is the union of:
 
 - the checks declared in the gate record plan; and
 - CI-parity checks inferred from the current diff.
@@ -422,6 +428,48 @@ changes require the corresponding lint, format, type, test, full-audit, and
 governance checks. Any file change after receipt generation invalidates the
 receipt because `HEAD`, diff, gate record, PR body, and check-set fingerprints
 must match the current candidate.
+
+Use the receipt runner for the hard gate transcript:
+
+```bash
+python -m scistudio.qa.governance.gate_receipt run \
+  --gate-record .workflow/records/<record>.json \
+  --base origin/main \
+  --pr-body-file .workflow/local/pr-body.md
+```
+
+For commands that need custom arguments, wrap the actual command with
+`gate_receipt exec`:
+
+```bash
+python -m scistudio.qa.governance.gate_receipt exec \
+  --name mypy \
+  --gate-record .workflow/records/<record>.json \
+  --base origin/main \
+  --pr-body-file .workflow/local/pr-body.md \
+  -- mypy src/scistudio/ --ignore-missing-imports
+```
+
+The receipt is local-only and lives under
+`.workflow/local/gate-receipts/<head-sha>.json` plus the matching `.log`
+transcript. A pre-PR receipt that includes a PR-body hash may use
+`<head-sha>-pr-<bodyhash>.json` so it can coexist with the no-body pre-push
+receipt for the same HEAD. The committed gate record still needs
+`gate_record check` entries; the local receipt is the hook-verifiable
+transcript for the exact candidate. Raw terminal output or chat summaries do
+not satisfy the hard receipt gate.
+
+Receipt generation has two modes:
+
+- Pre-PR: write the intended PR body to `.workflow/local/pr-body.md`, run
+  `gate_receipt run --pr-body-file .workflow/local/pr-body.md`, then create
+  the PR with the same body through `scripts/scistudio_pr_create.py`.
+- Pre-push: run or validate the receipt without `--pr-body-file` when no PR
+  body is part of the push candidate.
+
+This avoids a chicken-and-egg dependency on an already-created PR. After PR
+creation, `gate_record finalize` changes the gate record hash; rerun the
+receipt for that finalize commit before pushing it.
 
 ### 3.7 Step 6: Commit And Submit PR
 
@@ -436,11 +484,12 @@ Issue: #<number>
 Assisted-by: <runtime>:<model-or-agent-id>
 ```
 
-Push the branch and open the PR. **Prefer the
-`scripts/scistudio_pr_create.py` wrapper over invoking `gh pr create`
-directly** (#1360): it pre-flights `gate_record ci` with the real PR body
-locally and short-circuits the open-PR step when CI would reject the
-record. The wrapper filters `core_change_guard` / `pr_merge_guard` /
+Push the branch and open the PR. **Use the
+`scripts/scistudio_pr_create.py` wrapper instead of invoking `gh pr create`
+directly** (#1360, #1492): it validates the exact local `gate_receipt`, then
+pre-flights `gate_record ci` with the real PR body locally and short-circuits
+the open-PR step when CI would reject the record. The wrapper filters
+`core_change_guard` / `pr_merge_guard` /
 `human_bypass_guard` findings because those guards depend on PR labels
 that cannot exist before the PR does — CI is the authoritative enforcer
 for that subset.
@@ -452,6 +501,13 @@ python scripts/scistudio_pr_create.py \
   --body "<body>"
 ```
 
+Current Addendum 5 behavior: the wrapper first validates the local
+`gate_receipt` for the exact PR body and then runs `gate_record ci` locally.
+`gate_record ci` now invokes the shared local/CI workflow-gate orchestration,
+not only the structural gate-record validator. It still filters only findings
+that are impossible before the PR exists, such as administrator-applied PR
+labels and post-PR finalization.
+
 The wrapper accepts every `gh pr create` flag verbatim and passes them
 through. `--dry-run` runs the pre-flight without invoking `gh`. Set
 `SCISTUDIO_SKIP_PREFLIGHT=1` only for emergency one-off escapes; CI will
@@ -460,6 +516,14 @@ still run the full guard set in the cloud.
 Direct `gh pr create` invocation remains supported for non-AI work or
 when the wrapper is unavailable, but AI-authored PRs that skip the
 wrapper SHOULD expect more CI fix-and-push iterations.
+
+When wrapper, hook, gate-record, receipt, CI, or AI-runtime behavior changes,
+explicitly check whether these docs also need updates:
+`docs/ai-developer/rules.md`,
+`docs/ai-developer/specific_rules/gated-workflow.md`,
+`docs/ai-developer/specific_rules/agent-dispatch.md`, and
+`docs/ai-developer/templates/*dispatch*.md`. Record updated paths or N/A
+rationales in the gate record docs landing.
 
 Record final commit and PR evidence with:
 

--- a/docs/ai-developer/specific_rules/gated-workflow.md
+++ b/docs/ai-developer/specific_rules/gated-workflow.md
@@ -138,6 +138,33 @@ python -m scistudio.qa.governance.gate_record ci \
   --pr-body <path-or-text>
 ```
 
+ADR-042 Addendum 5 defines an additional local receipt gate for exact push or
+PR candidates. When `python -m scistudio.qa.governance.gate_receipt` is
+available in the checkout and the corresponding hooks are wired, AI agents must
+use it before push or PR creation:
+
+```bash
+python -m scistudio.qa.governance.gate_receipt run \
+  --gate-record .workflow/records/<issue>-<task-slug>.json \
+  --base <base-ref> \
+  --pr-body-file .workflow/local/pr-body.md
+```
+
+For a single manually selected command, wrap the command so stdout, stderr,
+exit code, and candidate fingerprints are recorded:
+
+```bash
+python -m scistudio.qa.governance.gate_receipt exec \
+  --name mypy \
+  --gate-record .workflow/records/<issue>-<task-slug>.json \
+  --base <base-ref> \
+  -- mypy src/scistudio/ --ignore-missing-imports
+```
+
+Raw command output in chat or terminal history is not hard-gate evidence. The
+receipt JSON under `.workflow/local/gate-receipts/` is the machine-readable
+local proof, and `.workflow/local/**` remains local-only and ignored.
+
 The legacy `.workflow/gate.py` may remain as a migration helper, but it is not
 sufficient gate evidence unless it delegates to this CLI or emits the committed
 gate record required by this workflow.
@@ -382,6 +409,20 @@ For Sentrux, the record must store free-tier mode, `rules_checked`,
 `total_rules_defined` when reported, pass/fail status, relevant thresholds from
 `.sentrux/rules.toml`, and `pro_required: false`.
 
+When ADR-042 Addendum 5 receipt tooling is available, Step 5 is not complete
+until the receipt runner has recorded every required check for the exact
+candidate. The required set is the union of:
+
+- the checks declared in the gate record plan; and
+- CI-parity checks inferred from the current diff.
+
+Frontend changes require receipt entries for the configured frontend lint,
+format, typecheck, test, and build commands. Python, QA, governance, and docs
+changes require the corresponding lint, format, type, test, full-audit, and
+governance checks. Any file change after receipt generation invalidates the
+receipt because `HEAD`, diff, gate record, PR body, and check-set fingerprints
+must match the current candidate.
+
 ### 3.7 Step 6: Commit And Submit PR
 
 Commit the gate record with the code or documentation change.
@@ -468,7 +509,11 @@ evidence helps review; CI evidence is authoritative.
 - MUST treat CI evidence as authoritative.
 - MUST use bypass labels exactly as accepted by the gate CLI.
 - MUST use local bypass labels only when the owner authorizes that bypass.
+- MUST treat `admin-approved:core-change` as authorization for protected core
+  paths only, not as a broad gate-record or receipt bypass.
 - MUST record bypass label use in the gate record or manager checklist.
+- MUST use `gate_receipt run` or `gate_receipt exec` when ADR-042 Addendum 5
+  receipt tooling is available and wired in the checkout.
 - MUST never merge a PR as an AI agent without explicit administrator
   authorization.
 
@@ -484,6 +529,8 @@ Local hooks or CI must fail AI-authored work when:
 - new gate records omit `persona` or use an unsupported persona;
 - staged or changed files exceed `scope.include` without an amendment;
 - staged or changed files match `scope.exclude`;
+- ADR-042 Addendum 5 receipt tooling is wired and the exact candidate lacks a
+  valid receipt with all required checks passing;
 - governance files are touched without `governance_touch=true`;
 - governance, CI, Sentrux, or quality thresholds are weakened without
   owner-approved scope;

--- a/docs/ai-developer/templates/agent-dispatch-checklist-template.md
+++ b/docs/ai-developer/templates/agent-dispatch-checklist-template.md
@@ -84,6 +84,17 @@ language_source: en
 | Pre-commit | `python -m scistudio.qa.governance.gate_record pre-commit --staged` | `<label or N/A>` | `[ ]` | `<output or summary>` |
 | Commit message | `python -m scistudio.qa.governance.gate_record commit-msg <commit-msg-file>` | `<label or N/A>` | `[ ]` | `<output or summary>` |
 | Pre-push | `python -m scistudio.qa.governance.gate_record pre-push` | `<label or N/A>` | `[ ]` | `<output or summary>` |
+| Receipt | `python -m scistudio.qa.governance.gate_receipt validate --gate-record <record> --base <base> --pr-body-file <body-file>` | `<broad label or N/A>` | `[ ]` | `<receipt path or error>` |
+
+## 5.1 Docs Impact Check
+
+- Wrapper/hook/gate-record/receipt/CI/runtime behavior changed: `<yes|no>`
+- AI docs checked:
+  `docs/ai-developer/rules.md`,
+  `docs/ai-developer/specific_rules/gated-workflow.md`,
+  `docs/ai-developer/specific_rules/agent-dispatch.md`,
+  `docs/ai-developer/templates/*dispatch*.md`
+- Updated docs or N/A rationale: `<paths or rationale>`
 
 ## 6. Dispatch Matrix
 

--- a/docs/ai-developer/templates/agent-dispatch-prompt-template.md
+++ b/docs/ai-developer/templates/agent-dispatch-prompt-template.md
@@ -99,8 +99,17 @@ Known deferred items:
 
 - <test command or N/A reason>
 - <lint/check command>
+- `python -m scistudio.qa.governance.gate_receipt run` or explicit
+  `gate_receipt exec` commands for every required Phase 5 check
 - <docs/audit command or N/A reason>
 - <Sentrux MCP/CLI command or N/A reason>
+
+If the task changes wrapper, hook, gate-record, receipt, CI, or AI-runtime
+behavior, check whether these docs need updates and record updated paths or
+N/A rationale: `docs/ai-developer/rules.md`,
+`docs/ai-developer/specific_rules/gated-workflow.md`,
+`docs/ai-developer/specific_rules/agent-dispatch.md`, and
+`docs/ai-developer/templates/*dispatch*.md`.
 
 ## Output Required
 

--- a/docs/specs/adr-042-local-gate-receipts.md
+++ b/docs/specs/adr-042-local-gate-receipts.md
@@ -38,9 +38,9 @@ governs:
     - scistudio.qa.governance.gate_record.validation.check_pre_push
     - scistudio.qa.governance.gate_record.validation.check_pr_ready
     - scistudio.qa.governance.gate_record.validation.check_pr
+    - scistudio.qa.governance.gate_record.workflow.run_ci
     - scistudio.qa.governance.gate_receipt.validate_receipt
     - scistudio.qa.governance.worktree_write_guard.check_hook_payload
-    - scistudio.qa.governance.workflow_gate.run_ci
     - scistudio.qa.governance.core_change_guard.check
     - scistudio.qa.governance.human_bypass_guard.check
   files:
@@ -317,7 +317,8 @@ scope before mutation.
 | `docs/adr/ADR-042-addendum5.md` | create | Accepted governance decision |
 | `docs/specs/adr-042-local-gate-receipts.md` | create | Implementation contract |
 | `src/scistudio/qa/governance/gate_receipt.py` or package | create | Receipt CLI, schema, execution, validation |
-| `src/scistudio/qa/governance/workflow_gate.py` | create | Shared local/CI workflow-gate orchestration |
+| `src/scistudio/qa/governance/gate_record/workflow.py` | create | Shared local/CI workflow-gate orchestration |
+| `src/scistudio/qa/governance/workflow_gate.py` | create | CLI wrapper for shared workflow-gate orchestration |
 | `src/scistudio/qa/governance/worktree_write_guard.py` | create | Pre-write worktree/scope enforcement |
 | `src/scistudio/qa/governance/gate_record/**` | modify | Scoped override handling and validation integration |
 | `scripts/scistudio_pr_create.py` | modify | Use shared orchestration and receipt validation |

--- a/docs/specs/adr-042-local-gate-receipts.md
+++ b/docs/specs/adr-042-local-gate-receipts.md
@@ -1,14 +1,13 @@
 ---
 spec_id: adr-042-local-gate-receipts
 title: "ADR-042 Local Gate Receipts And Worktree Guard Specification"
-status: Planned
+status: Implemented
 feature_branch: docs/issue-1492-adr042-local-gate-receipts
 created: 2026-05-23
 input: "Owner-approved ADR-042 Addendum 5: implement CI-parity local gate receipts, scoped override semantics, and AI worktree write guards."
 owners:
   - "@jiazhenz026"
-related_adrs:
-  - 42
+related_adrs: []
 related_specs:
   - adr-042-ai-governance-tools
   - adr-042-code-quality-tools
@@ -22,6 +21,8 @@ scope:
     - Scoped local and CI override semantics.
     - AI write-time worktree and path guards for supported runtimes.
     - AI developer documentation for receipt-based preflight.
+    - AI-facing rules, workflow guidance, dispatch templates, and wrapper usage
+      notes updated for the new receipt gate.
   out:
     - Replacing committed gate records.
     - Committing local receipt logs.
@@ -37,6 +38,9 @@ governs:
     - scistudio.qa.governance.gate_record.validation.check_pre_push
     - scistudio.qa.governance.gate_record.validation.check_pr_ready
     - scistudio.qa.governance.gate_record.validation.check_pr
+    - scistudio.qa.governance.gate_receipt.validate_receipt
+    - scistudio.qa.governance.worktree_write_guard.check_hook_payload
+    - scistudio.qa.governance.workflow_gate.run_ci
     - scistudio.qa.governance.core_change_guard.check
     - scistudio.qa.governance.human_bypass_guard.check
   files:
@@ -44,10 +48,16 @@ governs:
     - docs/adr/ADR-042-addendum5.md
     - docs/ai-developer/rules.md
     - docs/ai-developer/specific_rules/gated-workflow.md
+    - docs/ai-developer/specific_rules/agent-dispatch.md
+    - docs/ai-developer/personas/*.md
+    - docs/ai-developer/templates/agent-dispatch-checklist-template.md
+    - docs/ai-developer/templates/agent-dispatch-prompt-template.md
+    - AGENTS.md
+    - .agents/rules/rules.md
+    - .claude/rules/rules.md
+    - .codex/rules/rules.md
     - scripts/scistudio_pr_create.py
     - scripts/hooks/**
-    - .claude/settings.json
-    - .codex/config.toml
     - src/scistudio/agent_provisioning/**
     - src/scistudio/qa/governance/**
     - tests/qa/**
@@ -60,6 +70,9 @@ tests:
   - tests/qa/test_human_bypass_guard.py
   - tests/qa/test_gate_receipt.py
   - tests/qa/test_worktree_write_guard.py
+  - tests/agent_provisioning/test_hooks.py
+  - tests/agent_provisioning/test_codex_config.py
+  - tests/scripts/test_scistudio_pr_create.py
 acceptance_source: adr
 language_source: en
 ---
@@ -184,6 +197,10 @@ Acceptance Scenarios:
 
 - A PR body is not available before PR creation. The receipt must omit or hash
   an explicit body file and then require revalidation when the PR body changes.
+- Pre-PR receipt generation must not require an existing PR URL or PR number;
+  it uses the intended PR body that the wrapper will pass to `gh pr create`.
+- Finalizing the gate record after PR creation changes the gate record hash and
+  intentionally requires a fresh pre-push receipt.
 - A local dependency is unavailable. The receipt runner must record the failure
   or an accepted N/A rule; it must not silently pass.
 - A broad diff touches frontend and Python surfaces. The required check matrix
@@ -218,6 +235,11 @@ Acceptance Scenarios:
   failing receipts.
 - FR-010: Receipt validity MUST be based on input fingerprints. Freshness time
   limits MAY be added as a secondary stale-file guard only.
+- FR-010A: The implementation MUST support a pre-PR receipt mode that hashes
+  the intended PR body from `.workflow/local/pr-body.md` or another explicit
+  local body file and does not require an existing PR.
+- FR-010B: The implementation MUST support a pre-push receipt mode that omits
+  PR-body hashing when no PR body is part of the push candidate.
 - FR-011: Required-check resolution MUST combine gate-record Phase 5 checks
   with diff-inferred CI parity checks.
 - FR-012: Frontend diffs MUST require frontend lint, format, typecheck, test,
@@ -232,6 +254,22 @@ Acceptance Scenarios:
   define separate policy.
 - FR-017: AI developer docs MUST explain that raw command output is not hard
   gate evidence unless recorded through the receipt runner.
+- FR-018: AI-facing rules and workflow guidance MUST document current wrapper
+  usage after this change: `scripts/scistudio_pr_create.py` validates
+  `gate_receipt validate` and shared `gate_record ci` before invoking
+  `gh pr create`.
+- FR-019: AI-facing rules and workflow guidance MUST document the gate-record
+  CLI semantic change: `gate_record ci` is the shared local/CI workflow-gate
+  orchestration entry point, while `gate_record pre-push` remains the
+  structural branch-diff validator and receipt freshness/completeness is
+  handled by `gate_receipt validate`.
+- FR-020: AI workflow docs and dispatch templates MUST tell agents to check
+  whether additional docs need updates whenever wrapper, hook, gate-record,
+  receipt, CI, or AI-runtime behavior changes. The check must include at
+  least `docs/ai-developer/rules.md`,
+  `docs/ai-developer/specific_rules/gated-workflow.md`,
+  `docs/ai-developer/specific_rules/agent-dispatch.md`, and dispatch
+  templates.
 
 ### Key Entities
 
@@ -261,6 +299,13 @@ Add a receipt validator used by pre-push and pre-PR hooks. The validator
 compares the current candidate fingerprint with the receipt and verifies
 required-check completeness and exit status.
 
+Pre-PR validation and pre-push validation are different candidate modes.
+Pre-PR validation includes the intended PR body hash because the wrapper has
+the exact body it will submit. Pre-push validation validates only the branch
+push candidate and does not require a PR URL or PR body. After PR creation,
+`gate_record finalize` changes the committed gate record and requires a new
+pre-push receipt before the finalize commit is pushed.
+
 Add a worktree write guard script used by Claude Code and Codex project hooks.
 The guard resolves filesystem paths and checks branch, worktree, and gate
 scope before mutation.
@@ -277,13 +322,14 @@ scope before mutation.
 | `src/scistudio/qa/governance/gate_record/**` | modify | Scoped override handling and validation integration |
 | `scripts/scistudio_pr_create.py` | modify | Use shared orchestration and receipt validation |
 | `scripts/hooks/**` | modify/create | Pre-push, pre-PR, and pre-write hook entry points |
-| `.github/workflows/workflow-gate.yml` | modify | Call shared orchestration instead of duplicating inline logic |
-| `.claude/settings.json` | modify | Wire receipt and write-guard hooks for Claude Code |
-| `.codex/config.toml` | modify | Wire equivalent hooks for Codex when present |
+| `.github/workflows/workflow-gate.yml` | no change in initial implementation | Existing CI calls `gate_record ci`; this spec changes that command to invoke shared orchestration |
+| generated `.claude/settings.json` | modify via provisioning template | Wire receipt and write-guard hooks for Claude Code |
+| generated `.codex/config.toml` | modify via provisioning template | Wire equivalent hooks for Codex when present |
 | `src/scistudio/agent_provisioning/**` | modify | Provision equivalent runtime hooks |
 | `.gitignore` | verify/modify | Keep `.workflow/local/**` local-only |
 | `docs/ai-developer/rules.md` | modify | Explain scoped override semantics |
 | `docs/ai-developer/specific_rules/gated-workflow.md` | modify | Explain receipt runner and hard gate behavior |
+| `AGENTS.md`, runtime rules indexes, and persona docs | modify | Route every AI entry point to the shared gate CLI command set |
 | `tests/qa/test_gate_receipt.py` | create | Receipt schema, fingerprint, required-check, stale-check tests |
 | `tests/qa/test_worktree_write_guard.py` | create | Worktree/path/branch/scope guard tests |
 | `tests/qa/test_gate_record_ci.py` | modify | Local/CI orchestration parity regression tests |
@@ -302,7 +348,9 @@ scope before mutation.
 6. Implement `gate_receipt run` and `gate_receipt exec`.
 7. Implement receipt validation in pre-push and pre-PR hooks.
 8. Implement worktree write guard and wire it into supported AI runtimes.
-9. Update AI developer docs and dispatch templates as needed.
+9. Update AI developer docs and dispatch templates, including wrapper usage,
+   `gate_record` CLI semantics, receipt commands, and a required docs-impact
+   check for future governance-tool changes.
 10. Run focused QA tests, full audit, and the relevant frontend/Python checks.
 
 ### 4.4 Verification Plan

--- a/docs/specs/adr-042-local-gate-receipts.md
+++ b/docs/specs/adr-042-local-gate-receipts.md
@@ -1,0 +1,354 @@
+---
+spec_id: adr-042-local-gate-receipts
+title: "ADR-042 Local Gate Receipts And Worktree Guard Specification"
+status: Planned
+feature_branch: docs/issue-1492-adr042-local-gate-receipts
+created: 2026-05-23
+input: "Owner-approved ADR-042 Addendum 5: implement CI-parity local gate receipts, scoped override semantics, and AI worktree write guards."
+owners:
+  - "@jiazhenz026"
+related_adrs:
+  - 42
+related_specs:
+  - adr-042-ai-governance-tools
+  - adr-042-code-quality-tools
+  - adr-042-gate-record-sentrux-workflow
+scope:
+  in:
+    - Shared local/CI workflow-gate orchestration.
+    - "`gate_receipt` JSON/log receipt generation and validation."
+    - Phase 5 required-check completeness enforcement.
+    - Diff-inferred CI parity checks.
+    - Scoped local and CI override semantics.
+    - AI write-time worktree and path guards for supported runtimes.
+    - AI developer documentation for receipt-based preflight.
+  out:
+    - Replacing committed gate records.
+    - Committing local receipt logs.
+    - Weakening CI, branch protection, Sentrux, or governance checks.
+    - Applying GitHub labels or administrator approvals automatically.
+    - Requiring Sentrux Pro diagnostics.
+governs:
+  modules:
+    - scistudio.qa.governance
+    - scistudio.qa.governance.gate_record
+  contracts:
+    - scistudio.qa.governance.gate_record.validation.validate_gate_record
+    - scistudio.qa.governance.gate_record.validation.check_pre_push
+    - scistudio.qa.governance.gate_record.validation.check_pr_ready
+    - scistudio.qa.governance.gate_record.validation.check_pr
+    - scistudio.qa.governance.core_change_guard.check
+    - scistudio.qa.governance.human_bypass_guard.check
+  files:
+    - docs/specs/adr-042-local-gate-receipts.md
+    - docs/adr/ADR-042-addendum5.md
+    - docs/ai-developer/rules.md
+    - docs/ai-developer/specific_rules/gated-workflow.md
+    - scripts/scistudio_pr_create.py
+    - scripts/hooks/**
+    - .claude/settings.json
+    - .codex/config.toml
+    - src/scistudio/agent_provisioning/**
+    - src/scistudio/qa/governance/**
+    - tests/qa/**
+    - .gitignore
+tests:
+  - tests/qa/test_gate_record.py
+  - tests/qa/test_gate_record_ci.py
+  - tests/qa/test_gate_record_hooks.py
+  - tests/qa/test_core_change_guard.py
+  - tests/qa/test_human_bypass_guard.py
+  - tests/qa/test_gate_receipt.py
+  - tests/qa/test_worktree_write_guard.py
+acceptance_source: adr
+language_source: en
+---
+
+# ADR-042 Local Gate Receipts And Worktree Guard Specification
+
+## 1. Change Summary
+
+This spec implements ADR-042 Addendum 5. It defines a local preflight system
+that produces candidate-specific receipt JSON and stdout/stderr transcripts for
+AI-authored work before push or PR creation.
+
+The spec also narrows override-label semantics and adds write-time worktree
+guards. The goal is to move predictable failures from GitHub CI to local hard
+gates without replacing committed gate records or normal CI.
+
+## 2. User Scenarios & Testing
+
+### User Story 1 - Local gate matches CI gate behavior (Priority: P1)
+
+As a repository owner, I need local preflight to evaluate the same blocking
+workflow-gate rules as GitHub CI.
+
+Why this priority: If local and CI use different rule sets, agents can pass
+local checks and still fail predictable CI guards.
+
+Independent Test: Run shared workflow-gate fixtures through the local command
+and the CI orchestration entry point and assert identical blocking findings
+after filtering only pre-PR-impossible PR-state facts.
+
+Acceptance Scenarios:
+
+1. Given a gate record with missing docs landing, when local preflight runs,
+   then it reports the same blocking docs finding as CI.
+2. Given a gate record with an issue URL/content error, when local preflight
+   runs, then it reports the same issue-link finding as CI.
+3. Given a pre-PR run where only the final PR URL is missing, when local
+   preflight runs, then it may filter that PR-state finding and must report the
+   filtered count.
+
+### User Story 2 - Receipts prove exact candidate checks (Priority: P1)
+
+As a maintainer, I need a local receipt to prove that the exact current
+base/head/diff/gate-record/PR-body candidate passed its required checks.
+
+Why this priority: A freshness-only rule cannot catch checks run before a later
+change.
+
+Independent Test: Generate a passing receipt, modify the diff or gate record,
+and assert pre-push rejects the stale receipt.
+
+Acceptance Scenarios:
+
+1. Given all inputs match the receipt and all checks exited 0, when pre-push
+   validates, then it passes.
+2. Given `HEAD` changed after the receipt was written, when pre-push validates,
+   then it fails.
+3. Given the gate record changed after the receipt was written, when pre-push
+   validates, then it fails.
+
+### User Story 3 - Required checks are complete (Priority: P1)
+
+As a repository owner, I need every Phase 5 required check and every
+diff-inferred CI parity check to appear in the receipt.
+
+Why this priority: Missing one local check lets predictable failures escape to
+CI.
+
+Independent Test: Use fixtures for frontend, Python, docs, and governance
+diffs and assert the required check matrix includes the expected commands.
+
+Acceptance Scenarios:
+
+1. Given frontend files changed, when required checks are resolved, then lint,
+   format, typecheck, test, and build are required.
+2. Given Python source changed, when required checks are resolved, then lint,
+   format, typecheck, tests, and relevant audit/import checks are required.
+3. Given a receipt lacks one required check, when pre-push validates, then it
+   fails.
+
+### User Story 4 - Core-change approval is narrow (Priority: P1)
+
+As a repository owner, I need `admin-approved:core-change` to authorize only
+protected core path changes.
+
+Why this priority: A narrow approval must not become a general escape from
+scope, docs, issue, receipt, or required-check validation.
+
+Independent Test: Validate gate records with `admin-approved:core-change`
+against separate core path and outside-scope findings.
+
+Acceptance Scenarios:
+
+1. Given only a protected core path requires approval and the label is present,
+   when validation runs, then the core path finding is satisfied.
+2. Given a file is outside `scope.include`, when validation runs with
+   `admin-approved:core-change`, then scope validation still fails.
+3. Given receipt evidence is missing, when validation runs with
+   `admin-approved:core-change`, then receipt validation still fails.
+
+### User Story 5 - AI writes stay in assigned worktrees (Priority: P1)
+
+As a manager, I need AI write tools to fail before editing the root worktree or
+files outside the assigned scope.
+
+Why this priority: Push-time checks are too late to prevent root worktree
+collisions.
+
+Independent Test: Run the write guard against target paths in the assigned
+worktree, root `main` worktree, outside the repo, and outside gate scope.
+
+Acceptance Scenarios:
+
+1. Given the current branch is `main`, when an AI write tool targets a file,
+   then the guard blocks.
+2. Given the target path resolves outside the assigned worktree, when the guard
+   runs, then it blocks.
+3. Given the target path is in the gate scope and the branch matches, when the
+   guard runs, then it passes.
+
+### Edge Cases
+
+- A PR body is not available before PR creation. The receipt must omit or hash
+  an explicit body file and then require revalidation when the PR body changes.
+- A local dependency is unavailable. The receipt runner must record the failure
+  or an accepted N/A rule; it must not silently pass.
+- A broad diff touches frontend and Python surfaces. The required check matrix
+  must include both sets.
+- A receipt log contains sensitive local details. Logs remain gitignored and
+  are never committed.
+- A stacked PR targets a non-main base. The base ref must be part of the
+  receipt fingerprint.
+
+## 3. Requirements
+
+### Functional Requirements
+
+- FR-001: The implementation MUST provide a shared workflow-gate orchestration
+  entry point used by GitHub CI and local preflight.
+- FR-002: Local preflight MUST only filter findings that are impossible to
+  satisfy before PR creation.
+- FR-003: `admin-approved:core-change` MUST satisfy only protected core path
+  authorization.
+- FR-004: `admin-approved:core-change` MUST NOT bypass scope, issue, docs,
+  receipt, full-audit, required-check, or CI-parity validation.
+- FR-005: The implementation MUST provide `gate_receipt run` to execute the
+  required Phase 5 and CI-parity check matrix.
+- FR-006: The implementation MUST provide `gate_receipt exec` to record one
+  command into the receipt format.
+- FR-007: Receipt JSON MUST include current branch, base ref, head SHA, diff
+  fingerprint, gate record hash, PR body hash when available, required checks,
+  command records, exit codes, and final status.
+- FR-008: Receipt logs MUST contain stdout/stderr transcript text and remain
+  local-only under `.workflow/local/gate-receipts/`.
+- FR-009: Pre-push and pre-PR hooks MUST reject missing, stale, incomplete, or
+  failing receipts.
+- FR-010: Receipt validity MUST be based on input fingerprints. Freshness time
+  limits MAY be added as a secondary stale-file guard only.
+- FR-011: Required-check resolution MUST combine gate-record Phase 5 checks
+  with diff-inferred CI parity checks.
+- FR-012: Frontend diffs MUST require frontend lint, format, typecheck, test,
+  and build receipt entries.
+- FR-013: Python/source/governance diffs MUST require the configured Python
+  lint, format, type, test, audit, and import-contract checks where applicable.
+- FR-014: Worktree write guards MUST run before supported AI write tools mutate
+  files.
+- FR-015: Worktree write guards MUST compare resolved filesystem paths, not
+  only string prefixes.
+- FR-016: Runtime-specific hook files MUST point to shared scripts and must not
+  define separate policy.
+- FR-017: AI developer docs MUST explain that raw command output is not hard
+  gate evidence unless recorded through the receipt runner.
+
+### Key Entities
+
+| Entity | Description | Attributes | Relationships |
+|---|---|---|---|
+| `GateReceipt` | Candidate-specific local preflight result | schema version, branch, base ref, head SHA, diff fingerprint, gate record hash, PR body hash, required checks, commands, final status | Validated by pre-push and pre-PR hooks |
+| `ReceiptCommand` | One executed check command | name, argv, cwd, started_at, ended_at, exit_code, log references | Belongs to `GateReceipt` |
+| `RequiredCheckSet` | Resolved check matrix for the current candidate | gate checks, diff-inferred checks, N/A decisions | Produced before receipt execution |
+| `CandidateFingerprint` | Hashable identity of the exact push or PR candidate | base, head, diff summary/hash, gate record hash, PR body hash, labels/env hash | Compared against current state |
+| `WorktreeWriteContext` | Pre-write validation context | cwd, target path, branch, assigned worktree, gate scope | Consumed by write guard |
+
+## 4. Implementation Plan
+
+### 4.1 Technical Approach
+
+Move workflow-gate orchestration from inline GitHub Actions scripts into a
+Python module under `scistudio.qa.governance`. GitHub Actions and local
+preflight must call that same module.
+
+Add a `gate_receipt` module with two public command surfaces: `run` and `exec`.
+`run` resolves required checks, executes them, writes JSON/log output, and
+returns nonzero on any failed required check. `exec` records an individual
+command for advanced workflows but still computes and stores the same candidate
+fingerprint.
+
+Add a receipt validator used by pre-push and pre-PR hooks. The validator
+compares the current candidate fingerprint with the receipt and verifies
+required-check completeness and exit status.
+
+Add a worktree write guard script used by Claude Code and Codex project hooks.
+The guard resolves filesystem paths and checks branch, worktree, and gate
+scope before mutation.
+
+### 4.2 Affected Files
+
+| File or glob | Action | Rationale |
+|---|---|---|
+| `docs/adr/ADR-042-addendum5.md` | create | Accepted governance decision |
+| `docs/specs/adr-042-local-gate-receipts.md` | create | Implementation contract |
+| `src/scistudio/qa/governance/gate_receipt.py` or package | create | Receipt CLI, schema, execution, validation |
+| `src/scistudio/qa/governance/workflow_gate.py` | create | Shared local/CI workflow-gate orchestration |
+| `src/scistudio/qa/governance/worktree_write_guard.py` | create | Pre-write worktree/scope enforcement |
+| `src/scistudio/qa/governance/gate_record/**` | modify | Scoped override handling and validation integration |
+| `scripts/scistudio_pr_create.py` | modify | Use shared orchestration and receipt validation |
+| `scripts/hooks/**` | modify/create | Pre-push, pre-PR, and pre-write hook entry points |
+| `.github/workflows/workflow-gate.yml` | modify | Call shared orchestration instead of duplicating inline logic |
+| `.claude/settings.json` | modify | Wire receipt and write-guard hooks for Claude Code |
+| `.codex/config.toml` | modify | Wire equivalent hooks for Codex when present |
+| `src/scistudio/agent_provisioning/**` | modify | Provision equivalent runtime hooks |
+| `.gitignore` | verify/modify | Keep `.workflow/local/**` local-only |
+| `docs/ai-developer/rules.md` | modify | Explain scoped override semantics |
+| `docs/ai-developer/specific_rules/gated-workflow.md` | modify | Explain receipt runner and hard gate behavior |
+| `tests/qa/test_gate_receipt.py` | create | Receipt schema, fingerprint, required-check, stale-check tests |
+| `tests/qa/test_worktree_write_guard.py` | create | Worktree/path/branch/scope guard tests |
+| `tests/qa/test_gate_record_ci.py` | modify | Local/CI orchestration parity regression tests |
+| `tests/qa/test_core_change_guard.py` | modify | Scoped `admin-approved:core-change` regression tests |
+
+### 4.3 Implementation Sequence
+
+1. Add failing regression tests for #1464 local/CI workflow-gate mismatch.
+2. Extract shared workflow-gate orchestration and update CI to call it.
+3. Refactor local override handling so labels satisfy only their intended
+   guards.
+4. Define `GateReceipt`, `ReceiptCommand`, `RequiredCheckSet`, and
+   `CandidateFingerprint` models.
+5. Implement required-check resolution from gate record Phase 5 plus diff
+   surfaces.
+6. Implement `gate_receipt run` and `gate_receipt exec`.
+7. Implement receipt validation in pre-push and pre-PR hooks.
+8. Implement worktree write guard and wire it into supported AI runtimes.
+9. Update AI developer docs and dispatch templates as needed.
+10. Run focused QA tests, full audit, and the relevant frontend/Python checks.
+
+### 4.4 Verification Plan
+
+- `pytest tests/qa/test_gate_receipt.py --no-cov`
+- `pytest tests/qa/test_worktree_write_guard.py --no-cov`
+- `pytest tests/qa/test_gate_record_ci.py tests/qa/test_gate_record_hooks.py --no-cov`
+- `pytest tests/qa/test_core_change_guard.py tests/qa/test_human_bypass_guard.py --no-cov`
+- `ruff check src/scistudio/qa/governance tests/qa scripts`
+- `ruff format --check src/scistudio/qa/governance tests/qa scripts`
+- `mypy src/scistudio/ --ignore-missing-imports`
+- `PYTHONPATH=src python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json`
+- Frontend lint, format, typecheck, test, and build when frontend files or CI
+  parity matrix code changes touch frontend surfaces.
+
+### 4.5 Risks And Rollback
+
+The main risk is over-blocking local work when dependencies are missing or the
+required-check matrix is too conservative. Mitigate with explicit N/A rules
+only when the governing ADR/spec permits them, and keep CI authoritative.
+
+Rollback is to disable the new receipt hook while leaving CI Workflow Gate
+active. Rollback must not restore broad override behavior or weaken CI.
+
+## 5. Success Criteria
+
+### Measurable Outcomes
+
+- SC-001: Local preflight and GitHub Workflow Gate produce matching blocking
+  findings for shared fixtures.
+- SC-002: A receipt generated for an old commit is rejected after a new commit.
+- SC-003: A receipt generated before a gate record edit is rejected after the
+  edit.
+- SC-004: A frontend diff without lint, format, typecheck, test, and build
+  receipt entries is rejected.
+- SC-005: `admin-approved:core-change` does not bypass outside-scope or missing
+  receipt findings in tests.
+- SC-006: An AI write attempt in the root `main` worktree is blocked by the
+  write guard test fixture.
+- SC-007: `.workflow/local/gate-receipts/**` remains untracked and ignored.
+
+## 6. Assumptions
+
+- The repository keeps `.workflow/local/**` ignored for local-only state.
+- GitHub CI remains authoritative for final merge readiness.
+- Some PR-state facts are unavailable before PR creation and may be filtered
+  only with explicit reporting.
+- The initial implementation may require conservative local checks before it
+  learns finer-grained safe skip rules.

--- a/scripts/hooks/check-gate-before-pr.sh
+++ b/scripts/hooks/check-gate-before-pr.sh
@@ -69,12 +69,48 @@ done <<EOF
 $BYPASS_LABELS
 EOF
 
+PR_BODY=$(SCISTUDIO_CMD="$CMD" python - <<'PY'
+import os
+import shlex
+import sys
+from pathlib import Path
+
+try:
+    tokens = shlex.split(os.environ.get("SCISTUDIO_CMD", ""))
+except ValueError:
+    sys.exit(1)
+
+index = 0
+while index < len(tokens):
+    token = tokens[index]
+    value = None
+    if token in {"--body", "-b"} and index + 1 < len(tokens):
+        value = tokens[index + 1]
+        index += 1
+    elif token.startswith("--body=") or token.startswith("-b="):
+        value = token.split("=", 1)[1]
+    elif token == "--body-file" and index + 1 < len(tokens):
+        value = Path(tokens[index + 1]).read_text(encoding="utf-8")
+        index += 1
+    elif token.startswith("--body-file="):
+        value = Path(token.split("=", 1)[1]).read_text(encoding="utf-8")
+    if value is not None:
+        print(value, end="")
+        sys.exit(0)
+    index += 1
+sys.exit(2)
+PY
+) || {
+  echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"ADR-042 gate: gh pr create must provide the real PR body via --body or --body-file. Use scripts/scistudio_pr_create.py for receipt-backed PR creation."}}'
+  exit 0
+}
+
 if [ -n "$BROAD_BYPASS" ]; then
   OUTPUT=$(PYTHONPATH=src python -m scistudio.qa.governance.gate_record pr-ready \
     --repo-root . \
     --base "$BASE_REF" \
     --head HEAD \
-    --pr-body "$CMD" \
+    --pr-body "$PR_BODY" \
     "${LABEL_ARGS[@]}" 2>&1) || {
     REASON=$(printf '%s' "$OUTPUT" | python -c "import json,sys; print(json.dumps(sys.stdin.read()[:1800]))")
     echo "{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":$REASON}}"
@@ -84,7 +120,7 @@ if [ -n "$BROAD_BYPASS" ]; then
   exit 0
 fi
 
-if ! echo "$CMD" | grep -qiE '(closes|fixes|resolves)[[:space:]]+#?[0-9]+'; then
+if ! printf '%s' "$PR_BODY" | grep -qiE '(closes|fixes|resolves)[[:space:]]+#?[0-9]+'; then
   echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"ADR-042 gate: gh pr create command must include a PR body with Closes/Fixes/Resolves #N."}}'
   exit 0
 fi
@@ -93,7 +129,7 @@ OUTPUT=$(PYTHONPATH=src python -m scistudio.qa.governance.gate_record pr-ready \
   --repo-root . \
   --base "$BASE_REF" \
   --head HEAD \
-  --pr-body "$CMD" \
+  --pr-body "$PR_BODY" \
   "${LABEL_ARGS[@]}" 2>&1) || {
   REASON=$(printf '%s' "$OUTPUT" | python -c "import json,sys; print(json.dumps(sys.stdin.read()[:1800]))")
   echo "{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":$REASON}}"
@@ -128,7 +164,7 @@ RECEIPT_OUTPUT=$(PYTHONPATH=src python -m scistudio.qa.governance.gate_receipt v
   --gate-record "$GATE_RECORD" \
   --base "$BASE_REF" \
   --head HEAD \
-  --pr-body "$CMD" 2>&1) || {
+  --pr-body "$PR_BODY" 2>&1) || {
   REASON=$(printf '%s' "$RECEIPT_OUTPUT" | python -c "import json,sys; print(json.dumps(sys.stdin.read()[:1800]))")
   echo "{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":$REASON}}"
   exit 0

--- a/scripts/hooks/check-gate-before-pr.sh
+++ b/scripts/hooks/check-gate-before-pr.sh
@@ -60,6 +60,7 @@ PY
 )
 
 BASE_REF="${SCISTUDIO_GATE_BASE:-origin/main}"
+BROAD_BYPASS=$(printf '%s\n' "$BYPASS_LABELS" | grep -E '^(human-authored|admin-approved:ai-override)$' || true)
 LABEL_ARGS=()
 while IFS= read -r label; do
   [ -n "$label" ] || continue
@@ -68,7 +69,7 @@ done <<EOF
 $BYPASS_LABELS
 EOF
 
-if [ -n "$BYPASS_LABELS" ]; then
+if [ -n "$BROAD_BYPASS" ]; then
   OUTPUT=$(PYTHONPATH=src python -m scistudio.qa.governance.gate_record pr-ready \
     --repo-root . \
     --base "$BASE_REF" \
@@ -79,7 +80,7 @@ if [ -n "$BYPASS_LABELS" ]; then
     echo "{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":$REASON}}"
     exit 0
   }
-  echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow","permissionDecisionReason":"ADR-042 local gate bypassed by approved override label; CI/review still runs."}}'
+  echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow","permissionDecisionReason":"ADR-042 local gate bypassed by broad override label; CI/review still runs."}}'
   exit 0
 fi
 
@@ -95,6 +96,40 @@ OUTPUT=$(PYTHONPATH=src python -m scistudio.qa.governance.gate_record pr-ready \
   --pr-body "$CMD" \
   "${LABEL_ARGS[@]}" 2>&1) || {
   REASON=$(printf '%s' "$OUTPUT" | python -c "import json,sys; print(json.dumps(sys.stdin.read()[:1800]))")
+  echo "{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":$REASON}}"
+  exit 0
+}
+
+GATE_RECORD=$(SCISTUDIO_BRANCH="$BRANCH" python - <<'PY'
+import json
+import os
+from pathlib import Path
+
+branch = os.environ.get("SCISTUDIO_BRANCH", "")
+records = []
+for path in sorted(Path(".workflow/records").glob("*.json")):
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        continue
+    if data.get("branch") == branch:
+        records.append(path.as_posix())
+print(records[0] if len(records) == 1 else "")
+PY
+)
+
+if [ -z "$GATE_RECORD" ]; then
+  echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"ADR-042 gate: exactly one gate record must match the current branch before PR creation."}}'
+  exit 0
+fi
+
+RECEIPT_OUTPUT=$(PYTHONPATH=src python -m scistudio.qa.governance.gate_receipt validate \
+  --repo-root . \
+  --gate-record "$GATE_RECORD" \
+  --base "$BASE_REF" \
+  --head HEAD \
+  --pr-body "$CMD" 2>&1) || {
+  REASON=$(printf '%s' "$RECEIPT_OUTPUT" | python -c "import json,sys; print(json.dumps(sys.stdin.read()[:1800]))")
   echo "{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":$REASON}}"
   exit 0
 }

--- a/scripts/hooks/check-gate-before-push.sh
+++ b/scripts/hooks/check-gate-before-push.sh
@@ -53,6 +53,7 @@ PY
 )
 
 BASE_REF="${SCISTUDIO_GATE_BASE:-origin/main}"
+BROAD_BYPASS=$(printf '%s\n' "$BYPASS_LABELS" | grep -E '^(human-authored|admin-approved:ai-override)$' || true)
 LABEL_ARGS=()
 while IFS= read -r label; do
   [ -n "$label" ] || continue
@@ -70,9 +71,42 @@ OUTPUT=$(PYTHONPATH=src python -m scistudio.qa.governance.gate_record pre-push \
   exit 0
 }
 
-if [ -n "$BYPASS_LABELS" ]; then
-  echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow","permissionDecisionReason":"ADR-042 local gate bypassed by approved override label; CI/review still runs."}}'
+if [ -n "$BROAD_BYPASS" ]; then
+  echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow","permissionDecisionReason":"ADR-042 local gate bypassed by broad override label; CI/review still runs."}}'
   exit 0
 fi
+
+GATE_RECORD=$(SCISTUDIO_BRANCH="$BRANCH" python - <<'PY'
+import json
+import os
+from pathlib import Path
+
+branch = os.environ.get("SCISTUDIO_BRANCH", "")
+records = []
+for path in sorted(Path(".workflow/records").glob("*.json")):
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        continue
+    if data.get("branch") == branch:
+        records.append(path.as_posix())
+print(records[0] if len(records) == 1 else "")
+PY
+)
+
+if [ -z "$GATE_RECORD" ]; then
+  echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"ADR-042 gate: exactly one gate record must match the current branch before push."}}'
+  exit 0
+fi
+
+RECEIPT_OUTPUT=$(PYTHONPATH=src python -m scistudio.qa.governance.gate_receipt validate \
+  --repo-root . \
+  --gate-record "$GATE_RECORD" \
+  --base "$BASE_REF" \
+  --head HEAD 2>&1) || {
+  REASON=$(printf '%s' "$RECEIPT_OUTPUT" | python -c "import json,sys; print(json.dumps(sys.stdin.read()[:1800]))")
+  echo "{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":$REASON}}"
+  exit 0
+}
 
 echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow"}}'

--- a/scripts/hooks/check-worktree-write-guard.sh
+++ b/scripts/hooks/check-worktree-write-guard.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+set -eu
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+PYTHONPATH="$REPO_ROOT/src${PYTHONPATH:+:$PYTHONPATH}" \
+  python -m scistudio.qa.governance.worktree_write_guard --hook-json

--- a/scripts/scistudio_pr_create.py
+++ b/scripts/scistudio_pr_create.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Wrapper around ``gh pr create`` that pre-flights ``gate_record ci``.
+"""Wrapper around ``gh pr create`` that pre-flights ADR-042 local gates.
 
 Motivation: local ``gate_record pre-push`` only runs structural
 ``validate_gate_record`` checks. CI's ``Verify Workflow Compliance`` job
@@ -8,8 +8,9 @@ runs the full guard orchestration (``docs_landing``, ``issue_link``,
 PR-state guards). Issues in the first set surface only on CI today,
 causing avoidable fix-and-push cycles (see PR #1351).
 
-This wrapper closes that gap by running ``gate_record ci`` locally with
-the real ``--pr-body`` before invoking ``gh pr create``. It deliberately
+This wrapper closes that gap by running ``gate_receipt validate`` and
+``gate_record ci`` locally with the real ``--pr-body`` before invoking
+``gh pr create``. It deliberately
 filters findings from the three PR-state guards
 (``core_change_guard``, ``pr_merge_guard``, ``human_bypass_guard``)
 because their evidence (admin labels on the PR) cannot exist until the
@@ -224,6 +225,38 @@ def run_gate_record_ci(
         ) from exc
 
 
+def run_gate_receipt_validate(
+    repo_root: Path,
+    gate_record: Path,
+    pr_body: str,
+    *,
+    base: str = "origin/main",
+    head: str = "HEAD",
+) -> tuple[int, str, str]:
+    """Invoke ``gate_receipt validate`` for the exact PR candidate."""
+
+    cmd = [
+        sys.executable,
+        "-m",
+        "scistudio.qa.governance.gate_receipt",
+        "validate",
+        "--gate-record",
+        str(gate_record),
+        "--base",
+        base,
+        "--head",
+        head,
+        "--pr-body",
+        pr_body,
+    ]
+    env = os.environ.copy()
+    src_dir = repo_root / "src"
+    if src_dir.is_dir():
+        env["PYTHONPATH"] = str(src_dir) + os.pathsep + env.get("PYTHONPATH", "")
+    proc = subprocess.run(cmd, capture_output=True, text=True, env=env, cwd=str(repo_root), check=False)
+    return proc.returncode, proc.stdout, proc.stderr
+
+
 def main(argv: list[str] | None = None) -> int:
     argv = list(argv if argv is not None else sys.argv[1:])
     if "--help" in argv or "-h" in argv:
@@ -260,6 +293,24 @@ def main(argv: list[str] | None = None) -> int:
             return 1
 
         base = resolve_base_ref(extract_base(argv))
+
+        receipt_exit, receipt_stdout, receipt_stderr = run_gate_receipt_validate(
+            repo_root,
+            record,
+            body,
+            base=base,
+        )
+        if receipt_exit != 0:
+            print("\nERROR: local gate receipt is missing, stale, or failing.", file=sys.stderr)
+            print(receipt_stdout, file=sys.stderr, end="" if receipt_stdout.endswith("\n") else "\n")
+            print(receipt_stderr, file=sys.stderr, end="" if receipt_stderr.endswith("\n") else "\n")
+            print(
+                "\nRun `python -m scistudio.qa.governance.gate_receipt run "
+                f"--gate-record {record} --base {base} --pr-body-file <body-file>` "
+                "or record each command with `gate_receipt exec`.",
+                file=sys.stderr,
+            )
+            return 1
 
         try:
             report = run_gate_record_ci(repo_root, record, body, base=base)

--- a/src/scistudio/agent_provisioning/codex_config.py
+++ b/src/scistudio/agent_provisioning/codex_config.py
@@ -43,6 +43,11 @@ _TARGET_REL = ".codex/config.toml"
 # compatibility) and ``^apply_patch$`` so the same hook fires regardless
 # of which surface Codex routes through on a given turn.
 _PRE_HOOKS: tuple[tuple[str, str, str], ...] = (
+    (
+        "^(Edit|Write|MultiEdit|apply_patch)$",
+        "worktree_write_guard.py",
+        "Checking ADR-042 worktree and gate scope",
+    ),
     ("^Bash$", "deny_scistudio_cli.py", "Checking SciStudio CLI usage"),
     (
         "^(Edit|Write|MultiEdit|apply_patch)$",

--- a/src/scistudio/agent_provisioning/hooks.py
+++ b/src/scistudio/agent_provisioning/hooks.py
@@ -7,7 +7,8 @@ Per ADR §3.6 (matcher list expanded with ``MultiEdit`` per Codex P1
 review on PR #1047 — Claude Code treats ``MultiEdit`` as a distinct
 tool name; omitting it leaves a bypass path):
 
-  PreToolUse (3):
+  PreToolUse (4):
+    - hook_worktree_write_guard.py                 (matcher: Edit|Write|MultiEdit)
     - hook_deny_scistudio_cli.py                      (matcher: Bash)
     - hook_protect_workflow_yaml.py                 (matcher: Edit|Write|MultiEdit)
     - hook_enforce_list_blocks_before_block_write.py
@@ -36,6 +37,7 @@ _SETTINGS_REL = ".claude/settings.json"
 
 # (template_filename, destination_filename) — strip the "hook_" prefix.
 _HOOK_FILES: tuple[tuple[str, str], ...] = (
+    ("hook_worktree_write_guard.py", "worktree_write_guard.py"),
     ("hook_deny_scistudio_cli.py", "deny_scistudio_cli.py"),
     ("hook_protect_workflow_yaml.py", "protect_workflow_yaml.py"),
     (
@@ -77,6 +79,7 @@ def _build_settings_json(hooks_dir_rel: str) -> dict:
     # matcher so multi-edit operations are not a bypass path. Claude Code
     # treats MultiEdit as a distinct tool name.
     pre = [
+        ("Edit|Write|MultiEdit", "worktree_write_guard.py"),
         ("Bash", "deny_scistudio_cli.py"),
         ("Edit|Write|MultiEdit", "protect_workflow_yaml.py"),
         (

--- a/src/scistudio/agent_provisioning/templates/hook_worktree_write_guard.py
+++ b/src/scistudio/agent_provisioning/templates/hook_worktree_write_guard.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""Block AI writes outside the assigned ADR-042 worktree and gate scope."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _repo_root() -> Path:
+    try:
+        return Path(
+            subprocess.check_output(
+                ["git", "rev-parse", "--show-toplevel"],
+                text=True,
+                stderr=subprocess.DEVNULL,
+            ).strip()
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return Path.cwd()
+
+
+def main() -> int:
+    repo_root = _repo_root()
+    src_dir = repo_root / "src"
+    if src_dir.is_dir():
+        sys.path.insert(0, str(src_dir))
+    from scistudio.qa.governance.worktree_write_guard import main as guard_main
+
+    return guard_main(["--hook-json"])
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/scistudio/qa/governance/gate_receipt.py
+++ b/src/scistudio/qa/governance/gate_receipt.py
@@ -1,0 +1,449 @@
+"""Local ADR-042 gate receipts for CI-parity pre-PR checks."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import subprocess
+import sys
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from scistudio.qa.governance.gate_record.io import _load_record
+from scistudio.qa.governance.gate_record.paths import _normalize_path
+
+DEFAULT_RECEIPT_DIR = Path(".workflow/local/gate-receipts")
+DEFAULT_BASE = "origin/main"
+EMPTY_SHA256 = hashlib.sha256(b"").hexdigest()
+
+CHECK_COMMANDS: Mapping[str, tuple[str, ...]] = {
+    "ruff": ("ruff", "check", "."),
+    "format": ("ruff", "format", "--check", "."),
+    "mypy": ("mypy", "src/scistudio/", "--ignore-missing-imports", "--python-version", "3.13"),
+    "pytest-governance": ("pytest", "tests/qa", "--timeout=60", "--no-cov"),
+    "pytest-scripts": ("pytest", "tests/scripts", "--timeout=60", "--no-cov"),
+    "pytest-agent-provisioning": ("pytest", "tests/agent_provisioning", "--timeout=60", "--no-cov"),
+    "full_audit": (
+        sys.executable,
+        "-m",
+        "scistudio.qa.audit.full_audit",
+        "--repo-root",
+        ".",
+        "--format",
+        "json",
+        "--output",
+        "docs/audit/full-audit-latest.json",
+    ),
+    "frontend_lint": ("npm", "--prefix", "frontend", "run", "lint"),
+    "frontend_format": ("npm", "--prefix", "frontend", "run", "format:check"),
+    "frontend_typecheck": ("npm", "--prefix", "frontend", "run", "typecheck"),
+    "frontend_test": ("npm", "--prefix", "frontend", "test"),
+    "frontend_build": ("npm", "--prefix", "frontend", "run", "build"),
+}
+
+
+@dataclass(frozen=True)
+class CandidateFingerprint:
+    """Immutable state that a local receipt is valid for."""
+
+    base: str
+    head: str
+    head_sha: str
+    branch: str
+    changed_files: tuple[str, ...]
+    diff_sha256: str
+    gate_record_sha256: str
+    pr_body_sha256: str
+
+    def to_json(self) -> dict[str, Any]:
+        return {
+            "base": self.base,
+            "head": self.head,
+            "head_sha": self.head_sha,
+            "branch": self.branch,
+            "changed_files": list(self.changed_files),
+            "diff_sha256": self.diff_sha256,
+            "gate_record_sha256": self.gate_record_sha256,
+            "pr_body_sha256": self.pr_body_sha256,
+        }
+
+
+def _run_git_text(repo_root: Path, args: Sequence[str]) -> str:
+    return str(subprocess.check_output(["git", *args], cwd=repo_root, text=True, stderr=subprocess.DEVNULL))
+
+
+def _run_git_bytes(repo_root: Path, args: Sequence[str]) -> bytes:
+    return bytes(subprocess.check_output(["git", *args], cwd=repo_root, text=False, stderr=subprocess.DEVNULL))
+
+
+def _sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _sha256_text(text: str) -> str:
+    return _sha256_bytes(text.encode("utf-8"))
+
+
+def _file_sha256(path: Path) -> str:
+    return _sha256_bytes(path.read_bytes())
+
+
+def _read_pr_body(pr_body: str = "", pr_body_file: Path | None = None) -> str:
+    if pr_body_file is None:
+        return pr_body
+    return pr_body_file.read_text(encoding="utf-8")
+
+
+def build_candidate(
+    repo_root: Path,
+    *,
+    gate_record: Path,
+    base: str = DEFAULT_BASE,
+    head: str = "HEAD",
+    pr_body: str = "",
+) -> CandidateFingerprint:
+    """Return the exact branch/diff/body fingerprint a receipt must match."""
+
+    repo_root = repo_root.resolve()
+    record_path = gate_record if gate_record.is_absolute() else repo_root / gate_record
+    head_sha = _run_git_text(repo_root, ["rev-parse", head]).strip()
+    branch = _run_git_text(repo_root, ["branch", "--show-current"]).strip()
+    changed = _run_git_text(repo_root, ["diff", "--name-only", "--diff-filter=ACMRTUXB", f"{base}...{head}"])
+    diff = _run_git_bytes(repo_root, ["diff", "--binary", "--diff-filter=ACMRTUXB", f"{base}...{head}"])
+    changed_files = tuple(_normalize_path(line) for line in changed.splitlines() if line.strip())
+    return CandidateFingerprint(
+        base=base,
+        head=head,
+        head_sha=head_sha,
+        branch=branch,
+        changed_files=changed_files,
+        diff_sha256=_sha256_bytes(diff),
+        gate_record_sha256=_file_sha256(record_path),
+        pr_body_sha256=_sha256_text(pr_body),
+    )
+
+
+def receipt_paths(
+    repo_root: Path,
+    *,
+    head_sha: str,
+    pr_body_sha256: str = EMPTY_SHA256,
+    receipt_dir: Path = DEFAULT_RECEIPT_DIR,
+) -> tuple[Path, Path]:
+    root = repo_root.resolve()
+    directory = receipt_dir if receipt_dir.is_absolute() else root / receipt_dir
+    safe_sha = "".join(ch for ch in head_sha if ch.isalnum())[:40] or "unknown"
+    suffix = "" if pr_body_sha256 == EMPTY_SHA256 else f"-pr-{pr_body_sha256[:12]}"
+    return directory / f"{safe_sha}{suffix}.json", directory / f"{safe_sha}{suffix}.log"
+
+
+def infer_required_checks(
+    changed_files: Sequence[str],
+    *,
+    gate_required: Sequence[str] = (),
+) -> set[str]:
+    """Infer local CI-parity checks from the diff plus gate-record plan."""
+
+    required = set(gate_required)
+    normalized = [_normalize_path(path) for path in changed_files]
+    if any(path.startswith(("src/", "scripts/")) for path in normalized):
+        required.update({"ruff", "format", "mypy"})
+    if any(path.startswith("tests/") for path in normalized):
+        required.update({"ruff", "format"})
+    if any(path.startswith("tests/qa/") for path in normalized):
+        required.add("pytest-governance")
+    if any(path.startswith("tests/scripts/") for path in normalized):
+        required.add("pytest-scripts")
+    if any(path.startswith("tests/agent_provisioning/") for path in normalized):
+        required.add("pytest-agent-provisioning")
+    if any(
+        path.startswith(("src/scistudio/qa/governance/", ".github/workflows/", ".pre-commit-config.yaml"))
+        for path in normalized
+    ):
+        required.update({"full_audit", "gate_record_pre_push"})
+    if any(path.startswith(("docs/adr/", "docs/specs/", "docs/ai-developer/")) for path in normalized):
+        required.update({"frontmatter_lint", "full_audit"})
+    if any(path.startswith("frontend/") for path in normalized):
+        required.update({"frontend_lint", "frontend_format", "frontend_typecheck", "frontend_test", "frontend_build"})
+    return required
+
+
+def _load_receipt(path: Path) -> dict[str, Any]:
+    return dict(json.loads(path.read_text(encoding="utf-8")))
+
+
+def _initial_receipt(candidate: CandidateFingerprint) -> dict[str, Any]:
+    return {
+        "schema_version": "1",
+        "generated_at": datetime.now(UTC).isoformat(),
+        "candidate": candidate.to_json(),
+        "checks": [],
+    }
+
+
+def _write_receipt(path: Path, data: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def append_check(
+    repo_root: Path,
+    *,
+    gate_record: Path,
+    name: str,
+    command: Sequence[str],
+    base: str = DEFAULT_BASE,
+    head: str = "HEAD",
+    pr_body: str = "",
+    receipt_dir: Path = DEFAULT_RECEIPT_DIR,
+) -> int:
+    """Run one command and append stdout/stderr/exit code to the receipt."""
+
+    candidate = build_candidate(repo_root, gate_record=gate_record, base=base, head=head, pr_body=pr_body)
+    json_path, log_path = receipt_paths(
+        repo_root,
+        head_sha=candidate.head_sha,
+        pr_body_sha256=candidate.pr_body_sha256,
+        receipt_dir=receipt_dir,
+    )
+    existing = _load_receipt(json_path) if json_path.exists() else _initial_receipt(candidate)
+    if existing.get("candidate") != candidate.to_json():
+        existing = _initial_receipt(candidate)
+
+    env = os.environ.copy()
+    src_dir = repo_root / "src"
+    if src_dir.is_dir():
+        env["PYTHONPATH"] = str(src_dir) + os.pathsep + env.get("PYTHONPATH", "")
+    started_at = datetime.now(UTC).isoformat()
+    proc = subprocess.run(command, cwd=repo_root, env=env, text=True, capture_output=True, check=False)
+    ended_at = datetime.now(UTC).isoformat()
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    with log_path.open("a", encoding="utf-8", newline="\n") as log:
+        log.write(f"\n===== {name} | exit={proc.returncode} | started={started_at} | ended={ended_at} =====\n")
+        log.write("$ " + " ".join(command) + "\n")
+        log.write("--- stdout ---\n")
+        log.write(proc.stdout)
+        if proc.stdout and not proc.stdout.endswith("\n"):
+            log.write("\n")
+        log.write("--- stderr ---\n")
+        log.write(proc.stderr)
+        if proc.stderr and not proc.stderr.endswith("\n"):
+            log.write("\n")
+
+    checks = [check for check in existing.get("checks", []) if isinstance(check, Mapping) and check.get("name") != name]
+    checks.append(
+        {
+            "name": name,
+            "command": list(command),
+            "exit_code": proc.returncode,
+            "started_at": started_at,
+            "ended_at": ended_at,
+            "stdout_sha256": _sha256_text(proc.stdout),
+            "stderr_sha256": _sha256_text(proc.stderr),
+            "log_path": _normalize_path(str(log_path.relative_to(repo_root)))
+            if log_path.is_relative_to(repo_root)
+            else str(log_path),
+        }
+    )
+    existing["generated_at"] = ended_at
+    existing["candidate"] = candidate.to_json()
+    existing["checks"] = checks
+    _write_receipt(json_path, existing)
+    return proc.returncode
+
+
+def validate_receipt(
+    repo_root: Path,
+    *,
+    gate_record: Path,
+    base: str = DEFAULT_BASE,
+    head: str = "HEAD",
+    pr_body: str = "",
+    receipt_dir: Path = DEFAULT_RECEIPT_DIR,
+) -> tuple[bool, list[str]]:
+    """Validate receipt existence, fingerprint freshness, and zero-exit checks."""
+
+    candidate = build_candidate(repo_root, gate_record=gate_record, base=base, head=head, pr_body=pr_body)
+    json_path, _ = receipt_paths(
+        repo_root,
+        head_sha=candidate.head_sha,
+        pr_body_sha256=candidate.pr_body_sha256,
+        receipt_dir=receipt_dir,
+    )
+    if not json_path.exists():
+        return False, [f"missing gate receipt: {_normalize_path(str(json_path))}"]
+    try:
+        data = _load_receipt(json_path)
+    except (OSError, json.JSONDecodeError) as exc:
+        return False, [f"invalid gate receipt JSON: {exc}"]
+
+    errors: list[str] = []
+    if data.get("candidate") != candidate.to_json():
+        errors.append("gate receipt fingerprint does not match current HEAD/diff/gate record/PR body")
+
+    record = _load_record(gate_record)
+    required = infer_required_checks(candidate.changed_files, gate_required=record.required_checks)
+    checks = {str(check.get("name")): check for check in data.get("checks", []) if isinstance(check, Mapping)}
+    missing = sorted(required - set(checks))
+    for name in missing:
+        errors.append(f"missing gate receipt check: {name}")
+    for name in sorted(required & set(checks)):
+        exit_code = checks[name].get("exit_code")
+        if exit_code != 0:
+            errors.append(f"gate receipt check failed: {name} exit_code={exit_code}")
+    return not errors, errors
+
+
+def _command_for(
+    name: str,
+    *,
+    base: str,
+    head: str,
+    gate_record: Path,
+    candidate: CandidateFingerprint,
+) -> tuple[str, ...]:
+    if name == "frontmatter_lint":
+        targets = [
+            changed_file
+            for changed_file in candidate.changed_files
+            if changed_file.startswith(("docs/adr/", "docs/specs/"))
+        ]
+        if not targets:
+            raise ValueError("frontmatter_lint requires at least one changed ADR or spec file")
+        return (
+            sys.executable,
+            "-m",
+            "scistudio.qa.audit.frontmatter_lint",
+            *targets,
+            "--format",
+            "text",
+        )
+    if name == "docs_landing":
+        record = _load_record(gate_record)
+        docs_command = [
+            sys.executable,
+            "-m",
+            "scistudio.qa.governance.docs_landing",
+            "--repo-root",
+            ".",
+            "--docs-landing-json",
+            json.dumps(record.docs_landing),
+        ]
+        for changed_file in candidate.changed_files:
+            docs_command.extend(["--changed-file", changed_file])
+        return tuple(docs_command)
+    if name == "gate_record_pre_commit":
+        return (
+            sys.executable,
+            "-m",
+            "scistudio.qa.governance.gate_record",
+            "pre-commit",
+            "--repo-root",
+            ".",
+            "--gate-record",
+            _normalize_path(str(gate_record)),
+            "--staged",
+        )
+    if name == "gate_record_pre_push":
+        return (
+            sys.executable,
+            "-m",
+            "scistudio.qa.governance.gate_record",
+            "pre-push",
+            "--repo-root",
+            ".",
+            "--gate-record",
+            _normalize_path(str(gate_record)),
+            "--base",
+            base,
+            "--head",
+            head,
+        )
+    command = CHECK_COMMANDS.get(name)
+    if command is None:
+        raise ValueError(f"no built-in command for receipt check {name!r}; use gate_receipt exec --name {name} -- ...")
+    return tuple(command)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+    for name in ("validate", "run", "exec"):
+        command_parser = sub.add_parser(name)
+        command_parser.add_argument("--repo-root", type=Path, default=Path.cwd())
+        command_parser.add_argument("--gate-record", "--record", dest="gate_record", type=Path, required=True)
+        command_parser.add_argument("--base", default=DEFAULT_BASE)
+        command_parser.add_argument("--head", default="HEAD")
+        command_parser.add_argument("--pr-body", default="")
+        command_parser.add_argument("--pr-body-file", type=Path)
+        command_parser.add_argument("--receipt-dir", type=Path, default=DEFAULT_RECEIPT_DIR)
+    sub.choices["exec"].add_argument("--name", required=True)
+    sub.choices["exec"].add_argument("command_args", nargs=argparse.REMAINDER)
+    sub.choices["run"].add_argument("--check", action="append", default=[])
+
+    args = parser.parse_args(argv)
+    pr_body = _read_pr_body(args.pr_body, args.pr_body_file)
+    repo_root = args.repo_root.resolve()
+    gate_record = args.gate_record if args.gate_record.is_absolute() else repo_root / args.gate_record
+
+    if args.command == "validate":
+        ok, errors = validate_receipt(
+            repo_root,
+            gate_record=gate_record,
+            base=args.base,
+            head=args.head,
+            pr_body=pr_body,
+            receipt_dir=args.receipt_dir,
+        )
+        if ok:
+            print("gate_receipt: pass")
+            return 0
+        print("gate_receipt: fail", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        return 1
+
+    if args.command == "exec":
+        command_args = list(args.command_args)
+        if command_args and command_args[0] == "--":
+            command_args = command_args[1:]
+        if not command_args:
+            print("gate_receipt exec requires a command after --", file=sys.stderr)
+            return 2
+        return append_check(
+            repo_root,
+            gate_record=gate_record,
+            name=args.name,
+            command=command_args,
+            base=args.base,
+            head=args.head,
+            pr_body=pr_body,
+            receipt_dir=args.receipt_dir,
+        )
+
+    record = _load_record(gate_record)
+    candidate = build_candidate(repo_root, gate_record=gate_record, base=args.base, head=args.head, pr_body=pr_body)
+    checks = set(args.check) or infer_required_checks(candidate.changed_files, gate_required=record.required_checks)
+    exit_code = 0
+    for check in sorted(checks):
+        code = append_check(
+            repo_root,
+            gate_record=gate_record,
+            name=check,
+            command=_command_for(check, base=args.base, head=args.head, gate_record=gate_record, candidate=candidate),
+            base=args.base,
+            head=args.head,
+            pr_body=pr_body,
+            receipt_dir=args.receipt_dir,
+        )
+        exit_code = exit_code or code
+    return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/scistudio/qa/governance/gate_record/cli.py
+++ b/src/scistudio/qa/governance/gate_record/cli.py
@@ -284,7 +284,7 @@ def main(argv: list[str] | None = None) -> int:
         # ADR-042 Addendum 5: the CI subcommand is the local/CI shared
         # orchestration surface. Keep pre-push/pr-ready structural, but make
         # `ci` include the same blocking guard classes the workflow uses.
-        from scistudio.qa.governance.workflow_gate import run_ci
+        from scistudio.qa.governance.gate_record.workflow import run_ci
 
         report = run_ci(
             repo_root=args.repo_root,

--- a/src/scistudio/qa/governance/gate_record/cli.py
+++ b/src/scistudio/qa/governance/gate_record/cli.py
@@ -15,10 +15,7 @@ from pathlib import Path
 
 from pydantic import ValidationError
 
-from scistudio.qa.governance.gate_record.io import (
-    _git_lines,
-    _parse_issue_numbers,
-)
+from scistudio.qa.governance.gate_record.io import _parse_issue_numbers
 from scistudio.qa.governance.gate_record.paths import _normalize_path
 from scistudio.qa.governance.gate_record.stages import (
     amend_record,
@@ -32,7 +29,6 @@ from scistudio.qa.governance.gate_record.stages import (
 from scistudio.qa.governance.gate_record.validation import (
     _env_bypass_labels,
     check_commit_msg,
-    check_pr,
     check_pr_ready,
     check_pre_commit,
     check_pre_push,
@@ -285,12 +281,16 @@ def main(argv: list[str] | None = None) -> int:
             pr_labels=[*args.pr_label, *_env_bypass_labels()],
         )
     else:
-        changed_files = _git_lines(
-            args.repo_root, ["diff", "--name-only", "--diff-filter=ACMRTUXB", f"{args.base}...{args.head}"]
-        )
-        report = check_pr(
-            args.gate_record,
-            changed_files=changed_files,
+        # ADR-042 Addendum 5: the CI subcommand is the local/CI shared
+        # orchestration surface. Keep pre-push/pr-ready structural, but make
+        # `ci` include the same blocking guard classes the workflow uses.
+        from scistudio.qa.governance.workflow_gate import run_ci
+
+        report = run_ci(
+            repo_root=args.repo_root,
+            gate_record=args.gate_record,
+            base=args.base,
+            head=args.head,
             pr_body=args.pr_body,
             pr_labels=args.pr_label,
         )

--- a/src/scistudio/qa/governance/gate_record/io.py
+++ b/src/scistudio/qa/governance/gate_record/io.py
@@ -14,7 +14,7 @@ import re
 import subprocess
 from collections.abc import Mapping, Sequence
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 from scistudio.qa.governance.gate_record.models import (
     CheckEvidence,
@@ -32,9 +32,9 @@ def _load_record(record: GateRecord | Mapping[str, Any] | str | Path) -> GateRec
     if isinstance(record, GateRecord):
         return record
     if isinstance(record, Mapping):
-        return GateRecord.model_validate(record)
+        return cast(GateRecord, GateRecord.model_validate(record))
     path = Path(record)
-    return GateRecord.model_validate_json(path.read_text(encoding="utf-8"))
+    return cast(GateRecord, GateRecord.model_validate_json(path.read_text(encoding="utf-8")))
 
 
 def _slugify(value: str) -> str:

--- a/src/scistudio/qa/governance/gate_record/validation.py
+++ b/src/scistudio/qa/governance/gate_record/validation.py
@@ -171,12 +171,13 @@ def _local_bypass_report(labels: Sequence[str]) -> AuditReport | None:
                 for label in invalid
             ]
         )
-    valid = sorted(set(normalized) & VALID_OVERRIDE_LABELS)
+    broad_bypass_labels = {"human-authored", "admin-approved:ai-override"}
+    valid = sorted(set(normalized) & broad_bypass_labels)
     if valid:
         return _report(
             [],
             summary={
-                "skipped": "local ADR-042 hook bypassed by override label; CI/review remains authoritative",
+                "skipped": "local ADR-042 hook bypassed by broad override label; CI/review remains authoritative",
                 "bypass_labels": valid,
             },
         )

--- a/src/scistudio/qa/governance/gate_record/workflow.py
+++ b/src/scistudio/qa/governance/gate_record/workflow.py
@@ -1,0 +1,80 @@
+"""Shared local/CI ADR-042 workflow gate orchestration."""
+
+from __future__ import annotations
+
+import importlib
+import subprocess
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+from scistudio.qa.governance.gate_record.io import _load_record
+from scistudio.qa.governance.gate_record.validation import check_pr
+from scistudio.qa.schemas.report import AuditReport, AuditStatus
+
+
+def _git_lines(repo_root: Path, args: Sequence[str]) -> list[str]:
+    out = subprocess.check_output(["git", *args], cwd=repo_root, text=True, stderr=subprocess.DEVNULL)
+    return [line.strip().replace("\\", "/") for line in out.splitlines() if line.strip()]
+
+
+def _governance_module(name: str) -> Any:
+    return importlib.import_module(f"scistudio.qa.governance.{name}")
+
+
+def _combined(reports: Sequence[AuditReport], *, repo_root: Path) -> AuditReport:
+    findings = []
+    for report in reports:
+        findings.extend(report.findings)
+    mod_guard = _governance_module("mod_guard")
+    return AuditReport(
+        tool="workflow_gate",
+        status=AuditStatus.FAIL if any(report.blocks_merge for report in reports) else AuditStatus.PASS,
+        source_sha=str(mod_guard._source_sha(repo_root)),
+        findings=findings,
+        child_reports=list(reports),
+        summary={"children": [report.tool for report in reports]},
+    )
+
+
+def run_ci(
+    *,
+    repo_root: Path,
+    gate_record: Path,
+    base: str = "origin/main",
+    head: str = "HEAD",
+    pr_body: str = "",
+    pr_labels: Sequence[str] = (),
+) -> AuditReport:
+    """Run the local/CI-shared blocking guards over the exact branch diff."""
+
+    repo_root = repo_root.resolve()
+    changed_files = _git_lines(repo_root, ["diff", "--name-only", "--diff-filter=ACMRTUXB", f"{base}...{head}"])
+    record = _load_record(gate_record)
+    record_json = record.model_dump(mode="json")
+    issues = record_json.get("issues", [])
+    followups = [issue["number"] for issue in issues if not issue.get("close_in_pr", True)]
+    mod_guard = _governance_module("mod_guard")
+    mod_report = mod_guard.check(
+        repo_root,
+        base_ref=base,
+        head_ref=head,
+        allow_governance_change=bool(record.governance_touch),
+    )
+    issue_link = _governance_module("issue_link")
+    docs_landing = _governance_module("docs_landing")
+    weakened_ci_check = _governance_module("weakened_ci_check")
+    reports = [
+        check_pr(gate_record, changed_files=changed_files, pr_body=pr_body, pr_labels=pr_labels),
+        issue_link.check(
+            issues=issues,
+            pr_body=pr_body,
+            require_closing=True,
+            followup_issues=followups,
+            repo_root=repo_root,
+        ),
+        docs_landing.check(changed_files=changed_files, docs_landing=record.docs_landing, repo_root=repo_root),
+        mod_report,
+        weakened_ci_check.verify_no_weakening(repo_root, base_ref=base, head_ref=head),
+    ]
+    return _combined(reports, repo_root=repo_root)

--- a/src/scistudio/qa/governance/workflow_gate.py
+++ b/src/scistudio/qa/governance/workflow_gate.py
@@ -1,0 +1,111 @@
+"""Shared local/CI ADR-042 workflow gate orchestration."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from collections.abc import Sequence
+from pathlib import Path
+
+from scistudio.qa.governance import docs_landing, issue_link, mod_guard, weakened_ci_check
+from scistudio.qa.governance.gate_record.io import _load_record
+from scistudio.qa.governance.gate_record.validation import check_pr
+from scistudio.qa.schemas.report import AuditReport, AuditStatus
+
+
+def _git_lines(repo_root: Path, args: Sequence[str]) -> list[str]:
+    out = subprocess.check_output(["git", *args], cwd=repo_root, text=True, stderr=subprocess.DEVNULL)
+    return [line.strip().replace("\\", "/") for line in out.splitlines() if line.strip()]
+
+
+def _source_sha(repo_root: Path) -> str:
+    try:
+        return subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=repo_root, text=True).strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return "unknown"
+
+
+def _combined(reports: Sequence[AuditReport], *, repo_root: Path) -> AuditReport:
+    findings = []
+    for report in reports:
+        findings.extend(report.findings)
+    return AuditReport(
+        tool="workflow_gate",
+        status=AuditStatus.FAIL if any(report.blocks_merge for report in reports) else AuditStatus.PASS,
+        source_sha=_source_sha(repo_root),
+        findings=findings,
+        child_reports=list(reports),
+        summary={"children": [report.tool for report in reports]},
+    )
+
+
+def run_ci(
+    *,
+    repo_root: Path,
+    gate_record: Path,
+    base: str = "origin/main",
+    head: str = "HEAD",
+    pr_body: str = "",
+    pr_labels: Sequence[str] = (),
+) -> AuditReport:
+    """Run the local/CI-shared blocking guards over the exact branch diff."""
+
+    repo_root = repo_root.resolve()
+    changed_files = _git_lines(repo_root, ["diff", "--name-only", "--diff-filter=ACMRTUXB", f"{base}...{head}"])
+    record = _load_record(gate_record)
+    record_json = record.model_dump(mode="json")
+    issues = record_json.get("issues", [])
+    followups = [issue["number"] for issue in issues if not issue.get("close_in_pr", True)]
+    mod_report = mod_guard.check(
+        repo_root,
+        base_ref=base,
+        head_ref=head,
+        allow_governance_change=bool(record.governance_touch),
+    )
+    reports = [
+        check_pr(gate_record, changed_files=changed_files, pr_body=pr_body, pr_labels=pr_labels),
+        issue_link.check(
+            issues=issues, pr_body=pr_body, require_closing=True, followup_issues=followups, repo_root=repo_root
+        ),
+        docs_landing.check(changed_files=changed_files, docs_landing=record.docs_landing, repo_root=repo_root),
+        mod_report,
+        weakened_ci_check.verify_no_weakening(repo_root, base_ref=base, head_ref=head),
+    ]
+    return _combined(reports, repo_root=repo_root)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=("ci",))
+    parser.add_argument("--repo-root", type=Path, default=Path.cwd())
+    parser.add_argument("--gate-record", "--record", dest="gate_record", type=Path, required=True)
+    parser.add_argument("--base", default="origin/main")
+    parser.add_argument("--head", default="HEAD")
+    parser.add_argument("--pr-body", default="")
+    parser.add_argument("--pr-label", action="append", default=[])
+    parser.add_argument("--format", choices=("text", "json"), default="text")
+    args = parser.parse_args(argv)
+
+    report = run_ci(
+        repo_root=args.repo_root,
+        gate_record=args.gate_record,
+        base=args.base,
+        head=args.head,
+        pr_body=args.pr_body,
+        pr_labels=args.pr_label,
+    )
+    if args.format == "json":
+        print(json.dumps(report.model_dump(mode="json"), indent=2, sort_keys=True))
+    else:
+        if report.blocks_merge:
+            print("workflow_gate: fail")
+            for finding in report.findings:
+                print(f"- {finding.rule_id}: {finding.message}")
+        else:
+            print("workflow_gate: pass")
+    return 1 if report.blocks_merge else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/scistudio/qa/governance/workflow_gate.py
+++ b/src/scistudio/qa/governance/workflow_gate.py
@@ -1,78 +1,12 @@
-"""Shared local/CI ADR-042 workflow gate orchestration."""
+"""CLI wrapper for shared local/CI ADR-042 workflow gate orchestration."""
 
 from __future__ import annotations
 
 import argparse
 import json
-import subprocess
-from collections.abc import Sequence
 from pathlib import Path
 
-from scistudio.qa.governance import docs_landing, issue_link, mod_guard, weakened_ci_check
-from scistudio.qa.governance.gate_record.io import _load_record
-from scistudio.qa.governance.gate_record.validation import check_pr
-from scistudio.qa.schemas.report import AuditReport, AuditStatus
-
-
-def _git_lines(repo_root: Path, args: Sequence[str]) -> list[str]:
-    out = subprocess.check_output(["git", *args], cwd=repo_root, text=True, stderr=subprocess.DEVNULL)
-    return [line.strip().replace("\\", "/") for line in out.splitlines() if line.strip()]
-
-
-def _source_sha(repo_root: Path) -> str:
-    try:
-        return subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=repo_root, text=True).strip()
-    except (subprocess.CalledProcessError, FileNotFoundError):
-        return "unknown"
-
-
-def _combined(reports: Sequence[AuditReport], *, repo_root: Path) -> AuditReport:
-    findings = []
-    for report in reports:
-        findings.extend(report.findings)
-    return AuditReport(
-        tool="workflow_gate",
-        status=AuditStatus.FAIL if any(report.blocks_merge for report in reports) else AuditStatus.PASS,
-        source_sha=_source_sha(repo_root),
-        findings=findings,
-        child_reports=list(reports),
-        summary={"children": [report.tool for report in reports]},
-    )
-
-
-def run_ci(
-    *,
-    repo_root: Path,
-    gate_record: Path,
-    base: str = "origin/main",
-    head: str = "HEAD",
-    pr_body: str = "",
-    pr_labels: Sequence[str] = (),
-) -> AuditReport:
-    """Run the local/CI-shared blocking guards over the exact branch diff."""
-
-    repo_root = repo_root.resolve()
-    changed_files = _git_lines(repo_root, ["diff", "--name-only", "--diff-filter=ACMRTUXB", f"{base}...{head}"])
-    record = _load_record(gate_record)
-    record_json = record.model_dump(mode="json")
-    issues = record_json.get("issues", [])
-    followups = [issue["number"] for issue in issues if not issue.get("close_in_pr", True)]
-    mod_report = mod_guard.check(
-        repo_root,
-        base_ref=base,
-        head_ref=head,
-        allow_governance_change=bool(record.governance_touch),
-    )
-    reports = [
-        check_pr(gate_record, changed_files=changed_files, pr_body=pr_body, pr_labels=pr_labels),
-        issue_link.check(
-            issues=issues, pr_body=pr_body, require_closing=True, followup_issues=followups, repo_root=repo_root
-        ),
-        docs_landing.check(changed_files=changed_files, docs_landing=record.docs_landing, repo_root=repo_root),
-        mod_report,
-        weakened_ci_check.verify_no_weakening(repo_root, base_ref=base, head_ref=head),
-    ]
-    return _combined(reports, repo_root=repo_root)
+from scistudio.qa.governance.gate_record.workflow import run_ci
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/src/scistudio/qa/governance/worktree_write_guard.py
+++ b/src/scistudio/qa/governance/worktree_write_guard.py
@@ -1,0 +1,196 @@
+"""Pre-tool guard for AI writes in SciStudio worktrees."""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import json
+import subprocess
+import sys
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+from scistudio.qa.governance.gate_record.io import _load_record
+from scistudio.qa.governance.gate_record.paths import _normalize_path
+
+MAIN_BRANCHES = {"main", "master"}
+PATH_KEYS = ("file_path", "path", "notebook_path")
+BROAD_OVERRIDE_LABELS = {"human-authored", "admin-approved:ai-override"}
+
+
+def _git(repo_root: Path, args: Sequence[str]) -> str:
+    return subprocess.check_output(["git", *args], cwd=repo_root, text=True, stderr=subprocess.DEVNULL).strip()
+
+
+def _repo_root(start: Path) -> Path:
+    return Path(_git(start, ["rev-parse", "--show-toplevel"])).resolve()
+
+
+def _branch(repo_root: Path) -> str:
+    return _git(repo_root, ["rev-parse", "--abbrev-ref", "HEAD"])
+
+
+def _effective_include(record: Any) -> list[str]:
+    includes = list(record.scope.include)
+    for amendment in record.amendments:
+        includes.extend(amendment.include)
+    return includes
+
+
+def _effective_exclude(record: Any) -> list[str]:
+    excludes = list(record.scope.exclude)
+    for amendment in record.amendments:
+        excludes.extend(amendment.exclude)
+    return excludes
+
+
+def _matches(path: str, patterns: Sequence[str]) -> bool:
+    return any(fnmatch.fnmatchcase(path, pattern) for pattern in patterns)
+
+
+def _labels(payload: Mapping[str, Any]) -> set[str]:
+    raw = payload.get("bypass_labels") or payload.get("labels") or []
+    if isinstance(raw, str):
+        return {item.strip() for item in raw.replace(",", " ").split() if item.strip()}
+    if isinstance(raw, Sequence):
+        return {str(item).strip() for item in raw if str(item).strip()}
+    return set()
+
+
+def _tool_input(payload: Mapping[str, Any]) -> Mapping[str, Any]:
+    raw = payload.get("tool_input") or payload.get("arguments") or payload
+    return raw if isinstance(raw, Mapping) else {}
+
+
+def _extract_paths(payload: Mapping[str, Any]) -> list[str]:
+    tool_input = _tool_input(payload)
+    paths: list[str] = []
+    for key in PATH_KEYS:
+        value = tool_input.get(key)
+        if isinstance(value, str) and value.strip():
+            paths.append(value)
+    edits = tool_input.get("edits")
+    if isinstance(edits, Sequence) and not isinstance(edits, str):
+        for edit in edits:
+            if isinstance(edit, Mapping):
+                value = edit.get("file_path") or edit.get("path")
+                if isinstance(value, str) and value.strip():
+                    paths.append(value)
+    return paths
+
+
+def _discover_record(repo_root: Path, branch: str) -> Path | None:
+    records = []
+    records_dir = repo_root / ".workflow" / "records"
+    if not records_dir.is_dir():
+        return None
+    for path in sorted(records_dir.glob("*.json")):
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if isinstance(data, Mapping) and data.get("branch") == branch:
+            records.append(path)
+    if len(records) == 1:
+        return records[0]
+    managers = [path for path in records if json.loads(path.read_text(encoding="utf-8")).get("task_kind") == "manager"]
+    return managers[0] if len(managers) == 1 else None
+
+
+def check_paths(
+    *,
+    repo_root: Path,
+    target_paths: Sequence[str],
+    gate_record: Path | None = None,
+    branch: str | None = None,
+    bypass_labels: Sequence[str] = (),
+) -> list[str]:
+    """Return blocking errors for attempted AI writes."""
+
+    root = repo_root.resolve()
+    current_branch = branch or _branch(root)
+    if set(bypass_labels) & BROAD_OVERRIDE_LABELS:
+        return []
+    errors: list[str] = []
+    if current_branch in MAIN_BRANCHES or current_branch == "HEAD":
+        errors.append(f"AI writes must use a dedicated non-main branch/worktree; current branch is {current_branch!r}")
+    if not target_paths:
+        return errors
+
+    record_path = gate_record or _discover_record(root, current_branch)
+    if record_path is None:
+        errors.append("AI writes require exactly one committed gate record matching the current branch")
+        return errors
+    record = _load_record(record_path)
+    if record.branch != current_branch:
+        errors.append(f"gate record branch {record.branch!r} does not match current branch {current_branch!r}")
+
+    includes = _effective_include(record)
+    excludes = _effective_exclude(record)
+    for raw_path in target_paths:
+        candidate = Path(raw_path)
+        absolute = candidate if candidate.is_absolute() else root / candidate
+        try:
+            resolved = absolute.resolve()
+        except OSError:
+            resolved = absolute.absolute()
+        try:
+            rel = _normalize_path(str(resolved.relative_to(root)))
+        except ValueError:
+            errors.append(f"write target is outside the assigned worktree: {raw_path}")
+            continue
+        if includes and not _matches(rel, includes):
+            errors.append(f"write target is outside gate scope include patterns: {rel}")
+        if _matches(rel, excludes):
+            errors.append(f"write target is inside gate scope exclude patterns: {rel}")
+    return errors
+
+
+def check_hook_payload(payload: Mapping[str, Any], *, cwd: Path | None = None) -> list[str]:
+    """Validate a Claude/Codex hook stdin payload."""
+
+    start = Path(str(payload.get("cwd") or cwd or Path.cwd()))
+    root = _repo_root(start)
+    target_paths = _extract_paths(payload)
+    return check_paths(repo_root=root, target_paths=target_paths, bypass_labels=sorted(_labels(payload)))
+
+
+def _render_hook_block(errors: Sequence[str]) -> None:
+    if not errors:
+        return
+    print("ADR-042 worktree write guard blocked this AI write:", file=sys.stderr)
+    for error in errors:
+        print(f"- {error}", file=sys.stderr)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", type=Path)
+    parser.add_argument("--gate-record", type=Path)
+    parser.add_argument("--branch")
+    parser.add_argument("--target", action="append", default=[])
+    parser.add_argument("--hook-json", action="store_true")
+    args = parser.parse_args(argv)
+
+    if args.hook_json:
+        try:
+            payload = json.load(sys.stdin)
+        except json.JSONDecodeError as exc:
+            print(f"invalid hook JSON: {exc}", file=sys.stderr)
+            return 2
+        errors = check_hook_payload(payload)
+    else:
+        root = args.repo_root.resolve() if args.repo_root is not None else _repo_root(Path.cwd())
+        errors = check_paths(
+            repo_root=root,
+            target_paths=args.target,
+            gate_record=args.gate_record,
+            branch=args.branch,
+        )
+    _render_hook_block(errors)
+    return 2 if errors else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/agent_provisioning/test_codex_config.py
+++ b/tests/agent_provisioning/test_codex_config.py
@@ -41,8 +41,8 @@ def test_codex_config_mcp_block_matches_install_render(tmp_project_dir: Path) ->
     )
 
 
-def test_codex_config_emits_six_hooks(tmp_project_dir: Path) -> None:
-    """ADR-040 Addendum 4: Codex gets the same 6-hook surface as Claude.
+def test_codex_config_emits_hooks(tmp_project_dir: Path) -> None:
+    """ADR-040/042: Codex gets the same hook surface as Claude.
 
     Asserts ``features.hooks = true``, 3 PreToolUse + 3 PostToolUse
     matcher groups, and each hook command line references a script
@@ -58,10 +58,11 @@ def test_codex_config_emits_six_hooks(tmp_project_dir: Path) -> None:
 
     pre = data.get("hooks", {}).get("PreToolUse", [])
     post = data.get("hooks", {}).get("PostToolUse", [])
-    assert len(pre) == 3, f"expected 3 PreToolUse hooks, got {len(pre)}"
+    assert len(pre) == 4, f"expected 4 PreToolUse hooks, got {len(pre)}"
     assert len(post) == 3, f"expected 3 PostToolUse hooks, got {len(post)}"
 
     expected_pre_scripts = {
+        "worktree_write_guard.py",
         "deny_scistudio_cli.py",
         "protect_workflow_yaml.py",
         "enforce_list_blocks_before_block_write.py",

--- a/tests/agent_provisioning/test_hooks.py
+++ b/tests/agent_provisioning/test_hooks.py
@@ -16,6 +16,7 @@ import pytest
 from scistudio.agent_provisioning.hooks import write_hooks
 
 _HOOK_NAMES = (
+    "worktree_write_guard.py",
     "deny_scistudio_cli.py",
     "protect_workflow_yaml.py",
     "enforce_list_blocks_before_block_write.py",
@@ -35,7 +36,7 @@ def test_write_hooks_creates_settings_json(tmp_project_dir: Path) -> None:
     assert "hooks" in data
     pre = data["hooks"]["PreToolUse"]
     post = data["hooks"]["PostToolUse"]
-    assert len(pre) == 3
+    assert len(pre) == 4
     assert len(post) == 3
 
     # Every entry references a python interpreter and a hook script path.
@@ -53,8 +54,8 @@ def test_write_hooks_creates_settings_json(tmp_project_dir: Path) -> None:
         assert "MultiEdit" in matcher, f"matcher missing MultiEdit: {matcher!r}"
 
 
-def test_write_hooks_copies_six_scripts(tmp_project_dir: Path) -> None:
-    """All 6 hook scripts land in .claude/hooks/."""
+def test_write_hooks_copies_hook_scripts(tmp_project_dir: Path) -> None:
+    """All canonical hook scripts land in .claude/hooks/."""
     write_hooks(tmp_project_dir, force=False)
     hooks_dir = tmp_project_dir / ".claude" / "hooks"
     for name in _HOOK_NAMES:

--- a/tests/qa/test_gate_receipt.py
+++ b/tests/qa/test_gate_receipt.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+import scistudio.qa.governance.gate_receipt as gate_receipt
+from scistudio.qa.governance.gate_receipt import (
+    EMPTY_SHA256,
+    CandidateFingerprint,
+    infer_required_checks,
+    receipt_paths,
+    validate_receipt,
+)
+
+
+def _record(path: Path, *, required_checks: list[str]) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": "1",
+                "task_id": "1492-local-receipts",
+                "task_kind": "maintenance",
+                "persona": "implementer",
+                "branch": "feat/local-receipts",
+                "owner_directive": "test",
+                "issues": [{"number": 1492, "url": "https://github.com/zjzcpj/SciStudio/issues/1492"}],
+                "scope": {"include": ["src/**"], "exclude": []},
+                "governance_touch": True,
+                "stages": [
+                    {"stage": "scope_and_issue", "status": "done"},
+                    {"stage": "plan", "status": "done"},
+                    {"stage": "implement", "status": "done"},
+                    {"stage": "update_docs", "status": "done"},
+                    {"stage": "test_and_checks", "status": "done"},
+                    {"stage": "commit_and_submit_pr", "status": "pending"},
+                ],
+                "required_checks": required_checks,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def _candidate() -> CandidateFingerprint:
+    return CandidateFingerprint(
+        base="origin/main",
+        head="HEAD",
+        head_sha="abc123",
+        branch="feat/local-receipts",
+        changed_files=("src/scistudio/qa/governance/gate_receipt.py",),
+        diff_sha256="diff",
+        gate_record_sha256="record",
+        pr_body_sha256=EMPTY_SHA256,
+    )
+
+
+def test_infer_required_checks_combines_gate_record_and_diff() -> None:
+    checks = infer_required_checks(
+        ["src/scistudio/qa/governance/gate_receipt.py", "docs/specs/adr-042-local-gate-receipts.md"],
+        gate_required=["pytest-governance"],
+    )
+
+    assert {
+        "ruff",
+        "format",
+        "mypy",
+        "full_audit",
+        "gate_record_pre_push",
+        "frontmatter_lint",
+        "pytest-governance",
+    } <= checks
+
+
+def test_validate_receipt_rejects_missing_required_check(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    record = tmp_path / "record.json"
+    _record(record, required_checks=["ruff"])
+    candidate = _candidate()
+    receipt_dir = tmp_path / ".workflow" / "local" / "gate-receipts"
+    receipt_dir.mkdir(parents=True)
+    receipt, _ = receipt_paths(
+        tmp_path, head_sha=candidate.head_sha, pr_body_sha256=candidate.pr_body_sha256, receipt_dir=receipt_dir
+    )
+    receipt.write_text(
+        json.dumps({"schema_version": "1", "candidate": candidate.to_json(), "checks": []}),
+        encoding="utf-8",
+    )
+
+    def fake_build_candidate(*args: object, **kwargs: object) -> CandidateFingerprint:
+        return candidate
+
+    monkeypatch.setattr(gate_receipt, "build_candidate", fake_build_candidate)
+
+    ok, errors = validate_receipt(tmp_path, gate_record=record, receipt_dir=receipt_dir)
+
+    assert not ok
+    assert any("missing gate receipt check: ruff" in error for error in errors)
+
+
+def test_validate_receipt_rejects_stale_fingerprint(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    record = tmp_path / "record.json"
+    _record(record, required_checks=[])
+    candidate = _candidate()
+    receipt_dir = tmp_path / ".workflow" / "local" / "gate-receipts"
+    receipt_dir.mkdir(parents=True)
+    stale = candidate.to_json()
+    stale["diff_sha256"] = "old"
+    receipt, _ = receipt_paths(
+        tmp_path, head_sha=candidate.head_sha, pr_body_sha256=candidate.pr_body_sha256, receipt_dir=receipt_dir
+    )
+    receipt.write_text(
+        json.dumps({"schema_version": "1", "candidate": stale, "checks": []}),
+        encoding="utf-8",
+    )
+
+    def fake_build_candidate(*args: object, **kwargs: object) -> CandidateFingerprint:
+        return candidate
+
+    monkeypatch.setattr(gate_receipt, "build_candidate", fake_build_candidate)
+
+    ok, errors = validate_receipt(tmp_path, gate_record=record, receipt_dir=receipt_dir)
+
+    assert not ok
+    assert "fingerprint does not match" in "\n".join(errors)

--- a/tests/qa/test_gate_record.py
+++ b/tests/qa/test_gate_record.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import cast
 
 import pytest
 from pydantic import ValidationError
@@ -386,7 +387,7 @@ def test_pr_ready_does_not_require_commit_and_submit_pr_stage_done() -> None:
 
     record_data = _record()
     pending_stages: list[dict[str, object]] = []
-    for stage in record_data["stages"]:
+    for stage in cast(list[dict[str, object]], record_data["stages"]):
         copy = dict(stage)
         if stage["stage"] == GateStage.COMMIT_AND_SUBMIT_PR.value:
             copy["status"] = "pending"
@@ -415,7 +416,7 @@ def test_ci_still_requires_commit_and_submit_pr_stage_done() -> None:
 
     record_data = _record()
     pending_stages: list[dict[str, object]] = []
-    for stage in record_data["stages"]:
+    for stage in cast(list[dict[str, object]], record_data["stages"]):
         copy = dict(stage)
         if stage["stage"] == GateStage.COMMIT_AND_SUBMIT_PR.value:
             copy["status"] = "pending"
@@ -445,7 +446,7 @@ def test_pre_push_does_not_require_commit_and_submit_pr_stage_done() -> None:
 
     record_data = _record()
     pending_stages: list[dict[str, object]] = []
-    for stage in record_data["stages"]:
+    for stage in cast(list[dict[str, object]], record_data["stages"]):
         copy = dict(stage)
         if stage["stage"] == GateStage.COMMIT_AND_SUBMIT_PR.value:
             copy["status"] = "pending"
@@ -844,11 +845,9 @@ def test_pre_commit_is_lightweight_until_final_gate(tmp_path: Path) -> None:
     [
         "human-authored",
         "admin-approved:ai-override",
-        "admin-approved:core-change",
-        "admin-approved:merge",
     ],
 )
-def test_override_labels_bypass_local_intermediate_hooks(tmp_path: Path, label: str) -> None:
+def test_broad_override_labels_bypass_local_intermediate_hooks(tmp_path: Path, label: str) -> None:
     pre_commit = check_pre_commit(
         tmp_path,
         staged_files=["docs/adr/ADR-042.md"],
@@ -861,6 +860,32 @@ def test_override_labels_bypass_local_intermediate_hooks(tmp_path: Path, label: 
     for report in (pre_commit, commit_msg, pre_push, pr_ready):
         assert not report.blocks_merge
         assert report.summary["bypass_labels"] == [label]
+
+
+@pytest.mark.parametrize("label", ["admin-approved:core-change", "admin-approved:merge"])
+def test_narrow_admin_labels_do_not_bypass_scope_or_trailers(tmp_path: Path, label: str) -> None:
+    data = _record(
+        full_audit=None,
+        sentrux=None,
+        changed_test_paths=[],
+        scope={"include": ["src/scistudio/**"], "exclude": []},
+    )
+    record_path = tmp_path / ".workflow" / "records" / "1267-gate-record-core.json"
+    record_path.parent.mkdir(parents=True)
+    record_path.write_text(json.dumps(data), encoding="utf-8")
+
+    pre_commit = check_pre_commit(
+        tmp_path,
+        gate_record=record_path,
+        staged_files=["docs/adr/ADR-042.md"],
+        bypass_labels=[label],
+    )
+    commit_msg = check_commit_msg("fix: missing trailers", bypass_labels=[label])
+
+    assert pre_commit.blocks_merge
+    assert "gate-record.scope.outside-include" in {finding.rule_id for finding in pre_commit.findings}
+    assert commit_msg.blocks_merge
+    assert "gate-record.commit-trailer.missing" in {finding.rule_id for finding in commit_msg.findings}
 
 
 def test_invalid_override_label_does_not_bypass_local_hooks(tmp_path: Path) -> None:

--- a/tests/qa/test_gate_record_hooks.py
+++ b/tests/qa/test_gate_record_hooks.py
@@ -87,6 +87,16 @@ def test_local_push_and_pr_hooks_accept_adr042_override_labels() -> None:
     assert 'gh", "pr", "view"' in push_hook
 
 
+def test_pr_hook_validates_receipt_against_real_pr_body() -> None:
+    pr_hook = _text("scripts/hooks/check-gate-before-pr.sh")
+
+    assert 'token in {"--body", "-b"}' in pr_hook
+    assert 'token == "--body-file"' in pr_hook
+    assert '--pr-body "$PR_BODY"' in pr_hook
+    assert '--pr-body "$CMD"' not in pr_hook
+    assert "printf '%s' \"$PR_BODY\"" in pr_hook
+
+
 def test_workflow_orchestrates_adr042_governance_guards() -> None:
     workflow = _text(".github/workflows/workflow-gate.yml")
 

--- a/tests/qa/test_gate_record_hooks.py
+++ b/tests/qa/test_gate_record_hooks.py
@@ -81,7 +81,7 @@ def test_local_push_and_pr_hooks_accept_adr042_override_labels() -> None:
         assert "admin-approved:core-change" in hook
         assert "admin-approved:merge" in hook
         assert "SCISTUDIO_GATE_BYPASS_LABELS" in hook
-        assert "ADR-042 local gate bypassed by approved override label" in hook
+        assert "ADR-042 local gate bypassed by broad override label" in hook
 
     assert "--label" in pr_hook
     assert 'gh", "pr", "view"' in push_hook

--- a/tests/qa/test_worktree_write_guard.py
+++ b/tests/qa/test_worktree_write_guard.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scistudio.qa.governance.worktree_write_guard import check_hook_payload, check_paths
+
+
+def _record(path: Path, *, branch: str = "feat/guard") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": "1",
+                "task_id": "1492-worktree-guard",
+                "task_kind": "maintenance",
+                "persona": "implementer",
+                "branch": branch,
+                "owner_directive": "test",
+                "issues": [{"number": 1492, "url": "https://github.com/zjzcpj/SciStudio/issues/1492"}],
+                "scope": {"include": ["src/allowed.py"], "exclude": ["src/blocked.py"]},
+                "governance_touch": True,
+                "stages": [
+                    {"stage": "scope_and_issue", "status": "done"},
+                    {"stage": "plan", "status": "done"},
+                    {"stage": "implement", "status": "done"},
+                    {"stage": "update_docs", "status": "done"},
+                    {"stage": "test_and_checks", "status": "done"},
+                    {"stage": "commit_and_submit_pr", "status": "pending"},
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_check_paths_blocks_main_branch(tmp_path: Path) -> None:
+    record = tmp_path / ".workflow" / "records" / "1492.json"
+    _record(record, branch="main")
+
+    errors = check_paths(repo_root=tmp_path, gate_record=record, branch="main", target_paths=["src/allowed.py"])
+
+    assert any("dedicated non-main branch" in error for error in errors)
+
+
+def test_check_paths_blocks_outside_worktree_and_scope(tmp_path: Path) -> None:
+    record = tmp_path / ".workflow" / "records" / "1492.json"
+    _record(record)
+    outside = tmp_path.parent / "outside.py"
+
+    errors = check_paths(
+        repo_root=tmp_path,
+        gate_record=record,
+        branch="feat/guard",
+        target_paths=["src/other.py", str(outside)],
+    )
+
+    joined = "\n".join(errors)
+    assert "outside gate scope include patterns" in joined
+    assert "outside the assigned worktree" in joined
+
+
+def test_check_hook_payload_extracts_write_paths(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    record = tmp_path / ".workflow" / "records" / "1492.json"
+    _record(record)
+
+    def fake_repo_root(start: Path) -> Path:
+        return tmp_path
+
+    def fake_branch(root: Path) -> str:
+        return "feat/guard"
+
+    monkeypatch.setattr("scistudio.qa.governance.worktree_write_guard._repo_root", fake_repo_root)
+    monkeypatch.setattr("scistudio.qa.governance.worktree_write_guard._branch", fake_branch)
+
+    errors = check_hook_payload({"cwd": str(tmp_path), "tool_input": {"file_path": "src/blocked.py"}})
+
+    assert any("inside gate scope exclude patterns" in error for error in errors)

--- a/tests/scripts/test_scistudio_pr_create.py
+++ b/tests/scripts/test_scistudio_pr_create.py
@@ -1,3 +1,4 @@
+# mypy: disable-error-code=no-untyped-def
 """Tests for ``scripts/scistudio_pr_create.py``.
 
 Covers the four pure-function pieces (``extract_body``,
@@ -321,6 +322,7 @@ class TestMainBaseWiring:
             return {"findings": []}
 
         monkeypatch.setattr(wrapper, "run_gate_record_ci", _fake_run_gate_record_ci)
+        monkeypatch.setattr(wrapper, "run_gate_receipt_validate", lambda *args, **kwargs: (0, "", ""))
 
         # Avoid actually invoking gh pr create.
         def _fake_subprocess_call(cmd):
@@ -354,6 +356,7 @@ class TestMainBaseWiring:
             return {"findings": []}
 
         monkeypatch.setattr(wrapper, "run_gate_record_ci", _fake_run_gate_record_ci)
+        monkeypatch.setattr(wrapper, "run_gate_receipt_validate", lambda *args, **kwargs: (0, "", ""))
         monkeypatch.setattr(wrapper.subprocess, "call", lambda cmd: 0)
 
         rc = wrapper.main(["--title", "X", "--body", "Closes #1382"])


### PR DESCRIPTION
﻿## Summary
- Implements ADR-042 Addendum 5 local gate receipts and exact-candidate receipt validation.
- Adds worktree write guards for AI write tools and provisions them for Claude/Codex hook configs.
- Narrows local bypass semantics so admin-approved:core-change no longer bypasses scope/docs/receipt checks.
- Updates AI rules, AGENTS routing, personas, dispatch templates, and runtime rule indexes with the gate CLI command set.

Gate record: .workflow/records/1492-adr042-local-gate-receipts.json

Closes #1492
