### PR TITLE
refactor(previewers): make frontend_manifest a first-class session-envelope field

### DIFF
--- a/.workflow/records/1579-issue-1579-frontend-manifest.json
+++ b/.workflow/records/1579-issue-1579-frontend-manifest.json
@@ -1,0 +1,185 @@
+{
+  "branch": "track/issue-1579-frontend-manifest",
+  "check_events": [],
+  "check_na": [],
+  "commit": null,
+  "declared_scope": {
+    "exclude": [],
+    "include": []
+  },
+  "directive_events": [],
+  "docs_events": [
+    {
+      "at": "2026-06-11T05:31:59.690765Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/specs/adr-048-preview-system.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-11T05:31:59.690771Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/adr/ADR-048.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-11T05:31:59.690778Z",
+      "class": "block_development",
+      "kind": "na",
+      "path": null,
+      "rationale": "no old-channel manifest mentions in docs/block-development/** (grep clean)",
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": false,
+  "guard_events": [],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1579,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": null,
+  "owner_directive": "Fix issue #1579: promote frontend_manifest from envelope.metadata.extra to a first-class, framework-stamped PreviewEnvelope/session-envelope field; session manager auto-injects the resolved PreviewerSpec.frontend_manifest; frontend reads the first-class field; drop the imaging provider's manual embed; update spec/ADR docs.",
+  "persona": "implementer",
+  "pull_request": null,
+  "reconcile_events": [],
+  "record_id": "1579-issue-1579-frontend-manifest",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [],
+    "docs": [],
+    "guards": [],
+    "tests": []
+  },
+  "runtime": "claude",
+  "schema_version": 2,
+  "scope_events": [
+    {
+      "action": "add-include",
+      "at": "2026-06-11T05:31:59.690625Z",
+      "pattern": "src/scistudio/previewers/models.py",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-11T05:31:59.690650Z",
+      "pattern": "src/scistudio/previewers/session.py",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-11T05:31:59.690653Z",
+      "pattern": "src/scistudio/api/schemas.py",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-11T05:31:59.690655Z",
+      "pattern": "frontend/src/types/api.ts",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-11T05:31:59.690657Z",
+      "pattern": "frontend/src/components/DataPreview.parts/PreviewHost.tsx",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-11T05:31:59.690658Z",
+      "pattern": "frontend/src/components/DataPreview.parts/previewerHostApi.ts",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-11T05:31:59.690660Z",
+      "pattern": "packages/scistudio-blocks-imaging/src/scistudio_blocks_imaging/previewers/__init__.py",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-11T05:31:59.690662Z",
+      "pattern": "packages/scistudio-blocks-imaging/tests/test_previewer_registration.py",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-11T05:31:59.690663Z",
+      "pattern": "tests/api/test_previewers.py",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-11T05:31:59.690665Z",
+      "pattern": "tests/previewers/test_preview_session_manifest.py",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-11T05:31:59.690667Z",
+      "pattern": "frontend/src/components/DataPreview.parts/PreviewHost.test.tsx",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-11T05:31:59.690668Z",
+      "pattern": "docs/specs/adr-048-preview-system.md",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-11T05:31:59.690670Z",
+      "pattern": "docs/adr/ADR-048.md",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-11T05:31:59.690671Z",
+      "pattern": "docs/planning/issue-1579-impact-scope.md",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-11T05:31:59.690672Z",
+      "pattern": "CHANGELOG.md",
+      "reason": "plan"
+    }
+  ],
+  "session_id": "b28c63c7-9e1f-47f1-b8d1-14a58981d76b",
+  "strictness_tier": null,
+  "task_kind": "refactor",
+  "test_events": [
+    {
+      "at": "2026-06-11T05:31:59.690783Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/previewers/test_preview_session_manifest.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-11T05:31:59.690787Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/api/test_previewers.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-11T05:31:59.690789Z",
+      "class": null,
+      "kind": "path",
+      "path": "packages/scistudio-blocks-imaging/tests/test_previewer_registration.py",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/.workflow/records/1579-issue-1579-frontend-manifest.json
+++ b/.workflow/records/1579-issue-1579-frontend-manifest.json
@@ -1,7 +1,154 @@
 {
   "branch": "track/issue-1579-frontend-manifest",
-  "check_events": [],
-  "check_na": [],
+  "check_events": [
+    {
+      "at": "2026-06-11T05:48:21.230684Z",
+      "command": "pytest tests/architecture/ -v --no-cov",
+      "covered_surface": "architecture",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:a7c392a6c6ed1154d0cc254e6f0dad4514307321894ccf33cbf20dd5c378fa3d",
+      "name": "architecture_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/architecture_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-11T05:48:21.306204Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:a7c392a6c6ed1154d0cc254e6f0dad4514307321894ccf33cbf20dd5c378fa3d",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-11T05:48:25.275095Z",
+      "command": "(cd frontend && npm run lint)",
+      "covered_surface": "frontend",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:a7c392a6c6ed1154d0cc254e6f0dad4514307321894ccf33cbf20dd5c378fa3d",
+      "name": "frontend",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/frontend.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-11T05:48:34.068246Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:a7c392a6c6ed1154d0cc254e6f0dad4514307321894ccf33cbf20dd5c378fa3d",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-11T05:48:34.548989Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:a7c392a6c6ed1154d0cc254e6f0dad4514307321894ccf33cbf20dd5c378fa3d",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-11T05:48:34.641878Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:a7c392a6c6ed1154d0cc254e6f0dad4514307321894ccf33cbf20dd5c378fa3d",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-11T05:50:23.069987Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:a7c392a6c6ed1154d0cc254e6f0dad4514307321894ccf33cbf20dd5c378fa3d",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-11T05:51:18.066345Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:a7c392a6c6ed1154d0cc254e6f0dad4514307321894ccf33cbf20dd5c378fa3d",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-11T05:51:23.503528Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:a7c392a6c6ed1154d0cc254e6f0dad4514307321894ccf33cbf20dd5c378fa3d",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    }
+  ],
+  "check_na": [
+    {
+      "name": "python_tests",
+      "rationale": "win32-only failure of test_path_traversal_outside_allowlist_is_rejected (404 vs 400, drive-root etc absent on Windows); pre-existing on base branch; passes on CI ubuntu; not introduced by issue-1579"
+    }
+  ],
   "commit": null,
   "declared_scope": {
     "exclude": [],
@@ -35,7 +182,172 @@
     }
   ],
   "governance_touch": false,
-  "guard_events": [],
+  "guard_events": [
+    {
+      "at": "2026-06-11T05:43:44.722219Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-11T05:43:44.735117Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-11T05:43:44.747894Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-11T05:43:44.760615Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-11T05:43:44.774100Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-11T05:43:44.787942Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-11T05:43:44.801571Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-11T05:43:44.814947Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-11T05:43:44.828478Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-11T05:43:44.844972Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-11T05:51:23.544560Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-11T05:51:23.557914Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-11T05:51:23.570966Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-11T05:51:23.584381Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-11T05:51:23.597897Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-11T05:51:23.611522Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-11T05:51:23.625051Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-11T05:51:23.639270Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-11T05:51:23.652893Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-11T05:51:23.668503Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
   "issues": [
     {
       "close_in_pr": true,
@@ -45,19 +357,98 @@
     }
   ],
   "observed_admin_labels": [],
-  "observed_diff": null,
+  "observed_diff": {
+    "base": "origin/track/adr-048-spec1-preview-system",
+    "base_sha": "74c347d8",
+    "changed_files": [
+      ".workflow/records/1579-issue-1579-frontend-manifest.json",
+      "docs/adr/ADR-048.md",
+      "docs/planning/issue-1579-impact-scope.md",
+      "docs/specs/adr-048-preview-system.md",
+      "frontend/src/components/DataPreview.parts/PreviewHost.test.tsx",
+      "frontend/src/components/DataPreview.parts/PreviewHost.tsx",
+      "frontend/src/components/DataPreview.parts/previewerHostApi.ts",
+      "frontend/src/types/api.ts",
+      "packages/scistudio-blocks-imaging/src/scistudio_blocks_imaging/previewers/__init__.py",
+      "packages/scistudio-blocks-imaging/tests/test_previewer_registration.py",
+      "src/scistudio/api/schemas.py",
+      "src/scistudio/previewers/models.py",
+      "src/scistudio/previewers/session.py",
+      "tests/api/test_previewers.py",
+      "tests/previewers/test_preview_session_manifest.py"
+    ],
+    "diff_fingerprint": "sha256:86ef48e8ddb08e27519d0c08127da1f99ed938adb2e38b61ccbeab1272b14c77",
+    "head": "HEAD",
+    "head_sha": "7b7dcbc8",
+    "surfaces": {
+      "docs": 3,
+      "frontend": 4,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 8,
+      "packaging": 0,
+      "protected_core": 0,
+      "sentrux": 13,
+      "test": 4,
+      "workflow_ci": 0
+    }
+  },
   "owner_directive": "Fix issue #1579: promote frontend_manifest from envelope.metadata.extra to a first-class, framework-stamped PreviewEnvelope/session-envelope field; session manager auto-injects the resolved PreviewerSpec.frontend_manifest; frontend reads the first-class field; drop the imaging provider's manual embed; update spec/ADR docs.",
   "persona": "implementer",
   "pull_request": null,
-  "reconcile_events": [],
+  "reconcile_events": [
+    {
+      "at": "2026-06-11T05:43:44.845003Z",
+      "diff_fingerprint": "sha256:86ef48e8ddb08e27519d0c08127da1f99ed938adb2e38b61ccbeab1272b14c77",
+      "mode": "ci",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-11T05:51:23.668524Z",
+      "diff_fingerprint": "sha256:86ef48e8ddb08e27519d0c08127da1f99ed938adb2e38b61ccbeab1272b14c77",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.python_tests"
+      ]
+    }
+  ],
   "record_id": "1579-issue-1579-frontend-manifest",
   "requested_admin_labels": [],
   "required_obligations": {
     "admin_labels": [],
-    "checks": [],
-    "docs": [],
-    "guards": [],
-    "tests": []
+    "checks": [
+      "architecture_tests",
+      "format_check",
+      "frontend",
+      "full_audit",
+      "import_contracts",
+      "lint_format",
+      "python_tests",
+      "semantic_dup",
+      "type_check"
+    ],
+    "docs": [
+      "docs_required_or_na"
+    ],
+    "guards": [
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": [
+      "changed_test_required"
+    ]
   },
   "runtime": "claude",
   "schema_version": 2,
@@ -151,10 +542,100 @@
       "at": "2026-06-11T05:31:59.690672Z",
       "pattern": "CHANGELOG.md",
       "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-11T05:45:01.461194Z",
+      "pattern": "src/scistudio/previewers/models.py",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-11T05:45:01.461213Z",
+      "pattern": "src/scistudio/previewers/session.py",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-11T05:45:01.461216Z",
+      "pattern": "src/scistudio/api/schemas.py",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-11T05:45:01.461217Z",
+      "pattern": "frontend/src/types/api.ts",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-11T05:45:01.461219Z",
+      "pattern": "frontend/src/components/DataPreview.parts/PreviewHost.tsx",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-11T05:45:01.461220Z",
+      "pattern": "frontend/src/components/DataPreview.parts/previewerHostApi.ts",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-11T05:45:01.461222Z",
+      "pattern": "packages/scistudio-blocks-imaging/src/scistudio_blocks_imaging/previewers/__init__.py",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-11T05:45:01.461224Z",
+      "pattern": "packages/scistudio-blocks-imaging/tests/test_previewer_registration.py",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-11T05:45:01.461225Z",
+      "pattern": "tests/api/test_previewers.py",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-11T05:45:01.461227Z",
+      "pattern": "tests/previewers/test_preview_session_manifest.py",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-11T05:45:01.461229Z",
+      "pattern": "frontend/src/components/DataPreview.parts/PreviewHost.test.tsx",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-11T05:45:01.461230Z",
+      "pattern": "docs/specs/adr-048-preview-system.md",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-11T05:45:01.461231Z",
+      "pattern": "docs/adr/ADR-048.md",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-11T05:45:01.461233Z",
+      "pattern": "docs/planning/issue-1579-impact-scope.md",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-11T05:45:01.461234Z",
+      "pattern": "CHANGELOG.md",
+      "reason": "plan"
     }
   ],
   "session_id": "b28c63c7-9e1f-47f1-b8d1-14a58981d76b",
-  "strictness_tier": null,
+  "strictness_tier": 1,
   "task_kind": "refactor",
   "test_events": [
     {

--- a/docs/adr/ADR-048.md
+++ b/docs/adr/ADR-048.md
@@ -211,6 +211,11 @@ same-origin manifests. Remote CDN imports and arbitrary external URLs are not
 part of the contract. The manifest must name the previewer ID, ESM module URL,
 export name, optional CSS assets, version, and compatible preview API version.
 
+The session manager stamps the resolved previewer's `frontend_manifest` onto the
+`PreviewEnvelope` it returns, so providers declare the manifest once on their
+`PreviewerSpec` and never re-embed it per envelope; the host reads it from
+`envelope.frontend_manifest`.
+
 The frontend component receives a constrained `PreviewHost` API:
 
 - `previewSessionId`;

--- a/docs/planning/issue-1579-impact-scope.md
+++ b/docs/planning/issue-1579-impact-scope.md
@@ -1,0 +1,151 @@
+# Impact-Scope Report — Issue #1579
+
+`refactor(previewers): make frontend_manifest a first-class session-envelope field`
+
+Investigation agent output (read-only), committed verbatim and handed to the
+implementing agent. Branch: `track/issue-1579-frontend-manifest` (off ADR-048
+SPEC 1 `track/adr-048-spec1-preview-system`). Task kind: **refactor**.
+
+Refs #1579. Refs #1574 (origin audit).
+
+---
+
+## A. Current state — how the manifest flows today
+
+- **`FrontendManifest`** — `src/scistudio/previewers/models.py:178-218`. Frozen
+  dataclass: `previewer_id, module_url, export_name="default", css=(),
+  version="0", api_version=PREVIEWER_API_VERSION, asset_root: str | None = None`.
+  `to_dict()` (209-218) emits the wire shape and **omits `asset_root`**
+  (backend-only path-confinement value).
+- **`PreviewerSpec.frontend_manifest`** — `models.py:257`, serialized in
+  `PreviewerSpec.to_dict()` at line 277. Set by imaging `get_previewers()` at
+  `packages/.../previewers/__init__.py:400` (Image) / `:411` (Label), built by
+  `_frontend_manifest()` (89-99, which passes `asset_root`).
+- **Imaging embeds via `_embed_manifest`** (`previewers/__init__.py:189-198`),
+  writing `metadata.extra["frontend_manifest"]` at **3 call sites**:
+  `_error_envelope` (213), `image_provider` (290), `label_provider` (365).
+- **`PreviewSessionManager` does NOT touch the manifest.** `session.py` never
+  references it. The injection seam is `_render()` (`session.py:214-253`):
+  provider returns the envelope at line 240; manager calls
+  `envelope.with_session(session_id)` at line 253 before returning. `spec` is a
+  `_render` parameter, so `spec.frontend_manifest` is in scope.
+  **`with_session()` (`models.py:402-414`) rebuilds the frozen envelope
+  field-by-field — it must carry any new field or the field is dropped.**
+- **API serialization** — `src/scistudio/api/routes/data.py` builds
+  `PreviewEnvelopeModel(**envelope.to_dict())` (lines 164/175/188).
+  `PreviewEnvelope.to_dict()` (`models.py:389-400`) emits
+  `metadata: self.metadata.to_dict()`; `PreviewMetadata.to_dict()`
+  (`models.py:305-315`) does `data.update(self.extra)`, flattening
+  `metadata.extra["frontend_manifest"]` to a top-level `metadata.frontend_manifest`
+  wire key. `PreviewEnvelopeModel` (`schemas.py:272-283`) has **no
+  `frontend_manifest` field**; the manifest survives only inside the free-form
+  `metadata: dict[str, Any]`.
+- **Frontend read** — `PreviewHost.tsx` `readManifest()` (lines 64-71) reads
+  `envelope.metadata?.frontend_manifest` (the flattened top-level metadata key,
+  not `metadata.extra`). `dynamicPreviewer.ts` / `previewerHostApi.ts` only
+  consume the extracted manifest object.
+- **TS types** — `frontend/src/types/api.ts`: `PreviewerManifest` (291-306);
+  `PreviewMetadata` (321-333) already has `frontend_manifest?` at line 330 +
+  index signature; `PreviewEnvelope` (355-365) has **no** `frontend_manifest`.
+- **Legacy `/api/data/{ref}/preview` (FR-008)** — `api/runtime/_data.py`
+  `preview_data` → `_envelope_to_legacy_preview` (315-389) **discards
+  `metadata`**, never surfaced the manifest, needs **no change** (it shares the
+  provider path, so a stamped envelope is simply ignored — harmless).
+
+## B. Exact change set (ordered)
+
+1. **`src/scistudio/previewers/models.py`** — add
+   `frontend_manifest: FrontendManifest | None = None` to `PreviewEnvelope`
+   (after `error`, optional so plot/core/error envelopes stay valid). Update
+   `to_dict()` to emit
+   `"frontend_manifest": self.frontend_manifest.to_dict() if self.frontend_manifest else None`.
+   **Update `with_session()` to pass `frontend_manifest=self.frontend_manifest`**
+   (critical — it always runs at `session.py:253`). Update the class docstring.
+2. **`src/scistudio/previewers/session.py`** — in `_render()` before
+   `return envelope.with_session(session_id)`, stamp the spec default only when
+   absent:
+   ```python
+   if envelope.frontend_manifest is None and spec.frontend_manifest is not None:
+       envelope = replace(envelope, frontend_manifest=spec.frontend_manifest)
+   ```
+   Add `from dataclasses import replace`. The `MISSING_BUNDLE` early-return
+   (224-229) is left as-is (no provider ⇒ no mountable UI).
+3. **`src/scistudio/api/schemas.py`** — move `PreviewFrontendManifestModel`
+   (286-295) **above** `PreviewEnvelopeModel` (272-283), then add
+   `frontend_manifest: PreviewFrontendManifestModel | None = None` to
+   `PreviewEnvelopeModel`. The `**envelope.to_dict()` spread populates it; no
+   route change needed.
+4. **`frontend/src/types/api.ts`** — add `frontend_manifest?: PreviewerManifest | null;`
+   to the `PreviewEnvelope` interface (355-365) with a doc comment.
+5. **`frontend/src/components/DataPreview.parts/PreviewHost.tsx`** —
+   `readManifest()`: `const manifest = envelope.frontend_manifest ?? envelope.metadata?.frontend_manifest;`
+   (prefer first-class, keep metadata fallback). Update doc comments
+   (PreviewHost top + `previewerHostApi.ts:29`).
+6. **`packages/scistudio-blocks-imaging/.../previewers/__init__.py`** — delete
+   `_embed_manifest` (189-198); call sites → `extra=extra` (image/label),
+   `extra={}` (error). Update the "Manifest-delivery seam" docstring (23-29) to
+   say the manifest is framework-stamped by `PreviewSessionManager`. The spec's
+   `frontend_manifest=...` at 400/411 stays (single source of truth).
+
+## C. Compatibility / correctness decisions (locked)
+
+1. **Keep the frontend `metadata.frontend_manifest` fallback** —
+   `envelope.frontend_manifest ?? envelope.metadata?.frontend_manifest`. Primary
+   read is first-class; fallback is zero-risk defense for un-migrated providers.
+2. **Precedence: stamp only when `envelope.frontend_manifest is None`.** A
+   provider that sets its own manifest wins; providers that set nothing inherit
+   the spec default (the point of #1579).
+3. **Field is optional/`None`** — confirmed required for plot/core/collection/
+   error envelopes; a required field would break the core-fallback tests.
+4. **Legacy `/api/data/{ref}/preview`** — separate path, discards metadata,
+   no change.
+
+## D. Tests impacted / needed
+
+Update (assert on old `metadata.extra` channel):
+- `packages/scistudio-blocks-imaging/tests/test_previewer_registration.py`
+  lines 262-267, 287, 318 + header docstring 14-16 → retarget to assert the
+  manifest reaches the **session envelope** (drive through `PreviewSessionManager`
+  and assert `envelope.frontend_manifest`), and that the provider alone no longer
+  embeds into `metadata.extra`.
+- `frontend/.../PreviewHost.test.tsx` 133-141/161-169/191-200 still pass via the
+  fallback; **add** a case with a top-level `envelope.frontend_manifest`.
+
+New:
+- Backend session-manager test: spec manifest auto-injected when provider sets
+  none; provider-set manifest NOT overwritten (precedence); spec with no manifest
+  ⇒ `envelope.frontend_manifest is None`.
+- Backend serialization (`tests/api/test_previewers.py`): Image session JSON has
+  top-level `body["frontend_manifest"]["previewer_id"] == "imaging.image.viewer"`
+  (needs `SCISTUDIO_DEV=1` imaging discovery — see `test_collection_session_lists_items`);
+  core dataframe ⇒ `body["frontend_manifest"] is None`.
+- Frontend `PreviewHost.test.tsx`: first-class read case.
+
+## E. Docs (REQUIRED)
+
+1. `docs/specs/adr-048-preview-system.md` §3 — `PreviewEnvelope` table
+   (lines 323-335) add a `frontend_manifest` row: *"Optional same-origin
+   manifest, framework-stamped by the session manager from the resolved
+   `PreviewerSpec`. Null for core fallbacks."* Add a clause to FR-020 (269-270)
+   noting first-class delivery on `PreviewEnvelope.frontend_manifest`.
+2. `docs/adr/ADR-048.md` §4 (lines 209-212) — add: *"The session manager stamps
+   the resolved previewer's `frontend_manifest` onto the `PreviewEnvelope` it
+   returns, so providers declare the manifest once on their `PreviewerSpec` and
+   never re-embed it per envelope; the host reads it from
+   `envelope.frontend_manifest`."*
+3. `docs/block-development/**` — grep found **no** old-channel mentions ⇒ record
+   N/A in the gate ledger.
+
+## F. Governance / gate
+
+- `src/scistudio/previewers/**` and `src/scistudio/api/**` are **NOT**
+  protected-core (`gate_record/surfaces.py:73-79` lists only core/engine/blocks/
+  workflow/utils). **No `admin-approved:core-change` label.**
+- No governance surface touched (`docs/ai-developer/**` and `ADR-042*` only) ⇒
+  **no `governance_touch`**. ADR-048/spec are architecture/spec docs (normal
+  docs checks).
+- **No `pyproject.toml` / entry-point change.**
+- Sentrux applies (src/frontend/packages/tests/docs-adr-specs) ⇒ plan a
+  **PASS**, not a skip.
+- CHANGELOG `[Unreleased]` conflict risk if other PRs open (recurring).
+- Task kind **refactor**, implementation category ⇒ **tests mandatory**.

--- a/docs/specs/adr-048-preview-system.md
+++ b/docs/specs/adr-048-preview-system.md
@@ -267,7 +267,10 @@ Acceptance Scenarios:
 - FR-019: SVG rendering must be sanitized or sandboxed so script execution and
   external resource loading do not run in the app context.
 - FR-020: Frontend `PreviewHost` must mount previewers by validated manifest and
-  otherwise render core fallback components.
+  otherwise render core fallback components. The manifest is delivered
+  first-class on `PreviewEnvelope.frontend_manifest`, framework-stamped by the
+  session manager from the resolved `PreviewerSpec` (#1579); the host reads it
+  from there and retains a legacy `metadata.frontend_manifest` fallback.
 - FR-021: Frontend preview state must key caches by data reference or collection
   reference, previewer ID, session ID, query parameters, slice/page/sort state,
   and data version when available.
@@ -333,6 +336,7 @@ Acceptance Scenarios:
 | `metadata` | Shape, type, sampling, truncation, and display metadata. |
 | `diagnostics` | Non-fatal warnings and repair hints. |
 | `error` | Typed error when preview failed. |
+| `frontend_manifest` | Optional same-origin manifest, framework-stamped by the session manager from the resolved `PreviewerSpec`. Null for core fallbacks. |
 
 `PreviewSession` is backend-owned:
 

--- a/frontend/src/components/DataPreview.parts/PreviewHost.test.tsx
+++ b/frontend/src/components/DataPreview.parts/PreviewHost.test.tsx
@@ -215,6 +215,39 @@ describe("PreviewHost — dynamic manifest fallback (US2.3 / FR-022 / FR-029)", 
       "MOUNTED IMAGING VIEWER",
     );
   });
+
+  it("mounts from the first-class envelope.frontend_manifest field (#1579)", async () => {
+    // The session manager now stamps the manifest first-class on the envelope;
+    // the host must read it from there (no metadata.frontend_manifest present).
+    createPreviewSession.mockResolvedValue(
+      envelope({
+        previewer_id: "imaging.image.viewer",
+        kind: "array",
+        payload: { shape: [4, 4], dtype: "uint8", ndim: 2, src: "" },
+        metadata: { complete: true },
+        frontend_manifest: {
+          previewer_id: "imaging.image.viewer",
+          module_url: "/api/previews/assets/imaging.image.viewer/viewer.js",
+          export_name: "ImageViewer",
+          api_version: "1",
+        },
+      }),
+    );
+
+    const mount = vi.fn((container: HTMLElement) => {
+      container.textContent = "MOUNTED FIRST-CLASS VIEWER";
+      return { unmount: vi.fn() };
+    });
+    const fakeImporter = vi.fn(async () => ({ ImageViewer: { apiVersion: "1", mount } }));
+
+    render(<PreviewHost target={{ ...TARGET, recorded_type: "Image" }} importer={fakeImporter} />);
+
+    await waitFor(() => expect(mount).toHaveBeenCalled());
+    expect(screen.queryByTestId("core-array-viewer")).toBeNull();
+    expect(screen.getByTestId("preview-host-dynamic-mount")).toHaveTextContent(
+      "MOUNTED FIRST-CLASS VIEWER",
+    );
+  });
 });
 
 describe("PreviewHost — collection + child routing (US4)", () => {

--- a/frontend/src/components/DataPreview.parts/PreviewHost.tsx
+++ b/frontend/src/components/DataPreview.parts/PreviewHost.tsx
@@ -4,8 +4,9 @@
  * The routed preview container. For a selected {@link PreviewTarget} it:
  *   1. Creates a session via `POST /api/previews/sessions` and reads the
  *      {@link PreviewEnvelope}.
- *   2. If the resolved previewer surfaces a `frontend_manifest` (in
- *      `envelope.metadata.frontend_manifest`) → validates it (same-origin only,
+ *   2. If the resolved previewer surfaces a `frontend_manifest` (first-class on
+ *      `envelope.frontend_manifest`, with a legacy `envelope.metadata.frontend_manifest`
+ *      fallback) → validates it (same-origin only,
  *      FR-022), dynamically `import()`s it, and mounts the named export with a
  *      constrained {@link PreviewHostApi} (FR-023). On ANY validation / import /
  *      mount failure → renders diagnostics AND the core fallback viewer for
@@ -63,7 +64,9 @@ type Status = "idle" | "loading" | "ready" | "error";
 
 function readManifest(envelope: PreviewEnvelope | null): PreviewerManifest | undefined {
   if (!envelope) return undefined;
-  const manifest = envelope.metadata?.frontend_manifest;
+  // Prefer the first-class field the session manager stamps (#1579); fall back
+  // to the legacy flattened `metadata.frontend_manifest` for un-migrated providers.
+  const manifest = envelope.frontend_manifest ?? envelope.metadata?.frontend_manifest;
   if (manifest && typeof manifest === "object" && typeof manifest.module_url === "string") {
     return manifest;
   }

--- a/frontend/src/components/DataPreview.parts/previewerHostApi.ts
+++ b/frontend/src/components/DataPreview.parts/previewerHostApi.ts
@@ -26,7 +26,10 @@
  *     versions are incompatible, surfacing a diagnostic instead.
  *
  * Mount flow (see {@link mountDynamicPreviewer} in `dynamicPreviewer.ts`):
- *   1. PreviewHost reads `envelope.metadata.frontend_manifest`.
+ *   1. PreviewHost reads the first-class `envelope.frontend_manifest` (stamped
+ *      by the session manager from the resolved PreviewerSpec, #1579; a legacy
+ *      `envelope.metadata.frontend_manifest` fallback remains for un-migrated
+ *      providers).
  *   2. It validates `module_url` is same-origin (rejects http/https/`//`/data:).
  *   3. It `import(module_url)` and reads `module[manifest.export_name]`.
  *   4. That export is a {@link PreviewerModule}; the host calls

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -362,6 +362,10 @@ export interface PreviewEnvelope {
   metadata: PreviewMetadata;
   diagnostics: string[];
   error: PreviewErrorInfo | null;
+  /** First-class same-origin previewer manifest, framework-stamped by the
+   *  session manager from the resolved PreviewerSpec (ADR-048 §4 / #1579).
+   *  Absent for core fallbacks. Prefer this over `metadata.frontend_manifest`. */
+  frontend_manifest?: PreviewerManifest | null;
 }
 
 /** Request body for `POST /api/previews/sessions`. */

--- a/packages/scistudio-blocks-imaging/src/scistudio_blocks_imaging/previewers/__init__.py
+++ b/packages/scistudio-blocks-imaging/src/scistudio_blocks_imaging/previewers/__init__.py
@@ -21,12 +21,15 @@ What this module provides:
   array — FR-010) and return a :class:`PreviewEnvelope`.
 
 Manifest-delivery seam (FR-022/FR-024 + the verified frontend host contract):
-the preview *session* envelope does not otherwise carry the spec's frontend
-manifest. The frontend ``PreviewHost`` reads it from
-``envelope.metadata.extra["frontend_manifest"]``. Therefore each provider here
-embeds its :meth:`FrontendManifest.to_dict` (the wire shape WITHOUT
-``asset_root``) into ``metadata.extra["frontend_manifest"]`` so the host can
-locate and same-origin-import the packaged viewer module.
+the frontend manifest is now framework-stamped onto the
+:class:`~scistudio.previewers.models.PreviewEnvelope` by
+:class:`~scistudio.previewers.session.PreviewSessionManager`, which reads it
+from the resolved :class:`PreviewerSpec` (#1579). This package therefore
+declares the manifest exactly once on each spec via :func:`get_previewers`
+(``frontend_manifest=...``); the providers below no longer re-embed it per
+envelope. The frontend ``PreviewHost`` reads it first-class from
+``envelope.frontend_manifest`` to locate and same-origin-import the packaged
+viewer module.
 
 Fallback design (FR-026): the Image envelope uses ``kind=ARRAY`` and carries a
 PNG ``src`` data-URI plus shape/axes/slice metadata in exactly the shape the
@@ -186,18 +189,6 @@ def _image_metadata_panel(record_md: dict[str, Any]) -> dict[str, Any]:
     return panel
 
 
-def _embed_manifest(metadata_extra: dict[str, Any], previewer_id: str) -> dict[str, Any]:
-    """Return ``metadata_extra`` with the wire frontend manifest embedded.
-
-    The verified seam: the frontend host reads the manifest from
-    ``envelope.metadata.extra['frontend_manifest']`` because the session
-    envelope does not otherwise carry it.
-    """
-    enriched = dict(metadata_extra)
-    enriched["frontend_manifest"] = _frontend_manifest(previewer_id).to_dict()
-    return enriched
-
-
 def _error_envelope(request: PreviewRequest, message: str) -> PreviewEnvelope:
     """Embed a typed error envelope (providers must not raise for routine
     failures — FR-028)."""
@@ -207,11 +198,7 @@ def _error_envelope(request: PreviewRequest, message: str) -> PreviewEnvelope:
         previewer_id=request.spec.previewer_id,
         target=request.target,
         kind=EnvelopeKind.ERROR,
-        metadata=PreviewMetadata(
-            complete=False,
-            failed=True,
-            extra=_embed_manifest({}, request.spec.previewer_id),
-        ),
+        metadata=PreviewMetadata(complete=False, failed=True),
         error=PreviewErrorInfo(code=PreviewErrorCode.PROVIDER_EXCEPTION, message=message),
     )
 
@@ -287,7 +274,7 @@ def image_provider(request: PreviewRequest) -> PreviewEnvelope:
             sampled=plane.truncated,
             truncated=plane.truncated,
             complete=not plane.truncated,
-            extra=_embed_manifest(extra, request.spec.previewer_id),
+            extra=extra,
         ),
     )
 
@@ -362,7 +349,7 @@ def label_provider(request: PreviewRequest) -> PreviewEnvelope:
             sampled=truncated,
             truncated=truncated,
             complete=not truncated,
-            extra=_embed_manifest(extra, request.spec.previewer_id),
+            extra=extra,
         ),
     )
 

--- a/packages/scistudio-blocks-imaging/tests/test_previewer_registration.py
+++ b/packages/scistudio-blocks-imaging/tests/test_previewer_registration.py
@@ -12,8 +12,11 @@ Covers (per the SPEC 1 acceptance items):
 * Removing imaging -> ``Image`` falls back to ``core.array.basic`` via
   parent-type resolution (FR-026).
 * The Image provider returns a valid ``PreviewEnvelope`` with the 6 metadata
-  flags set and a same-origin ``frontend_manifest`` embedded in
-  ``metadata.extra`` (the verified manifest-delivery seam).
+  flags set, and the same-origin ``frontend_manifest`` reaches the *session*
+  envelope first-class — framework-stamped by
+  :class:`~scistudio.previewers.session.PreviewSessionManager` from the resolved
+  :class:`PreviewerSpec` (#1579) — while the provider called directly no longer
+  embeds it into ``metadata.extra``.
 
 These are pure-unit tests: they register the imaging specs explicitly (or run
 monorepo discovery) and never require the package to be pip-installed.
@@ -47,6 +50,7 @@ from scistudio.previewers.models import (
 )
 from scistudio.previewers.registry import PreviewerRegistry
 from scistudio.previewers.router import PreviewRouter
+from scistudio.previewers.session import PreviewSessionManager
 
 # Recorded type chains (general -> specific) the router walks. Image extends
 # Array; Label extends CompositeData.
@@ -224,13 +228,14 @@ def test_monorepo_discovery_registers_imaging_previewers() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Image provider envelope + embedded manifest seam
+# Image provider envelope + framework-stamped manifest seam (#1579)
 # ---------------------------------------------------------------------------
 
 
-def test_image_provider_returns_valid_envelope_with_embedded_manifest(
+def test_image_provider_returns_valid_envelope_without_self_embedding(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    """The provider alone returns a valid envelope but no longer embeds the manifest."""
     _install_fake_zarr(monkeypatch)
     spec = _image_spec()
     record_md = {
@@ -258,17 +263,42 @@ def test_image_provider_returns_valid_envelope_with_embedded_manifest(
     for flag in ("sampled", "truncated", "cached", "derived", "complete", "failed"):
         assert flag in md and isinstance(md[flag], bool)
 
-    # Manifest-delivery seam: embedded same-origin manifest in metadata.extra.
-    fm = envelope.metadata.extra["frontend_manifest"]
-    assert fm["previewer_id"] == IMAGE_PREVIEWER_ID
-    assert fm["module_url"] == f"/api/previews/assets/{IMAGE_PREVIEWER_ID}/viewer.js"
-    assert fm["export_name"] == "default"
-    assert not fm["module_url"].startswith(("http", "//", "data:"))
-    assert "asset_root" not in fm  # never serialised
+    # #1579: the provider no longer embeds the manifest into metadata.extra; it
+    # is framework-stamped by the session manager (see the session-driven test).
+    assert "frontend_manifest" not in envelope.metadata.extra
+    assert envelope.frontend_manifest is None
 
 
-def test_image_provider_embeds_manifest_even_on_error() -> None:
-    """A routine read failure embeds a typed error envelope (FR-028) + the manifest."""
+def test_session_manager_stamps_image_manifest_first_class(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Driven through PreviewSessionManager, the Image envelope carries the
+    resolved spec's manifest first-class on ``envelope.frontend_manifest``."""
+    _install_fake_zarr(monkeypatch)
+    manager = PreviewSessionManager(_registry())
+    target = _data_target("Image", _IMAGE_CHAIN)
+    query = {
+        "_storage": {
+            "backend": "zarr",
+            "path": str(_image_zarr_ref(tmp_path)),
+            "format": "zarr",
+            "metadata": {"axes": ["z", "y", "x"], "shape": [3, 16, 16]},
+        },
+    }
+    envelope = manager.render_target(target, query)
+
+    assert envelope.previewer_id == IMAGE_PREVIEWER_ID
+    # First-class manifest is stamped from the resolved spec.
+    fm = envelope.frontend_manifest
+    assert fm is not None
+    assert fm.previewer_id == IMAGE_PREVIEWER_ID
+    assert fm.module_url == f"/api/previews/assets/{IMAGE_PREVIEWER_ID}/viewer.js"
+    # Wire shape omits the backend-only asset_root.
+    assert "asset_root" not in fm.to_dict()
+    # And it is gone from the old metadata.extra channel.
+    assert "frontend_manifest" not in envelope.metadata.extra
+
+
+def test_image_provider_error_envelope_has_no_embedded_manifest() -> None:
+    """A routine read failure yields a typed error envelope (FR-028) with no embed."""
     from scistudio.previewers.data_access import PreviewDataAccess
 
     spec = _image_spec()
@@ -284,10 +314,11 @@ def test_image_provider_embeds_manifest_even_on_error() -> None:
     assert envelope.kind is EnvelopeKind.ERROR
     assert envelope.metadata.failed is True
     assert envelope.metadata.complete is False
-    assert envelope.metadata.extra["frontend_manifest"]["previewer_id"] == IMAGE_PREVIEWER_ID
+    assert "frontend_manifest" not in envelope.metadata.extra
+    assert envelope.frontend_manifest is None
 
 
-def test_label_provider_returns_composite_envelope_with_manifest() -> None:
+def test_label_provider_returns_composite_envelope_without_self_embedding() -> None:
     from scistudio.previewers.data_access import PreviewDataAccess
 
     spec = _label_spec()
@@ -314,8 +345,26 @@ def test_label_provider_returns_composite_envelope_with_manifest() -> None:
     # Each slot advertises a child-routing resource.
     resource_ids = {r.resource_id for r in envelope.resources}
     assert resource_ids == {"slot:raster", "slot:polygons"}
-    # Manifest embedded.
-    assert envelope.metadata.extra["frontend_manifest"]["previewer_id"] == LABEL_PREVIEWER_ID
+    # #1579: no per-envelope embed; the session manager stamps it first-class.
+    assert "frontend_manifest" not in envelope.metadata.extra
+    assert envelope.frontend_manifest is None
+
+
+def test_session_manager_stamps_label_manifest_first_class() -> None:
+    """The Label session envelope also carries the resolved spec's manifest."""
+    manager = PreviewSessionManager(_registry())
+    target = _data_target("Label", _LABEL_CHAIN)
+    query = {
+        "_storage": {"backend": "filesystem", "path": "/labels", "format": "zarr"},
+        "_record_metadata": {"slots": {"raster": "Array", "polygons": "DataFrame"}, "n_objects": 7},
+    }
+    envelope = manager.render_target(target, query)
+
+    assert envelope.previewer_id == LABEL_PREVIEWER_ID
+    fm = envelope.frontend_manifest
+    assert fm is not None
+    assert fm.previewer_id == LABEL_PREVIEWER_ID
+    assert "frontend_manifest" not in envelope.metadata.extra
 
 
 def test_provider_specs_have_distinct_ids_from_core() -> None:

--- a/src/scistudio/api/schemas.py
+++ b/src/scistudio/api/schemas.py
@@ -269,6 +269,17 @@ class PreviewSessionPatch(BaseModel):
     query: dict[str, Any] = Field(default_factory=dict, description="Query state to merge (slice/page/sort/slot/item).")
 
 
+class PreviewFrontendManifestModel(BaseModel):
+    """Wire shape of a previewer :class:`FrontendManifest` (same-origin only)."""
+
+    previewer_id: str
+    module_url: str
+    export_name: str = "default"
+    css: list[str] = Field(default_factory=list)
+    version: str = "0"
+    api_version: str = "1"
+
+
 class PreviewEnvelopeModel(BaseModel):
     """Wire shape of a canonical :class:`PreviewEnvelope`."""
 
@@ -281,17 +292,7 @@ class PreviewEnvelopeModel(BaseModel):
     metadata: dict[str, Any] = Field(default_factory=dict)
     diagnostics: list[str] = Field(default_factory=list)
     error: dict[str, Any] | None = None
-
-
-class PreviewFrontendManifestModel(BaseModel):
-    """Wire shape of a previewer :class:`FrontendManifest` (same-origin only)."""
-
-    previewer_id: str
-    module_url: str
-    export_name: str = "default"
-    css: list[str] = Field(default_factory=list)
-    version: str = "0"
-    api_version: str = "1"
+    frontend_manifest: PreviewFrontendManifestModel | None = None
 
 
 class PreviewerSpecModel(BaseModel):

--- a/src/scistudio/previewers/models.py
+++ b/src/scistudio/previewers/models.py
@@ -374,6 +374,12 @@ class PreviewEnvelope:
         metadata: :class:`PreviewMetadata`.
         diagnostics: Non-fatal warnings / repair hints.
         error: Typed error when the preview failed (kind == ``error``).
+        frontend_manifest: Optional same-origin manifest descriptor the host
+            mounts for this envelope. Framework-stamped by
+            :class:`~scistudio.previewers.session.PreviewSessionManager` from the
+            resolved :class:`PreviewerSpec` when a provider does not set its own
+            (ADR-048 §4 / #1579); ``None`` for core fallbacks. The wire shape
+            omits the backend-only ``asset_root``.
     """
 
     previewer_id: str
@@ -385,6 +391,7 @@ class PreviewEnvelope:
     metadata: PreviewMetadata = field(default_factory=PreviewMetadata)
     diagnostics: tuple[str, ...] = ()
     error: PreviewErrorInfo | None = None
+    frontend_manifest: FrontendManifest | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -397,6 +404,7 @@ class PreviewEnvelope:
             "metadata": self.metadata.to_dict(),
             "diagnostics": list(self.diagnostics),
             "error": self.error.to_dict() if self.error is not None else None,
+            "frontend_manifest": (self.frontend_manifest.to_dict() if self.frontend_manifest is not None else None),
         }
 
     def with_session(self, session_id: str | None) -> PreviewEnvelope:
@@ -411,6 +419,7 @@ class PreviewEnvelope:
             metadata=self.metadata,
             diagnostics=self.diagnostics,
             error=self.error,
+            frontend_manifest=self.frontend_manifest,
         )
 
 

--- a/src/scistudio/previewers/session.py
+++ b/src/scistudio/previewers/session.py
@@ -24,6 +24,7 @@ import logging
 import threading
 from collections import OrderedDict
 from collections.abc import Callable
+from dataclasses import replace
 from datetime import UTC, datetime
 from typing import Any
 from uuid import uuid4
@@ -250,6 +251,12 @@ class PreviewSessionManager:
                 f"provider {spec.previewer_id!r} raised: {exc}",
                 previewer_id=spec.previewer_id,
             )
+        # Stamp the resolved spec's frontend manifest onto the envelope so the
+        # frontend host reads it first-class (#1579). Precedence: a
+        # provider-set manifest wins; providers that set none inherit the spec
+        # default. Core fallbacks have no spec manifest, so this is a no-op.
+        if envelope.frontend_manifest is None and spec.frontend_manifest is not None:
+            envelope = replace(envelope, frontend_manifest=spec.frontend_manifest)
         return envelope.with_session(session_id)
 
     def _resolve_provider(self, spec: PreviewerSpec) -> PreviewProvider | None:

--- a/tests/api/test_previewers.py
+++ b/tests/api/test_previewers.py
@@ -41,6 +41,8 @@ def test_create_session_for_dataframe(client: TestClient, opened_project: Path) 
     # FR-011: metadata carries the mandatory display flags.
     for flag in ("sampled", "truncated", "cached", "derived", "complete", "failed"):
         assert flag in body["metadata"]
+    # #1579: a core fallback has no frontend manifest → first-class field is null.
+    assert body["frontend_manifest"] is None
 
 
 def test_read_and_patch_session_repaginate(client: TestClient, opened_project: Path) -> None:
@@ -136,6 +138,66 @@ def test_array_session_resource_tile(
     res = client.get(f"/api/previews/sessions/{sid}/resources/tile")
     assert res.status_code == 200
     assert "matrix" in res.json()["data"]
+
+
+def test_image_session_serializes_first_class_frontend_manifest(
+    client: TestClient,
+    runtime: ApiRuntime,
+    opened_project: Path,
+    monkeypatch,
+) -> None:
+    """#1579: an imaging-routed session JSON carries the manifest first-class.
+
+    Enables monorepo previewer discovery (SCISTUDIO_DEV=1, the CI default) so an
+    ``Image`` target routes to ``imaging.image.viewer``; the session manager then
+    stamps that spec's manifest onto the top-level ``frontend_manifest`` field.
+    """
+    import sys
+    import types
+
+    import numpy as np
+
+    monkeypatch.setenv("SCISTUDIO_DEV", "1")
+    # Rebuild the preview service so monorepo imaging previewers are registered.
+    runtime.refresh_preview_service()
+
+    matrix = np.arange(16 * 16, dtype=np.uint16).reshape(16, 16)
+
+    class _FakeArray:
+        shape = (3, 16, 16)
+        dtype = "uint16"
+
+        def __getitem__(self, key: object) -> np.ndarray:
+            return matrix
+
+    fake_zarr = types.ModuleType("zarr")
+    fake_zarr.Array = _FakeArray  # type: ignore[attr-defined]
+    fake_zarr.open = lambda path, mode="r": _FakeArray()  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "zarr", fake_zarr)
+
+    zarr_path = opened_project / "data" / "zarr" / "img.zarr"
+    zarr_path.mkdir(parents=True)
+    record = runtime.register_data_ref(
+        StorageReference(
+            backend="zarr",
+            path=str(zarr_path),
+            format="zarr",
+            metadata={"type_chain": ["DataObject", "Array", "Image"], "axes": ["z", "y", "x"]},
+        ),
+        type_name="Image",
+    )
+    created = _create_session(
+        client, ref=record.id, recorded_type="Image", type_chain=["DataObject", "Array", "Image"]
+    ).json()
+
+    assert created["previewer_id"] == "imaging.image.viewer"
+    # First-class manifest in the wire body (#1579).
+    assert created["frontend_manifest"]["previewer_id"] == "imaging.image.viewer"
+    assert created["frontend_manifest"]["module_url"] == "/api/previews/assets/imaging.image.viewer/viewer.js"
+    # The backend-only asset_root is never serialized.
+    assert "asset_root" not in created["frontend_manifest"]
+    # Old flattened metadata channel is no longer populated by the provider.
+    assert "frontend_manifest" not in created["metadata"]
 
 
 def test_resource_unknown_session_returns_404(client: TestClient, opened_project: Path) -> None:

--- a/tests/previewers/test_preview_session_manifest.py
+++ b/tests/previewers/test_preview_session_manifest.py
@@ -1,0 +1,119 @@
+"""Session-manager frontend-manifest stamping tests (ADR-048 §4 / #1579).
+
+:class:`PreviewSessionManager` promotes the resolved :class:`PreviewerSpec`'s
+``frontend_manifest`` to a first-class field on the returned
+:class:`PreviewEnvelope`:
+
+* a spec manifest is auto-injected when the provider sets none;
+* a provider-set manifest wins (precedence — never overwritten);
+* a spec with no manifest yields ``envelope.frontend_manifest is None``.
+
+These use a minimal in-memory registry with trivial providers; they never
+require a package install or real storage.
+"""
+
+from __future__ import annotations
+
+from scistudio.previewers.models import (
+    EnvelopeKind,
+    FrontendManifest,
+    OwnerKind,
+    PreviewEnvelope,
+    PreviewerSpec,
+    PreviewMetadata,
+    PreviewRequest,
+    PreviewTarget,
+    TargetKind,
+)
+from scistudio.previewers.registry import PreviewerRegistry
+from scistudio.previewers.session import PreviewSessionManager
+
+_SPEC_MANIFEST = FrontendManifest(
+    previewer_id="pkg.widget",
+    module_url="/api/previews/assets/pkg.widget/viewer.js",
+    asset_root="/backend/only/assets",
+)
+_PROVIDER_MANIFEST = FrontendManifest(
+    previewer_id="pkg.widget",
+    module_url="/api/previews/assets/pkg.widget/other.js",
+)
+
+
+def _target() -> PreviewTarget:
+    return PreviewTarget(
+        kind=TargetKind.DATA_REF,
+        ref="r",
+        recorded_type="Widget",
+        type_chain=("DataObject", "Widget"),
+    )
+
+
+def _spec(*, manifest: FrontendManifest | None, provider) -> PreviewerSpec:
+    return PreviewerSpec(
+        previewer_id="pkg.widget",
+        owner_kind=OwnerKind.PACKAGE,
+        owner_name="pkg",
+        target_type="Widget",
+        priority=100,
+        backend_provider=provider,
+        frontend_manifest=manifest,
+    )
+
+
+def _manager_for(spec: PreviewerSpec) -> PreviewSessionManager:
+    reg = PreviewerRegistry()
+    reg.register(spec)
+    return PreviewSessionManager(reg)
+
+
+def _bare_envelope(request: PreviewRequest) -> PreviewEnvelope:
+    """A trivial provider that sets NO frontend manifest."""
+    return PreviewEnvelope(
+        previewer_id=request.spec.previewer_id,
+        target=request.target,
+        kind=EnvelopeKind.ARRAY,
+        metadata=PreviewMetadata(),
+    )
+
+
+def _envelope_with_own_manifest(request: PreviewRequest) -> PreviewEnvelope:
+    """A trivial provider that DOES set its own frontend manifest."""
+    return PreviewEnvelope(
+        previewer_id=request.spec.previewer_id,
+        target=request.target,
+        kind=EnvelopeKind.ARRAY,
+        metadata=PreviewMetadata(),
+        frontend_manifest=_PROVIDER_MANIFEST,
+    )
+
+
+def test_spec_manifest_is_auto_injected_when_provider_sets_none() -> None:
+    manager = _manager_for(_spec(manifest=_SPEC_MANIFEST, provider=_bare_envelope))
+    envelope = manager.render_target(_target())
+    assert envelope.frontend_manifest is _SPEC_MANIFEST
+    # Wire shape never leaks the backend-only asset_root.
+    assert "asset_root" not in envelope.frontend_manifest.to_dict()
+    assert envelope.to_dict()["frontend_manifest"]["module_url"] == _SPEC_MANIFEST.module_url
+
+
+def test_provider_set_manifest_is_not_overwritten() -> None:
+    manager = _manager_for(_spec(manifest=_SPEC_MANIFEST, provider=_envelope_with_own_manifest))
+    envelope = manager.render_target(_target())
+    # Precedence: the provider's own manifest wins over the spec default.
+    assert envelope.frontend_manifest is _PROVIDER_MANIFEST
+
+
+def test_no_manifest_when_spec_declares_none() -> None:
+    manager = _manager_for(_spec(manifest=None, provider=_bare_envelope))
+    envelope = manager.render_target(_target())
+    assert envelope.frontend_manifest is None
+    assert envelope.to_dict()["frontend_manifest"] is None
+
+
+def test_stamp_also_applies_to_session_envelope() -> None:
+    """create_session goes through the same _render seam, so the manifest is
+    stamped on the session envelope too (with the session id bound)."""
+    manager = _manager_for(_spec(manifest=_SPEC_MANIFEST, provider=_bare_envelope))
+    envelope = manager.create_session(_target())
+    assert envelope.session_id is not None
+    assert envelope.frontend_manifest is _SPEC_MANIFEST


### PR DESCRIPTION
## Summary

Promotes the previewer `frontend_manifest` from `envelope.metadata.extra["frontend_manifest"]` to a **first-class, framework-stamped field** on the `PreviewEnvelope` / session envelope. Follow-up from the ADR-048 SPEC 1 audit (#1574); contract-hardening cleanup before more package previewers are added.

**Before:** `PreviewSessionManager` held the resolved `PreviewerSpec` but never injected its `frontend_manifest`, so every package/project provider had to manually re-embed the manifest on every envelope (`_embed_manifest`) or the host silently never loaded its UI. `PreviewEnvelopeModel` had no manifest field.

**After:** the session manager stamps the resolved spec's manifest onto the envelope; providers declare it once on their `PreviewerSpec`; the host reads it first-class.

## Changes

- **`PreviewEnvelope.frontend_manifest`** — optional field; `to_dict()` + `with_session()` carry it (`src/scistudio/previewers/models.py`).
- **`PreviewSessionManager._render`** stamps `spec.frontend_manifest` when the envelope sets none — provider-set manifest wins; core fallbacks stay `None` (`src/scistudio/previewers/session.py`).
- **`PreviewEnvelopeModel.frontend_manifest`** — `PreviewFrontendManifestModel` moved above it; the `**envelope.to_dict()` spread populates it, no route change (`src/scistudio/api/schemas.py`).
- **Frontend** `PreviewHost.readManifest()` reads `envelope.frontend_manifest` first-class with a legacy `metadata.frontend_manifest` fallback for un-migrated providers; the TS `PreviewEnvelope` type gains the field.
- **Imaging provider** drops the manual `_embed_manifest` (3 call sites) and declares the manifest once per spec via `get_previewers()`.

## Tests

- New `tests/previewers/test_preview_session_manifest.py`: auto-inject when provider sets none, provider-precedence (not overwritten), `None` when the spec declares none, `create_session` stamping.
- `tests/api/test_previewers.py`: Image-session JSON carries the top-level first-class `frontend_manifest`; core dataframe session is `None`.
- Imaging registration retargeted to assert the manifest reaches the session envelope (and the provider alone no longer embeds into `metadata.extra`).
- `PreviewHost.test.tsx`: first-class read case.

## Docs

- `docs/specs/adr-048-preview-system.md` §3 `PreviewEnvelope` table + FR-020 (first-class delivery).
- `docs/adr/ADR-048.md` §4 (session manager stamps the manifest).
- Scope report: `docs/planning/issue-1579-impact-scope.md`.

## Compatibility

No behavior change for working previewers — same-origin validation is unchanged and the frontend keeps the `metadata.frontend_manifest` fallback, so un-migrated providers still mount. Field is optional, so plot/core/collection/error envelopes are unaffected.

## Stacking / merge

Based on `track/adr-048-spec1-preview-system` (SPEC 1, PR #1577) because the preview subsystem lives on that branch. Intended to land after / as part of the SPEC 1 stack; GitHub retargets this PR to `main` once SPEC 1 merges. The `Closes #1579` keyword fires when the commit reaches `main` (it rides the commit message), so no manual close is needed once the stack lands.

Closes #1579
Refs #1574

🤖 Generated with [Claude Code](https://claude.com/claude-code)
