### PR TITLE
fix(#1500): stabilize ADR-043 unified IO hotfix

### DIFF
--- a/.workflow/records/1500-adr043-unified-io-gui-hotfix.json
+++ b/.workflow/records/1500-adr043-unified-io-gui-hotfix.json
@@ -1,0 +1,300 @@
+{
+  "admin_labels": [],
+  "amendments": [
+    {
+      "approved_by": null,
+      "exclude": [],
+      "include": [],
+      "reason": "Implementation complete within owner-guided hotfix scope"
+    },
+    {
+      "approved_by": null,
+      "exclude": [],
+      "include": [
+        "pyproject.toml",
+        "typings/imagecodecs/__init__.pyi",
+        "src/imagecodecs/__init__.pyi"
+      ],
+      "reason": "CI mypy exposed third-party imagecodecs stub parse failure after ADR-043 IO changes; add a local type-only stub and narrow type casts without relaxing project checks"
+    }
+  ],
+  "branch": "hotfix/adr043-unified-io-gui",
+  "changed_test_paths": [
+    "frontend/src/App.parts/useWorkflowExecutionActions.test.tsx",
+    "frontend/src/App.parts/useWorkflowSync.test.tsx",
+    "frontend/src/components/BottomPanel.parts/ConfigPanel.test.tsx",
+    "frontend/src/components/Toolbar.test.tsx",
+    "tests/api/test_blocks.py",
+    "tests/api/test_filesystem_dialog.py",
+    "tests/api/test_native_dialog.py",
+    "tests/api/test_projects.py",
+    "tests/api/test_ws.py",
+    "tests/blocks/io/test_save_data.py"
+  ],
+  "check_results": [
+    {
+      "command_or_tool": "PYTHONPATH=src python -m ruff check <targeted python files>",
+      "exit_code": 0,
+      "name": "python-ruff-targeted",
+      "output_path": "All checks passed",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "PYTHONPATH=src python -m ruff format --check <targeted python files>",
+      "exit_code": 0,
+      "name": "python-format-targeted",
+      "output_path": "14 files already formatted",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "PYTHONPATH=src SCISTUDIO_DEV=1 pytest tests/api/test_blocks.py tests/api/test_filesystem_dialog.py tests/api/test_native_dialog.py tests/api/test_projects.py tests/api/test_ws.py tests/blocks/io/test_save_data.py tests/engine/test_pty_control.py --no-cov",
+      "exit_code": 0,
+      "name": "pytest-targeted",
+      "output_path": "134 passed, 1 warning",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "cd frontend && npx prettier --check <targeted frontend files>",
+      "exit_code": 0,
+      "name": "frontend-prettier-targeted",
+      "output_path": "All matched files use Prettier code style",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "cd frontend && npx eslint <targeted frontend files> --no-warn-ignored",
+      "exit_code": 0,
+      "name": "frontend-eslint-targeted",
+      "output_path": "No problems after Prettier",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "cd frontend && npm run typecheck",
+      "exit_code": 0,
+      "name": "frontend-typecheck",
+      "output_path": "tsc --noEmit passed after Prettier",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "cd frontend && npm test -- --run src/App.parts/useWorkflowExecutionActions.test.tsx src/App.parts/useWorkflowSync.test.tsx src/components/BottomPanel.parts/ConfigPanel.test.tsx src/components/Toolbar.test.tsx",
+      "exit_code": 0,
+      "name": "frontend-vitest-targeted",
+      "output_path": "4 files passed, 18 tests passed after Prettier",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "cd frontend && npm run build",
+      "exit_code": 0,
+      "name": "frontend-build",
+      "output_path": "vite build passed after Prettier with existing large chunk warning",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "PYTHONPATH=src python -m scistudio.qa.governance.gate_record pre-commit --record .workflow/records/1500-adr043-unified-io-gui-hotfix.json --staged",
+      "exit_code": 0,
+      "name": "gate-pre-commit",
+      "output_path": "gate_record: pass",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "PYTHONPATH=src python -m scistudio.qa.governance.gate_record pre-push --record .workflow/records/1500-adr043-unified-io-gui-hotfix.json --base origin/main --head HEAD",
+      "exit_code": 0,
+      "name": "gate-pre-push",
+      "output_path": "gate_record: pass",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "mypy src/scistudio/ --ignore-missing-imports",
+      "exit_code": 0,
+      "name": "python-mypy-ci",
+      "output_path": "Success: no issues found in 289 source files",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "PowerShell: $env:PYTHONPATH=src; $env:SCISTUDIO_DEV=1; pytest tests/api/test_blocks.py tests/blocks/io/test_save_data.py --no-cov",
+      "exit_code": 0,
+      "name": "pytest-io-schema-retargeted",
+      "output_path": "94 passed in 8.73s",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json --out .workflow/local/semantic-dup-report.md --json-out .workflow/local/semantic-dup-current.json",
+      "exit_code": 0,
+      "name": "semantic-dup-ratchet-local",
+      "output_path": "OK: clusters 92 <= 92, duplicate_loc 5260 <= 5290",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    }
+  ],
+  "commit": {
+    "gate_record_path": ".workflow/records/1500-adr043-unified-io-gui-hotfix.json",
+    "shas": [
+      "b3c390be2c30dac72e40868fdff71d256be96f67"
+    ],
+    "trailers": {}
+  },
+  "docs_landing": {
+    "changelog": {
+      "not_applicable": true,
+      "rationale": "No product changelog is maintained for this owner-guided hotfix"
+    },
+    "checklist": {
+      "not_applicable": true,
+      "rationale": "Owner-guided live hotfix; issue #1500 and gate record define the checklist-equivalent scope"
+    },
+    "docs": {
+      "not_applicable": true,
+      "rationale": "Owner-guided hotfix for existing ADR-043 implementation and runtime regressions; no public user docs or ADR update required"
+    },
+    "spec": {
+      "not_applicable": true,
+      "rationale": "No contract change beyond completing existing ADR-043 intent"
+    }
+  },
+  "full_audit": {
+    "blocks_merge": true,
+    "command": "PYTHONPATH=src python -m scistudio.qa.audit.full_audit --repo-root . --format json --output docs/audit/full-audit-latest.json",
+    "exit_code": 0,
+    "known_debt": [],
+    "output_path": "docs/audit/full-audit-latest.json",
+    "status": "pass",
+    "summary": {},
+    "unclassified_failures": []
+  },
+  "governance_touch": false,
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1500,
+      "url": "https://github.com/zjzcpj/SciStudio/issues/1500"
+    }
+  ],
+  "owner_directive": "Owner-guided hotfix: complete ADR-043 unified Load/Save GUI/backend wiring and live-tested regressions, then submit PR and end hotfix.",
+  "persona": "implementer",
+  "planned_files": [
+    "frontend/src/App.parts/useWorkflowExecutionActions.ts",
+    "frontend/src/App.parts/useWorkflowSync.ts",
+    "frontend/src/components/BottomPanel.parts/ConfigPanel.tsx",
+    "frontend/src/components/Toolbar.parts/WorkflowGroups.tsx",
+    "frontend/src/components/nodes/BlockNode.tsx",
+    "frontend/vite.config.ts",
+    "src/scistudio/api/app.py",
+    "src/scistudio/api/routes/blocks.py",
+    "src/scistudio/api/routes/filesystem.py",
+    "src/scistudio/api/routes/workflows.py",
+    "src/scistudio/api/ws.py",
+    "src/scistudio/blocks/io/_unified_dispatch.py",
+    "src/scistudio/blocks/io/loaders/load_data.py",
+    "src/scistudio/blocks/io/savers/save_data.py"
+  ],
+  "pull_request": {
+    "body_closes_issues": [
+      1500
+    ],
+    "number": 1501,
+    "url": "https://github.com/zjzcpj/SciStudio/pull/1501"
+  },
+  "record_path": ".workflow/records/1500-adr043-unified-io-gui-hotfix.json",
+  "required_checks": [
+    "python-ruff-targeted",
+    "pytest-targeted",
+    "frontend-vitest-targeted",
+    "frontend-typecheck",
+    "frontend-ruff-targeted",
+    "gate-pre-commit",
+    "gate-pre-push"
+  ],
+  "schema_version": "1",
+  "scope": {
+    "exclude": [
+      ".tmp-*"
+    ],
+    "include": [
+      "frontend/src/**",
+      "frontend/vite.config.ts",
+      "src/scistudio/api/**",
+      "src/scistudio/blocks/io/**",
+      "tests/api/**",
+      "tests/blocks/io/**",
+      ".workflow/records/1500-adr043-unified-io-gui-hotfix.json"
+    ]
+  },
+  "sentrux": {
+    "command_or_tool": "sentrux check .",
+    "mode": "free-tier",
+    "name": "sentrux.free_tier",
+    "output_path": "Sentrux CLI/MCP not available in this hotfix environment; CI gate remains authoritative",
+    "pro_required": false,
+    "quality_signal": null,
+    "rules_checked": null,
+    "status": "skipped",
+    "summary": {},
+    "thresholds": {},
+    "total_rules_defined": null
+  },
+  "stages": [
+    {
+      "completed_at": null,
+      "stage": "scope_and_issue",
+      "status": "done",
+      "summary": null
+    },
+    {
+      "completed_at": null,
+      "stage": "plan",
+      "status": "done",
+      "summary": null
+    },
+    {
+      "completed_at": null,
+      "stage": "implement",
+      "status": "done",
+      "summary": null
+    },
+    {
+      "completed_at": null,
+      "stage": "update_docs",
+      "status": "done",
+      "summary": null
+    },
+    {
+      "completed_at": null,
+      "stage": "test_and_checks",
+      "status": "done",
+      "summary": null
+    },
+    {
+      "completed_at": null,
+      "stage": "commit_and_submit_pr",
+      "status": "done",
+      "summary": null
+    }
+  ],
+  "task_id": "1500-adr043-unified-io-gui-hotfix",
+  "task_kind": "hotfix"
+}

--- a/frontend/src/App.parts/useWorkflowExecutionActions.test.tsx
+++ b/frontend/src/App.parts/useWorkflowExecutionActions.test.tsx
@@ -1,0 +1,64 @@
+import { renderHook, act } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { useWorkflowExecutionActions } from "./useWorkflowExecutionActions";
+
+const apiMocks = vi.hoisted(() => ({
+  cancelWorkflow: vi.fn(),
+  executeFrom: vi.fn(),
+  executeWorkflow: vi.fn(),
+  pauseWorkflow: vi.fn(),
+  resumeWorkflow: vi.fn(),
+}));
+
+vi.mock("../lib/api", () => ({
+  api: apiMocks,
+}));
+
+function renderActions() {
+  const deps = {
+    currentProject: {
+      id: "p1",
+      name: "Project",
+      description: "",
+      path: "C:\\Project",
+      workflow_count: 1,
+      workflows: ["main"],
+      current_workflow_id: "main",
+    },
+    workflowId: "main",
+    selectedNodeId: "node-1",
+    saveWorkflow: vi.fn().mockResolvedValue(undefined),
+    setLastError: vi.fn(),
+    workflowPayloadId: "main",
+  };
+  const hook = renderHook(() => useWorkflowExecutionActions(deps));
+  return { deps, hook };
+}
+
+describe("useWorkflowExecutionActions", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("keeps Run from here precondition errors visible after async save side effects", async () => {
+    vi.useFakeTimers();
+    apiMocks.executeFrom.mockRejectedValueOnce(
+      new Error("Run the full workflow at least once before using 'Run from here'"),
+    );
+    const { deps, hook } = renderActions();
+
+    await act(async () => {
+      await hook.result.current.startFromSelected();
+    });
+
+    expect(deps.setLastError).not.toHaveBeenCalled();
+    act(() => {
+      vi.runOnlyPendingTimers();
+    });
+    expect(deps.setLastError).toHaveBeenCalledWith(
+      "Run the full workflow at least once before using 'Run from here'",
+    );
+  });
+});

--- a/frontend/src/App.parts/useWorkflowExecutionActions.ts
+++ b/frontend/src/App.parts/useWorkflowExecutionActions.ts
@@ -30,6 +30,14 @@ export interface WorkflowExecutionActions {
   handleRestartBlock: (blockId: string) => Promise<void>;
 }
 
+function surfaceExecutionError(
+  setLastError: (message: string | null) => void,
+  error: unknown,
+): void {
+  const message = error instanceof Error ? error.message : String(error);
+  window.setTimeout(() => setLastError(message), 0);
+}
+
 export function useWorkflowExecutionActions(deps: WorkflowExecutionDeps): WorkflowExecutionActions {
   const {
     currentProject,
@@ -48,7 +56,7 @@ export function useWorkflowExecutionActions(deps: WorkflowExecutionDeps): Workfl
       setLastError(null);
       // #793: do NOT auto-switch to the Logs tab.
     } catch (error) {
-      setLastError((error as Error).message);
+      surfaceExecutionError(setLastError, error);
     }
   }, [currentProject, saveWorkflow, setLastError, workflowPayloadId]);
 
@@ -74,7 +82,7 @@ export function useWorkflowExecutionActions(deps: WorkflowExecutionDeps): Workfl
       await api.executeFrom(workflowId, selectedNodeId);
       setLastError(null);
     } catch (error) {
-      setLastError((error as Error).message);
+      surfaceExecutionError(setLastError, error);
     }
   }, [saveWorkflow, selectedNodeId, setLastError, workflowId]);
 
@@ -86,7 +94,7 @@ export function useWorkflowExecutionActions(deps: WorkflowExecutionDeps): Workfl
         await api.executeFrom(workflowId, blockId);
         setLastError(null);
       } catch (error) {
-        setLastError((error as Error).message);
+        surfaceExecutionError(setLastError, error);
       }
     },
     [saveWorkflow, setLastError, workflowId],
@@ -100,7 +108,7 @@ export function useWorkflowExecutionActions(deps: WorkflowExecutionDeps): Workfl
         await api.executeFrom(workflowId, blockId);
         setLastError(null);
       } catch (error) {
-        setLastError((error as Error).message);
+        surfaceExecutionError(setLastError, error);
       }
     },
     [saveWorkflow, setLastError, workflowId],

--- a/frontend/src/App.parts/useWorkflowSync.test.tsx
+++ b/frontend/src/App.parts/useWorkflowSync.test.tsx
@@ -1,0 +1,106 @@
+import { renderHook, act } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { ProjectResponse, WorkflowResponse } from "../types/api";
+import { useWorkflowSync } from "./useWorkflowSync";
+
+const apiMocks = vi.hoisted(() => ({
+  createWorkflow: vi.fn(),
+  getBlockSchema: vi.fn(),
+  listBlocks: vi.fn(),
+  listProjects: vi.fn(),
+  openProject: vi.fn(),
+  updateWorkflow: vi.fn(),
+}));
+
+vi.mock("../lib/api", () => ({
+  ApiError: class ApiError extends Error {
+    status: number;
+
+    constructor(message: string, status: number) {
+      super(message);
+      this.name = "ApiError";
+      this.status = status;
+    }
+  },
+  api: apiMocks,
+}));
+
+const workflow: WorkflowResponse = {
+  id: "main",
+  version: "1.0.0",
+  description: "",
+  nodes: [],
+  edges: [],
+  metadata: {},
+};
+
+const project: ProjectResponse = {
+  id: "project-1",
+  name: "Project",
+  description: "",
+  path: "C:\\Project",
+  workflow_count: 1,
+  workflows: ["main"],
+  current_workflow_id: "main",
+};
+
+function renderSync(overrides: Partial<{ currentProject: ProjectResponse | null }> = {}) {
+  const deps = {
+    currentProject: overrides.currentProject ?? project,
+    setCurrentProject: vi.fn(),
+    setBlocks: vi.fn(),
+    setBlockSchema: vi.fn(),
+    setProjects: vi.fn(),
+    markWorkflowSaved: vi.fn(),
+    setLastError: vi.fn(),
+    workflowPayload: workflow,
+    workflowId: workflow.id,
+  };
+  const hook = renderHook(() => useWorkflowSync(deps));
+  return { deps, hook };
+}
+
+describe("useWorkflowSync", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("reopens the current project and retries when backend session lost", async () => {
+    const { ApiError } = await import("../lib/api");
+    const saved = { ...workflow };
+    const reopened = { ...project, workflow_count: 2 };
+    apiMocks.updateWorkflow
+      .mockRejectedValueOnce(new ApiError("No project is currently open.", 409))
+      .mockResolvedValueOnce(saved);
+    apiMocks.openProject.mockResolvedValueOnce(reopened);
+    apiMocks.listProjects.mockResolvedValueOnce([reopened]);
+    const { deps, hook } = renderSync();
+
+    await act(async () => {
+      await hook.result.current.saveWorkflow();
+    });
+
+    expect(apiMocks.openProject).toHaveBeenCalledWith(project.id);
+    expect(apiMocks.updateWorkflow).toHaveBeenCalledTimes(2);
+    expect(deps.setCurrentProject).toHaveBeenCalledWith(reopened);
+    expect(deps.markWorkflowSaved).toHaveBeenCalled();
+    expect(deps.setLastError).not.toHaveBeenCalled();
+  });
+
+  it("falls back to create only when update returns 404", async () => {
+    const { ApiError } = await import("../lib/api");
+    apiMocks.updateWorkflow.mockRejectedValueOnce(new ApiError("Not found", 404));
+    apiMocks.createWorkflow.mockResolvedValueOnce(workflow);
+    apiMocks.listProjects.mockResolvedValueOnce([project]);
+    const { deps, hook } = renderSync();
+
+    await act(async () => {
+      await hook.result.current.saveWorkflow();
+    });
+
+    expect(apiMocks.createWorkflow).toHaveBeenCalledWith(workflow);
+    expect(apiMocks.openProject).not.toHaveBeenCalled();
+    expect(deps.markWorkflowSaved).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/App.parts/useWorkflowSync.ts
+++ b/frontend/src/App.parts/useWorkflowSync.ts
@@ -12,7 +12,7 @@
 
 import { startTransition, useCallback } from "react";
 
-import { api } from "../lib/api";
+import { api, ApiError } from "../lib/api";
 import type {
   BlockSchemaResponse,
   BlockSummary,
@@ -37,6 +37,17 @@ export interface WorkflowSync {
   refreshBlocks: () => Promise<void>;
   saveWorkflow: () => Promise<void>;
   saveWorkflowAs: () => Promise<void>;
+}
+
+async function persistWorkflow(workflow: WorkflowResponse): Promise<WorkflowResponse> {
+  try {
+    return await api.updateWorkflow(workflow.id, workflow);
+  } catch (error) {
+    if (error instanceof ApiError && error.status !== 404) {
+      throw error;
+    }
+    return await api.createWorkflow(workflow);
+  }
 }
 
 export function useWorkflowSync(deps: WorkflowSyncDeps): WorkflowSync {
@@ -75,19 +86,26 @@ export function useWorkflowSync(deps: WorkflowSyncDeps): WorkflowSync {
     if (!currentProject) return;
     try {
       let saved: WorkflowResponse;
+      let projectForState = currentProject;
       try {
-        saved = await api.updateWorkflow(workflowPayload.id, workflowPayload);
-      } catch {
-        saved = await api.createWorkflow(workflowPayload);
+        saved = await persistWorkflow(workflowPayload);
+      } catch (error) {
+        if (!(error instanceof ApiError) || error.status !== 409) {
+          throw error;
+        }
+        const reopened = await api.openProject(currentProject.id);
+        projectForState = reopened;
+        setCurrentProject(reopened);
+        saved = await persistWorkflow(workflowPayload);
       }
       markWorkflowSaved();
       await refreshProjects();
       setCurrentProject({
-        ...currentProject,
+        ...projectForState,
         current_workflow_id: saved.id,
-        workflows: currentProject.workflows.includes(saved.id)
-          ? currentProject.workflows
-          : [...currentProject.workflows, saved.id],
+        workflows: projectForState.workflows.includes(saved.id)
+          ? projectForState.workflows
+          : [...projectForState.workflows, saved.id],
       });
     } catch (error) {
       setLastError((error as Error).message);

--- a/frontend/src/components/BottomPanel.parts/ConfigPanel.test.tsx
+++ b/frontend/src/components/BottomPanel.parts/ConfigPanel.test.tsx
@@ -1,0 +1,292 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { FormatCapabilityResponse } from "../../types/api";
+import { ConfigPanel } from "./ConfigPanel";
+
+const apiMocks = vi.hoisted(() => ({
+  browseFilesystem: vi.fn(),
+  openNativeDialog: vi.fn(),
+}));
+
+vi.mock("../../lib/api", () => ({
+  ApiError: class ApiError extends Error {
+    status: number;
+
+    constructor(message: string, status: number) {
+      super(message);
+      this.name = "ApiError";
+      this.status = status;
+    }
+  },
+  api: {
+    browseFilesystem: apiMocks.browseFilesystem,
+    openNativeDialog: apiMocks.openNativeDialog,
+  },
+}));
+
+function makeCapability(
+  overrides: Partial<FormatCapabilityResponse> = {},
+): FormatCapabilityResponse {
+  return {
+    id: "imaging.image.tiff.load",
+    direction: "load",
+    data_type: "Image",
+    format_id: "tiff",
+    extensions: [".tif", ".tiff"],
+    label: "TIFF",
+    block_type: "LoadImage",
+    handler: "load",
+    is_default: false,
+    priority: 0,
+    roundtrip_group: null,
+    metadata_fidelity: {
+      level: "pixel_only",
+      typed_meta_reads: [],
+      typed_meta_writes: [],
+      format_metadata_reads: [],
+      format_metadata_writes: [],
+      notes: null,
+    },
+    is_synthesized: false,
+    migration_scaffold: false,
+    ...overrides,
+  };
+}
+
+describe("ConfigPanel", () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+    apiMocks.browseFilesystem.mockReset();
+    apiMocks.openNativeDialog.mockReset();
+  });
+
+  it("uses the native dialog first from the config Browse button", async () => {
+    const onUpdateConfig = vi.fn();
+    apiMocks.openNativeDialog.mockResolvedValueOnce({
+      paths: ["C:\\Users\\jiazh\\image.tif"],
+    });
+
+    render(
+      <ConfigPanel
+        onUpdateConfig={onUpdateConfig}
+        selectedNode={{
+          id: "load-1",
+          block_type: "load_data",
+          config: { params: { path: "C:\\Users\\jiazh\\old.tif" } },
+        }}
+        schema={{
+          name: "Load",
+          type_name: "load_data",
+          base_category: "io",
+          subcategory: "",
+          description: "",
+          version: "0.1.0",
+          input_ports: [],
+          output_ports: [],
+          direction: "input",
+          config_schema: {
+            properties: {
+              path: {
+                type: "string",
+                title: "Path",
+                ui_priority: 0,
+                ui_widget: "file_browser",
+              },
+            },
+          },
+          type_hierarchy: [],
+        }}
+      />,
+    );
+
+    fireEvent.click(screen.getByTitle("Browse filesystem"));
+
+    await waitFor(() =>
+      expect(apiMocks.openNativeDialog).toHaveBeenCalledWith("file", "C:\\Users\\jiazh"),
+    );
+    await waitFor(() =>
+      expect(onUpdateConfig).toHaveBeenCalledWith({ path: "C:\\Users\\jiazh\\image.tif" }),
+    );
+    expect(apiMocks.browseFilesystem).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the in-app file browser when native dialog fails", async () => {
+    const { ApiError } = await import("../../lib/api");
+    apiMocks.openNativeDialog.mockRejectedValueOnce(
+      new ApiError("Native dialog command not available on this platform", 500),
+    );
+    apiMocks.browseFilesystem.mockResolvedValueOnce({
+      path: "C:\\Users\\jiazh",
+      entries: [],
+    });
+
+    render(
+      <ConfigPanel
+        onUpdateConfig={() => {}}
+        selectedNode={{
+          id: "load-1",
+          block_type: "load_data",
+          config: { params: { path: "" } },
+        }}
+        schema={{
+          name: "Load",
+          type_name: "load_data",
+          base_category: "io",
+          subcategory: "",
+          description: "",
+          version: "0.1.0",
+          input_ports: [],
+          output_ports: [],
+          direction: "input",
+          config_schema: {
+            properties: {
+              path: {
+                type: "string",
+                title: "Path",
+                ui_priority: 0,
+                ui_widget: "file_browser",
+              },
+            },
+          },
+          type_hierarchy: [],
+        }}
+      />,
+    );
+
+    fireEvent.click(screen.getByTitle("Browse filesystem"));
+
+    expect(await screen.findByText("Select File")).toBeInTheDocument();
+    expect(apiMocks.openNativeDialog).toHaveBeenCalledWith("file", undefined);
+    expect(apiMocks.browseFilesystem).toHaveBeenCalledWith("");
+  });
+
+  it("renders core IO fields as Path, Type, Format and inherits parent-type formats", () => {
+    const onUpdateConfig = vi.fn();
+
+    render(
+      <ConfigPanel
+        onUpdateConfig={onUpdateConfig}
+        selectedNode={{
+          id: "load-1",
+          block_type: "load_data",
+          config: { params: { core_type: "SRSImage", capability_id: "imaging.image.tiff.load" } },
+        }}
+        schema={{
+          name: "Load",
+          type_name: "load_data",
+          base_category: "io",
+          subcategory: "",
+          description: "",
+          version: "0.1.0",
+          input_ports: [],
+          output_ports: [],
+          direction: "input",
+          config_schema: {
+            properties: {
+              path: { type: "string", title: "Path", ui_priority: 0 },
+              core_type: {
+                type: "string",
+                title: "Type",
+                enum: ["DataFrame", "Image", "SRSImage"],
+                default: "DataFrame",
+                ui_priority: 1,
+              },
+            },
+          },
+          type_hierarchy: [
+            { name: "DataObject", base_type: "", description: "" },
+            { name: "Array", base_type: "DataObject", description: "" },
+            { name: "Image", base_type: "Array", description: "" },
+            { name: "SRSImage", base_type: "Image", description: "" },
+          ],
+          format_capabilities: [
+            makeCapability({
+              id: "core.dataframe.csv.load",
+              data_type: "DataFrame",
+              format_id: "csv",
+              extensions: [".csv"],
+              label: "CSV",
+            }),
+            makeCapability({ id: "imaging.image.tiff.load" }),
+          ],
+        }}
+      />,
+    );
+
+    const pathField = screen.getByLabelText("Path");
+    const typeField = screen.getByLabelText("Type");
+    const formatField = screen.getByLabelText("Format");
+    expect(pathField.compareDocumentPosition(typeField)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+    expect(typeField.compareDocumentPosition(formatField)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+    expect(screen.getByRole("option", { name: /TIFF/ })).toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: /CSV/ })).toBeNull();
+
+    fireEvent.change(screen.getByLabelText("Type"), { target: { value: "DataFrame" } });
+    expect(onUpdateConfig).toHaveBeenCalledWith({ core_type: "DataFrame", capability_id: null });
+  });
+
+  it("renders Artifact core IO as a single Any format", () => {
+    render(
+      <ConfigPanel
+        onUpdateConfig={() => {}}
+        selectedNode={{
+          id: "load-1",
+          block_type: "load_data",
+          config: { params: { core_type: "Artifact" } },
+        }}
+        schema={{
+          name: "Load",
+          type_name: "load_data",
+          base_category: "io",
+          subcategory: "",
+          description: "",
+          version: "0.1.0",
+          input_ports: [],
+          output_ports: [],
+          direction: "input",
+          config_schema: {
+            properties: {
+              path: { type: "string", title: "Path", ui_priority: 0 },
+              core_type: {
+                type: "string",
+                title: "Type",
+                enum: ["DataFrame", "Artifact"],
+                default: "DataFrame",
+                ui_priority: 1,
+              },
+            },
+          },
+          type_hierarchy: [
+            { name: "DataObject", base_type: "", description: "" },
+            { name: "Artifact", base_type: "DataObject", description: "" },
+          ],
+          format_capabilities: [
+            makeCapability({
+              id: "core.artifact.binary.load",
+              data_type: "Artifact",
+              format_id: "binary",
+              extensions: [".bin"],
+              label: "Binary",
+            }),
+            makeCapability({
+              id: "core.artifact.pdf.load",
+              data_type: "Artifact",
+              format_id: "pdf",
+              extensions: [".pdf"],
+              label: "PDF",
+            }),
+          ],
+        }}
+      />,
+    );
+
+    const formatField = screen.getByLabelText("Format") as HTMLSelectElement;
+    expect(formatField).toBeDisabled();
+    expect(screen.getByRole("option", { name: "Any" })).toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: /Binary/ })).toBeNull();
+    expect(screen.queryByRole("option", { name: /PDF/ })).toBeNull();
+    expect(screen.getByText("Artifact / any / pixel_only")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/BottomPanel.parts/ConfigPanel.tsx
+++ b/frontend/src/components/BottomPanel.parts/ConfigPanel.tsx
@@ -1,6 +1,14 @@
-import { api } from "../../lib/api";
-import type { BlockSchemaResponse, WorkflowNode } from "../../types/api";
+import { useState } from "react";
+
+import { api, ApiError } from "../../lib/api";
+import type {
+  BlockSchemaResponse,
+  FormatCapabilityResponse,
+  TypeHierarchyEntry,
+  WorkflowNode,
+} from "../../types/api";
 import { type PortRow, PortEditorTable } from "../PortEditorTable";
+import { FileBrowserModal } from "../nodes/BlockNode.parts/FileBrowserModal";
 
 import { CaretPreservingTextInput } from "./CaretPreservingTextInput";
 import { CodeBlockConfigEditor } from "./CodeBlockConfigEditor";
@@ -9,46 +17,91 @@ import { isCodeBlockConfigTarget } from "./codeBlockPorts";
 
 type BrowseMode = "file" | "directory" | null;
 
+function ancestorTypeNames(typeName: string, typeHierarchy: TypeHierarchyEntry[]): Set<string> {
+  const ancestors = new Set<string>();
+  if (!typeName) return ancestors;
+  ancestors.add(typeName);
+  const index = new Map(typeHierarchy.map((entry) => [entry.name, entry]));
+  let current = index.get(typeName);
+  while (current?.base_type && !ancestors.has(current.base_type)) {
+    ancestors.add(current.base_type);
+    current = index.get(current.base_type);
+  }
+  return ancestors;
+}
+
+function capabilitiesForType(
+  capabilities: FormatCapabilityResponse[],
+  selectedType: string,
+  typeHierarchy: TypeHierarchyEntry[],
+): FormatCapabilityResponse[] {
+  if (!selectedType) return [];
+  const acceptedTypes = ancestorTypeNames(selectedType, typeHierarchy);
+  const filtered = capabilities.filter((capability) => acceptedTypes.has(capability.data_type));
+  if (!acceptedTypes.has("Artifact")) return filtered;
+  let artifactInserted = false;
+  return filtered.flatMap((capability) => {
+    if (capability.data_type !== "Artifact") return [capability];
+    if (artifactInserted) return [];
+    artifactInserted = true;
+    return [
+      {
+        ...capability,
+        id: `core.artifact.any.${capability.direction}`,
+        data_type: "Artifact",
+        format_id: "any",
+        extensions: [],
+        label: "Any",
+        is_default: true,
+        roundtrip_group: null,
+        is_synthesized: false,
+        migration_scaffold: false,
+      },
+    ];
+  });
+}
+
 function browseModeFor(uiWidget: string | undefined): BrowseMode {
   if (uiWidget === "file_browser") return "file";
   if (uiWidget === "directory_browser") return "directory";
   return null;
 }
 
-async function runBrowseDialog(
+function nativeInitialDir(
   browseMode: NonNullable<BrowseMode>,
   current: string,
-  schemaTypeRaw: unknown,
-  onUpdateConfig: (patch: Record<string, unknown>) => void,
-  key: string,
-) {
-  // Mirror BlockNode's inline browse pattern (#484): use the
-  // backend's native dialog so the user gets their OS file
-  // picker. Failure surfaces in console; the text field
-  // remains usable as the manual fallback.
-  let initialDir: string | undefined;
-  if (current) {
-    const sep = current.includes("\\") ? "\\" : "/";
-    const parts = current.split(sep);
-    if (browseMode === "file" && parts.length > 1 && parts[parts.length - 1].includes(".")) {
-      initialDir = parts.slice(0, -1).join(sep);
-    } else {
-      initialDir = current;
-    }
+): string | undefined {
+  if (!current) return undefined;
+  const sep = current.includes("\\") ? "\\" : "/";
+  const parts = current.split(sep);
+  if (browseMode === "file" && parts.length > 1 && parts[parts.length - 1].includes(".")) {
+    return parts.slice(0, -1).join(sep);
   }
-  try {
-    const result = await api.openNativeDialog(browseMode, initialDir);
-    if (result.paths.length > 0) {
-      const supportsArray = Array.isArray(schemaTypeRaw)
-        ? schemaTypeRaw.includes("array")
-        : schemaTypeRaw === "array";
-      onUpdateConfig({
-        [key]: supportsArray && result.paths.length > 1 ? result.paths : result.paths[0],
-      });
+  return current;
+}
+
+function shouldFallbackToInAppModal(err: unknown): boolean {
+  if (err instanceof ApiError) {
+    if (err.status === 504) {
+      console.error(
+        "Native file dialog timed out (HTTP 504); not falling back to in-app picker.",
+        err,
+      );
+      return false;
     }
-  } catch (err) {
-    console.error("BottomPanel: native file dialog failed", err);
+    return true;
   }
+  return true;
+}
+
+function modalInitialPath(browseMode: NonNullable<BrowseMode>, current: string): string {
+  if (!current) return "";
+  const sep = current.includes("\\") ? "\\" : "/";
+  const parts = current.split(sep);
+  if (browseMode === "file" && parts.length > 1 && parts[parts.length - 1].includes(".")) {
+    return parts.slice(0, -1).join(sep);
+  }
+  return current;
 }
 
 function EnumField({
@@ -68,7 +121,13 @@ function EnumField({
       <span className="font-medium text-ink">{String(field.title ?? fieldKey)}</span>
       <select
         className="rounded-2xl border border-stone-300 bg-white px-4 py-3"
-        onChange={(event) => onUpdateConfig({ [fieldKey]: event.target.value })}
+        onChange={(event) =>
+          onUpdateConfig(
+            fieldKey === "core_type"
+              ? { [fieldKey]: event.target.value, capability_id: null }
+              : { [fieldKey]: event.target.value },
+          )
+        }
         value={String(currentValue)}
       >
         {enumValues.map((option) => (
@@ -94,6 +153,30 @@ function ScalarField({
 }) {
   const uiWidget = field.ui_widget as string | undefined;
   const browseMode = browseModeFor(uiWidget);
+  const [browseOpen, setBrowseOpen] = useState(false);
+  const applySelectedPath = (paths: string[]) => {
+    if (paths.length === 0) return;
+    const supportsArray = Array.isArray(field.type)
+      ? field.type.includes("array")
+      : field.type === "array";
+    onUpdateConfig({
+      [fieldKey]: supportsArray && paths.length > 1 ? paths : paths[0],
+    });
+  };
+  const handleBrowseClick = async () => {
+    if (!browseMode) return;
+    try {
+      const result = await api.openNativeDialog(
+        browseMode,
+        nativeInitialDir(browseMode, String(currentValue ?? "")),
+      );
+      applySelectedPath(result.paths);
+    } catch (err) {
+      if (shouldFallbackToInAppModal(err)) {
+        setBrowseOpen(true);
+      }
+    }
+  };
   return (
     <label className="grid gap-2 text-sm" key={fieldKey}>
       <span className="font-medium text-ink">{String(field.title ?? fieldKey)}</span>
@@ -114,20 +197,23 @@ function ScalarField({
             type="button"
             className="shrink-0 rounded-2xl border border-stone-300 bg-white px-3 text-sm text-stone-600 hover:bg-stone-50"
             title="Browse filesystem"
-            onClick={() =>
-              runBrowseDialog(
-                browseMode,
-                String(currentValue ?? ""),
-                field.type,
-                onUpdateConfig,
-                fieldKey,
-              )
-            }
+            onClick={() => void handleBrowseClick()}
           >
             ...
           </button>
         )}
       </div>
+      {browseOpen && browseMode && (
+        <FileBrowserModal
+          mode={browseMode === "directory" ? "directory_browser" : "file_browser"}
+          initialPath={modalInitialPath(browseMode, String(currentValue ?? ""))}
+          onSelect={(selectedPath) => {
+            applySelectedPath([selectedPath]);
+            setBrowseOpen(false);
+          }}
+          onCancel={() => setBrowseOpen(false)}
+        />
+      )}
     </label>
   );
 }
@@ -222,6 +308,25 @@ export function ConfigPanel({
   const allowedInputTypes = schema.allowed_input_types ?? [];
   const allowedOutputTypes = schema.allowed_output_types ?? [];
   const formatCapabilities = schema.format_capabilities ?? [];
+  const coreTypeSchema = schema.config_schema.properties?.core_type;
+  const hasCoreTypeField = coreTypeSchema != null;
+  const selectedType =
+    typeof params.core_type === "string"
+      ? params.core_type
+      : typeof coreTypeSchema?.default === "string"
+        ? coreTypeSchema.default
+        : "";
+  const visibleFormatCapabilities = hasCoreTypeField
+    ? capabilitiesForType(formatCapabilities, selectedType, typeHierarchy)
+    : formatCapabilities;
+  const formatSelector =
+    visibleFormatCapabilities.length > 0 ? (
+      <FormatCapabilityConfig
+        capabilities={visibleFormatCapabilities}
+        onChange={(capabilityId) => onUpdateConfig({ capability_id: capabilityId })}
+        value={params.capability_id}
+      />
+    ) : null;
 
   return (
     <div>
@@ -247,26 +352,22 @@ export function ConfigPanel({
           typeHierarchy={typeHierarchy}
         />
       )}
-      {formatCapabilities.length > 0 ? (
-        <div className="mb-4 max-w-2xl">
-          <FormatCapabilityConfig
-            capabilities={formatCapabilities}
-            onChange={(capabilityId) => onUpdateConfig({ capability_id: capabilityId })}
-            value={params.capability_id}
-          />
-        </div>
+      {!hasCoreTypeField && formatSelector ? (
+        <div className="mb-4 max-w-2xl">{formatSelector}</div>
       ) : null}
-      <div className="grid gap-4 md:grid-cols-2">
+      <div className={hasCoreTypeField ? "grid max-w-2xl gap-4" : "grid gap-4 md:grid-cols-2"}>
         {ordered.map(([key, value]) => {
           const currentValue = params[key] ?? value.default ?? "";
           return (
-            <ConfigField
-              key={key}
-              fieldKey={key}
-              field={value}
-              currentValue={currentValue}
-              onUpdateConfig={onUpdateConfig}
-            />
+            <div key={key} className="contents">
+              <ConfigField
+                fieldKey={key}
+                field={value}
+                currentValue={currentValue}
+                onUpdateConfig={onUpdateConfig}
+              />
+              {hasCoreTypeField && key === "core_type" && formatSelector}
+            </div>
           );
         })}
       </div>

--- a/frontend/src/components/Toolbar.parts/WorkflowGroups.tsx
+++ b/frontend/src/components/Toolbar.parts/WorkflowGroups.tsx
@@ -6,7 +6,6 @@ import {
   BoxSelect,
   Eye,
   Loader2,
-  Pause,
   Play,
   RefreshCw,
   RotateCcw,
@@ -37,7 +36,7 @@ export interface WorkflowGroupsProps {
 }
 
 function ExecutionControls(props: WorkflowGroupsProps) {
-  const { currentProject, workflowId, isRunning, onRun, onPause, onStop, onReset } = props;
+  const { currentProject, workflowId, isRunning, onRun, onStop, onReset } = props;
   return (
     <div className="flex items-center gap-1">
       <ToolbarButton
@@ -49,7 +48,6 @@ function ExecutionControls(props: WorkflowGroupsProps) {
         iconClassName={isRunning ? "animate-spin" : undefined}
         onClick={onRun}
       />
-      <ToolbarButton icon={Pause} label="Pause" disabled={!workflowId} onClick={onPause} />
       <ToolbarButton
         icon={Square}
         label="Stop"

--- a/frontend/src/components/Toolbar.test.tsx
+++ b/frontend/src/components/Toolbar.test.tsx
@@ -3,7 +3,7 @@
  *
  * Verifies that:
  *   - When ``activeTabKind === "workflow"`` (default), the existing button
- *     set is rendered: Run / Pause / Stop / Reset / Reload / Delete /
+ *     set is rendered: Run / Stop / Reset / Reload / Delete /
  *     Note / Group are all present.
  *   - When ``activeTabKind === "file"``, those workflow-only buttons are
  *     hidden; only New / Import / Save remain.
@@ -60,7 +60,7 @@ function makeProps(overrides: Partial<React.ComponentProps<typeof Toolbar>> = {}
 }
 
 describe("Toolbar — ADR-036 §3.7 kind-swap", () => {
-  it("workflow tab: Run / Pause / Stop / Reset / Reload / Delete / Note / Group are visible", () => {
+  it("workflow tab: Run / Stop / Reset / Reload / Delete / Note / Group are visible", () => {
     render(<Toolbar {...makeProps({ activeTabKind: "workflow" })} />);
     // Group 2 (always present)
     expect(screen.getByRole("button", { name: /^new$/i })).toBeTruthy();
@@ -68,7 +68,7 @@ describe("Toolbar — ADR-036 §3.7 kind-swap", () => {
     expect(screen.getByRole("button", { name: /^save$/i })).toBeTruthy();
     // Workflow-only groups
     expect(screen.getByRole("button", { name: /^run$/i })).toBeTruthy();
-    expect(screen.getByRole("button", { name: /^pause$/i })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /^pause$/i })).toBeNull();
     expect(screen.getByRole("button", { name: /^stop$/i })).toBeTruthy();
     expect(screen.getByRole("button", { name: /^reset$/i })).toBeTruthy();
     expect(screen.getByRole("button", { name: /^delete$/i })).toBeTruthy();

--- a/frontend/src/components/nodes/BlockNode.tsx
+++ b/frontend/src/components/nodes/BlockNode.tsx
@@ -20,6 +20,7 @@
 import { type Node, type NodeProps } from "@xyflow/react";
 import { useLayoutEffect, useRef, useState } from "react";
 
+import type { FormatCapabilityResponse, TypeHierarchyEntry } from "../../types/api";
 import type { BlockNodeData } from "../../types/ui";
 import { computeEffectivePorts } from "../../utils/computeEffectivePorts";
 import { LossySaveWarning } from "../WorkflowEditor/LossySaveWarning";
@@ -32,6 +33,60 @@ import { PortHandles } from "./BlockNode.parts/PortHandles";
 import { StatusBadge } from "./BlockNode.parts/StatusBadge";
 import { categoryIcons } from "./BlockNode.parts/badgeStyles";
 import { getTopConfigProperties } from "./BlockNode.parts/inlineConfigHelpers";
+
+function ancestorTypeNames(typeName: string, typeHierarchy: TypeHierarchyEntry[]): Set<string> {
+  const ancestors = new Set<string>();
+  if (!typeName) return ancestors;
+  ancestors.add(typeName);
+  const index = new Map(typeHierarchy.map((entry) => [entry.name, entry]));
+  let current = index.get(typeName);
+  while (current?.base_type && !ancestors.has(current.base_type)) {
+    ancestors.add(current.base_type);
+    current = index.get(current.base_type);
+  }
+  return ancestors;
+}
+
+function capabilitiesForType(
+  capabilities: FormatCapabilityResponse[],
+  selectedType: string | null,
+  typeHierarchy: TypeHierarchyEntry[],
+): FormatCapabilityResponse[] {
+  if (!selectedType) return capabilities;
+  const acceptedTypes = ancestorTypeNames(selectedType, typeHierarchy);
+  const filtered = capabilities.filter((capability) => acceptedTypes.has(capability.data_type));
+  if (!acceptedTypes.has("Artifact")) return filtered;
+  let artifactInserted = false;
+  return filtered.flatMap((capability) => {
+    if (capability.data_type !== "Artifact") return [capability];
+    if (artifactInserted) return [];
+    artifactInserted = true;
+    return [
+      {
+        ...capability,
+        id: `core.artifact.any.${capability.direction}`,
+        data_type: "Artifact",
+        format_id: "any",
+        extensions: [],
+        label: "Any",
+        is_default: true,
+        roundtrip_group: null,
+        is_synthesized: false,
+        migration_scaffold: false,
+      },
+    ];
+  });
+}
+
+function coreTypeFromConfig(
+  configProps: ReturnType<typeof getTopConfigProperties>,
+  config: BlockNodeData["config"],
+): string | null {
+  const coreTypeConfig = configProps.find((prop) => prop.key === "core_type")?.schema;
+  if (typeof config?.core_type === "string") return config.core_type;
+  if (typeof coreTypeConfig?.default === "string") return coreTypeConfig.default;
+  return null;
+}
 
 export function BlockNode({ id: nodeId, data, selected }: NodeProps<Node<BlockNodeData>>) {
   // ADR-028 Addendum 1 §B fix #2 / §C11: hide the ``direction`` config
@@ -50,10 +105,12 @@ export function BlockNode({ id: nodeId, data, selected }: NodeProps<Node<BlockNo
   // Blocks without a ``core_type`` field (e.g. imaging.threshold) are
   // unaffected because the filter is a no-op when ``coreType`` is null.
   const allFormatCapabilities = data.schema?.format_capabilities ?? [];
-  const coreType = typeof data.config?.core_type === "string" ? data.config.core_type : null;
-  const formatCapabilities = coreType
-    ? allFormatCapabilities.filter((cap) => cap.data_type === coreType)
-    : allFormatCapabilities;
+  const coreType = coreTypeFromConfig(configProps, data.config);
+  const formatCapabilities = capabilitiesForType(
+    allFormatCapabilities,
+    coreType,
+    data.schema?.type_hierarchy ?? [],
+  );
   const categoryIcon = categoryIcons[data.category] ?? categoryIcons.custom;
   // ADR-028 Addendum 1 §B fix #3 / §C8: read ``direction`` from the schema
   // (class-level ClassVar, populated by the backend at scan time) instead
@@ -118,7 +175,9 @@ export function BlockNode({ id: nodeId, data, selected }: NodeProps<Node<BlockNo
   }, [configProps.length, effectiveInputPorts.length, effectiveOutputPorts.length]);
 
   const handleConfigChange = (key: string, value: unknown) => {
-    data.onUpdateConfig?.({ [key]: value });
+    data.onUpdateConfig?.(
+      key === sourceConfigKey ? { [key]: value, capability_id: null } : { [key]: value },
+    );
   };
 
   // ADR-029 D2: variadic port UI — [+] and [-] controls.
@@ -203,23 +262,23 @@ export function BlockNode({ id: nodeId, data, selected }: NodeProps<Node<BlockNo
         ref={configSectionRef}
         className="nodrag nowheel space-y-2 overflow-hidden border-b border-stone-100 px-3 py-2"
       >
+        {configProps.length > 0
+          ? configProps.map((prop) => (
+              <InlineConfigField
+                key={prop.key}
+                prop={prop}
+                value={data.config?.[prop.key]}
+                onChange={handleConfigChange}
+              />
+            ))
+          : null}
         {formatCapabilities.length > 0 ? (
           <InlineCapabilitySelector
             capabilities={formatCapabilities}
             value={data.config?.capability_id}
             onChange={(capabilityId) => data.onUpdateConfig?.({ capability_id: capabilityId })}
           />
-        ) : null}
-        {configProps.length > 0 ? (
-          configProps.map((prop) => (
-            <InlineConfigField
-              key={prop.key}
-              prop={prop}
-              value={data.config?.[prop.key]}
-              onChange={handleConfigChange}
-            />
-          ))
-        ) : formatCapabilities.length === 0 ? (
+        ) : configProps.length === 0 ? (
           <p className="text-center text-[11px] italic text-stone-400">No parameters</p>
         ) : null}
       </div>

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -2,6 +2,9 @@ import path from "path";
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
+const apiProxyTarget = process.env.SCISTUDIO_API_PROXY ?? "http://localhost:8000";
+const wsProxyTarget = apiProxyTarget.replace(/^http/, "ws");
+
 export default defineConfig({
   base: "./",
   plugins: [react()],
@@ -15,16 +18,16 @@ export default defineConfig({
       // PTY WebSocket — must match before the generic /api rule so the
       // upgrade request is routed through a proxy with ws:true.
       "/api/ai/pty": {
-        target: "ws://localhost:8000",
+        target: wsProxyTarget,
         ws: true,
         changeOrigin: true,
       },
       "/api": {
-        target: "http://localhost:8000",
+        target: apiProxyTarget,
         changeOrigin: true,
       },
       "/ws": {
-        target: "ws://localhost:8000",
+        target: wsProxyTarget,
         ws: true,
         changeOrigin: true,
       },

--- a/src/imagecodecs/__init__.pyi
+++ b/src/imagecodecs/__init__.pyi
@@ -1,0 +1,2 @@
+# Third-party imagecodecs stubs use Python 3.12+ syntax that our mypy config
+# cannot parse while python_version remains pinned to 3.11.

--- a/src/scistudio/api/app.py
+++ b/src/scistudio/api/app.py
@@ -172,9 +172,13 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         # D39-3.2 (#968): the standalone git_watcher was deleted — its
         # ``.git/`` surface is now covered by the unified workflow_watcher
         # observer above. No separate teardown required.
+        pending_run_tasks = []
         for run in runtime.workflow_runs.values():
             if not run.task.done():
                 run.task.cancel()
+                pending_run_tasks.append(run.task)
+        if pending_run_tasks:
+            await asyncio.gather(*pending_run_tasks, return_exceptions=True)
         app.state.registry.terminate_all(grace_period_sec=5.0)
         if mcp_server is not None:
             try:

--- a/src/scistudio/api/routes/blocks.py
+++ b/src/scistudio/api/routes/blocks.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import importlib.resources as importlib_resources
 import logging
-from typing import Annotated, Any
+from typing import Annotated, Any, cast
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
@@ -42,8 +42,49 @@ def _port_response(port: Any, *, direction: str) -> BlockPortResponse:
     )
 
 
-def _config_schema_for_block(spec: Any) -> dict[str, Any]:
-    return spec.config_schema or {"type": "object", "properties": {}}
+def _type_names_for_io_direction(
+    registry: Any,
+    type_registry: Any,
+    *,
+    direction: str,
+) -> list[str]:
+    """Return all registered type names, with IO-capable types first."""
+    registered = set(type_registry.all_types().keys())
+    capable = {capability.data_type.__name__ for capability in registry.list_format_capabilities(direction=direction)}
+    core_order = ["Array", "DataFrame", "Series", "Text", "Artifact", "CompositeData"]
+    ordered = [name for name in core_order if name in registered]
+    ordered.extend(sorted(capable - set(ordered)))
+    ordered.extend(sorted(registered - set(ordered)))
+    return ordered
+
+
+def _config_schema_for_block(spec: Any, registry: Any = None, type_registry: Any = None) -> dict[str, Any]:
+    schema = spec.config_schema or {"type": "object", "properties": {}}
+    if registry is None or type_registry is None:
+        return schema
+    if spec.type_name not in {"load_data", "save_data"}:
+        return schema
+
+    import copy
+
+    direction = "load" if spec.type_name == "load_data" else "save"
+    merged = copy.deepcopy(schema)
+    properties = merged.setdefault("properties", {})
+    properties.pop("allow_pickle", None)
+    type_names = _type_names_for_io_direction(registry, type_registry, direction=direction)
+    properties["core_type"] = {
+        **properties.get("core_type", {}),
+        "title": "Type",
+        "enum": type_names,
+        "default": "DataFrame" if "DataFrame" in type_names else (type_names[0] if type_names else ""),
+        "ui_priority": 1,
+    }
+    if "path" in properties:
+        properties["path"]["title"] = "Path"
+        properties["path"]["ui_priority"] = 0
+        properties["path"]["ui_widget"] = "file_browser"
+    merged["required"] = ["path", "core_type"]
+    return merged
 
 
 def _map_source(raw: str) -> str:
@@ -89,6 +130,67 @@ def _format_capability_response(capability: Any) -> FormatCapabilityResponse:
     )
 
 
+def _artifact_any_response(direction: str, template: FormatCapabilityResponse) -> FormatCapabilityResponse:
+    fidelity = template.metadata_fidelity
+    return FormatCapabilityResponse(
+        id=f"core.artifact.any.{direction}",
+        direction=direction,
+        data_type="Artifact",
+        format_id="any",
+        extensions=[],
+        label="Any",
+        block_type=template.block_type,
+        handler=template.handler,
+        is_default=True,
+        priority=template.priority,
+        roundtrip_group=None,
+        metadata_fidelity=MetadataFidelityResponse(
+            level=fidelity.level,
+            typed_meta_reads=list(fidelity.typed_meta_reads),
+            typed_meta_writes=list(fidelity.typed_meta_writes),
+            format_metadata_reads=list(fidelity.format_metadata_reads),
+            format_metadata_writes=list(fidelity.format_metadata_writes),
+            notes=fidelity.notes,
+        ),
+        is_synthesized=False,
+        migration_scaffold=False,
+    )
+
+
+def _collapse_artifact_capabilities_for_core_io(
+    capabilities: list[FormatCapabilityResponse],
+    *,
+    direction: str,
+) -> list[FormatCapabilityResponse]:
+    """Expose Artifact IO as one opaque Any choice in core Load/Save."""
+    collapsed: list[FormatCapabilityResponse] = []
+    artifact_template: FormatCapabilityResponse | None = None
+    artifact_inserted = False
+    for capability in capabilities:
+        if capability.data_type != "Artifact":
+            collapsed.append(capability)
+            continue
+        if artifact_template is None:
+            artifact_template = capability
+        if not artifact_inserted:
+            collapsed.append(_artifact_any_response(direction, capability))
+            artifact_inserted = True
+    return collapsed
+
+
+def _format_capability_responses_for_spec(spec: Any, registry: Any = None) -> list[FormatCapabilityResponse]:
+    if registry is not None:
+        capabilities = _all_format_capabilities_for_core_io(registry, spec)
+    else:
+        capabilities = list(getattr(spec, "format_capabilities", []))
+    responses = [_format_capability_response(capability) for capability in capabilities]
+    if spec.type_name == "load_data":
+        return _collapse_artifact_capabilities_for_core_io(responses, direction="load")
+    if spec.type_name == "save_data":
+        return _collapse_artifact_capabilities_for_core_io(responses, direction="save")
+    return responses
+
+
 def _is_plugin_package(name: str) -> bool:
     """Return True if *name* looks like an external plugin package.
 
@@ -101,7 +203,15 @@ def _is_plugin_package(name: str) -> bool:
     return name.startswith("scistudio-blocks-")
 
 
-def _summary(spec: Any) -> BlockSummary:
+def _all_format_capabilities_for_core_io(registry: Any, spec: Any) -> list[Any]:
+    if spec.type_name == "load_data":
+        return cast(list[Any], registry.list_format_capabilities(direction="load"))
+    if spec.type_name == "save_data":
+        return cast(list[Any], registry.list_format_capabilities(direction="save"))
+    return list(getattr(spec, "format_capabilities", []))
+
+
+def _summary(spec: Any, registry: Any = None) -> BlockSummary:
     raw_pkg = getattr(spec, "package_name", "") or ""
     # Only keep the package_name for genuine plugin packages so the
     # frontend groups core blocks together under "SciStudio Core".
@@ -120,16 +230,36 @@ def _summary(spec: Any) -> BlockSummary:
         package_name=package_name,
         variadic_inputs=bool(getattr(spec, "variadic_inputs", False)),
         variadic_outputs=bool(getattr(spec, "variadic_outputs", False)),
-        format_capabilities=[
-            _format_capability_response(capability) for capability in getattr(spec, "format_capabilities", [])
-        ],
+        format_capabilities=_format_capability_responses_for_spec(spec, registry),
     )
+
+
+def _is_replaced_io_palette_block(spec: Any) -> bool:
+    """Hide package-specific IO blocks now represented by core Load/Save."""
+    if spec.type_name in {"load_data", "save_data"}:
+        return False
+    if getattr(spec, "direction", "") not in {"input", "output"}:
+        return False
+    return bool(getattr(spec, "format_capabilities", []))
+
+
+def _dynamic_ports_for_core_io(spec: Any, registry: Any, type_registry: Any) -> dict[str, Any] | None:
+    if spec.type_name not in {"load_data", "save_data"}:
+        return cast(dict[str, Any] | None, spec.dynamic_ports)
+    direction = "load" if spec.type_name == "load_data" else "save"
+    type_names = _type_names_for_io_direction(registry, type_registry, direction=direction)
+    enum_map = {name: [name] for name in type_names}
+    if spec.type_name == "load_data":
+        return {"source_config_key": "core_type", "output_port_mapping": {"data": enum_map}}
+    return {"source_config_key": "core_type", "input_port_mapping": {"data": enum_map}}
 
 
 @router.get("/", response_model=BlockListResponse)
 async def list_blocks(registry: BlockRegistryDep) -> BlockListResponse:
     """Return the full block palette available in the current registry."""
-    blocks = [_summary(spec) for spec in registry.all_specs().values()]
+    blocks = [
+        _summary(spec, registry) for spec in registry.all_specs().values() if not _is_replaced_io_palette_block(spec)
+    ]
     blocks.sort(key=lambda item: (item.base_category, item.subcategory, item.name))
     return BlockListResponse(blocks=blocks)
 
@@ -240,8 +370,8 @@ async def get_block_schema(
     if spec is None:
         raise HTTPException(status_code=404, detail=f"Unknown block type: {block_type}")
     return BlockSchemaResponse(
-        **_summary(spec).model_dump(),
-        config_schema=_config_schema_for_block(spec),
+        **_summary(spec, registry).model_dump(),
+        config_schema=_config_schema_for_block(spec, registry, type_registry),
         type_hierarchy=[
             TypeHierarchyEntry(
                 name=entry.name,
@@ -253,7 +383,7 @@ async def get_block_schema(
         # ADR-028 Addendum 1 D4 / D7: surface dynamic-port descriptor and IO
         # direction to the frontend so BlockNode.tsx can render dynamic-port
         # UI and IO-specific controls without hardcoded type checks.
-        dynamic_ports=spec.dynamic_ports,
+        dynamic_ports=_dynamic_ports_for_core_io(spec, registry, type_registry),
         # ADR-029 D11: variadic port type constraints for frontend port editor.
         allowed_input_types=list(getattr(spec, "allowed_input_types", []) or []),
         allowed_output_types=list(getattr(spec, "allowed_output_types", []) or []),

--- a/src/scistudio/api/routes/filesystem.py
+++ b/src/scistudio/api/routes/filesystem.py
@@ -330,6 +330,20 @@ def _native_dialog_windows(
     safe_initial_dir = _ps_single_quote_escape(initial_dir or "")
     safe_default_filename = _ps_single_quote_escape(default_filename or "")
     safe_file_filter = _ps_single_quote_escape(file_filter or "YAML files (*.yaml)|*.yaml|All files (*.*)|*.*")
+    owner_form_setup = (
+        "Add-Type -AssemblyName System.Windows.Forms;"
+        "[System.Windows.Forms.Application]::EnableVisualStyles();"
+        "$owner = New-Object System.Windows.Forms.Form;"
+        "$owner.StartPosition = 'CenterScreen';"
+        "$owner.Width = 1;"
+        "$owner.Height = 1;"
+        "$owner.Opacity = 0;"
+        "$owner.ShowInTaskbar = $false;"
+        "$owner.TopMost = $true;"
+        "$owner.Show();"
+        "$owner.Activate();"
+    )
+    owner_form_teardown = "if ($owner) { $owner.Close(); $owner.Dispose(); }"
     if mode == "directory":
         # Use modern IFileOpenDialog COM with FOS_PICKFOLDERS for Vista+ style
         # instead of the legacy Win2000-era FolderBrowserDialog.
@@ -383,13 +397,13 @@ public interface IShellItem {
 }
 
 public static class FolderPicker {
-    public static string Pick(string title) {
+    public static string Pick(string title, IntPtr owner) {
         var dlg = (IFileDialog)new FileOpenDialogClass();
         uint opts;
         dlg.GetOptions(out opts);
         dlg.SetOptions(opts | 0x20 | 0x40);
         if (title != null) dlg.SetTitle(title);
-        int hr = dlg.Show(IntPtr.Zero);
+        int hr = dlg.Show(owner);
         if (hr != 0) return null;
         IShellItem item;
         dlg.GetResult(out item);
@@ -401,30 +415,43 @@ public static class FolderPicker {
 """
         # Pass C# source in a PowerShell single-quoted string (escape ' as '').
         ps_script = (
-            "Add-Type -TypeDefinition '" + cs_source.replace("'", "''") + "';"
-            "$result = [FolderPicker]::Pick('Select Folder');"
-            "if ($result) { $result } else { '' }"
+            owner_form_setup
+            + "Add-Type -TypeDefinition '"
+            + cs_source.replace("'", "''")
+            + "';"
+            + "try {"
+            + "$result = [FolderPicker]::Pick('Select Folder', $owner.Handle);"
+            + "if ($result) { $result } else { '' }"
+            + "} finally {"
+            + owner_form_teardown
+            + "}"
         )
     elif mode == "save_file":
         ps_script = (
-            "Add-Type -AssemblyName System.Windows.Forms;"
-            "[System.Windows.Forms.Application]::EnableVisualStyles();"
-            "$d = New-Object System.Windows.Forms.SaveFileDialog;"
-            f"$d.InitialDirectory = '{safe_initial_dir}';"
-            f"$d.FileName = '{safe_default_filename}';"
-            f"$d.Filter = '{safe_file_filter}';"
-            "if ($d.ShowDialog() -eq 'OK') { $d.FileName } else { '' }"
+            owner_form_setup
+            + "$d = New-Object System.Windows.Forms.SaveFileDialog;"
+            + f"$d.InitialDirectory = '{safe_initial_dir}';"
+            + f"$d.FileName = '{safe_default_filename}';"
+            + f"$d.Filter = '{safe_file_filter}';"
+            + "try {"
+            + "if ($d.ShowDialog($owner) -eq 'OK') { $d.FileName } else { '' }"
+            + "} finally {"
+            + owner_form_teardown
+            + "}"
         )
     else:
         # Bug 1 fix: single braces for non-f-string lines.
         # Bug 2 fix: enable Multiselect and return pipe-separated FileNames.
         ps_script = (
-            "Add-Type -AssemblyName System.Windows.Forms;"
-            "[System.Windows.Forms.Application]::EnableVisualStyles();"
-            "$d = New-Object System.Windows.Forms.OpenFileDialog;"
-            "$d.Multiselect = $true;"
-            f"$d.InitialDirectory = '{safe_initial_dir}';"
-            "if ($d.ShowDialog() -eq 'OK') { ($d.FileNames -join '|') } else { '' }"
+            owner_form_setup
+            + "$d = New-Object System.Windows.Forms.OpenFileDialog;"
+            + "$d.Multiselect = $true;"
+            + f"$d.InitialDirectory = '{safe_initial_dir}';"
+            + "try {"
+            + "if ($d.ShowDialog($owner) -eq 'OK') { ($d.FileNames -join '|') } else { '' }"
+            + "} finally {"
+            + owner_form_teardown
+            + "}"
         )
     # No timeout: this is a desktop-local server and the user may legitimately
     # spend an arbitrary amount of time browsing the dialog (#678).

--- a/src/scistudio/api/routes/workflows.py
+++ b/src/scistudio/api/routes/workflows.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import contextlib
 import logging
+import os
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Annotated, Any
@@ -32,6 +33,7 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/workflows", tags=["workflows"])
 RuntimeDep = Annotated[ApiRuntime, Depends(get_runtime)]
 _API_SOURCES = {"canvas", "agent", "gitRestore", "import", "external"}
+_NO_ACTIVE_PROJECT_MESSAGE = "No project is currently open."
 
 
 def _yaml_error_detail(workflow_id: str, exc: yaml.YAMLError) -> dict[str, Any]:
@@ -89,6 +91,16 @@ def _get_run_or_404(runtime: ApiRuntime, workflow_id: str) -> WorkflowRun:
         return runtime.get_run(workflow_id)
     except KeyError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
+def _workflow_session_error(exc: RuntimeError) -> HTTPException:
+    status_code = 409 if str(exc) == _NO_ACTIVE_PROJECT_MESSAGE else 400
+    return HTTPException(status_code=status_code, detail=str(exc))
+
+
+def _bind_engine_api_url(request: Request) -> None:
+    """Publish this API process URL so worker subprocesses can call back."""
+    os.environ["SCISTUDIO_ENGINE_API_URL"] = str(request.base_url).rstrip("/")
 
 
 def _request_source_id(request: Request, body: Any | None = None) -> str | None:
@@ -188,7 +200,7 @@ async def list_workflows(runtime: RuntimeDep) -> list[str]:
     try:
         return runtime.list_project_workflows()
     except RuntimeError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+        raise _workflow_session_error(exc) from exc
 
 
 @router.post("/import", response_model=VersionedWorkflowResponse)
@@ -299,7 +311,7 @@ async def create_workflow(body: WorkflowCreate, runtime: RuntimeDep, request: Re
         # Cycle detection and other validation errors → 422
         raise HTTPException(status_code=422, detail=str(exc)) from exc
     except RuntimeError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+        raise _workflow_session_error(exc) from exc
 
     source_id = _request_source_id(request, body)
     source = _request_source(request)
@@ -377,6 +389,8 @@ async def update_workflow(
     except ValueError as exc:
         # Cycle detection and other validation errors → 422
         raise HTTPException(status_code=422, detail=str(exc)) from exc
+    except RuntimeError as exc:
+        raise _workflow_session_error(exc) from exc
 
     # changed_by: prefer an explicit ``X-Changed-By`` header (set by the MCP
     # tool / the embedded agent), else fall back to a generic "api" tag.
@@ -437,9 +451,14 @@ async def delete_workflow(workflow_id: str, runtime: RuntimeDep) -> None:
 
 
 @router.post("/{workflow_id}/execute", response_model=WorkflowExecutionResponse)
-async def execute_workflow(workflow_id: str, runtime: RuntimeDep) -> WorkflowExecutionResponse:
+async def execute_workflow(
+    workflow_id: str,
+    runtime: RuntimeDep,
+    request: Request,
+) -> WorkflowExecutionResponse:
     """Start execution of a workflow."""
     try:
+        _bind_engine_api_url(request)
         result = runtime.start_workflow(workflow_id)
     except FileNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
@@ -501,6 +520,7 @@ async def execute_from_workflow(
     workflow_id: str,
     body: ExecuteFromRequest,
     runtime: RuntimeDep,
+    request: Request,
 ) -> ExecuteFromResponse:
     """Re-run a workflow from a specific block using checkpointed inputs.
 
@@ -530,6 +550,7 @@ async def execute_from_workflow(
                 exc_info=True,
             )
     try:
+        _bind_engine_api_url(request)
         result = runtime.start_workflow(
             workflow_id,
             execute_from=body.block_id,

--- a/src/scistudio/api/ws.py
+++ b/src/scistudio/api/ws.py
@@ -37,6 +37,10 @@ from scistudio.engine.events import (
 
 logger = logging.getLogger(__name__)
 
+_GUI_DISCONNECT_GRACE_SEC = 2.0
+_gui_ws_clients: set[int] = set()
+_gui_disconnect_cancel_task: asyncio.Task[None] | None = None
+
 # ADR-036 §3.5 (I36c): outbound event type emitted after a successful
 # blocks/*.py save passes lint and hot_reload runs. Declared here as a
 # bare string (not a constant in scistudio.engine.events) because the
@@ -153,6 +157,69 @@ def serialise_event(event: EngineEvent) -> dict[str, Any]:
     }
 
 
+async def _cancel_running_workflows_for_gui_disconnect(event_bus: EventBus) -> None:
+    """Cancel active workflows when the GUI session disappears."""
+    runtime = getattr(event_bus, "runtime", None)
+    runs = getattr(runtime, "workflow_runs", None)
+    if not isinstance(runs, dict):
+        return
+
+    for workflow_id, run in list(runs.items()):
+        task = getattr(run, "task", None)
+        if task is not None and callable(getattr(task, "done", None)) and task.done():
+            continue
+        scheduler = getattr(run, "scheduler", None)
+        cancel_workflow = getattr(scheduler, "cancel_workflow", None)
+        if not callable(cancel_workflow):
+            continue
+        try:
+            await cancel_workflow()
+            logger.info("Cancelled workflow %s after GUI websocket disconnect", workflow_id)
+        except Exception:
+            logger.warning("Failed to cancel workflow %s after GUI websocket disconnect", workflow_id, exc_info=True)
+            continue
+
+        if task is not None and callable(getattr(task, "done", None)) and not task.done():
+            try:
+                await asyncio.wait_for(asyncio.shield(task), timeout=5.0)
+            except (asyncio.CancelledError, TimeoutError):
+                pass
+            except Exception:
+                logger.debug(
+                    "Workflow %s task finished with exception after GUI disconnect", workflow_id, exc_info=True
+                )
+
+
+def _has_active_workflow_runs(event_bus: EventBus) -> bool:
+    runtime = getattr(event_bus, "runtime", None)
+    runs = getattr(runtime, "workflow_runs", None)
+    if not isinstance(runs, dict):
+        return False
+    for run in runs.values():
+        task = getattr(run, "task", None)
+        if task is None:
+            continue
+        if not callable(getattr(task, "done", None)) or not task.done():
+            return True
+    return False
+
+
+async def _cancel_after_gui_disconnect_grace(event_bus: EventBus) -> None:
+    """Debounce transient reconnects before cancelling browser-owned runs."""
+    global _gui_disconnect_cancel_task
+
+    try:
+        await asyncio.sleep(_GUI_DISCONNECT_GRACE_SEC)
+        if _gui_ws_clients:
+            return
+        await _cancel_running_workflows_for_gui_disconnect(event_bus)
+    except asyncio.CancelledError:
+        raise
+    finally:
+        if asyncio.current_task() is _gui_disconnect_cancel_task:
+            _gui_disconnect_cancel_task = None
+
+
 async def websocket_handler(websocket: WebSocket, event_bus: EventBus) -> None:
     """Handle a WebSocket connection for real-time workflow updates.
 
@@ -171,9 +238,15 @@ async def websocket_handler(websocket: WebSocket, event_bus: EventBus) -> None:
     # narrow.
     from scistudio.api.routes import ai_pty as ai_pty_module
 
+    global _gui_disconnect_cancel_task
+
     await websocket.accept()
 
     outbound_queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
+    client_token = id(outbound_queue)
+    _gui_ws_clients.add(client_token)
+    if _gui_disconnect_cancel_task is not None and not _gui_disconnect_cancel_task.done():
+        _gui_disconnect_cancel_task.cancel()
 
     def _on_event(event: EngineEvent) -> None:
         """Callback for EventBus — enqueue event for outbound delivery."""
@@ -273,6 +346,9 @@ async def websocket_handler(websocket: WebSocket, event_bus: EventBus) -> None:
     except (WebSocketDisconnect, asyncio.CancelledError):
         pass
     finally:
+        _gui_ws_clients.discard(client_token)
         for event_type in _OUTBOUND_EVENTS:
             event_bus.unsubscribe(event_type, _on_event)
         ai_pty_module.unregister_ai_pty_subscriber(_on_ai_pty_message)
+        if not _gui_ws_clients and _has_active_workflow_runs(event_bus):
+            _gui_disconnect_cancel_task = asyncio.create_task(_cancel_after_gui_disconnect_grace(event_bus))

--- a/src/scistudio/blocks/io/_unified_dispatch.py
+++ b/src/scistudio/blocks/io/_unified_dispatch.py
@@ -1,0 +1,149 @@
+"""Runtime helpers for ADR-043 unified Load/Save dispatch.
+
+Core ``Load`` / ``Save`` remain the user-facing blocks. When their selected
+capability belongs to a package IO block, these helpers resolve and invoke the
+owning block while preserving the stable core block surface in workflow YAML.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any, cast
+
+from scistudio.blocks.base.config import BlockConfig
+from scistudio.blocks.io.capabilities import FormatCapability
+from scistudio.core.types.base import DataObject
+
+
+def _scan_runtime_registry(
+    registry: Any, *, project_child: str, home_child: str, scan_method: str, always_home: bool
+) -> Any:
+    """Apply runtime project/user scan paths and execute the requested scan."""
+    project_dir = os.environ.get("SCISTUDIO_PROJECT_DIR")
+    if project_dir:
+        registry.add_scan_dir(Path(project_dir) / project_child)
+    if always_home or project_dir:
+        registry.add_scan_dir(Path.home() / ".scistudio" / home_child)
+    getattr(registry, scan_method)(include_monorepo=os.environ.get("SCISTUDIO_DEV") == "1")
+    return registry
+
+
+def runtime_block_registry() -> Any:
+    """Build a registry that mirrors API/worker project scan locations."""
+    from scistudio.blocks.registry import BlockRegistry
+
+    return _scan_runtime_registry(
+        BlockRegistry(), project_child="blocks", home_child="blocks", scan_method="scan", always_home=False
+    )
+
+
+def runtime_type_registry() -> Any:
+    """Build a type registry that includes core, package, and custom types."""
+    from scistudio.core.types.registry import TypeRegistry
+
+    return _scan_runtime_registry(
+        TypeRegistry(), project_child="types", home_child="types", scan_method="scan_all", always_home=True
+    )
+
+
+def resolve_type_class(type_name: str) -> type[DataObject] | None:
+    """Resolve a registered ``DataObject`` subclass by display name."""
+    try:
+        cls = runtime_type_registry().load_class(type_name)
+    except Exception:
+        return None
+    if isinstance(cls, type) and issubclass(cls, DataObject):
+        return cls
+    return None
+
+
+def capability_by_id(registry: Any, capability_id: str, *, direction: str) -> FormatCapability | None:
+    """Return a registered capability by stable id and direction."""
+    for capability in registry.list_format_capabilities(direction=direction):
+        if capability.id == capability_id:
+            return cast(FormatCapability, capability)
+    return None
+
+
+def capability_owner_class(registry: Any, capability: FormatCapability) -> type[Any]:
+    """Load the block class that owns ``capability``."""
+    block_cls = registry._resolve_capability_class(capability)
+    if block_cls is None:
+        raise LookupError(
+            f"ADR-043 capability {capability.id!r} resolved but owner {capability.block_type!r} could not be imported."
+        )
+    return cast(type[Any], block_cls)
+
+
+def selected_capability(
+    *,
+    direction: str,
+    params: dict[str, Any],
+    data_type: type[DataObject] | None,
+) -> tuple[Any, FormatCapability | None]:
+    """Resolve the selected capability from ``capability_id`` or path/type."""
+    registry = runtime_block_registry()
+    raw_id = params.get("capability_id")
+    capability_id = raw_id if isinstance(raw_id, str) and raw_id.strip() else None
+    if capability_id:
+        return registry, capability_by_id(registry, capability_id, direction=direction)
+
+    if data_type is None:
+        return registry, None
+    raw_path = params.get("path")
+    extension = None
+    if isinstance(raw_path, str) and raw_path:
+        suffixes = Path(raw_path).suffixes
+        extension = "".join(suffixes) if suffixes else None
+    finder = registry.find_loader_capability if direction == "load" else registry.find_saver_capability
+    try:
+        return registry, finder(data_type, extension)
+    except Exception:
+        return registry, None
+
+
+def delegate_params(params: dict[str, Any], capability: FormatCapability) -> dict[str, Any]:
+    """Build config params for the package IO block behind a core proxy."""
+    delegated = {key: value for key, value in params.items() if key != "core_type"}
+    delegated["capability_id"] = capability.id
+    delegated["format_id"] = capability.format_id
+    return delegated
+
+
+def delegate_load(
+    *,
+    config: BlockConfig,
+    output_dir: str,
+    core_type: str,
+) -> DataObject:
+    """Load through the package block selected by a core Load capability."""
+    data_type = resolve_type_class(core_type)
+    registry, capability = selected_capability(direction="load", params=dict(config.params), data_type=data_type)
+    if capability is None:
+        raise ValueError(f"Load: no ADR-043 load capability is registered for type {core_type!r}.")
+    if capability.block_type == "LoadData":
+        raise ValueError(f"Load: selected capability {capability.id!r} did not resolve to a package loader.")
+    loader_cls = capability_owner_class(registry, capability)
+    params = delegate_params(dict(config.params), capability)
+    loader = loader_cls(config={"params": params})
+    return cast(DataObject, loader.load(BlockConfig(params=params), output_dir))
+
+
+def delegate_save(
+    *,
+    obj: DataObject,
+    config: BlockConfig,
+    core_type: str,
+) -> None:
+    """Save through the package block selected by a core Save capability."""
+    data_type = resolve_type_class(core_type) or type(obj)
+    registry, capability = selected_capability(direction="save", params=dict(config.params), data_type=data_type)
+    if capability is None:
+        raise ValueError(f"Save: no ADR-043 save capability is registered for type {core_type!r}.")
+    if capability.block_type == "SaveData":
+        raise ValueError(f"Save: selected capability {capability.id!r} did not resolve to a package saver.")
+    saver_cls = capability_owner_class(registry, capability)
+    params = delegate_params(dict(config.params), capability)
+    saver = saver_cls(config={"params": params})
+    saver.save(obj, BlockConfig(params=params))

--- a/src/scistudio/blocks/io/loaders/load_data.py
+++ b/src/scistudio/blocks/io/loaders/load_data.py
@@ -130,11 +130,6 @@ class LoadData(IOBlock):
                 "ui_priority": 0,
             },
             # ADR-030: ``path`` is inherited from IOBlock base class via MRO merge.
-            "allow_pickle": {
-                "type": "boolean",
-                "default": False,
-                "ui_priority": 2,
-            },
         },
         "required": ["core_type"],
     }
@@ -173,7 +168,11 @@ class LoadData(IOBlock):
         block produces a Collection rather than a bare DataObject.
         """
         type_name = self.config.get("core_type", "DataFrame")
-        cls = _CORE_TYPE_MAP.get(type_name, DataFrame)
+        cls = _CORE_TYPE_MAP.get(type_name)
+        if cls is None:
+            from scistudio.blocks.io._unified_dispatch import resolve_type_class
+
+            cls = resolve_type_class(str(type_name)) or DataObject
         is_multi = isinstance(self.config.get("path"), list)
         return [OutputPort(name="data", accepted_types=[cls], is_collection=is_multi)]
 
@@ -200,6 +199,13 @@ class LoadData(IOBlock):
         object return behavior is preserved.
         """
         type_name = config.get("core_type", "DataFrame")
+        if type_name not in _CORE_TYPE_MAP:
+            from scistudio.blocks.io._unified_dispatch import delegate_load, resolve_type_class
+
+            if resolve_type_class(str(type_name)) is None:
+                raise ValueError(f"Unknown core_type: {type_name}")
+
+            return delegate_load(config=config, output_dir=output_dir, core_type=str(type_name))
 
         # ADR-031: dispatch table. Functions that don't need output_dir
         # are wrapped with lambdas to accept and ignore the parameter,

--- a/src/scistudio/blocks/io/savers/save_data.py
+++ b/src/scistudio/blocks/io/savers/save_data.py
@@ -182,11 +182,6 @@ class SaveData(IOBlock):
             },
             # ADR-030: ``path`` is inherited from IOBlock base class via MRO merge.
             # Direction-aware post-processing auto-switches to directory_browser.
-            "allow_pickle": {
-                "type": "boolean",
-                "default": False,
-                "ui_priority": 2,
-            },
         },
         "required": ["core_type"],
     }
@@ -219,7 +214,11 @@ class SaveData(IOBlock):
         documented default in :attr:`config_schema`).
         """
         type_name = self.config.get("core_type", "DataFrame")
-        cls = _CORE_TYPE_MAP.get(type_name, DataFrame)
+        cls = _CORE_TYPE_MAP.get(type_name)
+        if cls is None:
+            from scistudio.blocks.io._unified_dispatch import resolve_type_class
+
+            cls = resolve_type_class(str(type_name)) or DataFrame
         return [InputPort(name="data", accepted_types=[cls], required=True)]
 
     def load(self, config: BlockConfig, output_dir: str = "") -> DataObject | Collection:
@@ -240,6 +239,17 @@ class SaveData(IOBlock):
         :class:`ValueError`.
         """
         type_name = config.get("core_type", "DataFrame")
+        if type_name not in _CORE_TYPE_MAP:
+            from scistudio.blocks.io._unified_dispatch import delegate_save, resolve_type_class
+
+            if resolve_type_class(str(type_name)) is None:
+                raise ValueError(f"Unknown core_type {type_name!r}; expected a registered DataObject type.")
+            if isinstance(obj, Collection):
+                raise ValueError(f"SaveData custom core_type {type_name!r} requires a single DataObject input.")
+
+            delegate_save(obj=obj, config=config, core_type=str(type_name))
+            return
+
         if type_name not in _CORE_TYPE_MAP:
             raise ValueError(f"Unknown core_type {type_name!r}; expected one of {sorted(_CORE_TYPE_MAP.keys())}.")
 

--- a/tests/api/test_blocks.py
+++ b/tests/api/test_blocks.py
@@ -71,8 +71,8 @@ def test_validate_connection_endpoint_uses_registry_type_information(client: Tes
         json={
             "source_block": "process_block",
             "source_port": "output",
-            "target_block": "Merge",
-            "target_port": "left",
+            "target_block": "imaging.axis_merge",
+            "target_port": "images",
         },
     )
     assert bidirectional.status_code == 200
@@ -307,14 +307,72 @@ def test_block_schema_exposes_serializable_format_capabilities(client: TestClien
 
 
 def test_list_blocks_keeps_palette_compact_with_capability_metadata(client: TestClient) -> None:
-    """ADR-043 capabilities must not expand one aggregate IOBlock into many blocks."""
+    """ADR-043 package IO capabilities are surfaced through core Load/Save."""
     response = client.get("/api/blocks/")
     assert response.status_code == 200
     blocks = response.json()["blocks"]
 
-    load_image_blocks = [block for block in blocks if block["type_name"] == "imaging.load_image"]
-    assert len(load_image_blocks) == 1
-    assert load_image_blocks[0]["format_capabilities"]
+    assert [block for block in blocks if block["type_name"] == "imaging.load_image"] == []
+    assert [block for block in blocks if block["type_name"] == "imaging.save_image"] == []
+
+    load = next(block for block in blocks if block["type_name"] == "load_data")
+    save = next(block for block in blocks if block["type_name"] == "save_data")
+    assert any(capability["data_type"] == "Image" for capability in load["format_capabilities"])
+    assert any(capability["data_type"] == "Image" for capability in save["format_capabilities"])
+
+
+def test_core_load_save_schema_aggregates_registered_io_types(client: TestClient) -> None:
+    """Core Load/Save schema exposes package types and removes allow_pickle UI."""
+    load_response = client.get("/api/blocks/load_data/schema")
+    assert load_response.status_code == 200
+    load_payload = load_response.json()
+    load_props = load_payload["config_schema"]["properties"]
+    assert "Image" in load_props["core_type"]["enum"]
+    assert "allow_pickle" not in load_props
+    assert load_props["path"]["ui_widget"] == "file_browser"
+    assert any(capability["data_type"] == "Image" for capability in load_payload["format_capabilities"])
+    assert load_payload["dynamic_ports"]["output_port_mapping"]["data"]["Image"] == ["Image"]
+
+    save_response = client.get("/api/blocks/save_data/schema")
+    assert save_response.status_code == 200
+    save_payload = save_response.json()
+    save_props = save_payload["config_schema"]["properties"]
+    assert "Image" in save_props["core_type"]["enum"]
+    assert "allow_pickle" not in save_props
+    assert save_props["path"]["ui_widget"] == "file_browser"
+    assert any(capability["data_type"] == "Image" for capability in save_payload["format_capabilities"])
+    assert save_payload["dynamic_ports"]["input_port_mapping"]["data"]["Image"] == ["Image"]
+
+
+def test_core_load_save_schema_collapses_artifact_formats_to_any(client: TestClient) -> None:
+    """Artifact is opaque bytes, so the unified GUI exposes Any, not extensions."""
+    load_response = client.get("/api/blocks/load_data/schema")
+    assert load_response.status_code == 200
+    load_payload = load_response.json()
+    load_artifact = [
+        capability for capability in load_payload["format_capabilities"] if capability["data_type"] == "Artifact"
+    ]
+    assert len(load_artifact) == 1
+    assert load_artifact[0]["id"] == "core.artifact.any.load"
+    assert load_artifact[0]["direction"] == "load"
+    assert load_artifact[0]["format_id"] == "any"
+    assert load_artifact[0]["extensions"] == []
+    assert load_artifact[0]["label"] == "Any"
+    assert load_artifact[0]["is_default"] is True
+
+    save_response = client.get("/api/blocks/save_data/schema")
+    assert save_response.status_code == 200
+    save_payload = save_response.json()
+    save_artifact = [
+        capability for capability in save_payload["format_capabilities"] if capability["data_type"] == "Artifact"
+    ]
+    assert len(save_artifact) == 1
+    assert save_artifact[0]["id"] == "core.artifact.any.save"
+    assert save_artifact[0]["direction"] == "save"
+    assert save_artifact[0]["format_id"] == "any"
+    assert save_artifact[0]["extensions"] == []
+    assert save_artifact[0]["label"] == "Any"
+    assert save_artifact[0]["is_default"] is True
 
 
 # ----------------------------------------------------------------------------

--- a/tests/api/test_filesystem_dialog.py
+++ b/tests/api/test_filesystem_dialog.py
@@ -69,6 +69,8 @@ def test_save_file_dialog_escapes_apostrophes_in_initial_dir() -> None:
     # closing delimiter.
     assert r"$d.InitialDirectory = 'C:\Users\Bob''s runs';" in script
     assert "$d.FileName = 'workflow.yaml';" in script
+    assert "$owner.TopMost = $true;" in script
+    assert "$d.ShowDialog($owner)" in script
     # Sanity: the raw single apostrophe with no doubling does NOT appear.
     assert "Bob's runs" not in script
 
@@ -125,6 +127,8 @@ def test_open_file_dialog_escapes_apostrophes_in_initial_dir() -> None:
 
     script = _captured_ps_script(captured)
     assert r"$d.InitialDirectory = 'D:\Bob''s data';" in script
+    assert "$owner.TopMost = $true;" in script
+    assert "$d.ShowDialog($owner)" in script
 
 
 def test_dialog_with_none_initial_dir_does_not_crash() -> None:

--- a/tests/api/test_native_dialog.py
+++ b/tests/api/test_native_dialog.py
@@ -34,6 +34,8 @@ class TestNativeDialogWindowsDirectory:
         assert "FolderPicker" in ps_script
         assert "IFileDialog" in ps_script
         assert "Add-Type -TypeDefinition" in ps_script
+        assert "$owner.TopMost = $true;" in ps_script
+        assert "[FolderPicker]::Pick('Select Folder', $owner.Handle)" in ps_script
         assert "FolderBrowserDialog" not in ps_script
 
         assert result == [r"C:\Users\test\Documents"]
@@ -67,6 +69,8 @@ class TestNativeDialogWindowsDirectory:
 
         assert "OpenFileDialog" in ps_script
         assert "FolderPicker" not in ps_script
+        assert "$owner.TopMost = $true;" in ps_script
+        assert "$d.ShowDialog($owner)" in ps_script
         assert result == [r"C:\file1.txt", r"C:\file2.txt"]
 
 

--- a/tests/api/test_projects.py
+++ b/tests/api/test_projects.py
@@ -2,11 +2,16 @@
 
 from __future__ import annotations
 
+import os
 import time
 from pathlib import Path
+from typing import Any
 from urllib.parse import quote
 
+import pytest
 from fastapi.testclient import TestClient
+
+from scistudio.api.runtime import ApiRuntime
 
 
 def test_project_crud_and_path_opening(client: TestClient, project_parent: Path) -> None:
@@ -59,6 +64,42 @@ def test_project_crud_and_path_opening(client: TestClient, project_parent: Path)
     deleted = client.delete(f"/api/projects/{first_payload['id']}")
     assert deleted.status_code == 204
     assert not Path(first_payload["path"]).exists()
+
+
+def test_workflow_save_without_active_project_returns_session_conflict(client: TestClient) -> None:
+    """Backend session loss should be distinguishable from workflow validation errors."""
+    workflow = {
+        "id": "main",
+        "nodes": [],
+        "edges": [],
+        "metadata": {},
+    }
+
+    created = client.post("/api/workflows/", json=workflow)
+    assert created.status_code == 409
+    assert created.json()["detail"] == "No project is currently open."
+
+    updated = client.put("/api/workflows/main", json=workflow)
+    assert updated.status_code == 409
+    assert updated.json()["detail"] == "No project is currently open."
+
+
+def test_execute_workflow_sets_engine_api_url_for_workers(
+    client: TestClient,
+    runtime: ApiRuntime,
+    opened_project: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AIBlock worker subprocesses need the engine API callback URL."""
+    monkeypatch.delenv("SCISTUDIO_ENGINE_API_URL", raising=False)
+
+    def fake_start_workflow(workflow_id: str, **_: Any) -> dict[str, str]:
+        assert os.environ["SCISTUDIO_ENGINE_API_URL"] == "http://testserver"
+        return {"workflow_id": workflow_id, "status": "running", "message": "started"}
+
+    monkeypatch.setattr(runtime, "start_workflow", fake_start_workflow)
+    response = client.post("/api/workflows/main/execute")
+    assert response.status_code == 200
 
 
 def test_list_projects_sorted_by_last_opened(client: TestClient, project_parent: Path) -> None:

--- a/tests/api/test_ws.py
+++ b/tests/api/test_ws.py
@@ -4,10 +4,13 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+from types import SimpleNamespace
+from typing import Any
 from unittest.mock import AsyncMock
 
 from fastapi.testclient import TestClient
 
+import scistudio.api.ws as ws_module
 from scistudio.api.runtime import ApiRuntime
 from scistudio.api.ws import _OUTBOUND_EVENTS, websocket_handler
 from scistudio.engine.events import (
@@ -94,5 +97,46 @@ def test_websocket_handler_handles_cancelled_error_on_shutdown() -> None:
         # The handler should exit without propagating CancelledError
         with contextlib.suppress(asyncio.CancelledError):
             await task
+
+    asyncio.run(_run())
+
+
+def test_last_gui_disconnect_cancels_active_workflow(monkeypatch: Any) -> None:
+    """When the browser session disappears, running workflows must not leave lineage running."""
+
+    async def _run() -> None:
+        ws_module._gui_ws_clients.clear()
+        if ws_module._gui_disconnect_cancel_task is not None:
+            ws_module._gui_disconnect_cancel_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await ws_module._gui_disconnect_cancel_task
+            ws_module._gui_disconnect_cancel_task = None
+
+        monkeypatch.setattr(ws_module, "_GUI_DISCONNECT_GRACE_SEC", 0.01)
+
+        task = asyncio.create_task(asyncio.sleep(60))
+
+        async def cancel_workflow() -> None:
+            task.cancel()
+
+        scheduler = SimpleNamespace(cancel_workflow=AsyncMock(side_effect=cancel_workflow))
+        runtime = SimpleNamespace(workflow_runs={"wf-browser-owned": SimpleNamespace(task=task, scheduler=scheduler)})
+        event_bus = EventBus()
+        event_bus.runtime = runtime  # type: ignore[attr-defined]
+
+        ws = AsyncMock()
+        ws.accept = AsyncMock()
+        ws.receive_text = AsyncMock(side_effect=asyncio.CancelledError)
+        ws.send_json = AsyncMock(side_effect=asyncio.CancelledError)
+
+        handler = asyncio.create_task(websocket_handler(ws, event_bus))
+        await asyncio.sleep(0.02)
+        handler.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await handler
+
+        await asyncio.sleep(0.05)
+        scheduler.cancel_workflow.assert_awaited_once()
+        assert task.cancelled()
 
     asyncio.run(_run())

--- a/tests/blocks/io/test_save_data.py
+++ b/tests/blocks/io/test_save_data.py
@@ -104,7 +104,7 @@ class TestSaveDataClassShape:
         schema = SaveData.config_schema
         assert schema["required"] == ["core_type"]
         assert schema["properties"]["core_type"]["default"] == "DataFrame"
-        assert schema["properties"]["allow_pickle"]["default"] is False
+        assert "allow_pickle" not in schema["properties"]
         # core_type enum exposes all six core types.
         assert set(schema["properties"]["core_type"]["enum"]) == set(_CORE_TYPE_MAP.keys())
 


### PR DESCRIPTION
﻿## Summary

Closes #1500.
Related: #1204.

Owner-guided hotfix for ADR-043 unified IO GUI/backend wiring and regressions found during live testing.

## Changes

- Route package/custom IO capabilities through core `Load` / `Save`, aggregate registered type + format metadata, hide package-specific IO palette entries, and support inherited type formats plus Artifact `Any` behavior.
- Rework Load/Save config UX ordering and file browsing, including native Windows dialog ownership/focus fixes.
- Recover workflow saves after backend project-session loss and bind worker PTY callback URL for direct uvicorn launches.
- Keep run-from-here errors visible, remove the nonfunctional Pause toolbar action, and cancel active workflows when the GUI websocket disappears so lineage does not remain `running`.

## Validation

- `PYTHONPATH=src python -m ruff check <targeted python files>`
- `PYTHONPATH=src python -m ruff format --check <targeted python files>`
- `PYTHONPATH=src SCISTUDIO_DEV=1 pytest tests/api/test_blocks.py tests/api/test_filesystem_dialog.py tests/api/test_native_dialog.py tests/api/test_projects.py tests/api/test_ws.py tests/blocks/io/test_save_data.py tests/engine/test_pty_control.py --no-cov` -> 134 passed, 1 warning
- `cd frontend && npx prettier --check <targeted frontend files>`
- `cd frontend && npx eslint <targeted frontend files> --no-warn-ignored`
- `cd frontend && npm run typecheck`
- `cd frontend && npm test -- --run src/App.parts/useWorkflowExecutionActions.test.tsx src/App.parts/useWorkflowSync.test.tsx src/components/BottomPanel.parts/ConfigPanel.test.tsx src/components/Toolbar.test.tsx` -> 18 passed
- `cd frontend && npm run build` -> passed with existing large chunk warning
- `PYTHONPATH=src python -m scistudio.qa.audit.full_audit --repo-root . --format json --output docs/audit/full-audit-latest.json`
- `PYTHONPATH=src python -m scistudio.qa.governance.gate_record pre-push --record .workflow/records/1500-adr043-unified-io-gui-hotfix.json --base origin/main --head HEAD`

## Gate

Gate-Record: `.workflow/records/1500-adr043-unified-io-gui-hotfix.json`
Task-Kind: hotfix
