### PR TITLE
fix(#1627): honor SCISTUDIO_GATE_BASE in gate base resolution for stacked sub-PRs

### DIFF
--- a/.workflow/records/1627-gate-base-env.json
+++ b/.workflow/records/1627-gate-base-env.json
@@ -1,0 +1,66 @@
+{
+  "branch": "fix/gate-base-env-1627",
+  "check_events": [],
+  "check_na": [],
+  "commit": null,
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "src/scistudio/qa/governance/gate_record/io.py",
+      "tests/qa/test_gate_record.py",
+      "docs/ai-developer/gate-cli-command-set.md"
+    ]
+  },
+  "directive_events": [],
+  "docs_events": [
+    {
+      "at": "2026-06-13T00:08:12.804609Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/ai-developer/gate-cli-command-set.md",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": true,
+  "guard_events": [],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1627,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": null,
+  "owner_directive": "Fix #1609 regression: commit-msg/pre-commit base hardcodes origin/main, blocking all track-stacked sub-PR commits (#1604/#1606/#1605-reland). Honor SCISTUDIO_GATE_BASE in resolve_default_base.",
+  "persona": "implementer",
+  "pull_request": null,
+  "reconcile_events": [],
+  "record_id": "1627-gate-base-env",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [],
+    "docs": [],
+    "guards": [],
+    "tests": []
+  },
+  "runtime": "claude-code:claude-fable-5",
+  "schema_version": 2,
+  "scope_events": [],
+  "session_id": "50c65fa3-88b0-403d-b1cd-f2f6c6c2a52d",
+  "strictness_tier": null,
+  "task_kind": "bugfix",
+  "test_events": [
+    {
+      "at": "2026-06-13T00:08:12.804632Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/qa/test_gate_record.py",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/docs/ai-developer/gate-cli-command-set.md
+++ b/docs/ai-developer/gate-cli-command-set.md
@@ -215,7 +215,7 @@ python -m scistudio.qa.governance.gate_record check \
 
 | Argument | Required | Repeatable | Meaning |
 |---|---:|---:|---|
-| `--base` | no | no | Base ref for diff; default `git merge-base origin/main HEAD`, falling back to `origin/main`. Deeply-stacked branches may need an explicit `--base` |
+| `--base` | no | no | Base ref for diff; default `git merge-base <upstream> HEAD` falling back to the raw upstream. When `--base` is omitted, `<upstream>` is the `SCISTUDIO_GATE_BASE` env var if set, else `origin/main`. Set `SCISTUDIO_GATE_BASE=origin/track/<name>` so the commit-msg / pre-commit framework hooks of a **track-stacked sub-PR** diff against their track (not `origin/main`, which would misread the whole track delta as authored here) — the same var the push/PR wrappers already honor (#1627). An explicit `--base` still wins. Deeply-stacked branches may need an explicit `--base` |
 | `--head` | no | no | Head ref for diff; default `HEAD` |
 | `--mode` | no | no | One of `local` (default), `pre-commit`, `commit-msg`, `pre-push`, `pre-pr`, `ci` |
 | `--pr-body-file` | no | no | Intended PR body file for pre-PR issue-closure checks |

--- a/src/scistudio/qa/governance/gate_record/io.py
+++ b/src/scistudio/qa/governance/gate_record/io.py
@@ -151,17 +151,32 @@ def git_lines(repo_root: Path, args: list[str]) -> list[str]:
 
 DEFAULT_BASE_REF = "origin/main"
 
+# Environment override honored when no explicit ``--base`` is given. The push /
+# PR shell wrappers (``check-gate-before-{push,pr}.sh``) already read this
+# variable; the gate CLI's base resolution honoring it too lets the commit-msg /
+# pre-commit framework hooks (which invoke the CLI with no ``--base``) diff a
+# track-stacked sub-PR against its track instead of the hardcoded ``origin/main``
+# — which otherwise misreads the whole track delta as authored here (#1627).
+GATE_BASE_ENV_VAR = "SCISTUDIO_GATE_BASE"
 
-def resolve_default_base(repo_root: Path, *, upstream: str = DEFAULT_BASE_REF, head: str = "HEAD") -> str:
+
+def resolve_default_base(repo_root: Path, *, upstream: str | None = None, head: str = "HEAD") -> str:
     """Resolve the default diff base to the merge-base of ``upstream`` and ``head``.
 
     A branch's delta is its own commits, so the correct default base is
-    ``git merge-base origin/main HEAD`` rather than raw ``origin/main`` (Fix D /
-    §7.5). This is correct for normal branches and better for stacked branches.
-    When the merge-base cannot be computed (no common ancestor, missing upstream,
-    git unavailable), fall back to the raw upstream ref. Deeply-stacked branches
-    may still need an explicit ``--base``.
+    ``git merge-base <upstream> HEAD`` rather than the raw ref (Fix D / §7.5).
+    When ``upstream`` is not given, it resolves from the ``SCISTUDIO_GATE_BASE``
+    environment variable (so the commit-msg / pre-commit framework hooks of a
+    track-stacked sub-PR diff against their track rather than the hardcoded
+    ``origin/main`` that misreads the whole track delta as authored here, #1627),
+    falling back to ``origin/main``. An explicit ``upstream`` (e.g. a resolved
+    ``--base``) is honored verbatim and never env-overridden. When the merge-base
+    cannot be computed (no common ancestor, missing upstream, git unavailable),
+    fall back to the raw upstream ref.
     """
+
+    if upstream is None:
+        upstream = os.environ.get(GATE_BASE_ENV_VAR, "").strip() or DEFAULT_BASE_REF
 
     try:
         out = _git_output(repo_root, ["merge-base", upstream, head]).strip()

--- a/tests/qa/test_gate_record.py
+++ b/tests/qa/test_gate_record.py
@@ -607,6 +607,40 @@ def test_resolve_default_base_falls_back_when_no_merge_base(git_repo: Path) -> N
     assert resolved == "origin/main"
 
 
+# ---------------------------------------------------------------------------
+# #1627: SCISTUDIO_GATE_BASE overrides the default base so the commit-msg /
+# pre-commit hooks of a track-stacked sub-PR diff against their track, not the
+# hardcoded origin/main (which would misread the whole track delta as authored
+# here). Env only fills the default; an explicit upstream still wins.
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_default_base_honors_gate_base_env(git_repo: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    track_tip = io.resolve_sha(git_repo, "HEAD")  # the track/x tip
+    _git(git_repo, "checkout", "-q", "-b", "sub-pr")
+    _commit(git_repo, "feature.py", "f\n")  # the sub-PR's own commit on top of the track
+    monkeypatch.setenv("SCISTUDIO_GATE_BASE", "track/x")
+    resolved = io.resolve_default_base(git_repo)  # no explicit upstream -> resolve from env
+    # merge-base(track/x, HEAD) is the track tip; the sub-PR delta is just its own commit.
+    assert io.resolve_sha(git_repo, resolved) == track_tip
+
+
+def test_resolve_default_base_default_is_origin_main_without_env(
+    git_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("SCISTUDIO_GATE_BASE", raising=False)
+    # No env override + no explicit upstream -> origin/main (unresolvable here -> raw ref).
+    assert io.resolve_default_base(git_repo) == "origin/main"
+
+
+def test_resolve_default_base_explicit_upstream_not_env_overridden(
+    git_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("SCISTUDIO_GATE_BASE", "track/x")
+    # An explicit upstream wins over the env override (env only fills the default).
+    assert io.resolve_default_base(git_repo, upstream="origin/main") == "origin/main"
+
+
 def test_explicit_base_is_honored_verbatim(git_repo: Path) -> None:
     base = workflow._resolve_base(git_repo, "HEAD~0", "HEAD")
     assert base == "HEAD~0"


### PR DESCRIPTION
## Summary

Fixes a #1609 regression that blocks **all** track-stacked ADR-048 sub-PR commits.

#1609 made the previously-broken `commit-msg` hook actually enforce. But the gate CLI's
`resolve_default_base` (`gate_record/io.py`) hardcodes the diff base to
`merge-base(origin/main, HEAD)`. For any feature branch stacked on an ADR-048 track (which has
merged main), that base resolves to **main**, so the scope check reads the *entire track delta* as
authored by the branch → `scope.out-of-scope`, making the commit structurally unsatisfiable. The
push/PR shell wrappers already honor `SCISTUDIO_GATE_BASE`, but the gate CLI did not, so the
`commit-msg`/`pre-commit` framework hooks (invoked with no `--base`) couldn't be pointed at the track.

This is currently blocking #1604, #1606, and the #1603 array-viewer re-land.

## Change

`resolve_default_base` now resolves its default upstream from `SCISTUDIO_GATE_BASE` (falling back to
`origin/main`) when no explicit `--base`/upstream is given — the same variable the push/PR wrappers
already use, now extended to the gate CLI for consistency.

- **Opt-in**: behavior is unchanged unless `SCISTUDIO_GATE_BASE` is set.
- **Not a weakening**: scope is still fully enforced — just against the correct (track) base.
- An explicit `--base`/upstream still wins (env only fills the unspecified default).

## Tests

`tests/qa/test_gate_record.py`: env selects the track base for a stacked branch; default stays
`origin/main` without the env; an explicit upstream is not env-overridden. Full gate suite green.

## Docs

Documents `SCISTUDIO_GATE_BASE` in the gate CLI reference (`docs/ai-developer/gate-cli-command-set.md`).

## Governance

Touches `src/scistudio/qa/**` and `docs/ai-developer/**` (governance surfaces) — `governance_touch`
declared in the ledger; owner review via this PR.

Closes #1627
