### PR TITLE
docs(#1496): route ADR-042 Addendum 5 into personas, specific_rules, templates, and AGENTS.md

### DIFF
--- a/.workflow/records/1496-adr042-addendum5-routing.json
+++ b/.workflow/records/1496-adr042-addendum5-routing.json
@@ -1,0 +1,193 @@
+{
+  "admin_labels": [
+    {
+      "name": "admin-approved:core-change"
+    }
+  ],
+  "amendments": [
+    {
+      "approved_by": null,
+      "exclude": [],
+      "include": [
+        ".workflow/local/**"
+      ],
+      "reason": "Add .workflow/local/** to scope.include so worktree write guard does not block the local-only Addendum 5 receipt artifacts (pr-body.md, receipt logs). These paths are gitignored and never committed."
+    },
+    {
+      "approved_by": null,
+      "exclude": [],
+      "include": [
+        ".workflow/records/1496-adr042-addendum5-routing.json"
+      ],
+      "reason": "Add the gate record file itself to scope.include."
+    }
+  ],
+  "branch": "docs/issue-1496-adr042-addendum5-routing",
+  "changed_test_paths": [],
+  "check_results": [
+    {
+      "command_or_tool": "python -m scistudio.qa.audit.frontmatter_lint --repo-root . <19 edited paths>",
+      "exit_code": 0,
+      "name": "frontmatter_lint",
+      "output_path": "warnings-only: AI-developer docs are out of frontmatter_lint scope (ADR/spec/architecture only); ran clean over all 19 edited paths",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    }
+  ],
+  "commit": null,
+  "docs_landing": {
+    "adr": {
+      "not_applicable": true,
+      "rationale": "No ADR edit needed; Addendum 5 contract (ADR-042-addendum5.md) is unchanged. Pointers reference it."
+    },
+    "changelog": {
+      "not_applicable": true,
+      "rationale": "Audit report itself documents the routing change; no user-visible behavior change requires a CHANGELOG entry."
+    },
+    "checklist": {},
+    "docs": {
+      "paths": [
+        "AGENTS.md",
+        "docs/ai-developer/rules.md",
+        "docs/ai-developer/personas/manager.md",
+        "docs/ai-developer/personas/implementer.md",
+        "docs/ai-developer/personas/adr-author.md",
+        "docs/ai-developer/personas/audit-reviewer.md",
+        "docs/ai-developer/personas/test-engineer.md",
+        "docs/ai-developer/specific_rules/gated-workflow.md",
+        "docs/ai-developer/specific_rules/agent-dispatch.md",
+        "docs/ai-developer/specific_rules/bug-fix.md",
+        "docs/ai-developer/specific_rules/new-feature.md",
+        "docs/ai-developer/specific_rules/hotfix.md",
+        "docs/ai-developer/specific_rules/docs-change.md",
+        "docs/ai-developer/specific_rules/test-engineering.md",
+        "docs/ai-developer/templates/agent-dispatch-prompt-template.md",
+        "docs/ai-developer/templates/agent-dispatch-checklist-template.md",
+        "docs/ai-developer/templates/agent-dispatch-audit-with-context-prompt-template.md",
+        "docs/ai-developer/templates/agent-dispatch-audit-no-context-prompt-template.md",
+        "docs/audit/2026-05-23-adr042-addendum5-routing-audit.md"
+      ]
+    },
+    "specs": {
+      "not_applicable": true,
+      "rationale": "No spec edit needed; only short routing pointers are added per ADR-042 \u00a73.5."
+    },
+    "tests": {
+      "not_applicable": true,
+      "rationale": "Documentation-only routing-pointer PR; ADR-042 \u00a73.5 disallows policy duplication in pointer files, so no behavior change to test."
+    }
+  },
+  "full_audit": {
+    "blocks_merge": false,
+    "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output docs/audit/full-audit-latest.json",
+    "exit_code": 0,
+    "known_debt": [],
+    "output_path": "docs/audit/full-audit-latest.json",
+    "status": "pass",
+    "summary": {},
+    "unclassified_failures": []
+  },
+  "governance_touch": false,
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1496,
+      "url": "https://github.com/zjzcpj/SciStudio/issues/1496"
+    }
+  ],
+  "owner_directive": "Owner approved 2026-05-23 chat 4-step plan: routing audit found ADR-042 Addendum 5 (receipt/wrapper/worktree write guard) only partially routed; add pointers (no policy duplication) into ~14 AI-developer docs and commit the audit report.",
+  "persona": "adr_author",
+  "planned_files": [
+    "AGENTS.md",
+    "docs/ai-developer/rules.md",
+    "docs/ai-developer/personas/manager.md",
+    "docs/ai-developer/personas/implementer.md",
+    "docs/ai-developer/personas/adr-author.md",
+    "docs/ai-developer/personas/audit-reviewer.md",
+    "docs/ai-developer/personas/test-engineer.md",
+    "docs/ai-developer/specific_rules/gated-workflow.md",
+    "docs/ai-developer/specific_rules/agent-dispatch.md",
+    "docs/ai-developer/specific_rules/bug-fix.md",
+    "docs/ai-developer/specific_rules/new-feature.md",
+    "docs/ai-developer/specific_rules/hotfix.md",
+    "docs/ai-developer/specific_rules/docs-change.md",
+    "docs/ai-developer/specific_rules/test-engineering.md",
+    "docs/ai-developer/templates/agent-dispatch-prompt-template.md",
+    "docs/ai-developer/templates/agent-dispatch-checklist-template.md",
+    "docs/ai-developer/templates/agent-dispatch-audit-with-context-prompt-template.md",
+    "docs/ai-developer/templates/agent-dispatch-audit-no-context-prompt-template.md",
+    "docs/audit/2026-05-23-adr042-addendum5-routing-audit.md"
+  ],
+  "pull_request": null,
+  "record_path": ".workflow/records/1496-adr042-addendum5-routing.json",
+  "required_checks": [
+    "frontmatter_lint",
+    "full_audit"
+  ],
+  "schema_version": "1",
+  "scope": {
+    "exclude": [
+      "docs/ai-developer/specific_rules/document-standards.md"
+    ],
+    "include": [
+      "AGENTS.md",
+      "docs/ai-developer/**",
+      "docs/audit/**"
+    ]
+  },
+  "sentrux": {
+    "command_or_tool": "sentrux check",
+    "mode": "free-tier",
+    "name": "sentrux.free_tier",
+    "output_path": "Sentrux does not apply: docs-only routing-pointer change in AGENTS.md + docs/ai-developer/** + docs/audit/**. Per sentrux_gate.sentrux_applies_to_changes, sentrux applies only to src/ tests/ packages/ frontend/ scripts/hooks/ .github/workflows/ .workflow/ .sentrux/ docs/adr|specs|architecture/.",
+    "pro_required": false,
+    "quality_signal": null,
+    "rules_checked": null,
+    "status": "skipped",
+    "summary": {},
+    "thresholds": {},
+    "total_rules_defined": null
+  },
+  "stages": [
+    {
+      "completed_at": null,
+      "stage": "scope_and_issue",
+      "status": "done",
+      "summary": null
+    },
+    {
+      "completed_at": null,
+      "stage": "plan",
+      "status": "done",
+      "summary": null
+    },
+    {
+      "completed_at": null,
+      "stage": "implement",
+      "status": "done",
+      "summary": null
+    },
+    {
+      "completed_at": null,
+      "stage": "update_docs",
+      "status": "done",
+      "summary": null
+    },
+    {
+      "completed_at": null,
+      "stage": "test_and_checks",
+      "status": "done",
+      "summary": null
+    },
+    {
+      "completed_at": null,
+      "stage": "commit_and_submit_pr",
+      "status": "pending",
+      "summary": null
+    }
+  ],
+  "task_id": "1496-adr042-addendum5-routing",
+  "task_kind": "docs"
+}

--- a/.workflow/records/1496-adr042-addendum5-routing.json
+++ b/.workflow/records/1496-adr042-addendum5-routing.json
@@ -1,6 +1,8 @@
 {
   "admin_labels": [
     {
+      "applied_at": null,
+      "applied_by": null,
       "name": "admin-approved:core-change"
     }
   ],
@@ -35,7 +37,13 @@
       "timestamp": null
     }
   ],
-  "commit": null,
+  "commit": {
+    "gate_record_path": ".workflow/records/1496-adr042-addendum5-routing.json",
+    "shas": [
+      "985b65dd5c35b2ab36b45b81007b09451ac0a082"
+    ],
+    "trailers": {}
+  },
   "docs_landing": {
     "adr": {
       "not_applicable": true,
@@ -120,7 +128,13 @@
     "docs/ai-developer/templates/agent-dispatch-audit-no-context-prompt-template.md",
     "docs/audit/2026-05-23-adr042-addendum5-routing-audit.md"
   ],
-  "pull_request": null,
+  "pull_request": {
+    "body_closes_issues": [
+      1496
+    ],
+    "number": 1497,
+    "url": "https://github.com/zjzcpj/SciStudio/pull/1497"
+  },
   "record_path": ".workflow/records/1496-adr042-addendum5-routing.json",
   "required_checks": [
     "frontmatter_lint",
@@ -184,7 +198,7 @@
     {
       "completed_at": null,
       "stage": "commit_and_submit_pr",
-      "status": "pending",
+      "status": "done",
       "summary": null
     }
   ],

--- a/.workflow/records/1496-adr042-addendum5-routing.json
+++ b/.workflow/records/1496-adr042-addendum5-routing.json
@@ -22,6 +22,12 @@
         ".workflow/records/1496-adr042-addendum5-routing.json"
       ],
       "reason": "Add the gate record file itself to scope.include."
+    },
+    {
+      "approved_by": null,
+      "exclude": [],
+      "include": [],
+      "reason": "AGENTS.md is in mod_guard.PROTECTED_PATTERNS; gate record must declare governance_touch=true for CI's gate_record ci to pass mod_guard via allow_governance_change=True. Original start omitted --governance-touch; this amend corrects the flag and records the rationale."
     }
   ],
   "branch": "docs/issue-1496-adr042-addendum5-routing",
@@ -96,7 +102,7 @@
     "summary": {},
     "unclassified_failures": []
   },
-  "governance_touch": false,
+  "governance_touch": true,
   "issues": [
     {
       "close_in_pr": true,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,6 +141,16 @@ plugin-based extension, manual review steps, and AI-assisted orchestration.
 - Local candidate receipts must be generated or validated with:
   `python -m scistudio.qa.governance.gate_receipt`.
 
+- AI-authored PRs must use the gate-aware wrapper
+  `python scripts/scistudio_pr_create.py` per ADR-042 Addendum 5.
+  Direct `gh pr create` invocations may pass the open-PR step but typically
+  trigger more CI fix-and-push cycles.
+
+- The worktree write guard PreToolUse hook
+  (`scripts/hooks/check-worktree-write-guard.sh`) blocks AI Edit/Write outside
+  the active branch's committed gate scope. Use `gate_record amend` before
+  touching newly discovered files.
+
 - The AI-facing gate command set is indexed in
   `docs/ai-developer/rules.md#5-gate-cli-command-set`.
 

--- a/docs/ai-developer/personas/adr-author.md
+++ b/docs/ai-developer/personas/adr-author.md
@@ -121,5 +121,10 @@ language_source: en
 - Manager dispatch rules, when dispatched:
   `docs/ai-developer/specific_rules/agent-dispatch.md`
 
+- ADR-042 Addendum 5 governance documents:
+  `docs/adr/ADR-042-addendum5.md` and
+  `docs/specs/adr-042-local-gate-receipts.md` are the contract for any edits
+  to receipt, wrapper, or write-guard behavior.
+
 - Root policy:
   `AGENTS.md`

--- a/docs/ai-developer/personas/audit-reviewer.md
+++ b/docs/ai-developer/personas/audit-reviewer.md
@@ -107,5 +107,11 @@ language_source: en
 - ADR-042 document standards reference:
   `docs/ai-developer/specific_rules/document-standards.md`
 
+- ADR-042 Addendum 5 receipt audit:
+  Verify `.workflow/local/gate-receipts/<head-sha>.json` exists for the PR
+  candidate, fingerprint matches, and every required check has
+  `exit_code == 0`. Treat `admin-approved:core-change` as narrow
+  protected-core authorization only, never as a scope/docs/receipt bypass.
+
 - Root policy:
   `AGENTS.md`

--- a/docs/ai-developer/personas/implementer.md
+++ b/docs/ai-developer/personas/implementer.md
@@ -93,5 +93,13 @@ language_source: en
 - Manager dispatch rules, when dispatched:
   `docs/ai-developer/specific_rules/agent-dispatch.md`
 
+- ADR-042 Addendum 5 receipt and PR-creation wrapper:
+  `python -m scistudio.qa.governance.gate_receipt`,
+  `python scripts/scistudio_pr_create.py`
+
+- Worktree write guard PreToolUse hook (blocks Edit/Write outside the active
+  gate scope):
+  `scripts/hooks/check-worktree-write-guard.sh`
+
 - Root policy:
   `AGENTS.md`

--- a/docs/ai-developer/personas/manager.md
+++ b/docs/ai-developer/personas/manager.md
@@ -116,5 +116,11 @@ language_source: en
   and
   `docs/ai-developer/templates/agent-dispatch-audit-no-context-prompt-template.md`
 
+- ADR-042 Addendum 5 PR-creation wrapper for the final dispatch PR:
+  `scripts/scistudio_pr_create.py`
+
+- Post-integration receipt validation:
+  `python -m scistudio.qa.governance.gate_receipt validate --gate-record <record> --base origin/main --pr-body-file .workflow/local/pr-body.md`
+
 - Root policy:
   `AGENTS.md`

--- a/docs/ai-developer/personas/test-engineer.md
+++ b/docs/ai-developer/personas/test-engineer.md
@@ -96,5 +96,11 @@ language_source: en
 - E2E workflow:
   `docs/ai-developer/skills/scistudio-e2e-test/SKILL.md`
 
+- ADR-042 Addendum 5 receipt transcript:
+  Wrap test runs with
+  `python -m scistudio.qa.governance.gate_receipt exec --name <name> -- <command>`
+  so stdout/stderr land in the candidate `.log` transcript and exit codes feed
+  receipt validation.
+
 - Root policy:
   `AGENTS.md`

--- a/docs/ai-developer/rules.md
+++ b/docs/ai-developer/rules.md
@@ -138,10 +138,17 @@ quick command index every persona should route back to.
 | Generate exact-candidate local receipt | `python -m scistudio.qa.governance.gate_receipt run --gate-record <record> --base <base-ref> --pr-body-file .workflow/local/pr-body.md` |
 | Record one custom command in the receipt | `python -m scistudio.qa.governance.gate_receipt exec --name <name> --gate-record <record> --base <base-ref> -- <command>` |
 | Validate receipt freshness/completeness | `python -m scistudio.qa.governance.gate_receipt validate --gate-record <record> --base <base-ref> --pr-body-file .workflow/local/pr-body.md` |
+| Open AI-authored PR via gate-aware wrapper | `python scripts/scistudio_pr_create.py --title "<title>" --body "<body>"` |
 | Finalize commit and PR evidence | `python -m scistudio.qa.governance.gate_record finalize --record <record> --commit <sha> --pr <url> --closes "#<issue>"` |
 
 `admin-approved:core-change` is not a broad bypass for these commands. It only
 answers protected-core authorization where that guard applies.
+
+The worktree write guard PreToolUse hook
+(`scripts/hooks/check-worktree-write-guard.sh`) blocks Edit/Write outside the
+active branch's committed gate scope. New worktrees are auto-provisioned with
+this hook via
+`src/scistudio/agent_provisioning/templates/hook_worktree_write_guard.py`.
 
 ## 6. Routing
 

--- a/docs/ai-developer/specific_rules/agent-dispatch.md
+++ b/docs/ai-developer/specific_rules/agent-dispatch.md
@@ -169,6 +169,13 @@ python -m scistudio.qa.governance.gate_receipt validate \
   --pr-body-file .workflow/local/pr-body.md
 ```
 
+Each dispatched worktree is auto-provisioned with the worktree write guard
+PreToolUse hook
+(`scripts/hooks/check-worktree-write-guard.sh`,
+`src/scistudio/agent_provisioning/templates/hook_worktree_write_guard.py`). The
+manager does not re-register the hook per dispatch, but should expect agents
+to hit it whenever a write strays outside the gate scope.
+
 ## 7. Verification Rules
 
 - MUST run the checks declared in the manager gate record after integration.

--- a/docs/ai-developer/specific_rules/bug-fix.md
+++ b/docs/ai-developer/specific_rules/bug-fix.md
@@ -80,3 +80,7 @@ Use these rules with:
   findings
 - `docs/ai-developer/personas/adr-author.md` when the fix requires ADR/spec
   text
+
+ADR-042 Addendum 5 receipt and the `scripts/scistudio_pr_create.py` wrapper
+are mandatory for every bug-fix PR; see
+`docs/ai-developer/specific_rules/gated-workflow.md` §3.6 and §3.7.

--- a/docs/ai-developer/specific_rules/docs-change.md
+++ b/docs/ai-developer/specific_rules/docs-change.md
@@ -79,3 +79,8 @@ Use these rules with:
 - `docs/ai-developer/specific_rules/gated-workflow.md`
 - `docs/ai-developer/personas/adr-author.md` when editing ADRs or specs
 - `docs/ai-developer/personas/audit-reviewer.md` when fixing audit findings
+
+ADR-042 Addendum 5 receipt and the `scripts/scistudio_pr_create.py` wrapper
+apply to every docs-change PR that touches `docs/adr/`, `docs/specs/`, or
+`docs/ai-developer/`; see
+`docs/ai-developer/specific_rules/gated-workflow.md` §3.6 and §3.7.

--- a/docs/ai-developer/specific_rules/gated-workflow.md
+++ b/docs/ai-developer/specific_rules/gated-workflow.md
@@ -295,6 +295,15 @@ agent stages or commits the extra files.
 
 Keep changes within `scope.include` and outside `scope.exclude`.
 
+The worktree write guard PreToolUse hook
+(`scripts/hooks/check-worktree-write-guard.sh`) enforces this at Edit/Write
+time by reading the committed gate record matching the current branch. New
+worktrees are auto-provisioned with this hook via
+`src/scistudio/agent_provisioning/templates/hook_worktree_write_guard.py`. The
+hook fails with exit code 2 when the current branch is `main`/`master`/`HEAD`,
+when no committed gate record matches the branch, when the target is outside
+`scope.include`, or when it matches `scope.exclude`.
+
 Before touching newly discovered files outside the original plan, update the
 gate record with:
 

--- a/docs/ai-developer/specific_rules/hotfix.md
+++ b/docs/ai-developer/specific_rules/hotfix.md
@@ -80,6 +80,10 @@ language_source: en
 Use these rules with:
 
 - `docs/ai-developer/rules.md`
+- `docs/ai-developer/specific_rules/gated-workflow.md` for the final-gate
+  workflow that every hotfix exit must complete, including ADR-042 Addendum 5
+  receipt under §3.6 and the `scripts/scistudio_pr_create.py` wrapper under
+  §3.7
 - `docs/ai-developer/specific_rules/bug-fix.md`
 - `docs/ai-developer/personas/implementer.md`
 - `docs/ai-developer/personas/audit-reviewer.md` when the hotfix comes from

--- a/docs/ai-developer/specific_rules/new-feature.md
+++ b/docs/ai-developer/specific_rules/new-feature.md
@@ -66,3 +66,7 @@ Use these rules with:
 - `docs/ai-developer/personas/implementer.md`
 - `docs/ai-developer/personas/adr-author.md` when the feature includes
   spec or ADR writing
+
+ADR-042 Addendum 5 receipt and the `scripts/scistudio_pr_create.py` wrapper
+are mandatory for every feature PR; see
+`docs/ai-developer/specific_rules/gated-workflow.md` §3.6 and §3.7.

--- a/docs/ai-developer/specific_rules/test-engineering.md
+++ b/docs/ai-developer/specific_rules/test-engineering.md
@@ -106,3 +106,11 @@ Use these rules with:
 - `docs/ai-developer/skills/scistudio-e2e-test/SKILL.md` when running live e2e
 - `docs/ai-developer/specific_rules/agent-dispatch.md` when dispatched by a
   manager
+
+ADR-042 Addendum 5 receipt is the canonical home for test-runner stdout and
+stderr; wrap pytest or other test commands with
+`python -m scistudio.qa.governance.gate_receipt exec --name <name> -- <cmd>`
+so transcripts feed receipt validation. The
+`scripts/scistudio_pr_create.py` wrapper is the required final-PR entry point
+for any test-engineering PR (see
+`docs/ai-developer/specific_rules/gated-workflow.md` §3.7).

--- a/docs/ai-developer/templates/agent-dispatch-audit-no-context-prompt-template.md
+++ b/docs/ai-developer/templates/agent-dispatch-audit-no-context-prompt-template.md
@@ -90,6 +90,7 @@ Run or verify:
 - <test command>
 - <audit command>
 - <Sentrux MCP/CLI command or N/A reason>
+- `python -m scistudio.qa.governance.gate_receipt validate --gate-record <record> --base origin/main` to confirm any ADR-042 Addendum 5 receipt files under `.workflow/local/gate-receipts/` match the current `HEAD` and required checks pass (this does not require manager context)
 
 ## Output Required
 

--- a/docs/ai-developer/templates/agent-dispatch-audit-with-context-prompt-template.md
+++ b/docs/ai-developer/templates/agent-dispatch-audit-with-context-prompt-template.md
@@ -96,6 +96,7 @@ Run or verify:
 - <audit command>
 - <Sentrux MCP/CLI command or N/A reason>
 - <frontend/browser smoke check or N/A reason>
+- `python -m scistudio.qa.governance.gate_receipt validate --gate-record <record> --base origin/main --pr-body-file .workflow/local/pr-body.md` to confirm ADR-042 Addendum 5 receipt fingerprint and required-check completeness
 
 ## Output Required
 

--- a/docs/ai-developer/templates/agent-dispatch-checklist-template.md
+++ b/docs/ai-developer/templates/agent-dispatch-checklist-template.md
@@ -163,6 +163,8 @@ amendment.
 | Tests | `<targeted pytest command>` | `[ ]` | `<output path or summary>` |
 | Full audit | `python -m scistudio.qa.audit.full_audit ...` | `[ ]` | `<output path>` |
 | Sentrux | `<MCP tool or CLI command>` | `[ ]` | `<evidence or N/A reason>` |
+| Addendum 5 receipt | `python -m scistudio.qa.governance.gate_receipt run --gate-record <record> --base origin/main --pr-body-file .workflow/local/pr-body.md` | `[ ]` | `<receipt path>` |
+| Wrapper preflight | `python scripts/scistudio_pr_create.py --dry-run --title "<title>" --body "<body>"` | `[ ]` | `<output>` |
 
 ## 9. Drift Log
 

--- a/docs/ai-developer/templates/agent-dispatch-prompt-template.md
+++ b/docs/ai-developer/templates/agent-dispatch-prompt-template.md
@@ -101,6 +101,8 @@ Known deferred items:
 - <lint/check command>
 - `python -m scistudio.qa.governance.gate_receipt run` or explicit
   `gate_receipt exec` commands for every required Phase 5 check
+- `python scripts/scistudio_pr_create.py` for the final PR (do not use
+  `gh pr create` directly; ADR-042 Addendum 5)
 - <docs/audit command or N/A reason>
 - <Sentrux MCP/CLI command or N/A reason>
 

--- a/docs/audit/2026-05-23-adr042-addendum5-routing-audit.md
+++ b/docs/audit/2026-05-23-adr042-addendum5-routing-audit.md
@@ -1,0 +1,187 @@
+---
+title: "ADR-042 Addendum 5 Routing Audit"
+status: Approved
+owners:
+  - "@jiazhenz026"
+related_adrs:
+  - 42
+language_source: en
+---
+
+# ADR-042 Addendum 5 Routing Audit
+
+## 1. Change Summary
+
+This audit verifies whether the AI-developer documentation under
+`docs/ai-developer/` and the runtime rule indexes route agents to the new QA
+behaviors introduced by ADR-042 Addendum 5 (PR #1495, merged 2026-05-23).
+
+Source of audit: owner-requested 4-step plan on 2026-05-23.
+Issue: #1496.
+
+The audit finds that the core behaviors are fully wired only in
+`docs/ai-developer/specific_rules/gated-workflow.md` and partially in
+`docs/ai-developer/rules.md` and
+`docs/ai-developer/specific_rules/agent-dispatch.md`. The remaining 14 docs
+(all 5 personas, 5 of 7 specific_rules, 2 of 4 dispatch templates, AGENTS.md
+§3.7, and the three runtime rule indexes) are silent or only transitively
+link, so agents arriving through the persona or task-kind entry point never
+learn about the wrapper, receipt, or write guard until something blocks
+them.
+
+This document records the matrix, the critical gaps, and the remediation
+landed in PR #1496-followup so the corrected routing remains auditable.
+
+## 2. Audit Scope And Method
+
+In scope:
+
+- `AGENTS.md`
+- `docs/ai-developer/rules.md`
+- `docs/ai-developer/specific_rules/*.md` (7 files)
+- `docs/ai-developer/personas/*.md` (5 files)
+- `docs/ai-developer/templates/*.md` (4 files)
+- `.agents/rules/rules.md`, `.claude/rules/rules.md`, `.codex/rules/rules.md`
+
+Method:
+
+- enumerate the new QA behaviors landed by ADR-042 Addendum 5;
+- grep each document for canonical keywords;
+- inspect each `Where Your Rules Are`, `Route`, or `## Checks` section
+  for explicit routing to the new behaviors;
+- record whether the routing is direct, transitive via
+  `docs/ai-developer/rules.md` §5, or missing.
+
+Canonical keywords:
+
+- `gate_receipt` (Addendum 5 receipt CLI)
+- `gate_record ci` (shared local/CI workflow gate)
+- `Addendum 5` (explicit naming)
+- `scistudio_pr_create` (PR-creation wrapper)
+- `worktree_write_guard` / `check-worktree-write-guard.sh` (PreToolUse hook)
+- `admin-approved:core-change` (narrowed semantics)
+- `.workflow/local/gate-receipts/` (receipt path)
+
+## 3. Routing Coverage Matrix
+
+`✓` direct mention. `△` partial or transitive. `✗` missing.
+
+| Document | receipt CLI | `gate_record ci` | Addendum 5 named | wrapper | write guard | core-change narrowed |
+|---|:-:|:-:|:-:|:-:|:-:|:-:|
+| `AGENTS.md` | △ §3.7 one line | ✗ | ✗ | ✗ | ✗ | ✗ |
+| `docs/ai-developer/rules.md` | ✓ §3+§5 | ✓ §5 | △ implicit | ✗ | ✗ | ✓ §4 |
+| `.agents/rules/rules.md` | △ transitive | ✗ | ✗ | ✗ | ✗ | ✗ |
+| `.claude/rules/rules.md` | △ transitive | ✗ | ✗ | ✗ | ✗ | ✗ |
+| `.codex/rules/rules.md` | △ transitive | ✗ | ✗ | ✗ | ✗ | ✗ |
+| `personas/manager.md` | △ transitive | ✗ | ✗ | ✗ | ✗ | ✗ |
+| `personas/implementer.md` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
+| `personas/adr-author.md` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
+| `personas/audit-reviewer.md` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
+| `personas/test-engineer.md` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
+| `specific_rules/gated-workflow.md` | ✓ §2+§3.6 | ✓ §3.6 | ✓ §3.6/§3.7 | ✓ §3.7 | ✗ | △ mentioned |
+| `specific_rules/agent-dispatch.md` | ✓ §6 | ✗ | ✗ | ✗ | ✗ | ✓ §6 |
+| `specific_rules/bug-fix.md` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
+| `specific_rules/new-feature.md` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
+| `specific_rules/hotfix.md` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
+| `specific_rules/docs-change.md` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
+| `specific_rules/test-engineering.md` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
+| `templates/agent-dispatch-prompt-template.md` | ✓ L102 | ✗ | ✗ | ✗ | ✗ | ✗ |
+| `templates/agent-dispatch-checklist-template.md` | ✓ §5 L87 | ✗ | ✗ | ✗ | ✗ | ✓ §5 L78 |
+| `templates/agent-dispatch-audit-with-context-prompt-template.md` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
+| `templates/agent-dispatch-audit-no-context-prompt-template.md` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
+
+`document-standards.md` is N/A for these behaviors: it is a structural
+reference for document schemas only.
+
+## 4. Critical Gaps
+
+### 4.1 worktree write guard is undocumented in every AI-developer doc
+
+The PreToolUse hook `scripts/hooks/check-worktree-write-guard.sh` and its
+Python backend `src/scistudio/qa/governance/worktree_write_guard.py` block
+AI Edit/Write/MultiEdit/NotebookEdit calls when the current branch is
+`main`/`master`/`HEAD`, when no committed gate record matches the current
+branch, when the write target is outside `scope.include`, or when it is
+inside `scope.exclude`. The hook is provisioned automatically by
+`agent_provisioning/templates/hook_worktree_write_guard.py` for new
+worktrees, but no AI-developer doc names the hook by name. Agents discover
+the hook only when an edit is rejected, which produces a poor first
+experience and turns a hard gate into a discovery cost.
+
+### 4.2 Wrapper mandate only routes through gated-workflow.md §3.7
+
+`scripts/scistudio_pr_create.py` is the required PR-creation entry point
+for AI-authored PRs per ADR-042 Addendum 5. Routing to it lives only in
+`gated-workflow.md` §3.7. Agents that enter through `bug-fix.md`,
+`new-feature.md`, a persona file, or a dispatch template never see the
+wrapper requirement and reach for `gh pr create` instead. That choice does
+not fail the open-PR step, but it produces extra CI fix-and-push cycles.
+The wrapper deserves a dedicated row in the `rules.md` §5 command table
+and a one-line mention in each persona and dispatch template.
+
+### 4.3 Persona docs have no Addendum 5 routing
+
+All five personas mention `gated-workflow.md` and `rules.md §5` in their
+`Where Your Rules Are` section, but none explicitly call out:
+
+- the receipt runner that captures persona-specific evidence (test runner
+  output for `test_engineer`, lint/format/audit for `implementer`,
+  frontmatter lint / full audit for `adr_author`, receipt completeness as
+  an audit check for `audit_reviewer`, post-integration receipt validation
+  for `manager`);
+- the wrapper mandate;
+- the worktree write guard;
+- the narrowed `admin-approved:core-change` semantics for the
+  `audit_reviewer` and `manager` who review override-label use.
+
+Without persona-specific anchors, the routing is purely transitive and the
+persona file fails to make Addendum 5 actionable for the role.
+
+## 5. Remediation In This PR
+
+Per ADR-042 §3.5 (no new policy in runtime/skill/index files; pointers
+only), this PR adds short routing pointers without duplicating policy:
+
+- `AGENTS.md` §3.7: name the wrapper and the worktree write guard and link
+  to `gated-workflow.md`.
+- `docs/ai-developer/rules.md` §5: add a PR-creation row for the wrapper;
+  add a worktree write guard pointer.
+- `docs/ai-developer/specific_rules/gated-workflow.md` §3.4: name the
+  worktree write guard hook so implementers know which Edit/Write calls
+  the hook gates.
+- `docs/ai-developer/specific_rules/agent-dispatch.md` §6: name the hook
+  and confirm new worktrees are provisioned with it.
+- 5 persona docs: add one or two `Where Your Rules Are` lines each that
+  link Addendum 5 receipt + wrapper to the role.
+- 5 specific_rules (`bug-fix.md`, `new-feature.md`, `hotfix.md`,
+  `docs-change.md`, `test-engineering.md`): add a single-line routing
+  pointer back to `gated-workflow.md` §3.6-§3.7 for receipt + wrapper.
+- 4 dispatch templates: the prompt template gains an explicit wrapper
+  reference, the checklist template gains a Verification Evidence row for
+  the receipt, and the two audit templates list `gate_receipt validate`
+  in `## Checks`.
+
+`document-standards.md` is left unchanged because it carries no routing
+content. The three runtime indexes (`.agents`/`.claude`/`.codex`
+`rules/rules.md`) are left unchanged because they correctly transitively
+route through `docs/ai-developer/rules.md` §5; that table is the source of
+truth they delegate to.
+
+## 6. Acceptance
+
+The PR is acceptable when every cell of the matrix in §3 that this PR
+targets becomes `✓` or `△` with a pointer, and no cell regresses. The
+`gated-workflow.md` text remains the single normative source for the
+behaviors; all other edits are pointers, not policy.
+
+## 7. Out Of Scope
+
+- Editing `document-standards.md`.
+- Rewriting any behavior policy.
+- Modifying the wrapper, hook, receipt, or gate-record CLI.
+- Touching `src/scistudio/qa/governance/` or `scripts/scistudio_pr_create.py`.
+- Resolving the worktree-aware behavior of the write guard hook when
+  Claude Code session cwd diverges from the active worktree; the current
+  observation is that Claude Code propagates the Bash subprocess cwd to
+  hook payloads, so the hook sees the worktree branch correctly. A
+  separate issue can track formal worktree-awareness if needed.


### PR DESCRIPTION
## Summary

- Adds short ADR-042 §3.5-compliant routing pointers (no policy duplication) for ADR-042 Addendum 5 behaviors — receipt CLI, `scistudio_pr_create.py` wrapper, worktree write guard PreToolUse hook, narrowed `admin-approved:core-change` semantics — across 18 AI-developer docs and AGENTS.md §3.7.
- Adds a PR-creation row and a worktree write guard pointer to `docs/ai-developer/rules.md` §5 command table.
- Adds 5 persona routing entries, 5 specific_rules pointers, and 4 dispatch-template references so every entry point reaches the new behaviors.
- Commits the routing audit report at `docs/audit/2026-05-23-adr042-addendum5-routing-audit.md`.
- No behavior or policy change. Pointers only.

Gate record: .workflow/records/1496-adr042-addendum5-routing.json
Audit report: docs/audit/2026-05-23-adr042-addendum5-routing-audit.md

Closes #1496
