### PR TITLE
fix: stop unresolved preview cache reuse

### DIFF
--- a/.workflow/records/1649-pr1577-resolved-cache-only.json
+++ b/.workflow/records/1649-pr1577-resolved-cache-only.json
@@ -1,0 +1,492 @@
+{
+  "branch": "fix/pr1577-resolved-cache-only-20260613",
+  "check_events": [
+    {
+      "at": "2026-06-13T21:43:35.840383Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-13T21:43:48.666258Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-13T21:43:48.757810Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-13T21:45:06.982864Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:968d6d94c8cb43322431946d713d6bba51334ab4d2910e8f11d16572bdaa10fd",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-13T21:45:09.942481Z",
+      "command": "(cd frontend && npm run lint)",
+      "covered_surface": "frontend",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:968d6d94c8cb43322431946d713d6bba51334ab4d2910e8f11d16572bdaa10fd",
+      "name": "frontend",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/frontend.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-13T21:45:19.465270Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:968d6d94c8cb43322431946d713d6bba51334ab4d2910e8f11d16572bdaa10fd",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-13T21:45:19.503091Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:968d6d94c8cb43322431946d713d6bba51334ab4d2910e8f11d16572bdaa10fd",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-13T21:46:17.864729Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:968d6d94c8cb43322431946d713d6bba51334ab4d2910e8f11d16572bdaa10fd",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    }
+  ],
+  "check_na": [],
+  "commit": {
+    "sha": null,
+    "shas": [],
+    "trailers": []
+  },
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "frontend/src/components/DataPreview.parts/PreviewHost.tsx",
+      "frontend/src/components/DataPreview.parts/PreviewHost.test.tsx",
+      ".workflow/records/1649-pr1577-resolved-cache-only.json"
+    ]
+  },
+  "directive_events": [],
+  "docs_events": [
+    {
+      "at": "2026-06-13T21:40:19.766673Z",
+      "class": "adr048-spec",
+      "kind": "na",
+      "path": null,
+      "rationale": "implementation tightens cache behavior to match existing FR-021 identity requirement; no spec text change",
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": false,
+  "guard_events": [
+    {
+      "at": "2026-06-13T21:43:48.877843Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T21:43:48.943364Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T21:43:49.004030Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T21:43:49.064486Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T21:43:49.132867Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T21:43:49.203636Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T21:43:49.270989Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T21:43:49.335530Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T21:43:49.396813Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T21:43:49.473539Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T21:46:17.994054Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T21:46:18.052187Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T21:46:18.116288Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T21:46:18.174599Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T21:46:18.232640Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T21:46:18.290150Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T21:46:18.354279Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T21:46:18.411541Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T21:46:18.468073Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T21:46:18.533191Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T21:47:10.554866Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T21:47:10.607369Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T21:47:10.660910Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T21:47:10.717267Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T21:47:10.777100Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T21:47:10.833270Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T21:47:10.891628Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T21:47:10.947746Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T21:47:11.009955Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T21:47:11.064434Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1649,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": {
+    "base": "origin/track/adr-048-spec1-preview-system",
+    "base_sha": "4199de25",
+    "changed_files": [
+      ".workflow/records/1649-pr1577-resolved-cache-only.json",
+      "frontend/src/components/DataPreview.parts/PreviewHost.test.tsx",
+      "frontend/src/components/DataPreview.parts/PreviewHost.tsx"
+    ],
+    "diff_fingerprint": "sha256:79714bea0b7679d3f1371b4fe520527035a0bb2c2230c074623b59d408361604",
+    "head": "HEAD",
+    "head_sha": "6219fe37",
+    "surfaces": {
+      "docs": 0,
+      "frontend": 2,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 2,
+      "packaging": 0,
+      "protected_core": 0,
+      "sentrux": 2,
+      "test": 1,
+      "workflow_ci": 0
+    }
+  },
+  "owner_directive": "Fix follow-up P1: stop reading/writing unresolved preview cache aliases; only cache envelopes under resolved preview identity keys.",
+  "persona": "implementer",
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [],
+    "number": 1651,
+    "url": null
+  },
+  "reconcile_events": [
+    {
+      "at": "2026-06-13T21:43:49.473594Z",
+      "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "mode": "local",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-13T21:46:18.533224Z",
+      "diff_fingerprint": "sha256:2794274ed71a75e956c3b077269b7d52229f4ab865f209cffd2e30236e4ac5e4",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-13T21:47:11.064470Z",
+      "diff_fingerprint": "sha256:79714bea0b7679d3f1371b4fe520527035a0bb2c2230c074623b59d408361604",
+      "mode": "ci",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    }
+  ],
+  "record_id": "1649-pr1577-resolved-cache-only",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [],
+    "docs": [
+      "docs_required_or_na"
+    ],
+    "guards": [
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": [
+      "changed_test_required"
+    ]
+  },
+  "runtime": "codex",
+  "schema_version": 2,
+  "scope_events": [],
+  "session_id": "2439d730-59b0-46c8-ae68-c43b4f9c6fb7",
+  "strictness_tier": 2,
+  "task_kind": "bugfix",
+  "test_events": [
+    {
+      "at": "2026-06-13T21:40:19.766693Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/components/DataPreview.parts/PreviewHost.test.tsx",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/frontend/src/components/DataPreview.parts/PreviewHost.test.tsx
+++ b/frontend/src/components/DataPreview.parts/PreviewHost.test.tsx
@@ -483,27 +483,41 @@ describe("FR-021 cache key + FR-022 same-origin validation", () => {
 });
 
 describe("PreviewHost — session-envelope cache (FR-021)", () => {
-  it("reads from the cache before creating a session", async () => {
-    const cached = envelope({
+  it("does not reuse unresolved cache aliases before creating a session", async () => {
+    const stale = envelope({
+      session_id: "pv-stale",
       previewer_id: "core.text.basic",
       kind: "text",
-      payload: { content: "cached body", truncated: false },
+      payload: { content: "stale body", truncated: false },
     });
-    const getCachedEnvelope = vi.fn(() => cached);
-    const buildCacheKey = vi.fn(() => "the-key");
+    createPreviewSession.mockResolvedValue(
+      envelope({
+        previewer_id: "core.text.basic",
+        kind: "text",
+        payload: { content: "fresh body", truncated: false },
+      }),
+    );
+    const getCachedEnvelope = vi.fn(() => stale);
+    const cacheEnvelope = vi.fn();
 
     render(
       <PreviewHost
         target={TARGET}
+        cacheEnvelope={cacheEnvelope}
         getCachedEnvelope={getCachedEnvelope}
-        buildCacheKey={buildCacheKey}
+        buildCacheKey={buildPreviewCacheKey}
       />,
     );
 
     expect(await screen.findByTestId("core-text-viewer")).toBeInTheDocument();
-    expect(screen.getByText("cached body")).toBeInTheDocument();
-    expect(createPreviewSession).not.toHaveBeenCalled();
-    expect(getCachedEnvelope).toHaveBeenCalledWith("the-key");
+    expect(screen.getByText("fresh body")).toBeInTheDocument();
+    expect(screen.queryByText("stale body")).toBeNull();
+    expect(createPreviewSession).toHaveBeenCalledWith(TARGET, {});
+    expect(getCachedEnvelope).not.toHaveBeenCalled();
+    expect(cacheEnvelope).toHaveBeenCalledTimes(1);
+    const [key] = cacheEnvelope.mock.calls[0];
+    expect(String(key)).toContain("previewer=core.text.basic");
+    expect(String(key)).toContain("session=pv-1");
   });
 
   it("caches patched array envelopes with resolved identity and axis_indices", async () => {
@@ -557,6 +571,12 @@ describe("PreviewHost — session-envelope cache (FR-021)", () => {
     );
 
     expect(await screen.findByTestId("core-array-viewer")).toBeInTheDocument();
+    let keys = cacheEnvelope.mock.calls.map(([key]) => String(key));
+    expect(keys).toHaveLength(1);
+    expect(keys[0]).toContain("previewer=core.array.basic");
+    expect(keys[0]).toContain("session=pv-1");
+    expect(keys[0]).toContain("version=v7");
+    expect(keys[0]).not.toBe(buildPreviewCacheKey({ ...TARGET, recorded_type: "Array" }, {}));
     cacheEnvelope.mockClear();
 
     fireEvent.change(screen.getByTestId("array-slice-slider-1"), { target: { value: "4" } });
@@ -565,7 +585,8 @@ describe("PreviewHost — session-envelope cache (FR-021)", () => {
     const [, patch] = patchPreviewSession.mock.calls[0];
     expect(patch).toMatchObject({ axis_indices: { "0": 1, "1": 4 } });
     await waitFor(() => expect(cacheEnvelope).toHaveBeenCalled());
-    const keys = cacheEnvelope.mock.calls.map(([key]) => String(key));
+    keys = cacheEnvelope.mock.calls.map(([key]) => String(key));
+    expect(keys).toHaveLength(1);
     expect(
       keys.some(
         (key) =>

--- a/frontend/src/components/DataPreview.parts/PreviewHost.tsx
+++ b/frontend/src/components/DataPreview.parts/PreviewHost.tsx
@@ -49,10 +49,9 @@ export interface PreviewHostProps {
   /** Optional initial query state (slice/page/sort). */
   initialQuery?: Record<string, unknown>;
   /**
-   * Optional session-keyed cache hooks (FR-021). When provided, the host reads
-   * a cached envelope before creating a session and writes the rendered
-   * envelope back. The cache key already encodes target + previewer + query +
-   * data version (see `previewSlice`); the host passes the rendered envelope.
+   * Optional session-keyed cache hooks (FR-021). The host writes rendered
+   * envelopes only after the backend has resolved preview identity, so cache
+   * keys include target + previewer + session + query + data version.
    */
   getCachedEnvelope?: (key: string) => PreviewEnvelope | undefined;
   cacheEnvelope?: (key: string, envelope: PreviewEnvelope) => void;
@@ -111,19 +110,14 @@ function cacheEnvelopeForQuery(
   target: PreviewTarget,
   query: Record<string, unknown>,
   envelope: PreviewEnvelope,
-  unresolvedKey?: string,
 ) {
   if (!cacheEnvelope || !buildCacheKey) return;
-  const keys = new Set<string>();
-  if (unresolvedKey) keys.add(unresolvedKey);
-  keys.add(buildCacheKey(target, query, cacheIdentityFromEnvelope(envelope)));
-  keys.forEach((key) => cacheEnvelope(key, envelope));
+  cacheEnvelope(buildCacheKey(target, query, cacheIdentityFromEnvelope(envelope)), envelope);
 }
 
 export function PreviewHost({
   target,
   initialQuery,
-  getCachedEnvelope,
   cacheEnvelope,
   buildCacheKey,
   importer,
@@ -151,14 +145,6 @@ export function PreviewHost({
     const query = { ...(initialQuery ?? {}) };
     queryRef.current = query;
 
-    const cacheKey = buildCacheKey?.(target, query);
-    const cached = cacheKey ? getCachedEnvelope?.(cacheKey) : undefined;
-    if (cached) {
-      setEnvelope(cached);
-      setStatus("ready");
-      return;
-    }
-
     setStatus("loading");
     setRequestError(null);
     api
@@ -167,7 +153,7 @@ export function PreviewHost({
         if (cancelled) return;
         setEnvelope(env);
         setStatus("ready");
-        cacheEnvelopeForQuery(cacheEnvelope, buildCacheKey, target, query, env, cacheKey);
+        cacheEnvelopeForQuery(cacheEnvelope, buildCacheKey, target, query, env);
       })
       .catch((err: unknown) => {
         if (cancelled) return;


### PR DESCRIPTION
## Summary

- Stops `PreviewHost` from reading an unresolved cache key before the backend resolves previewer/session/data-version identity.
- Stops writing the initial envelope under the unresolved alias; envelopes are cached only under resolved identity-aware keys.
- Updates the PreviewHost regression tests to prove stale unresolved cache aliases are ignored and resolved cache writes are singular.

## Tests

- `npm run test -- PreviewHost.test.tsx`
- `npm run typecheck`
- `python -m scistudio.qa.governance.gate_record check --record .workflow/records/1649-pr1577-resolved-cache-only.json --issue 1649 --base origin/track/adr-048-spec1-preview-system --head HEAD --mode local`

Closes #1649
