### PR TITLE
fix: harden ADR-048 preview cache keys

### DIFF
--- a/.workflow/records/1649-pr1577-preview-cache-legacy-cleanup.json
+++ b/.workflow/records/1649-pr1577-preview-cache-legacy-cleanup.json
@@ -1,0 +1,369 @@
+{
+  "branch": "fix/pr1577-preview-cache-legacy-cleanup-20260613",
+  "check_events": [
+    {
+      "at": "2026-06-13T21:15:54.901629Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-13T21:16:07.490141Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-13T21:16:07.570822Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    }
+  ],
+  "check_na": [],
+  "commit": {
+    "sha": null,
+    "shas": [],
+    "trailers": []
+  },
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "frontend/src/store/previewSlice.ts",
+      "frontend/src/components/DataPreview.tsx",
+      "frontend/src/components/DataPreview.parts/PreviewHost.tsx",
+      "frontend/src/components/DataPreview.parts/PreviewHost.test.tsx",
+      "src/scistudio/previewers/session.py",
+      "tests/previewers",
+      "frontend/e2e/support/systemMocks.ts"
+    ]
+  },
+  "directive_events": [],
+  "docs_events": [
+    {
+      "at": "2026-06-13T21:03:58.096551Z",
+      "class": "adr048-spec",
+      "kind": "na",
+      "path": null,
+      "rationale": "implementation now conforms to existing ADR-048/SPEC 1 cache and legacy-removal requirements; no contract text changes",
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": false,
+  "guard_events": [
+    {
+      "at": "2026-06-13T21:16:07.681126Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T21:16:07.734198Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T21:16:07.799104Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T21:16:07.852303Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T21:16:07.915202Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T21:16:07.972265Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T21:16:08.035563Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T21:16:08.089267Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T21:16:08.150382Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T21:16:08.200625Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T21:26:56.943264Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T21:26:56.994158Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T21:26:57.044243Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T21:26:57.093888Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T21:26:57.145050Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T21:26:57.194517Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T21:26:57.244114Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T21:26:57.293462Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T21:26:57.344653Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T21:26:57.396050Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1649,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": {
+    "base": "origin/track/adr-048-spec1-preview-system",
+    "base_sha": "d3209847",
+    "changed_files": [
+      ".workflow/records/1649-pr1577-preview-cache-legacy-cleanup.json",
+      "frontend/e2e/support/systemMocks.ts",
+      "frontend/src/components/DataPreview.parts/PreviewHost.test.tsx",
+      "frontend/src/components/DataPreview.parts/PreviewHost.tsx",
+      "frontend/src/components/DataPreview.tsx",
+      "frontend/src/store/previewSlice.ts",
+      "src/scistudio/previewers/fallbacks.py",
+      "src/scistudio/previewers/session.py",
+      "tests/previewers/test_fallback_array.py",
+      "tests/previewers/test_preview_session_cache_key.py"
+    ],
+    "diff_fingerprint": "sha256:ddda2f935eb1b2f9a6a03cb208278e16e1008162bffd75dd944c7bf1fd6519bc",
+    "head": "HEAD",
+    "head_sha": "c3a7859a",
+    "surfaces": {
+      "docs": 0,
+      "frontend": 5,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 7,
+      "packaging": 0,
+      "protected_core": 0,
+      "sentrux": 9,
+      "test": 3,
+      "workflow_ci": 0
+    }
+  },
+  "owner_directive": "Fix PR #1577 audit P1 preview cache key bug and P3 stale legacy preview cleanup; leave P2 E2E scope out.",
+  "persona": "implementer",
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [],
+    "number": 1650,
+    "url": null
+  },
+  "reconcile_events": [
+    {
+      "at": "2026-06-13T21:16:08.200677Z",
+      "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "mode": "local",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-13T21:26:57.396083Z",
+      "diff_fingerprint": "sha256:ddda2f935eb1b2f9a6a03cb208278e16e1008162bffd75dd944c7bf1fd6519bc",
+      "mode": "ci",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    }
+  ],
+  "record_id": "1649-pr1577-preview-cache-legacy-cleanup",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [],
+    "docs": [
+      "docs_required_or_na"
+    ],
+    "guards": [
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": [
+      "changed_test_required"
+    ]
+  },
+  "runtime": "codex",
+  "schema_version": 2,
+  "scope_events": [
+    {
+      "action": "add-include",
+      "at": "2026-06-13T21:03:46.394773Z",
+      "pattern": "src/scistudio/previewers/fallbacks.py",
+      "reason": "P3 stale legacy cleanup also touches core array fallback comments and its provider test comment."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-13T21:03:46.394792Z",
+      "pattern": "tests/previewers/test_fallback_array.py",
+      "reason": "P3 stale legacy cleanup also touches core array fallback comments and its provider test comment."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-13T21:03:58.096443Z",
+      "pattern": "tests/previewers/test_preview_session_cache_key.py",
+      "reason": "plan"
+    }
+  ],
+  "session_id": "d73e58f0-1754-477d-a495-77411307d545",
+  "strictness_tier": 2,
+  "task_kind": "bugfix",
+  "test_events": [
+    {
+      "at": "2026-06-13T21:03:58.096561Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/components/DataPreview.parts/PreviewHost.test.tsx",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-13T21:03:58.096566Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/previewers/test_preview_session_cache_key.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-13T21:03:58.096569Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/previewers/test_fallback_array.py",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/frontend/e2e/support/systemMocks.ts
+++ b/frontend/e2e/support/systemMocks.ts
@@ -120,9 +120,9 @@ const commits = [
   },
 ];
 
-async function fulfill(route: Route, body: JsonBody): Promise<void> {
+async function fulfill(route: Route, body: JsonBody, status = 200): Promise<void> {
   await route.fulfill({
-    status: 200,
+    status,
     contentType: "application/json",
     body: JSON.stringify(body),
   });
@@ -202,11 +202,7 @@ export async function installSystemMocks(page: Page): Promise<void> {
     if (path === "/api/runs") return fulfill(route, { runs: [runSummary] });
     if (path === "/api/runs/run-1") return fulfill(route, runDetail);
     if (path === "/api/data/obj-1/preview") {
-      return fulfill(route, {
-        ref: "obj-1",
-        type_name: "table",
-        preview: { columns: ["a"], rows: [{ a: 1 }] },
-      });
+      return fulfill(route, { detail: "ADR-048 removed the one-shot preview route" }, 404);
     }
     if (path === "/api/git/status") {
       return fulfill(route, {

--- a/frontend/src/components/DataPreview.parts/PreviewHost.test.tsx
+++ b/frontend/src/components/DataPreview.parts/PreviewHost.test.tsx
@@ -393,7 +393,7 @@ describe("PreviewHost — DataFrame pagination/sort through the routed session (
     // #1604: the core DataFrameViewer reuses TableViewer, which now paginates
     // through the routed session PATCH (api.patchPreviewSession) — the same
     // path the ArrayViewer uses for slice selection — NOT the deleted legacy
-    // GET /api/data/{ref}/preview adapter. The patched envelope carries the
+    // deleted one-shot data-preview route. The patched envelope carries the
     // next page's payload, which flows back into the table.
     const page1 = Array.from({ length: 50 }, (_, i) => ({ A: i, B: i * 2 }));
     const page2 = Array.from({ length: 50 }, (_, i) => ({ A: 50 + i, B: (50 + i) * 2 }));
@@ -456,7 +456,7 @@ describe("FR-021 cache key + FR-022 same-origin validation", () => {
   it("buildPreviewCacheKey includes ref, kind, previewer, session, query, version", () => {
     const key = buildPreviewCacheKey(
       { kind: "data_ref", ref: "data-1" },
-      { slice_index: 3, page: 2, _storage: { x: 1 } },
+      { slice_index: 3, page: 2, axis_indices: { "0": 1, "1": 4 }, _storage: { x: 1 } },
       { previewerId: "core.array.basic", sessionId: "pv-9", dataVersion: "v7" },
     );
     expect(key).toContain("data-1");
@@ -466,6 +466,8 @@ describe("FR-021 cache key + FR-022 same-origin validation", () => {
     expect(key).toContain("v7");
     expect(key).toContain("slice_index=3");
     expect(key).toContain("page=2");
+    expect(key).toContain('axis_indices={"0":1,"1":4}');
+    expect(key).not.toContain("[object Object]");
     // private enrichment keys never widen the key
     expect(key).not.toContain("_storage");
   });
@@ -502,5 +504,77 @@ describe("PreviewHost — session-envelope cache (FR-021)", () => {
     expect(screen.getByText("cached body")).toBeInTheDocument();
     expect(createPreviewSession).not.toHaveBeenCalled();
     expect(getCachedEnvelope).toHaveBeenCalledWith("the-key");
+  });
+
+  it("caches patched array envelopes with resolved identity and axis_indices", async () => {
+    const initialPayload = {
+      shape: [4, 6, 2, 3],
+      dtype: "float64",
+      axes: ["t", "z", "y", "x"],
+      ndim: 4,
+      matrix: [
+        [-1, 0, 2],
+        [3, -4, 5],
+      ],
+      vmin: -4,
+      vmax: 5,
+      slice_axes: [
+        { axis: 0, name: "t", size: 4, index: 1 },
+        { axis: 1, name: "z", size: 6, index: 2 },
+      ],
+    };
+    const patchedPayload = {
+      ...initialPayload,
+      slice_axes: [
+        { axis: 0, name: "t", size: 4, index: 1 },
+        { axis: 1, name: "z", size: 6, index: 4 },
+      ],
+    };
+    createPreviewSession.mockResolvedValue(
+      envelope({
+        previewer_id: "core.array.basic",
+        kind: "array",
+        payload: initialPayload,
+        metadata: { complete: true, data_version: "v7" },
+      }),
+    );
+    patchPreviewSession.mockResolvedValue(
+      envelope({
+        previewer_id: "core.array.basic",
+        kind: "array",
+        payload: patchedPayload,
+        metadata: { complete: true, data_version: "v7" },
+      }),
+    );
+    const cacheEnvelope = vi.fn();
+
+    render(
+      <PreviewHost
+        target={{ ...TARGET, recorded_type: "Array" }}
+        cacheEnvelope={cacheEnvelope}
+        buildCacheKey={buildPreviewCacheKey}
+      />,
+    );
+
+    expect(await screen.findByTestId("core-array-viewer")).toBeInTheDocument();
+    cacheEnvelope.mockClear();
+
+    fireEvent.change(screen.getByTestId("array-slice-slider-1"), { target: { value: "4" } });
+
+    await waitFor(() => expect(patchPreviewSession).toHaveBeenCalledTimes(1));
+    const [, patch] = patchPreviewSession.mock.calls[0];
+    expect(patch).toMatchObject({ axis_indices: { "0": 1, "1": 4 } });
+    await waitFor(() => expect(cacheEnvelope).toHaveBeenCalled());
+    const keys = cacheEnvelope.mock.calls.map(([key]) => String(key));
+    expect(
+      keys.some(
+        (key) =>
+          key.includes("previewer=core.array.basic") &&
+          key.includes("session=pv-1") &&
+          key.includes("version=v7") &&
+          key.includes('axis_indices={"0":1,"1":4}'),
+      ),
+    ).toBe(true);
+    expect(keys.every((key) => !key.includes("_storage"))).toBe(true);
   });
 });

--- a/frontend/src/components/DataPreview.parts/PreviewHost.tsx
+++ b/frontend/src/components/DataPreview.parts/PreviewHost.tsx
@@ -56,12 +56,21 @@ export interface PreviewHostProps {
    */
   getCachedEnvelope?: (key: string) => PreviewEnvelope | undefined;
   cacheEnvelope?: (key: string, envelope: PreviewEnvelope) => void;
-  buildCacheKey?: (target: PreviewTarget, query: Record<string, unknown>) => string;
+  buildCacheKey?: (
+    target: PreviewTarget,
+    query: Record<string, unknown>,
+    opts?: PreviewCacheKeyOptions,
+  ) => string;
   /** Test seam: inject a fake dynamic-module importer. */
   importer?: Parameters<typeof mountDynamicPreviewer>[3];
 }
 
 type Status = "idle" | "loading" | "ready" | "error";
+type PreviewCacheKeyOptions = {
+  previewerId?: string | null;
+  sessionId?: string | null;
+  dataVersion?: string | number | null;
+};
 const RESOURCE_PARAMS_MAX_CHARS = 8192;
 
 function readManifest(envelope: PreviewEnvelope | null): PreviewerManifest | undefined {
@@ -73,6 +82,42 @@ function readManifest(envelope: PreviewEnvelope | null): PreviewerManifest | und
     return manifest;
   }
   return undefined;
+}
+
+function cacheDataVersionFromEnvelope(envelope: PreviewEnvelope): string | number | null {
+  const candidates = [
+    envelope.metadata?.data_version,
+    envelope.metadata?.dataVersion,
+    envelope.payload?.data_version,
+    envelope.payload?.dataVersion,
+  ];
+  const value = candidates.find(
+    (candidate) => typeof candidate === "string" || typeof candidate === "number",
+  );
+  return typeof value === "string" || typeof value === "number" ? value : null;
+}
+
+function cacheIdentityFromEnvelope(envelope: PreviewEnvelope): PreviewCacheKeyOptions {
+  return {
+    previewerId: envelope.previewer_id,
+    sessionId: envelope.session_id,
+    dataVersion: cacheDataVersionFromEnvelope(envelope),
+  };
+}
+
+function cacheEnvelopeForQuery(
+  cacheEnvelope: PreviewHostProps["cacheEnvelope"],
+  buildCacheKey: PreviewHostProps["buildCacheKey"],
+  target: PreviewTarget,
+  query: Record<string, unknown>,
+  envelope: PreviewEnvelope,
+  unresolvedKey?: string,
+) {
+  if (!cacheEnvelope || !buildCacheKey) return;
+  const keys = new Set<string>();
+  if (unresolvedKey) keys.add(unresolvedKey);
+  keys.add(buildCacheKey(target, query, cacheIdentityFromEnvelope(envelope)));
+  keys.forEach((key) => cacheEnvelope(key, envelope));
 }
 
 export function PreviewHost({
@@ -122,7 +167,7 @@ export function PreviewHost({
         if (cancelled) return;
         setEnvelope(env);
         setStatus("ready");
-        if (cacheKey && cacheEnvelope) cacheEnvelope(cacheKey, env);
+        cacheEnvelopeForQuery(cacheEnvelope, buildCacheKey, target, query, env, cacheKey);
       })
       .catch((err: unknown) => {
         if (cancelled) return;
@@ -147,9 +192,8 @@ export function PreviewHost({
       queryRef.current = { ...queryRef.current, ...patch };
       const next = await api.patchPreviewSession(current.session_id, patch);
       setEnvelope(next);
-      if (buildCacheKey && cacheEnvelope && target) {
-        cacheEnvelope(buildCacheKey(target, queryRef.current), next);
-      }
+      if (target)
+        cacheEnvelopeForQuery(cacheEnvelope, buildCacheKey, target, queryRef.current, next);
       return next;
     },
     [envelope, buildCacheKey, cacheEnvelope, target],
@@ -241,10 +285,11 @@ export function PreviewHost({
       session: {
         refresh: async () =>
           activeEnvelope.session_id ? api.getPreviewSession(activeEnvelope.session_id) : null,
-        patchQuery: async (q) =>
-          activeEnvelope.session_id
-            ? api.patchPreviewSession(activeEnvelope.session_id, q)
-            : activeEnvelope,
+        patchQuery: async (q) => {
+          if (!activeEnvelope.session_id) return activeEnvelope;
+          if (activeEnvelope.session_id === envelope?.session_id) return patchQuery(q);
+          return api.patchPreviewSession(activeEnvelope.session_id, q);
+        },
         getResource: async (resourceId, params) => {
           if (!activeEnvelope.session_id) return null;
           const resource = activeEnvelope.resources.find((r) => r.resource_id === resourceId);
@@ -292,7 +337,7 @@ export function PreviewHost({
         setHostDiagnostics((d) => [...d, message]);
       },
     };
-  }, [activeEnvelope, manifest]);
+  }, [activeEnvelope, envelope?.session_id, manifest, patchQuery]);
 
   useEffect(() => {
     // Tear down any prior instance whenever the focus changes.

--- a/frontend/src/components/DataPreview.tsx
+++ b/frontend/src/components/DataPreview.tsx
@@ -219,7 +219,7 @@ export function DataPreview({
               target={plotTarget ?? target}
               getCachedEnvelope={(key) => previewEnvelopeCache[key]}
               cacheEnvelope={cachePreviewEnvelope}
-              buildCacheKey={(t, q) => buildPreviewCacheKey(t, q)}
+              buildCacheKey={(t, q, opts) => buildPreviewCacheKey(t, q, opts)}
             />
           </div>
         </>

--- a/frontend/src/store/previewSlice.ts
+++ b/frontend/src/store/previewSlice.ts
@@ -4,32 +4,57 @@ import type { PreviewTarget } from "../types/api";
 
 import type { AppStore, PreviewSlice } from "./types";
 
+export interface PreviewCacheKeyOptions {
+  previewerId?: string | null;
+  sessionId?: string | null;
+  dataVersion?: string | number | null;
+}
+
+function stablePreviewCacheValue(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stablePreviewCacheValue(item)).join(",")}]`;
+  }
+  if (value && typeof value === "object") {
+    const record = value as Record<string, unknown>;
+    return `{${Object.keys(record)
+      .filter((key) => record[key] !== undefined)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${stablePreviewCacheValue(record[key])}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
 /**
- * ADR-048 SPEC 1 — build the routed-preview cache key (FR-021).
+ * ADR-048 SPEC 1 cache key construction (FR-021).
  *
  * Keys the session-envelope cache by data/collection reference, previewer id
- * (when known), session id (when known), the query parameters that change the
- * rendered envelope (slice/page/sort/slot/item), and the data version when the
- * caller can provide one. Private `_`-prefixed enrichment keys (`_storage`,
+ * (when known), session id (when known), every public query parameter that
+ * can change the rendered envelope, and the data version when the caller can
+ * provide one. Private `_`-prefixed enrichment keys (`_storage`,
  * `_record_metadata`, ...) are excluded so they never widen the key.
  */
 export function buildPreviewCacheKey(
   target: PreviewTarget,
   query: Record<string, unknown>,
-  opts?: { previewerId?: string; sessionId?: string; dataVersion?: string },
+  opts?: PreviewCacheKeyOptions,
 ): string {
-  const QUERY_KEYS = ["slice_index", "page", "page_size", "sort_by", "sort_dir", "slot", "item"];
-  const queryParts = QUERY_KEYS.filter((k) => query[k] !== undefined && query[k] !== null)
+  const queryParts = Object.keys(query)
+    .filter((k) => !k.startsWith("_") && query[k] !== undefined && query[k] !== null)
     .sort()
-    .map((k) => `${k}=${String(query[k])}`);
+    .map((k) => `${k}=${stablePreviewCacheValue(query[k])}`);
   return [
-    target.ref,
-    target.kind,
-    opts?.previewerId ?? "",
-    opts?.sessionId ?? "",
-    opts?.dataVersion ?? "",
+    `ref=${target.ref}`,
+    `kind=${target.kind}`,
+    opts?.previewerId ? `previewer=${opts.previewerId}` : "",
+    opts?.sessionId ? `session=${opts.sessionId}` : "",
+    opts?.dataVersion !== undefined && opts.dataVersion !== null
+      ? `version=${opts.dataVersion}`
+      : "",
     ...queryParts,
-  ].join("|");
+  ]
+    .filter(Boolean)
+    .join("|");
 }
 
 export const createPreviewSlice: StateCreator<AppStore, [], [], PreviewSlice> = (set) => ({

--- a/src/scistudio/previewers/fallbacks.py
+++ b/src/scistudio/previewers/fallbacks.py
@@ -179,9 +179,7 @@ def array_previewer(request: PreviewRequest) -> PreviewEnvelope:
     # The numeric heatmap table (matrix + vmin/vmax) is the primary view; the
     # core ArrayViewer ignores ``src``. The grayscale PNG ``src`` is retained as
     # the raster fallback that the imaging package's Image previewer reuses when
-    # its packaged viewer module fails to load (FR-026). (The legacy one-shot
-    # ``GET /api/data/{ref}/preview`` adapter that also consumed it was removed
-    # under ADR-048 no-compat, #1604.)
+    # its packaged viewer module fails to load (FR-026).
     src = request.data_access.png_data_uri(plane.matrix)
     resources = (
         PreviewResource(
@@ -211,7 +209,7 @@ def array_previewer(request: PreviewRequest) -> PreviewEnvelope:
             "thumbnail": plane.matrix,
             "vmin": plane.vmin,
             "vmax": plane.vmax,
-            # Legacy-compat raster (FR-008); NOT used by the new numeric viewer.
+            # Raster fallback for package viewers; NOT used by the numeric viewer.
             "src": src,
         },
         resources=resources,

--- a/src/scistudio/previewers/session.py
+++ b/src/scistudio/previewers/session.py
@@ -9,8 +9,8 @@ Ties the registry, router, and bounded data access together (ADR-048 FR-007):
   re-renders.
 * :meth:`read_resource` performs a bounded follow-up resource read for a
   session (e.g. an array tile or a child preview).
-* :meth:`render_target` renders a one-shot envelope WITHOUT a session — used by
-  the legacy REST compatibility adapter.
+* :meth:`render_target` renders a one-shot envelope WITHOUT a session for
+  routed child-resource previews and direct provider tests.
 
 Provider calls are wrapped defensively: a routing/typed error becomes an error
 envelope; an unexpected provider exception becomes a
@@ -21,6 +21,7 @@ API (FR-028/FR-029). Sessions never mutate workflow/data/lineage state.
 from __future__ import annotations
 
 import base64
+import json
 import logging
 import threading
 from collections import OrderedDict
@@ -103,13 +104,14 @@ class PreviewSessionManager:
         except PreviewError as exc:
             return self._error_envelope(target, exc.code, exc.message, previewer_id="", detail=exc.detail)
 
+        session_id = f"pv-{uuid4().hex}"
         session = PreviewSession(
-            session_id=f"pv-{uuid4().hex}",
+            session_id=session_id,
             previewer_id=spec.previewer_id,
             target=target,
             created_at=_now_iso(),
             query=query,
-            cache_key=self._cache_key(spec, target, query),
+            cache_key=self._cache_key(spec, target, query, session_id=session_id),
             limits=PreviewLimits(),
         )
         with self._lock:
@@ -143,6 +145,7 @@ class PreviewSessionManager:
                 self._registry.get(session.previewer_id) or _missing_spec(session.previewer_id),
                 session.target,
                 session.query,
+                session_id=session_id,
             )
             self._sessions.move_to_end(session_id)
             target = session.target
@@ -211,10 +214,10 @@ class PreviewSessionManager:
         """Return the session record (no re-render)."""
         return self._get_session(session_id)
 
-    # -- one-shot (compatibility) ------------------------------------------
+    # -- one-shot rendering -------------------------------------------------
 
     def render_target(self, target: PreviewTarget, query: dict[str, Any] | None = None) -> PreviewEnvelope:
-        """Render a one-shot envelope without creating a session (compat adapter)."""
+        """Render a one-shot envelope without creating a session."""
         query = dict(query or {})
         try:
             spec = self._router.resolve(target)
@@ -323,21 +326,30 @@ class PreviewSessionManager:
             self._sessions.popitem(last=False)
 
     @staticmethod
-    def _cache_key(spec: PreviewerSpec, target: PreviewTarget, query: dict[str, Any]) -> str:
-        relevant = {
-            k: v
-            for k, v in query.items()
-            if not k.startswith("_")
-            and k in {"slice_index", "page", "page_size", "sort_by", "sort_dir", "slot", "item"}
-        }
+    def _cache_key(
+        spec: PreviewerSpec,
+        target: PreviewTarget,
+        query: dict[str, Any],
+        *,
+        session_id: str | None = None,
+    ) -> str:
+        relevant = {k: v for k, v in query.items() if not k.startswith("_") and v is not None}
         version = ""
         storage = query.get("_storage")
         if isinstance(storage, dict):
             md = storage.get("metadata")
             if isinstance(md, dict):
                 version = str(md.get("data_version", ""))
-        parts = [spec.previewer_id, target.ref, version]
-        parts.extend(f"{k}={relevant[k]}" for k in sorted(relevant))
+        parts = [
+            f"previewer={spec.previewer_id}",
+            f"kind={target.kind.value}",
+            f"ref={target.ref}",
+        ]
+        if session_id:
+            parts.append(f"session={session_id}")
+        if version:
+            parts.append(f"version={version}")
+        parts.extend(f"{k}={_stable_cache_value(relevant[k])}" for k in sorted(relevant))
         return "|".join(parts)
 
     @staticmethod
@@ -487,6 +499,19 @@ def _storage_ref_from_query(query: dict[str, Any], fallback_ref: str) -> Any:
 def _public_resource_params(params: dict[str, Any]) -> dict[str, Any]:
     """Return resource params without private session-enrichment keys."""
     return {str(key): value for key, value in params.items() if not str(key).startswith("_")}
+
+
+def _stable_cache_value(value: Any) -> str:
+    if isinstance(value, dict):
+        parts = [
+            f"{json.dumps(str(key), separators=(',', ':'))}:{_stable_cache_value(value[key])}"
+            for key in sorted(value, key=lambda item: str(item))
+            if value[key] is not None
+        ]
+        return "{" + ",".join(parts) + "}"
+    if isinstance(value, (list, tuple)):
+        return "[" + ",".join(_stable_cache_value(item) for item in value) + "]"
+    return json.dumps(value, separators=(",", ":"), default=str)
 
 
 def _data_uri(mime_type: str, payload: bytes) -> str:

--- a/tests/previewers/test_fallback_array.py
+++ b/tests/previewers/test_fallback_array.py
@@ -99,7 +99,7 @@ def test_array_previewer_emits_numeric_heatmap_payload() -> None:
     ]
     # ``thumbnail`` remains an alias of the matrix for the scalar/1-D paths.
     assert payload["thumbnail"] == payload["matrix"]
-    # Legacy-compat raster src kept for the REST adapter (FR-008).
+    # Raster src remains available for package-viewer fallback paths.
     assert isinstance(payload["src"], str)
 
 

--- a/tests/previewers/test_preview_session_cache_key.py
+++ b/tests/previewers/test_preview_session_cache_key.py
@@ -1,0 +1,78 @@
+"""Regression tests for ADR-048 routed preview session cache keys."""
+
+from __future__ import annotations
+
+from scistudio.previewers.models import (
+    EnvelopeKind,
+    OwnerKind,
+    PreviewEnvelope,
+    PreviewerSpec,
+    PreviewRequest,
+    PreviewTarget,
+    TargetKind,
+)
+from scistudio.previewers.registry import PreviewerRegistry
+from scistudio.previewers.session import PreviewSessionManager
+
+
+def _target() -> PreviewTarget:
+    return PreviewTarget(
+        kind=TargetKind.DATA_REF,
+        ref="array-1",
+        recorded_type="Array",
+        type_chain=("DataObject", "Array"),
+    )
+
+
+def _provider(request: PreviewRequest) -> PreviewEnvelope:
+    return PreviewEnvelope(
+        previewer_id=request.spec.previewer_id,
+        target=request.target,
+        kind=EnvelopeKind.ARRAY,
+    )
+
+
+def _manager() -> PreviewSessionManager:
+    registry = PreviewerRegistry()
+    registry.register(
+        PreviewerSpec(
+            previewer_id="core.array.basic",
+            owner_kind=OwnerKind.CORE,
+            owner_name="scistudio",
+            target_type="Array",
+            backend_provider=_provider,
+        )
+    )
+    return PreviewSessionManager(registry)
+
+
+def test_session_cache_key_distinguishes_axis_indices_and_identity() -> None:
+    manager = _manager()
+    envelope = manager.create_session(
+        _target(),
+        {
+            "axis_indices": {"0": 1, "1": 2},
+            "_storage": {"metadata": {"data_version": "v7"}},
+        },
+    )
+    assert envelope.session_id is not None
+
+    session = manager.get_session(envelope.session_id)
+    first_key = session.cache_key
+    assert first_key is not None
+    assert "previewer=core.array.basic" in first_key
+    assert "kind=data_ref" in first_key
+    assert "ref=array-1" in first_key
+    assert f"session={envelope.session_id}" in first_key
+    assert "version=v7" in first_key
+    assert 'axis_indices={"0":1,"1":2}' in first_key
+    assert "_storage" not in first_key
+
+    manager.patch_session(envelope.session_id, {"axis_indices": {"0": 1, "1": 4}})
+    patched_key = manager.get_session(envelope.session_id).cache_key
+
+    assert patched_key is not None
+    assert patched_key != first_key
+    assert 'axis_indices={"0":1,"1":4}' in patched_key
+    assert f"session={envelope.session_id}" in patched_key
+    assert "version=v7" in patched_key


### PR DESCRIPTION
## Summary

- Fixes ADR-048 preview cache keys so public render-affecting query state, including `axis_indices`, is stably represented.
- Adds resolved preview identity to production cache writes when available: previewer ID, session ID, and data version.
- Cleans stale legacy one-shot preview wording and changes the E2E system mock so the removed `/api/data/{ref}/preview` path fails with 404 instead of returning legacy preview data.

## Tests

- `python -m pytest tests/previewers/test_preview_session_cache_key.py tests/previewers/test_fallback_array.py -q --no-cov --timeout=60`
- `python -m pytest tests/previewers tests/api/test_data.py tests/api/test_previewers.py -q --no-cov --timeout=120`
- `npm run test -- PreviewHost.test.tsx coreViewers.test.tsx`
- `npm run typecheck`
- `npm run test:e2e -- --reporter=list`
- `python -m scistudio.qa.governance.gate_record check --record .workflow/records/1649-pr1577-preview-cache-legacy-cleanup.json --issue 1649 --base origin/track/adr-048-spec1-preview-system --head HEAD --mode local`

Closes #1649
