### PR TITLE
docs(#1566): ADR-048 + spec for extensible preview providers

### DIFF
--- a/.workflow/records/1566-adr-048-extensible-preview.json
+++ b/.workflow/records/1566-adr-048-extensible-preview.json
@@ -1,0 +1,358 @@
+{
+  "branch": "docs/adr-048-extensible-preview",
+  "check_events": [
+    {
+      "at": "2026-06-10T18:56:59.020237Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:60b23b7dc067ab298543c3d5637f6d75b8386f1722dc7acac75df568b4bfa0fa",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-10T18:56:59.407345Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:60b23b7dc067ab298543c3d5637f6d75b8386f1722dc7acac75df568b4bfa0fa",
+      "name": "semantic_dup",
+      "parity_detail": "missing module: fastembed",
+      "parity_gap": true,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "fail",
+      "summary": "parity gap: missing module: fastembed",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-10T18:59:32.980295Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:60b23b7dc067ab298543c3d5637f6d75b8386f1722dc7acac75df568b4bfa0fa",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-10T18:59:33.120932Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:60b23b7dc067ab298543c3d5637f6d75b8386f1722dc7acac75df568b4bfa0fa",
+      "name": "semantic_dup",
+      "parity_detail": "missing module: fastembed",
+      "parity_gap": true,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "fail",
+      "summary": "parity gap: missing module: fastembed",
+      "tool_versions": {}
+    }
+  ],
+  "check_na": [],
+  "commit": null,
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "docs/adr/ADR-048.md",
+      "docs/specs/adr-048-extensible-preview.md"
+    ]
+  },
+  "directive_events": [],
+  "docs_events": [
+    {
+      "at": "2026-06-10T18:54:35.189616Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/adr/ADR-048.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-10T18:54:35.189639Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/specs/adr-048-extensible-preview.md",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": false,
+  "guard_events": [
+    {
+      "at": "2026-06-10T18:56:59.447365Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T18:56:59.464019Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T18:56:59.481470Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T18:56:59.498566Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T18:56:59.515192Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T18:56:59.532384Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T18:56:59.550251Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T18:56:59.567654Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T18:56:59.584246Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T18:56:59.603470Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T18:59:33.156712Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T18:59:33.170648Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T18:59:33.185589Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T18:59:33.199628Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T18:59:33.213397Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T18:59:33.227984Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T18:59:33.242066Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T18:59:33.255833Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T18:59:33.270282Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T18:59:33.287123Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1566,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": {
+    "base": "origin/main",
+    "base_sha": "a13a460c",
+    "changed_files": [
+      ".workflow/records/1566-adr-048-extensible-preview.json",
+      "docs/adr/ADR-048.md",
+      "docs/specs/adr-048-extensible-preview.md"
+    ],
+    "diff_fingerprint": "sha256:b663ca615f387b6b72fd30f6888b2858d2c61d7b3b3aaa0e05e11bacdc0ef9d0",
+    "head": "HEAD",
+    "head_sha": "f455b772",
+    "surfaces": {
+      "docs": 2,
+      "frontend": 0,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 0,
+      "packaging": 0,
+      "protected_core": 0,
+      "sentrux": 2,
+      "test": 0,
+      "workflow_ci": 0
+    }
+  },
+  "owner_directive": "Author ADR-048 + spec for extensible preview providers: package-defined renderers (runtime dynamic load) + user-defined matplotlib plot functions, with a provider resolution chain and core fallback viewers. Docs-only, no code today.",
+  "persona": "adr_author",
+  "pull_request": null,
+  "reconcile_events": [
+    {
+      "at": "2026-06-10T18:56:59.603496Z",
+      "diff_fingerprint": "sha256:0efe0c9779d321bdbe49a6ff684cf8b0e43a2cd4f6c91d9b1f635b6f1edfb421",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 3,
+      "unsatisfied": [
+        "checks.full_audit",
+        "parity.environment-not-ci-equivalent"
+      ]
+    },
+    {
+      "at": "2026-06-10T18:59:33.287139Z",
+      "diff_fingerprint": "sha256:b663ca615f387b6b72fd30f6888b2858d2c61d7b3b3aaa0e05e11bacdc0ef9d0",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 3,
+      "unsatisfied": [
+        "parity.environment-not-ci-equivalent"
+      ]
+    }
+  ],
+  "record_id": "1566-adr-048-extensible-preview",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [
+      "full_audit",
+      "semantic_dup"
+    ],
+    "docs": [],
+    "guards": [
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": []
+  },
+  "runtime": "claude-code",
+  "schema_version": 2,
+  "scope_events": [],
+  "session_id": "a55e0a02-2414-41a5-8a93-90cd6934eff1",
+  "strictness_tier": 3,
+  "task_kind": "docs",
+  "test_events": [
+    {
+      "at": "2026-06-10T18:54:35.189651Z",
+      "class": "implementation",
+      "kind": "na",
+      "path": null,
+      "rationale": "Docs-only ADR-048 + spec; no code in this PR. Implementation and its tests are sequenced after ADR-048 acceptance per the spec's Implementation Plan.",
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/docs/adr/ADR-048.md
+++ b/docs/adr/ADR-048.md
@@ -1,0 +1,288 @@
+---
+adr: 48
+title: "Extensible Preview Providers"
+status: Proposed
+date_created: 2026-06-10
+date_accepted: null
+date_superseded: null
+
+supersedes: []
+superseded_by: null
+related: [17, 27, 31, 32, 43]
+closes_issues: [1566]
+tracking_issue: 1566
+
+is_code_implementation: false
+governs:
+  modules:
+    - scistudio.api.runtime
+    - scistudio.core.types
+  contracts: []
+  entry_points: []
+  files:
+    - docs/adr/ADR-048.md
+    - docs/specs/adr-048-extensible-preview.md
+    - src/scistudio/api/runtime/_data.py
+    - src/scistudio/api/routes/data.py
+    - frontend/src/components/DataPreview.parts/PreviewRenderer.tsx
+    - frontend/src/components/DataPreview.tsx
+    - frontend/src/components/DataPreview.parts/ImageViewer.tsx
+    - src/scistudio/core/types/**
+    - packages/scistudio-blocks-imaging/**
+  excludes:
+    - tests/**
+    - docs/audit/**
+
+tests: []
+agent_editable: false
+assisted_by:
+  - "Claude:claude-fable-5"
+phase: planning
+tags:
+  - preview
+  - extensibility
+  - plugin
+  - frontend
+  - plotting
+  - package-renderer
+  - user-plot
+owner: "@jiazhenz026"
+co_authors: []
+language_source: en
+translations: []
+---
+
+# ADR-048: Extensible Preview Providers
+
+## 1. Decision Summary
+
+When someone opens the Preview panel on a block's output, two pieces of
+hardcoded machinery run. On the backend, `preview_data()` reads the output's
+type name and file extension and walks an `if/elif` chain to build a `preview`
+packet tagged with one of six kinds. On the frontend, `PreviewRenderer` reads
+that kind and picks one of six built-in renderers. This was the right shape for
+a prototype: a fixed menu of previews for a fixed menu of types. It is the
+wrong shape for a platform whose premise is multimodal scientific data, where
+the set of meaningful types — and the set of meaningful ways to look at them —
+is open-ended and owned by domains, not by core.
+
+This ADR decides that Preview stops being a fixed menu and becomes an open,
+extensible surface, and it commits to doing so without leaving the seam between
+"what we built first" and "what we add later" as technical debt. The mechanism
+is a single **provider resolution chain**: for any output, Preview asks "who
+renders this?" and walks from the most specific answer to the most general.
+Onto that chain we open exactly two authoring surfaces — one for **package
+authors**, who ship interactive renderers bound to the data types they define,
+and one for **end users**, who write a matplotlib function in their own project
+to plot a specific result. Core retreats to providing only the basic fallback
+viewers for the base data types.
+
+The reason this avoids debt is structural rather than a matter of effort. The
+chain's tiers, and the produce/render modes behind them, are a closed set,
+chosen so that every preview — today's six, the imaging team's future viewers,
+a user's one-off plot — is a combination of already-defined parts rather than a
+new branch in a switch. The heaviest part to build (loading package UI at
+runtime, safely) is isolated as one value of one mode, so the rest of the
+system does not wait on it and is not reshaped by it. The contracts that make
+this concrete are specified in `docs/specs/adr-048-extensible-preview.md`; this
+ADR records why the shape is what it is.
+
+### 1.1 Problems Addressed
+
+| Problem | Risk | ADR response | Detailed section |
+|---|---|---|---|
+| Preview dispatch is hardcoded in two places (backend `if/elif`, frontend `switch`) and cannot grow | New and domain types can never be previewed properly; every addition is a core edit | Replace both with one provider resolution chain | Section 3 |
+| There is no way for a user to plot their own data | Plotting is table stakes for scientific data; its absence pushes work out of the tool | Let users write a backend matplotlib function bound to an output | Section 4 |
+| Packages can contribute types and blocks but no preview UI; the plugin boundary is backend-only | Domains cannot express how their data should look; richness can only be added by editing core | Let packages ship renderers loaded at runtime, behind a sandbox | Section 5 |
+| The one rich viewer (image) lives in core although it is an imaging-domain concern | Plugin logic sits in core, against the architecture; core carries domain knowledge it should not | Move the image viewer into the imaging package; core keeps only base-type viewers | Section 6 |
+| Preview is single-object and cannot render a whole collection together | Common needs (ten spectra drawn together) are impossible; the data model and the view disagree | Make Preview collection-level and reference-based | Section 7 |
+
+## 2. Why now
+
+The prototype's fixed menu has already started to chafe. The imaging package
+defines `Image`, `Mask`, `Label`, and `Transform`, but none of them can say how
+they want to be seen — `Image` borrows the generic array path and `Label`
+borrows the generic composite path. There is no plotting at all, which for a
+scientific tool is a conspicuous gap. And the most capable viewer we have, the
+image viewer with pan, zoom, and lookup-table control, lives in core even
+though it encodes imaging-domain assumptions. Each of these is a symptom of the
+same root cause: preview behavior is owned by core and selected by a closed
+switch. The decision here is to change the ownership model, not to add a
+seventh case to the switch.
+
+## 3. One preview, one resolution chain
+
+The core decision is to delete the two switches and route every preview through
+a single chain. For a given output, the chain is evaluated most-specific-first:
+
+1. a user plot bound to that exact output;
+2. a user plot bound to that output's type, scoped to the project;
+3. a package renderer bound to that output's type;
+4. the core basic viewer for the output's base type.
+
+A tier that has no applicable provider falls through to the next, and the chain
+always terminates at a core viewer, so no resolvable output is ever left with
+"no preview". This ordering is not arbitrary — it follows ownership. The most
+specific thing in the system is a user's intent about one result in their own
+analysis, so that wins; a package's opinion about a whole type is next; core's
+generic knowledge of a base type is the floor. Each tier has a natural author,
+and because the order is strict there is no ambiguity when more than one
+provider could apply.
+
+The payoff of having exactly one dispatch is that "extensible preview" reduces
+to "add a provider to a tier". The two surfaces below are simply the two tiers
+that are not core's.
+
+## 4. Users plot their own data
+
+The first surface is for the end user, and it is deliberately the cheaper one,
+because it rides rails the runtime already has. A user writes a Python function
+in their own project whose body is ordinary matplotlib and which returns a
+figure. Conceptually this is a small hidden block attached to the output: its
+input is the output, its output is a figure. We model it that way in practice —
+it executes in the backend under the same subprocess isolation the runtime uses
+for block code, so running user-authored plot code introduces no new trust
+surface; it is the trust posture we already accept for blocks and packages.
+
+Two properties make this fit cleanly. First, it is lazy: the plot runs when
+Preview is opened for the output, not on every workflow run, so a project does
+not pay for plots it is not looking at, and the result is cached as a figure
+artifact. Second, because a matplotlib figure renders to an image, Preview
+displays it through the image path that already exists, and "save/export" is
+free because the figure is just an artifact. The user writes a function body;
+everything around it is machinery we already have. A user authors Python, never
+JavaScript — which is what keeps this surface small and is why the user never
+appears in the package-renderer tier.
+
+## 5. Packages ship their own renderers
+
+The second surface is for the package author, and it is where the real
+engineering lives. A package should be able to give its types a genuinely
+custom, interactive view — the imaging team's idea of how an `Image` or a
+`Label` should look is theirs, not core's. The decision is that a package ships
+an interactive renderer, bound to a data type, that the application loads at
+**runtime**: a user installs the package, reloads, and the renderer is there,
+with no rebuild of the frontend. We chose runtime loading over compiling
+package UI into the application at build time because the whole point is an
+ecosystem where domains extend the tool independently; a model where every new
+package forces a rebuild contradicts that, and is especially poor for a desktop
+build.
+
+Runtime-loaded third-party UI is the part that demands care, and the decision
+is to contain rather than trust it. A package renderer runs inside a sandbox —
+an isolated frame — and can reach the host only through a declared, typed
+bridge that exposes the data-access API and rendering hints. It cannot touch
+host credentials, host storage, or the host DOM directly. Each renderer
+declares the renderer-API version it targets, and the host refuses to load a
+version it does not support, falling back down the chain and recording why. The
+cost of this surface is real (a loader, a sandbox, a versioned bridge), which
+is exactly why it is isolated as one tier: the chain and the user-plot surface
+ship and deliver value before this is finished, and when it is finished it
+slots in without reshaping anything above it.
+
+## 6. Core keeps only the basics, and the image viewer goes home
+
+If packages own domain views, then core should own only the generic ones. Core
+provides a basic viewer for each base type — `Array`, `Series`, `DataFrame`,
+`Text`, `CompositeData`, and `Artifact` — and nothing domain-specific. The
+composite viewer is intentionally minimal: it shows which named slots a
+`CompositeData` contains and the data type of each, a structural inspector
+rather than a deep render, because anything richer is a domain opinion that
+belongs to a package.
+
+This makes the existing image viewer an anomaly to be corrected: it is imaging
+domain knowledge sitting in core. The decision is to migrate it out of core and
+into the imaging package as the first package renderer, bound to `Image`. This
+does double duty. It removes plugin logic from core, which the architecture
+asks for. And it is the dogfood that proves the runtime-loading mechanism end
+to end on a real, non-trivial viewer rather than a toy — if the migrated image
+viewer loads, sandboxes, reads its data, and renders, the package surface is
+real. Because the migration depends on the loader existing, it is sequenced
+after it; core retains a basic `Array` viewer so that, with imaging absent, an
+array still previews.
+
+## 7. Collection-level, by reference
+
+A quiet but load-bearing decision is that Preview operates over the whole
+collection behind an output, not a single object. The motivating case is
+ordinary: ten spectra stored as a ten-object collection that the user wants
+drawn together. The decision is that a provider always receives the collection;
+a single object is presented as a collection of length one, so single- and
+multi-object cases are one code path.
+
+The collection is passed by **reference**, not as a pre-serialized payload —
+and this is what makes the whole design tractable. A SciStudio collection is
+already a reference under the ADR-031 reference-only data contract, so the
+contract is simply "give the provider the reference and let it read what it
+needs". A backend user plot receives the in-process collection the way a block
+does. A frontend package renderer receives the collection's reference and reads
+through the data-access API, pulling object references and per-object data and
+metadata on demand. There is no moment where core serializes a whole collection
+into a packet, which is what would otherwise make a ten-thousand-image
+collection explode; the renderer reads only what it draws.
+
+## 8. Scope
+
+In scope for this decision: the resolution chain and its priority order; the
+two extension surfaces (user plots and package renderers) and the core
+fallback viewers; the runtime-loading and sandbox posture for package
+renderers; the collection-level, reference-based data model for preview; and
+the migration of the image viewer into the imaging package.
+
+Out of scope: the implementation itself, which is sequenced after this ADR is
+accepted and tracked separately; letting end users ship JavaScript renderers
+(users author Python only); interactive re-rendering of a user's matplotlib
+output (a matplotlib figure is static by nature); and any change to the
+reference-only transport (ADR-031), named axes (ADR-027), or metadata store
+(ADR-032), which are reused unchanged.
+
+## 9. Verification and tooling impact
+
+Because this ADR ships no code, its own verification is documentary: the ADR
+and the companion spec pass frontmatter and structure validation and the
+ADR-042 full audit, and the gate record for this docs task reconciles. The
+spec carries the testable obligations the implementation must later satisfy —
+provider resolution honoring the priority and fall-through, isolated user-plot
+execution, collection enumerate/read access, renderer registration and version
+gating, the sandbox boundary, and a live end-to-end smoke of both surfaces
+(per the repository rule that UI-touching work needs a real smoke test, not
+only unit tests). No CI tool, quality threshold, or protected path is weakened
+by this decision.
+
+## 10. Consequences
+
+The positive consequences are the point: any data type can be given a proper
+preview by the people who own it; plotting exists; core sheds domain knowledge;
+and a single dispatch replaces two brittle switches. The model also composes —
+a future need is a new provider on an existing tier, not a new concept.
+
+The accepted costs are honest. The package-renderer surface is a substantial
+build: a runtime module loader, a sandbox, and a versioned host bridge, plus
+the ongoing responsibility of versioning that bridge as it evolves. Running
+third-party UI, even sandboxed, is a security surface that must be maintained.
+And the image-viewer migration is a real move with regression risk, bounded by
+keeping a basic array viewer in core. None of these are reasons to prefer the
+status quo, in which none of the value is reachable at all; they are the price
+of the value, taken deliberately.
+
+## 11. Alternatives considered
+
+| Alternative | Why rejected |
+|---|---|
+| Keep the switch, add cases as needed | The thing we are replacing; it makes core the owner of every preview and cannot support an ecosystem |
+| Declarative-only previews (packages describe views with a fixed vocabulary of primitives; no package code runs) | Cheaper and safer, but bounded by the vocabulary; for a platform aiming to preview *any* type, the ceiling is the wrong tradeoff — the owner chose package code with full freedom |
+| Compile package UI into the app at build time | Simpler and needs no sandbox, but every new package forces a frontend rebuild, which defeats install-and-go and is poor for a desktop build |
+| Let users ship JavaScript renderers too | Unnecessary: users want to plot, and matplotlib over the backend covers that without putting another JS-execution surface in front of end users |
+| Pre-serialize collection data into the preview payload | Does not scale; a large collection would blow up the payload. Reference-based access reads only what is drawn |
+
+## 12. References
+
+- `docs/specs/adr-048-extensible-preview.md` — the contracts this ADR decides
+- ADR-017 / ADR-020 / ADR-021 / ADR-022 — subprocess isolation and collection
+  transport reused by user-plot execution and reference-based reads
+- ADR-027 — named axes carried by `Array` types and used by viewers
+- ADR-031 — reference-only data contract that makes reference-passing natural
+- ADR-032 — metadata store that supplies preview-relevant metadata
+- ADR-043 — package/type capability registration, the pattern the new
+  `scistudio.preview_renderers` registration follows
+- Issue #1566 — tracking issue for this ADR and spec

--- a/docs/specs/adr-048-extensible-preview.md
+++ b/docs/specs/adr-048-extensible-preview.md
@@ -1,0 +1,477 @@
+---
+spec_id: adr-048-extensible-preview
+title: "Extensible Preview Providers"
+status: Draft
+feature_branch: docs/adr-048-extensible-preview
+created: 2026-06-10
+input: "Owner request (2026-06-10): make Preview extensible so any data type can be previewed — package-defined renderers loaded at runtime plus user-defined matplotlib plot functions — with a provider resolution chain and core fallback viewers."
+owners:
+  - "@jiazhenz026"
+related_adrs:
+  - 48
+related_specs: []
+scope:
+  in:
+    - The preview provider resolution chain and its fixed priority order.
+    - Core fallback viewers for every base type (Array, Series, DataFrame, Text, CompositeData, Artifact).
+    - The user-defined matplotlib plot-function contract, its binding model, backend execution, caching, and figure export.
+    - The package-defined renderer contract, runtime dynamic loading, sandbox/trust model, and versioned renderer API.
+    - Collection-aware, reference-based data access shared by user plots and package renderers.
+    - Migration of the existing image viewer out of core into the imaging package as the first package renderer.
+  out:
+    - Implementation code. This spec is the contract; implementation is sequenced after ADR-048 is accepted.
+    - Letting end users ship JavaScript renderers. End users author Python/matplotlib only.
+    - Interactive (zoom/pan/hover) re-rendering of user matplotlib output. A matplotlib plot is a static figure.
+    - Changing the reference-only data transport (ADR-031) or the named-axes contract (ADR-027). They are reused unchanged.
+    - Real-time collaborative or multi-user preview concerns.
+governs:
+  modules:
+    - scistudio.api.runtime
+    - scistudio.core.types
+  contracts: []
+  files:
+    - docs/specs/adr-048-extensible-preview.md
+    - docs/adr/ADR-048.md
+    - src/scistudio/api/runtime/_data.py
+    - src/scistudio/api/routes/data.py
+    - frontend/src/components/DataPreview.parts/PreviewRenderer.tsx
+    - frontend/src/components/DataPreview.tsx
+    - frontend/src/components/DataPreview.parts/ImageViewer.tsx
+    - src/scistudio/core/types/**
+    - packages/scistudio-blocks-imaging/**
+  excludes:
+    - tests/**
+    - docs/audit/**
+tests: []
+acceptance_source: adr
+language_source: en
+---
+
+# Extensible Preview Providers
+
+## 1. Change Summary
+
+Today the Preview panel is hardcoded from end to end. The backend
+`preview_data()` decides what to show through an `if/elif` chain keyed on a
+data object's type name and file extension, and the frontend `PreviewRenderer`
+switches on a fixed set of six `preview.kind` strings (`table`, `image`,
+`chart`, `text`, `composite`, `artifact`). A package can already contribute new
+data **types** through the `scistudio.types` entry point, but it cannot
+contribute any preview **behavior**. As a result the imaging package's `Image`
+and `Label` types borrow the generic array and composite paths, there is no way
+to plot scientific data, and the one rich viewer that does exist — the image
+viewer with pan/zoom/LUT — lives in core even though it is an imaging-domain
+concern.
+
+This spec defines how Preview becomes extensible without leaving technical
+debt. It replaces the two hardcoded dispatch points with a single **provider
+resolution chain**, and it opens exactly two authoring surfaces on that chain:
+**package-defined renderers** (interactive UI a package ships and the app loads
+at runtime) and **user-defined plot functions** (a matplotlib function a user
+writes in their own project, executed in the backend). Core keeps only basic
+fallback viewers for the base types. The chain's priority order, the data each
+provider receives, and the closed set of produce/render modes are all specified
+here so that every future preview is a combination of already-defined parts
+rather than a new special case.
+
+This spec is derived from the owner request recorded in ADR-048 and is the
+contract that the (separately sequenced) implementation must satisfy. It does
+not itself change code.
+
+## 2. User Scenarios & Testing
+
+### User Story 1 - Core fallback viewers on a resolution chain (Priority: P1)
+
+Every block output — of any base type — still previews after the hardcoded
+dispatch is replaced by the resolution chain. When no package renderer and no
+user plot apply, core's basic per-type viewer renders the output. A
+`CompositeData` output shows which named slots it contains and the data type of
+each slot.
+
+**Why this priority**: This is the foundation. The chain plus the core
+fallback viewers must exist before any extension surface can plug into it, and
+it must preserve the previews users already rely on. Shipping only this story
+is a net-neutral refactor that unlocks everything else.
+
+**Independent Test**: Produce one output of each base type (Array, Series,
+DataFrame, Text, CompositeData, Artifact) in a project with no package
+renderers and no user plots, open Preview for each, and confirm each renders
+with the correct core viewer and that the CompositeData viewer lists its slot
+names and per-slot types.
+
+**Acceptance Scenarios**:
+
+1. **Given** a project with no package renderers and no user plots, **When** a
+   user opens Preview for a `DataFrame` output, **Then** the core table viewer
+   renders it exactly as it does today.
+2. **Given** the same project, **When** a user opens Preview for a
+   `CompositeData` output that contains slots `raster: Array` and
+   `polygons: DataFrame`, **Then** the core composite viewer shows the two slot
+   names and their data types.
+3. **Given** an output whose type has no more-specific provider, **When**
+   Preview resolves a provider, **Then** the resolution ends at the core viewer
+   for that type's base type and never errors with "no preview available".
+
+### User Story 2 - User plots their own data with matplotlib (Priority: P2)
+
+A user writes a matplotlib plot function in their own project and binds it to a
+block's output. Opening Preview for that output runs the function in the
+backend and shows the resulting figure in the same place the output's preview
+appears. The figure can be saved/exported.
+
+**Why this priority**: This is the headline new capability — plotting, which
+scientific data work requires — and it is the cheaper of the two extension
+surfaces because it reuses the existing backend code-execution and image-render
+paths. It delivers standalone value the moment the chain (P1) exists.
+
+**Independent Test**: In a project, add a plot function bound to a specific
+block output, open Preview for that output, and confirm the rendered figure
+matches the function; then trigger save/export and confirm a figure artifact is
+produced. No application rebuild or restart is required between writing the
+function and seeing the figure.
+
+**Acceptance Scenarios**:
+
+1. **Given** a block output and a user plot function bound to it, **When** the
+   user opens Preview for that output, **Then** the backend executes the
+   function and Preview shows the returned figure.
+2. **Given** a displayed user-plot figure, **When** the user saves/exports it,
+   **Then** a figure artifact is produced and retrievable.
+3. **Given** a user plot function that raises an error, **When** Preview runs
+   it, **Then** the error is surfaced to the user and the provider chain falls
+   back to the next applicable provider rather than crashing the panel.
+
+### User Story 3 - A package ships a renderer for its data type (Priority: P3)
+
+A package author ships an interactive renderer bound to a data type the package
+defines. After the package is installed, the application loads the renderer at
+runtime — no frontend rebuild — and outputs of that type render with the
+package's UI. The current core image viewer is migrated into the imaging
+package as the first such renderer; core keeps only a basic array viewer.
+
+**Why this priority**: This is the most powerful and the heaviest surface
+(runtime module loading plus a sandbox). It is also the one that cleans up the
+core/plugin boundary by moving the image viewer where it belongs. It depends on
+the chain (P1) and is exercised end to end by the imaging migration.
+
+**Independent Test**: Install a package that registers a renderer for one of
+its types, reload the app (no rebuild), open Preview for an output of that type,
+and confirm the package renderer is shown. Then disable/remove the renderer and
+confirm Preview falls back to the core viewer for that type's base type.
+
+**Acceptance Scenarios**:
+
+1. **Given** an installed package that registers a renderer for type `Image`,
+   **When** a user opens Preview for an `Image` output, **Then** the package
+   renderer is loaded at runtime and renders the output.
+2. **Given** no installed renderer for a type, **When** a user opens Preview
+   for an output of that type, **Then** the chain falls back to the core basic
+   viewer.
+3. **Given** a package renderer running in the host, **When** it attempts to
+   read host credentials or reach into the host DOM outside the sandbox bridge,
+   **Then** the attempt is denied by the sandbox.
+4. **Given** the migrated imaging renderer, **When** the imaging package is not
+   installed, **Then** core contains no imaging-specific viewer code and an
+   `Array` still previews through the core array viewer.
+
+### User Story 4 - Plot a whole collection together (Priority: P4)
+
+A user's plot function receives the entire collection behind an output, not a
+single object, so that data such as ten spectra stored as a ten-object
+collection can be drawn together in one figure.
+
+**Why this priority**: It is a refinement of the user-plot surface that the
+owner called out explicitly. It is valuable but builds directly on P2 and the
+collection-aware data access shared with P3.
+
+**Independent Test**: Produce a block output that is a collection of N `Series`
+objects, bind a user plot that iterates the collection and overlays each
+series, open Preview, and confirm all N series appear in a single figure.
+
+**Acceptance Scenarios**:
+
+1. **Given** a block output that resolves to a collection of N objects,
+   **When** the bound user plot runs, **Then** the function receives all N
+   objects and the figure contains all N.
+2. **Given** a block output that resolves to a single object, **When** a user
+   plot runs, **Then** the function receives a collection of length 1, so the
+   single-object and multi-object cases use one code path.
+
+### Edge Cases
+
+- A type has both a package renderer and a user plot bound to the same output:
+  resolution priority decides; the user plot (output binding) wins.
+- A package renderer declares a renderer-API version the host does not support:
+  the renderer is skipped and the chain falls back, with a recorded
+  incompatibility reason.
+- A user plot or package renderer requests an object that no longer exists in
+  the collection (stale reference): the data-access API returns a not-found
+  result the provider must handle; Preview does not 500.
+- A very large collection is bound to a user plot: the function still receives
+  the whole collection by reference and is responsible for sampling; the
+  contract documents this rather than silently truncating.
+- Two user plots are bound, one to the output and one to the output's type:
+  the output binding wins per the priority order.
+
+## 3. Requirements
+
+### Functional Requirements
+
+- **FR-001**: Preview MUST resolve which provider renders a given block output
+  through a single resolution chain evaluated in this fixed priority order,
+  most specific first: (1) a user plot bound to that output; (2) a user plot
+  bound to that output's type within the project; (3) a package renderer bound
+  to that output's type; (4) the core basic viewer for the output's base type.
+- **FR-002**: The resolution chain MUST fall through to the next tier whenever
+  a higher tier has no applicable provider, and MUST always terminate at a core
+  viewer so that no resolvable output is left without a preview.
+- **FR-003**: Core MUST provide a basic viewer for each base type: `Array`,
+  `Series`, `DataFrame`, `Text`, `CompositeData`, and `Artifact`.
+- **FR-004**: The core `CompositeData` viewer MUST display the composite's
+  named slots and the data type of each slot. It is a structural inspector, not
+  a deep render of slot contents.
+- **FR-005**: Core MUST NOT contain viewers specific to a package-defined
+  domain type. Domain viewers MUST be contributed by their package.
+- **FR-006**: A user MUST be able to define a plot as a Python function in their
+  own project whose body uses matplotlib, conforming to a fixed signature that
+  receives the bound output as a collection and returns a matplotlib figure.
+- **FR-007**: A user plot MUST be bindable to a specific block output (primary
+  binding) and MAY be bindable to a data type within the project (secondary
+  binding), with the priority defined in FR-001.
+- **FR-008**: A user plot MUST execute in the backend under the same isolation
+  the runtime uses to execute block code, and MUST run lazily at preview time
+  (on demand), not as part of normal workflow execution.
+- **FR-009**: The result of a user plot MUST be a figure that Preview displays
+  and that the user can save/export as an artifact.
+- **FR-010**: When a user plot raises, Preview MUST surface the error and the
+  chain MUST fall back to the next applicable provider; the panel MUST NOT
+  crash.
+- **FR-011**: A package MUST be able to register a renderer bound to a data
+  type through a declared extension point, distinct from the existing
+  `scistudio.types` and `scistudio.blocks` entry points.
+- **FR-012**: A registered package renderer MUST be loaded by the frontend at
+  runtime after the package is installed, with no frontend rebuild required
+  (install-and-go).
+- **FR-013**: A package renderer MUST run inside a sandbox that prevents it from
+  accessing host credentials, host storage, or the host DOM except through a
+  declared, typed host bridge.
+- **FR-014**: A package renderer MUST declare the renderer-API version it
+  targets. The host MUST refuse to load a renderer whose version it does not
+  support and MUST fall back per FR-002, recording the incompatibility reason.
+- **FR-015**: Preview MUST operate over the entire collection behind an output.
+  A single object MUST be presented to providers as a collection of length one
+  so that single- and multi-object cases share one contract.
+- **FR-016**: Providers MUST receive the data as a reference, not as a
+  pre-serialized payload. A user plot receives the in-process collection the
+  way a block does; a package renderer receives the collection's reference and
+  reads through the data-access API.
+- **FR-017**: The data-access API MUST let a renderer enumerate the objects in a
+  collection and read each object's data and metadata on demand, so a renderer
+  pulls only what it needs.
+- **FR-018**: The existing image viewer MUST be migrated from core into the
+  imaging package as a package renderer bound to `Image`, and core MUST retain
+  only a basic `Array` viewer after the migration.
+
+### Key Entities
+
+- **PreviewProvider**: The unit the chain resolves to. Attributes: `binding`
+  (output id, type name, or base type), `source` (`user-plot`,
+  `package-renderer`, or `core-viewer`), `produce_mode` (`backend-figure` or
+  `reference-read`), `render_mode` (`image`, `core-viewer`, or
+  `package-component`). Relationship: many providers may apply to one output;
+  the chain selects the highest-priority applicable one.
+- **ProviderResolution**: The result of evaluating the chain for one output.
+  Attributes: `output_ref`, `selected_provider`, `fallback_reason` (when a
+  higher tier was skipped). Relationship: one resolution per output per preview
+  request.
+- **UserPlotFunction**: A user-authored Python function. Attributes: `binding`
+  (output id or type), `signature` (receives a `Collection` and a plot context,
+  returns a figure), `source_location` (project file). Relationship: produces a
+  `FigureArtifact`.
+- **PlotContext**: The non-data argument passed to a user plot. Attributes:
+  rendering hints such as size/theme and any declared helpers. Relationship:
+  supplied by the runtime at execution time.
+- **PackageRendererRegistration**: A package's declaration that a renderer
+  serves a type. Attributes: `type_name`, `module_ref` (the loadable renderer
+  module), `api_version`. Relationship: resolved by the chain at tier 3.
+- **PreviewDataAccess**: The reference-plus-API contract a provider uses to read
+  data. Attributes: `collection_ref`, `enumerate()` over object refs,
+  `read(object_ref)` for data/metadata. Relationship: shared by user plots
+  (in-process) and package renderers (over the API).
+- **FigureArtifact**: The saved output of a user plot. Attributes: `format`
+  (raster/vector), `source_output_ref`. Relationship: produced by a
+  `UserPlotFunction`, exportable by the user.
+
+## 4. Implementation Plan
+
+### 4.1 Technical Approach
+
+The two hardcoded dispatch points — the backend `preview_data()` `if/elif`
+chain and the frontend `PreviewRenderer` switch — are replaced by one
+**resolution chain** that both sides consult. For a given output the chain
+returns a `ProviderResolution` naming the selected provider and how to render
+it. Because the chain is the only dispatch, every preview path is one of the
+four tiers in FR-001, and the produce/render modes are a closed set, every
+future preview is a combination of defined parts rather than a new branch.
+
+There are two execution paths behind the chain, unified by the resolution:
+
+- **Backend figure path** (user plots, and any package renderer that chooses to
+  render server-side): the runtime executes Python that returns a matplotlib
+  figure; the figure is rendered to an image and Preview displays it through the
+  same image path that exists today. User plot execution reuses the block
+  execution isolation (subprocess) so running user code carries no new trust
+  model — it is the trust model the runtime already has for block and package
+  code. Execution is lazy: it happens when Preview is opened for the output and
+  the result is cached as a figure artifact keyed by the output and inputs.
+- **Frontend renderer path** (package renderers, and the core viewers): the
+  backend hands the frontend the collection's reference and the selected
+  provider; the frontend renders. Core viewers are built in. Package renderers
+  are pre-built JavaScript modules the host loads at runtime via dynamic import
+  and runs inside a sandbox (an isolated frame) that exposes only a typed host
+  bridge: the data-access API and rendering hints. The renderer reads data by
+  pulling object refs and per-object data/metadata through that bridge over the
+  existing data HTTP API; it never receives a large pre-serialized payload and
+  cannot reach host credentials, storage, or DOM directly. Each renderer
+  declares the renderer-API version it targets so the host can refuse
+  incompatible modules and fall back.
+
+Data is passed by reference throughout. A SciStudio collection is already a
+reference under the ADR-031 reference-only data contract, so "give the provider
+the reference and let it read what it needs" is the natural contract: a backend
+user plot receives the in-process `Collection` exactly as a block does, and a
+frontend package renderer receives the collection ref and reads through the
+data-access API. Preview is collection-level: a single object is wrapped as a
+length-one collection so providers have one shape to handle.
+
+The renderer registration uses a new extension point (sibling to
+`scistudio.types` and `scistudio.blocks`) keyed by data type, so a package
+declares "type X → renderer module" the same way it declares its types and
+blocks today. The core/plugin boundary is enforced by migrating the existing
+image viewer out of core into the imaging package as the first registered
+renderer; this both proves the runtime-loading mechanism end to end and removes
+imaging-domain UI from core.
+
+### 4.2 Affected Files
+
+| File or surface | Action | Rationale |
+|---|---|---|
+| `src/scistudio/api/runtime/_data.py` | modify | Replace the `if/elif` preview dispatch with provider-chain resolution; keep core base-type producers. |
+| `src/scistudio/api/routes/data.py` | modify | Preview endpoint returns the resolved provider; add collection enumerate/read access for renderers. |
+| API preview response schema (`src/scistudio/api/**/schemas.py`) | modify | `DataPreviewResponse` carries the resolved provider descriptor instead of a fixed `kind`. |
+| Preview provider resolver (new core module under `src/scistudio/api/runtime/` or `src/scistudio/core/`) | create | Single place that evaluates the FR-001 chain. |
+| User-plot runner (new module) | create | Executes a project plot function under block isolation and caches the figure artifact. |
+| Renderer registry + entry-point group `scistudio.preview_renderers` (new) | create | Type → renderer registration discovered like `scistudio.types`. |
+| `frontend/src/components/DataPreview.parts/PreviewRenderer.tsx` | modify | Replace the `kind` switch with provider-driven rendering: core viewer, image, or sandboxed package renderer host. |
+| `frontend/src/components/DataPreview.tsx` | modify | Drive panel from the resolved provider; route figure results through the image path. |
+| Renderer host/loader + sandbox bridge (new frontend module) | create | Dynamic-import + sandbox + typed host bridge (data access, hints) with API versioning. |
+| Core base-type viewers (`frontend/src/components/DataPreview.parts/` — array/series/text/composite; `TableViewer` already exists) | create/modify | Basic viewers for the FR-003 base types; composite slot inspector per FR-004. |
+| `frontend/src/components/DataPreview.parts/ImageViewer.tsx` | delete (move) | Migrated into the imaging package per FR-018. |
+| `packages/scistudio-blocks-imaging/**` | modify | Register and ship the `Image` renderer (the migrated viewer) and its renderer-API version. |
+| User project plot config/template | create | The fixed plot-function signature and a fill-in scaffold users edit. |
+| `docs/adr/ADR-048.md`, `docs/specs/adr-048-extensible-preview.md` | create | This decision and contract. |
+
+New modules are listed by role; their final paths are fixed during
+implementation and are not yet created (this task is docs-only).
+
+### 4.3 Implementation Sequence
+
+1. **Resolution chain + core viewers (US1)**: introduce the provider chain and
+   move the current behavior behind it as core base-type viewers, preserving
+   today's previews. Net-neutral.
+2. **User plot backend execution (US2)**: the plot-function contract, output
+   binding, lazy isolated execution, figure caching, and save/export.
+3. **Collection-aware data access (supports US3/US4)**: enumerate/read API over
+   a collection reference, and the length-one wrapping of single objects.
+4. **Renderer registration + runtime loader + sandbox (US3)**: the
+   `scistudio.preview_renderers` entry point, dynamic import, sandbox bridge,
+   and API versioning.
+5. **Migrate the image viewer into imaging (US3, dogfood)**: register it as the
+   `Image` renderer; remove imaging-specific viewer code from core; keep a
+   basic core `Array` viewer.
+6. **Collection-together plotting (US4)**: the user plot receives the whole
+   collection; verify multi-object overlay.
+
+Steps 4–5 are the heaviest. They sit behind the chain from step 1, so steps 1–3
+deliver value without waiting on the runtime loader.
+
+### 4.4 Verification Plan
+
+- **Backend tests**: provider resolution honors the FR-001 priority and
+  fall-through; core base-type producers (incl. the composite slot inspector);
+  user-plot execution runs under isolation and caches a figure; collection
+  enumerate/read access; renderer registration discovery and version gating.
+- **Frontend tests**: provider-driven rendering replaces the `kind` switch;
+  core viewers render each base type; the renderer host loads a module, applies
+  the sandbox bridge, and falls back on unsupported API version; figure results
+  route through the image path.
+- **End-to-end (Chrome smoke)**: a user plot bound to a real block output
+  renders and exports; the migrated imaging `Image` renderer loads at runtime
+  and renders; removing it falls back to the core array viewer. (Per the
+  repository rule that UI-touching work needs a live smoke test, not only unit
+  tests.)
+- **Checks**: `ruff`/`mypy`, frontend lint/typecheck/test/build, ADR-042 full
+  audit, and the workflow-gate docs/closure checks for this spec and ADR-048.
+- **Security check**: confirm a package renderer cannot read host credentials,
+  host storage, or host DOM outside the sandbox bridge.
+
+### 4.5 Risks And Rollback
+
+- **Running package JavaScript in the host (highest risk)**: mitigated by the
+  sandbox (isolated frame + typed bridge) and renderer-API versioning. If the
+  sandbox is not ready, tiers 1–2 (core viewers and user plots) still ship; the
+  package-renderer tier stays behind the chain and is disabled.
+- **Running user Python**: rides the existing block-execution isolation, so it
+  introduces no new trust surface beyond what the runtime already accepts for
+  block and package code.
+- **Large collections**: reference-based access avoids a payload blow-up; user
+  plots receive the whole collection and are documented as responsible for
+  sampling rather than silently truncated.
+- **Renderer-API churn**: versioning lets the host reject incompatible
+  renderers and fall back, so an API change degrades to a core viewer rather
+  than a broken panel.
+- **Image viewer migration**: regression risk is bounded because core retains a
+  basic array viewer; if the imaging renderer is absent, `Array` still
+  previews.
+- **Rollback**: the resolution chain can default to core viewers only, which
+  reproduces today's behavior, so the extension surfaces can be disabled
+  without removing the chain.
+
+## 5. Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: With no package renderers and no user plots installed, every base
+  type (Array, Series, DataFrame, Text, CompositeData, Artifact) previews
+  through a core viewer with no regression relative to the current six preview
+  kinds.
+- **SC-002**: A user can add a matplotlib plot bound to a block output and see
+  its figure in Preview without rebuilding or restarting the application.
+- **SC-003**: Installing a package that registers a renderer for a type and
+  reloading the app shows that renderer for the type's outputs with no frontend
+  rebuild.
+- **SC-004**: Disabling or removing a provider causes Preview to fall back to
+  the next tier deterministically, ending at a core viewer.
+- **SC-005**: A collection of N objects can be drawn together in a single figure
+  by one user plot function.
+- **SC-006**: The image viewer is served from the imaging package, and core
+  contains no imaging-specific viewer code, while an `Array` still previews
+  through the core array viewer.
+- **SC-007**: A package renderer cannot access host credentials, host storage,
+  or host DOM outside the sandbox bridge.
+
+## 6. Assumptions
+
+- A SciStudio collection is a reference under the ADR-031 reference-only data
+  contract, so passing a reference and reading through the data-access API is
+  feasible without a new transport. (Source: existing-system)
+- Block execution runs in subprocess isolation (ADR-017/020/021/022), which
+  user-plot execution reuses. (Source: adr)
+- A data HTTP API exists (`/api/data/...`) and can be extended with
+  collection enumerate/read access for renderers. (Source: existing-system)
+- End users author Python/matplotlib, not JavaScript; only package authors ship
+  JavaScript renderers. (Source: owner)
+- Named axes (ADR-027) and the metadata store (ADR-032) remain the source of a
+  type's preview-relevant metadata. (Source: existing-system)
+- This spec is docs-only; implementation is sequenced after ADR-048 is
+  accepted. (Source: owner)


### PR DESCRIPTION
## Summary

This PR adds **ADR-048** and its companion spec, deciding and specifying how
SciStudio's Preview becomes extensible. It is **docs-only — no code**.

Today the Preview panel is hardcoded end to end: the backend `preview_data()`
walks an `if/elif` chain keyed on type name + file extension, and the frontend
`PreviewRenderer` switches on six fixed `preview.kind` values. Packages can
contribute data **types** but no preview **behavior**; there is no plotting; and
the rich image viewer lives in core although it is an imaging-domain concern.

ADR-048 replaces both hardcoded dispatch points with a single **provider
resolution chain** and opens two authoring surfaces on it:

- **Package-defined renderers** — interactive UI a package ships, bound to a
  data type, loaded at runtime (install-and-go) inside a sandbox with a typed
  host bridge and a versioned renderer API.
- **User-defined plot functions** — a matplotlib function a user writes in their
  own project, executed in the backend under block isolation, displayed and
  saved as a figure.

Core retreats to basic per-base-type viewers; the image viewer migrates into the
imaging package as the first package renderer (and the dogfood of the
runtime-loading mechanism). Preview becomes collection-level and reference-based
("pass the reference, the renderer reads it itself").

## What's in this PR

- `docs/adr/ADR-048.md` — the design narrative and why the shape avoids tech
  debt (a closed set of tiers and produce/render modes).
- `docs/specs/adr-048-extensible-preview.md` — the contracts: the 4-tier
  resolution chain, the user-plot function contract + binding, package renderer
  registration (`scistudio.preview_renderers`) + runtime loading + sandbox + API
  versioning, collection-aware reference-based data access, the core viewer
  inventory, and the ImageViewer→imaging migration. Four prioritized user
  stories, 18 functional requirements, 7 success criteria.

## Open author-proposals for review

These were authored as the most reasonable choice but are open for your call:

1. Sandbox = isolated iframe + typed host bridge.
2. New registration entry point `scistudio.preview_renderers` (sibling to
   `scistudio.types` / `scistudio.blocks`).
3. User plot signature `preview_plot(data: Collection, ctx: PlotContext) -> Figure`.

## Scope

Docs-only / planning. No code. Implementation is sequenced after ADR-048 is
accepted.

Closes #1566
