### PR TITLE
fix(#1505): stabilize SaveData unified IO hotfix

### DIFF
--- a/.workflow/records/1505-hotfix-save-data-extension.json
+++ b/.workflow/records/1505-hotfix-save-data-extension.json
@@ -1,0 +1,260 @@
+{
+  "admin_labels": [],
+  "amendments": [],
+  "branch": "hotfix-save-data-extension",
+  "changed_test_paths": [
+    "frontend/src/components/BottomPanel.parts/LogViewer.test.tsx",
+    "frontend/src/components/nodes/__tests__/BlockNode/ports.test.tsx",
+    "frontend/src/store/executionSlice.parts/eventReducer.test.ts",
+    "tests/api/test_blocks.py",
+    "tests/blocks/io/test_load_data.py",
+    "tests/blocks/io/test_save_data.py",
+    "packages/scistudio-blocks-imaging/tests/test_save_image.py"
+  ],
+  "check_results": [
+    {
+      "command_or_tool": "PYTHONPATH=src:packages/scistudio-blocks-imaging/src:packages/scistudio-blocks-lcms/src python -m ruff check <changed python files>",
+      "exit_code": 0,
+      "name": "python-ruff-targeted",
+      "output_path": "All checks passed",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "PYTHONPATH=src:packages/scistudio-blocks-imaging/src:packages/scistudio-blocks-lcms/src python -m ruff format --check <changed python files>",
+      "exit_code": 0,
+      "name": "python-format-targeted",
+      "output_path": "13 files already formatted",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "PYTHONPATH=src:packages/scistudio-blocks-lcms/src python -m pytest -o addopts='' tests/blocks/io/test_save_data.py tests/blocks/io/test_load_data.py tests/api/test_blocks.py -q",
+      "exit_code": 0,
+      "name": "pytest-core-io-api",
+      "output_path": "176 passed in 4.64s",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "PYTHONPATH=src:packages/scistudio-blocks-imaging/src:packages/scistudio-blocks-lcms/src python -m pytest -o addopts='' packages/scistudio-blocks-imaging/tests/test_save_image.py -q",
+      "exit_code": 0,
+      "name": "pytest-imaging-save-image",
+      "output_path": "26 passed in 1.52s",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "Combined root tests and package tests in one pytest process",
+      "exit_code": 0,
+      "name": "pytest-combined-layout-note",
+      "output_path": "Skipped: pytest import mismatch from duplicate tests.conftest package names; equivalent suites run separately and passed",
+      "status": "skipped",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "cd frontend && npx prettier --check <changed frontend files>",
+      "exit_code": 0,
+      "name": "frontend-prettier-targeted",
+      "output_path": "All matched files use Prettier code style",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "cd frontend && npx eslint <changed frontend files>",
+      "exit_code": 0,
+      "name": "frontend-eslint-targeted",
+      "output_path": "No problems",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "cd frontend && npm run test -- --run <targeted frontend tests>",
+      "exit_code": 0,
+      "name": "frontend-vitest-targeted",
+      "output_path": "7 files passed, 53 tests passed; existing jsdom active-context URL warnings",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "cd frontend && npm run typecheck",
+      "exit_code": 0,
+      "name": "frontend-typecheck",
+      "output_path": "tsc --noEmit passed",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    },
+    {
+      "command_or_tool": "cd frontend && npm run build",
+      "exit_code": 0,
+      "name": "frontend-build",
+      "output_path": "vite build passed with existing large chunk warning",
+      "status": "pass",
+      "summary": {},
+      "timestamp": null
+    }
+  ],
+  "commit": null,
+  "docs_landing": {
+    "adr": {
+      "not_applicable": true,
+      "rationale": "No new architectural decision; implementation restores already accepted ADR behavior"
+    },
+    "changelog": {
+      "not_applicable": true,
+      "rationale": "No product changelog maintained for owner-guided hotfix branch"
+    },
+    "checklist": {
+      "not_applicable": true,
+      "rationale": "Issue #1505 and gate record carry the hotfix checklist-equivalent scope"
+    },
+    "docs": {
+      "not_applicable": true,
+      "rationale": "Owner-guided hotfix completes existing ADR-043/ADR-028 behavior and fixes regressions without changing public docs contracts"
+    },
+    "spec": {
+      "not_applicable": true,
+      "rationale": "No new contract beyond existing ADR-043 capability registry and ADR-028 dynamic-port intent"
+    }
+  },
+  "full_audit": {
+    "blocks_merge": true,
+    "command": "PYTHONPATH=src python -m scistudio.qa.audit.full_audit --repo-root . --format json --output docs/audit/full-audit-latest.json",
+    "exit_code": 0,
+    "known_debt": [],
+    "output_path": "docs/audit/full-audit-latest.json",
+    "status": "pass",
+    "summary": {},
+    "unclassified_failures": []
+  },
+  "governance_touch": false,
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1505,
+      "url": "https://github.com/zjzcpj/SciStudio/issues/1505"
+    }
+  ],
+  "owner_directive": "Owner-guided hotfix batch for SaveData folder/filename/collection/overwrite/error UX, LoadData preview filenames and dynamic ports, and unified IO package capability delegation; submit PR.",
+  "persona": "manager",
+  "planned_files": [
+    "frontend/src/App.parts/useWorkflowExecutionActions.ts",
+    "frontend/src/App.tsx",
+    "frontend/src/components/BottomPanel.parts/ConfigPanel.tsx",
+    "frontend/src/components/BottomPanel.parts/LogViewer.tsx",
+    "frontend/src/components/BottomPanel.parts/LogViewer.test.tsx",
+    "frontend/src/components/nodes/BlockNode.tsx",
+    "frontend/src/components/nodes/__tests__/BlockNode/ports.test.tsx",
+    "frontend/src/lib/api/filesystem.ts",
+    "frontend/src/lib/api/workflows.ts",
+    "frontend/src/store/executionSlice.parts/eventReducer.ts",
+    "frontend/src/store/executionSlice.parts/eventReducer.test.ts",
+    "frontend/src/types/api.ts",
+    "packages/scistudio-blocks-imaging/tests/test_save_image.py",
+    "src/scistudio/api/routes/blocks.py",
+    "src/scistudio/api/routes/filesystem.py",
+    "src/scistudio/api/routes/workflows.py",
+    "src/scistudio/api/runtime/_runs.py",
+    "src/scistudio/api/schemas.py",
+    "src/scistudio/blocks/io/_unified_dispatch.py",
+    "src/scistudio/blocks/io/loaders/load_data.py",
+    "src/scistudio/blocks/io/savers/_capability.py",
+    "src/scistudio/blocks/io/savers/save_data.py",
+    "tests/api/test_blocks.py",
+    "tests/blocks/io/test_load_data.py",
+    "tests/blocks/io/test_save_data.py"
+  ],
+  "pull_request": null,
+  "record_path": ".workflow/records/1505-hotfix-save-data-extension.json",
+  "required_checks": [
+    "python-ruff-targeted",
+    "pytest-io-api",
+    "frontend-vitest-targeted",
+    "frontend-typecheck",
+    "frontend-eslint-targeted",
+    "frontend-prettier-targeted",
+    "frontend-build",
+    "full-audit",
+    "sentrux",
+    "gate-pre-commit",
+    "gate-receipt"
+  ],
+  "schema_version": "1",
+  "scope": {
+    "exclude": [
+      ".tmp-*"
+    ],
+    "include": [
+      "frontend/src/**",
+      "src/scistudio/api/**",
+      "src/scistudio/blocks/io/**",
+      "packages/scistudio-blocks-imaging/tests/test_save_image.py",
+      "tests/api/**",
+      "tests/blocks/io/**",
+      ".workflow/records/1505-hotfix-save-data-extension.json"
+    ]
+  },
+  "sentrux": {
+    "command_or_tool": "sentrux check .",
+    "mode": "free-tier",
+    "name": "sentrux.free_tier",
+    "output_path": "Sentrux CLI/MCP not available in this environment; CI remains authoritative",
+    "pro_required": false,
+    "quality_signal": null,
+    "rules_checked": null,
+    "status": "skipped",
+    "summary": {},
+    "thresholds": {},
+    "total_rules_defined": null
+  },
+  "stages": [
+    {
+      "completed_at": null,
+      "stage": "scope_and_issue",
+      "status": "done",
+      "summary": null
+    },
+    {
+      "completed_at": null,
+      "stage": "plan",
+      "status": "done",
+      "summary": null
+    },
+    {
+      "completed_at": null,
+      "stage": "implement",
+      "status": "done",
+      "summary": null
+    },
+    {
+      "completed_at": null,
+      "stage": "update_docs",
+      "status": "done",
+      "summary": null
+    },
+    {
+      "completed_at": null,
+      "stage": "test_and_checks",
+      "status": "done",
+      "summary": null
+    },
+    {
+      "completed_at": null,
+      "stage": "commit_and_submit_pr",
+      "status": "pending",
+      "summary": null
+    }
+  ],
+  "task_id": "1505-hotfix-save-data-extension",
+  "task_kind": "hotfix"
+}

--- a/.workflow/records/1505-hotfix-save-data-extension.json
+++ b/.workflow/records/1505-hotfix-save-data-extension.json
@@ -103,7 +103,13 @@
       "timestamp": null
     }
   ],
-  "commit": null,
+  "commit": {
+    "gate_record_path": ".workflow/records/1505-hotfix-save-data-extension.json",
+    "shas": [
+      "5e93937f"
+    ],
+    "trailers": {}
+  },
   "docs_landing": {
     "adr": {
       "not_applicable": true,
@@ -174,7 +180,13 @@
     "tests/blocks/io/test_load_data.py",
     "tests/blocks/io/test_save_data.py"
   ],
-  "pull_request": null,
+  "pull_request": {
+    "body_closes_issues": [
+      1505
+    ],
+    "number": 1506,
+    "url": "https://github.com/zjzcpj/SciStudio/pull/1506"
+  },
   "record_path": ".workflow/records/1505-hotfix-save-data-extension.json",
   "required_checks": [
     "python-ruff-targeted",
@@ -251,7 +263,7 @@
     {
       "completed_at": null,
       "stage": "commit_and_submit_pr",
-      "status": "pending",
+      "status": "done",
       "summary": null
     }
   ],

--- a/frontend/src/App.parts/useWorkflowExecutionActions.ts
+++ b/frontend/src/App.parts/useWorkflowExecutionActions.ts
@@ -9,7 +9,12 @@
 import { useCallback } from "react";
 
 import { api } from "../lib/api";
-import type { ProjectResponse } from "../types/api";
+import type {
+  BlockSchemaResponse,
+  FormatCapabilityResponse,
+  ProjectResponse,
+  WorkflowNode,
+} from "../types/api";
 
 export interface WorkflowExecutionDeps {
   currentProject: ProjectResponse | null;
@@ -18,6 +23,8 @@ export interface WorkflowExecutionDeps {
   saveWorkflow: () => Promise<void>;
   setLastError: (message: string | null) => void;
   workflowPayloadId: string;
+  workflowNodes?: WorkflowNode[];
+  blockSchemas?: Record<string, BlockSchemaResponse>;
 }
 
 export interface WorkflowExecutionActions {
@@ -38,6 +45,96 @@ function surfaceExecutionError(
   window.setTimeout(() => setLastError(message), 0);
 }
 
+function pathJoin(dir: string, name: string): string {
+  const sep = dir.includes("\\") ? "\\" : "/";
+  return `${dir.replace(/[\\/]+$/, "")}${sep}${name}`;
+}
+
+function pathHasExtension(path: string): boolean {
+  const name =
+    path
+      .replace(/[\\/]+$/, "")
+      .split(/[\\/]/)
+      .pop() ?? "";
+  return /\.[^./\\]+$/.test(name);
+}
+
+function capabilityForNode(
+  node: WorkflowNode,
+  schema: BlockSchemaResponse | undefined,
+): FormatCapabilityResponse | undefined {
+  const params = (node.config.params as Record<string, unknown> | undefined) ?? {};
+  const selectedType =
+    typeof params.core_type === "string"
+      ? params.core_type
+      : typeof schema?.config_schema.properties?.core_type?.default === "string"
+        ? schema.config_schema.properties.core_type.default
+        : "";
+  const capabilities = (schema?.format_capabilities ?? []).filter(
+    (capability) => capability.direction === "save" && capability.data_type === selectedType,
+  );
+  const capabilityId = params.capability_id;
+  if (typeof capabilityId === "string") {
+    const selected = capabilities.find((capability) => capability.id === capabilityId);
+    if (selected) return selected;
+  }
+  return capabilities.find((capability) => capability.is_default) ?? capabilities[0];
+}
+
+function filenameForNode(
+  node: WorkflowNode,
+  schema: BlockSchemaResponse | undefined,
+): string | null {
+  const params = (node.config.params as Record<string, unknown> | undefined) ?? {};
+  const capability = capabilityForNode(node, schema);
+  const extension = capability?.extensions[0] ?? "";
+  const coreType =
+    typeof params.core_type === "string"
+      ? params.core_type
+      : typeof schema?.config_schema.properties?.core_type?.default === "string"
+        ? schema.config_schema.properties.core_type.default
+        : "data";
+  const raw =
+    typeof params.filename === "string" && params.filename.trim() ? params.filename.trim() : "";
+  const base = raw ? raw.split(/[\\/]/).pop() || raw : `${coreType.toLowerCase()}${extension}`;
+  if (!extension || pathHasExtension(base)) return base;
+  return `${base}${extension}`;
+}
+
+async function confirmOverwriteNodes(
+  nodes: WorkflowNode[],
+  schemas: Record<string, BlockSchemaResponse>,
+): Promise<string[]> {
+  const hits: Array<{ nodeId: string; path: string }> = [];
+  for (const node of nodes) {
+    if (node.block_type !== "save_data") continue;
+    const params = (node.config.params as Record<string, unknown> | undefined) ?? {};
+    if (params.overwrite === true || typeof params.path !== "string" || !params.path.trim())
+      continue;
+    const schema = schemas[node.block_type];
+    const pathStat = await api.statFilesystem(params.path).catch(() => null);
+    let target = params.path;
+    if (pathStat?.exists && pathStat.type === "directory") {
+      const filename = filenameForNode(node, schema);
+      if (!filename) continue;
+      target = pathJoin(params.path, filename);
+    } else if (!pathHasExtension(target)) {
+      const capability = capabilityForNode(node, schema);
+      const extension = capability?.extensions[0] ?? "";
+      if (extension) target = `${target}${extension}`;
+    }
+    const targetStat = await api.statFilesystem(target).catch(() => null);
+    if (targetStat?.exists) hits.push({ nodeId: node.id, path: target });
+  }
+  if (hits.length === 0) return [];
+  const message = [
+    "The following Save outputs already exist. Overwrite them?",
+    "",
+    ...hits.map((hit) => hit.path),
+  ].join("\n");
+  return window.confirm(message) ? hits.map((hit) => hit.nodeId) : ["__cancel__"];
+}
+
 export function useWorkflowExecutionActions(deps: WorkflowExecutionDeps): WorkflowExecutionActions {
   const {
     currentProject,
@@ -46,19 +143,23 @@ export function useWorkflowExecutionActions(deps: WorkflowExecutionDeps): Workfl
     saveWorkflow,
     setLastError,
     workflowPayloadId,
+    workflowNodes = [],
+    blockSchemas = {},
   } = deps;
 
   const runWorkflow = useCallback(async () => {
     if (!currentProject) return;
     try {
       await saveWorkflow();
-      await api.executeWorkflow(workflowPayloadId);
+      const overwriteNodeIds = await confirmOverwriteNodes(workflowNodes, blockSchemas);
+      if (overwriteNodeIds.includes("__cancel__")) return;
+      await api.executeWorkflow(workflowPayloadId, { overwriteNodeIds });
       setLastError(null);
       // #793: do NOT auto-switch to the Logs tab.
     } catch (error) {
       surfaceExecutionError(setLastError, error);
     }
-  }, [currentProject, saveWorkflow, setLastError, workflowPayloadId]);
+  }, [blockSchemas, currentProject, saveWorkflow, setLastError, workflowNodes, workflowPayloadId]);
 
   const pauseWorkflow = useCallback(async () => {
     if (!workflowId) return;
@@ -79,25 +180,29 @@ export function useWorkflowExecutionActions(deps: WorkflowExecutionDeps): Workfl
     if (!workflowId || !selectedNodeId) return;
     try {
       await saveWorkflow();
-      await api.executeFrom(workflowId, selectedNodeId);
+      const overwriteNodeIds = await confirmOverwriteNodes(workflowNodes, blockSchemas);
+      if (overwriteNodeIds.includes("__cancel__")) return;
+      await api.executeFrom(workflowId, selectedNodeId, { overwriteNodeIds });
       setLastError(null);
     } catch (error) {
       surfaceExecutionError(setLastError, error);
     }
-  }, [saveWorkflow, selectedNodeId, setLastError, workflowId]);
+  }, [blockSchemas, saveWorkflow, selectedNodeId, setLastError, workflowId, workflowNodes]);
 
   const handleRunBlock = useCallback(
     async (blockId: string) => {
       if (!workflowId) return;
       try {
         await saveWorkflow();
-        await api.executeFrom(workflowId, blockId);
+        const overwriteNodeIds = await confirmOverwriteNodes(workflowNodes, blockSchemas);
+        if (overwriteNodeIds.includes("__cancel__")) return;
+        await api.executeFrom(workflowId, blockId, { overwriteNodeIds });
         setLastError(null);
       } catch (error) {
         surfaceExecutionError(setLastError, error);
       }
     },
-    [saveWorkflow, setLastError, workflowId],
+    [blockSchemas, saveWorkflow, setLastError, workflowId, workflowNodes],
   );
 
   const handleRestartBlock = useCallback(
@@ -105,13 +210,15 @@ export function useWorkflowExecutionActions(deps: WorkflowExecutionDeps): Workfl
       if (!workflowId) return;
       try {
         await saveWorkflow();
-        await api.executeFrom(workflowId, blockId);
+        const overwriteNodeIds = await confirmOverwriteNodes(workflowNodes, blockSchemas);
+        if (overwriteNodeIds.includes("__cancel__")) return;
+        await api.executeFrom(workflowId, blockId, { overwriteNodeIds });
         setLastError(null);
       } catch (error) {
         surfaceExecutionError(setLastError, error);
       }
     },
-    [saveWorkflow, setLastError, workflowId],
+    [blockSchemas, saveWorkflow, setLastError, workflowId, workflowNodes],
   );
 
   return {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -268,6 +268,8 @@ export default function App() {
     saveWorkflow,
     setLastError,
     workflowPayloadId: workflowPayload.id,
+    workflowNodes,
+    blockSchemas,
   });
 
   // Canvas / toolbar handlers (palette add, edge connect, view source, save).

--- a/frontend/src/components/BottomPanel.parts/ConfigPanel.tsx
+++ b/frontend/src/components/BottomPanel.parts/ConfigPanel.tsx
@@ -151,9 +151,23 @@ function ScalarField({
   currentValue: unknown;
   onUpdateConfig: (patch: Record<string, unknown>) => void;
 }) {
+  const [browseOpen, setBrowseOpen] = useState(false);
+  if (field.type === "boolean") {
+    return (
+      <label className="flex items-center gap-3 text-sm" key={fieldKey}>
+        <input
+          checked={Boolean(currentValue)}
+          className="h-4 w-4 rounded border-stone-300"
+          onChange={(event) => onUpdateConfig({ [fieldKey]: event.target.checked })}
+          type="checkbox"
+        />
+        <span className="font-medium text-ink">{String(field.title ?? fieldKey)}</span>
+      </label>
+    );
+  }
+
   const uiWidget = field.ui_widget as string | undefined;
   const browseMode = browseModeFor(uiWidget);
-  const [browseOpen, setBrowseOpen] = useState(false);
   const applySelectedPath = (paths: string[]) => {
     if (paths.length === 0) return;
     const supportsArray = Array.isArray(field.type)

--- a/frontend/src/components/BottomPanel.parts/LogViewer.test.tsx
+++ b/frontend/src/components/BottomPanel.parts/LogViewer.test.tsx
@@ -1,0 +1,34 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { LogEntry } from "../../types/api";
+import { LogViewer } from "./LogViewer";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("LogViewer", () => {
+  it("shows a concise error message with expandable traceback details", () => {
+    const entries: LogEntry[] = [
+      {
+        timestamp: "2026-05-26T00:00:00Z",
+        level: "error",
+        message: "Choose a new output path.",
+        details: [
+          "Traceback (most recent call last):",
+          '  File "worker.py", line 1, in main',
+          "ValueError: Choose a new output path.",
+        ].join("\n"),
+        workflow_id: "wf-1",
+        block_id: "save-1",
+      },
+    ];
+
+    render(<LogViewer entries={entries} />);
+
+    expect(screen.getByText("Choose a new output path.")).toBeInTheDocument();
+    expect(screen.getByText("Show traceback")).toBeInTheDocument();
+    expect(screen.getByText(/Traceback/)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/BottomPanel.parts/LogViewer.tsx
+++ b/frontend/src/components/BottomPanel.parts/LogViewer.tsx
@@ -23,15 +23,31 @@ export function LogViewer({ entries }: { entries: LogEntry[] }) {
       </div>
       <div className="flex-1 overflow-auto rounded-[1.4rem] border border-stone-200 bg-stone-950 p-4">
         {filtered.length ? (
-          filtered.map((entry, index) => (
+          filtered.map((entry) => (
             <div
               className="border-b border-stone-800 py-2 text-sm text-stone-100"
-              key={`${entry.timestamp}-${index}`}
+              key={[
+                entry.timestamp,
+                entry.level,
+                entry.workflow_id ?? "workflow",
+                entry.block_id ?? "system",
+                entry.message,
+              ].join("|")}
             >
               <p className="text-[11px] uppercase tracking-[0.3em] text-stone-500">
                 {entry.level} · {entry.workflow_id ?? "workflow"} · {entry.block_id ?? "system"}
               </p>
-              <p className="mt-1">{entry.message}</p>
+              <p className="mt-1 break-words">{entry.message}</p>
+              {entry.details && entry.details !== entry.message ? (
+                <details className="mt-2">
+                  <summary className="cursor-pointer text-xs font-medium text-stone-400 hover:text-stone-200">
+                    Show traceback
+                  </summary>
+                  <pre className="mt-2 max-h-80 overflow-auto whitespace-pre-wrap rounded border border-stone-800 bg-stone-900 p-3 text-xs leading-5 text-stone-300">
+                    {entry.details}
+                  </pre>
+                </details>
+              ) : null}
             </div>
           ))
         ) : (

--- a/frontend/src/components/nodes/BlockNode.tsx
+++ b/frontend/src/components/nodes/BlockNode.tsx
@@ -88,6 +88,18 @@ function coreTypeFromConfig(
   return null;
 }
 
+function dynamicPortConfigValue(
+  configProps: ReturnType<typeof getTopConfigProperties>,
+  config: BlockNodeData["config"],
+  sourceConfigKey: string | undefined,
+): string | undefined {
+  if (sourceConfigKey == null) return undefined;
+  const configured = config?.[sourceConfigKey];
+  if (typeof configured === "string" && configured) return configured;
+  const schemaDefault = configProps.find((prop) => prop.key === sourceConfigKey)?.schema.default;
+  return typeof schemaDefault === "string" && schemaDefault ? schemaDefault : undefined;
+}
+
 export function BlockNode({ id: nodeId, data, selected }: NodeProps<Node<BlockNodeData>>) {
   // ADR-028 Addendum 1 §B fix #2 / §C11: hide the ``direction`` config
   // field for any IO block (not just the legacy abstract-base type_name).
@@ -125,8 +137,7 @@ export function BlockNode({ id: nodeId, data, selected }: NodeProps<Node<BlockNo
   // user changes the dropdown.
   const dynamicPorts = data.schema?.dynamic_ports ?? null;
   const sourceConfigKey = dynamicPorts?.source_config_key;
-  const drivingConfigValue =
-    sourceConfigKey != null ? (data.config?.[sourceConfigKey] as string | undefined) : undefined;
+  const drivingConfigValue = dynamicPortConfigValue(configProps, data.config, sourceConfigKey);
   const effectiveInputPorts = computeEffectivePorts(
     dynamicPorts,
     drivingConfigValue,

--- a/frontend/src/components/nodes/__tests__/BlockNode/ports.test.tsx
+++ b/frontend/src/components/nodes/__tests__/BlockNode/ports.test.tsx
@@ -117,24 +117,24 @@ describe("BlockNode — dynamic port live-update (ADR-028 Addendum 1 §D4)", () 
     expect(titles.some((t) => t.includes("DataObject"))).toBe(false);
   });
 
-  it("falls back to the placeholder type when core_type is unset", () => {
-    // Static block path: no core_type in config means no override applies.
+  it("uses the schema default dynamic type when core_type is unset", () => {
     const { container } = renderNode({
       category: "io",
       blockType: "load_data",
-      config: {}, // no core_type
+      config: {},
       outputPorts: [makePort("data", "output", ["DataObject"])],
       schema: makeSchema({
         base_category: "io",
         direction: "input",
         output_ports: [makePort("data", "output", ["DataObject"])],
         dynamic_ports: LOAD_DATA_DYNAMIC,
+        config_schema: LOAD_DATA_CONFIG_SCHEMA,
       }),
     });
     const handles = container.querySelectorAll('[data-handleid="data"]');
     const titles = Array.from(handles).map((h) => h.getAttribute("title") ?? "");
-    // Title format changed in #445: now shows primary type name, not "portName: typeList"
-    expect(titles.some((t) => t.includes("DataObject"))).toBe(true);
+    expect(titles.some((t) => t.includes("DataFrame"))).toBe(true);
+    expect(titles.some((t) => t.includes("DataObject"))).toBe(false);
   });
 
   it("renders the SaveData input port with accepted_types=['Series'] when core_type=Series", () => {

--- a/frontend/src/lib/api/filesystem.ts
+++ b/frontend/src/lib/api/filesystem.ts
@@ -4,12 +4,14 @@
  * Extracted from `frontend/src/lib/api.ts` (#1422).
  */
 
-import type { FilesystemBrowseResponse } from "../../types/api";
+import type { FilesystemBrowseResponse, FilesystemStatResponse } from "../../types/api";
 import { apiFetch, JSON_HEADERS } from "./core";
 
 export const filesystemApi = {
   browseFilesystem: (path: string) =>
     apiFetch<FilesystemBrowseResponse>(`/api/filesystem/browse?path=${encodeURIComponent(path)}`),
+  statFilesystem: (path: string) =>
+    apiFetch<FilesystemStatResponse>(`/api/filesystem/stat?path=${encodeURIComponent(path)}`),
   revealInExplorer: (path: string) =>
     apiFetch<{ status: string }>("/api/filesystem/reveal", {
       method: "POST",

--- a/frontend/src/lib/api/workflows.ts
+++ b/frontend/src/lib/api/workflows.ts
@@ -8,6 +8,7 @@
 import type {
   CancelPropagationResponse,
   ExecuteFromResponse,
+  WorkflowExecutionOptions,
   WorkflowExecutionResponse,
   WorkflowResponse,
 } from "../../types/api";
@@ -75,11 +76,17 @@ export const workflowsApi = {
     apiFetch<void>(`/api/workflows/${encodeURIComponent(workflowId)}`, {
       method: "DELETE",
     }),
-  executeWorkflow: (workflowId: string) =>
+  executeWorkflow: (workflowId: string, options?: WorkflowExecutionOptions) =>
     apiFetch<WorkflowExecutionResponse>(
       `/api/workflows/${encodeURIComponent(workflowId)}/execute`,
       {
         method: "POST",
+        ...(options?.overwriteNodeIds?.length
+          ? {
+              headers: JSON_HEADERS,
+              body: JSON.stringify({ overwrite_node_ids: options.overwriteNodeIds }),
+            }
+          : {}),
       },
     ),
   pauseWorkflow: (workflowId: string) =>
@@ -99,11 +106,14 @@ export const workflowsApi = {
       `/api/workflows/${encodeURIComponent(workflowId)}/blocks/${encodeURIComponent(blockId)}/cancel`,
       { method: "POST" },
     ),
-  executeFrom: (workflowId: string, blockId: string) =>
+  executeFrom: (workflowId: string, blockId: string, options?: WorkflowExecutionOptions) =>
     apiFetch<ExecuteFromResponse>(`/api/workflows/${encodeURIComponent(workflowId)}/execute-from`, {
       method: "POST",
       headers: JSON_HEADERS,
-      body: JSON.stringify({ block_id: blockId }),
+      body: JSON.stringify({
+        block_id: blockId,
+        overwrite_node_ids: options?.overwriteNodeIds ?? [],
+      }),
     }),
   exportWorkflowToPath: (workflowId: string, path: string) =>
     apiFetch<{ status: string; path: string }>("/api/workflows/export-path", {

--- a/frontend/src/store/executionSlice.parts/eventReducer.test.ts
+++ b/frontend/src/store/executionSlice.parts/eventReducer.test.ts
@@ -13,6 +13,7 @@ import {
   nextBlockStates,
   nextErrorMaps,
   nextIsRunning,
+  summarizeErrorText,
 } from "./eventReducer";
 
 function makeEvent(overrides: Partial<WorkflowEventMessage> = {}): WorkflowEventMessage {
@@ -47,11 +48,35 @@ describe("eventReducer helpers", () => {
       expect(result.summaryText).toBe("short");
     });
 
+    it("derives a one-line summary from a traceback when no summary is provided", () => {
+      const traceback = [
+        "Traceback (most recent call last):",
+        '  File "worker.py", line 1, in main',
+        "ValueError: SaveData cannot infer an output filename.",
+      ].join("\n");
+      const result = extractBlockError(
+        makeEvent({
+          type: "block_error",
+          data: { error: traceback },
+        }),
+      );
+      expect(result.errorText).toBe(traceback);
+      expect(result.summaryText).toBe("SaveData cannot infer an output filename.");
+    });
+
     it("returns isBlockError=false when block_id missing", () => {
       const result = extractBlockError(
         makeEvent({ type: "block_error", block_id: null, data: { error: "x" } }),
       );
       expect(result.isBlockError).toBe(false);
+    });
+  });
+
+  describe("summarizeErrorText", () => {
+    it("keeps the final exception message concise", () => {
+      expect(summarizeErrorText("Traceback\nRuntimeError: Something failed")).toBe(
+        "Something failed",
+      );
     });
   });
 
@@ -131,7 +156,7 @@ describe("eventReducer helpers", () => {
     it("appends a structured log row for block_error", () => {
       const result = maybeAppendErrorLog(
         makeEvent({ type: "block_error" }),
-        { isBlockError: true, errorText: "boom", summaryText: undefined },
+        { isBlockError: true, errorText: "RuntimeError: boom", summaryText: "boom" },
         [],
       );
       expect(result.appended).toBe(true);
@@ -139,7 +164,24 @@ describe("eventReducer helpers", () => {
       expect(result.logEntries[0]).toMatchObject({
         level: "error",
         message: "boom",
+        details: "RuntimeError: boom",
         block_id: "block-1",
+      });
+    });
+    it("stores the full traceback as expandable log details", () => {
+      const traceback = [
+        "Traceback (most recent call last):",
+        '  File "worker.py", line 1, in main',
+        "ValueError: Choose a new output path.",
+      ].join("\n");
+      const result = maybeAppendErrorLog(
+        makeEvent({ type: "block_error" }),
+        { isBlockError: true, errorText: traceback, summaryText: "Choose a new output path." },
+        [],
+      );
+      expect(result.logEntries[0]).toMatchObject({
+        message: "Choose a new output path.",
+        details: traceback,
       });
     });
     it("caps at 400 entries", () => {
@@ -150,7 +192,7 @@ describe("eventReducer helpers", () => {
       })) as LogEntry[];
       const result = maybeAppendErrorLog(
         makeEvent({ type: "block_error" }),
-        { isBlockError: true, errorText: "new", summaryText: undefined },
+        { isBlockError: true, errorText: "new", summaryText: "new" },
         fill,
       );
       expect(result.logEntries).toHaveLength(400);

--- a/frontend/src/store/executionSlice.parts/eventReducer.ts
+++ b/frontend/src/store/executionSlice.parts/eventReducer.ts
@@ -8,11 +8,27 @@
 import type { LogEntry, WorkflowEventMessage } from "../../types/api";
 
 type ExecutionEvent = WorkflowEventMessage;
+const MAX_ERROR_SUMMARY_LEN = 160;
+const PYTHON_EXCEPTION_PREFIX = /^[A-Za-z_][A-Za-z0-9_.]*(?:Error|Exception|Warning):\s*/;
 
 export interface BlockErrorExtraction {
   isBlockError: boolean;
   errorText: string | undefined;
   summaryText: string | undefined;
+}
+
+export function summarizeErrorText(errorText: string | undefined): string | undefined {
+  if (errorText === undefined) return undefined;
+  const lines = errorText
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+  const lastLine = lines[lines.length - 1] ?? errorText.trim();
+  const cleaned = lastLine.replace(PYTHON_EXCEPTION_PREFIX, "").replace(/\s+/g, " ").trim();
+  const summary = cleaned || "Block failed.";
+  return summary.length > MAX_ERROR_SUMMARY_LEN
+    ? `${summary.slice(0, MAX_ERROR_SUMMARY_LEN - 1)}…`
+    : summary;
 }
 
 /** Detect a block_error event and pull out the error/summary strings. */
@@ -23,8 +39,9 @@ export function extractBlockError(event: ExecutionEvent): BlockErrorExtraction {
     return { isBlockError: false, errorText: undefined, summaryText: undefined };
   }
   const errorText = typeof event.data.error === "string" ? event.data.error : undefined;
-  const summaryText =
-    typeof event.data.error_summary === "string" ? event.data.error_summary : undefined;
+  const rawSummary =
+    typeof event.data.error_summary === "string" ? event.data.error_summary : errorText;
+  const summaryText = summarizeErrorText(rawSummary);
   return { isBlockError, errorText, summaryText };
 }
 
@@ -96,14 +113,15 @@ export function maybeAppendErrorLog(
   extraction: BlockErrorExtraction,
   current: LogEntry[],
 ): { logEntries: LogEntry[]; appended: boolean } {
-  const { isBlockError, errorText } = extraction;
-  if (!isBlockError || errorText === undefined) {
+  const { isBlockError, errorText, summaryText } = extraction;
+  if (!isBlockError || (errorText === undefined && summaryText === undefined)) {
     return { logEntries: current, appended: false };
   }
   const next: LogEntry = {
     timestamp: event.timestamp,
     level: "error",
-    message: errorText,
+    message: summaryText ?? errorText ?? "Block failed.",
+    details: errorText !== undefined && errorText !== summaryText ? errorText : undefined,
     workflow_id: event.workflow_id ?? null,
     block_id: event.block_id ?? null,
   };

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -31,6 +31,10 @@ export interface WorkflowExecutionResponse {
   message: string;
 }
 
+export interface WorkflowExecutionOptions {
+  overwriteNodeIds?: string[];
+}
+
 export interface ExecuteFromResponse extends WorkflowExecutionResponse {
   reused_blocks: string[];
   reset_blocks: string[];
@@ -255,6 +259,7 @@ export interface LogEntry {
   timestamp: string;
   level: string;
   message: string;
+  details?: string | null;
   workflow_id?: string | null;
   block_id?: string | null;
 }
@@ -268,6 +273,13 @@ export interface FilesystemEntry {
 export interface FilesystemBrowseResponse {
   path: string;
   entries: FilesystemEntry[];
+}
+
+export interface FilesystemStatResponse {
+  path: string;
+  exists: boolean;
+  type?: "file" | "directory" | null;
+  size?: number | null;
 }
 
 export interface TreeEntry {

--- a/packages/scistudio-blocks-imaging/tests/test_save_image.py
+++ b/packages/scistudio-blocks-imaging/tests/test_save_image.py
@@ -12,6 +12,7 @@ from scistudio_blocks_imaging.io.save_image import SaveImage
 from scistudio_blocks_imaging.types import Image
 
 from scistudio.blocks.base.config import BlockConfig
+from scistudio.blocks.io.savers import SaveData
 from scistudio.core.types.collection import Collection
 
 
@@ -51,6 +52,49 @@ def test_save_single_image_to_tiff(tmp_path: Path) -> None:
     assert np.array_equal(back, arr)
 
 
+def test_unified_save_data_proxy_writes_image_to_directory(tmp_path: Path) -> None:
+    arr = np.arange(12, dtype=np.uint16).reshape(3, 4)
+    img = _make_image(arr, ["y", "x"])
+    block = SaveData(
+        config={
+            "params": {
+                "core_type": "Image",
+                "path": str(tmp_path),
+                "capability_id": "scistudio-blocks-imaging.image.tiff.save",
+                "filename": "image",
+            }
+        }
+    )
+
+    block.save(img, block.config)
+
+    out_path = tmp_path / "image.tif"
+    assert out_path.is_file()
+    assert block.config.get("path") == str(out_path)
+
+
+def test_unified_save_data_proxy_refuses_existing_image_file(tmp_path: Path) -> None:
+    arr = np.arange(12, dtype=np.uint16).reshape(3, 4)
+    img = _make_image(arr, ["y", "x"])
+    out_path = tmp_path / "image.tif"
+    out_path.write_bytes(b"existing")
+    block = SaveData(
+        config={
+            "params": {
+                "core_type": "Image",
+                "path": str(tmp_path),
+                "capability_id": "scistudio-blocks-imaging.image.tiff.save",
+                "filename": "image",
+            }
+        }
+    )
+
+    with pytest.raises(ValueError, match="refuses to overwrite existing output"):
+        block.save(img, block.config)
+
+    assert out_path.read_bytes() == b"existing"
+
+
 def test_save_collection_tiff_round_trip_preserves_data_and_axes(
     tmp_path: Path,
 ) -> None:
@@ -66,8 +110,8 @@ def test_save_collection_tiff_round_trip_preserves_data_and_axes(
     out = loaded[0]
     assert out.axes == ["c", "y", "x"]
     assert out.shape == (2, 3, 5)
-    assert out.dtype == np.int16
-    assert np.array_equal(out._data, arr)
+    assert out.dtype == str(np.dtype(np.int16))
+    assert np.array_equal(out.get_in_memory_data(), arr)
 
 
 def test_save_zarr_round_trip(tmp_path: Path) -> None:
@@ -81,7 +125,7 @@ def test_save_zarr_round_trip(tmp_path: Path) -> None:
     loaded = LoadImage().load(BlockConfig(params={"path": str(out_path)}))
     out = loaded[0]
     assert out.axes == ["c", "y", "x"]
-    assert np.array_equal(out._data, arr)
+    assert np.array_equal(out.get_in_memory_data(), arr)
 
 
 def test_save_format_override_forces_tiff(tmp_path: Path) -> None:

--- a/src/scistudio/api/routes/blocks.py
+++ b/src/scistudio/api/routes/blocks.py
@@ -82,7 +82,7 @@ def _config_schema_for_block(spec: Any, registry: Any = None, type_registry: Any
     if "path" in properties:
         properties["path"]["title"] = "Path"
         properties["path"]["ui_priority"] = 0
-        properties["path"]["ui_widget"] = "file_browser"
+        properties["path"]["ui_widget"] = "file_browser" if spec.type_name == "load_data" else "directory_browser"
     merged["required"] = ["path", "core_type"]
     return merged
 

--- a/src/scistudio/api/routes/filesystem.py
+++ b/src/scistudio/api/routes/filesystem.py
@@ -105,6 +105,15 @@ class FilesystemBrowseResponse(BaseModel):
     entries: list[FilesystemEntry]
 
 
+class FilesystemStatResponse(BaseModel):
+    """Response from the filesystem stat endpoint."""
+
+    path: str
+    exists: bool
+    type: str | None = None
+    size: int | None = None
+
+
 # ---------------------------------------------------------------------------
 # Project tree endpoint (scoped to project root)
 # ---------------------------------------------------------------------------
@@ -239,6 +248,28 @@ async def browse_filesystem(
 
     entries = _list_directory(target)
     return FilesystemBrowseResponse(path=str(target), entries=entries)
+
+
+@router.get("/api/filesystem/stat", response_model=FilesystemStatResponse)
+async def stat_filesystem(
+    path: str = Query(..., description="File or directory path to inspect."),
+) -> FilesystemStatResponse:
+    """Return existence and coarse type information for a safe path."""
+
+    try:
+        target = _resolve_safe_path(path)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    if not target.exists():
+        return FilesystemStatResponse(path=str(target), exists=False)
+    kind = "directory" if target.is_dir() else "file"
+    size: int | None = None
+    if target.is_file():
+        try:
+            size = target.stat().st_size
+        except OSError:
+            size = None
+    return FilesystemStatResponse(path=str(target), exists=True, type=kind, size=size)
 
 
 # ---------------------------------------------------------------------------

--- a/src/scistudio/api/routes/workflows.py
+++ b/src/scistudio/api/routes/workflows.py
@@ -20,6 +20,7 @@ from scistudio.api.schemas import (
     CancelPropagationResponse,
     ExecuteFromRequest,
     ExecuteFromResponse,
+    ExecuteWorkflowRequest,
     WorkflowCreate,
     WorkflowEdge,
     WorkflowExecutionResponse,
@@ -455,11 +456,15 @@ async def execute_workflow(
     workflow_id: str,
     runtime: RuntimeDep,
     request: Request,
+    body: ExecuteWorkflowRequest | None = None,
 ) -> WorkflowExecutionResponse:
     """Start execution of a workflow."""
     try:
         _bind_engine_api_url(request)
-        result = runtime.start_workflow(workflow_id)
+        result = runtime.start_workflow(
+            workflow_id,
+            overwrite_node_ids=set(body.overwrite_node_ids) if body is not None else None,
+        )
     except FileNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     return WorkflowExecutionResponse(**result)
@@ -555,6 +560,7 @@ async def execute_from_workflow(
             workflow_id,
             execute_from=body.block_id,
             parent_run_id=parent_run_id,
+            overwrite_node_ids=set(body.overwrite_node_ids),
         )
     except FileNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc

--- a/src/scistudio/api/runtime/_runs.py
+++ b/src/scistudio/api/runtime/_runs.py
@@ -6,6 +6,7 @@ Issue #1430 / umbrella #1427: behavior unchanged.
 from __future__ import annotations
 
 import asyncio
+import copy
 import logging
 from datetime import UTC
 from pathlib import Path
@@ -165,6 +166,7 @@ def start_workflow(
     *,
     execute_from: str | None = None,
     parent_run_id: str | None = None,
+    overwrite_node_ids: set[str] | None = None,
 ) -> dict[str, Any]:
     """Schedule a workflow run.
 
@@ -234,6 +236,13 @@ def start_workflow(
         )
 
     workflow = self.load_workflow(workflow_id)
+    if overwrite_node_ids:
+        workflow = copy.deepcopy(workflow)
+        for node in workflow.nodes:
+            if node.id in overwrite_node_ids:
+                params = node.config.setdefault("params", {})
+                if isinstance(params, dict):
+                    params["overwrite"] = True
     checkpoint_manager = CheckpointManager(self.checkpoint_dir_for(workflow_id))
     checkpoint = checkpoint_manager.load(workflow_id) if execute_from is not None else None
     if execute_from is not None and checkpoint is None:

--- a/src/scistudio/api/schemas.py
+++ b/src/scistudio/api/schemas.py
@@ -54,10 +54,17 @@ class WorkflowExecutionResponse(BaseModel):
     message: str
 
 
+class ExecuteWorkflowRequest(BaseModel):
+    """Request body for workflow execution."""
+
+    overwrite_node_ids: list[str] = Field(default_factory=list)
+
+
 class ExecuteFromRequest(BaseModel):
     """Request body for selective re-run."""
 
     block_id: str
+    overwrite_node_ids: list[str] = Field(default_factory=list)
 
 
 class ExecuteFromResponse(WorkflowExecutionResponse):

--- a/src/scistudio/blocks/io/_unified_dispatch.py
+++ b/src/scistudio/blocks/io/_unified_dispatch.py
@@ -118,32 +118,6 @@ def _default_delegated_filename(data_type: type[DataObject], capability: FormatC
     return f"{data_type.__name__.lower()}{capability.extensions[0]}"
 
 
-def _source_filename(obj: DataObject) -> str | None:
-    raw_file_path = getattr(obj, "file_path", None)
-    if raw_file_path:
-        return Path(str(raw_file_path)).name
-    framework = getattr(obj, "framework", None)
-    source = getattr(framework, "source", "")
-    if isinstance(source, str) and source:
-        return Path(source).name
-    return None
-
-
-def _filename_config(params: dict[str, Any]) -> str | None:
-    raw = params.get("filename")
-    if raw is None:
-        return None
-    if not isinstance(raw, str):
-        raise ValueError(f"SaveData: config['filename'] must be a string or omitted, got {type(raw).__name__}")
-    cleaned = raw.strip()
-    if not cleaned:
-        return None
-    name = Path(cleaned).name
-    if name in {"", ".", ".."}:
-        raise ValueError("SaveData: filename must be a file name, not a directory path.")
-    return name
-
-
 def _filename_with_extension(name: str, capability: FormatCapability) -> str:
     if not capability.extensions:
         return name
@@ -162,6 +136,12 @@ def _delegated_filename(
     data_type: type[DataObject],
     capability: FormatCapability,
 ) -> str:
+    # Reuse the canonical filename helpers from the saver capability module
+    # instead of maintaining near-identical private copies here (ADR-028
+    # Addendum 1 §C9 "prefer existing helpers"; dedups the semantic-dup
+    # clusters that copies of these two functions otherwise create).
+    from scistudio.blocks.io.savers._capability import _filename_config, _source_filename
+
     configured = _filename_config(params)
     if configured is not None:
         return _filename_with_extension(configured, capability)

--- a/src/scistudio/blocks/io/_unified_dispatch.py
+++ b/src/scistudio/blocks/io/_unified_dispatch.py
@@ -108,7 +108,97 @@ def delegate_params(params: dict[str, Any], capability: FormatCapability) -> dic
     delegated = {key: value for key, value in params.items() if key != "core_type"}
     delegated["capability_id"] = capability.id
     delegated["format_id"] = capability.format_id
+    delegated.setdefault("format", capability.format_id)
     return delegated
+
+
+def _default_delegated_filename(data_type: type[DataObject], capability: FormatCapability) -> str | None:
+    if not capability.extensions:
+        return None
+    return f"{data_type.__name__.lower()}{capability.extensions[0]}"
+
+
+def _source_filename(obj: DataObject) -> str | None:
+    raw_file_path = getattr(obj, "file_path", None)
+    if raw_file_path:
+        return Path(str(raw_file_path)).name
+    framework = getattr(obj, "framework", None)
+    source = getattr(framework, "source", "")
+    if isinstance(source, str) and source:
+        return Path(source).name
+    return None
+
+
+def _filename_config(params: dict[str, Any]) -> str | None:
+    raw = params.get("filename")
+    if raw is None:
+        return None
+    if not isinstance(raw, str):
+        raise ValueError(f"SaveData: config['filename'] must be a string or omitted, got {type(raw).__name__}")
+    cleaned = raw.strip()
+    if not cleaned:
+        return None
+    name = Path(cleaned).name
+    if name in {"", ".", ".."}:
+        raise ValueError("SaveData: filename must be a file name, not a directory path.")
+    return name
+
+
+def _filename_with_extension(name: str, capability: FormatCapability) -> str:
+    if not capability.extensions:
+        return name
+    path = Path(name)
+    supported = {extension.lower() for extension in capability.extensions}
+    if path.suffix.lower() in supported:
+        return path.name
+    stem = path.stem if path.suffix else path.name
+    return f"{stem}{capability.extensions[0]}"
+
+
+def _delegated_filename(
+    params: dict[str, Any],
+    *,
+    obj: DataObject,
+    data_type: type[DataObject],
+    capability: FormatCapability,
+) -> str:
+    configured = _filename_config(params)
+    if configured is not None:
+        return _filename_with_extension(configured, capability)
+    source_name = _source_filename(obj)
+    if source_name:
+        return _filename_with_extension(source_name, capability)
+    default = _default_delegated_filename(data_type, capability)
+    if default is not None and not Path(str(params.get("path", ""))).is_dir():
+        return default
+    raise ValueError(
+        "SaveData cannot infer an output filename because the input object has no source filename. "
+        "Set the Save block filename field."
+    )
+
+
+def _resolve_delegated_save_path(
+    params: dict[str, Any],
+    *,
+    obj: DataObject,
+    data_type: type[DataObject],
+    capability: FormatCapability,
+) -> None:
+    raw_path = params.get("path")
+    if not isinstance(raw_path, str) or not raw_path:
+        return
+    path = Path(raw_path)
+    original_path = path
+    if path.is_dir():
+        path = path / _delegated_filename(params, obj=obj, data_type=data_type, capability=capability)
+    elif not path.suffix and capability.extensions:
+        path = path.with_suffix(capability.extensions[0])
+    if path != original_path:
+        params["path"] = str(path)
+    if path.exists() and not bool(params.get("overwrite", False)):
+        raise ValueError(
+            f"SaveData refuses to overwrite existing output {str(path)!r}. Choose an empty folder or a new output path."
+        )
 
 
 def delegate_load(
@@ -145,5 +235,8 @@ def delegate_save(
         raise ValueError(f"Save: selected capability {capability.id!r} did not resolve to a package saver.")
     saver_cls = capability_owner_class(registry, capability)
     params = delegate_params(dict(config.params), capability)
+    _resolve_delegated_save_path(params, obj=obj, data_type=data_type, capability=capability)
+    if params.get("path") != config.params.get("path"):
+        config.params["path"] = params["path"]
     saver = saver_cls(config={"params": params})
     saver.save(obj, BlockConfig(params=params))

--- a/src/scistudio/blocks/io/loaders/load_data.py
+++ b/src/scistudio/blocks/io/loaders/load_data.py
@@ -58,6 +58,7 @@ from scistudio.blocks.io.loaders._helpers import (
     _check_pickle_allowed,
     _resolve_path,
 )
+from scistudio.core.meta.framework import FrameworkMeta
 from scistudio.core.types.array import Array
 from scistudio.core.types.artifact import Artifact
 from scistudio.core.types.base import DataObject
@@ -66,6 +67,12 @@ from scistudio.core.types.composite import CompositeData
 from scistudio.core.types.dataframe import DataFrame
 from scistudio.core.types.series import Series
 from scistudio.core.types.text import Text
+
+
+def _source_framework(path: Path) -> FrameworkMeta:
+    """Return framework metadata that preserves the boundary source path."""
+
+    return FrameworkMeta(source=str(path))
 
 
 class LoadData(IOBlock):
@@ -341,6 +348,7 @@ def _load_array(config: BlockConfig, block: LoadData | None = None) -> Array:
             axes=[f"axis_{i}" for i in range(arr.ndim)],
             shape=tuple(arr.shape),
             dtype=str(arr.dtype),
+            framework=_source_framework(path),
         )
         result._data = arr  # type: ignore[attr-defined]
         return result
@@ -353,6 +361,7 @@ def _load_array(config: BlockConfig, block: LoadData | None = None) -> Array:
             axes=[f"axis_{i}" for i in range(arr.ndim)],
             shape=tuple(arr.shape),
             dtype=str(arr.dtype),
+            framework=_source_framework(path),
         )
         result._data = arr  # type: ignore[attr-defined]
         return result
@@ -369,6 +378,7 @@ def _load_array(config: BlockConfig, block: LoadData | None = None) -> Array:
             axes=[f"axis_{i}" for i in range(arr.ndim)],
             shape=tuple(arr.shape),
             dtype=str(arr.dtype),
+            framework=_source_framework(path),
         )
         result._data = arr  # type: ignore[attr-defined]
         return result
@@ -395,6 +405,7 @@ def _load_array(config: BlockConfig, block: LoadData | None = None) -> Array:
             axes=[f"axis_{i}" for i in range(ndim)],
             shape=shape,
             dtype=dtype,
+            framework=_source_framework(path),
             storage_ref=ref,
         )
 
@@ -412,6 +423,7 @@ def _load_array(config: BlockConfig, block: LoadData | None = None) -> Array:
             axes=[f"axis_{i}" for i in range(arr.ndim)],
             shape=tuple(arr.shape),
             dtype=str(arr.dtype),
+            framework=_source_framework(path),
         )
         result._data = arr  # type: ignore[attr-defined]
         return result
@@ -467,6 +479,7 @@ def _load_dataframe(config: BlockConfig, block: LoadData | None = None) -> DataF
         df = DataFrame(
             columns=list(table.column_names),
             row_count=int(table.num_rows),
+            framework=_source_framework(path),
         )
         df._arrow_table = table  # type: ignore[attr-defined]
         return df
@@ -478,6 +491,7 @@ def _load_dataframe(config: BlockConfig, block: LoadData | None = None) -> DataF
         df = DataFrame(
             columns=list(table.column_names),
             row_count=int(table.num_rows),
+            framework=_source_framework(path),
         )
         df._arrow_table = table  # type: ignore[attr-defined]
         return df
@@ -505,6 +519,7 @@ def _load_dataframe(config: BlockConfig, block: LoadData | None = None) -> DataF
         df = DataFrame(
             columns=list(table.column_names),
             row_count=int(table.num_rows),
+            framework=_source_framework(path),
         )
         df._arrow_table = table  # type: ignore[attr-defined]
         return df
@@ -564,6 +579,7 @@ def _load_series(config: BlockConfig, block: Any = None, output_dir: str = "") -
             index_name=None,
             value_name=df.columns[0],
             length=df.row_count,
+            framework=_source_framework(path),
             storage_ref=storage_ref,
         )
 
@@ -609,6 +625,7 @@ def _load_text(config: BlockConfig, block: LoadData | None = None) -> Text:
         content=content,
         format=_TEXT_FORMAT_MAP[suffix],
         encoding="utf-8",
+        framework=_source_framework(path),
     )
 
 
@@ -632,6 +649,7 @@ def _load_artifact(config: BlockConfig) -> Artifact:
         file_path=path,
         mime_type=mime,
         description=path.name,
+        framework=_source_framework(path),
     )
 
     sidecar = path.with_suffix(path.suffix + ".meta.json")
@@ -736,4 +754,4 @@ def _load_composite_data(config: BlockConfig, block: Any = None, output_dir: str
                 del slot_obj._arrow_table  # type: ignore[attr-defined]
         loaded_slots[slot_name] = slot_obj
 
-    return CompositeData(slots=loaded_slots)
+    return CompositeData(slots=loaded_slots, framework=_source_framework(path))

--- a/src/scistudio/blocks/io/savers/_capability.py
+++ b/src/scistudio/blocks/io/savers/_capability.py
@@ -419,42 +419,240 @@ def _legacy_save_extension_map(
 _SAVE_EXTENSION_MAP: dict[str, str] = _legacy_save_extension_map(_SAVE_CAPABILITIES)
 
 
-def _supported_save_extensions() -> tuple[str, ...]:
-    """Return the sorted tuple of every extension declared by SaveData.
+def _supported_save_extensions(data_type: type[DataObject] | None = None) -> tuple[str, ...]:
+    """Return the sorted tuple of extensions declared by SaveData.
 
     Replaces the legacy ``sorted(SaveData.supported_extensions.keys())``
     call sites in user-facing error messages.
     """
 
-    return tuple(sorted(_SAVE_EXTENSION_MAP.keys()))
+    if data_type is None:
+        return tuple(sorted(_SAVE_EXTENSION_MAP.keys()))
+    extensions = {
+        extension
+        for capability in _SAVE_CAPABILITIES
+        if capability.data_type is data_type
+        for extension in capability.extensions
+    }
+    return tuple(sorted(extensions))
 
 
-def _resolve_save_format(path: Path) -> str | None:
+def _save_capability_for_id(capability_id: str, data_type: type[DataObject] | None) -> FormatCapability:
+    for capability in _SAVE_CAPABILITIES:
+        if capability.id != capability_id:
+            continue
+        if data_type is not None and capability.data_type is not data_type:
+            raise ValueError(
+                f"SaveData: capability_id {capability_id!r} targets {capability.data_type.__name__}, "
+                f"but core_type is {data_type.__name__}."
+            )
+        return capability
+    raise ValueError(
+        f"SaveData: capability_id {capability_id!r} is not declared in SaveData.format_capabilities; "
+        f"valid ids are {sorted(c.id for c in _SAVE_CAPABILITIES)}"
+    )
+
+
+def _save_format_from_explicit(explicit: str, data_type: type[DataObject] | None) -> str:
+    value = explicit.strip().lower()
+    if not value:
+        raise ValueError("SaveData: config['format'] must not be empty.")
+    if value.startswith("."):
+        normalized_ext = value
+        matches = [
+            capability
+            for capability in _SAVE_CAPABILITIES
+            if (data_type is None or capability.data_type is data_type) and normalized_ext in capability.extensions
+        ]
+        if matches:
+            return matches[0].format_id
+    candidates = {
+        capability.format_id
+        for capability in _SAVE_CAPABILITIES
+        if data_type is None or capability.data_type is data_type
+    }
+    aliases = {"pkl": "pickle", "pickle": "pickle"}
+    fmt = aliases.get(value, value)
+    if fmt not in candidates:
+        raise ValueError(f"SaveData: unsupported format {explicit!r}; supported formats are {sorted(candidates)}")
+    return fmt
+
+
+def _default_save_extension(format_id: str, data_type: type[DataObject]) -> str:
+    for capability in _SAVE_CAPABILITIES:
+        if capability.data_type is data_type and capability.format_id == format_id:
+            return capability.extensions[0]
+    raise ValueError(
+        f"SaveData: format {format_id!r} is not declared for {data_type.__name__}; "
+        f"supported formats are {sorted(c.format_id for c in _SAVE_CAPABILITIES if c.data_type is data_type)}"
+    )
+
+
+def _default_save_filename(format_id: str, data_type: type[DataObject]) -> str:
+    return f"{data_type.__name__.lower()}{_default_save_extension(format_id, data_type)}"
+
+
+def _source_filename(obj: DataObject | None) -> str | None:
+    if obj is None:
+        return None
+    if isinstance(obj, Artifact) and obj.file_path is not None:
+        return Path(obj.file_path).name
+    source = getattr(obj.framework, "source", "")
+    if isinstance(source, str) and source:
+        return Path(source).name
+    return None
+
+
+def _filename_config(config: object) -> str | None:
+    raw = config.get("filename")
+    if raw is None:
+        return None
+    if not isinstance(raw, str):
+        raise ValueError(f"SaveData: config['filename'] must be a string or omitted, got {type(raw).__name__}")
+    cleaned = raw.strip()
+    if not cleaned:
+        return None
+    name = Path(cleaned).name
+    if name in {"", ".", ".."}:
+        raise ValueError("SaveData: filename must be a file name, not a directory path.")
+    return name
+
+
+def _filename_with_format(name: str, format_id: str, data_type: type[DataObject]) -> str:
+    extension = _default_save_extension(format_id, data_type)
+    candidate = Path(name)
+    supported = {
+        ext.lower()
+        for capability in _SAVE_CAPABILITIES
+        if capability.data_type is data_type and capability.format_id == format_id
+        for ext in capability.extensions
+    }
+    if candidate.suffix.lower() in supported:
+        return candidate.name
+    stem = candidate.stem if candidate.suffix else candidate.name
+    return f"{stem}{extension}"
+
+
+def _configured_or_source_filename(
+    format_id: str,
+    data_type: type[DataObject],
+    config: object,
+    obj: DataObject | None,
+) -> str:
+    configured = _filename_config(config)
+    if configured is not None:
+        return _filename_with_format(configured, format_id, data_type)
+    source_name = _source_filename(obj)
+    if source_name:
+        return _filename_with_format(source_name, format_id, data_type)
+    raise ValueError(
+        "SaveData cannot infer an output filename because the input object has no source filename. "
+        "Set the Save block filename field."
+    )
+
+
+def _resolve_save_format(
+    path: Path,
+    *,
+    explicit: str | None = None,
+    capability_id: str | None = None,
+    data_type: type[DataObject] | None = None,
+) -> str | None:
     """Resolve a path's format identifier from the SaveData capability map.
 
     ADR-043 / spec FR-003: format dispatch is now derived from explicit
     :attr:`SaveData.format_capabilities` rather than the deleted
-    ``supported_extensions`` ClassVar. Compound-suffix-first,
-    case-insensitive lookup matching :meth:`IOBlock._detect_format`
-    semantics.
+    ``supported_extensions`` ClassVar. Resolution mirrors SaveImage:
+    explicit ``config['format']`` wins, then ``capability_id``, then
+    compound-suffix-first extension dispatch.
     """
 
+    if explicit is not None:
+        return _save_format_from_explicit(explicit, data_type)
+    if capability_id is not None:
+        return _save_capability_for_id(capability_id, data_type).format_id
     if not _SAVE_EXTENSION_MAP:
         return None
+    if data_type is None:
+        extension_map = _SAVE_EXTENSION_MAP
+    else:
+        extension_map = {
+            extension: capability.format_id
+            for capability in _SAVE_CAPABILITIES
+            if capability.data_type is data_type
+            for extension in capability.extensions
+        }
     suffixes = [s.lower() for s in path.suffixes]
     for start in range(len(suffixes)):
         candidate = "".join(suffixes[start:])
-        if candidate in _SAVE_EXTENSION_MAP:
-            return _SAVE_EXTENSION_MAP[candidate]
+        if candidate in extension_map:
+            return extension_map[candidate]
     return None
+
+
+def _resolve_save_path_and_format(
+    path: Path,
+    data_type: type[DataObject],
+    config: object,
+    obj: DataObject | None = None,
+) -> tuple[Path, str | None]:
+    """Return the output path and format for a SaveData write.
+
+    GUI workflows may store the chosen format separately from ``path``.
+    When a path has no suffix, the resolved format supplies the default
+    extension so the runtime writes an actual file instead of failing on
+    an empty extension.
+    """
+
+    raw_format = config.get("format")
+    if raw_format is not None and not isinstance(raw_format, str):
+        raise ValueError(f"SaveData: config['format'] must be a string or omitted, got {type(raw_format).__name__}")
+    raw_capability_id = config.get("capability_id")
+    if raw_capability_id is not None and not isinstance(raw_capability_id, str):
+        raise ValueError(
+            f"SaveData: config['capability_id'] must be a string or omitted, got {type(raw_capability_id).__name__}"
+        )
+
+    explicit = raw_format.strip() if isinstance(raw_format, str) and raw_format.strip() else None
+    capability_id = (
+        raw_capability_id.strip() if isinstance(raw_capability_id, str) and raw_capability_id.strip() else None
+    )
+    fmt = _resolve_save_format(path, explicit=explicit, capability_id=capability_id, data_type=data_type)
+    if not path.suffix and fmt is None:
+        for capability in _SAVE_CAPABILITIES:
+            if capability.data_type is data_type:
+                fmt = capability.format_id
+                break
+    original_path = path
+    if path.is_dir() and fmt is not None:
+        path = path / _configured_or_source_filename(fmt, data_type, config, obj)
+    if not path.suffix and fmt is not None:
+        path = path.with_suffix(_default_save_extension(fmt, data_type))
+    if path != original_path:
+        params = getattr(config, "params", None)
+        if isinstance(params, dict):
+            params["path"] = str(path)
+    return path, fmt
+
+
+def _ensure_save_target_available(path: Path, config: object) -> None:
+    """Reject existing output targets unless overwrite is explicit."""
+
+    if not path.exists() or bool(config.get("overwrite", False)):
+        return
+    raise ValueError(
+        f"SaveData refuses to overwrite existing output {str(path)!r}. Choose an empty folder or a new output path."
+    )
 
 
 __all__ = [
     "_PICKLE_NOTE",
     "_SAVE_CAPABILITIES",
     "_SAVE_EXTENSION_MAP",
+    "_ensure_save_target_available",
     "_legacy_save_extension_map",
     "_resolve_save_format",
+    "_resolve_save_path_and_format",
     "_save_capability",
     "_supported_save_extensions",
 ]

--- a/src/scistudio/blocks/io/savers/_capability.py
+++ b/src/scistudio/blocks/io/savers/_capability.py
@@ -503,7 +503,7 @@ def _source_filename(obj: DataObject | None) -> str | None:
     return None
 
 
-def _filename_config(config: object) -> str | None:
+def _filename_config(config: dict[str, object]) -> str | None:
     raw = config.get("filename")
     if raw is None:
         return None
@@ -536,7 +536,7 @@ def _filename_with_format(name: str, format_id: str, data_type: type[DataObject]
 def _configured_or_source_filename(
     format_id: str,
     data_type: type[DataObject],
-    config: object,
+    config: dict[str, object],
     obj: DataObject | None,
 ) -> str:
     configured = _filename_config(config)
@@ -593,7 +593,7 @@ def _resolve_save_format(
 def _resolve_save_path_and_format(
     path: Path,
     data_type: type[DataObject],
-    config: object,
+    config: dict[str, object],
     obj: DataObject | None = None,
 ) -> tuple[Path, str | None]:
     """Return the output path and format for a SaveData write.
@@ -635,7 +635,7 @@ def _resolve_save_path_and_format(
     return path, fmt
 
 
-def _ensure_save_target_available(path: Path, config: object) -> None:
+def _ensure_save_target_available(path: Path, config: dict[str, object]) -> None:
     """Reject existing output targets unless overwrite is explicit."""
 
     if not path.exists() or bool(config.get("overwrite", False)):

--- a/src/scistudio/blocks/io/savers/_capability.py
+++ b/src/scistudio/blocks/io/savers/_capability.py
@@ -20,6 +20,7 @@ Extracted from :mod:`scistudio.blocks.io.savers.save_data` in issue #1459
 from __future__ import annotations
 
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from scistudio.blocks.io.capabilities import FormatCapability, MetadataFidelity
 from scistudio.core.types.array import Array
@@ -29,6 +30,9 @@ from scistudio.core.types.composite import CompositeData
 from scistudio.core.types.dataframe import DataFrame
 from scistudio.core.types.series import Series
 from scistudio.core.types.text import Text
+
+if TYPE_CHECKING:
+    from scistudio.blocks.base.config import BlockConfig
 
 _PICKLE_NOTE: str = "requires allow_pickle=True"
 
@@ -503,7 +507,7 @@ def _source_filename(obj: DataObject | None) -> str | None:
     return None
 
 
-def _filename_config(config: dict[str, object]) -> str | None:
+def _filename_config(config: BlockConfig | dict[str, object]) -> str | None:
     raw = config.get("filename")
     if raw is None:
         return None
@@ -536,7 +540,7 @@ def _filename_with_format(name: str, format_id: str, data_type: type[DataObject]
 def _configured_or_source_filename(
     format_id: str,
     data_type: type[DataObject],
-    config: dict[str, object],
+    config: BlockConfig | dict[str, object],
     obj: DataObject | None,
 ) -> str:
     configured = _filename_config(config)
@@ -593,7 +597,7 @@ def _resolve_save_format(
 def _resolve_save_path_and_format(
     path: Path,
     data_type: type[DataObject],
-    config: dict[str, object],
+    config: BlockConfig | dict[str, object],
     obj: DataObject | None = None,
 ) -> tuple[Path, str | None]:
     """Return the output path and format for a SaveData write.
@@ -635,7 +639,7 @@ def _resolve_save_path_and_format(
     return path, fmt
 
 
-def _ensure_save_target_available(path: Path, config: dict[str, object]) -> None:
+def _ensure_save_target_available(path: Path, config: BlockConfig | dict[str, object]) -> None:
     """Reject existing output targets unless overwrite is explicit."""
 
     if not path.exists() or bool(config.get("overwrite", False)):

--- a/src/scistudio/blocks/io/savers/save_data.py
+++ b/src/scistudio/blocks/io/savers/save_data.py
@@ -60,6 +60,7 @@ from __future__ import annotations
 import json
 import pickle
 import shutil
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any, ClassVar
 
@@ -76,8 +77,10 @@ from scistudio.blocks.io.savers._capability import (
     _PICKLE_NOTE,  # noqa: F401  re-export for backward compat
     _SAVE_CAPABILITIES,
     _SAVE_EXTENSION_MAP,
+    _ensure_save_target_available,
     _legacy_save_extension_map,  # noqa: F401  re-export for backward compat
-    _resolve_save_format,
+    _resolve_save_format,  # noqa: F401  re-export for backward compat
+    _resolve_save_path_and_format,
     _save_capability,  # noqa: F401  re-export for backward compat
     _supported_save_extensions,
 )
@@ -105,6 +108,77 @@ from scistudio.core.types.composite import CompositeData
 from scistudio.core.types.dataframe import DataFrame
 from scistudio.core.types.series import Series
 from scistudio.core.types.text import Text
+
+
+def _source_file_stem(obj: DataObject) -> tuple[str, str]:
+    if isinstance(obj, Artifact) and obj.file_path is not None:
+        source_name = Path(obj.file_path).name
+    else:
+        source = getattr(obj.framework, "source", "")
+        source_name = Path(source).name if isinstance(source, str) and source else ""
+    if not source_name:
+        return type(obj).__name__.lower(), ""
+    source_path = Path(source_name)
+    return source_path.stem or source_path.name, source_path.name
+
+
+def _collection_item_filename(
+    configured: str | None,
+    item: DataObject,
+    *,
+    index: int,
+) -> str:
+    _stem, name = _source_file_stem(item)
+    if configured and configured.strip():
+        path = Path(configured.strip()).name
+        candidate = Path(path)
+        return f"{candidate.stem}-{index}{candidate.suffix}" if candidate.suffix else f"{path}-{index}"
+    if name:
+        return name
+    raise ValueError(
+        "SaveData cannot name collection items because no source filename is available. "
+        "Set the Save block filename field."
+    )
+
+
+def _save_collection(
+    collection: Collection,
+    *,
+    target_cls: type[DataObject],
+    dispatch_fn: Callable[[DataObject, BlockConfig], None],
+    config: BlockConfig,
+) -> None:
+    items = list(collection)
+    if not items:
+        raise ValueError("SaveData received an empty Collection; nothing to save.")
+    for item in items:
+        if not isinstance(item, target_cls):
+            raise ValueError(
+                f"SaveData(core_type={target_cls.__name__}) received a "
+                f"Collection item of type {type(item).__name__}; all items must match the configured core_type."
+            )
+    output_dir = _require_path(config)
+    if output_dir.exists() and not output_dir.is_dir():
+        raise ValueError("SaveData received a multi-item Collection; config.path must be a folder path.")
+    output_dir.mkdir(parents=True, exist_ok=True)
+    configured = config.get("filename")
+    if configured is not None and not isinstance(configured, str):
+        raise ValueError(f"SaveData: config['filename'] must be a string or omitted, got {type(configured).__name__}")
+    for idx, item in enumerate(items, start=1):
+        params = dict(config.params)
+        params["path"] = str(output_dir)
+        params["filename"] = _collection_item_filename(configured, item, index=idx)
+        item_config = BlockConfig(params=params)
+        dispatch_fn(item, item_config)
+
+
+def _selected_package_save_capability(config: BlockConfig) -> str | None:
+    raw = config.get("capability_id")
+    if not isinstance(raw, str) or not raw.strip():
+        return None
+    capability_id = raw.strip()
+    core_capability_ids = {capability.id for capability in _SAVE_CAPABILITIES}
+    return None if capability_id in core_capability_ids else capability_id
 
 
 class SaveData(IOBlock):
@@ -180,6 +254,18 @@ class SaveData(IOBlock):
                 "default": "DataFrame",
                 "ui_priority": 0,
             },
+            "filename": {
+                "type": "string",
+                "title": "Filename",
+                "default": "",
+                "ui_priority": 2,
+            },
+            "overwrite": {
+                "type": "boolean",
+                "title": "Overwrite",
+                "default": False,
+                "ui_priority": 3,
+            },
             # ADR-030: ``path`` is inherited from IOBlock base class via MRO merge.
             # Direction-aware post-processing auto-switches to directory_browser.
         },
@@ -232,11 +318,10 @@ class SaveData(IOBlock):
     def save(self, obj: DataObject | Collection, config: BlockConfig) -> None:
         """Dispatch to the matching ``_save_*`` function based on ``core_type``.
 
-        ``obj`` may be a bare :class:`DataObject` (the common case) or
-        a single-item :class:`Collection` whose ``item_type`` matches
-        the configured ``core_type``. Mixed-type Collections are
-        explicitly out-of-scope per spec §j and raise
-        :class:`ValueError`.
+        ``obj`` may be a bare :class:`DataObject` or a homogeneous
+        :class:`Collection` whose items match the configured
+        ``core_type``. Multi-item Collections are written as one file per
+        item under the configured folder path.
         """
         type_name = config.get("core_type", "DataFrame")
         if type_name not in _CORE_TYPE_MAP:
@@ -250,14 +335,17 @@ class SaveData(IOBlock):
             delegate_save(obj=obj, config=config, core_type=str(type_name))
             return
 
-        if type_name not in _CORE_TYPE_MAP:
-            raise ValueError(f"Unknown core_type {type_name!r}; expected one of {sorted(_CORE_TYPE_MAP.keys())}.")
-
-        # Unwrap a single-item Collection so the dispatch functions
-        # always see a bare DataObject. Mixed-type Collections are
-        # rejected with an explicit ValueError per spec §j.
         target_cls = _CORE_TYPE_MAP[type_name]
-        unwrapped = _unwrap_for_save(obj, target_cls)
+        if _selected_package_save_capability(config) is not None:
+            from scistudio.blocks.io._unified_dispatch import delegate_save
+
+            if isinstance(obj, Collection):
+                raise ValueError(
+                    f"SaveData package capability {config.get('capability_id')!r} requires a single DataObject input."
+                )
+            unwrapped = _unwrap_for_save(obj, target_cls)
+            delegate_save(obj=unwrapped, config=config, core_type=str(type_name))
+            return
 
         dispatch: dict[str, Any] = {
             "Array": _save_array,
@@ -267,6 +355,11 @@ class SaveData(IOBlock):
             "Artifact": _save_artifact,
             "CompositeData": _save_composite_data,
         }
+        if isinstance(obj, Collection) and len(obj) > 1:
+            _save_collection(obj, target_cls=target_cls, dispatch_fn=dispatch[type_name], config=config)
+            return
+
+        unwrapped = _unwrap_for_save(obj, target_cls)
         dispatch[type_name](unwrapped, config)
 
 
@@ -291,7 +384,8 @@ def _save_array(obj: DataObject, config: BlockConfig) -> None:
     assert isinstance(obj, Array), f"Expected Array, got {type(obj).__name__}"
     path = _require_path(config)
     # ADR-043 FR-003: format dispatch through SaveData.format_capabilities.
-    fmt = _resolve_save_format(path)
+    path, fmt = _resolve_save_path_and_format(path, Array, config, obj)
+    _ensure_save_target_available(path, config)
 
     if _check_pickle_gate(path, config):
         data = obj.get_in_memory_data()
@@ -356,7 +450,7 @@ def _save_array(obj: DataObject, config: BlockConfig) -> None:
 
     raise ValueError(
         f"Unsupported Array file extension {path.suffix.lower()!r}. "
-        f"Supported extensions: {list(_supported_save_extensions())} "
+        f"Supported extensions: {list(_supported_save_extensions(Array))} "
         f"(.pkl/.pickle require allow_pickle=True)."
     )
 
@@ -373,7 +467,8 @@ def _save_dataframe(obj: DataObject, config: BlockConfig) -> None:
     assert isinstance(obj, DataFrame), f"Expected DataFrame, got {type(obj).__name__}"
     path = _require_path(config)
     # ADR-043 FR-003: format dispatch through SaveData.format_capabilities.
-    fmt = _resolve_save_format(path)
+    path, fmt = _resolve_save_path_and_format(path, DataFrame, config, obj)
+    _ensure_save_target_available(path, config)
 
     if _check_pickle_gate(path, config):
         data = obj.get_in_memory_data()
@@ -406,7 +501,7 @@ def _save_dataframe(obj: DataObject, config: BlockConfig) -> None:
 
     raise ValueError(
         f"Unsupported DataFrame file extension {path.suffix.lower()!r}. "
-        f"Supported extensions: {list(_supported_save_extensions())} "
+        f"Supported extensions: {list(_supported_save_extensions(DataFrame))} "
         f"(.pkl/.pickle require allow_pickle=True)."
     )
 
@@ -422,7 +517,8 @@ def _save_series(obj: DataObject, config: BlockConfig) -> None:
     assert isinstance(obj, Series), f"Expected Series, got {type(obj).__name__}"
     path = _require_path(config)
     # ADR-043 FR-003: format dispatch through SaveData.format_capabilities.
-    fmt = _resolve_save_format(path)
+    path, fmt = _resolve_save_path_and_format(path, Series, config, obj)
+    _ensure_save_target_available(path, config)
 
     if _check_pickle_gate(path, config):
         data = obj.get_in_memory_data()
@@ -469,7 +565,7 @@ def _save_series(obj: DataObject, config: BlockConfig) -> None:
 
     raise ValueError(
         f"Unsupported Series file extension {path.suffix.lower()!r}. "
-        f"Supported extensions: {list(_supported_save_extensions())} "
+        f"Supported extensions: {list(_supported_save_extensions(Series))} "
         f"(.pkl/.pickle require allow_pickle=True)."
     )
 
@@ -483,6 +579,8 @@ def _save_text(obj: DataObject, config: BlockConfig) -> None:
     """
     assert isinstance(obj, Text), f"Expected Text, got {type(obj).__name__}"
     path = _require_path(config)
+    path, _fmt = _resolve_save_path_and_format(path, Text, config, obj)
+    _ensure_save_target_available(path, config)
     # ADR-043 FR-003: cross-check via the SaveData capability map (the
     # canonical registry-visible set). The internal ``supported`` frozenset
     # below is a permissive superset retained for backward compatibility
@@ -507,7 +605,7 @@ def _save_text(obj: DataObject, config: BlockConfig) -> None:
     if suffix not in supported:
         raise ValueError(
             f"Unsupported Text file extension {suffix!r}. "
-            f"Supported extensions: {list(_supported_save_extensions())} "
+            f"Supported extensions: {list(_supported_save_extensions(Text))} "
             f"(Text-specific superset: {sorted(supported)})."
         )
 
@@ -530,6 +628,8 @@ def _save_artifact(obj: DataObject, config: BlockConfig) -> None:
     """
     assert isinstance(obj, Artifact), f"Expected Artifact, got {type(obj).__name__}"
     path = _require_path(config)
+    path, _fmt = _resolve_save_path_and_format(path, Artifact, config, obj)
+    _ensure_save_target_available(path, config)
 
     if obj.file_path is not None and Path(obj.file_path).exists():
         shutil.copy2(str(obj.file_path), str(path))
@@ -570,6 +670,8 @@ def _save_composite_data(obj: DataObject, config: BlockConfig) -> None:
     """
     assert isinstance(obj, CompositeData), f"Expected CompositeData, got {type(obj).__name__}"
     path = _require_path(config)
+    path, _fmt = _resolve_save_path_and_format(path, CompositeData, config, obj)
+    _ensure_save_target_available(path, config)
     if path.suffix.lower() != ".json":
         raise ValueError(f"CompositeData manifest must use the .json extension, got {path.suffix!r}.")
 

--- a/tests/api/test_blocks.py
+++ b/tests/api/test_blocks.py
@@ -339,8 +339,12 @@ def test_core_load_save_schema_aggregates_registered_io_types(client: TestClient
     save_props = save_payload["config_schema"]["properties"]
     assert "Image" in save_props["core_type"]["enum"]
     assert "allow_pickle" not in save_props
-    assert save_props["path"]["ui_widget"] == "file_browser"
+    assert save_props["path"]["ui_widget"] == "directory_browser"
     assert any(capability["data_type"] == "Image" for capability in save_payload["format_capabilities"])
+    assert any(
+        capability["id"] == "scistudio-blocks-lcms.table.xlsx.save"
+        for capability in save_payload["format_capabilities"]
+    )
     assert save_payload["dynamic_ports"]["input_port_mapping"]["data"]["Image"] == ["Image"]
 
 

--- a/tests/blocks/io/test_load_data.py
+++ b/tests/blocks/io/test_load_data.py
@@ -110,6 +110,7 @@ def test_load_csv_to_dataframe(tmp_path: Path) -> None:
     assert isinstance(df, DataFrame)
     assert df.columns == ["a", "b", "c"]
     assert df.row_count == 3
+    assert df.framework.source == str(csv_path)
     # Phase 1 _load_dataframe_with_persist persists to arrow storage.
     # Verify data is accessible via storage_ref or get_in_memory_data().
     table = df.get_in_memory_data()

--- a/tests/blocks/io/test_save_data.py
+++ b/tests/blocks/io/test_save_data.py
@@ -35,6 +35,7 @@ import pytest
 
 from scistudio.blocks.io import SaveData
 from scistudio.blocks.io.savers.save_data import _CORE_TYPE_MAP
+from scistudio.core.meta.framework import FrameworkMeta
 from scistudio.core.types.array import Array
 from scistudio.core.types.artifact import Artifact
 from scistudio.core.types.base import DataObject
@@ -159,10 +160,10 @@ def _make_arrow_table() -> pa.Table:
     return pa.table({"x": [1, 2, 3], "y": [4.0, 5.0, 6.0]})
 
 
-def _make_dataframe() -> DataFrame:
+def _make_dataframe(**kwargs: object) -> DataFrame:
     """Build a DataFrame DataObject with an in-memory _arrow_table."""
     table = _make_arrow_table()
-    df = DataFrame(columns=table.column_names, row_count=table.num_rows)
+    df = DataFrame(columns=table.column_names, row_count=table.num_rows, **kwargs)
     df._arrow_table = table  # type: ignore[attr-defined]
     return df
 
@@ -193,6 +194,94 @@ class TestRoundTripDataFrame:
             parse_options=pcsv.ParseOptions(delimiter="\t"),
         )
         assert recovered.column_names == ["x", "y"]
+
+    def test_dataframe_path_without_extension_defaults_to_csv(self, tmp_path: Path) -> None:
+        path = tmp_path / "df"
+        expected = tmp_path / "df.csv"
+        block = SaveData(config={"params": {"core_type": "DataFrame", "path": str(path)}})
+        block.save(_make_dataframe(), block.config)
+
+        assert expected.exists()
+        assert block.config.get("path") == str(expected)
+        recovered = pcsv.read_csv(str(expected))
+        assert recovered.column_names == ["x", "y"]
+
+    def test_dataframe_directory_path_uses_source_filename(self, tmp_path: Path) -> None:
+        source = tmp_path / "input.tsv"
+        expected = tmp_path / "input.csv"
+        block = SaveData(config={"params": {"core_type": "DataFrame", "path": str(tmp_path)}})
+        block.save(_make_dataframe(framework=FrameworkMeta(source=str(source))), block.config)
+
+        assert expected.exists()
+        assert block.config.get("path") == str(expected)
+        recovered = pcsv.read_csv(str(expected))
+        assert recovered.column_names == ["x", "y"]
+
+    def test_dataframe_directory_path_refuses_existing_source_file(self, tmp_path: Path) -> None:
+        source = tmp_path / "input.csv"
+        expected = tmp_path / "input.csv"
+        expected.write_text("existing\n", encoding="utf-8")
+        block = SaveData(config={"params": {"core_type": "DataFrame", "path": str(tmp_path)}})
+
+        with pytest.raises(ValueError, match="refuses to overwrite existing output"):
+            block.save(_make_dataframe(framework=FrameworkMeta(source=str(source))), block.config)
+
+        assert expected.read_text(encoding="utf-8") == "existing\n"
+
+    def test_dataframe_directory_path_can_overwrite_when_explicit(self, tmp_path: Path) -> None:
+        source = tmp_path / "input.csv"
+        expected = tmp_path / "input.csv"
+        expected.write_text("existing\n", encoding="utf-8")
+        block = SaveData(config={"params": {"core_type": "DataFrame", "path": str(tmp_path), "overwrite": True}})
+        block.save(_make_dataframe(framework=FrameworkMeta(source=str(source))), block.config)
+
+        recovered = pcsv.read_csv(str(expected))
+        assert recovered.column_names == ["x", "y"]
+
+    def test_dataframe_path_without_extension_uses_explicit_tsv_format(self, tmp_path: Path) -> None:
+        path = tmp_path / "df"
+        expected = tmp_path / "df.tsv"
+        block = SaveData(config={"params": {"core_type": "DataFrame", "path": str(path), "format": "tsv"}})
+        block.save(_make_dataframe(), block.config)
+
+        assert expected.exists()
+        assert block.config.get("path") == str(expected)
+        recovered = pcsv.read_csv(
+            str(expected),
+            parse_options=pcsv.ParseOptions(delimiter="\t"),
+        )
+        assert recovered.column_names == ["x", "y"]
+
+    def test_dataframe_directory_path_uses_explicit_tsv_format(self, tmp_path: Path) -> None:
+        source = tmp_path / "input.csv"
+        expected = tmp_path / "input.tsv"
+        block = SaveData(config={"params": {"core_type": "DataFrame", "path": str(tmp_path), "format": "tsv"}})
+        block.save(_make_dataframe(framework=FrameworkMeta(source=str(source))), block.config)
+
+        assert expected.exists()
+        assert block.config.get("path") == str(expected)
+        recovered = pcsv.read_csv(
+            str(expected),
+            parse_options=pcsv.ParseOptions(delimiter="\t"),
+        )
+        assert recovered.column_names == ["x", "y"]
+
+    def test_dataframe_path_without_extension_uses_capability_id(self, tmp_path: Path) -> None:
+        path = tmp_path / "df"
+        expected = tmp_path / "df.tsv"
+        block = SaveData(
+            config={
+                "params": {
+                    "core_type": "DataFrame",
+                    "path": str(path),
+                    "capability_id": "core.dataframe.tsv.save",
+                }
+            }
+        )
+        block.save(_make_dataframe(), block.config)
+
+        assert expected.exists()
+        assert block.config.get("path") == str(expected)
 
     def test_dataframe_round_trip_parquet(self, tmp_path: Path) -> None:
         path = tmp_path / "df.parquet"
@@ -540,15 +629,57 @@ class TestMixedTypeRejection:
         with pytest.raises(ValueError, match="Collection item of type Text"):
             block.save(text_collection, block.config)
 
-    def test_multi_item_collection_raises(self, tmp_path: Path) -> None:
-        """A Collection of >1 same-type items must raise because core
-        SaveData writes one file at the configured path."""
-        path = tmp_path / "df.csv"
-        block = SaveData(config={"params": {"core_type": "DataFrame", "path": str(path)}})
-        df1 = _make_dataframe()
-        df2 = _make_dataframe()
+    def test_multi_item_collection_writes_one_file_per_item(self, tmp_path: Path) -> None:
+        """A Collection of >1 same-type items writes a batch of files."""
+        block = SaveData(
+            config={
+                "params": {
+                    "core_type": "DataFrame",
+                    "path": str(tmp_path),
+                    "capability_id": "core.dataframe.tsv.save",
+                }
+            }
+        )
+        df1 = _make_dataframe(framework=FrameworkMeta(source=str(tmp_path / "first.csv")))
+        df2 = _make_dataframe(framework=FrameworkMeta(source=str(tmp_path / "second.csv")))
         coll = Collection(items=[df1, df2], item_type=DataFrame)
-        with pytest.raises(ValueError, match="Collection of 2 items"):
+
+        block.save(coll, block.config)
+
+        assert (tmp_path / "first.tsv").exists()
+        assert (tmp_path / "second.tsv").exists()
+
+    def test_multi_item_collection_gui_filename_adds_index(self, tmp_path: Path) -> None:
+        block = SaveData(
+            config={
+                "params": {
+                    "core_type": "DataFrame",
+                    "path": str(tmp_path),
+                    "capability_id": "core.dataframe.csv.save",
+                    "filename": "batch",
+                }
+            }
+        )
+        coll = Collection(items=[_make_dataframe(), _make_dataframe()], item_type=DataFrame)
+
+        block.save(coll, block.config)
+
+        assert (tmp_path / "batch-1.csv").exists()
+        assert (tmp_path / "batch-2.csv").exists()
+
+    def test_multi_item_collection_without_source_or_filename_raises(self, tmp_path: Path) -> None:
+        block = SaveData(
+            config={
+                "params": {
+                    "core_type": "DataFrame",
+                    "path": str(tmp_path),
+                    "capability_id": "core.dataframe.csv.save",
+                }
+            }
+        )
+        coll = Collection(items=[_make_dataframe(), _make_dataframe()], item_type=DataFrame)
+
+        with pytest.raises(ValueError, match="no source filename"):
             block.save(coll, block.config)
 
     def test_empty_collection_raises(self, tmp_path: Path) -> None:
@@ -566,6 +697,81 @@ class TestMixedTypeRejection:
         # Must not raise — the single-item Collection is unwrapped.
         block.save(coll, block.config)
         assert path.exists()
+
+
+class TestSaveDataFilename:
+    def test_directory_target_uses_configured_filename(self, tmp_path: Path) -> None:
+        block = SaveData(
+            config={
+                "params": {
+                    "core_type": "DataFrame",
+                    "path": str(tmp_path),
+                    "capability_id": "core.dataframe.tsv.save",
+                    "filename": "custom-name",
+                }
+            }
+        )
+
+        block.save(_make_dataframe(), block.config)
+
+        assert (tmp_path / "custom-name.tsv").exists()
+
+    def test_directory_target_uses_source_filename_when_filename_blank(self, tmp_path: Path) -> None:
+        source = tmp_path / "input.csv"
+        df = _make_dataframe(framework=FrameworkMeta(source=str(source)))
+        block = SaveData(
+            config={
+                "params": {
+                    "core_type": "DataFrame",
+                    "path": str(tmp_path),
+                    "capability_id": "core.dataframe.tsv.save",
+                }
+            }
+        )
+
+        block.save(df, block.config)
+
+        assert (tmp_path / "input.tsv").exists()
+
+    def test_directory_target_without_source_or_filename_raises(self, tmp_path: Path) -> None:
+        block = SaveData(
+            config={
+                "params": {
+                    "core_type": "DataFrame",
+                    "path": str(tmp_path),
+                    "capability_id": "core.dataframe.tsv.save",
+                }
+            }
+        )
+
+        with pytest.raises(ValueError, match="no source filename"):
+            block.save(_make_dataframe(), block.config)
+
+    def test_package_owned_capability_delegates_to_registered_saver(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("SCISTUDIO_DEV", "1")
+        source = tmp_path / "input.csv"
+        df = _make_dataframe(framework=FrameworkMeta(source=str(source)))
+        block = SaveData(
+            config={
+                "params": {
+                    "core_type": "DataFrame",
+                    "path": str(tmp_path),
+                    "capability_id": "scistudio-blocks-lcms.table.xlsx.save",
+                }
+            }
+        )
+
+        block.save(df, block.config)
+
+        output = tmp_path / "input.xlsx"
+        assert output.exists()
+        import pandas as pd
+
+        frame = pd.read_excel(output)
+        assert list(frame.columns) == ["x", "y"]
+        assert frame["x"].tolist() == [1, 2, 3]
 
 
 # ---------------------------------------------------------------------------
@@ -776,7 +982,7 @@ class TestCapabilityDerivedExtensionDispatch:
         with pytest.raises(ValueError) as excinfo:
             block.save(arr, block.config)
         msg = str(excinfo.value)
-        for key in _supported_save_extensions():
+        for key in _supported_save_extensions(Array):
             assert re.search(re.escape(repr(key)), msg), f"missing {key!r} in error: {msg}"
 
     def test_unknown_extension_dataframe_error_lists_supported_set(self, tmp_path: Path) -> None:
@@ -788,6 +994,7 @@ class TestCapabilityDerivedExtensionDispatch:
             block.save(df, block.config)
         msg = str(excinfo.value)
         assert ".csv" in msg
+        assert ".tsv" in msg
         assert ".parquet" in msg
 
     def test_supported_extensions_inherits_empty_default_from_ioblock(self) -> None:

--- a/tests/blocks/io/test_save_data.py
+++ b/tests/blocks/io/test_save_data.py
@@ -29,6 +29,14 @@ from pathlib import Path
 
 import numpy as np
 import pyarrow as pa
+
+try:
+    import openpyxl  # noqa: F401
+    import pandas  # noqa: F401
+
+    _PANDAS_AVAILABLE = True
+except ImportError:
+    _PANDAS_AVAILABLE = False
 import pyarrow.csv as pcsv
 import pyarrow.parquet as pq
 import pytest
@@ -747,6 +755,10 @@ class TestSaveDataFilename:
         with pytest.raises(ValueError, match="no source filename"):
             block.save(_make_dataframe(), block.config)
 
+    @pytest.mark.skipif(
+        not _PANDAS_AVAILABLE,
+        reason="pandas or openpyxl not installed (LCMS plugin required)",
+    )
     def test_package_owned_capability_delegates_to_registered_saver(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
## Summary

- Fix SaveData folder-target saves, filename resolution, collection saves, overwrite confirmation flow, and concise error display.
- Preserve source filenames from LoadData previews and allow GUI-provided filenames, including numbered collection outputs.
- Restore registered unified IO capability behavior so package-owned formats such as LCMS table xlsx can be selected only when registered and delegated correctly.
- Restore LoadData dynamic output port typing from selected/default data type.

## Tests

- `PYTHONPATH=src:packages/scistudio-blocks-imaging/src:packages/scistudio-blocks-lcms/src python -m ruff check src/scistudio/api/routes/blocks.py src/scistudio/api/routes/filesystem.py src/scistudio/api/routes/workflows.py src/scistudio/api/runtime/_runs.py src/scistudio/api/schemas.py src/scistudio/blocks/io/_unified_dispatch.py src/scistudio/blocks/io/loaders/load_data.py src/scistudio/blocks/io/savers/_capability.py src/scistudio/blocks/io/savers/save_data.py tests/api/test_blocks.py tests/blocks/io/test_load_data.py tests/blocks/io/test_save_data.py packages/scistudio-blocks-imaging/tests/test_save_image.py`
- `PYTHONPATH=src:packages/scistudio-blocks-imaging/src:packages/scistudio-blocks-lcms/src python -m ruff format --check src/scistudio/api/routes/blocks.py src/scistudio/api/routes/filesystem.py src/scistudio/api/routes/workflows.py src/scistudio/api/runtime/_runs.py src/scistudio/api/schemas.py src/scistudio/blocks/io/_unified_dispatch.py src/scistudio/blocks/io/loaders/load_data.py src/scistudio/blocks/io/savers/_capability.py src/scistudio/blocks/io/savers/save_data.py tests/api/test_blocks.py tests/blocks/io/test_load_data.py tests/blocks/io/test_save_data.py packages/scistudio-blocks-imaging/tests/test_save_image.py`
- `PYTHONPATH=src:packages/scistudio-blocks-lcms/src python -m pytest -o addopts='' tests/blocks/io/test_save_data.py tests/blocks/io/test_load_data.py tests/api/test_blocks.py -q`
- `PYTHONPATH=src:packages/scistudio-blocks-imaging/src:packages/scistudio-blocks-lcms/src python -m pytest -o addopts='' packages/scistudio-blocks-imaging/tests/test_save_image.py -q`
- `cd frontend && npx prettier --check frontend/src/App.parts/useWorkflowExecutionActions.ts frontend/src/App.tsx frontend/src/components/BottomPanel.parts/ConfigPanel.tsx frontend/src/components/BottomPanel.parts/LogViewer.test.tsx frontend/src/components/BottomPanel.parts/LogViewer.tsx frontend/src/components/nodes/BlockNode.tsx frontend/src/components/nodes/__tests__/BlockNode/ports.test.tsx frontend/src/lib/api/filesystem.ts frontend/src/lib/api/workflows.ts frontend/src/store/executionSlice.parts/eventReducer.test.ts frontend/src/store/executionSlice.parts/eventReducer.ts frontend/src/types/api.ts`
- `cd frontend && npx eslint frontend/src/App.parts/useWorkflowExecutionActions.ts frontend/src/App.tsx frontend/src/components/BottomPanel.parts/ConfigPanel.tsx frontend/src/components/BottomPanel.parts/LogViewer.test.tsx frontend/src/components/BottomPanel.parts/LogViewer.tsx frontend/src/components/nodes/BlockNode.tsx frontend/src/components/nodes/__tests__/BlockNode/ports.test.tsx frontend/src/lib/api/filesystem.ts frontend/src/lib/api/workflows.ts frontend/src/store/executionSlice.parts/eventReducer.test.ts frontend/src/store/executionSlice.parts/eventReducer.ts frontend/src/types/api.ts`
- `cd frontend && npm run test -- --run src/App.parts/useWorkflowExecutionActions.test.tsx src/components/BottomPanel.parts/ConfigPanel.test.tsx src/components/BottomPanel.parts/LogViewer.test.tsx src/store/executionSlice.parts/eventReducer.test.ts src/hooks/useWebSocket.test.ts src/components/nodes/__tests__/BlockNode/ports.test.tsx src/components/nodes/__tests__/BlockNode/capabilities.test.tsx`
- `cd frontend && npm run typecheck`
- `cd frontend && npm run build`
- `PYTHONPATH=src python -m scistudio.qa.audit.full_audit --repo-root . --format json --output docs/audit/full-audit-latest.json`

Gate record: `.workflow/records/1505-hotfix-save-data-extension.json`

Closes #1505
