### PR TITLE
Fix PR1577 ADR-048 preview plot save flow

### DIFF
--- a/.workflow/records/1623-fix-pr1577-user-preview-plot-flow.json
+++ b/.workflow/records/1623-fix-pr1577-user-preview-plot-flow.json
@@ -1,0 +1,1724 @@
+{
+  "branch": "fix/pr1577-user-preview-plot-flow",
+  "check_events": [
+    {
+      "at": "2026-06-13T22:51:23.340115Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-13T22:51:34.868957Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-13T22:51:34.949158Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-13T22:52:59.750133Z",
+      "command": "pytest tests/architecture/ -v --no-cov",
+      "covered_surface": "architecture",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:c483ff07b8e1ff395053cae3f1cccf15b78996a5cb6fc3ada5f573eaa5f2fd65",
+      "name": "architecture_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/architecture_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-13T22:53:00.604667Z",
+      "command": "python scripts/deferral_scan.py --check docs/audit/baselines/deferral-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:c483ff07b8e1ff395053cae3f1cccf15b78996a5cb6fc3ada5f573eaa5f2fd65",
+      "name": "deferral_discipline",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/deferral_discipline.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-13T22:53:00.639899Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:c483ff07b8e1ff395053cae3f1cccf15b78996a5cb6fc3ada5f573eaa5f2fd65",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-13T22:53:04.417400Z",
+      "command": "(cd frontend && npm run lint)",
+      "covered_surface": "frontend",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:c483ff07b8e1ff395053cae3f1cccf15b78996a5cb6fc3ada5f573eaa5f2fd65",
+      "name": "frontend",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/frontend.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-13T22:53:13.321008Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:c483ff07b8e1ff395053cae3f1cccf15b78996a5cb6fc3ada5f573eaa5f2fd65",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-13T22:53:13.753890Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:c483ff07b8e1ff395053cae3f1cccf15b78996a5cb6fc3ada5f573eaa5f2fd65",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-13T22:53:13.792920Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:c483ff07b8e1ff395053cae3f1cccf15b78996a5cb6fc3ada5f573eaa5f2fd65",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-13T22:56:21.244772Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:c483ff07b8e1ff395053cae3f1cccf15b78996a5cb6fc3ada5f573eaa5f2fd65",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-13T22:57:17.206615Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:c483ff07b8e1ff395053cae3f1cccf15b78996a5cb6fc3ada5f573eaa5f2fd65",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-13T22:57:26.506491Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:c483ff07b8e1ff395053cae3f1cccf15b78996a5cb6fc3ada5f573eaa5f2fd65",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    },
+    {
+      "at": "2026-06-13T22:57:39.681105Z",
+      "command": "python -m build --wheel",
+      "covered_surface": "packaging",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:c483ff07b8e1ff395053cae3f1cccf15b78996a5cb6fc3ada5f573eaa5f2fd65",
+      "name": "wheel_release_smoke",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/wheel_release_smoke.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-13T23:03:36.970565Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:2b82465284f7993aa6cfc9d75b26361bb9be883d3a8c2fd6e50d37b446f169f8",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-13T23:03:39.788145Z",
+      "command": "(cd frontend && npm run lint)",
+      "covered_surface": "frontend",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:2b82465284f7993aa6cfc9d75b26361bb9be883d3a8c2fd6e50d37b446f169f8",
+      "name": "frontend",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/frontend.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-13T23:03:48.973734Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:2b82465284f7993aa6cfc9d75b26361bb9be883d3a8c2fd6e50d37b446f169f8",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-13T23:03:49.208615Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:2b82465284f7993aa6cfc9d75b26361bb9be883d3a8c2fd6e50d37b446f169f8",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-13T23:03:49.245988Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:2b82465284f7993aa6cfc9d75b26361bb9be883d3a8c2fd6e50d37b446f169f8",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-13T23:06:39.758656Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:2b82465284f7993aa6cfc9d75b26361bb9be883d3a8c2fd6e50d37b446f169f8",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-13T23:07:37.174059Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:2b82465284f7993aa6cfc9d75b26361bb9be883d3a8c2fd6e50d37b446f169f8",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-13T23:07:39.246043Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:2b82465284f7993aa6cfc9d75b26361bb9be883d3a8c2fd6e50d37b446f169f8",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    },
+    {
+      "at": "2026-06-13T23:08:44.408666Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:2b82465284f7993aa6cfc9d75b26361bb9be883d3a8c2fd6e50d37b446f169f8",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-13T23:08:47.285156Z",
+      "command": "(cd frontend && npm run lint)",
+      "covered_surface": "frontend",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:2b82465284f7993aa6cfc9d75b26361bb9be883d3a8c2fd6e50d37b446f169f8",
+      "name": "frontend",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/frontend.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-13T23:08:56.400107Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:2b82465284f7993aa6cfc9d75b26361bb9be883d3a8c2fd6e50d37b446f169f8",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-13T23:08:56.655883Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:2b82465284f7993aa6cfc9d75b26361bb9be883d3a8c2fd6e50d37b446f169f8",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-13T23:08:56.691450Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:2b82465284f7993aa6cfc9d75b26361bb9be883d3a8c2fd6e50d37b446f169f8",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-13T23:11:49.826532Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:2b82465284f7993aa6cfc9d75b26361bb9be883d3a8c2fd6e50d37b446f169f8",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-13T23:12:44.073597Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:2b82465284f7993aa6cfc9d75b26361bb9be883d3a8c2fd6e50d37b446f169f8",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-13T23:12:44.804496Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:2b82465284f7993aa6cfc9d75b26361bb9be883d3a8c2fd6e50d37b446f169f8",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    },
+    {
+      "at": "2026-06-13T23:14:34.189835Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:2b82465284f7993aa6cfc9d75b26361bb9be883d3a8c2fd6e50d37b446f169f8",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-13T23:14:36.996630Z",
+      "command": "(cd frontend && npm run lint)",
+      "covered_surface": "frontend",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:2b82465284f7993aa6cfc9d75b26361bb9be883d3a8c2fd6e50d37b446f169f8",
+      "name": "frontend",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/frontend.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-13T23:14:46.074473Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:2b82465284f7993aa6cfc9d75b26361bb9be883d3a8c2fd6e50d37b446f169f8",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-13T23:14:46.300274Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:2b82465284f7993aa6cfc9d75b26361bb9be883d3a8c2fd6e50d37b446f169f8",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-13T23:14:46.337698Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:2b82465284f7993aa6cfc9d75b26361bb9be883d3a8c2fd6e50d37b446f169f8",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-13T23:17:46.081231Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:2b82465284f7993aa6cfc9d75b26361bb9be883d3a8c2fd6e50d37b446f169f8",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-13T23:18:41.269350Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:2b82465284f7993aa6cfc9d75b26361bb9be883d3a8c2fd6e50d37b446f169f8",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-13T23:18:41.979496Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:2b82465284f7993aa6cfc9d75b26361bb9be883d3a8c2fd6e50d37b446f169f8",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    },
+    {
+      "at": "2026-06-13T23:19:19.295274Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:2b82465284f7993aa6cfc9d75b26361bb9be883d3a8c2fd6e50d37b446f169f8",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-13T23:19:22.117355Z",
+      "command": "(cd frontend && npm run lint)",
+      "covered_surface": "frontend",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:2b82465284f7993aa6cfc9d75b26361bb9be883d3a8c2fd6e50d37b446f169f8",
+      "name": "frontend",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/frontend.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-13T23:19:31.761451Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:2b82465284f7993aa6cfc9d75b26361bb9be883d3a8c2fd6e50d37b446f169f8",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-13T23:19:31.980936Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:2b82465284f7993aa6cfc9d75b26361bb9be883d3a8c2fd6e50d37b446f169f8",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-13T23:19:32.016589Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:2b82465284f7993aa6cfc9d75b26361bb9be883d3a8c2fd6e50d37b446f169f8",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-13T23:22:27.359291Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:2b82465284f7993aa6cfc9d75b26361bb9be883d3a8c2fd6e50d37b446f169f8",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-13T23:23:21.981456Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:2b82465284f7993aa6cfc9d75b26361bb9be883d3a8c2fd6e50d37b446f169f8",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-13T23:23:22.665749Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:2b82465284f7993aa6cfc9d75b26361bb9be883d3a8c2fd6e50d37b446f169f8",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    }
+  ],
+  "check_na": [],
+  "commit": {
+    "sha": "HEAD",
+    "shas": [
+      "HEAD"
+    ],
+    "trailers": []
+  },
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "src/scistudio/api/**",
+      "src/scistudio/ai/agent/mcp/tools_plot/**",
+      "frontend/src/components/DataPreview*",
+      "frontend/src/components/DataPreview.parts/**",
+      "frontend/src/lib/api/**",
+      "frontend/src/types/**",
+      "tests/**",
+      "frontend/src/**/*.test.tsx",
+      "frontend/src/**/*.test.ts"
+    ]
+  },
+  "directive_events": [],
+  "docs_events": [
+    {
+      "at": "2026-06-13T22:50:25.859911Z",
+      "class": "implementation-docs",
+      "kind": "na",
+      "path": null,
+      "rationale": "ADR-048/spec/issues already define the intended preview, plot, and save/export behavior; this bugfix wires implementation and tests without changing the documented contract.",
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": false,
+  "guard_events": [
+    {
+      "at": "2026-06-13T22:51:35.068829Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T22:51:35.128465Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T22:51:35.183364Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T22:51:35.239450Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T22:51:35.294805Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T22:51:35.348020Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T22:51:35.403987Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T22:51:35.462905Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T22:51:35.518659Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T22:51:35.571706Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T22:57:39.797354Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T22:57:39.848993Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T22:57:39.901253Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T22:57:39.955540Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T22:57:40.008997Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "docs/ai-developer/e2e/2026-06-13-adr048-pr1577-viewers.md",
+          "finding_class": "governance",
+          "git_evidence": null,
+          "id": "governance.mod_guard.unauthorized-change",
+          "line": null,
+          "message": "governance-critical file changed without authorization; declare governance_touch in the ledger and obtain owner review",
+          "path": "docs/ai-developer/e2e/2026-06-13-adr048-pr1577-viewers.md",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "governance.mod_guard.unauthorized-change",
+          "severity": "error",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "docs/ai-developer/gate-cli-command-set.md",
+          "finding_class": "governance",
+          "git_evidence": null,
+          "id": "governance.mod_guard.unauthorized-change",
+          "line": null,
+          "message": "governance-critical file changed without authorization; declare governance_touch in the ledger and obtain owner review",
+          "path": "docs/ai-developer/gate-cli-command-set.md",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "governance.mod_guard.unauthorized-change",
+          "severity": "error",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "pyproject.toml",
+          "finding_class": "governance",
+          "git_evidence": null,
+          "id": "governance.mod_guard.unauthorized-change",
+          "line": null,
+          "message": "governance-critical file changed without authorization; declare governance_touch in the ledger and obtain owner review",
+          "path": "pyproject.toml",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "governance.mod_guard.unauthorized-change",
+          "severity": "error",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/qa/governance/gate_record/io.py",
+          "finding_class": "governance",
+          "git_evidence": null,
+          "id": "governance.mod_guard.unauthorized-change",
+          "line": null,
+          "message": "governance-critical file changed without authorization; declare governance_touch in the ledger and obtain owner review",
+          "path": "src/scistudio/qa/governance/gate_record/io.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "governance.mod_guard.unauthorized-change",
+          "severity": "error",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "mod_guard",
+      "status": "fail"
+    },
+    {
+      "at": "2026-06-13T22:57:40.064314Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T22:57:40.116895Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T22:57:40.169120Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T22:57:40.225854Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T22:57:40.279645Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T23:07:39.360433Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T23:07:39.413139Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T23:07:39.470309Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T23:07:39.528819Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T23:07:39.584349Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T23:07:39.641373Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T23:07:39.693543Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T23:07:39.744697Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T23:07:39.803326Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T23:07:39.868494Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T23:08:27.470302Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T23:08:27.521953Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T23:08:27.573375Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T23:08:27.624917Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T23:08:27.677098Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T23:08:27.735042Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T23:08:27.787761Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T23:08:27.845729Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T23:08:27.897313Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T23:08:27.954175Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T23:12:44.926019Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T23:12:44.977709Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T23:12:45.028169Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T23:12:45.079067Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T23:12:45.132413Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T23:12:45.184402Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T23:12:45.238883Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T23:12:45.294613Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T23:12:45.347845Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T23:12:45.406225Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T23:18:42.122436Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T23:18:42.181679Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T23:18:42.236538Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T23:18:42.293050Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T23:18:42.347734Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T23:18:42.409546Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T23:18:42.463302Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T23:18:42.520245Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T23:18:42.573728Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T23:18:42.642148Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T23:23:22.791802Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T23:23:22.848648Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T23:23:22.904521Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T23:23:22.961246Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T23:23:23.016464Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T23:23:23.073228Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T23:23:23.132036Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T23:23:23.195898Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T23:23:23.252674Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T23:23:23.318323Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T23:23:45.496408Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T23:23:45.559428Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T23:23:45.610489Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T23:23:45.662087Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T23:23:45.719267Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T23:23:45.775021Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T23:23:45.831994Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T23:23:45.883820Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T23:23:45.935222Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-13T23:23:45.991730Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1623,
+      "url": null
+    },
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1626,
+      "url": null
+    },
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1649,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": {
+    "base": "origin/track/adr-048-spec1-preview-system",
+    "base_sha": "f36e3290",
+    "changed_files": [
+      ".workflow/records/1623-fix-pr1577-user-preview-plot-flow.json",
+      "frontend/src/components/DataPreview.parts/PreviewHost.test.tsx",
+      "frontend/src/components/DataPreview.parts/PreviewHost.tsx",
+      "frontend/src/components/DataPreview.parts/refEntries.test.ts",
+      "frontend/src/components/DataPreview.parts/refEntries.ts",
+      "frontend/src/components/DataPreview.test.tsx",
+      "frontend/src/components/DataPreview.tsx",
+      "frontend/src/lib/api/__tests__/plotPreview.test.ts",
+      "frontend/src/lib/api/data.ts",
+      "frontend/src/types/api.ts",
+      "src/scistudio/api/routes/data.py",
+      "src/scistudio/api/routes/plots.py",
+      "src/scistudio/api/routes/runs.py",
+      "src/scistudio/api/schemas.py",
+      "src/scistudio/api/spa.py",
+      "src/scistudio/previewers/session.py",
+      "tests/api/test_plot_preview_wiring.py",
+      "tests/api/test_spa_fallback.py"
+    ],
+    "diff_fingerprint": "sha256:5699298d9a11ae6696c24d50e70685135a97b3b3af17a45e6a2dc5f6a7b02ed3",
+    "head": "HEAD",
+    "head_sha": "2fa7fe75",
+    "surfaces": {
+      "docs": 0,
+      "frontend": 9,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 15,
+      "packaging": 0,
+      "protected_core": 0,
+      "sentrux": 17,
+      "test": 6,
+      "workflow_ci": 0
+    }
+  },
+  "owner_directive": "Fix PR1577 user-facing ADR-048 blockers: legacy API SPA fallback must not return 200 HTML; block output collections preview collection-first; block-bound plot GUI run entry in the right preview pane; save/export uses system file dialog to save to a user-selected path.",
+  "persona": "implementer",
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [
+      1623,
+      1626,
+      1649
+    ],
+    "number": 1653,
+    "url": null
+  },
+  "reconcile_events": [
+    {
+      "at": "2026-06-13T22:51:35.571760Z",
+      "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "mode": "local",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-13T22:57:40.279704Z",
+      "diff_fingerprint": "sha256:d178cc43b12cf38cd9965c9f1a29566ee98d7be1a4835873a92360c3c090224b",
+      "mode": "local",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.python_tests",
+        "checks.type_check",
+        "guard.mod_guard",
+        "scope.out-of-scope"
+      ]
+    },
+    {
+      "at": "2026-06-13T23:07:39.868536Z",
+      "diff_fingerprint": "sha256:b0a7466e0f41ef9e214226e3c7bac695bd26e52a20ce955b61087036cc0d98f6",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-13T23:08:27.954217Z",
+      "diff_fingerprint": "sha256:ca768fbc6dd9fdd0cb096d0ecd0473aa19358b6d11f5c79bc0e2d20b84c88827",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-13T23:12:45.406270Z",
+      "diff_fingerprint": "sha256:ca768fbc6dd9fdd0cb096d0ecd0473aa19358b6d11f5c79bc0e2d20b84c88827",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-13T23:18:42.642183Z",
+      "diff_fingerprint": "sha256:5699298d9a11ae6696c24d50e70685135a97b3b3af17a45e6a2dc5f6a7b02ed3",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.python_tests"
+      ]
+    },
+    {
+      "at": "2026-06-13T23:23:23.318373Z",
+      "diff_fingerprint": "sha256:5699298d9a11ae6696c24d50e70685135a97b3b3af17a45e6a2dc5f6a7b02ed3",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-13T23:23:45.991771Z",
+      "diff_fingerprint": "sha256:5699298d9a11ae6696c24d50e70685135a97b3b3af17a45e6a2dc5f6a7b02ed3",
+      "mode": "ci",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    }
+  ],
+  "record_id": "1623-fix-pr1577-user-preview-plot-flow",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [],
+    "docs": [
+      "docs_required_or_na"
+    ],
+    "guards": [
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": [
+      "changed_test_required"
+    ]
+  },
+  "runtime": "codex",
+  "schema_version": 2,
+  "scope_events": [
+    {
+      "action": "add-include",
+      "at": "2026-06-13T23:01:38.389100Z",
+      "pattern": "src/scistudio/previewers/**",
+      "reason": "Preview resource save requires session-manager support to reuse bounded resource reads and sanitized plot export payloads."
+    }
+  ],
+  "session_id": "0e2a668b-3e8f-4657-aeea-3303d7987b45",
+  "strictness_tier": 2,
+  "task_kind": "bugfix",
+  "test_events": [
+    {
+      "at": "2026-06-13T22:50:25.859935Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/api/test_spa_fallback.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-13T22:50:25.859941Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/api/test_plot_preview_wiring.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-13T22:50:25.859943Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/components/DataPreview.test.tsx",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-13T22:50:25.859945Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/components/DataPreview.parts/refEntries.test.ts",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-13T22:50:25.859947Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/components/DataPreview.parts/PreviewHost.test.tsx",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-13T22:50:25.859948Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/lib/api/__tests__/plotPreview.test.ts",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-13T22:59:52.288830Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/api/test_runs_routes.py",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/frontend/src/components/DataPreview.parts/PreviewHost.test.tsx
+++ b/frontend/src/components/DataPreview.parts/PreviewHost.test.tsx
@@ -22,6 +22,8 @@ const createPreviewSession = vi.fn();
 const patchPreviewSession = vi.fn();
 const getPreviewResource = vi.fn();
 const getPreviewSession = vi.fn();
+const openNativeSaveDialog = vi.fn();
+const savePreviewResource = vi.fn();
 const fetchMock = vi.fn();
 let anchorClickSpy: ReturnType<typeof vi.spyOn> | null = null;
 
@@ -31,12 +33,15 @@ vi.mock("../../lib/api", () => ({
     patchPreviewSession: (...a: unknown[]) => patchPreviewSession(...a),
     getPreviewResource: (...a: unknown[]) => getPreviewResource(...a),
     getPreviewSession: (...a: unknown[]) => getPreviewSession(...a),
+    openNativeSaveDialog: (...a: unknown[]) => openNativeSaveDialog(...a),
+    savePreviewResource: (...a: unknown[]) => savePreviewResource(...a),
   },
 }));
 
 import { PreviewHost } from "./PreviewHost";
 import { buildPreviewCacheKey } from "../../store/previewSlice";
 import { isSameOriginModuleUrl } from "./dynamicPreviewer";
+import type { PreviewHostApi } from "./previewerHostApi";
 
 function envelope(partial: Partial<PreviewEnvelope>): PreviewEnvelope {
   return {
@@ -75,6 +80,15 @@ beforeEach(() => {
   patchPreviewSession.mockReset();
   getPreviewResource.mockReset();
   getPreviewSession.mockReset();
+  openNativeSaveDialog.mockReset();
+  openNativeSaveDialog.mockResolvedValue({ paths: ["C:/Users/test/plot.svg"] });
+  savePreviewResource.mockReset();
+  savePreviewResource.mockResolvedValue({
+    path: "C:/Users/test/plot.svg",
+    filename: "plot.svg",
+    size_bytes: 7,
+    mime_type: "image/svg+xml",
+  });
   fetchMock.mockReset();
   vi.stubGlobal("fetch", fetchMock);
   anchorClickSpy = vi
@@ -265,6 +279,46 @@ describe("PreviewHost — dynamic manifest fallback (US2.3 / FR-022 / FR-029)", 
       "MOUNTED FIRST-CLASS VIEWER",
     );
   });
+
+  it("exposes saveArtifact through the native save dialog and session save endpoint", async () => {
+    createPreviewSession.mockResolvedValue(
+      envelope({
+        previewer_id: "imaging.image.viewer",
+        kind: "array",
+        payload: { shape: [4, 4], dtype: "uint8", ndim: 2, src: "" },
+        resources: [{ resource_id: "export", kind: "asset", params: { format: "svg" } }],
+        metadata: { complete: true },
+        frontend_manifest: {
+          previewer_id: "imaging.image.viewer",
+          module_url: "/api/previews/assets/imaging.image.viewer/viewer.js",
+          export_name: "ImageViewer",
+          api_version: "1",
+        },
+      }),
+    );
+
+    const capturedHost: { current: PreviewHostApi | null } = { current: null };
+    const mount = vi.fn((_container: HTMLElement, host: PreviewHostApi) => {
+      capturedHost.current = host;
+      return { unmount: vi.fn() };
+    });
+    const fakeImporter = vi.fn(async () => ({ ImageViewer: { apiVersion: "1", mount } }));
+
+    render(<PreviewHost target={{ ...TARGET, recorded_type: "Image" }} importer={fakeImporter} />);
+
+    await waitFor(() => expect(mount).toHaveBeenCalled());
+    if (!capturedHost.current) throw new Error("host API was not captured");
+    await capturedHost.current.saveArtifact({ resourceId: "export", filename: "figure.svg" });
+
+    expect(openNativeSaveDialog).toHaveBeenCalledWith({
+      defaultFilename: "figure.svg",
+      fileFilter: "SVG (*.svg)|*.svg|All files (*.*)|*.*",
+    });
+    expect(savePreviewResource).toHaveBeenCalledWith("pv-1", "export", {
+      destination_path: "C:/Users/test/plot.svg",
+      params: { format: "svg" },
+    });
+  });
 });
 
 describe("PreviewHost — collection + child routing (US4)", () => {
@@ -350,22 +404,16 @@ describe("PreviewHost — plot viewer (FR-018 / FR-019)", () => {
     expect(screen.getByTestId("plot-export-button")).toBeEnabled();
     expect(screen.getByTestId("preview-diagnostics")).toHaveTextContent(/sanitized SVG/);
 
-    fetchMock.mockResolvedValue(
-      okJson({
-        resource_id: "export",
-        data: {
-          format: "svg",
-          mime_type: "image/svg+xml",
-          filename: "plot.svg",
-          data_uri: "data:image/svg+xml;base64,PHN2Zy8+",
-        },
-      }),
-    );
     fireEvent.click(screen.getByTestId("plot-export-button"));
-    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
-    const url = new URL(String(fetchMock.mock.calls[0][0]), "http://localhost");
-    expect(url.pathname).toBe("/api/previews/sessions/pv-1/resources/export");
-    expect(JSON.parse(url.searchParams.get("params") ?? "{}")).toEqual({ format: "svg" });
+    await waitFor(() => expect(openNativeSaveDialog).toHaveBeenCalledTimes(1));
+    expect(openNativeSaveDialog).toHaveBeenCalledWith({
+      defaultFilename: "core.plot.basic.svg",
+      fileFilter: "SVG (*.svg)|*.svg|All files (*.*)|*.*",
+    });
+    expect(savePreviewResource).toHaveBeenCalledWith("pv-1", "export", {
+      destination_path: "C:/Users/test/plot.svg",
+      params: { format: "svg" },
+    });
   });
 
   it("renders a PDF artifact in a frame with an export control", async () => {

--- a/frontend/src/components/DataPreview.parts/PreviewHost.tsx
+++ b/frontend/src/components/DataPreview.parts/PreviewHost.tsx
@@ -131,6 +131,7 @@ export function PreviewHost({
   const [childStack, setChildStack] = useState<PreviewEnvelope[]>([]);
 
   const queryRef = useRef<Record<string, unknown>>(initialQuery ?? {});
+  const initialQueryKey = useMemo(() => JSON.stringify(initialQuery ?? {}), [initialQuery]);
 
   // -- session creation ----------------------------------------------------
   useEffect(() => {
@@ -166,7 +167,7 @@ export function PreviewHost({
     // initialQuery is captured intentionally on target change only; later
     // query updates go through patchQuery below.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [target?.ref, target?.kind]);
+  }, [target?.ref, target?.kind, initialQueryKey]);
 
   // -- patch query (slice/page/sort/slot) ----------------------------------
   const patchQuery = useCallback(
@@ -214,36 +215,50 @@ export function PreviewHost({
   const popChild = useCallback(() => setChildStack((stack) => stack.slice(0, -1)), []);
 
   // -- export / save -------------------------------------------------------
+  const saveEnvelopeResource = useCallback(
+    async (
+      active: PreviewEnvelope,
+      resourceId: string,
+      params?: Record<string, unknown>,
+      filename?: string,
+    ) => {
+      if (!active.session_id) {
+        throw new Error("no preview session");
+      }
+      const defaultFilename = filename ?? defaultResourceFilename(active, params);
+      const dialog = await api.openNativeSaveDialog({
+        defaultFilename,
+        fileFilter: fileFilterForFilename(defaultFilename),
+      });
+      const destinationPath = dialog.paths[0];
+      if (!destinationPath) return;
+      await api.savePreviewResource(active.session_id, resourceId, {
+        destination_path: destinationPath,
+        params: params ?? {},
+      });
+    },
+    [],
+  );
+
   const exportResource = useCallback(
     async (resource: PreviewResource) => {
       const active = childStack[childStack.length - 1] ?? envelope;
       if (!active) return;
-      // Plot export: a same-origin asset download for the displayed artifact.
-      const src = active.payload?.src;
-      if (typeof src === "string" && src.startsWith("data:")) {
-        triggerDownload(src, `${active.previewer_id}.${resource.params?.format ?? "bin"}`);
-        return;
-      }
-      if (active.session_id) {
-        try {
-          const result = await fetchPreviewResource(
-            active.session_id,
-            resource.resource_id,
-            resource.params,
-          );
-          triggerResourceDownload(
-            result.data,
-            `${active.previewer_id}.${resource.params?.format ?? "bin"}`,
-          );
-        } catch (err) {
-          setHostDiagnostics((d) => [
-            ...d,
-            `export failed: ${err instanceof Error ? err.message : String(err)}`,
-          ]);
-        }
+      try {
+        await saveEnvelopeResource(
+          active,
+          resource.resource_id,
+          resource.params,
+          defaultResourceFilename(active, resource.params),
+        );
+      } catch (err) {
+        setHostDiagnostics((d) => [
+          ...d,
+          `export failed: ${err instanceof Error ? err.message : String(err)}`,
+        ]);
       }
     },
-    [childStack, envelope],
+    [childStack, envelope, saveEnvelopeResource],
   );
 
   // The envelope currently in focus (top of the drill-down stack, else root).
@@ -292,38 +307,38 @@ export function PreviewHost({
       assetUrl: (assetPath: string) =>
         `/api/previews/assets/${encodeURIComponent(activeEnvelope.previewer_id)}/${assetPath.replace(/^\/+/, "")}`,
       exportArtifact: async (request) => {
-        const src = activeEnvelope.payload?.src;
-        if (typeof src === "string" && src.startsWith("data:")) {
-          triggerDownload(src, request?.filename ?? `${activeEnvelope.previewer_id}.bin`);
-          return;
-        }
-        if (!activeEnvelope.session_id) return;
         const resourceId = request?.resourceId ?? "export";
         const resource = activeEnvelope.resources.find((r) => r.resource_id === resourceId);
         const params = mergeResourceParams(resource, {
           ...(request?.params ?? {}),
           ...(request?.format ? { format: request.format } : {}),
         });
-        const result = await fetchPreviewResource(activeEnvelope.session_id, resourceId, params);
-        triggerResourceDownload(
-          result.data,
-          request?.filename ?? `${activeEnvelope.previewer_id}.${request?.format ?? "bin"}`,
+        await saveEnvelopeResource(
+          activeEnvelope,
+          resourceId,
+          params,
+          request?.filename ?? defaultResourceFilename(activeEnvelope, params),
         );
       },
-      saveArtifact: async () => {
-        // No host-mediated save target wired yet; modules must tolerate a
-        // rejection. The plot-job run + routed preview path is wired (#1606,
-        // api.runPlotJob -> plotTargetFromRunResponse -> PreviewHost); the
-        // explicit save-to-project flow is a separate destination contract.
-        // TODO(#1626): wire saveArtifact to the backend plot-artifact save flow.
-        //   Out of scope per #1606 (preview wiring only); follow-up: issue #1626.
-        return Promise.reject(new Error("save not available"));
+      saveArtifact: async (request) => {
+        const resourceId = request?.resourceId ?? "export";
+        const resource = activeEnvelope.resources.find((r) => r.resource_id === resourceId);
+        const params = mergeResourceParams(resource, {
+          ...(request?.params ?? {}),
+          ...(request?.format ? { format: request.format } : {}),
+        });
+        await saveEnvelopeResource(
+          activeEnvelope,
+          resourceId,
+          params,
+          request?.filename ?? defaultResourceFilename(activeEnvelope, params),
+        );
       },
       reportError: (message: string) => {
         setHostDiagnostics((d) => [...d, message]);
       },
     };
-  }, [activeEnvelope, envelope?.session_id, manifest, patchQuery]);
+  }, [activeEnvelope, envelope?.session_id, manifest, patchQuery, saveEnvelopeResource]);
 
   useEffect(() => {
     // Tear down any prior instance whenever the focus changes.
@@ -441,15 +456,6 @@ export function PreviewHost({
   );
 }
 
-function triggerDownload(href: string, filename: string): void {
-  const link = document.createElement("a");
-  link.href = href;
-  link.download = filename;
-  document.body.appendChild(link);
-  link.click();
-  document.body.removeChild(link);
-}
-
 async function fetchPreviewResource(
   sessionId: string,
   resourceId: string,
@@ -497,13 +503,24 @@ function mergeResourceParams(
   return Object.keys(merged).length > 0 ? merged : undefined;
 }
 
-function triggerResourceDownload(data: Record<string, unknown>, fallbackFilename: string): void {
-  const href =
-    typeof data.data_uri === "string"
-      ? data.data_uri
-      : typeof data.src === "string" && data.src.startsWith("data:")
-        ? data.src
-        : null;
-  if (!href) return;
-  triggerDownload(href, typeof data.filename === "string" ? data.filename : fallbackFilename);
+function defaultResourceFilename(
+  envelope: PreviewEnvelope,
+  params?: Record<string, unknown>,
+): string {
+  const payloadPath = envelope.payload?.path;
+  if (typeof payloadPath === "string" && payloadPath) {
+    const normalized = payloadPath.replace(/[\\/]+$/, "");
+    const parts = normalized.split(/[\\/]/);
+    const name = parts[parts.length - 1];
+    if (name) return name;
+  }
+  const format = typeof params?.format === "string" && params.format ? params.format : "bin";
+  return `${envelope.previewer_id}.${format}`;
+}
+
+function fileFilterForFilename(filename: string): string {
+  const match = /\.([A-Za-z0-9]+)$/.exec(filename);
+  if (!match) return "All files (*.*)|*.*";
+  const extension = match[1].toLowerCase();
+  return `${extension.toUpperCase()} (*.${extension})|*.${extension}|All files (*.*)|*.*`;
 }

--- a/frontend/src/components/DataPreview.parts/refEntries.test.ts
+++ b/frontend/src/components/DataPreview.parts/refEntries.test.ts
@@ -11,13 +11,19 @@ describe("extractRefEntries", () => {
 
   it("extracts a single entry from a top-level data_ref", () => {
     expect(extractRefEntries({ data_ref: "data-abc" })).toEqual([
-      { ref: "data-abc", displayName: "data-abc" },
+      {
+        id: "data-abc",
+        ref: "data-abc",
+        displayName: "data-abc",
+        outputPort: undefined,
+        target: { kind: "data_ref", ref: "data-abc" },
+      },
     ]);
   });
 
   it("falls back to truncated ref when no metadata source available", () => {
     expect(extractRefEntries({ data_ref: "data-abcdefghij-tail" })).toEqual([
-      { ref: "data-abcdefghij-tail", displayName: "data-abcde" },
+      expect.objectContaining({ ref: "data-abcdefghij-tail", displayName: "data-abcde" }),
     ]);
   });
 
@@ -26,7 +32,9 @@ describe("extractRefEntries", () => {
       data_ref: "data-xyz",
       metadata: { framework: { source: "/tmp/beads.tif" } },
     });
-    expect(result).toEqual([{ ref: "data-xyz", displayName: "beads.tif" }]);
+    expect(result).toEqual([
+      expect.objectContaining({ ref: "data-xyz", displayName: "beads.tif" }),
+    ]);
   });
 
   it("falls back to metadata.meta.source_file when framework absent", () => {
@@ -34,7 +42,9 @@ describe("extractRefEntries", () => {
       data_ref: "data-xyz",
       metadata: { meta: { source_file: "/data/input.csv" } },
     });
-    expect(result).toEqual([{ ref: "data-xyz", displayName: "input.csv" }]);
+    expect(result).toEqual([
+      expect.objectContaining({ ref: "data-xyz", displayName: "input.csv" }),
+    ]);
   });
 
   it("falls back to metadata.meta.file_path when source_file absent", () => {
@@ -42,17 +52,40 @@ describe("extractRefEntries", () => {
       data_ref: "data-xyz",
       metadata: { meta: { file_path: "C:\\data\\sample.tif" } },
     });
-    expect(result).toEqual([{ ref: "data-xyz", displayName: "sample.tif" }]);
+    expect(result).toEqual([
+      expect.objectContaining({ ref: "data-xyz", displayName: "sample.tif" }),
+    ]);
   });
 
-  it("handles collection kind by flattening its items", () => {
+  it("handles collection kind as one collection-first preview entry", () => {
     const result = extractRefEntries({
-      kind: "collection",
-      items: [{ data_ref: "data-1" }, { data_ref: "data-2" }],
+      images: {
+        kind: "collection",
+        item_type: "DataFrame",
+        items: [{ data_ref: "data-1", type_name: "DataFrame" }, { data_ref: "data-2" }],
+      },
     });
     expect(result).toEqual([
-      { ref: "data-1", displayName: "data-1" },
-      { ref: "data-2", displayName: "data-2" },
+      expect.objectContaining({
+        id: "collection:images",
+        ref: "collection:images",
+        displayName: "images (2)",
+        outputPort: "images",
+        target: expect.objectContaining({
+          kind: "collection_ref",
+          ref: "collection:images",
+          recorded_type: "DataFrame",
+          collection_item_type: "DataFrame",
+        }),
+        initialQuery: expect.objectContaining({
+          _collection_count: 2,
+          _collection_item_type: "DataFrame",
+          _collection_items: [
+            { data_ref: "data-1", type_name: "DataFrame" },
+            { data_ref: "data-2" },
+          ],
+        }),
+      }),
     ]);
   });
 

--- a/frontend/src/components/DataPreview.parts/refEntries.ts
+++ b/frontend/src/components/DataPreview.parts/refEntries.ts
@@ -10,9 +10,15 @@
  * Mirror of `LossySaveWarning.extractRefEntries` shape — keep in sync.
  */
 
+import type { PreviewTarget } from "../../types/api";
+
 export interface RefEntry {
+  id: string;
   ref: string;
   displayName: string;
+  outputPort?: string;
+  target: PreviewTarget;
+  initialQuery?: Record<string, unknown>;
 }
 
 function basename(p: string): string {
@@ -45,16 +51,87 @@ function deriveDisplayName(ref: string, dataItem: Record<string, unknown>): stri
   return ref.slice(0, 10);
 }
 
-export function extractRefEntries(payload: unknown): RefEntry[] {
+function collectionItemType(
+  record: Record<string, unknown>,
+  items: Record<string, unknown>[],
+): string {
+  const explicit =
+    record.item_type ?? record.item_type_name ?? record.collection_item_type ?? record.type_name;
+  if (typeof explicit === "string" && explicit) return explicit;
+  const firstType = items.find((item) => typeof item.type_name === "string")?.type_name;
+  return typeof firstType === "string" && firstType ? firstType : "DataObject";
+}
+
+function normalizeCollectionItem(item: unknown): Record<string, unknown> | null {
+  if (!item || typeof item !== "object") return null;
+  const record = item as Record<string, unknown>;
+  const ref = record.data_ref ?? record.ref;
+  if (typeof ref !== "string" || !ref) return null;
+  const out: Record<string, unknown> = { data_ref: ref };
+  if (typeof record.type_name === "string") out.type_name = record.type_name;
+  if (record.metadata && typeof record.metadata === "object") out.metadata = record.metadata;
+  return out;
+}
+
+function typeChainFor(typeName: string): string[] {
+  if (!typeName || typeName === "DataObject") return ["DataObject"];
+  return ["DataObject", typeName];
+}
+
+function displayNameForPath(path: string[], fallback: string): string {
+  return path[path.length - 1] || fallback;
+}
+
+function visit(payload: unknown, path: string[]): RefEntry[] {
   if (!payload || typeof payload !== "object") {
     return [];
   }
   const record = payload as Record<string, unknown>;
   if (typeof record.data_ref === "string") {
-    return [{ ref: record.data_ref, displayName: deriveDisplayName(record.data_ref, record) }];
+    return [
+      {
+        id: record.data_ref,
+        ref: record.data_ref,
+        displayName: deriveDisplayName(record.data_ref, record),
+        outputPort: path[0],
+        target: { kind: "data_ref", ref: record.data_ref },
+      },
+    ];
   }
   if (record.kind === "collection" && Array.isArray(record.items)) {
-    return record.items.flatMap((item) => extractRefEntries(item));
+    const items = record.items
+      .map((item) => normalizeCollectionItem(item))
+      .filter((item): item is Record<string, unknown> => item !== null);
+    const itemType = collectionItemType(record, items);
+    const ref =
+      typeof record.collection_ref === "string" && record.collection_ref
+        ? record.collection_ref
+        : `collection:${path.join(".") || "root"}`;
+    const displayName = displayNameForPath(path, "Collection");
+    return [
+      {
+        id: ref,
+        ref,
+        displayName: `${displayName} (${record.count ?? items.length})`,
+        outputPort: path[0],
+        target: {
+          kind: "collection_ref",
+          ref,
+          recorded_type: itemType,
+          type_chain: typeChainFor(itemType),
+          collection_item_type: itemType,
+        },
+        initialQuery: {
+          _collection_items: items,
+          _collection_count: typeof record.count === "number" ? record.count : items.length,
+          _collection_item_type: itemType,
+        },
+      },
+    ];
   }
-  return Object.values(record).flatMap((value) => extractRefEntries(value));
+  return Object.entries(record).flatMap(([key, value]) => visit(value, [...path, key]));
+}
+
+export function extractRefEntries(payload: unknown): RefEntry[] {
+  return visit(payload, []);
 }

--- a/frontend/src/components/DataPreview.test.tsx
+++ b/frontend/src/components/DataPreview.test.tsx
@@ -9,6 +9,7 @@ const createPreviewSession = vi.fn();
 const patchPreviewSession = vi.fn();
 const getPreviewSession = vi.fn();
 const runPlotJob = vi.fn();
+const listPlots = vi.fn();
 vi.mock("../lib/api", async (importOriginal) => {
   const actual = await importOriginal<Record<string, unknown>>();
   const actualApi = (actual.api ?? {}) as Record<string, unknown>;
@@ -20,6 +21,7 @@ vi.mock("../lib/api", async (importOriginal) => {
       patchPreviewSession: (...a: unknown[]) => patchPreviewSession(...a),
       getPreviewSession: (...a: unknown[]) => getPreviewSession(...a),
       runPlotJob: (...a: unknown[]) => runPlotJob(...a),
+      listPlots: (...a: unknown[]) => listPlots(...a),
     },
   };
 });
@@ -63,6 +65,8 @@ beforeEach(() => {
     textEnvelope(target.ref, `preview of ${target.ref}`),
   );
   runPlotJob.mockReset();
+  listPlots.mockReset();
+  listPlots.mockResolvedValue({ plots: [], count: 0, warnings: [] });
   // Each test owns a clean envelope cache (the store is a global singleton).
   useAppStore.getState().clearPreviewEnvelopeCache();
 });
@@ -115,10 +119,8 @@ describe("DataPreview", () => {
       <DataPreview
         blockOutputs={{
           "load-1": {
-            images: {
-              kind: "collection",
-              items: [{ data_ref: "data-a" }, { data_ref: "data-b" }],
-            },
+            output_a: { data_ref: "data-a" },
+            output_b: { data_ref: "data-b" },
           },
         }}
         selectedNodeId="load-1"
@@ -143,7 +145,64 @@ describe("DataPreview", () => {
     });
   });
 
+  it("opens collection outputs as collection-level sessions", async () => {
+    render(
+      <DataPreview
+        blockOutputs={{
+          "load-1": {
+            images: {
+              kind: "collection",
+              item_type: "DataFrame",
+              items: [{ data_ref: "data-a", type_name: "DataFrame" }, { data_ref: "data-b" }],
+            },
+          },
+        }}
+        selectedNodeId="load-1"
+        selectedNodeLabel="Load Table"
+      />,
+    );
+
+    expect(await screen.findByRole("button", { name: "images (2)" })).toBeInTheDocument();
+    await waitFor(() => {
+      expect(createPreviewSession).toHaveBeenCalledWith(
+        expect.objectContaining({
+          kind: "collection_ref",
+          ref: "collection:images",
+          recorded_type: "DataFrame",
+          collection_item_type: "DataFrame",
+          source: expect.objectContaining({ node_id: "load-1", output_port: "images" }),
+        }),
+        expect.objectContaining({
+          _collection_count: 2,
+          _collection_item_type: "DataFrame",
+          _collection_items: [
+            { data_ref: "data-a", type_name: "DataFrame" },
+            { data_ref: "data-b" },
+          ],
+        }),
+      );
+    });
+  });
+
   it("runs a plot job and mounts PreviewHost for the returned plot artifact (#1623)", async () => {
+    listPlots.mockResolvedValue({
+      plots: [
+        {
+          plot_id: "p1",
+          title: "P1",
+          workflow_id: "main",
+          node_id: "node-1",
+          output_port: "output",
+          display_label: "Process Block / output",
+          language: "python",
+          preferred_format: "svg",
+          manifest_path: "plots/p1/plot.yaml",
+          script_path: "plots/p1/render.py",
+        },
+      ],
+      count: 1,
+      warnings: [],
+    });
     runPlotJob.mockResolvedValue(plotRunResponse());
 
     render(
@@ -161,8 +220,7 @@ describe("DataPreview", () => {
       );
     });
 
-    fireEvent.change(screen.getByLabelText("Plot id"), { target: { value: "p1" } });
-    fireEvent.click(screen.getByRole("button", { name: "Run plot" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Run plot P1" }));
 
     await waitFor(() => expect(runPlotJob).toHaveBeenCalledWith({ plot_id: "p1" }));
     await waitFor(() => {
@@ -186,20 +244,15 @@ describe("DataPreview", () => {
       <DataPreview
         blockOutputs={{
           "load-1": {
-            images: {
-              kind: "collection",
-              items: [
-                {
-                  data_ref: "data-abcdef",
-                  metadata: { framework: { source: "C:/data/beads.tif" } },
-                },
-                {
-                  data_ref: "data-123456",
-                  metadata: { meta: { source_file: "/home/u/sample_002.tif" } },
-                },
-                { data_ref: "data-xyz789", metadata: { framework: { source: "" } } },
-              ],
+            image_a: {
+              data_ref: "data-abcdef",
+              metadata: { framework: { source: "C:/data/beads.tif" } },
             },
+            image_b: {
+              data_ref: "data-123456",
+              metadata: { meta: { source_file: "/home/u/sample_002.tif" } },
+            },
+            image_c: { data_ref: "data-xyz789", metadata: { framework: { source: "" } } },
           },
         }}
         selectedNodeId="load-1"

--- a/frontend/src/components/DataPreview.tsx
+++ b/frontend/src/components/DataPreview.tsx
@@ -1,10 +1,15 @@
-import { useEffect, useMemo, useState, type FormEvent } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import { api } from "../lib/api";
 import { plotTargetFromRunResponse } from "../lib/api/data";
 import { useAppStore } from "../store";
 import { buildPreviewCacheKey } from "../store/previewSlice";
-import type { BlockPortResponse, BlockSchemaResponse, PreviewTarget } from "../types/api";
+import type {
+  BlockPortResponse,
+  BlockSchemaResponse,
+  PlotListItem,
+  PreviewTarget,
+} from "../types/api";
 
 import { PortInfoPanel } from "./DataPreview.parts/PortInfoPanel";
 import { PreviewHost } from "./DataPreview.parts/PreviewHost";
@@ -66,44 +71,78 @@ export function DataPreview({
     if (!selectedNodeId) return [];
     return extractRefEntries(blockOutputs[selectedNodeId] ?? {});
   }, [blockOutputs, selectedNodeId]);
-  const outputRefs = useMemo(() => refEntries.map((e) => e.ref), [refEntries]);
+  const outputEntryIds = useMemo(() => refEntries.map((e) => e.id), [refEntries]);
 
-  // Local active-ref selection. The effective ref defaults to the first output
-  // and stays valid as the selected node's outputs change (no effect needed).
-  const [pickedRef, setPickedRef] = useState<string | null>(null);
-  const activeRef =
-    pickedRef && outputRefs.includes(pickedRef) ? pickedRef : (outputRefs[0] ?? null);
+  // Local active-output selection. It defaults to the first output and stays
+  // valid as the selected node's outputs change (no effect needed).
+  const [pickedEntryId, setPickedEntryId] = useState<string | null>(null);
+  const activeEntry =
+    (pickedEntryId ? refEntries.find((entry) => entry.id === pickedEntryId) : null) ??
+    refEntries[0] ??
+    null;
 
   // ADR-048 FR-021 — the routed-preview envelope cache lives in the Zustand
   // preview slice; the host reads/writes it through these callbacks.
   const previewEnvelopeCache = useAppStore((s) => s.previewEnvelopeCache);
   const cachePreviewEnvelope = useAppStore((s) => s.cachePreviewEnvelope);
+  const workflowId = useAppStore((s) => s.workflowId);
 
-  // The frontend has no authoritative type chain; it sends a minimal data_ref
-  // target and the backend rebuilds the routed target from its catalog (#1592).
-  const target: PreviewTarget | null = activeRef ? { kind: "data_ref", ref: activeRef } : null;
-  const [plotId, setPlotId] = useState("");
+  const target: PreviewTarget | null = activeEntry
+    ? {
+        ...activeEntry.target,
+        source: activeEntry.target.source ?? {
+          workflow_id: workflowId,
+          node_id: selectedNodeId,
+          output_port: activeEntry.outputPort ?? null,
+        },
+      }
+    : null;
+  const [availablePlots, setAvailablePlots] = useState<PlotListItem[]>([]);
   const [plotTarget, setPlotTarget] = useState<PreviewTarget | null>(null);
   const [plotRunError, setPlotRunError] = useState<string | null>(null);
-  const [plotRunning, setPlotRunning] = useState(false);
+  const [plotListError, setPlotListError] = useState<string | null>(null);
+  const [plotLoading, setPlotLoading] = useState(false);
+  const [plotRunningId, setPlotRunningId] = useState<string | null>(null);
 
   useEffect(() => {
+    setPickedEntryId(null);
     setPlotTarget(null);
     setPlotRunError(null);
-    setPlotRunning(false);
+    setPlotRunningId(null);
   }, [selectedNodeId]);
 
-  async function handlePlotRun(event: FormEvent<HTMLFormElement>) {
-    event.preventDefault();
-    const requestedPlotId = plotId.trim();
-    if (!requestedPlotId) {
-      setPlotRunError("Enter a plot id.");
+  useEffect(() => {
+    let cancelled = false;
+    setAvailablePlots([]);
+    setPlotListError(null);
+    if (!selectedNodeId) {
+      setPlotLoading(false);
       return;
     }
-    setPlotRunning(true);
+    setPlotLoading(true);
+    api
+      .listPlots({ workflowId, nodeId: selectedNodeId })
+      .then((result) => {
+        if (cancelled) return;
+        setAvailablePlots(result.plots);
+      })
+      .catch((error: unknown) => {
+        if (cancelled) return;
+        setPlotListError(error instanceof Error ? error.message : String(error));
+      })
+      .finally(() => {
+        if (!cancelled) setPlotLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedNodeId, workflowId]);
+
+  async function handlePlotRun(plot: PlotListItem) {
+    setPlotRunningId(plot.plot_id);
     setPlotRunError(null);
     try {
-      const result = await api.runPlotJob({ plot_id: requestedPlotId });
+      const result = await api.runPlotJob({ plot_id: plot.plot_id });
       const nextTarget = plotTargetFromRunResponse(result);
       if (!nextTarget) {
         setPlotTarget(null);
@@ -115,7 +154,7 @@ export function DataPreview({
       setPlotTarget(null);
       setPlotRunError(error instanceof Error ? error.message : String(error));
     } finally {
-      setPlotRunning(false);
+      setPlotRunningId(null);
     }
   }
 
@@ -152,60 +191,81 @@ export function DataPreview({
         <div className="mt-6 rounded-[1.8rem] border border-dashed border-stone-300 px-4 py-6 text-sm text-stone-500">
           Pick a block to inspect its latest outputs and cached previews.
         </div>
-      ) : outputRefs.length === 0 ? (
-        <div className="mt-6 min-h-0 flex-1 rounded-[1.8rem] border border-dashed border-stone-300 px-4 py-6 text-sm text-stone-500">
-          This block has no previewable outputs yet.
-        </div>
       ) : (
         <>
-          <div className="mt-5 flex flex-wrap gap-2">
-            {refEntries.map((entry) => (
-              <button
-                className={`rounded-full px-3 py-1 text-xs ${!plotTarget && activeRef === entry.ref ? "bg-ink text-white" : "bg-white text-stone-600"}`}
-                key={entry.ref}
-                onClick={() => {
-                  setPickedRef(entry.ref);
-                  setPlotTarget(null);
-                  setPlotRunError(null);
-                }}
-                title={entry.ref}
-                type="button"
-              >
-                {entry.displayName}
-              </button>
-            ))}
-            {plotTarget ? (
-              <button
-                className="rounded-full bg-ink px-3 py-1 text-xs text-white"
-                onClick={() => setPlotTarget(plotTarget)}
-                title={plotTarget.ref}
-                type="button"
-              >
-                Plot artifact
-              </button>
-            ) : null}
-          </div>
-          <form className="mt-3 flex items-center gap-2" onSubmit={handlePlotRun}>
-            <label className="sr-only" htmlFor="data-preview-plot-id">
-              Plot id
-            </label>
-            <input
-              className="min-w-0 flex-1 rounded border border-stone-300 bg-white px-3 py-1 text-xs text-stone-700 outline-none focus:border-ink"
-              disabled={plotRunning}
-              id="data-preview-plot-id"
-              onChange={(event) => setPlotId(event.target.value)}
-              placeholder="plot_id"
-              value={plotId}
-            />
-            <button
-              aria-label="Run plot"
-              className="rounded border border-stone-300 bg-white px-3 py-1 text-xs text-stone-700 disabled:opacity-50"
-              disabled={plotRunning}
-              type="submit"
+          {outputEntryIds.length === 0 ? (
+            <div className="mt-6 rounded-[1.8rem] border border-dashed border-stone-300 px-4 py-6 text-sm text-stone-500">
+              This block has no previewable outputs yet.
+            </div>
+          ) : (
+            <div className="mt-5 flex flex-wrap gap-2">
+              {refEntries.map((entry) => (
+                <button
+                  className={`rounded-full px-3 py-1 text-xs ${!plotTarget && activeEntry?.id === entry.id ? "bg-ink text-white" : "bg-white text-stone-600"}`}
+                  key={entry.id}
+                  onClick={() => {
+                    setPickedEntryId(entry.id);
+                    setPlotTarget(null);
+                    setPlotRunError(null);
+                  }}
+                  title={entry.ref}
+                  type="button"
+                >
+                  {entry.displayName}
+                </button>
+              ))}
+              {plotTarget ? (
+                <button
+                  className="rounded-full bg-ink px-3 py-1 text-xs text-white"
+                  onClick={() => setPlotTarget(plotTarget)}
+                  title={plotTarget.ref}
+                  type="button"
+                >
+                  Plot artifact
+                </button>
+              ) : null}
+            </div>
+          )}
+          {availablePlots.length > 0 || plotLoading || plotListError ? (
+            <div className="mt-3 flex flex-wrap items-center gap-2">
+              {plotLoading ? (
+                <span className="text-xs text-stone-500">Loading plots...</span>
+              ) : null}
+              {availablePlots.map((plot) => (
+                <button
+                  aria-label={`Run plot ${plot.title || plot.plot_id}`}
+                  className="rounded border border-stone-300 bg-white px-3 py-1 text-xs text-stone-700 disabled:opacity-50"
+                  disabled={plotRunningId !== null}
+                  key={plot.plot_id}
+                  onClick={() => void handlePlotRun(plot)}
+                  title={plot.display_label || plot.plot_id}
+                  type="button"
+                >
+                  {plotRunningId === plot.plot_id
+                    ? "Running"
+                    : `Plot: ${plot.title || plot.plot_id}`}
+                </button>
+              ))}
+              {plotTarget && outputEntryIds.length === 0 ? (
+                <button
+                  className="rounded-full bg-ink px-3 py-1 text-xs text-white"
+                  onClick={() => setPlotTarget(plotTarget)}
+                  title={plotTarget.ref}
+                  type="button"
+                >
+                  Plot artifact
+                </button>
+              ) : null}
+            </div>
+          ) : null}
+          {plotListError ? (
+            <div
+              className="mt-2 rounded border border-amber-300 bg-amber-50 px-3 py-2 text-xs text-amber-900"
+              role="status"
             >
-              {plotRunning ? "Running" : "Run"}
-            </button>
-          </form>
+              {plotListError}
+            </div>
+          ) : null}
           {plotRunError ? (
             <div
               className="mt-2 rounded border border-red-300 bg-red-50 px-3 py-2 text-xs text-red-800"
@@ -217,6 +277,7 @@ export function DataPreview({
           <div className="mt-4 min-h-0 flex-1 overflow-y-auto scrollbar-thin">
             <PreviewHost
               target={plotTarget ?? target}
+              initialQuery={plotTarget ? undefined : activeEntry?.initialQuery}
               getCachedEnvelope={(key) => previewEnvelopeCache[key]}
               cacheEnvelope={cachePreviewEnvelope}
               buildCacheKey={(t, q, opts) => buildPreviewCacheKey(t, q, opts)}

--- a/frontend/src/lib/api/__tests__/plotPreview.test.ts
+++ b/frontend/src/lib/api/__tests__/plotPreview.test.ts
@@ -90,3 +90,69 @@ describe("dataApi.runPlotJob (#1606 run route)", () => {
     vi.unstubAllGlobals();
   });
 });
+
+describe("dataApi plot list + preview resource save", () => {
+  it("GETs /api/plots with block filters", async () => {
+    const body = {
+      plots: [
+        {
+          plot_id: "p1",
+          title: "P1",
+          workflow_id: "main",
+          node_id: "node_a",
+          output_port: "measurements",
+          display_label: "Seg / measurements",
+          language: "python",
+          preferred_format: "svg",
+          manifest_path: "plots/p1/plot.yaml",
+          script_path: "plots/p1/render.py",
+        },
+      ],
+      count: 1,
+      warnings: [],
+    };
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve(body),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const out = await dataApi.listPlots({ workflowId: "main", nodeId: "node_a" });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][0]).toBe("/api/plots?workflow_id=main&node_id=node_a");
+    expect(out).toEqual(body);
+    vi.unstubAllGlobals();
+  });
+
+  it("POSTs preview resource saves to the selected destination path", async () => {
+    const body = {
+      path: "C:/Users/test/plot.svg",
+      filename: "plot.svg",
+      size_bytes: 7,
+      mime_type: "image/svg+xml",
+    };
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve(body),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const out = await dataApi.savePreviewResource("pv-1", "export", {
+      destination_path: "C:/Users/test/plot.svg",
+      params: { format: "svg" },
+    });
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("/api/previews/sessions/pv-1/resources/export/save");
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(init.body as string)).toEqual({
+      destination_path: "C:/Users/test/plot.svg",
+      params: { format: "svg" },
+    });
+    expect(out).toEqual(body);
+    vi.unstubAllGlobals();
+  });
+});

--- a/frontend/src/lib/api/data.ts
+++ b/frontend/src/lib/api/data.ts
@@ -9,10 +9,13 @@
 import type {
   DataMetadataResponse,
   DataUploadResponse,
+  PlotListResponse,
   PlotRunRequest,
   PlotRunResponse,
   PreviewEnvelope,
   PreviewResourceResponse,
+  PreviewResourceSaveRequest,
+  PreviewResourceSaveResponse,
   PreviewTarget,
 } from "../../types/api";
 import { JSON_HEADERS, apiFetch } from "./core";
@@ -98,6 +101,24 @@ export const dataApi = {
       )}`,
     ),
 
+  /** Save a bounded provider resource to a user-selected absolute file path
+   *  (`POST /api/previews/sessions/{id}/resources/{resource_id}/save`). */
+  savePreviewResource: (
+    sessionId: string,
+    resourceId: string,
+    request: PreviewResourceSaveRequest,
+  ) =>
+    apiFetch<PreviewResourceSaveResponse>(
+      `/api/previews/sessions/${encodeURIComponent(sessionId)}/resources/${encodeURIComponent(
+        resourceId,
+      )}/save`,
+      {
+        method: "POST",
+        headers: JSON_HEADERS,
+        body: JSON.stringify(request),
+      },
+    ),
+
   // -- ADR-048 SPEC 2 / #1606: plot-job run + preview wiring ----------------
 
   /** Run a plot job and register its artifact for routed preview
@@ -111,4 +132,18 @@ export const dataApi = {
       headers: JSON_HEADERS,
       body: JSON.stringify(request),
     }),
+
+  /** List project-local plot manifests, optionally scoped to a workflow block. */
+  listPlots: (params?: {
+    workflowId?: string | null;
+    nodeId?: string | null;
+    outputPort?: string | null;
+  }) => {
+    const search = new URLSearchParams();
+    if (params?.workflowId) search.set("workflow_id", params.workflowId);
+    if (params?.nodeId) search.set("node_id", params.nodeId);
+    if (params?.outputPort) search.set("output_port", params.outputPort);
+    const suffix = search.toString();
+    return apiFetch<PlotListResponse>(`/api/plots${suffix ? `?${suffix}` : ""}`);
+  },
 };

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -370,6 +370,20 @@ export interface PreviewResourceResponse {
   data: Record<string, unknown>;
 }
 
+/** Request body for saving a bounded session resource to a user-selected path. */
+export interface PreviewResourceSaveRequest {
+  destination_path: string;
+  params?: Record<string, unknown>;
+}
+
+/** Response body after a session resource save. */
+export interface PreviewResourceSaveResponse {
+  path: string;
+  filename: string;
+  size_bytes: number;
+  mime_type?: string | null;
+}
+
 // ---------------------------------------------------------------------------
 // ADR-048 SPEC 2 / #1606: plot-job run + preview wiring.
 // ---------------------------------------------------------------------------
@@ -399,6 +413,27 @@ export interface PlotRunResponse {
   source: PreviewSource | null;
   warnings: string[];
   errors: string[];
+}
+
+/** One project-local plot manifest returned by `GET /api/plots`. */
+export interface PlotListItem {
+  plot_id: string;
+  title: string;
+  workflow_id?: string | null;
+  node_id: string;
+  output_port: string;
+  display_label: string;
+  language: string;
+  preferred_format: string;
+  manifest_path: string;
+  script_path: string;
+}
+
+/** Response body for `GET /api/plots`. */
+export interface PlotListResponse {
+  plots: PlotListItem[];
+  count: number;
+  warnings: string[];
 }
 
 export interface CancelPropagationResponse {

--- a/src/scistudio/api/routes/data.py
+++ b/src/scistudio/api/routes/data.py
@@ -19,12 +19,15 @@ from fastapi import APIRouter, Depends, File, HTTPException, Query, UploadFile
 from fastapi.responses import FileResponse
 
 from scistudio.api.deps import get_runtime
+from scistudio.api.routes.filesystem import _resolve_safe_path
 from scistudio.api.runtime import ApiRuntime
 from scistudio.api.schemas import (
     DataMetadataResponse,
     DataUploadResponse,
     PreviewEnvelopeModel,
     PreviewResourceResponse,
+    PreviewResourceSaveRequest,
+    PreviewResourceSaveResponse,
     PreviewSessionCreate,
     PreviewSessionPatch,
 )
@@ -242,6 +245,37 @@ async def read_preview_resource(
     except (UnknownTargetError, PreviewError) as exc:
         raise HTTPException(status_code=400, detail=getattr(exc, "message", str(exc))) from exc
     return PreviewResourceResponse(resource_id=resource_id, data=data)
+
+
+@previews_router.post(
+    "/sessions/{session_id}/resources/{resource_id}/save",
+    response_model=PreviewResourceSaveResponse,
+)
+async def save_preview_resource(
+    session_id: str,
+    resource_id: str,
+    payload: PreviewResourceSaveRequest,
+    runtime: RuntimeDep,
+) -> PreviewResourceSaveResponse:
+    """Save a bounded provider resource to a path selected by the native dialog."""
+    _validate_resource_param_value(payload.params)
+    try:
+        destination = _resolve_safe_path(payload.destination_path)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    if destination.exists() and destination.is_dir():
+        raise HTTPException(status_code=400, detail="save destination must be a file path")
+    if not destination.parent.is_dir():
+        raise HTTPException(status_code=400, detail="save destination parent directory does not exist")
+
+    service = runtime.get_preview_service()
+    try:
+        result = service.sessions.save_resource(session_id, resource_id, destination, payload.params)
+    except UnknownPreviewerError as exc:
+        raise HTTPException(status_code=404, detail=exc.message) from exc
+    except (UnknownTargetError, PreviewError) as exc:
+        raise HTTPException(status_code=400, detail=getattr(exc, "message", str(exc))) from exc
+    return PreviewResourceSaveResponse(**result)
 
 
 @previews_router.get("/assets/{previewer_id}/{asset_path:path}")

--- a/src/scistudio/api/routes/plots.py
+++ b/src/scistudio/api/routes/plots.py
@@ -31,19 +31,73 @@ from __future__ import annotations
 
 import logging
 from functools import partial
+from pathlib import Path
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from starlette.concurrency import run_in_threadpool
 
 from scistudio.api.deps import get_runtime
 from scistudio.api.runtime import ApiRuntime
-from scistudio.api.schemas import PlotRunRequest, PlotRunResponse
+from scistudio.api.schemas import PlotListItem, PlotListResponse, PlotRunRequest, PlotRunResponse
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/plots", tags=["plots"])
 RuntimeDep = Annotated[ApiRuntime, Depends(get_runtime)]
+
+
+@router.get("", response_model=PlotListResponse)
+async def list_plots(
+    runtime: RuntimeDep,
+    workflow_id: Annotated[str | None, Query()] = None,
+    node_id: Annotated[str | None, Query()] = None,
+    output_port: Annotated[str | None, Query()] = None,
+) -> PlotListResponse:
+    """List project-local plot manifests, optionally filtered to a block output."""
+    from scistudio.ai.agent.mcp.tools_plot.validation import load_plot
+
+    try:
+        project = runtime.require_active_project()
+    except RuntimeError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+
+    project_root = Path(project.path).resolve()
+    plots_dir = project_root / "plots"
+    if not plots_dir.is_dir():
+        return PlotListResponse(plots=[], count=0)
+
+    items: list[PlotListItem] = []
+    warnings: list[str] = []
+    for manifest_path in sorted(plots_dir.glob("*/plot.yaml")):
+        try:
+            loaded = load_plot(plot_id=manifest_path.parent.name)
+        except Exception as exc:
+            warnings.append(f"{_project_relative(project_root, manifest_path)}: {exc}")
+            continue
+        target = loaded.manifest.target
+        if workflow_id is not None and target.workflow_id != workflow_id:
+            continue
+        if node_id is not None and target.node_id != node_id:
+            continue
+        if output_port is not None and target.output_port != output_port:
+            continue
+        items.append(
+            PlotListItem(
+                plot_id=loaded.plot_id,
+                title=loaded.manifest.title,
+                workflow_id=target.workflow_id,
+                node_id=target.node_id,
+                output_port=target.output_port,
+                display_label=target.display_label,
+                language=loaded.manifest.script.language,
+                preferred_format=loaded.manifest.outputs.preferred_format,
+                manifest_path=_project_relative(project_root, loaded.manifest_path),
+                script_path=_project_relative(project_root, loaded.script_path),
+            )
+        )
+    items.sort(key=lambda item: (item.title.lower() or item.plot_id.lower(), item.plot_id.lower()))
+    return PlotListResponse(plots=items, count=len(items), warnings=warnings)
 
 
 @router.post("/run", response_model=PlotRunResponse)
@@ -131,3 +185,10 @@ async def run_plot(payload: PlotRunRequest, runtime: RuntimeDep) -> PlotRunRespo
         warnings=list(result.warnings),
         errors=list(result.errors),
     )
+
+
+def _project_relative(project_root: Path, path: Path) -> str:
+    try:
+        return path.resolve().relative_to(project_root).as_posix()
+    except ValueError:
+        return str(path)

--- a/src/scistudio/api/routes/runs.py
+++ b/src/scistudio/api/routes/runs.py
@@ -87,6 +87,7 @@ def runs_health(store: Any = _LineageStoreDep) -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 
+@router.get("/", include_in_schema=False)
 @router.get("")
 def list_runs(
     workflow_id: str | None = Query(default=None, description="Filter by workflow_id."),

--- a/src/scistudio/api/schemas.py
+++ b/src/scistudio/api/schemas.py
@@ -310,6 +310,22 @@ class PreviewResourceResponse(BaseModel):
     data: dict[str, Any] = Field(default_factory=dict)
 
 
+class PreviewResourceSaveRequest(BaseModel):
+    """Request body for saving a bounded preview resource to a user path."""
+
+    destination_path: str = Field(description="Absolute path selected by the native save dialog.")
+    params: dict[str, Any] = Field(default_factory=dict, description="Resource params copied from the descriptor.")
+
+
+class PreviewResourceSaveResponse(BaseModel):
+    """Response body after a preview resource is saved to disk."""
+
+    path: str
+    filename: str
+    size_bytes: int
+    mime_type: str | None = None
+
+
 # ---------------------------------------------------------------------------
 # ADR-048 SPEC 2 / #1606: plot-job run + preview wiring.
 #
@@ -359,6 +375,29 @@ class PlotRunResponse(BaseModel):
     )
     warnings: list[str] = Field(default_factory=list)
     errors: list[str] = Field(default_factory=list)
+
+
+class PlotListItem(BaseModel):
+    """One project-local plot manifest summary for the app shell."""
+
+    plot_id: str
+    title: str = ""
+    workflow_id: str | None = None
+    node_id: str
+    output_port: str
+    display_label: str = ""
+    language: str
+    preferred_format: str
+    manifest_path: str
+    script_path: str
+
+
+class PlotListResponse(BaseModel):
+    """Response body for ``GET /api/plots``."""
+
+    plots: list[PlotListItem] = Field(default_factory=list)
+    count: int
+    warnings: list[str] = Field(default_factory=list)
 
 
 class ProjectCreate(BaseModel):

--- a/src/scistudio/api/spa.py
+++ b/src/scistudio/api/spa.py
@@ -10,20 +10,38 @@ from __future__ import annotations
 import os
 from typing import cast
 
+from starlette.exceptions import HTTPException
+from starlette.responses import Response
 from starlette.staticfiles import StaticFiles
+from starlette.types import Scope
 
 
 class SPAStaticFiles(StaticFiles):
     """Serve ``index.html`` for paths that do not match a real file.
 
-    All ``/api/*`` and ``/ws`` requests are handled by FastAPI route
-    handlers registered *before* this mount, so they are never
-    intercepted by the SPA fallback.
+    Known ``/api/*`` and ``/ws`` requests are handled by FastAPI route
+    handlers registered *before* this mount. Unknown API/WebSocket paths must
+    remain 404s instead of becoming ``index.html``.
     """
+
+    async def get_response(self, path: str, scope: Scope) -> Response:
+        """Serve SPA routes, but never rewrite unknown API/WebSocket paths."""
+        if _is_api_or_ws_path(path):
+            raise HTTPException(status_code=404)
+        return await super().get_response(path, scope)
 
     def lookup_path(self, path: str) -> tuple[str, os.stat_result | None]:
         """Return the real file if it exists, otherwise ``index.html``."""
         full_path, stat_result = super().lookup_path(path)
         if stat_result is None:
+            if _is_api_or_ws_path(path):
+                return full_path, stat_result
             return cast(tuple[str, os.stat_result | None], super().lookup_path("index.html"))
         return full_path, stat_result
+
+
+def _is_api_or_ws_path(path: str) -> bool:
+    normalized = path.replace("\\", "/").lstrip("/")
+    while normalized.startswith("./"):
+        normalized = normalized[2:]
+    return normalized == "api" or normalized.startswith("api/") or normalized == "ws" or normalized.startswith("ws/")

--- a/src/scistudio/previewers/session.py
+++ b/src/scistudio/previewers/session.py
@@ -30,6 +30,7 @@ from dataclasses import replace
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
+from urllib.parse import unquote_to_bytes
 from uuid import uuid4
 
 from scistudio.previewers.data_access import PreviewDataAccess
@@ -209,6 +210,34 @@ class PreviewSessionManager:
             f"unknown resource id {resource_id!r} for session {session_id}",
             detail={"resource_id": resource_id},
         )
+
+    def save_resource(
+        self,
+        session_id: str,
+        resource_id: str,
+        destination_path: Path,
+        params: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Save a bounded resource payload to a user-selected destination."""
+        data = self.read_resource(session_id, resource_id, params)
+        payload, mime_type = _payload_from_data_uri(data)
+        if len(payload) > self._get_session(session_id).limits.max_bytes:
+            raise ProviderError(
+                "preview resource exceeds save byte budget",
+                detail={"resource_id": resource_id, "size_bytes": len(payload)},
+            )
+        if not destination_path.parent.is_dir():
+            raise ProviderError(
+                "save destination parent directory does not exist",
+                detail={"resource_id": resource_id, "path": str(destination_path)},
+            )
+        destination_path.write_bytes(payload)
+        return {
+            "path": str(destination_path),
+            "filename": destination_path.name,
+            "size_bytes": len(payload),
+            "mime_type": str(data.get("mime_type") or mime_type or ""),
+        }
 
     def get_session(self, session_id: str) -> PreviewSession:
         """Return the session record (no re-render)."""
@@ -516,6 +545,22 @@ def _stable_cache_value(value: Any) -> str:
 
 def _data_uri(mime_type: str, payload: bytes) -> str:
     return f"data:{mime_type};base64,{base64.b64encode(payload).decode('ascii')}"
+
+
+def _payload_from_data_uri(data: dict[str, Any]) -> tuple[bytes, str | None]:
+    data_uri = data.get("data_uri") or data.get("src")
+    if not isinstance(data_uri, str) or not data_uri.startswith("data:"):
+        raise ProviderError("preview resource is not a saveable data URI", detail={"resource": data})
+    header, sep, payload = data_uri.partition(",")
+    if sep == "":
+        raise ProviderError("preview resource data URI is malformed", detail={"header": header})
+    mime_type = header[5:].split(";", 1)[0] or None
+    if ";base64" in header.lower():
+        try:
+            return base64.b64decode(payload.encode("ascii"), validate=True), mime_type
+        except Exception as exc:
+            raise ProviderError("preview resource data URI payload is invalid", detail={"header": header}) from exc
+    return unquote_to_bytes(payload), mime_type
 
 
 def _missing_spec(previewer_id: str) -> PreviewerSpec:

--- a/tests/api/test_plot_preview_wiring.py
+++ b/tests/api/test_plot_preview_wiring.py
@@ -202,6 +202,91 @@ def test_plot_run_route_registers_artifact_and_preview_session_renders_plot(
     assert any(r["resource_id"] == "export" for r in env["resources"])
 
 
+def test_plot_list_route_filters_manifests_to_selected_block(
+    client: TestClient,
+    runtime: ApiRuntime,
+    opened_project: Path,
+) -> None:
+    """The App Shell can discover plots bound to the selected block."""
+    _seed_block_output(runtime, opened_project)
+    _write_workflow_and_plot(client, opened_project)
+
+    plot_dir = opened_project / "plots" / "p2"
+    plot_dir.mkdir(parents=True, exist_ok=True)
+    (plot_dir / "plot.yaml").write_text(
+        "schema_version: 1\n"
+        "id: p2\n"
+        "title: P2\n"
+        "target:\n"
+        "  workflow_path: workflows/main.yaml\n"
+        "  workflow_id: main\n"
+        "  node_id: node_b\n"
+        "  output_port: other\n"
+        "  display_label: Other / other\n"
+        "script:\n"
+        "  language: python\n"
+        "  path: render.py\n"
+        "  entrypoint: render\n",
+        encoding="utf-8",
+    )
+    (plot_dir / "render.py").write_text("def render(collection, context):\n    return None\n", encoding="utf-8")
+
+    resp = client.get("/api/plots", params={"workflow_id": "main", "node_id": "node_a"})
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["count"] == 1
+    assert body["plots"][0]["plot_id"] == "p1"
+    assert body["plots"][0]["node_id"] == "node_a"
+    assert body["plots"][0]["output_port"] == "measurements"
+
+
+def test_plot_preview_resource_save_writes_export_to_user_selected_path(
+    client: TestClient,
+    runtime: ApiRuntime,
+    opened_project: Path,
+) -> None:
+    """Save/export uses the session resource path and writes the selected file."""
+    _seed_block_output(runtime, opened_project)
+    _write_workflow_and_plot(client, opened_project)
+
+    run = client.post("/api/plots/run", json={"plot_id": "p1"})
+    assert run.status_code == 200, run.text
+    body = run.json()
+    session = client.post(
+        "/api/previews/sessions",
+        json={
+            "target": {
+                "kind": "plot_artifact",
+                "ref": body["data_ref"],
+                "recorded_type": body["recorded_type"],
+                "type_chain": body["type_chain"],
+                "source": body["source"],
+            },
+            "query": {},
+        },
+    )
+    assert session.status_code == 200, session.text
+    env = session.json()
+    sid = env["session_id"]
+    export_dir = opened_project / "exports"
+    export_dir.mkdir()
+    destination = export_dir / "chosen-name.svg"
+
+    save = client.post(
+        f"/api/previews/sessions/{sid}/resources/export/save",
+        json={"destination_path": str(destination), "params": {"format": "svg"}},
+    )
+
+    assert save.status_code == 200, save.text
+    payload = save.json()
+    assert payload["path"] == str(destination.resolve())
+    assert payload["filename"] == "chosen-name.svg"
+    assert payload["mime_type"] == "image/svg+xml"
+    assert destination.is_file()
+    assert "<svg" in destination.read_text(encoding="utf-8")
+
+
 def test_registered_plot_artifact_classifies_as_plot_target(
     client: TestClient,
     runtime: ApiRuntime,

--- a/tests/api/test_spa_fallback.py
+++ b/tests/api/test_spa_fallback.py
@@ -71,3 +71,11 @@ class TestSPAStaticFiles:
         response = client.get("/api/test")
         assert response.status_code == 200
         assert response.json() == {"status": "ok"}
+
+    def test_unknown_api_path_not_rewritten_to_spa_index(self, tmp_path: Path) -> None:
+        """Deleted legacy API routes must stay 404s, not return index.html."""
+        static_dir = _setup_static_dir(tmp_path)
+        client = TestClient(_make_spa_app(static_dir))
+        response = client.get("/api/data/obj-1/preview")
+        assert response.status_code == 404
+        assert "SPA" not in response.text


### PR DESCRIPTION
﻿## Summary

- Stop unknown `/api/*` and `/ws/*` paths from falling through to the SPA shell, while preserving the known `/api/runs/` trailing-slash list route.
- Preview collection outputs as collection sessions first, instead of flattening them into item pills.
- Add a block-bound plot GUI action in the right preview panel by listing plots for the selected workflow node and opening the produced plot artifact automatically.
- Route export/save through the native save dialog and backend preview-resource save endpoint, including dynamic previewer `exportArtifact`/`saveArtifact`.

## Tests

- `python -m pytest tests/api/test_spa_fallback.py tests/api/test_plot_preview_wiring.py tests/api/test_runs_routes.py::TestGetRun::test_empty_run_id_segment_routes_elsewhere -q --no-cov --timeout=180`
- `npm --prefix frontend test -- src/components/DataPreview.test.tsx src/components/DataPreview.parts/refEntries.test.ts src/components/DataPreview.parts/PreviewHost.test.tsx src/lib/api/__tests__/plotPreview.test.ts`
- `npm --prefix frontend run typecheck`
- `python -m ruff check src/scistudio/api/spa.py src/scistudio/api/schemas.py src/scistudio/api/routes/data.py src/scistudio/api/routes/plots.py src/scistudio/api/routes/runs.py src/scistudio/previewers/session.py tests/api/test_spa_fallback.py tests/api/test_plot_preview_wiring.py tests/api/test_runs_routes.py`
- `mypy src/scistudio/ --ignore-missing-imports`
- `python -m scistudio.qa.governance.gate_record check --mode pre-pr --base origin/pr/1577 --head HEAD`

Closes #1623
Closes #1626
Closes #1649
