### PR TITLE
fix(gate): validate finalized ledgers in CI

### DIFF
--- a/.workflow/records/1568-finalized-ledger-ci.json
+++ b/.workflow/records/1568-finalized-ledger-ci.json
@@ -990,7 +990,13 @@
     }
   ],
   "check_na": [],
-  "commit": null,
+  "commit": {
+    "sha": "c639d98952c13c1df60a611df7156bceb07036e3",
+    "shas": [
+      "c639d98952c13c1df60a611df7156bceb07036e3"
+    ],
+    "trailers": []
+  },
   "declared_scope": {
     "exclude": [],
     "include": [
@@ -1601,6 +1607,88 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-06-10T20:35:18.617596Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T20:35:18.644840Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T20:35:18.671264Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T20:35:18.698118Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T20:35:18.728475Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T20:35:18.756083Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T20:35:18.783563Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T20:35:18.813270Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T20:35:18.840371Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T20:35:18.868260Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -1613,37 +1701,44 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "origin/main",
+    "base": "35ab776ed08e5acf9c21e4b174fad2fcd3c00687",
     "base_sha": "35ab776e",
     "changed_files": [
       ".workflow/records/1568-finalized-ledger-ci.json",
       "docs/ai-developer/gate-cli-command-set.md",
       "docs/ai-developer/specific_rules/gated-workflow.md",
       "pyproject.toml",
+      "src/scistudio/qa/governance/gate_record/checks.py",
       "src/scistudio/qa/governance/gate_record/io.py",
+      "src/scistudio/qa/governance/gate_record/parity.py",
       "src/scistudio/qa/governance/gate_record/workflow.py",
       "tests/qa/test_gate_evaluator.py",
       "tests/qa/test_gate_parity_provision.py"
     ],
-    "diff_fingerprint": "sha256:be3c20ac60422e13ae38ddbcd4e5e072888a9473fee901070154bacbebc3d82d",
+    "diff_fingerprint": "sha256:10234993175d4eec6b50cadcc526f928051eef7c2509d73bdf913ae2cf5e89a1",
     "head": "HEAD",
-    "head_sha": "8c1f11d5",
+    "head_sha": "c639d989",
     "surfaces": {
       "docs": 2,
       "frontend": 0,
-      "governance": 5,
+      "governance": 7,
       "governed_docs": 2,
-      "implementation": 3,
+      "implementation": 5,
       "packaging": 1,
       "protected_core": 0,
-      "sentrux": 4,
+      "sentrux": 6,
       "test": 2,
       "workflow_ci": 0
     }
   },
   "owner_directive": "Fix issue #1568: CI mode must discover and validate post-PR finalized gate ledgers instead of reporting no ledger found.",
   "persona": "implementer",
-  "pull_request": null,
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [],
+    "number": 1569,
+    "url": "https://github.com/zjzcpj/SciStudio/pull/1569"
+  },
   "reconcile_events": [
     {
       "at": "2026-06-10T19:56:32.117887Z",
@@ -1716,23 +1811,21 @@
       "unsatisfied": [
         "checks.python_tests"
       ]
+    },
+    {
+      "at": "2026-06-10T20:35:18.868292Z",
+      "diff_fingerprint": "sha256:10234993175d4eec6b50cadcc526f928051eef7c2509d73bdf913ae2cf5e89a1",
+      "mode": "ci",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
     }
   ],
   "record_id": "1568-finalized-ledger-ci",
   "requested_admin_labels": [],
   "required_obligations": {
     "admin_labels": [],
-    "checks": [
-      "architecture_tests",
-      "format_check",
-      "full_audit",
-      "import_contracts",
-      "lint_format",
-      "python_tests",
-      "semantic_dup",
-      "type_check",
-      "wheel_release_smoke"
-    ],
+    "checks": [],
     "docs": [
       "docs_required_or_na"
     ],

--- a/.workflow/records/1568-finalized-ledger-ci.json
+++ b/.workflow/records/1568-finalized-ledger-ci.json
@@ -1,0 +1,1820 @@
+{
+  "branch": "codex/fix-finalized-ledger-ci",
+  "check_events": [
+    {
+      "at": "2026-06-10T19:52:19.199728Z",
+      "command": "pytest tests/architecture/ -v --no-cov",
+      "covered_surface": "architecture",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:50bc28ef6bb223c1ac63756cb49c8f88e6a9e2329d1edbe3be405ee207b021a2",
+      "name": "architecture_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/architecture_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-10T19:52:19.312731Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:50bc28ef6bb223c1ac63756cb49c8f88e6a9e2329d1edbe3be405ee207b021a2",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-10T19:52:27.611099Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:50bc28ef6bb223c1ac63756cb49c8f88e6a9e2329d1edbe3be405ee207b021a2",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-10T19:52:28.074140Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:50bc28ef6bb223c1ac63756cb49c8f88e6a9e2329d1edbe3be405ee207b021a2",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-10T19:52:28.154824Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:50bc28ef6bb223c1ac63756cb49c8f88e6a9e2329d1edbe3be405ee207b021a2",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-10T19:55:34.809417Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:50bc28ef6bb223c1ac63756cb49c8f88e6a9e2329d1edbe3be405ee207b021a2",
+      "name": "python_tests",
+      "parity_detail": "missing module: setuptools",
+      "parity_gap": true,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "parity gap: missing module: setuptools",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-10T19:56:22.938793Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:50bc28ef6bb223c1ac63756cb49c8f88e6a9e2329d1edbe3be405ee207b021a2",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-10T19:56:31.808280Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:50bc28ef6bb223c1ac63756cb49c8f88e6a9e2329d1edbe3be405ee207b021a2",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    },
+    {
+      "at": "2026-06-10T19:56:31.842194Z",
+      "command": "python -m build --wheel",
+      "covered_surface": "packaging",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:50bc28ef6bb223c1ac63756cb49c8f88e6a9e2329d1edbe3be405ee207b021a2",
+      "name": "wheel_release_smoke",
+      "parity_detail": "missing module: build",
+      "parity_gap": true,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/wheel_release_smoke.log",
+      "status": "fail",
+      "summary": "parity gap: missing module: build",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-10T19:57:24.707227Z",
+      "command": "pytest tests/architecture/ -v --no-cov",
+      "covered_surface": "architecture",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:50bc28ef6bb223c1ac63756cb49c8f88e6a9e2329d1edbe3be405ee207b021a2",
+      "name": "architecture_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/architecture_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-10T19:57:24.753321Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:50bc28ef6bb223c1ac63756cb49c8f88e6a9e2329d1edbe3be405ee207b021a2",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-10T19:57:32.442039Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:50bc28ef6bb223c1ac63756cb49c8f88e6a9e2329d1edbe3be405ee207b021a2",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-10T19:57:32.648399Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:50bc28ef6bb223c1ac63756cb49c8f88e6a9e2329d1edbe3be405ee207b021a2",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-10T19:57:32.684930Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:50bc28ef6bb223c1ac63756cb49c8f88e6a9e2329d1edbe3be405ee207b021a2",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-10T20:00:07.770093Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:50bc28ef6bb223c1ac63756cb49c8f88e6a9e2329d1edbe3be405ee207b021a2",
+      "name": "python_tests",
+      "parity_detail": "missing module: setuptools",
+      "parity_gap": true,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "parity gap: missing module: setuptools",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-10T20:00:53.629057Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:50bc28ef6bb223c1ac63756cb49c8f88e6a9e2329d1edbe3be405ee207b021a2",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-10T20:00:54.295128Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:50bc28ef6bb223c1ac63756cb49c8f88e6a9e2329d1edbe3be405ee207b021a2",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    },
+    {
+      "at": "2026-06-10T20:00:54.327302Z",
+      "command": "python -m build --wheel",
+      "covered_surface": "packaging",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:50bc28ef6bb223c1ac63756cb49c8f88e6a9e2329d1edbe3be405ee207b021a2",
+      "name": "wheel_release_smoke",
+      "parity_detail": "missing module: build",
+      "parity_gap": true,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/wheel_release_smoke.log",
+      "status": "fail",
+      "summary": "parity gap: missing module: build",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-10T20:06:02.492384Z",
+      "command": "pytest tests/architecture/ -v --no-cov",
+      "covered_surface": "architecture",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:50bc28ef6bb223c1ac63756cb49c8f88e6a9e2329d1edbe3be405ee207b021a2",
+      "name": "architecture_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/architecture_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-10T20:06:02.535973Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:50bc28ef6bb223c1ac63756cb49c8f88e6a9e2329d1edbe3be405ee207b021a2",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-10T20:06:10.489601Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:50bc28ef6bb223c1ac63756cb49c8f88e6a9e2329d1edbe3be405ee207b021a2",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-10T20:06:10.934366Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:50bc28ef6bb223c1ac63756cb49c8f88e6a9e2329d1edbe3be405ee207b021a2",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-10T20:06:10.972508Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:50bc28ef6bb223c1ac63756cb49c8f88e6a9e2329d1edbe3be405ee207b021a2",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-10T20:08:53.147492Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:50bc28ef6bb223c1ac63756cb49c8f88e6a9e2329d1edbe3be405ee207b021a2",
+      "name": "python_tests",
+      "parity_detail": "missing module: tifffile",
+      "parity_gap": true,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "parity gap: missing module: tifffile",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-10T20:09:40.190562Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:50bc28ef6bb223c1ac63756cb49c8f88e6a9e2329d1edbe3be405ee207b021a2",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-10T20:09:41.114111Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:50bc28ef6bb223c1ac63756cb49c8f88e6a9e2329d1edbe3be405ee207b021a2",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    },
+    {
+      "at": "2026-06-10T20:09:53.901667Z",
+      "command": "python -m build --wheel",
+      "covered_surface": "packaging",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:50bc28ef6bb223c1ac63756cb49c8f88e6a9e2329d1edbe3be405ee207b021a2",
+      "name": "wheel_release_smoke",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/wheel_release_smoke.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-10T20:11:31.472839Z",
+      "command": "pytest tests/architecture/ -v --no-cov",
+      "covered_surface": "architecture",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:50bc28ef6bb223c1ac63756cb49c8f88e6a9e2329d1edbe3be405ee207b021a2",
+      "name": "architecture_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/architecture_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-10T20:11:31.516322Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:50bc28ef6bb223c1ac63756cb49c8f88e6a9e2329d1edbe3be405ee207b021a2",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-10T20:11:39.166588Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:50bc28ef6bb223c1ac63756cb49c8f88e6a9e2329d1edbe3be405ee207b021a2",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-10T20:11:39.599611Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:50bc28ef6bb223c1ac63756cb49c8f88e6a9e2329d1edbe3be405ee207b021a2",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-10T20:11:39.638040Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:50bc28ef6bb223c1ac63756cb49c8f88e6a9e2329d1edbe3be405ee207b021a2",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-10T20:14:23.006570Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:50bc28ef6bb223c1ac63756cb49c8f88e6a9e2329d1edbe3be405ee207b021a2",
+      "name": "python_tests",
+      "parity_detail": "missing module: pandas",
+      "parity_gap": true,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "parity gap: missing module: pandas",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-10T20:15:09.823488Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:50bc28ef6bb223c1ac63756cb49c8f88e6a9e2329d1edbe3be405ee207b021a2",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-10T20:15:10.530346Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 2,
+      "input_fingerprint": "sha256:50bc28ef6bb223c1ac63756cb49c8f88e6a9e2329d1edbe3be405ee207b021a2",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "fail",
+      "summary": "exit 2",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    },
+    {
+      "at": "2026-06-10T20:15:19.669134Z",
+      "command": "python -m build --wheel",
+      "covered_surface": "packaging",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:50bc28ef6bb223c1ac63756cb49c8f88e6a9e2329d1edbe3be405ee207b021a2",
+      "name": "wheel_release_smoke",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/wheel_release_smoke.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-10T20:16:14.480761Z",
+      "command": "pytest tests/architecture/ -v --no-cov",
+      "covered_surface": "architecture",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:50bc28ef6bb223c1ac63756cb49c8f88e6a9e2329d1edbe3be405ee207b021a2",
+      "name": "architecture_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/architecture_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-10T20:16:14.522367Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:50bc28ef6bb223c1ac63756cb49c8f88e6a9e2329d1edbe3be405ee207b021a2",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-10T20:16:22.853144Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:50bc28ef6bb223c1ac63756cb49c8f88e6a9e2329d1edbe3be405ee207b021a2",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-10T20:16:23.345633Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:50bc28ef6bb223c1ac63756cb49c8f88e6a9e2329d1edbe3be405ee207b021a2",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-10T20:16:23.385812Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:50bc28ef6bb223c1ac63756cb49c8f88e6a9e2329d1edbe3be405ee207b021a2",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-10T20:19:08.819725Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:50bc28ef6bb223c1ac63756cb49c8f88e6a9e2329d1edbe3be405ee207b021a2",
+      "name": "python_tests",
+      "parity_detail": "missing module: skimage",
+      "parity_gap": true,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "parity gap: missing module: skimage",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-10T20:19:56.491131Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:50bc28ef6bb223c1ac63756cb49c8f88e6a9e2329d1edbe3be405ee207b021a2",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-10T20:19:57.276948Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 2,
+      "input_fingerprint": "sha256:50bc28ef6bb223c1ac63756cb49c8f88e6a9e2329d1edbe3be405ee207b021a2",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "fail",
+      "summary": "exit 2",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    },
+    {
+      "at": "2026-06-10T20:20:06.160162Z",
+      "command": "python -m build --wheel",
+      "covered_surface": "packaging",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:50bc28ef6bb223c1ac63756cb49c8f88e6a9e2329d1edbe3be405ee207b021a2",
+      "name": "wheel_release_smoke",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/wheel_release_smoke.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-10T20:23:58.408235Z",
+      "command": "pytest tests/architecture/ -v --no-cov",
+      "covered_surface": "architecture",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:50bc28ef6bb223c1ac63756cb49c8f88e6a9e2329d1edbe3be405ee207b021a2",
+      "name": "architecture_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/architecture_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-10T20:23:58.446990Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:50bc28ef6bb223c1ac63756cb49c8f88e6a9e2329d1edbe3be405ee207b021a2",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-10T20:24:06.408017Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:50bc28ef6bb223c1ac63756cb49c8f88e6a9e2329d1edbe3be405ee207b021a2",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-10T20:24:06.641364Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:50bc28ef6bb223c1ac63756cb49c8f88e6a9e2329d1edbe3be405ee207b021a2",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-10T20:24:06.680136Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:50bc28ef6bb223c1ac63756cb49c8f88e6a9e2329d1edbe3be405ee207b021a2",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-10T20:26:43.410228Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:50bc28ef6bb223c1ac63756cb49c8f88e6a9e2329d1edbe3be405ee207b021a2",
+      "name": "python_tests",
+      "parity_detail": "tool/interpreter not found",
+      "parity_gap": true,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "parity gap: tool/interpreter not found",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-10T20:27:29.399099Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:50bc28ef6bb223c1ac63756cb49c8f88e6a9e2329d1edbe3be405ee207b021a2",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-10T20:27:30.063150Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:50bc28ef6bb223c1ac63756cb49c8f88e6a9e2329d1edbe3be405ee207b021a2",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    },
+    {
+      "at": "2026-06-10T20:27:39.047706Z",
+      "command": "python -m build --wheel",
+      "covered_surface": "packaging",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:50bc28ef6bb223c1ac63756cb49c8f88e6a9e2329d1edbe3be405ee207b021a2",
+      "name": "wheel_release_smoke",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/wheel_release_smoke.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-10T20:29:48.191214Z",
+      "command": "pytest tests/architecture/ -v --no-cov",
+      "covered_surface": "architecture",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:50bc28ef6bb223c1ac63756cb49c8f88e6a9e2329d1edbe3be405ee207b021a2",
+      "name": "architecture_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/architecture_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-10T20:29:48.332992Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:50bc28ef6bb223c1ac63756cb49c8f88e6a9e2329d1edbe3be405ee207b021a2",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-10T20:29:56.201757Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:50bc28ef6bb223c1ac63756cb49c8f88e6a9e2329d1edbe3be405ee207b021a2",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-10T20:29:56.413802Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:50bc28ef6bb223c1ac63756cb49c8f88e6a9e2329d1edbe3be405ee207b021a2",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-10T20:29:56.453113Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:50bc28ef6bb223c1ac63756cb49c8f88e6a9e2329d1edbe3be405ee207b021a2",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-10T20:32:32.496273Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:50bc28ef6bb223c1ac63756cb49c8f88e6a9e2329d1edbe3be405ee207b021a2",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-10T20:33:19.405197Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:50bc28ef6bb223c1ac63756cb49c8f88e6a9e2329d1edbe3be405ee207b021a2",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-10T20:33:20.143279Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:50bc28ef6bb223c1ac63756cb49c8f88e6a9e2329d1edbe3be405ee207b021a2",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    },
+    {
+      "at": "2026-06-10T20:33:28.721368Z",
+      "command": "python -m build --wheel",
+      "covered_surface": "packaging",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:50bc28ef6bb223c1ac63756cb49c8f88e6a9e2329d1edbe3be405ee207b021a2",
+      "name": "wheel_release_smoke",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/wheel_release_smoke.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    }
+  ],
+  "check_na": [],
+  "commit": null,
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "src/scistudio/qa/governance/gate_record/io.py",
+      "src/scistudio/qa/governance/gate_record/workflow.py",
+      "tests/qa/test_gate_evaluator.py",
+      "docs/ai-developer/gate-cli-command-set.md",
+      "docs/ai-developer/specific_rules/gated-workflow.md"
+    ]
+  },
+  "directive_events": [
+    {
+      "at": "2026-06-10T19:45:09.755873Z",
+      "owner_directive": "Also fix fastembed missing from parity venv auto-provision so gate_record check can install the semantic-dup dependency.",
+      "reason": "Owner added the related parity auto-provision bug: fastembed is required by the semantic-dup check but missing from pyproject dependencies."
+    }
+  ],
+  "docs_events": [
+    {
+      "at": "2026-06-10T19:44:22.155522Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/ai-developer/gate-cli-command-set.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-10T19:44:22.155542Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/ai-developer/specific_rules/gated-workflow.md",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": true,
+  "guard_events": [
+    {
+      "at": "2026-06-10T19:56:31.898150Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T19:56:31.920827Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T19:56:31.943822Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T19:56:31.966279Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T19:56:31.989474Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T19:56:32.017450Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T19:56:32.040713Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T19:56:32.066145Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T19:56:32.091718Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T19:56:32.117861Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T20:00:54.513392Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T20:00:54.535828Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T20:00:54.558317Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T20:00:54.580602Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T20:00:54.602630Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T20:00:54.625983Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T20:00:54.654016Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T20:00:54.676856Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T20:00:54.699500Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T20:00:54.723093Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T20:09:53.962344Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T20:09:53.987680Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T20:09:54.011643Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T20:09:54.165031Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T20:09:54.190505Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T20:09:54.213573Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T20:09:54.237987Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T20:09:54.263031Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T20:09:54.289212Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T20:09:54.316680Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T20:15:19.725683Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T20:15:19.747676Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T20:15:19.770609Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T20:15:19.793191Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T20:15:19.815809Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T20:15:19.839525Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T20:15:19.863234Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T20:15:19.885870Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T20:15:19.909173Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T20:15:19.932873Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T20:20:06.225801Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T20:20:06.249320Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T20:20:06.273030Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T20:20:06.296990Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T20:20:06.449157Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T20:20:06.472158Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T20:20:06.498064Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T20:20:06.524202Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T20:20:06.548658Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T20:20:06.574403Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T20:27:39.109295Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T20:27:39.137370Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T20:27:39.162938Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T20:27:39.187984Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T20:27:39.213920Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T20:27:39.238824Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T20:27:39.262837Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T20:27:39.286121Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T20:27:39.309774Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T20:27:39.335063Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T20:33:28.782075Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T20:33:28.809898Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T20:33:28.836188Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T20:33:28.862397Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T20:33:28.888344Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T20:33:28.913932Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T20:33:28.938937Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T20:33:28.963865Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T20:33:28.986958Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-10T20:33:29.011922Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1568,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": {
+    "base": "origin/main",
+    "base_sha": "35ab776e",
+    "changed_files": [
+      ".workflow/records/1568-finalized-ledger-ci.json",
+      "docs/ai-developer/gate-cli-command-set.md",
+      "docs/ai-developer/specific_rules/gated-workflow.md",
+      "pyproject.toml",
+      "src/scistudio/qa/governance/gate_record/io.py",
+      "src/scistudio/qa/governance/gate_record/workflow.py",
+      "tests/qa/test_gate_evaluator.py",
+      "tests/qa/test_gate_parity_provision.py"
+    ],
+    "diff_fingerprint": "sha256:be3c20ac60422e13ae38ddbcd4e5e072888a9473fee901070154bacbebc3d82d",
+    "head": "HEAD",
+    "head_sha": "8c1f11d5",
+    "surfaces": {
+      "docs": 2,
+      "frontend": 0,
+      "governance": 5,
+      "governed_docs": 2,
+      "implementation": 3,
+      "packaging": 1,
+      "protected_core": 0,
+      "sentrux": 4,
+      "test": 2,
+      "workflow_ci": 0
+    }
+  },
+  "owner_directive": "Fix issue #1568: CI mode must discover and validate post-PR finalized gate ledgers instead of reporting no ledger found.",
+  "persona": "implementer",
+  "pull_request": null,
+  "reconcile_events": [
+    {
+      "at": "2026-06-10T19:56:32.117887Z",
+      "diff_fingerprint": "sha256:a228856df017cd9cb52ebc934c9c9d12c0df58457d1bbb166c13247cdbac2bfe",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "parity.environment-not-ci-equivalent"
+      ]
+    },
+    {
+      "at": "2026-06-10T20:00:54.723117Z",
+      "diff_fingerprint": "sha256:be3c20ac60422e13ae38ddbcd4e5e072888a9473fee901070154bacbebc3d82d",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "parity.environment-not-ci-equivalent"
+      ]
+    },
+    {
+      "at": "2026-06-10T20:09:54.316706Z",
+      "diff_fingerprint": "sha256:be3c20ac60422e13ae38ddbcd4e5e072888a9473fee901070154bacbebc3d82d",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "parity.environment-not-ci-equivalent"
+      ]
+    },
+    {
+      "at": "2026-06-10T20:15:19.932898Z",
+      "diff_fingerprint": "sha256:be3c20ac60422e13ae38ddbcd4e5e072888a9473fee901070154bacbebc3d82d",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.type_check",
+        "parity.environment-not-ci-equivalent"
+      ]
+    },
+    {
+      "at": "2026-06-10T20:20:06.574430Z",
+      "diff_fingerprint": "sha256:be3c20ac60422e13ae38ddbcd4e5e072888a9473fee901070154bacbebc3d82d",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.type_check",
+        "parity.environment-not-ci-equivalent"
+      ]
+    },
+    {
+      "at": "2026-06-10T20:27:39.335091Z",
+      "diff_fingerprint": "sha256:be3c20ac60422e13ae38ddbcd4e5e072888a9473fee901070154bacbebc3d82d",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "parity.environment-not-ci-equivalent"
+      ]
+    },
+    {
+      "at": "2026-06-10T20:33:29.011945Z",
+      "diff_fingerprint": "sha256:be3c20ac60422e13ae38ddbcd4e5e072888a9473fee901070154bacbebc3d82d",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.python_tests"
+      ]
+    }
+  ],
+  "record_id": "1568-finalized-ledger-ci",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [
+      "architecture_tests",
+      "format_check",
+      "full_audit",
+      "import_contracts",
+      "lint_format",
+      "python_tests",
+      "semantic_dup",
+      "type_check",
+      "wheel_release_smoke"
+    ],
+    "docs": [
+      "docs_required_or_na"
+    ],
+    "guards": [
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": [
+      "changed_test_required"
+    ]
+  },
+  "runtime": "codex",
+  "schema_version": 2,
+  "scope_events": [
+    {
+      "action": "add-include",
+      "at": "2026-06-10T19:45:09.755891Z",
+      "pattern": "pyproject.toml",
+      "reason": "Owner added the related parity auto-provision bug: fastembed is required by the semantic-dup check but missing from pyproject dependencies."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-10T19:48:39.855572Z",
+      "pattern": "tests/qa/test_gate_parity_provision.py",
+      "reason": "Add regression coverage for semantic-dup parity dependency declarations."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-10T20:03:05.253117Z",
+      "pattern": "src/scistudio/qa/governance/gate_record/parity.py",
+      "reason": "Fix stale parity venv reprovision after dependency marker changes."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-10T20:22:21.096892Z",
+      "pattern": "src/scistudio/qa/governance/gate_record/checks.py",
+      "reason": "Fix parity-cause detection so pytest skip summaries do not mask genuine check failures."
+    }
+  ],
+  "session_id": "4b4efe75-9060-4e5d-8b38-245f0e56385d",
+  "strictness_tier": 1,
+  "task_kind": "bugfix",
+  "test_events": [
+    {
+      "at": "2026-06-10T19:44:22.155548Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/qa/test_gate_evaluator.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-10T19:48:39.855594Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/qa/test_gate_parity_provision.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-10T20:03:05.253160Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/qa/test_gate_parity_provision.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-10T20:22:21.096916Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/qa/test_gate_evaluator.py",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/docs/ai-developer/gate-cli-command-set.md
+++ b/docs/ai-developer/gate-cli-command-set.md
@@ -298,6 +298,11 @@ metadata; it fails when checks are stale, required issue closure is missing from
 the PR body, required docs/tests are absent, or tier-selected check obligations
 are unsatisfied.
 
+After post-PR `finalize`, commit and push the ledger update. CI-mode ledger
+discovery includes finalized ledgers so the committed PR provenance is still
+validated by `gate_record check --mode ci`; only ordinary local active-session
+discovery excludes finalized ledgers.
+
 ## 3. The `--mode` Family
 
 `check` (and the mode-specific compatibility aliases) dispatch on `--mode`. All

--- a/docs/ai-developer/specific_rules/gated-workflow.md
+++ b/docs/ai-developer/specific_rules/gated-workflow.md
@@ -310,6 +310,11 @@ PR metadata. It fails when checks are stale, required issue closure is missing
 from the PR body, required docs or tests are absent, or tier-selected check
 obligations are unsatisfied.
 
+CI mode still discovers and validates this post-PR finalized ledger after it is
+committed back to the PR branch. Finalized ledger state is excluded only from
+ordinary local active-session discovery, where it means "do not keep editing this
+completed gate as the current task."
+
 ### 2.6 Compatibility Aliases
 
 | Old subcommand | Delegates to |
@@ -661,6 +666,10 @@ python -m scistudio.qa.governance.gate_record finalize \
   --pr <url-or-number> \
   --pr-body-file .workflow/local/pr-body.md
 ```
+
+Commit and push the resulting ledger update. The CI workflow's
+`gate_record check --mode ci` discovery includes finalized ledgers so the
+committed PR provenance remains machine-verifiable.
 
 When wrapper, hook, gate-record, CI, or AI-runtime behavior changes, explicitly
 check whether these docs also need updates:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,9 +49,24 @@ dev = [
     "import-linter>=2.0",
     "griffe>=1.7",
     "pre-commit>=4.0",
+    # ADR-042 Addendum 6 parity venvs must be able to run the local mirror of
+    # ci.yml jobs. Keep build-system helpers in the dev extra so python_tests
+    # and wheel_release_smoke do not fail as environment-parity gaps.
+    "setuptools>=68.0",
+    "build>=1.2",
+    # Several selected python_tests import tabular and TIFF preview/inspection
+    # paths. Keep the CI-equivalent dev environment complete without making
+    # these optional data-format helpers core runtime dependencies.
+    "pandas>=2.2",
+    "tifffile>=2024.8",
     # #1340: vulture wires into full_audit as informational dead-code child
     # report (ADR-042 code-quality stack named vulture but never installed it).
     "vulture>=2.11",
+    # ADR-042 Addendum 2 / Addendum 6: semantic-dup parity checks run
+    # scripts/semantic_dup_scan.py locally from the gate_record parity venv.
+    # CI installs fastembed explicitly for the same ratchet job; keep the dev
+    # extra in sync so auto-provisioned local parity environments can run it.
+    "fastembed>=0.7",
     # ADR-043 / spec adr-043-package-migration FR-017: ome-types is a required
     # dep of scistudio-blocks-imaging now that Image.Meta carries a typed
     # ``ome: OME | None`` field. Listed here as well so the skeleton import
@@ -163,6 +178,13 @@ packages = ["scistudio"]
 # See issue #693.
 [[tool.mypy.overrides]]
 module = ["zarr", "zarr.*"]
+follow_imports = "skip"
+
+# tifffile uses Python 3.12+ type-alias syntax in current releases. The package
+# remains an optional/dev data-format helper for tests, while SciStudio's mypy
+# target is still Python 3.11, so do not parse tifffile internals.
+[[tool.mypy.overrides]]
+module = ["tifffile", "tifffile.*"]
 follow_imports = "skip"
 
 [tool.pytest.ini_options]

--- a/src/scistudio/qa/governance/gate_record/checks.py
+++ b/src/scistudio/qa/governance/gate_record/checks.py
@@ -263,6 +263,7 @@ _PARITY_CAUSE_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
 
 # A pytest collection error specifically (distinct from test-body failures).
 _PYTEST_COLLECTION_ERROR_RE = re.compile(r"errors? during collection|ERROR collecting", re.IGNORECASE)
+_PYTEST_TEST_FAILURE_RE = re.compile(r"=+\s+FAILURES\s+=+|^FAILED\s+", re.IGNORECASE | re.MULTILINE)
 
 
 def detect_parity_cause(output: str) -> str | None:
@@ -277,14 +278,25 @@ def detect_parity_cause(output: str) -> str | None:
 
     if not output:
         return None
+    has_pytest_body_failure = _PYTEST_TEST_FAILURE_RE.search(output) is not None
+    has_pytest_collection_error = _PYTEST_COLLECTION_ERROR_RE.search(output) is not None
     for pattern, template in _PARITY_CAUSE_PATTERNS:
         match = pattern.search(output)
         if match is None:
             continue
+        if (
+            (
+                template in {"tool/interpreter not found", "missing distribution/dependency"}
+                or template.startswith("missing module")
+            )
+            and has_pytest_body_failure
+            and not has_pytest_collection_error
+        ):
+            continue
         # An ImportError reported INSIDE a normal test body (not at collection)
         # could be a genuine bug; only treat import/module errors as parity gaps
         # when they look like collection-time or top-level import problems.
-        if template == "import error during collection" and not _PYTEST_COLLECTION_ERROR_RE.search(output):
+        if template == "import error during collection" and not has_pytest_collection_error:
             # A bare ImportError without a collection marker is ambiguous; if a
             # ModuleNotFoundError/No-module signature also matched it is covered
             # by an earlier pattern, so here we skip to avoid false positives.

--- a/src/scistudio/qa/governance/gate_record/io.py
+++ b/src/scistudio/qa/governance/gate_record/io.py
@@ -370,15 +370,22 @@ def current_branch(repo_root: Path) -> str | None:
     return None
 
 
-def discover_ledger(repo_root: Path, *, branch: str | None = None) -> DiscoveryResult:
+def discover_ledger(
+    repo_root: Path,
+    *,
+    branch: str | None = None,
+    include_finalized: bool = False,
+) -> DiscoveryResult:
     """Discover the active ledger for the CURRENT branch (§5.1 / §10.2).
 
     A record matches only when its ``branch`` equals the target branch, it is a
-    schema-v2 ledger, and it is not finalized. Then:
+    schema-v2 ledger, and it is not finalized unless ``include_finalized`` is
+    true. Then:
 
     - exactly one match -> accepted;
     - zero matches -> ``DiscoveryResult(None, [])`` so the caller prints "run init"
-      (stale, other-branch, finalized, and old-format records never match);
+      (stale, other-branch, finalized unless explicitly included, and
+      old-format records never match);
     - multiple same-branch matches -> ``DiscoveryResult(None, matches)`` so the
       caller lists candidates and asks for ``--record``.
 
@@ -400,7 +407,7 @@ def discover_ledger(repo_root: Path, *, branch: str | None = None) -> DiscoveryR
         active = []
         for path in records:
             _record_branch, is_v2, is_finalized = _ledger_meta(path)
-            if is_v2 and not is_finalized:
+            if is_v2 and (include_finalized or not is_finalized):
                 active.append(path)
         if len(active) == 1:
             return DiscoveryResult(active[0], active)
@@ -409,7 +416,7 @@ def discover_ledger(repo_root: Path, *, branch: str | None = None) -> DiscoveryR
     matches = []
     for path in records:
         record_branch, is_v2, is_finalized = _ledger_meta(path)
-        if record_branch == target_branch and is_v2 and not is_finalized:
+        if record_branch == target_branch and is_v2 and (include_finalized or not is_finalized):
             matches.append(path)
     if len(matches) == 1:
         return DiscoveryResult(matches[0], matches)

--- a/src/scistudio/qa/governance/gate_record/parity.py
+++ b/src/scistudio/qa/governance/gate_record/parity.py
@@ -290,6 +290,32 @@ def _create_venv(repo_root: Path, venv: Path) -> tuple[bool, str]:
     return _run([sys.executable, "-m", "venv", str(venv)], cwd=repo_root)
 
 
+def _remove_stale_venv(repo_root: Path, venv: Path) -> tuple[bool, str]:
+    """Remove a stale per-worktree parity venv before re-provisioning.
+
+    The path is fixed by ``venv_path(repo_root)`` and lives under
+    ``.workflow/local``. Fail closed if a caller passes anything else.
+    """
+
+    try:
+        expected = venv_path(repo_root).resolve()
+        local_root = (repo_root / ".workflow" / "local").resolve()
+        target = venv.resolve()
+    except OSError as exc:
+        return False, f"{type(exc).__name__} resolving venv"
+    if target != expected:
+        return False, "refusing to remove unexpected venv path"
+    if target == local_root or local_root not in target.parents:
+        return False, "refusing to remove venv outside .workflow/local"
+    try:
+        shutil.rmtree(target)
+    except FileNotFoundError:
+        return True, "ok"
+    except OSError as exc:
+        return False, f"{type(exc).__name__} removing stale venv"
+    return True, "ok"
+
+
 def _install_deps(repo_root: Path, venv: Path) -> tuple[bool, str]:
     """Install ``-e ".[dev]"`` into the venv with uv (preferred) or pip.
 
@@ -333,6 +359,14 @@ def provision_venv(repo_root: Path, *, force: bool = False) -> ParityReport:
         )
 
     venv.parent.mkdir(parents=True, exist_ok=True)
+    if venv.exists():
+        removed, remove_summary = _remove_stale_venv(repo_root, venv)
+        if not removed:
+            return ParityReport(
+                importable=False,
+                resolved_versions=resolved,
+                gaps=[f"cannot remove stale isolated per-worktree venv: {remove_summary}"],
+            )
     created, create_summary = _create_venv(repo_root, venv)
     if not created:
         return ParityReport(

--- a/src/scistudio/qa/governance/gate_record/workflow.py
+++ b/src/scistudio/qa/governance/gate_record/workflow.py
@@ -65,14 +65,19 @@ def _print_outcome(outcome: CommandOutcome) -> int:
 # ---------------------------------------------------------------------------
 
 
-def _resolve_ledger_path(repo_root: Path, record: str | None) -> tuple[Path | None, CommandOutcome | None]:
+def _resolve_ledger_path(
+    repo_root: Path,
+    record: str | None,
+    *,
+    include_finalized: bool = False,
+) -> tuple[Path | None, CommandOutcome | None]:
     if record is not None:
         path = Path(record)
         path = path if path.is_absolute() else repo_root / path
         if not path.exists():
             return None, CommandOutcome(EXIT_USAGE, [f"ledger not found: {record}"])
         return path, None
-    discovery = io.discover_ledger(repo_root)
+    discovery = io.discover_ledger(repo_root, include_finalized=include_finalized)
     if discovery.found:
         return discovery.path, None
     if discovery.ambiguous:
@@ -378,7 +383,7 @@ def _read_pr_context(repo_root: Path, pr_context_file: str | None) -> dict[str, 
 
 def run_check(repo_root: Path, args: Any, *, mode: str | None = None) -> int:
     effective_mode = mode or getattr(args, "mode", "local") or "local"
-    path, err = _resolve_ledger_path(repo_root, args.record)
+    path, err = _resolve_ledger_path(repo_root, args.record, include_finalized=effective_mode == "ci")
     if err:
         return _print_outcome(err)
     assert path is not None
@@ -464,7 +469,8 @@ def run_check(repo_root: Path, args: Any, *, mode: str | None = None) -> int:
 
 
 def run_finalize(repo_root: Path, args: Any) -> int:
-    path, err = _resolve_ledger_path(repo_root, args.record)
+    is_post_pr = bool(getattr(args, "pr", None))
+    path, err = _resolve_ledger_path(repo_root, args.record, include_finalized=is_post_pr)
     if err:
         return _print_outcome(err)
     assert path is not None
@@ -473,7 +479,6 @@ def run_finalize(repo_root: Path, args: Any) -> int:
         return _print_outcome(load_err)
     assert ledger is not None
 
-    is_post_pr = bool(getattr(args, "pr", None))
     if not is_post_pr and not getattr(args, "pr_body_file", None):
         return _print_outcome(CommandOutcome(EXIT_USAGE, ["pre-PR finalize requires --pr-body-file"]))
 

--- a/tests/qa/test_gate_evaluator.py
+++ b/tests/qa/test_gate_evaluator.py
@@ -9,10 +9,11 @@ from __future__ import annotations
 
 import subprocess
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
-from scistudio.qa.governance.gate_record import checks, evaluator, io, surfaces
+from scistudio.qa.governance.gate_record import checks, evaluator, io, surfaces, workflow
 from scistudio.qa.governance.gate_record.io import SanitizationError
 from scistudio.qa.governance.gate_record.ledger import (
     CheckEvent,
@@ -20,8 +21,11 @@ from scistudio.qa.governance.gate_record.ledger import (
     DocsEvent,
     GateLedger,
     IssueRef,
+    PullRequestEvidence,
+    RequiredObligations,
     TestEvent,
 )
+from scistudio.qa.schemas.report import AuditReport, AuditStatus
 
 
 def _git(repo: Path, *args: str) -> None:
@@ -62,6 +66,78 @@ def _add_change(repo: Path, rel: str, content: str = "x\n") -> None:
     path.write_text(content, encoding="utf-8")
     _git(repo, "add", rel)
     _git(repo, "commit", "-q", "-m", f"add {rel}")
+
+
+# ---------------------------------------------------------------------------
+# Ledger discovery and post-PR finalize behavior.
+# ---------------------------------------------------------------------------
+
+
+def test_discover_ledger_can_include_finalized_for_ci(tmp_path: Path) -> None:
+    records_dir = tmp_path / ".workflow" / "records"
+    records_dir.mkdir(parents=True)
+    record_path = records_dir / "1568-finalized-ledger-ci.json"
+    ledger = _ledger(branch="track/x")
+    ledger.pull_request = PullRequestEvidence(url="https://github.com/zjzcpj/SciStudio/pull/1568", number=1568)
+    io.write_ledger(record_path, ledger, repo_root=tmp_path)
+
+    default_discovery = io.discover_ledger(tmp_path, branch="track/x")
+    assert not default_discovery.found
+    assert default_discovery.candidates == []
+
+    ci_discovery = io.discover_ledger(tmp_path, branch="track/x", include_finalized=True)
+    assert ci_discovery.found
+    assert ci_discovery.path == record_path
+
+
+def test_ci_mode_check_resolves_finalized_ledger(
+    git_repo: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _git(git_repo, "checkout", "-q", "-b", "track/x")
+    records_dir = git_repo / ".workflow" / "records"
+    records_dir.mkdir(parents=True)
+    record_path = records_dir / "1568-finalized-ledger-ci.json"
+    ledger = _ledger(branch="track/x")
+    ledger.pull_request = PullRequestEvidence(url="https://github.com/zjzcpj/SciStudio/pull/1568", number=1568)
+    io.write_ledger(record_path, ledger, repo_root=git_repo)
+
+    def _fake_reconcile(**kwargs: object) -> evaluator.ReconcileResult:
+        resolved = kwargs["ledger"]
+        assert isinstance(resolved, GateLedger)
+        assert resolved.pull_request is not None
+        return evaluator.ReconcileResult(
+            report=AuditReport(tool="gate_record", status=AuditStatus.PASS, source_sha="test"),
+            strictness_tier=2,
+            required_obligations=RequiredObligations(),
+        )
+
+    monkeypatch.setattr(workflow.evaluator, "reconcile", _fake_reconcile)
+    args = SimpleNamespace(
+        record=None,
+        mode="ci",
+        owner_directive=[],
+        include=[],
+        exclude=[],
+        issue=[],
+        docs_updated=[],
+        docs_na=[],
+        test_path=[],
+        test_na=[],
+        check=[],
+        check_na=[],
+        admin_label=[],
+        skip_execution=True,
+        only=[],
+        pr_body_file=None,
+        pr_context_file=None,
+        head="HEAD",
+        base="HEAD",
+    )
+
+    assert workflow.run_check(git_repo, args) == workflow.EXIT_OK
+    output = capsys.readouterr().out
+    assert "no gate ledger found" not in output
+    assert "reconciliation passed" in output
 
 
 # ---------------------------------------------------------------------------
@@ -481,6 +557,21 @@ def test_detect_parity_cause_ignores_genuine_assertion_failure() -> None:
     from scistudio.qa.governance.gate_record import checks
 
     out = "def test_x():\n>       assert 1 == 2\nE       assert 1 == 2\n1 failed in 0.01s"
+    assert checks.detect_parity_cause(out) is None
+
+
+def test_detect_parity_cause_ignores_missing_optional_module_in_skip_summary() -> None:
+    from scistudio.qa.governance.gate_record import checks
+
+    out = "\n".join(
+        [
+            "================================== FAILURES ===================================",
+            "FAILED tests/example.py::test_real_failure - AssertionError: boom",
+            "E   ValueError: Command executable not found: 'echo'. Ensure it is on PATH",
+            "=========================== short test summary info ===========================",
+            "SKIPPED [1] tests/plugins/test_phase11_skeleton.py: could not import 'skimage': No module named 'skimage'",
+        ]
+    )
     assert checks.detect_parity_cause(out) is None
 
 

--- a/tests/qa/test_gate_parity_provision.py
+++ b/tests/qa/test_gate_parity_provision.py
@@ -22,6 +22,7 @@ from pathlib import Path
 
 import pytest
 
+import scistudio.qa.governance.gate_record.checks as checks
 import scistudio.qa.governance.gate_record.parity as parity
 
 # Capture the real implementation before the autouse conftest fixture stubs it.
@@ -109,6 +110,20 @@ def test_marker_changes_with_deps(tmp_path: Path) -> None:
     assert marker_a.startswith("sha256:")
 
 
+def test_local_ci_tool_dependencies_are_in_dev_extra() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    assert "semantic_dup" in checks.CHECK_CATALOG
+    assert "wheel_release_smoke" in checks.CHECK_CATALOG
+    assert "python_tests" in checks.CHECK_CATALOG
+    dev_deps = parity._dev_extras(repo_root)
+    normalized = [dep.lower() for dep in dev_deps]
+    assert any(dep.lower().startswith("fastembed") for dep in dev_deps)
+    assert any(dep.startswith("build") for dep in normalized)
+    assert any(dep.startswith("pandas") for dep in normalized)
+    assert any(dep.startswith("setuptools") for dep in normalized)
+    assert any(dep.startswith("tifffile") for dep in normalized)
+
+
 def _make_src(repo: Path) -> None:
     (repo / "src" / "scistudio").mkdir(parents=True, exist_ok=True)
     (repo / "src" / "scistudio" / "__init__.py").write_text("", encoding="utf-8")
@@ -139,17 +154,42 @@ def test_marker_mismatch_triggers_reprovision(tmp_path: Path, monkeypatch: pytes
     venv = parity.venv_path(tmp_path)
     venv.mkdir(parents=True)
     (venv / parity._MARKER_NAME).write_text("sha256:stale\n", encoding="utf-8")
+    (venv / "stale.txt").write_text("old dependency state", encoding="utf-8")
 
     calls: list[str] = []
-    monkeypatch.setattr(parity, "_create_venv", lambda *a, **k: calls.append("create") or (True, "ok"))
+
+    def _fake_create(_repo_root: Path, venv_path: Path) -> tuple[bool, str]:
+        calls.append("create")
+        assert not venv_path.exists()
+        venv_path.mkdir(parents=True)
+        return True, "ok"
+
+    monkeypatch.setattr(parity, "_create_venv", _fake_create)
     monkeypatch.setattr(parity, "_install_deps", lambda *a, **k: calls.append("install") or (True, "ok"))
     monkeypatch.setattr(parity, "check_importable_env", lambda _repo, **_k: True)
 
     report = real_provision(tmp_path)
     assert report.ok and report.provisioned
     assert calls == ["create", "install"]
+    assert not (venv / "stale.txt").exists()
     # The fresh marker is written so the next run is warm.
     assert (venv / parity._MARKER_NAME).read_text(encoding="utf-8").strip() == parity.provisioning_marker(tmp_path)
+
+
+def test_stale_venv_removal_fails_closed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, real_provision) -> None:
+    _make_src(tmp_path)
+    venv = parity.venv_path(tmp_path)
+    venv.mkdir(parents=True)
+    (venv / parity._MARKER_NAME).write_text("sha256:stale\n", encoding="utf-8")
+
+    monkeypatch.setattr(parity, "_remove_stale_venv", lambda *a, **k: (False, "refusing test path"))
+    create_called: list[str] = []
+    monkeypatch.setattr(parity, "_create_venv", lambda *a, **k: create_called.append("create") or (True, "ok"))
+
+    report = real_provision(tmp_path)
+    assert not report.ok
+    assert any("cannot remove stale isolated per-worktree venv" in gap for gap in report.gaps)
+    assert create_called == []
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Allow CI-mode gate ledger discovery to include post-PR finalized ledgers.
- Keep ordinary local active-session discovery excluding finalized ledgers.
- Let repeated post-PR finalize resolve finalized ledgers instead of falling into "no ledger found".
- Add missing dev extra parity dependencies and stale-venv cleanup so auto-provisioned gate venvs can rebuild after dependency marker changes.
- Tighten parity-cause detection so pytest skip summaries do not mask genuine test failures.

## Validation

- `PYTHONPATH=src python -m pytest tests/qa/test_gate_evaluator.py tests/qa/test_gate_parity_provision.py -q --no-cov`
- `.workflow/local/venv/Scripts/mypy.exe src/scistudio/ --ignore-missing-imports`
- `PYTHONPATH=src python -m ruff check src/scistudio/qa/governance/gate_record/io.py src/scistudio/qa/governance/gate_record/workflow.py src/scistudio/qa/governance/gate_record/parity.py src/scistudio/qa/governance/gate_record/checks.py tests/qa/test_gate_evaluator.py tests/qa/test_gate_parity_provision.py`
- `PYTHONPATH=src python -m ruff format --check src/scistudio/qa/governance/gate_record/io.py src/scistudio/qa/governance/gate_record/workflow.py src/scistudio/qa/governance/gate_record/parity.py src/scistudio/qa/governance/gate_record/checks.py tests/qa/test_gate_evaluator.py tests/qa/test_gate_parity_provision.py`
- `PYTHONPATH=src python -m scistudio.qa.governance.gate_record check --base origin/main --head HEAD --mode pre-pr --pr-body-file .workflow/local/pr-body.md` records all gate checks; on this Windows worktree it still reports the existing full-suite `checks.python_tests` failure (`pytest -n auto --timeout=60 --timeout-method=thread`). GitHub's Ubuntu CI is the authoritative merge gate for that job.

Gate record: .workflow/records/1568-finalized-ledger-ci.json

Closes #1568
