### PR TITLE
fix(#1655): restore previewer discovery and plot UX

### DIFF
--- a/.workflow/records/1655-hotfix-plugin-discovery-visibility.json
+++ b/.workflow/records/1655-hotfix-plugin-discovery-visibility.json
@@ -1,0 +1,865 @@
+{
+  "branch": "hotfix/plugin-discovery-visibility",
+  "check_events": [
+    {
+      "at": "2026-06-14T02:24:52.733670Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-14T02:25:03.740869Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-14T02:25:03.831591Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-14T02:30:26.644665Z",
+      "command": "pytest tests/architecture/ -v --no-cov",
+      "covered_surface": "architecture",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:8694bf858d3af37777839821928bac57830f6dc9aca049aa026577d679bb5dee",
+      "name": "architecture_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/architecture_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-14T02:30:27.495355Z",
+      "command": "python scripts/deferral_scan.py --check docs/audit/baselines/deferral-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:8694bf858d3af37777839821928bac57830f6dc9aca049aa026577d679bb5dee",
+      "name": "deferral_discipline",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/deferral_discipline.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-14T02:30:27.533470Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:8694bf858d3af37777839821928bac57830f6dc9aca049aa026577d679bb5dee",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-14T02:30:30.601656Z",
+      "command": "(cd frontend && npm run lint)",
+      "covered_surface": "frontend",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:8694bf858d3af37777839821928bac57830f6dc9aca049aa026577d679bb5dee",
+      "name": "frontend",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/frontend.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-14T02:30:40.389972Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:8694bf858d3af37777839821928bac57830f6dc9aca049aa026577d679bb5dee",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-14T02:30:40.653103Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:8694bf858d3af37777839821928bac57830f6dc9aca049aa026577d679bb5dee",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-14T02:30:40.693958Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:8694bf858d3af37777839821928bac57830f6dc9aca049aa026577d679bb5dee",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-14T02:33:50.429045Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:8694bf858d3af37777839821928bac57830f6dc9aca049aa026577d679bb5dee",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-14T02:34:50.527461Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:8694bf858d3af37777839821928bac57830f6dc9aca049aa026577d679bb5dee",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-14T02:34:52.759021Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:8694bf858d3af37777839821928bac57830f6dc9aca049aa026577d679bb5dee",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    }
+  ],
+  "check_na": [],
+  "commit": {
+    "sha": "010bf6f56c626ba5b6ff8aa7ad6ae94c3fb4d387",
+    "shas": [
+      "010bf6f56c626ba5b6ff8aa7ad6ae94c3fb4d387"
+    ],
+    "trailers": []
+  },
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "src/scistudio/**",
+      "frontend/src/**",
+      "packages/scistudio-blocks-imaging/**",
+      "tests/**"
+    ]
+  },
+  "directive_events": [
+    {
+      "at": "2026-06-14T02:23:33.052699Z",
+      "owner_directive": "Hotfix batch completed through live owner testing: package discovery, image/array preview, multi-image load, new plot dialog/R template/editor allowlist, plot/image UX, context completions, and preview empty state.",
+      "reason": "plan"
+    },
+    {
+      "at": "2026-06-14T02:27:41.261533Z",
+      "owner_directive": "Owner requested root-cause hotfix in core/plugin discovery and load dispatch rather than surface-only fixes.",
+      "reason": "Owner-authorized hotfix touches protected core/runtime discovery and IO dispatch surfaces."
+    }
+  ],
+  "docs_events": [
+    {
+      "at": "2026-06-14T02:23:33.052833Z",
+      "class": "user-docs",
+      "kind": "na",
+      "path": null,
+      "rationale": "hotfix restores and wires existing user-facing preview/plot/editor behavior; PR body and issue capture release-note level summary",
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": false,
+  "guard_events": [
+    {
+      "at": "2026-06-14T02:25:03.942605Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T02:25:03.993532Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T02:25:04.043448Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T02:25:04.098927Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T02:25:04.149985Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T02:25:04.203480Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T02:25:04.254970Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T02:25:04.306220Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T02:25:04.355827Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T02:25:04.403404Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T02:34:52.916865Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/io/_unified_dispatch.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/io/_unified_dispatch.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/io/capabilities.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/io/capabilities.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/registry/__init__.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/registry/__init__.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T02:34:52.972018Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T02:34:53.037917Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T02:34:53.091736Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T02:34:53.145664Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T02:34:53.197016Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T02:34:53.256841Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T02:34:53.316401Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T02:34:53.368155Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T02:34:53.437123Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T02:40:55.593232Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T02:40:55.641183Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T02:40:55.693741Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T02:40:55.743925Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T02:40:55.800718Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T02:40:55.855051Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T02:40:55.903770Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T02:40:55.955590Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T02:40:56.004663Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T02:40:56.072186Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1655,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": {
+    "base": "origin/main",
+    "base_sha": "25c0176e",
+    "changed_files": [
+      ".workflow/records/1655-hotfix-plugin-discovery-visibility.json",
+      "frontend/src/App.parts/useProjectActions.ts",
+      "frontend/src/App.tsx",
+      "frontend/src/components/CodeEditor.parts/plotCompletions.test.ts",
+      "frontend/src/components/CodeEditor.parts/plotCompletions.ts",
+      "frontend/src/components/CodeEditor.tsx",
+      "frontend/src/components/DataPreview.parts/PreviewHost.test.tsx",
+      "frontend/src/components/DataPreview.parts/PreviewHost.tsx",
+      "frontend/src/components/DataPreview.parts/coreViewers.test.tsx",
+      "frontend/src/components/DataPreview.parts/coreViewers.tsx",
+      "frontend/src/components/DataPreview.parts/refEntries.ts",
+      "frontend/src/components/DataPreview.test.tsx",
+      "frontend/src/components/DataPreview.tsx",
+      "frontend/src/components/NewPlotDialog.test.tsx",
+      "frontend/src/components/NewPlotDialog.tsx",
+      "frontend/src/components/ProjectTree.tsx",
+      "frontend/src/components/Toolbar.parts/FileOperationsGroup.tsx",
+      "frontend/src/components/Toolbar.test.tsx",
+      "frontend/src/components/Toolbar.tsx",
+      "frontend/src/components/__tests__/CodeEditor.test.tsx",
+      "frontend/src/components/__tests__/ProjectTree.test.tsx",
+      "frontend/src/lib/api/__tests__/api-surface.test.ts",
+      "frontend/src/lib/api/__tests__/plotPreview.test.ts",
+      "frontend/src/lib/api/data.ts",
+      "frontend/src/store/__tests__/tabHelpers.test.ts",
+      "frontend/src/store/tabSlice.parts/tabHelpers.ts",
+      "frontend/src/store/types.ts",
+      "frontend/src/types/api.ts",
+      "packages/scistudio-blocks-imaging/pyproject.toml",
+      "packages/scistudio-blocks-imaging/src/scistudio_blocks_imaging/previewers/assets/viewer.js",
+      "packages/scistudio-blocks-imaging/tests/test_previewer_registration.py",
+      "src/scistudio/ai/agent/mcp/tools_plot/scaffold.py",
+      "src/scistudio/api/file_contracts.py",
+      "src/scistudio/api/routes/plots.py",
+      "src/scistudio/api/runtime/__init__.py",
+      "src/scistudio/api/runtime/_data.py",
+      "src/scistudio/api/schemas.py",
+      "src/scistudio/blocks/io/_unified_dispatch.py",
+      "src/scistudio/blocks/io/capabilities.py",
+      "src/scistudio/blocks/registry/__init__.py",
+      "src/scistudio/previewers/__init__.py",
+      "src/scistudio/previewers/registry.py",
+      "src/scistudio/previewers/session.py",
+      "tests/ai/test_mcp_tools_plot.py",
+      "tests/api/test_file_endpoints.py",
+      "tests/api/test_plot_preview_wiring.py",
+      "tests/api/test_previewers.py",
+      "tests/blocks/io/test_load_data.py",
+      "tests/previewers/test_preview_registry.py"
+    ],
+    "diff_fingerprint": "sha256:2b4c41b7aa400ee06cee28f01559ba913067c4a0ab33933c16e24d174aaf1c53",
+    "head": "HEAD",
+    "head_sha": "010bf6f5",
+    "surfaces": {
+      "docs": 0,
+      "frontend": 27,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 41,
+      "packaging": 0,
+      "protected_core": 3,
+      "sentrux": 48,
+      "test": 18,
+      "workflow_ci": 0
+    }
+  },
+  "owner_directive": "Owner-authorized hotfix mode: restore plugin discovery visibility, routed preview behavior, plot creation UX, editor completion, and preview empty-state regressions.",
+  "persona": "implementer",
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [
+      1655
+    ],
+    "number": null,
+    "url": null
+  },
+  "reconcile_events": [
+    {
+      "at": "2026-06-14T02:25:04.403462Z",
+      "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-14T02:34:53.437152Z",
+      "diff_fingerprint": "sha256:2b4c41b7aa400ee06cee28f01559ba913067c4a0ab33933c16e24d174aaf1c53",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.semantic_dup"
+      ]
+    },
+    {
+      "at": "2026-06-14T02:40:56.072237Z",
+      "diff_fingerprint": "sha256:5c7a802abaccc44cb94976e02e4935383e3c9db62a179d126c4d33211e791d55",
+      "mode": "pre-commit",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "tests.changed_test_required"
+      ]
+    }
+  ],
+  "record_id": "1655-hotfix-plugin-discovery-visibility",
+  "requested_admin_labels": [
+    {
+      "actor_permission": null,
+      "applied_at": null,
+      "applied_by": null,
+      "name": "admin-approved:core-change"
+    }
+  ],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [
+      "format_check",
+      "full_audit",
+      "import_contracts",
+      "lint_format",
+      "type_check"
+    ],
+    "docs": [
+      "docs_required_or_na"
+    ],
+    "guards": [
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": [
+      "changed_test_required"
+    ]
+  },
+  "runtime": "codex",
+  "schema_version": 2,
+  "scope_events": [
+    {
+      "action": "add-include",
+      "at": "2026-06-14T02:23:33.052718Z",
+      "pattern": "src/scistudio/**",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-14T02:23:33.052727Z",
+      "pattern": "frontend/src/**",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-14T02:23:33.052729Z",
+      "pattern": "packages/scistudio-blocks-imaging/**",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-14T02:23:33.052731Z",
+      "pattern": "tests/**",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-14T02:27:41.261549Z",
+      "pattern": "src/scistudio/blocks/io/_unified_dispatch.py",
+      "reason": "Owner-authorized hotfix touches protected core/runtime discovery and IO dispatch surfaces."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-14T02:27:41.261555Z",
+      "pattern": "src/scistudio/blocks/io/capabilities.py",
+      "reason": "Owner-authorized hotfix touches protected core/runtime discovery and IO dispatch surfaces."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-14T02:27:41.261557Z",
+      "pattern": "src/scistudio/blocks/registry/__init__.py",
+      "reason": "Owner-authorized hotfix touches protected core/runtime discovery and IO dispatch surfaces."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-14T02:40:24.540572Z",
+      "pattern": "src/scistudio/previewers/registry.py",
+      "reason": "Semantic-dup refactor of previewer monorepo scan remains covered by preview registry discovery tests."
+    }
+  ],
+  "session_id": "9b4f1327-8839-4e18-8009-5358f3843056",
+  "strictness_tier": 2,
+  "task_kind": "hotfix",
+  "test_events": [
+    {
+      "at": "2026-06-14T02:23:33.052843Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/previewers/test_preview_registry.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-14T02:23:33.052848Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/api/test_previewers.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-14T02:23:33.052850Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/api/test_plot_preview_wiring.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-14T02:23:33.052852Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/api/test_file_endpoints.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-14T02:23:33.052853Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/blocks/io/test_load_data.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-14T02:23:33.052855Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/ai/test_mcp_tools_plot.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-14T02:23:33.052856Z",
+      "class": null,
+      "kind": "path",
+      "path": "packages/scistudio-blocks-imaging/tests/test_previewer_registration.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-14T02:23:33.052858Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/components/DataPreview.test.tsx",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-14T02:23:33.052859Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/components/DataPreview.parts/PreviewHost.test.tsx",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-14T02:23:33.052861Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/components/CodeEditor.parts/plotCompletions.test.ts",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-14T02:23:33.052863Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/components/__tests__/CodeEditor.test.tsx",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-14T02:23:33.052865Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/components/NewPlotDialog.test.tsx",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-14T02:23:33.052866Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/store/__tests__/tabHelpers.test.ts",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-14T02:40:24.540595Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/previewers/test_preview_registry.py",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/.workflow/records/1655-hotfix-plugin-discovery-visibility.json
+++ b/.workflow/records/1655-hotfix-plugin-discovery-visibility.json
@@ -205,13 +205,325 @@
       "tool_versions": {
         "mypy": "2.1.0"
       }
+    },
+    {
+      "at": "2026-06-14T02:41:57.549825Z",
+      "command": "pytest tests/architecture/ -v --no-cov",
+      "covered_surface": "architecture",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:8694bf858d3af37777839821928bac57830f6dc9aca049aa026577d679bb5dee",
+      "name": "architecture_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/architecture_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-14T02:41:58.408683Z",
+      "command": "python scripts/deferral_scan.py --check docs/audit/baselines/deferral-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:8694bf858d3af37777839821928bac57830f6dc9aca049aa026577d679bb5dee",
+      "name": "deferral_discipline",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/deferral_discipline.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-14T02:41:58.445579Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:8694bf858d3af37777839821928bac57830f6dc9aca049aa026577d679bb5dee",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-14T02:42:01.591864Z",
+      "command": "(cd frontend && npm run lint)",
+      "covered_surface": "frontend",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:8694bf858d3af37777839821928bac57830f6dc9aca049aa026577d679bb5dee",
+      "name": "frontend",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/frontend.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-14T02:42:11.108520Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:8694bf858d3af37777839821928bac57830f6dc9aca049aa026577d679bb5dee",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-14T02:42:11.345255Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:8694bf858d3af37777839821928bac57830f6dc9aca049aa026577d679bb5dee",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-14T02:42:11.383128Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:8694bf858d3af37777839821928bac57830f6dc9aca049aa026577d679bb5dee",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-14T02:45:01.764864Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:8694bf858d3af37777839821928bac57830f6dc9aca049aa026577d679bb5dee",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-14T02:45:59.219184Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:8694bf858d3af37777839821928bac57830f6dc9aca049aa026577d679bb5dee",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-14T02:46:00.563350Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:8694bf858d3af37777839821928bac57830f6dc9aca049aa026577d679bb5dee",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    },
+    {
+      "at": "2026-06-14T02:46:13.287167Z",
+      "command": "pytest tests/architecture/ -v --no-cov",
+      "covered_surface": "architecture",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:8694bf858d3af37777839821928bac57830f6dc9aca049aa026577d679bb5dee",
+      "name": "architecture_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/architecture_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-14T02:46:14.166737Z",
+      "command": "python scripts/deferral_scan.py --check docs/audit/baselines/deferral-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:8694bf858d3af37777839821928bac57830f6dc9aca049aa026577d679bb5dee",
+      "name": "deferral_discipline",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/deferral_discipline.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-14T02:46:14.206307Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:8694bf858d3af37777839821928bac57830f6dc9aca049aa026577d679bb5dee",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-14T02:46:17.344537Z",
+      "command": "(cd frontend && npm run lint)",
+      "covered_surface": "frontend",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:8694bf858d3af37777839821928bac57830f6dc9aca049aa026577d679bb5dee",
+      "name": "frontend",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/frontend.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-14T02:46:27.529258Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:8694bf858d3af37777839821928bac57830f6dc9aca049aa026577d679bb5dee",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-14T02:46:27.775991Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:8694bf858d3af37777839821928bac57830f6dc9aca049aa026577d679bb5dee",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-14T02:46:27.813635Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:8694bf858d3af37777839821928bac57830f6dc9aca049aa026577d679bb5dee",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-14T02:49:21.108739Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:8694bf858d3af37777839821928bac57830f6dc9aca049aa026577d679bb5dee",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-14T02:50:18.486898Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:8694bf858d3af37777839821928bac57830f6dc9aca049aa026577d679bb5dee",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-14T02:50:19.156493Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:8694bf858d3af37777839821928bac57830f6dc9aca049aa026577d679bb5dee",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
     }
   ],
   "check_na": [],
   "commit": {
-    "sha": "010bf6f56c626ba5b6ff8aa7ad6ae94c3fb4d387",
+    "sha": "a6a10708bbca4be002ce91e5b91661611ea625bd",
     "shas": [
-      "010bf6f56c626ba5b6ff8aa7ad6ae94c3fb4d387"
+      "a6a10708bbca4be002ce91e5b91661611ea625bd"
     ],
     "trailers": []
   },
@@ -535,6 +847,298 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-06-14T02:46:00.695034Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/io/_unified_dispatch.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/io/_unified_dispatch.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/io/capabilities.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/io/capabilities.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/registry/__init__.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/registry/__init__.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T02:46:00.752685Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T02:46:00.808242Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T02:46:00.865402Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T02:46:00.928540Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T02:46:00.987183Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T02:46:01.044361Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T02:46:01.106287Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T02:46:01.155446Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T02:46:01.212377Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T02:50:19.289351Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/io/_unified_dispatch.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/io/_unified_dispatch.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/io/capabilities.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/io/capabilities.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/registry/__init__.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/registry/__init__.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T02:50:19.356251Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T02:50:19.410072Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T02:50:19.463910Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T02:50:19.524981Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T02:50:19.581504Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T02:50:19.636005Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T02:50:19.703438Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T02:50:19.759272Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T02:50:19.833452Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -600,9 +1204,9 @@
       "tests/blocks/io/test_load_data.py",
       "tests/previewers/test_preview_registry.py"
     ],
-    "diff_fingerprint": "sha256:2b4c41b7aa400ee06cee28f01559ba913067c4a0ab33933c16e24d174aaf1c53",
+    "diff_fingerprint": "sha256:3d9f137c89668b52122f21eb39d4546cccb37617ade286a9b945fe7fc29a1204",
     "head": "HEAD",
-    "head_sha": "010bf6f5",
+    "head_sha": "a6a10708",
     "surfaces": {
       "docs": 0,
       "frontend": 27,
@@ -654,6 +1258,22 @@
       "unsatisfied": [
         "tests.changed_test_required"
       ]
+    },
+    {
+      "at": "2026-06-14T02:46:01.212405Z",
+      "diff_fingerprint": "sha256:3d9f137c89668b52122f21eb39d4546cccb37617ade286a9b945fe7fc29a1204",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-14T02:50:19.833490Z",
+      "diff_fingerprint": "sha256:3d9f137c89668b52122f21eb39d4546cccb37617ade286a9b945fe7fc29a1204",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
     }
   ],
   "record_id": "1655-hotfix-plugin-discovery-visibility",
@@ -666,12 +1286,19 @@
     }
   ],
   "required_obligations": {
-    "admin_labels": [],
+    "admin_labels": [
+      "admin-approved:core-change"
+    ],
     "checks": [
+      "architecture_tests",
+      "deferral_discipline",
       "format_check",
+      "frontend",
       "full_audit",
       "import_contracts",
       "lint_format",
+      "python_tests",
+      "semantic_dup",
       "type_check"
     ],
     "docs": [
@@ -746,7 +1373,7 @@
     }
   ],
   "session_id": "9b4f1327-8839-4e18-8009-5358f3843056",
-  "strictness_tier": 2,
+  "strictness_tier": 1,
   "task_kind": "hotfix",
   "test_events": [
     {

--- a/frontend/src/App.parts/useProjectActions.ts
+++ b/frontend/src/App.parts/useProjectActions.ts
@@ -220,10 +220,7 @@ interface FileActionDeps {
   openFileTab: ProjectActionsDeps["openFileTab"];
 }
 
-function useFileActions({
-  currentProject,
-  openFileTab,
-}: FileActionDeps) {
+function useFileActions({ currentProject, openFileTab }: FileActionDeps) {
   /** ADR-036 §3.7 / §3.12 (I36c) — "New custom block". */
   const createNewCustomBlock = useCallback(async () => {
     if (!currentProject) return;
@@ -307,14 +304,8 @@ function useFileActions({
 }
 
 export function useProjectActions(deps: ProjectActionsDeps): ProjectActions {
-  const {
-    currentProject,
-    openTab,
-    openFileTab,
-    resetExecution,
-    setCurrentProject,
-    setLastError,
-  } = deps;
+  const { currentProject, openTab, openFileTab, resetExecution, setCurrentProject, setLastError } =
+    deps;
 
   const { loadWorkflowForProject, loadWorkflowById } = useWorkflowLoaders({
     openTab,

--- a/frontend/src/App.parts/useProjectActions.ts
+++ b/frontend/src/App.parts/useProjectActions.ts
@@ -220,7 +220,10 @@ interface FileActionDeps {
   openFileTab: ProjectActionsDeps["openFileTab"];
 }
 
-function useFileActions({ currentProject, openFileTab }: FileActionDeps) {
+function useFileActions({
+  currentProject,
+  openFileTab,
+}: FileActionDeps) {
   /** ADR-036 §3.7 / §3.12 (I36c) — "New custom block". */
   const createNewCustomBlock = useCallback(async () => {
     if (!currentProject) return;
@@ -304,8 +307,14 @@ function useFileActions({ currentProject, openFileTab }: FileActionDeps) {
 }
 
 export function useProjectActions(deps: ProjectActionsDeps): ProjectActions {
-  const { currentProject, openTab, openFileTab, resetExecution, setCurrentProject, setLastError } =
-    deps;
+  const {
+    currentProject,
+    openTab,
+    openFileTab,
+    resetExecution,
+    setCurrentProject,
+    setLastError,
+  } = deps;
 
   const { loadWorkflowForProject, loadWorkflowById } = useWorkflowLoaders({
     openTab,
@@ -318,7 +327,10 @@ export function useProjectActions(deps: ProjectActionsDeps): ProjectActions {
     loadWorkflowForProject,
   });
 
-  const { createNewCustomBlock, createNewNote } = useFileActions({ currentProject, openFileTab });
+  const { createNewCustomBlock, createNewNote } = useFileActions({
+    currentProject,
+    openFileTab,
+  });
 
   const newWorkflow = useCallback(() => {
     const name = window.prompt("Workflow name:", "Untitled");

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -43,6 +43,7 @@ import { useWorkflowExecutionActions } from "./App.parts/useWorkflowExecutionAct
 import { useWorkflowSync } from "./App.parts/useWorkflowSync";
 
 import { ProjectDialog } from "./components/ProjectDialog";
+import { NewPlotDialog } from "./components/NewPlotDialog";
 import { Toolbar } from "./components/Toolbar";
 import { WelcomeScreen } from "./components/WelcomeScreen";
 import { TooltipProvider } from "./components/ui/tooltip";
@@ -114,6 +115,7 @@ export default function App() {
   const toggleMinimap = useAppStore((state) => state.toggleMinimap);
   const setPanelSize = useAppStore((state) => state.setPanelSize);
   const setLastError = useAppStore((state) => state.setLastError);
+  const bumpProjectTreeRefresh = useAppStore((state) => state.bumpProjectTreeRefresh);
 
   const blocks = useAppStore((state) => state.blocks);
   const blockSchemas = useAppStore((state) => state.blockSchemas);
@@ -143,6 +145,7 @@ export default function App() {
 
   const [busy, setBusy] = useState(false);
   const [leftTab, setLeftTab] = useState<"blocks" | "project">("blocks");
+  const [newPlotDialogOpen, setNewPlotDialogOpen] = useState(false);
 
   // Bottom-panel imperative controls + cross-component callbacks.
   const {
@@ -354,6 +357,13 @@ export default function App() {
                   }
                 : undefined
             }
+            onNewPlot={
+              currentProject
+                ? () => {
+                    setNewPlotDialogOpen(true);
+                  }
+                : undefined
+            }
             onViewSource={currentProject && workflowId ? handleViewSource : undefined}
             onSave={handleSave}
             onSaveAs={() => void saveWorkflowAs()}
@@ -458,6 +468,19 @@ export default function App() {
             open={projectDialogOpen}
             path={projectDialog.path}
             recentProjects={recentProjects}
+          />
+
+          <NewPlotDialog
+            onClose={() => setNewPlotDialogOpen(false)}
+            onCreated={(created) => {
+              bumpProjectTreeRefresh();
+              openFileTab(created.script_path);
+              setLastError(created.warnings.length > 0 ? created.warnings.join("\n") : null);
+            }}
+            open={Boolean(currentProject && newPlotDialogOpen)}
+            saveWorkflow={saveWorkflow}
+            selectedNodeId={selectedNodeId}
+            workflowId={workflowId}
           />
 
           {/* #591/#594: Interactive block modals. */}

--- a/frontend/src/components/CodeEditor.parts/plotCompletions.test.ts
+++ b/frontend/src/components/CodeEditor.parts/plotCompletions.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import { isPlotRenderFilePath, suggestPlotContextCompletions } from "./plotCompletions";
+
+describe("plotCompletions", () => {
+  it("detects plot render files only", () => {
+    expect(isPlotRenderFilePath("plots/qc/render.py")).toBe(true);
+    expect(isPlotRenderFilePath("plots/qc/render.R")).toBe(true);
+    expect(isPlotRenderFilePath("blocks/render.py")).toBe(false);
+    expect(isPlotRenderFilePath("plots/qc/helper.py")).toBe(false);
+  });
+
+  it("suggests Python context helpers for plot render scripts", () => {
+    const suggestions = suggestPlotContextCompletions({
+      language: "python",
+      filePath: "plots/qc/render.py",
+      linePrefix: "    context.",
+    }).map((item) => item.label);
+    expect(suggestions).toEqual(
+      expect.arrayContaining(["to_dataframe", "items", "plt", "save_figure", "save_plot"]),
+    );
+  });
+
+  it("suggests R context helpers for plot render scripts", () => {
+    const suggestions = suggestPlotContextCompletions({
+      language: "r",
+      filePath: "plots/qc/render.R",
+      linePrefix: "  context$",
+    }).map((item) => item.label);
+    expect(suggestions).toEqual(
+      expect.arrayContaining(["to_dataframe", "save_plot", "save_figure"]),
+    );
+  });
+
+  it("does not leak plot-only helpers into ordinary scripts", () => {
+    expect(
+      suggestPlotContextCompletions({
+        language: "python",
+        filePath: "blocks/sample.py",
+        linePrefix: "context.",
+      }),
+    ).toEqual([]);
+  });
+});

--- a/frontend/src/components/CodeEditor.parts/plotCompletions.ts
+++ b/frontend/src/components/CodeEditor.parts/plotCompletions.ts
@@ -1,0 +1,238 @@
+/**
+ * SciStudio plot-render completions for Monaco.
+ *
+ * Monaco only knows generic Python/R tokens here; it cannot infer the
+ * preview-side ``context`` object that SciStudio injects into
+ * ``plots/<id>/render.py`` and ``plots/<id>/render.R``. Keep this scoped to
+ * plot render files so normal project scripts are not polluted with plot-only
+ * helpers.
+ */
+
+export interface PlotCompletionSpec {
+  label: string;
+  insertText: string;
+  detail: string;
+  documentation: string;
+  kind: "function" | "property";
+}
+
+interface MonacoPosition {
+  lineNumber: number;
+  column: number;
+}
+
+interface MonacoWordRange {
+  startColumn: number;
+  endColumn: number;
+}
+
+interface MonacoModel {
+  uri?: {
+    path?: string;
+    toString?: () => string;
+  };
+  getLineContent?: (lineNumber: number) => string;
+  getWordUntilPosition?: (position: MonacoPosition) => MonacoWordRange;
+}
+
+interface MonacoCompletionRange {
+  startLineNumber: number;
+  startColumn: number;
+  endLineNumber: number;
+  endColumn: number;
+}
+
+interface MonacoCompletionItem {
+  label: string;
+  kind: number;
+  insertText: string;
+  insertTextRules?: number;
+  detail: string;
+  documentation: string;
+  range?: MonacoCompletionRange;
+}
+
+interface MonacoCompletionProvider {
+  triggerCharacters?: string[];
+  provideCompletionItems: (
+    model: MonacoModel,
+    position: MonacoPosition,
+  ) => { suggestions: MonacoCompletionItem[] };
+}
+
+interface MonacoLanguages {
+  CompletionItemKind?: {
+    Function?: number;
+    Property?: number;
+  };
+  CompletionItemInsertTextRule?: {
+    InsertAsSnippet?: number;
+  };
+  registerCompletionItemProvider?: (
+    language: string,
+    provider: MonacoCompletionProvider,
+  ) => { dispose: () => void };
+}
+
+interface MonacoNamespace {
+  languages?: MonacoLanguages;
+  __scistudioPlotCompletionsRegistered?: boolean;
+}
+
+const PYTHON_CONTEXT_COMPLETIONS: PlotCompletionSpec[] = [
+  {
+    label: "to_dataframe",
+    insertText: "to_dataframe(collection, max_rows=${1:10000})",
+    detail: "SciStudio plot helper",
+    documentation: "Return a bounded pandas DataFrame from the bound input collection.",
+    kind: "function",
+  },
+  {
+    label: "items",
+    insertText: "items(collection, max_items=${1:5})",
+    detail: "SciStudio plot helper",
+    documentation: "Iterate over a bounded list of input data references.",
+    kind: "function",
+  },
+  {
+    label: "plt",
+    insertText: "plt",
+    detail: "SciStudio plot helper",
+    documentation: "matplotlib.pyplot configured with the non-interactive Agg backend.",
+    kind: "property",
+  },
+  {
+    label: "save_figure",
+    insertText: 'save_figure(${1:fig}, "${2:figure.svg}")',
+    detail: "SciStudio plot helper",
+    documentation: "Save a matplotlib figure as PNG, JPEG, SVG, or PDF and return the path.",
+    kind: "function",
+  },
+  {
+    label: "save_plot",
+    insertText: 'save_plot(${1:fig}, "${2:figure.svg}")',
+    detail: "SciStudio plot helper",
+    documentation: "Alias for save_figure, matching the R helper name.",
+    kind: "function",
+  },
+];
+
+const R_CONTEXT_COMPLETIONS: PlotCompletionSpec[] = [
+  {
+    label: "to_dataframe",
+    insertText: "to_dataframe(collection, max_rows = ${1:10000})",
+    detail: "SciStudio plot helper",
+    documentation: "Return a bounded data.frame from the bound input collection.",
+    kind: "function",
+  },
+  {
+    label: "save_plot",
+    insertText: 'save_plot(${1:p}, "${2:figure.pdf}")',
+    detail: "SciStudio plot helper",
+    documentation: "Save a ggplot, grob, or base-R plot as PNG, JPEG, SVG, or PDF.",
+    kind: "function",
+  },
+  {
+    label: "save_figure",
+    insertText: 'save_figure(${1:p}, "${2:figure.svg}")',
+    detail: "SciStudio plot helper",
+    documentation: "Alias for save_plot, matching the Python helper name.",
+    kind: "function",
+  },
+];
+
+export function isPlotRenderFilePath(filePath: string): boolean {
+  const normalized = filePath.replace(/\\/g, "/").split(/[?#]/, 1)[0].toLowerCase();
+  return /(?:^|\/)plots\/[^/]+\/render\.(py|r)$/.test(normalized);
+}
+
+export function suggestPlotContextCompletions(args: {
+  language: string;
+  filePath: string;
+  linePrefix: string;
+}): PlotCompletionSpec[] {
+  if (!isPlotRenderFilePath(args.filePath)) return [];
+  if (args.language === "python") {
+    return /\bcontext\.[A-Za-z_][A-Za-z0-9_]*$|\bcontext\.$/.test(args.linePrefix)
+      ? PYTHON_CONTEXT_COMPLETIONS
+      : [];
+  }
+  if (args.language === "r") {
+    return /\bcontext\$[A-Za-z_.][A-Za-z0-9_.]*$|\bcontext\$$/.test(args.linePrefix)
+      ? R_CONTEXT_COMPLETIONS
+      : [];
+  }
+  return [];
+}
+
+export function registerPlotCompletions(monaco: MonacoNamespace): void {
+  if (monaco.__scistudioPlotCompletionsRegistered) return;
+  const register = monaco.languages?.registerCompletionItemProvider;
+  if (!register) return;
+
+  register("python", buildProvider(monaco, "python", ["."]));
+  register("r", buildProvider(monaco, "r", ["$"]));
+  monaco.__scistudioPlotCompletionsRegistered = true;
+}
+
+function buildProvider(
+  monaco: MonacoNamespace,
+  language: "python" | "r",
+  triggerCharacters: string[],
+): MonacoCompletionProvider {
+  return {
+    triggerCharacters,
+    provideCompletionItems(model, position) {
+      const filePath = modelPath(model);
+      const linePrefix = (model.getLineContent?.(position.lineNumber) ?? "").slice(
+        0,
+        Math.max(0, position.column - 1),
+      );
+      const suggestions = suggestPlotContextCompletions({ language, filePath, linePrefix });
+      const range = completionRange(model, position);
+      return {
+        suggestions: suggestions.map((spec) => toMonacoCompletion(monaco, spec, range)),
+      };
+    },
+  };
+}
+
+function modelPath(model: MonacoModel): string {
+  const uri = model.uri;
+  if (!uri) return "";
+  if (typeof uri.path === "string" && uri.path.length > 0) return uri.path;
+  const text = uri.toString?.();
+  return typeof text === "string" ? text : "";
+}
+
+function completionRange(
+  model: MonacoModel,
+  position: MonacoPosition,
+): MonacoCompletionRange | undefined {
+  const word = model.getWordUntilPosition?.(position);
+  if (!word) return undefined;
+  return {
+    startLineNumber: position.lineNumber,
+    startColumn: word.startColumn,
+    endLineNumber: position.lineNumber,
+    endColumn: word.endColumn,
+  };
+}
+
+function toMonacoCompletion(
+  monaco: MonacoNamespace,
+  spec: PlotCompletionSpec,
+  range: MonacoCompletionRange | undefined,
+): MonacoCompletionItem {
+  const kinds = monaco.languages?.CompletionItemKind;
+  const snippetRule = monaco.languages?.CompletionItemInsertTextRule?.InsertAsSnippet;
+  return {
+    label: spec.label,
+    kind: spec.kind === "property" ? (kinds?.Property ?? 10) : (kinds?.Function ?? 1),
+    insertText: spec.insertText,
+    insertTextRules: snippetRule,
+    detail: spec.detail,
+    documentation: spec.documentation,
+    range,
+  };
+}

--- a/frontend/src/components/CodeEditor.tsx
+++ b/frontend/src/components/CodeEditor.tsx
@@ -28,6 +28,7 @@ import { useEffect, useRef, useState } from "react";
 
 import { useAppStore } from "../store";
 import type { FileTab } from "../store/types";
+import { registerPlotCompletions } from "./CodeEditor.parts/plotCompletions";
 import { defineSoftDarkTheme } from "./CodeEditor.parts/theme";
 import { useConflictDecorations } from "./CodeEditor.parts/useConflictDecorations";
 import { useLintMarkers } from "./CodeEditor.parts/useLintMarkers";
@@ -172,6 +173,12 @@ export function CodeEditor({ tab, onContentChange, onSave }: CodeEditorProps) {
     }
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  function handleBeforeMount(monaco: any) {
+    defineSoftDarkTheme(monaco);
+    registerPlotCompletions(monaco);
+  }
+
   // Editor onChange: forward content + schedule lint.
   function handleEditorChange(value: string | undefined) {
     const next = value ?? "";
@@ -215,7 +222,7 @@ export function CodeEditor({ tab, onContentChange, onSave }: CodeEditorProps) {
             insertSpaces: true,
             wordWrap: "off",
           }}
-          beforeMount={defineSoftDarkTheme}
+          beforeMount={handleBeforeMount}
           onMount={handleEditorMount}
           onChange={handleEditorChange}
         />

--- a/frontend/src/components/DataPreview.parts/PreviewHost.test.tsx
+++ b/frontend/src/components/DataPreview.parts/PreviewHost.test.tsx
@@ -319,6 +319,92 @@ describe("PreviewHost — dynamic manifest fallback (US2.3 / FR-022 / FR-029)", 
       params: { format: "svg" },
     });
   });
+
+  it("updates a dynamic child preview through host session.patchQuery", async () => {
+    const childManifest = {
+      previewer_id: "imaging.image.viewer",
+      module_url: "/api/previews/assets/imaging.image.viewer/viewer.js",
+      export_name: "ImageViewer",
+      api_version: "1",
+    };
+    createPreviewSession.mockResolvedValue(
+      envelope({
+        session_id: "pv-root",
+        previewer_id: "core.collection.basic",
+        kind: "collection",
+        payload: {
+          count: 1,
+          item_type: "Image",
+          items: [{ data_ref: "img-0", type_name: "Image" }],
+        },
+        resources: [
+          {
+            resource_id: "item:0",
+            kind: "child",
+            params: { index: 0, item: { data_ref: "img-0", type_name: "Image" } },
+          },
+        ],
+      }),
+    );
+    fetchMock.mockResolvedValue(
+      okJson({
+        resource_id: "item:0",
+        data: envelope({
+          session_id: "pv-child",
+          previewer_id: "imaging.image.viewer",
+          kind: "array",
+          payload: { marker: "before" },
+          frontend_manifest: childManifest,
+        }) as unknown as Record<string, unknown>,
+      }),
+    );
+    patchPreviewSession.mockResolvedValue(
+      envelope({
+        session_id: "pv-child",
+        previewer_id: "imaging.image.viewer",
+        kind: "array",
+        payload: { marker: "after" },
+        frontend_manifest: childManifest,
+      }),
+    );
+
+    const capturedHosts: PreviewHostApi[] = [];
+    const update = vi.fn((next: PreviewEnvelope) => {
+      screen.getByTestId("preview-host-dynamic-mount").textContent = String(next.payload.marker);
+    });
+    const mount = vi.fn((container: HTMLElement, host: PreviewHostApi) => {
+      capturedHosts.push(host);
+      container.textContent = String(host.envelope.payload.marker);
+      return { update, unmount: vi.fn() };
+    });
+    const fakeImporter = vi.fn(async () => ({ ImageViewer: { apiVersion: "1", mount } }));
+
+    render(
+      <PreviewHost
+        target={{ ...TARGET, kind: "collection_ref", collection_item_type: "Image" }}
+        importer={fakeImporter}
+      />,
+    );
+
+    expect(await screen.findByTestId("core-collection-viewer")).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId("collection-item-0"));
+
+    await waitFor(() => expect(mount).toHaveBeenCalledTimes(1));
+    expect(screen.getByTestId("preview-host-dynamic-mount")).toHaveTextContent("before");
+
+    const host = capturedHosts[capturedHosts.length - 1];
+    if (!host) throw new Error("host API was not captured");
+    await host.session.patchQuery({ axis_indices: { "0": 2 } });
+
+    await waitFor(() =>
+      expect(patchPreviewSession).toHaveBeenCalledWith("pv-child", {
+        axis_indices: { "0": 2 },
+      }),
+    );
+    await waitFor(() => expect(update).toHaveBeenCalledTimes(1));
+    expect(mount).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId("preview-host-dynamic-mount")).toHaveTextContent("after");
+  });
 });
 
 describe("PreviewHost — collection + child routing (US4)", () => {
@@ -380,6 +466,99 @@ describe("PreviewHost — collection + child routing (US4)", () => {
     expect(await screen.findByTestId("core-array-viewer")).toBeInTheDocument();
     expect(screen.getByTestId("preview-host-back")).toBeInTheDocument();
   });
+
+  it("patches the active child array session and updates the focused panel", async () => {
+    createPreviewSession.mockResolvedValue(
+      envelope({
+        session_id: "pv-root",
+        previewer_id: "core.collection.basic",
+        kind: "collection",
+        payload: {
+          count: 1,
+          item_type: "Array",
+          items: [{ data_ref: "array-0", type_name: "Array" }],
+        },
+        resources: [
+          {
+            resource_id: "item:0",
+            kind: "child",
+            params: { index: 0, item: { data_ref: "array-0", type_name: "Array" } },
+          },
+        ],
+      }),
+    );
+    fetchMock.mockResolvedValue(
+      okJson({
+        resource_id: "item:0",
+        data: envelope({
+          session_id: "pv-child",
+          previewer_id: "core.array.basic",
+          kind: "array",
+          payload: {
+            shape: [4, 6, 2, 2],
+            dtype: "float32",
+            axes: ["t", "z", "y", "x"],
+            ndim: 4,
+            matrix: [
+              [1, 2],
+              [3, 4],
+            ],
+            vmin: 1,
+            vmax: 12,
+            slice_axes: [
+              { axis: 0, name: "t", size: 4, index: 1 },
+              { axis: 1, name: "z", size: 6, index: 2 },
+            ],
+          },
+        }) as unknown as Record<string, unknown>,
+      }),
+    );
+    patchPreviewSession.mockResolvedValue(
+      envelope({
+        session_id: "pv-child",
+        previewer_id: "core.array.basic",
+        kind: "array",
+        payload: {
+          shape: [4, 6, 2, 2],
+          dtype: "float32",
+          axes: ["t", "z", "y", "x"],
+          ndim: 4,
+          matrix: [
+            [9, 10],
+            [11, 12],
+          ],
+          vmin: 1,
+          vmax: 12,
+          slice_axes: [
+            { axis: 0, name: "t", size: 4, index: 1 },
+            { axis: 1, name: "z", size: 6, index: 4 },
+          ],
+        },
+      }),
+    );
+
+    render(
+      <PreviewHost target={{ ...TARGET, kind: "collection_ref", collection_item_type: "Array" }} />,
+    );
+
+    expect(await screen.findByTestId("core-collection-viewer")).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId("collection-item-0"));
+
+    expect(await screen.findByTestId("core-array-viewer")).toBeInTheDocument();
+    expect(screen.getByTestId("array-cell-0-0")).toHaveTextContent("1");
+
+    fireEvent.change(screen.getByTestId("array-slice-slider-1"), { target: { value: "4" } });
+
+    await waitFor(() =>
+      expect(patchPreviewSession).toHaveBeenCalledWith("pv-child", {
+        axis_indices: { "0": 1, "1": 4 },
+      }),
+    );
+    await waitFor(() => expect(screen.getByTestId("array-cell-0-0")).toHaveTextContent("9"));
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const url = new URL(String(fetchMock.mock.calls[0][0]), "http://localhost");
+    expect(url.pathname).toBe("/api/previews/sessions/pv-root/resources/item%3A0");
+  });
 });
 
 describe("PreviewHost — plot viewer (FR-018 / FR-019)", () => {
@@ -402,6 +581,7 @@ describe("PreviewHost — plot viewer (FR-018 / FR-019)", () => {
     // Sandboxed iframe with an empty sandbox attr → no script execution.
     expect(frame.getAttribute("sandbox")).toBe("");
     expect(screen.getByTestId("plot-export-button")).toBeEnabled();
+    expect(screen.getByTestId("plot-export-button")).toHaveTextContent("Save");
     expect(screen.getByTestId("preview-diagnostics")).toHaveTextContent(/sanitized SVG/);
 
     fireEvent.click(screen.getByTestId("plot-export-button"));

--- a/frontend/src/components/DataPreview.parts/PreviewHost.tsx
+++ b/frontend/src/components/DataPreview.parts/PreviewHost.tsx
@@ -83,6 +83,16 @@ function readManifest(envelope: PreviewEnvelope | null): PreviewerManifest | und
   return undefined;
 }
 
+function manifestIdentityKey(manifest: PreviewerManifest | undefined): string | null {
+  if (!manifest) return null;
+  return [
+    manifest.previewer_id,
+    manifest.module_url,
+    manifest.export_name,
+    manifest.api_version ?? "",
+  ].join("|");
+}
+
 function cacheDataVersionFromEnvelope(envelope: PreviewEnvelope): string | number | null {
   const candidates = [
     envelope.metadata?.data_version,
@@ -172,18 +182,22 @@ export function PreviewHost({
   // -- patch query (slice/page/sort/slot) ----------------------------------
   const patchQuery = useCallback(
     async (patch: Record<string, unknown>): Promise<PreviewEnvelope> => {
-      const current = envelope;
+      const current = childStack[childStack.length - 1] ?? envelope;
       if (!current?.session_id) {
         return current ?? Promise.reject(new Error("no session"));
       }
       queryRef.current = { ...queryRef.current, ...patch };
       const next = await api.patchPreviewSession(current.session_id, patch);
-      setEnvelope(next);
-      if (target)
+      if (current.session_id === envelope?.session_id) {
+        setEnvelope(next);
+      } else {
+        setChildStack((stack) => (stack.length > 0 ? [...stack.slice(0, -1), next] : stack));
+      }
+      if (target && current.session_id === envelope?.session_id)
         cacheEnvelopeForQuery(cacheEnvelope, buildCacheKey, target, queryRef.current, next);
       return next;
     },
-    [envelope, buildCacheKey, cacheEnvelope, target],
+    [childStack, envelope, buildCacheKey, cacheEnvelope, target],
   );
 
   // -- child routing (composite slot / collection item) --------------------
@@ -264,6 +278,17 @@ export function PreviewHost({
   // The envelope currently in focus (top of the drill-down stack, else root).
   const activeEnvelope = childStack[childStack.length - 1] ?? envelope;
   const manifest = useMemo(() => readManifest(activeEnvelope), [activeEnvelope]);
+  const manifestKey = useMemo(() => manifestIdentityKey(manifest), [manifest]);
+  const dynamicMountKey =
+    manifestKey && activeEnvelope
+      ? `${manifestKey}|${activeEnvelope.session_id ?? activeEnvelope.target.ref}`
+      : null;
+  const activeEnvelopeRef = useRef<PreviewEnvelope | null>(activeEnvelope);
+  const manifestRef = useRef<PreviewerManifest | undefined>(manifest);
+  const patchQueryRef = useRef(patchQuery);
+  activeEnvelopeRef.current = activeEnvelope;
+  manifestRef.current = manifest;
+  patchQueryRef.current = patchQuery;
 
   // -- dynamic previewer mount ---------------------------------------------
   const mountRef = useRef<HTMLDivElement | null>(null);
@@ -271,74 +296,96 @@ export function PreviewHost({
   const [dynamicFailed, setDynamicFailed] = useState(false);
 
   const hostApi: PreviewHostApi | null = useMemo(() => {
-    if (!activeEnvelope || !manifest) return null;
+    const initialEnvelope = activeEnvelopeRef.current;
+    if (!initialEnvelope || !dynamicMountKey) return null;
+    const currentEnvelope = () => activeEnvelopeRef.current ?? initialEnvelope;
     const provider: PreviewProviderIdentity = {
-      previewerId: activeEnvelope.previewer_id,
+      previewerId: initialEnvelope.previewer_id,
       capabilities: [],
-      source: activeEnvelope.target.source ?? null,
+      source: initialEnvelope.target.source ?? null,
     };
     return {
       apiVersion: PREVIEWER_HOST_API_VERSION,
-      previewSessionId: activeEnvelope.session_id,
-      envelope: activeEnvelope,
-      kind: activeEnvelope.kind,
-      provider,
+      get previewSessionId() {
+        return currentEnvelope().session_id;
+      },
+      get envelope() {
+        return currentEnvelope();
+      },
+      get kind() {
+        return currentEnvelope().kind;
+      },
+      get provider() {
+        const current = currentEnvelope();
+        return {
+          ...provider,
+          previewerId: current.previewer_id,
+          source: current.target.source ?? null,
+        };
+      },
       session: {
-        refresh: async () =>
-          activeEnvelope.session_id ? api.getPreviewSession(activeEnvelope.session_id) : null,
+        refresh: async () => {
+          const sessionId = currentEnvelope().session_id;
+          return sessionId ? api.getPreviewSession(sessionId) : null;
+        },
         patchQuery: async (q) => {
-          if (!activeEnvelope.session_id) return activeEnvelope;
-          if (activeEnvelope.session_id === envelope?.session_id) return patchQuery(q);
-          return api.patchPreviewSession(activeEnvelope.session_id, q);
+          const current = currentEnvelope();
+          if (!current.session_id) return current;
+          return patchQueryRef.current(q);
         },
         getResource: async (resourceId, params) => {
-          if (!activeEnvelope.session_id) return null;
-          const resource = activeEnvelope.resources.find((r) => r.resource_id === resourceId);
+          const current = currentEnvelope();
+          if (!current.session_id) return null;
+          const resource = current.resources.find((r) => r.resource_id === resourceId);
           return (
             await fetchPreviewResource(
-              activeEnvelope.session_id,
+              current.session_id,
               resourceId,
               mergeResourceParams(resource, params),
             )
           ).data;
         },
-        resources: activeEnvelope.resources,
+        get resources() {
+          return currentEnvelope().resources;
+        },
       },
       assetUrl: (assetPath: string) =>
-        `/api/previews/assets/${encodeURIComponent(activeEnvelope.previewer_id)}/${assetPath.replace(/^\/+/, "")}`,
+        `/api/previews/assets/${encodeURIComponent(currentEnvelope().previewer_id)}/${assetPath.replace(/^\/+/, "")}`,
       exportArtifact: async (request) => {
+        const current = currentEnvelope();
         const resourceId = request?.resourceId ?? "export";
-        const resource = activeEnvelope.resources.find((r) => r.resource_id === resourceId);
+        const resource = current.resources.find((r) => r.resource_id === resourceId);
         const params = mergeResourceParams(resource, {
           ...(request?.params ?? {}),
           ...(request?.format ? { format: request.format } : {}),
         });
         await saveEnvelopeResource(
-          activeEnvelope,
+          current,
           resourceId,
           params,
-          request?.filename ?? defaultResourceFilename(activeEnvelope, params),
+          request?.filename ?? defaultResourceFilename(current, params),
         );
       },
       saveArtifact: async (request) => {
+        const current = currentEnvelope();
         const resourceId = request?.resourceId ?? "export";
-        const resource = activeEnvelope.resources.find((r) => r.resource_id === resourceId);
+        const resource = current.resources.find((r) => r.resource_id === resourceId);
         const params = mergeResourceParams(resource, {
           ...(request?.params ?? {}),
           ...(request?.format ? { format: request.format } : {}),
         });
         await saveEnvelopeResource(
-          activeEnvelope,
+          current,
           resourceId,
           params,
-          request?.filename ?? defaultResourceFilename(activeEnvelope, params),
+          request?.filename ?? defaultResourceFilename(current, params),
         );
       },
       reportError: (message: string) => {
         setHostDiagnostics((d) => [...d, message]);
       },
     };
-  }, [activeEnvelope, envelope?.session_id, manifest, patchQuery, saveEnvelopeResource]);
+  }, [dynamicMountKey, saveEnvelopeResource]);
 
   useEffect(() => {
     // Tear down any prior instance whenever the focus changes.
@@ -352,10 +399,11 @@ export function PreviewHost({
     }
     setDynamicFailed(false);
 
-    if (!manifest || !hostApi || !mountRef.current) return;
+    const currentManifest = manifestRef.current;
+    if (!currentManifest || !hostApi || !mountRef.current) return;
     let disposed = false;
     const container = mountRef.current;
-    void mountDynamicPreviewer(manifest, container, hostApi, importer).then(
+    void mountDynamicPreviewer(currentManifest, container, hostApi, importer).then(
       (result: LoadResult) => {
         if (disposed) return;
         if (result.ok) {
@@ -378,7 +426,7 @@ export function PreviewHost({
         instanceRef.current = null;
       }
     };
-  }, [manifest, hostApi, importer]);
+  }, [dynamicMountKey, hostApi, importer]);
 
   // Push new envelopes into a live dynamic instance.
   useEffect(() => {
@@ -391,7 +439,7 @@ export function PreviewHost({
   if (!target || status === "idle") {
     return (
       <div className="rounded-[1.6rem] border border-dashed border-stone-300 px-4 py-6 text-sm text-stone-500">
-        Nothing to preview.
+        Nothing to preview yet
       </div>
     );
   }

--- a/frontend/src/components/DataPreview.parts/coreViewers.test.tsx
+++ b/frontend/src/components/DataPreview.parts/coreViewers.test.tsx
@@ -19,6 +19,7 @@ import {
   ArrayHeatmapTable,
   ArrayLegend,
   ArrayViewer,
+  CollectionViewer,
   formatCell,
   heatmapColor,
 } from "./coreViewers";
@@ -31,6 +32,20 @@ function arrayEnvelope(payload: Record<string, unknown>): PreviewEnvelope {
     previewer_id: "core.array.basic",
     target: { kind: "data_ref", ref: "data-1" },
     kind: "array",
+    payload,
+    resources: [],
+    metadata: { sampled: false, truncated: false, cached: false, derived: false, complete: true },
+    diagnostics: [],
+    error: null,
+  } as unknown as PreviewEnvelope;
+}
+
+function collectionEnvelope(payload: Record<string, unknown>): PreviewEnvelope {
+  return {
+    session_id: "pv-collection",
+    previewer_id: "core.collection.basic",
+    target: { kind: "collection_ref", ref: "collection:arrays" },
+    kind: "collection",
     payload,
     resources: [],
     metadata: { sampled: false, truncated: false, cached: false, derived: false, complete: true },
@@ -204,5 +219,35 @@ describe("ArrayViewer — numeric heatmap + per-axis slice selectors", () => {
       />,
     );
     expect(screen.getByTestId("array-scalar")).toHaveTextContent("42");
+  });
+});
+
+describe("CollectionViewer", () => {
+  it("shows the source filename for parent item cards instead of the data ref", () => {
+    render(
+      <CollectionViewer
+        envelope={collectionEnvelope({
+          count: 1,
+          item_type: "Array",
+          items: [
+            {
+              data_ref: "data-2330b123456789",
+              type_name: "Array",
+              metadata: {
+                framework: {
+                  source:
+                    "C:/Users/jiazh/Desktop/workspace/Example/array/random_10x30x30x30_float32.npy",
+                },
+              },
+            },
+          ],
+        })}
+      />,
+    );
+
+    expect(screen.getByTestId("collection-item-0")).toHaveTextContent(
+      "random_10x30x30x30_float32.npy",
+    );
+    expect(screen.queryByText("data-2330b123456789")).toBeNull();
   });
 });

--- a/frontend/src/components/DataPreview.parts/coreViewers.tsx
+++ b/frontend/src/components/DataPreview.parts/coreViewers.tsx
@@ -24,6 +24,7 @@ import Plot from "react-plotly.js";
 
 import type { EnvelopeKind, PreviewEnvelope, PreviewResource } from "../../types/api";
 
+import { deriveDisplayName } from "./refEntries";
 import { TableViewer, type TableViewerInitial } from "./TableViewer";
 
 // ---------------------------------------------------------------------------
@@ -719,6 +720,7 @@ export function CollectionViewer({
         {items.map((item, idx) => {
           const resource = itemResources[idx];
           const ref = asString(item.data_ref ?? item.ref, `item ${idx}`);
+          const displayName = deriveDisplayName(ref, item);
           return (
             <button
               key={idx}
@@ -727,7 +729,9 @@ export function CollectionViewer({
               onClick={() => (resource && onOpenResource ? onOpenResource(resource) : undefined)}
               className="rounded-2xl border border-stone-200 bg-white px-3 py-2 text-left text-xs hover:bg-stone-50"
             >
-              <span className="block truncate text-ink">{ref}</span>
+              <span className="block truncate text-ink" title={ref}>
+                {displayName}
+              </span>
               <span className="text-stone-400">{asString(item.type_name, itemType)}</span>
             </button>
           );
@@ -794,12 +798,12 @@ export function PlotViewer({
         <button
           type="button"
           data-testid="plot-export-button"
-          aria-label={`Export plot as ${format || "file"}`}
+          aria-label={`Save plot as ${format || "file"}`}
           disabled={!exportResource}
           onClick={() => (exportResource && onExport ? onExport(exportResource) : undefined)}
           className="ml-auto rounded border border-stone-300 bg-white px-3 py-0.5 disabled:opacity-50"
         >
-          Export / Save
+          Save
         </button>
       </div>
       <MetadataBadges envelope={envelope} />

--- a/frontend/src/components/DataPreview.parts/refEntries.ts
+++ b/frontend/src/components/DataPreview.parts/refEntries.ts
@@ -27,7 +27,7 @@ function basename(p: string): string {
   return parts[parts.length - 1] || trimmed;
 }
 
-function deriveDisplayName(ref: string, dataItem: Record<string, unknown>): string {
+export function deriveDisplayName(ref: string, dataItem: Record<string, unknown>): string {
   const md = dataItem.metadata;
   if (md && typeof md === "object") {
     const mdRec = md as Record<string, unknown>;

--- a/frontend/src/components/DataPreview.test.tsx
+++ b/frontend/src/components/DataPreview.test.tsx
@@ -89,7 +89,8 @@ describe("DataPreview", () => {
         selectedNodeLabel="Empty Block"
       />,
     );
-    expect(screen.getByText(/no previewable outputs/i)).toBeInTheDocument();
+    expect(screen.queryByText(/no previewable outputs/i)).not.toBeInTheDocument();
+    expect(screen.getAllByText("Nothing to preview yet")).toHaveLength(1);
   });
 
   it("mounts the routed PreviewHost for the active output ref (#1592)", async () => {

--- a/frontend/src/components/DataPreview.tsx
+++ b/frontend/src/components/DataPreview.tsx
@@ -193,11 +193,7 @@ export function DataPreview({
         </div>
       ) : (
         <>
-          {outputEntryIds.length === 0 ? (
-            <div className="mt-6 rounded-[1.8rem] border border-dashed border-stone-300 px-4 py-6 text-sm text-stone-500">
-              This block has no previewable outputs yet.
-            </div>
-          ) : (
+          {outputEntryIds.length > 0 ? (
             <div className="mt-5 flex flex-wrap gap-2">
               {refEntries.map((entry) => (
                 <button
@@ -225,7 +221,7 @@ export function DataPreview({
                 </button>
               ) : null}
             </div>
-          )}
+          ) : null}
           {availablePlots.length > 0 || plotLoading || plotListError ? (
             <div className="mt-3 flex flex-wrap items-center gap-2">
               {plotLoading ? (

--- a/frontend/src/components/NewPlotDialog.test.tsx
+++ b/frontend/src/components/NewPlotDialog.test.tsx
@@ -1,0 +1,146 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { PlotTargetItem } from "../types/api";
+
+const listPlotTargets = vi.fn();
+const createPlot = vi.fn();
+
+vi.mock("../lib/api", () => ({
+  api: {
+    listPlotTargets: (...args: unknown[]) => listPlotTargets(...args),
+    createPlot: (...args: unknown[]) => createPlot(...args),
+  },
+}));
+
+import { NewPlotDialog } from "./NewPlotDialog";
+
+function target(overrides: Partial<PlotTargetItem>): PlotTargetItem {
+  return {
+    target_id: "target-a",
+    workflow_path: "workflows/main.yaml",
+    workflow_id: "main",
+    node_id: "node_a",
+    node_label: "Node A",
+    block_type: "demo.block",
+    output_port: "out",
+    output_type: "DataFrame",
+    is_collection: false,
+    latest_run_id: "run-1",
+    latest_output_available: true,
+    diagnostics: [],
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  listPlotTargets.mockReset();
+  createPlot.mockReset();
+});
+
+afterEach(cleanup);
+
+describe("NewPlotDialog", () => {
+  it("defaults to the selected node target and can create an R plot", async () => {
+    const saveWorkflow = vi.fn(async () => undefined);
+    const onClose = vi.fn();
+    const onCreated = vi.fn();
+    const selectedTarget = target({
+      target_id: "target-b",
+      node_id: "node_b",
+      node_label: "Selected Node",
+      output_port: "measurements",
+    });
+    listPlotTargets.mockResolvedValue({
+      count: 2,
+      targets: [
+        target({ target_id: "target-a", node_id: "node_a", node_label: "Other Node" }),
+        selectedTarget,
+      ],
+    });
+    createPlot.mockResolvedValue({
+      plot_id: "QC_Plot",
+      manifest_path: "plots/QC_Plot/plot.yaml",
+      script_path: "plots/QC_Plot/render.R",
+      bytes_written: 100,
+      warnings: [],
+      target: selectedTarget,
+    });
+
+    render(
+      <NewPlotDialog
+        onClose={onClose}
+        onCreated={onCreated}
+        open
+        saveWorkflow={saveWorkflow}
+        selectedNodeId="node_b"
+        workflowId="main"
+      />,
+    );
+
+    await waitFor(() =>
+      expect(listPlotTargets).toHaveBeenCalledWith({
+        workflowId: "main",
+        includeUnavailable: true,
+      }),
+    );
+    expect(saveWorkflow).toHaveBeenCalledTimes(1);
+    expect(screen.getByLabelText("Bind to")).toHaveValue("target-b");
+
+    fireEvent.change(screen.getByLabelText("Name"), { target: { value: "QC Plot" } });
+    fireEvent.change(screen.getByLabelText("Language"), { target: { value: "r" } });
+    fireEvent.click(screen.getByText("Create"));
+
+    await waitFor(() =>
+      expect(createPlot).toHaveBeenCalledWith({
+        plot_id: "QC_Plot",
+        target_id: "target-b",
+        title: "QC Plot",
+        language: "r",
+      }),
+    );
+    expect(onCreated).toHaveBeenCalledWith(
+      expect.objectContaining({ script_path: "plots/QC_Plot/render.R" }),
+    );
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not reset fields when the parent rerenders with a new save callback", async () => {
+    const firstSaveWorkflow = vi.fn(async () => undefined);
+    const secondSaveWorkflow = vi.fn(async () => undefined);
+    const selectedTarget = target({ target_id: "target-b", node_id: "node_b" });
+    listPlotTargets.mockResolvedValue({ count: 1, targets: [selectedTarget] });
+
+    const { rerender } = render(
+      <NewPlotDialog
+        onClose={vi.fn()}
+        onCreated={vi.fn()}
+        open
+        saveWorkflow={firstSaveWorkflow}
+        selectedNodeId="node_b"
+        workflowId="main"
+      />,
+    );
+
+    await waitFor(() => expect(screen.getByLabelText("Bind to")).toHaveValue("target-b"));
+    fireEvent.change(screen.getByLabelText("Name"), { target: { value: "edited plot" } });
+    fireEvent.change(screen.getByLabelText("Language"), { target: { value: "r" } });
+
+    rerender(
+      <NewPlotDialog
+        onClose={vi.fn()}
+        onCreated={vi.fn()}
+        open
+        saveWorkflow={secondSaveWorkflow}
+        selectedNodeId="node_b"
+        workflowId="main"
+      />,
+    );
+
+    expect(screen.getByLabelText("Name")).toHaveValue("edited plot");
+    expect(screen.getByLabelText("Language")).toHaveValue("r");
+    expect(screen.getByLabelText("Bind to")).toHaveValue("target-b");
+    expect(listPlotTargets).toHaveBeenCalledTimes(1);
+    expect(secondSaveWorkflow).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/NewPlotDialog.tsx
+++ b/frontend/src/components/NewPlotDialog.tsx
@@ -194,7 +194,9 @@ export function NewPlotDialog({
               value={targetId}
             >
               {loading ? <option value="">Loading...</option> : null}
-              {!loading && orderedTargets.length === 0 ? <option value="">No outputs</option> : null}
+              {!loading && orderedTargets.length === 0 ? (
+                <option value="">No outputs</option>
+              ) : null}
               {orderedTargets.map((target) => (
                 <option key={target.target_id} value={target.target_id}>
                   {describePlotTarget(target)}

--- a/frontend/src/components/NewPlotDialog.tsx
+++ b/frontend/src/components/NewPlotDialog.tsx
@@ -1,0 +1,229 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+
+import { api } from "../lib/api";
+import type { PlotCreateResponse, PlotLanguage, PlotTargetItem } from "../types/api";
+
+interface NewPlotDialogProps {
+  open: boolean;
+  workflowId?: string | null;
+  selectedNodeId?: string | null;
+  saveWorkflow?: () => Promise<void>;
+  onClose: () => void;
+  onCreated: (created: PlotCreateResponse) => void;
+}
+
+function slugifyPlotId(raw: string): string {
+  return raw
+    .trim()
+    .replace(/\s+/g, "_")
+    .replace(/[^A-Za-z0-9_-]/g, "_")
+    .replace(/_+/g, "_")
+    .replace(/^[^A-Za-z0-9]+/, "")
+    .slice(0, 64);
+}
+
+function describePlotTarget(target: PlotTargetItem): string {
+  const nodeLabel = target.node_label || target.node_id;
+  const workflowLabel = target.workflow_id || target.workflow_path;
+  const typeLabel = target.output_type ? ` (${target.output_type})` : "";
+  const pendingLabel = target.latest_output_available ? "" : " [run workflow first]";
+  return `${nodeLabel} / ${target.output_port}${typeLabel} - ${workflowLabel}${pendingLabel}`;
+}
+
+function orderedPlotTargets(targets: PlotTargetItem[], selectedNodeId?: string | null) {
+  return [...targets].sort((a, b) => {
+    const aSelected = selectedNodeId && a.node_id === selectedNodeId ? 0 : 1;
+    const bSelected = selectedNodeId && b.node_id === selectedNodeId ? 0 : 1;
+    if (aSelected !== bSelected) return aSelected - bSelected;
+    return describePlotTarget(a).localeCompare(describePlotTarget(b));
+  });
+}
+
+export function NewPlotDialog({
+  open,
+  workflowId,
+  selectedNodeId,
+  saveWorkflow,
+  onClose,
+  onCreated,
+}: NewPlotDialogProps) {
+  const [title, setTitle] = useState("my_plot");
+  const [language, setLanguage] = useState<PlotLanguage>("python");
+  const [targets, setTargets] = useState<PlotTargetItem[]>([]);
+  const [targetId, setTargetId] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const saveWorkflowRef = useRef(saveWorkflow);
+
+  useEffect(() => {
+    saveWorkflowRef.current = saveWorkflow;
+  }, [saveWorkflow]);
+
+  const orderedTargets = useMemo(
+    () => orderedPlotTargets(targets, selectedNodeId),
+    [selectedNodeId, targets],
+  );
+
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    setTitle("my_plot");
+    setLanguage("python");
+    setTargetId("");
+    setError(null);
+    setLoading(true);
+
+    async function loadTargets() {
+      try {
+        if (workflowId && saveWorkflowRef.current) {
+          await saveWorkflowRef.current();
+        }
+        const response = await api.listPlotTargets({
+          workflowId,
+          includeUnavailable: true,
+        });
+        if (cancelled) return;
+        const ordered = orderedPlotTargets(response.targets, selectedNodeId);
+        setTargets(response.targets);
+        const selected =
+          ordered.find((target) => selectedNodeId && target.node_id === selectedNodeId) ??
+          ordered[0];
+        setTargetId(selected?.target_id ?? "");
+        if (ordered.length === 0) {
+          setError("No block outputs are available to bind this plot.");
+        }
+      } catch (err) {
+        if (!cancelled) setError(err instanceof Error ? err.message : String(err));
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+
+    void loadTargets();
+    return () => {
+      cancelled = true;
+    };
+  }, [open, selectedNodeId, workflowId]);
+
+  if (!open) return null;
+
+  async function handleSubmit() {
+    const trimmed = title.trim();
+    const plotId = slugifyPlotId(trimmed);
+    if (!trimmed) {
+      setError("Plot name must not be empty.");
+      return;
+    }
+    if (!plotId) {
+      setError("Plot name must start with a letter or digit.");
+      return;
+    }
+    if (!targetId) {
+      setError("Choose a block output.");
+      return;
+    }
+    setSubmitting(true);
+    setError(null);
+    try {
+      const created = await api.createPlot({
+        plot_id: plotId,
+        target_id: targetId,
+        title: trimmed,
+        language,
+      });
+      onCreated(created);
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-stone-950/55 p-4 backdrop-blur-sm">
+      <div
+        aria-modal="true"
+        role="dialog"
+        className="w-full max-w-xl rounded-[1.5rem] border border-stone-200 bg-stone-50 p-6 shadow-panel"
+      >
+        <div className="mb-5 flex items-start justify-between gap-4">
+          <div>
+            <p className="text-xs uppercase tracking-[0.35em] text-stone-500">Plots</p>
+            <h2 className="mt-2 font-display text-2xl text-ink">New plot</h2>
+          </div>
+          <button
+            className="rounded-full border border-stone-300 px-3 py-1 text-sm"
+            onClick={onClose}
+            type="button"
+          >
+            Close
+          </button>
+        </div>
+
+        <div className="space-y-4">
+          <label className="block text-sm font-medium text-stone-700">
+            Name
+            <input
+              autoFocus
+              className="mt-1 w-full rounded-xl border border-stone-300 bg-white px-3 py-2 text-sm outline-none focus:border-ink"
+              onChange={(event) => setTitle(event.currentTarget.value)}
+              value={title}
+            />
+          </label>
+
+          <label className="block text-sm font-medium text-stone-700">
+            Language
+            <select
+              className="mt-1 w-full rounded-xl border border-stone-300 bg-white px-3 py-2 text-sm outline-none focus:border-ink"
+              onChange={(event) => setLanguage(event.currentTarget.value as PlotLanguage)}
+              value={language}
+            >
+              <option value="python">Python</option>
+              <option value="r">R</option>
+            </select>
+          </label>
+
+          <label className="block text-sm font-medium text-stone-700">
+            Bind to
+            <select
+              className="mt-1 w-full rounded-xl border border-stone-300 bg-white px-3 py-2 text-sm outline-none focus:border-ink disabled:bg-stone-100"
+              disabled={loading || orderedTargets.length === 0}
+              onChange={(event) => setTargetId(event.currentTarget.value)}
+              value={targetId}
+            >
+              {loading ? <option value="">Loading...</option> : null}
+              {!loading && orderedTargets.length === 0 ? <option value="">No outputs</option> : null}
+              {orderedTargets.map((target) => (
+                <option key={target.target_id} value={target.target_id}>
+                  {describePlotTarget(target)}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+
+        {error ? <p className="mt-4 text-sm text-red-600">{error}</p> : null}
+
+        <div className="mt-6 flex justify-end gap-3">
+          <button
+            className="rounded-full border border-stone-300 px-4 py-2 text-sm"
+            onClick={onClose}
+            type="button"
+          >
+            Cancel
+          </button>
+          <button
+            className="rounded-full bg-ink px-5 py-2 text-sm font-medium text-stone-50 transition hover:bg-pine disabled:opacity-50"
+            disabled={loading || submitting || orderedTargets.length === 0}
+            onClick={() => void handleSubmit()}
+            type="button"
+          >
+            {submitting ? "Creating..." : "Create"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/ProjectTree.tsx
+++ b/frontend/src/components/ProjectTree.tsx
@@ -40,7 +40,7 @@ function formatSize(size: number | null | undefined): string {
 
 // ADR-036 §3.5 (Phase 2C / I36c): file extensions the embedded Monaco editor
 // knows how to render. Anything outside this set is ignored on double-click.
-const EDITABLE_EXTENSIONS: readonly string[] = ["py", "txt", "md", "json", "csv"];
+const EDITABLE_EXTENSIONS: readonly string[] = ["py", "r", "txt", "md", "json", "csv"];
 
 function TreeNodeRow({
   node,

--- a/frontend/src/components/Toolbar.parts/FileOperationsGroup.tsx
+++ b/frontend/src/components/Toolbar.parts/FileOperationsGroup.tsx
@@ -3,6 +3,7 @@
  * Toolbar. Extracted in #1413.
  */
 import {
+  ChartLine,
   ChevronDown,
   FileCode2,
   FilePlus2,
@@ -30,6 +31,7 @@ export interface FileOperationsGroupProps {
   onNewWorkflow: () => void;
   onNewCustomBlock?: () => void;
   onNewNote?: () => void;
+  onNewPlot?: () => void;
   onImport: () => void;
   onSave: () => void;
   onSaveAs: () => void;
@@ -41,6 +43,7 @@ export function FileOperationsGroup({
   onNewWorkflow,
   onNewCustomBlock,
   onNewNote,
+  onNewPlot,
   onImport,
   onSave,
   onSaveAs,
@@ -48,8 +51,8 @@ export function FileOperationsGroup({
   return (
     <div className="flex items-center gap-1">
       {/*
-       * ADR-036 §3.7 / §3.12 (I36c) — "New" is a constrained three-item
-       * menu: workflow / custom block / note. No "New arbitrary file" entry.
+       * ADR-036 §3.7 / §3.12 (I36c) — "New" is a constrained project-authoring
+       * menu. No "New arbitrary file" entry.
        */}
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
@@ -74,6 +77,10 @@ export function FileOperationsGroup({
           <DropdownMenuItem onClick={onNewNote} disabled={!currentProject || !onNewNote}>
             <FileText className="size-4" />
             New note
+          </DropdownMenuItem>
+          <DropdownMenuItem onClick={onNewPlot} disabled={!currentProject || !onNewPlot}>
+            <ChartLine className="size-4" />
+            New plot
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>

--- a/frontend/src/components/Toolbar.test.tsx
+++ b/frontend/src/components/Toolbar.test.tsx
@@ -114,16 +114,18 @@ describe("Toolbar — ADR-036 §3.7/§3.12 New menu (I36c)", () => {
     });
   }
 
-  it('clicking "New" opens a menu with workflow / custom block / note', async () => {
+  it('clicking "New" opens a menu with workflow / custom block / note / plot', async () => {
     const onNewWorkflow = vi.fn();
     const onNewCustomBlock = vi.fn();
     const onNewNote = vi.fn();
+    const onNewPlot = vi.fn();
     const user = makeUser();
-    render(<Toolbar {...makeProps({ onNewWorkflow, onNewCustomBlock, onNewNote })} />);
+    render(<Toolbar {...makeProps({ onNewWorkflow, onNewCustomBlock, onNewNote, onNewPlot })} />);
     await user.click(screen.getByRole("button", { name: /^new$/i }));
     expect(await screen.findByRole("menuitem", { name: /new workflow/i })).toBeTruthy();
     expect(screen.getByRole("menuitem", { name: /new custom block/i })).toBeTruthy();
     expect(screen.getByRole("menuitem", { name: /new note/i })).toBeTruthy();
+    expect(screen.getByRole("menuitem", { name: /new plot/i })).toBeTruthy();
   });
 
   it('selecting "New workflow" calls onNewWorkflow', async () => {
@@ -151,6 +153,15 @@ describe("Toolbar — ADR-036 §3.7/§3.12 New menu (I36c)", () => {
     await user.click(screen.getByRole("button", { name: /^new$/i }));
     await user.click(await screen.findByRole("menuitem", { name: /new note/i }));
     expect(onNewNote).toHaveBeenCalledTimes(1);
+  });
+
+  it('selecting "New plot" calls onNewPlot', async () => {
+    const onNewPlot = vi.fn();
+    const user = makeUser();
+    render(<Toolbar {...makeProps({ onNewPlot })} />);
+    await user.click(screen.getByRole("button", { name: /^new$/i }));
+    await user.click(await screen.findByRole("menuitem", { name: /new plot/i }));
+    expect(onNewPlot).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/frontend/src/components/Toolbar.tsx
+++ b/frontend/src/components/Toolbar.tsx
@@ -41,6 +41,7 @@ interface ToolbarProps {
   onNewCustomBlock?: () => void;
   /** ADR-036 §3.7 / §3.12 — optional. */
   onNewNote?: () => void;
+  onNewPlot?: () => void;
   /** ADR-036 §3.4 — optional. Opens read-only YAML view of active workflow. */
   onViewSource?: () => void;
   onSave: () => void;
@@ -82,6 +83,7 @@ export function Toolbar(props: ToolbarProps) {
     onNewWorkflow,
     onNewCustomBlock,
     onNewNote,
+    onNewPlot,
     onViewSource,
     onSave,
     onSaveAs,
@@ -139,6 +141,7 @@ export function Toolbar(props: ToolbarProps) {
           onNewWorkflow={onNewWorkflow}
           onNewCustomBlock={onNewCustomBlock}
           onNewNote={onNewNote}
+          onNewPlot={onNewPlot}
           onImport={onImport}
           onSave={onSave}
           onSaveAs={onSaveAs}

--- a/frontend/src/components/__tests__/CodeEditor.test.tsx
+++ b/frontend/src/components/__tests__/CodeEditor.test.tsx
@@ -20,6 +20,26 @@ interface DefinedTheme {
   colors: Record<string, string>;
 }
 
+interface MockCompletionProvider {
+  triggerCharacters?: string[];
+  provideCompletionItems: (
+    model: {
+      uri?: { path?: string };
+      getLineContent?: (lineNumber: number) => string;
+      getWordUntilPosition?: (position: { lineNumber: number; column: number }) => {
+        startColumn: number;
+        endColumn: number;
+      };
+    },
+    position: { lineNumber: number; column: number },
+  ) => { suggestions: Array<{ label: string; insertText: string }> };
+}
+
+interface RegisteredCompletionProvider {
+  language: string;
+  provider: MockCompletionProvider;
+}
+
 interface MockEditorState {
   lastProps: Record<string, unknown> | null;
   // The latest mounted-editor object passed to onMount.
@@ -31,6 +51,7 @@ interface MockEditorState {
   markersByOwner: Map<string, unknown[]>;
   // Themes registered via monaco.editor.defineTheme during beforeMount.
   definedThemes: Map<string, DefinedTheme>;
+  completionProviders: RegisteredCompletionProvider[];
 }
 
 const editorState: MockEditorState = {
@@ -40,6 +61,7 @@ const editorState: MockEditorState = {
   onChangeCb: null,
   markersByOwner: new Map(),
   definedThemes: new Map(),
+  completionProviders: [],
 };
 
 class FakeMonacoEditor {
@@ -64,6 +86,14 @@ class FakeMonacoEditor {
 class FakeMonacoNamespace {
   KeyMod = { CtrlCmd: 0x800 };
   KeyCode = { KeyS: 49 };
+  languages = {
+    CompletionItemKind: { Function: 1, Property: 10 },
+    CompletionItemInsertTextRule: { InsertAsSnippet: 4 },
+    registerCompletionItemProvider: (language: string, provider: MockCompletionProvider) => {
+      editorState.completionProviders.push({ language, provider });
+      return { dispose: vi.fn() };
+    },
+  };
   editor = {
     setModelMarkers: (_model: unknown, owner: string, markers: unknown[]) => {
       editorState.markersByOwner.set(owner, markers);
@@ -133,6 +163,7 @@ beforeEach(() => {
   editorState.onChangeCb = null;
   editorState.markersByOwner.clear();
   editorState.definedThemes.clear();
+  editorState.completionProviders = [];
   fetchSpy = vi.fn().mockResolvedValue({
     ok: true,
     json: async () => ({ diagnostics: [] }),
@@ -296,5 +327,60 @@ describe("CodeEditor", () => {
     expect(theme?.inherit).toBe(true);
     // Background MUST be the soft warm gray (#282c34), not pure vs-dark #1e1e1e.
     expect(theme?.colors["editor.background"]).toBe("#282c34");
+  });
+
+  it("registers SciStudio plot context completions for Python and R render files", async () => {
+    render(
+      <CodeEditor
+        tab={makeFileTab({ filePath: "plots/qc/render.py", content: "context." })}
+        onContentChange={vi.fn()}
+        onSave={vi.fn()}
+      />,
+    );
+    await waitFor(() => expect(editorState.lastProps).not.toBeNull());
+    expect(editorState.completionProviders.map((entry) => entry.language)).toEqual([
+      "python",
+      "r",
+    ]);
+
+    const pythonProvider = editorState.completionProviders.find(
+      (entry) => entry.language === "python",
+    )?.provider;
+    expect(pythonProvider).toBeDefined();
+    const pythonResult = pythonProvider?.provideCompletionItems(
+      {
+        uri: { path: "/plots/qc/render.py" },
+        getLineContent: () => "context.",
+        getWordUntilPosition: () => ({ startColumn: 9, endColumn: 9 }),
+      },
+      { lineNumber: 1, column: 9 },
+    );
+    expect(pythonResult?.suggestions.map((item) => item.label)).toEqual(
+      expect.arrayContaining(["to_dataframe", "items", "plt", "save_figure", "save_plot"]),
+    );
+
+    const rProvider = editorState.completionProviders.find((entry) => entry.language === "r")
+      ?.provider;
+    const rResult = rProvider?.provideCompletionItems(
+      {
+        uri: { path: "/plots/qc/render.R" },
+        getLineContent: () => "context$",
+        getWordUntilPosition: () => ({ startColumn: 9, endColumn: 9 }),
+      },
+      { lineNumber: 1, column: 9 },
+    );
+    expect(rResult?.suggestions.map((item) => item.label)).toEqual(
+      expect.arrayContaining(["to_dataframe", "save_plot", "save_figure"]),
+    );
+
+    const nonPlotResult = pythonProvider?.provideCompletionItems(
+      {
+        uri: { path: "/blocks/sample.py" },
+        getLineContent: () => "context.",
+        getWordUntilPosition: () => ({ startColumn: 9, endColumn: 9 }),
+      },
+      { lineNumber: 1, column: 9 },
+    );
+    expect(nonPlotResult?.suggestions).toEqual([]);
   });
 });

--- a/frontend/src/components/__tests__/CodeEditor.test.tsx
+++ b/frontend/src/components/__tests__/CodeEditor.test.tsx
@@ -338,10 +338,7 @@ describe("CodeEditor", () => {
       />,
     );
     await waitFor(() => expect(editorState.lastProps).not.toBeNull());
-    expect(editorState.completionProviders.map((entry) => entry.language)).toEqual([
-      "python",
-      "r",
-    ]);
+    expect(editorState.completionProviders.map((entry) => entry.language)).toEqual(["python", "r"]);
 
     const pythonProvider = editorState.completionProviders.find(
       (entry) => entry.language === "python",
@@ -359,8 +356,9 @@ describe("CodeEditor", () => {
       expect.arrayContaining(["to_dataframe", "items", "plt", "save_figure", "save_plot"]),
     );
 
-    const rProvider = editorState.completionProviders.find((entry) => entry.language === "r")
-      ?.provider;
+    const rProvider = editorState.completionProviders.find(
+      (entry) => entry.language === "r",
+    )?.provider;
     const rResult = rProvider?.provideCompletionItems(
       {
         uri: { path: "/plots/qc/render.R" },

--- a/frontend/src/components/__tests__/ProjectTree.test.tsx
+++ b/frontend/src/components/__tests__/ProjectTree.test.tsx
@@ -5,7 +5,7 @@
  * action:
  *   - workflows/<name>.yaml -> onLoadWorkflow
  *   - blocks/<name>.py      -> onReloadBlocks AND store.openFileTab
- *   - <name>.{py,md,json,csv,txt} anywhere -> store.openFileTab
+ *   - <name>.{py,r,md,json,csv,txt} anywhere -> store.openFileTab
  *   - <name>.tiff (not in editable set) -> NO action
  */
 
@@ -103,6 +103,7 @@ describe("ProjectTree — ADR-036 §3.5 double-click wiring (I36c)", () => {
     ["data.json", "data.json"],
     ["table.csv", "table.csv"],
     ["readme.txt", "readme.txt"],
+    ["render.R", "render.R"],
   ])("double-click on %s opens %s in the editor", async (name, expectedPath) => {
     const openFileTab = vi.fn();
     useAppStore.setState({ openFileTab });

--- a/frontend/src/lib/api/__tests__/api-surface.test.ts
+++ b/frontend/src/lib/api/__tests__/api-surface.test.ts
@@ -44,7 +44,10 @@ const EXPECTED_API_KEYS = [
   // data — ADR-048 SPEC 2 / #1606 plot-job run + preview wiring.
   // The legacy one-shot `getDataPreview` was removed under #1604; the catalog
   // is previewed exclusively through the routed previewer session API.
+  "listPlotTargets",
+  "createPlot",
   "runPlotJob",
+  "listPlots",
   // filesystem
   "browseFilesystem",
   "revealInExplorer",

--- a/frontend/src/lib/api/__tests__/plotPreview.test.ts
+++ b/frontend/src/lib/api/__tests__/plotPreview.test.ts
@@ -92,6 +92,90 @@ describe("dataApi.runPlotJob (#1606 run route)", () => {
 });
 
 describe("dataApi plot list + preview resource save", () => {
+  it("GETs /api/plots/targets with the active workflow filter", async () => {
+    const body = {
+      targets: [
+        {
+          target_id: "tgt_1",
+          workflow_path: "workflows/main.yaml",
+          workflow_id: "main",
+          node_id: "node_a",
+          node_label: "Load",
+          block_type: "io.load",
+          output_port: "data",
+          output_type: "DataFrame",
+          is_collection: false,
+          latest_run_id: null,
+          latest_output_available: false,
+          diagnostics: [],
+        },
+      ],
+      count: 1,
+    };
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve(body),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const out = await dataApi.listPlotTargets({ workflowId: "main" });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][0]).toBe("/api/plots/targets?workflow_id=main");
+    expect(out).toEqual(body);
+    vi.unstubAllGlobals();
+  });
+
+  it("POSTs a plot scaffold request to /api/plots", async () => {
+    const body = {
+      plot_id: "my_plot",
+      manifest_path: "plots/my_plot/plot.yaml",
+      script_path: "plots/my_plot/render.py",
+      bytes_written: 100,
+      warnings: [],
+      target: {
+        target_id: "tgt_1",
+        workflow_path: "workflows/main.yaml",
+        workflow_id: "main",
+        node_id: "node_a",
+        node_label: "Load",
+        block_type: "io.load",
+        output_port: "data",
+        output_type: "DataFrame",
+        is_collection: false,
+        latest_run_id: null,
+        latest_output_available: false,
+        diagnostics: [],
+      },
+    };
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve(body),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const out = await dataApi.createPlot({
+      plot_id: "my_plot",
+      target_id: "tgt_1",
+      title: "My Plot",
+      language: "python",
+    });
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("/api/plots");
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(init.body as string)).toEqual({
+      plot_id: "my_plot",
+      target_id: "tgt_1",
+      title: "My Plot",
+      language: "python",
+    });
+    expect(out).toEqual(body);
+    vi.unstubAllGlobals();
+  });
+
   it("GETs /api/plots with block filters", async () => {
     const body = {
       plots: [

--- a/frontend/src/lib/api/data.ts
+++ b/frontend/src/lib/api/data.ts
@@ -9,9 +9,12 @@
 import type {
   DataMetadataResponse,
   DataUploadResponse,
+  PlotCreateRequest,
+  PlotCreateResponse,
   PlotListResponse,
   PlotRunRequest,
   PlotRunResponse,
+  PlotTargetListResponse,
   PreviewEnvelope,
   PreviewResourceResponse,
   PreviewResourceSaveRequest,
@@ -120,6 +123,32 @@ export const dataApi = {
     ),
 
   // -- ADR-048 SPEC 2 / #1606: plot-job run + preview wiring ----------------
+
+  /** List workflow output targets available for a new plot scaffold. */
+  listPlotTargets: (params?: {
+    workflowId?: string | null;
+    workflowPath?: string | null;
+    nodeId?: string | null;
+    outputPort?: string | null;
+    includeUnavailable?: boolean;
+  }) => {
+    const search = new URLSearchParams();
+    if (params?.workflowId) search.set("workflow_id", params.workflowId);
+    if (params?.workflowPath) search.set("workflow_path", params.workflowPath);
+    if (params?.nodeId) search.set("node_id", params.nodeId);
+    if (params?.outputPort) search.set("output_port", params.outputPort);
+    if (params?.includeUnavailable === false) search.set("include_unavailable", "false");
+    const suffix = search.toString();
+    return apiFetch<PlotTargetListResponse>(`/api/plots/targets${suffix ? `?${suffix}` : ""}`);
+  },
+
+  /** Create plots/<id>/plot.yaml plus a render script from the plot template. */
+  createPlot: (request: PlotCreateRequest) =>
+    apiFetch<PlotCreateResponse>("/api/plots", {
+      method: "POST",
+      headers: JSON_HEADERS,
+      body: JSON.stringify(request),
+    }),
 
   /** Run a plot job and register its artifact for routed preview
    *  (`POST /api/plots/run`). On success the response's `data_ref` opens a

--- a/frontend/src/store/__tests__/tabHelpers.test.ts
+++ b/frontend/src/store/__tests__/tabHelpers.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+
+import { languageForPath } from "../tabSlice.parts/tabHelpers";
+
+describe("tabHelpers", () => {
+  it("maps R scripts to Monaco's R language id", () => {
+    expect(languageForPath("plots/qc/render.R")).toBe("r");
+    expect(languageForPath("plots/qc/render.r")).toBe("r");
+  });
+});

--- a/frontend/src/store/tabSlice.parts/tabHelpers.ts
+++ b/frontend/src/store/tabSlice.parts/tabHelpers.ts
@@ -68,6 +68,7 @@ export function restoreTab(tab: TabState): Partial<AppStore> {
 export function languageForPath(filePath: string): FileTab["language"] {
   const lower = filePath.toLowerCase();
   if (lower.endsWith(".py")) return "python";
+  if (lower.endsWith(".r")) return "r";
   if (lower.endsWith(".yaml") || lower.endsWith(".yml")) return "yaml";
   if (lower.endsWith(".json")) return "json";
   if (lower.endsWith(".md")) return "markdown";

--- a/frontend/src/store/types.ts
+++ b/frontend/src/store/types.ts
@@ -344,7 +344,7 @@ export interface FileTab {
   id: string;
   filePath: string;
   displayName: string;
-  language: "python" | "yaml" | "json" | "text" | "markdown";
+  language: "python" | "r" | "yaml" | "json" | "text" | "markdown";
   content: string;
   contentLoadedAt: number;
   baseVersion?: number | null;

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -388,6 +388,49 @@ export interface PreviewResourceSaveResponse {
 // ADR-048 SPEC 2 / #1606: plot-job run + preview wiring.
 // ---------------------------------------------------------------------------
 
+export type PlotLanguage = "python" | "r";
+
+/** One workflow output target a new plot can bind to. */
+export interface PlotTargetItem {
+  target_id: string;
+  workflow_path: string;
+  workflow_id?: string | null;
+  node_id: string;
+  node_label: string;
+  block_type: string;
+  output_port: string;
+  output_type: string;
+  is_collection: boolean;
+  latest_run_id?: string | null;
+  latest_output_available: boolean;
+  diagnostics: string[];
+}
+
+/** Response body for `GET /api/plots/targets`. */
+export interface PlotTargetListResponse {
+  targets: PlotTargetItem[];
+  count: number;
+}
+
+/** Request body for `POST /api/plots`. */
+export interface PlotCreateRequest {
+  plot_id: string;
+  target_id: string;
+  title?: string | null;
+  language?: PlotLanguage;
+  overwrite?: boolean;
+}
+
+/** Response body for `POST /api/plots`. */
+export interface PlotCreateResponse {
+  plot_id: string;
+  manifest_path: string;
+  script_path: string;
+  bytes_written: number;
+  warnings: string[];
+  target: PlotTargetItem;
+}
+
 /** Request body for `POST /api/plots/run` (backend `PlotRunRequest`). */
 export interface PlotRunRequest {
   plot_id: string;

--- a/packages/scistudio-blocks-imaging/pyproject.toml
+++ b/packages/scistudio-blocks-imaging/pyproject.toml
@@ -70,9 +70,6 @@ artifacts = [
     "src/scistudio_blocks_imaging/previewers/assets/*.svg",
 ]
 
-[tool.hatch.build.targets.wheel.force-include]
-"src/scistudio_blocks_imaging/previewers/assets" = "scistudio_blocks_imaging/previewers/assets"
-
 [tool.pytest.ini_options]
 markers = [
     "requires_cellpose: needs the [cellpose] extra",

--- a/packages/scistudio-blocks-imaging/src/scistudio_blocks_imaging/previewers/assets/viewer.js
+++ b/packages/scistudio-blocks-imaging/src/scistudio_blocks_imaging/previewers/assets/viewer.js
@@ -513,23 +513,44 @@ const previewerModule = {
     maxCtl.readout.textContent = String(state.maxDisplay);
 
     // Slice slider: drive the server re-render via the bounded session API.
-    let sliceTimer = null;
+    let disposed = false;
+    let sliceInFlight = false;
+    let pendingSliceIndex = null;
+    let sliceRequestSeq = 0;
+    function pumpSliceRequest() {
+      if (disposed || sliceInFlight || pendingSliceIndex === null) return;
+      const idx = pendingSliceIndex;
+      pendingSliceIndex = null;
+      sliceInFlight = true;
+      const seq = (sliceRequestSeq += 1);
+      try {
+        const p = host.session.patchQuery({ slice_index: idx });
+        if (p && typeof p.then === "function") {
+          p.then((env) => {
+            if (env && !disposed && pendingSliceIndex === null && seq === sliceRequestSeq) {
+              instance.update(env);
+            }
+          })
+            .catch((err) => host.reportError("slice fetch failed", { error: String(err) }))
+            .finally(() => {
+              sliceInFlight = false;
+              pumpSliceRequest();
+            });
+        } else {
+          sliceInFlight = false;
+          pumpSliceRequest();
+        }
+      } catch (err) {
+        sliceInFlight = false;
+        host.reportError("slice fetch failed", { error: String(err) });
+        pumpSliceRequest();
+      }
+    }
     sliceInput.addEventListener("input", () => {
       const idx = Number(sliceInput.value);
       sliceReadout.textContent = `${idx + 1}/${state.vm.sliceAxisSize || 1}`;
-      if (sliceTimer) clearTimeout(sliceTimer);
-      sliceTimer = setTimeout(() => {
-        try {
-          const p = host.session.patchQuery({ slice_index: idx });
-          if (p && typeof p.then === "function") {
-            p.then((env) => {
-              if (env) instance.update(env);
-            }).catch((err) => host.reportError("slice fetch failed", { error: String(err) }));
-          }
-        } catch (err) {
-          host.reportError("slice fetch failed", { error: String(err) });
-        }
-      }, 200);
+      pendingSliceIndex = idx;
+      pumpSliceRequest();
     });
 
     container.appendChild(root);
@@ -542,7 +563,7 @@ const previewerModule = {
         renderAll();
       },
       unmount() {
-        if (sliceTimer) clearTimeout(sliceTimer);
+        disposed = true;
         stage.removeEventListener("wheel", onWheel);
         stage.removeEventListener("mousedown", onMouseDown);
         stage.removeEventListener("mousemove", onMouseMove);

--- a/packages/scistudio-blocks-imaging/tests/test_previewer_registration.py
+++ b/packages/scistudio-blocks-imaging/tests/test_previewer_registration.py
@@ -179,6 +179,16 @@ def test_pyproject_declares_installed_previewer_entry_point() -> None:
     }
 
 
+def test_pyproject_declares_single_viewer_asset_inclusion_path() -> None:
+    """Wheel builds must include viewer assets once so package reinstall works."""
+    pyproject = Path(__file__).resolve().parents[1] / "pyproject.toml"
+    data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+    wheel = data["tool"]["hatch"]["build"]["targets"]["wheel"]
+
+    assert "src/scistudio_blocks_imaging/previewers/assets/*.js" in wheel["artifacts"]
+    assert "force-include" not in wheel
+
+
 def test_installed_entry_point_registers_imaging_previewers(monkeypatch: pytest.MonkeyPatch) -> None:
     """The registry discovers imaging previewers from entry points without monorepo fallback."""
     entry_point = importlib.metadata.EntryPoint(

--- a/src/scistudio/ai/agent/mcp/tools_plot/scaffold.py
+++ b/src/scistudio/ai/agent/mcp/tools_plot/scaffold.py
@@ -26,11 +26,22 @@ from scistudio.ai.agent.mcp.tools_plot.targets import PlotTarget
 _PLOT_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$")
 _RESERVED_IDS = frozenset({"con", "prn", "aux", "nul", "current", "."})
 
-_PYTHON_TEMPLATE = '''"""Render script scaffolded by SciStudio scaffold_plot (ADR-048 plot job).
+_PYTHON_TEMPLATE = '''"""Render script created by SciStudio.
 
 This is a PREVIEW-ONLY plot job. It is NOT a workflow block and never becomes a
-DAG node. ``collection`` is the latest output of the bound block port; use the
-``context`` helpers to read it and to save a figure.
+DAG node.
+
+What ``collection`` means:
+  ``collection`` is the read-only data passed from the workflow output this plot
+  is bound to. If the block output is one table, the collection contains one
+  table-like item. If the block output is a collection of five arrays, it
+  contains five array items. Treat it as input data, not as workflow state.
+
+What ``context`` means:
+  ``context`` is the small plot-runtime helper object SciStudio gives this
+  script. It loads bounded input data, exposes matplotlib as ``context.plt``,
+  and saves the final artifact. It is not the workflow engine context and it
+  should not mutate blocks, nodes, files, or lineage records.
 """
 
 from __future__ import annotations
@@ -44,6 +55,28 @@ def render(collection, context):
       * context.items(collection, max_items=...)        -> bounded iterator
       * context.plt                                      -> matplotlib.pyplot
       * context.save_figure(fig, "figure.svg")           -> save PNG/JPEG/SVG/PDF
+
+    Minimal examples you can paste over the default plot:
+
+      # Example A: collection contains up to 5 NumPy .npy arrays; draw each
+      # flattened value distribution.
+      # import numpy as np
+      # fig, ax = context.plt.subplots()
+      # for index, item in enumerate(context.items(collection, max_items=5)):
+      #     path = item.get("path")
+      #     if not path:
+      #         continue
+      #     array = np.load(path)
+      #     ax.hist(np.asarray(array).ravel(), bins=64, alpha=0.35, label="array " + str(index + 1))
+      # ax.legend()
+      # return context.save_figure(fig, "figure.svg")
+
+      # Example B: collection contains one dataframe; draw a box plot from the
+      # 2nd and 3rd dataframe columns.
+      # df = context.to_dataframe(collection, max_rows=10000)
+      # fig, ax = context.plt.subplots()
+      # df.iloc[:, [1, 2]].plot(kind="box", ax=ax)
+      # return context.save_figure(fig, "figure.svg")
     """
     df = context.to_dataframe(collection, max_rows={max_rows})
     fig, ax = context.plt.subplots()
@@ -52,15 +85,54 @@ def render(collection, context):
     return context.save_figure(fig, "figure.{ext}")
 '''
 
-_R_TEMPLATE = """# Render script scaffolded by SciStudio scaffold_plot (ADR-048 plot job).
+_R_TEMPLATE = """# Render script created by SciStudio.
 #
 # This is a PREVIEW-ONLY plot job. It is NOT a workflow block and never becomes a
-# DAG node. `collection` is the latest output of the bound block port; use the
-# `context` helpers to read it and to save a plot.
+# DAG node.
+#
+# What `collection` means:
+#   `collection` is the read-only data passed from the workflow output this plot
+#   is bound to. If the block output is one table, the collection contains one
+#   table-like item. If the block output is a collection of five arrays, it
+#   contains five array items. In R it is a list of item references; each item
+#   usually has fields such as `path`, `format`, and metadata.
+#
+# What `context` means:
+#   `context` is the small plot-runtime helper object SciStudio gives this
+#   script. It loads bounded input data and saves the final artifact. It is not
+#   the workflow engine context and it should not mutate blocks, nodes, files,
+#   or lineage records.
 #
 # Available context helpers:
 #   * context$to_dataframe(collection, max_rows = ...) -> data.frame
 #   * context$save_plot(plot_or_grob, "figure.pdf")    -> save PNG/JPEG/SVG/PDF
+#
+# Minimal examples you can paste over the default plot:
+#
+#   # Example A: collection contains one dataframe; draw a box plot from the
+#   # 2nd and 3rd dataframe columns.
+#   # df <- context$to_dataframe(collection, max_rows = 10000)
+#   # value_cols <- names(df)[2:3]
+#   # long <- stack(df[value_cols])
+#   # p <- ggplot2::ggplot(long, ggplot2::aes(x = ind, y = values)) +
+#   #   ggplot2::geom_boxplot()
+#   # context$save_plot(p, "figure.pdf")
+#
+#   # Example B: collection contains several CSV tables; draw each first-column
+#   # distribution.
+#   # frames <- list()
+#   # for (item in collection) {{
+#   #   if (!is.null(item$path) && tools::file_ext(item$path) == "csv") {{
+#   #     frames[[length(frames) + 1]] <- utils::read.csv(item$path)
+#   #   }}
+#   # }}
+#   # values <- data.frame()
+#   # for (index in seq_along(frames)) {{
+#   #   values <- rbind(values, data.frame(value = frames[[index]][[1]], source = paste("table", index)))
+#   # }}
+#   # p <- ggplot2::ggplot(values, ggplot2::aes(x = value, fill = source)) +
+#   #   ggplot2::geom_histogram(bins = 40, alpha = 0.35, position = "identity")
+#   # context$save_plot(p, "figure.pdf")
 
 render <- function(collection, context) {{
   df <- context$to_dataframe(collection, max_rows = {max_rows})

--- a/src/scistudio/api/file_contracts.py
+++ b/src/scistudio/api/file_contracts.py
@@ -10,6 +10,7 @@ FILE_ENTITY_CLASS: str = "file"
 
 ADR036_FILE_ALLOWLIST: tuple[str, ...] = (
     ".py",
+    ".r",
     ".txt",
     ".md",
     ".yaml",

--- a/src/scistudio/api/routes/plots.py
+++ b/src/scistudio/api/routes/plots.py
@@ -32,14 +32,23 @@ from __future__ import annotations
 import logging
 from functools import partial
 from pathlib import Path
-from typing import Annotated
+from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from starlette.concurrency import run_in_threadpool
 
 from scistudio.api.deps import get_runtime
 from scistudio.api.runtime import ApiRuntime
-from scistudio.api.schemas import PlotListItem, PlotListResponse, PlotRunRequest, PlotRunResponse
+from scistudio.api.schemas import (
+    PlotCreateRequest,
+    PlotCreateResponse,
+    PlotListItem,
+    PlotListResponse,
+    PlotRunRequest,
+    PlotRunResponse,
+    PlotTargetItem,
+    PlotTargetListResponse,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -98,6 +107,83 @@ async def list_plots(
         )
     items.sort(key=lambda item: (item.title.lower() or item.plot_id.lower(), item.plot_id.lower()))
     return PlotListResponse(plots=items, count=len(items), warnings=warnings)
+
+
+@router.get("/targets", response_model=PlotTargetListResponse)
+async def list_plot_targets(
+    runtime: RuntimeDep,
+    workflow_id: Annotated[str | None, Query()] = None,
+    workflow_path: Annotated[str | None, Query()] = None,
+    node_id: Annotated[str | None, Query()] = None,
+    output_port: Annotated[str | None, Query()] = None,
+    include_unavailable: Annotated[bool, Query()] = True,
+) -> PlotTargetListResponse:
+    """List workflow output targets a new plot can bind to."""
+    from scistudio.ai.agent.mcp.tools_plot.targets import discover_targets
+
+    try:
+        runtime.require_active_project()
+        targets = discover_targets(workflow_path=workflow_path, include_unavailable=include_unavailable)
+    except RuntimeError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except (PermissionError, ValueError) as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    items: list[PlotTargetItem] = []
+    for target in targets:
+        if workflow_id is not None and target.workflow_id != workflow_id:
+            continue
+        if node_id is not None and target.node_id != node_id:
+            continue
+        if output_port is not None and target.output_port != output_port:
+            continue
+        items.append(_target_item(target))
+    return PlotTargetListResponse(targets=items, count=len(items))
+
+
+@router.post("", response_model=PlotCreateResponse)
+async def create_plot(payload: PlotCreateRequest, runtime: RuntimeDep) -> PlotCreateResponse:
+    """Create ``plots/<id>/plot.yaml`` plus a render script from the plot template."""
+    from scistudio.ai.agent.mcp.tools_plot.scaffold import PlotScaffoldError, scaffold_plot_files
+    from scistudio.ai.agent.mcp.tools_plot.targets import resolve_target_by_id
+
+    try:
+        project = runtime.require_active_project()
+    except RuntimeError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+
+    target = resolve_target_by_id(payload.target_id)
+    if target is None:
+        raise HTTPException(status_code=400, detail="Unknown plot target. Choose a block output from the target list.")
+
+    warnings: list[str] = []
+    if not target.latest_output_available:
+        warnings.append("The bound block output has no recorded data yet. Run the workflow before running this plot.")
+    try:
+        manifest_path, script_path, bytes_written = scaffold_plot_files(
+            Path(project.path).resolve(),
+            payload.plot_id,
+            target,
+            payload.language,
+            payload.title,
+            payload.overwrite,
+        )
+    except FileExistsError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except PlotScaffoldError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except OSError as exc:
+        raise HTTPException(status_code=500, detail=f"Failed to create plot files: {exc}") from exc
+
+    project_root = Path(project.path).resolve()
+    return PlotCreateResponse(
+        plot_id=payload.plot_id,
+        manifest_path=_project_relative(project_root, manifest_path),
+        script_path=_project_relative(project_root, script_path),
+        bytes_written=bytes_written,
+        warnings=warnings,
+        target=_target_item(target),
+    )
 
 
 @router.post("/run", response_model=PlotRunResponse)
@@ -192,3 +278,20 @@ def _project_relative(project_root: Path, path: Path) -> str:
         return path.resolve().relative_to(project_root).as_posix()
     except ValueError:
         return str(path)
+
+
+def _target_item(target: Any) -> PlotTargetItem:
+    return PlotTargetItem(
+        target_id=str(target.target_id),
+        workflow_path=str(target.workflow_path),
+        workflow_id=target.workflow_id,
+        node_id=str(target.node_id),
+        node_label=str(target.node_label or ""),
+        block_type=str(target.block_type),
+        output_port=str(target.output_port),
+        output_type=str(target.output_type or ""),
+        is_collection=bool(target.is_collection),
+        latest_run_id=target.latest_run_id,
+        latest_output_available=bool(target.latest_output_available),
+        diagnostics=list(target.diagnostics or []),
+    )

--- a/src/scistudio/api/runtime/__init__.py
+++ b/src/scistudio/api/runtime/__init__.py
@@ -734,6 +734,7 @@ class ApiRuntime:
     refresh_preview_service = _data.refresh_preview_service
     enrich_preview_query = _data.enrich_preview_query
     resolve_session_target = _data.resolve_session_target
+    resolve_child_preview_context = _data.resolve_child_preview_context
     _build_preview_target = _data._build_preview_target
 
     # Workflow execution + lineage (_runs)

--- a/src/scistudio/api/runtime/_data.py
+++ b/src/scistudio/api/runtime/_data.py
@@ -220,7 +220,10 @@ def get_preview_service(self: ApiRuntime) -> PreviewService:
     service = getattr(self, "_preview_service", None)
     if service is None:
         project_dir = Path(self.active_project.path) if self.active_project else None
-        service = build_preview_service(project_dir=project_dir)
+        service = build_preview_service(
+            project_dir=project_dir,
+            child_context_resolver=self.resolve_child_preview_context,
+        )
         self._preview_service = service  # type: ignore[attr-defined]
     return service
 
@@ -228,7 +231,10 @@ def get_preview_service(self: ApiRuntime) -> PreviewService:
 def refresh_preview_service(self: ApiRuntime) -> PreviewService:
     """Rebuild the runtime preview service for the active project (FR-002)."""
     project_dir = Path(self.active_project.path) if self.active_project else None
-    service = build_preview_service(project_dir=project_dir)
+    service = build_preview_service(
+        project_dir=project_dir,
+        child_context_resolver=self.resolve_child_preview_context,
+    )
     self._preview_service = service  # type: ignore[attr-defined]
     return service
 
@@ -318,3 +324,22 @@ def resolve_session_target(self: ApiRuntime, target: PreviewTarget) -> PreviewTa
         return target
     resolved_cls = self._resolve_record_class(record)
     return self._build_preview_target(record, resolved_cls)
+
+
+def resolve_child_preview_context(
+    self: ApiRuntime,
+    target: PreviewTarget,
+    query: dict[str, Any],
+) -> tuple[PreviewTarget, dict[str, Any]]:
+    """Apply runtime catalog truth to a child preview target.
+
+    Collection/composite resources are resolved inside PreviewSessionManager,
+    below the FastAPI route that normally calls resolve_session_target() and
+    enrich_preview_query(). Reapply the same catalog-backed normalization here
+    so child data_refs keep their recorded type chain and storage descriptor.
+    """
+    resolved_target = self.resolve_session_target(target)
+    child_query = dict(query)
+    child_query.pop("_storage", None)
+    child_query.pop("_record_metadata", None)
+    return resolved_target, self.enrich_preview_query(resolved_target.ref, child_query)

--- a/src/scistudio/api/schemas.py
+++ b/src/scistudio/api/schemas.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field
 
@@ -348,6 +348,51 @@ class PlotRunRequest(BaseModel):
         default=None,
         description="Optional override of the manifest timeout (re-clamped to the absolute ceiling).",
     )
+
+
+class PlotTargetItem(BaseModel):
+    """One selectable workflow output target for a new plot."""
+
+    target_id: str
+    workflow_path: str
+    workflow_id: str | None = None
+    node_id: str
+    node_label: str = ""
+    block_type: str
+    output_port: str
+    output_type: str = ""
+    is_collection: bool = False
+    latest_run_id: str | None = None
+    latest_output_available: bool = False
+    diagnostics: list[str] = Field(default_factory=list)
+
+
+class PlotTargetListResponse(BaseModel):
+    """Response body for ``GET /api/plots/targets``."""
+
+    targets: list[PlotTargetItem] = Field(default_factory=list)
+    count: int
+
+
+class PlotCreateRequest(BaseModel):
+    """Request body for ``POST /api/plots``."""
+
+    plot_id: str = Field(description="Plot id and plots/<id> directory name.")
+    target_id: str = Field(description="Target id selected from GET /api/plots/targets.")
+    title: str | None = Field(default=None, description="Human title written to plot.yaml.")
+    language: Literal["python", "r"] = Field(default="python")
+    overwrite: bool = Field(default=False)
+
+
+class PlotCreateResponse(BaseModel):
+    """Response body after creating a plot scaffold."""
+
+    plot_id: str
+    manifest_path: str
+    script_path: str
+    bytes_written: int
+    warnings: list[str] = Field(default_factory=list)
+    target: PlotTargetItem
 
 
 class PlotRunResponse(BaseModel):

--- a/src/scistudio/blocks/io/_unified_dispatch.py
+++ b/src/scistudio/blocks/io/_unified_dispatch.py
@@ -71,9 +71,21 @@ def capability_owner_class(registry: Any, capability: FormatCapability) -> type[
     block_cls = registry._resolve_capability_class(capability)
     if block_cls is None:
         raise LookupError(
-            f"ADR-043 capability {capability.id!r} resolved but owner {capability.block_type!r} could not be imported."
+            f"IO capability {capability.id!r} resolved but owner {capability.block_type!r} could not be imported."
         )
     return cast(type[Any], block_cls)
+
+
+def _path_extension(params: dict[str, Any]) -> str | None:
+    """Infer the lookup extension from a single path or a multi-path list."""
+    raw_path = params.get("path")
+    paths = raw_path if isinstance(raw_path, list) else [raw_path]
+    for candidate in paths:
+        if isinstance(candidate, str) and candidate:
+            suffixes = Path(candidate).suffixes
+            if suffixes:
+                return "".join(suffixes)
+    return None
 
 
 def selected_capability(
@@ -91,11 +103,7 @@ def selected_capability(
 
     if data_type is None:
         return registry, None
-    raw_path = params.get("path")
-    extension = None
-    if isinstance(raw_path, str) and raw_path:
-        suffixes = Path(raw_path).suffixes
-        extension = "".join(suffixes) if suffixes else None
+    extension = _path_extension(params)
     finder = registry.find_loader_capability if direction == "load" else registry.find_saver_capability
     try:
         return registry, finder(data_type, extension)
@@ -191,7 +199,7 @@ def delegate_load(
     data_type = resolve_type_class(core_type)
     registry, capability = selected_capability(direction="load", params=dict(config.params), data_type=data_type)
     if capability is None:
-        raise ValueError(f"Load: no ADR-043 load capability is registered for type {core_type!r}.")
+        raise ValueError(f"Load: no load capability is registered for type {core_type!r}.")
     if capability.block_type == "LoadData":
         raise ValueError(f"Load: selected capability {capability.id!r} did not resolve to a package loader.")
     loader_cls = capability_owner_class(registry, capability)
@@ -210,7 +218,7 @@ def delegate_save(
     data_type = resolve_type_class(core_type) or type(obj)
     registry, capability = selected_capability(direction="save", params=dict(config.params), data_type=data_type)
     if capability is None:
-        raise ValueError(f"Save: no ADR-043 save capability is registered for type {core_type!r}.")
+        raise ValueError(f"Save: no save capability is registered for type {core_type!r}.")
     if capability.block_type == "SaveData":
         raise ValueError(f"Save: selected capability {capability.id!r} did not resolve to a package saver.")
     saver_cls = capability_owner_class(registry, capability)

--- a/src/scistudio/blocks/io/capabilities.py
+++ b/src/scistudio/blocks/io/capabilities.py
@@ -28,7 +28,7 @@ VALID_METADATA_FIDELITY_LEVELS: frozenset[str] = frozenset({"pixel_only", "typed
 
 
 class CapabilityValidationError(ValueError):
-    """Base class for invalid ADR-043 capability declarations."""
+    """Base class for invalid IO capability declarations."""
 
 
 class InvalidExtensionError(CapabilityValidationError):
@@ -36,7 +36,7 @@ class InvalidExtensionError(CapabilityValidationError):
 
 
 class InvalidMetadataFidelityError(CapabilityValidationError):
-    """Raised when a metadata fidelity declaration violates ADR-043."""
+    """Raised when a metadata fidelity declaration is invalid."""
 
 
 class InvalidFormatCapabilityError(CapabilityValidationError):

--- a/src/scistudio/blocks/registry/__init__.py
+++ b/src/scistudio/blocks/registry/__init__.py
@@ -53,11 +53,11 @@ class BlockRegistrationError(Exception):
 
 
 class CapabilityRegistrationError(BlockRegistrationError):
-    """Raised when an ADR-043 format capability cannot be indexed."""
+    """Raised when an IO format capability cannot be indexed."""
 
 
 class CapabilityLookupError(LookupError):
-    """Base class for ADR-043 format capability lookup failures."""
+    """Base class for IO format capability lookup failures."""
 
     def __init__(
         self,

--- a/src/scistudio/previewers/__init__.py
+++ b/src/scistudio/previewers/__init__.py
@@ -23,8 +23,10 @@ from __future__ import annotations
 import logging
 import os
 import threading
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 from scistudio.previewers.data_access import PreviewDataAccess
 from scistudio.previewers.models import (
@@ -80,6 +82,8 @@ def build_preview_service(
     *,
     project_dir: Path | None = None,
     include_monorepo: bool | None = None,
+    child_context_resolver: Callable[[PreviewTarget, dict[str, Any]], tuple[PreviewTarget, dict[str, Any]]]
+    | None = None,
 ) -> PreviewService:
     """Build a fully-loaded :class:`PreviewService` (FR-001/FR-002/FR-030).
 
@@ -96,7 +100,10 @@ def build_preview_service(
     load_project_previewers(registry, project_dir)
 
     router = PreviewRouter(registry)
-    sessions = PreviewSessionManager(registry)
+    sessions = PreviewSessionManager(
+        registry,
+        child_context_resolver=child_context_resolver,
+    )
     return PreviewService(registry=registry, router=router, sessions=sessions)
 
 

--- a/src/scistudio/previewers/registry.py
+++ b/src/scistudio/previewers/registry.py
@@ -24,6 +24,7 @@ import importlib
 import importlib.metadata
 import logging
 import sys
+from contextlib import suppress
 from pathlib import Path
 from typing import Any
 
@@ -35,6 +36,35 @@ from scistudio.previewers.models import (
 logger = logging.getLogger(__name__)
 
 PREVIEWER_ENTRY_POINT_GROUP = "scistudio.previewers"
+COMPANION_ENTRY_POINT_GROUPS = ("scistudio.blocks", "scistudio.types")
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_PACKAGES_DIR = _REPO_ROOT / "packages"
+
+
+def _monorepo_package_module_names() -> list[str]:
+    if not _PACKAGES_DIR.is_dir():
+        return []
+    return [p.name.replace("-", "_") for p in sorted(_PACKAGES_DIR.glob("scistudio-blocks-*")) if (p / "src").is_dir()]
+
+
+def _prepend_monorepo_src(module_name: str) -> None:
+    src_dir = _PACKAGES_DIR / module_name.replace("_", "-") / "src"
+    if src_dir.is_dir() and str(src_dir) not in sys.path:
+        sys.path.insert(0, str(src_dir))
+
+
+def _import_monorepo_module(module_name: str) -> Any | None:
+    _prepend_monorepo_src(module_name)
+    with suppress(Exception):
+        return importlib.import_module(module_name)
+    logger.warning("Failed to import monorepo package '%s' for previewers", module_name)
+    return None
+
+
+def _previewer_factory_for(module_name: str) -> Any | None:
+    module = _import_monorepo_module(module_name)
+    factory = getattr(module, "get_previewers", None) if module else None
+    return factory if callable(factory) else None
 
 
 class PreviewerRegistry:
@@ -110,6 +140,7 @@ class PreviewerRegistry:
     def load_packages(self, *, include_monorepo: bool = False) -> None:
         """Load package previewers from entry points + monorepo fallback (FR-002/FR-030)."""
         self._scan_entry_points()
+        self._scan_companion_entry_point_packages()
         if include_monorepo:
             self._scan_monorepo_packages()
 
@@ -128,37 +159,66 @@ class PreviewerRegistry:
                 continue
             self._register_from_factory(ep.name, factory)
 
-    def _scan_monorepo_packages(self) -> None:
-        """Dev fallback: import ``packages/scistudio-blocks-*`` and call get_previewers().
+    def _scan_companion_entry_point_packages(self) -> None:
+        """Discover previewers re-exported by installed block/type packages.
 
-        Mirrors :meth:`TypeRegistry._scan_monorepo_types` and
-        :func:`blocks.registry._scan._scan_monorepo_packages`. ``__file__``
-        sits at ``src/scistudio/previewers/registry.py`` so the repo root is
-        ``parents[3]`` (previewers -> scistudio -> src -> root).
+        Some package installs can expose ``scistudio.blocks`` / ``scistudio.types``
+        entry points while their installed metadata is missing the newer
+        ``scistudio.previewers`` group. Treat an already-declared SciStudio
+        package as an authoritative companion source and call its conventional
+        ``get_previewers()`` factory when present. Explicit previewer entry
+        points remain authoritative because existing ids are skipped silently.
         """
-        repo_root = Path(__file__).resolve().parents[3]
-        packages_dir = repo_root / "packages"
-        if not packages_dir.is_dir():
-            return
-        for pkg_dir in sorted(packages_dir.glob("scistudio-blocks-*")):
-            src_dir = pkg_dir / "src"
-            if not src_dir.is_dir():
-                continue
-            src_dir_str = str(src_dir)
-            if src_dir_str not in sys.path:
-                sys.path.insert(0, src_dir_str)
-            module_name = pkg_dir.name.replace("-", "_")
+        seen_modules: set[str] = set()
+        for group in COMPANION_ENTRY_POINT_GROUPS:
             try:
-                module = importlib.import_module(module_name)
+                eps = importlib.metadata.entry_points(group=group)
             except Exception:
-                logger.warning("Failed to import monorepo package '%s' for previewers", module_name, exc_info=True)
+                logger.warning("Failed to enumerate '%s' entry points", group, exc_info=True)
                 continue
-            factory = getattr(module, "get_previewers", None)
-            if not callable(factory):
-                continue
-            self._register_from_factory(module_name, factory)
 
-    def _register_from_factory(self, source: str, factory: Any) -> None:
+            for ep in eps:
+                root_name = _entry_point_root_module(ep)
+                if not root_name:
+                    continue
+                for module_name in (root_name, f"{root_name}.previewers"):
+                    if module_name in seen_modules:
+                        continue
+                    seen_modules.add(module_name)
+                    try:
+                        module = importlib.import_module(module_name)
+                    except ModuleNotFoundError as exc:
+                        if exc.name != module_name:
+                            logger.debug(
+                                "Companion previewer import failed for '%s'",
+                                module_name,
+                                exc_info=True,
+                            )
+                        continue
+                    except Exception:
+                        logger.debug(
+                            "Companion previewer import failed for '%s'",
+                            module_name,
+                            exc_info=True,
+                        )
+                        continue
+
+                    factory = getattr(module, "get_previewers", None)
+                    if not callable(factory):
+                        continue
+                    self._register_from_factory(
+                        f"{group}:{ep.name}:{module_name}",
+                        factory,
+                        skip_existing=True,
+                    )
+                    break
+
+    def _scan_monorepo_packages(self) -> None:
+        for module_name in _monorepo_package_module_names():
+            if factory := _previewer_factory_for(module_name):
+                self._register_from_factory(module_name, factory)
+
+    def _register_from_factory(self, source: str, factory: Any, *, skip_existing: bool = False) -> None:
         """Invoke a previewer entry-point/monorepo factory and register results."""
         try:
             specs = factory()
@@ -175,7 +235,19 @@ class PreviewerRegistry:
             if not isinstance(spec, PreviewerSpec):
                 self._diagnostics.append(f"previewer factory '{source}' returned non-PreviewerSpec item; skipping")
                 continue
+            if skip_existing and spec.previewer_id in self._by_id:
+                continue
             self.register(spec)
 
 
-__all__ = ["PREVIEWER_ENTRY_POINT_GROUP", "PreviewerRegistry"]
+def _entry_point_root_module(ep: importlib.metadata.EntryPoint) -> str | None:
+    """Return the top-level module named by an entry point value."""
+    value = getattr(ep, "value", "")
+    module_name = str(value).split(":", 1)[0].strip()
+    module_name = module_name.split("[", 1)[0].strip()
+    if not module_name:
+        return None
+    return module_name.split(".", 1)[0]
+
+
+__all__ = ["COMPANION_ENTRY_POINT_GROUPS", "PREVIEWER_ENTRY_POINT_GROUP", "PreviewerRegistry"]

--- a/src/scistudio/previewers/session.py
+++ b/src/scistudio/previewers/session.py
@@ -65,6 +65,7 @@ _PLOT_EXPORT_MIME = {
     ".svg": "image/svg+xml",
     ".pdf": "application/pdf",
 }
+ChildContextResolver = Callable[[PreviewTarget, dict[str, Any]], tuple[PreviewTarget, dict[str, Any]]]
 
 
 class PreviewSessionManager:
@@ -76,6 +77,7 @@ class PreviewSessionManager:
         *,
         max_sessions: int = _DEFAULT_MAX_SESSIONS,
         data_access_factory: Callable[[PreviewLimits], PreviewDataAccess] | None = None,
+        child_context_resolver: ChildContextResolver | None = None,
     ) -> None:
         self._registry = registry
         self._router = PreviewRouter(registry)
@@ -83,6 +85,7 @@ class PreviewSessionManager:
         self._lock = threading.RLock()
         self._max_sessions = max(1, int(max_sessions))
         self._data_access_factory = data_access_factory or self._default_data_access
+        self._child_context_resolver = child_context_resolver
 
     @property
     def router(self) -> PreviewRouter:
@@ -201,7 +204,10 @@ class PreviewSessionManager:
                     f"resource {resource_id!r} could not resolve a child target",
                     detail={"resource_id": resource_id},
                 )
-            return self.render_target(child_target, merged).to_dict()
+            child_query = merged
+            if self._child_context_resolver is not None:
+                child_target, child_query = self._child_context_resolver(child_target, child_query)
+            return self.create_session(child_target, child_query).to_dict()
 
         if resource_id == "export":
             return self._export_plot_resource(session, merged)

--- a/tests/ai/test_mcp_tools_plot.py
+++ b/tests/ai/test_mcp_tools_plot.py
@@ -297,6 +297,8 @@ def test_scaffold_creates_python_plot(project: Path) -> None:
     assert res.next_step
     assert (project / "plots" / "cell_scatter" / "plot.yaml").is_file()
     assert (project / "plots" / "cell_scatter" / "render.py").is_file()
+    body = (project / "plots" / "cell_scatter" / "render.py").read_text(encoding="utf-8")
+    assert "ADR-048" not in body
 
 
 def test_scaffold_creates_r_plot(project: Path) -> None:
@@ -306,6 +308,10 @@ def test_scaffold_creates_r_plot(project: Path) -> None:
     assert (project / "plots" / "r_plot" / "render.R").is_file()
     body = (project / "plots" / "r_plot" / "render.R").read_text(encoding="utf-8")
     assert "render <- function(collection, context)" in body
+    assert "What `collection` means" in body
+    assert "What `context` means" in body
+    assert "Minimal examples" in body
+    assert "ADR-048" not in body
 
 
 def test_scaffold_refuses_overwrite_by_default(project: Path) -> None:

--- a/tests/api/test_file_endpoints.py
+++ b/tests/api/test_file_endpoints.py
@@ -21,7 +21,7 @@ def _open(client: TestClient, project_path: Path) -> str:
         json={"name": "T", "description": "", "path": str(project_path)},
     )
     assert response.status_code == 200, response.text
-    project_id = response.json()["id"]
+    project_id = str(response.json()["id"])
     # Trigger open so the runtime tracks active_project (matches GUI flow).
     client.get(f"/api/projects/{project_id}")
     return project_id
@@ -47,6 +47,20 @@ def test_read_file_happy_path(client: TestClient, project_parent: Path) -> None:
     assert body["encoding"] == "utf-8"
     assert body["size"] == 6
     assert body["mtime"] > 0
+
+
+def test_read_file_accepts_uppercase_r_plot_script(client: TestClient, project_parent: Path) -> None:
+    pid = _open(client, project_parent / "p1_r")
+    project_root = Path(client.app.state.runtime.known_projects[pid].path)
+    plot_dir = project_root / "plots" / "my_plot_R"
+    plot_dir.mkdir(parents=True, exist_ok=True)
+    target = plot_dir / "render.R"
+    target.write_text("render <- function(collection, context) {}\n", encoding="utf-8")
+
+    r = client.get(f"/api/projects/{pid}/file?path=plots/my_plot_R/render.R")
+
+    assert r.status_code == 200, r.text
+    assert "render <- function" in r.json()["content"]
 
 
 def test_read_file_404_missing(client: TestClient, project_parent: Path) -> None:

--- a/tests/api/test_plot_preview_wiring.py
+++ b/tests/api/test_plot_preview_wiring.py
@@ -241,6 +241,47 @@ def test_plot_list_route_filters_manifests_to_selected_block(
     assert body["plots"][0]["output_port"] == "measurements"
 
 
+def test_plot_create_route_scaffolds_manifest_and_render_script(
+    client: TestClient,
+    runtime: ApiRuntime,
+    opened_project: Path,
+) -> None:
+    """The app shell can create a new plot from a selected workflow output target."""
+    _seed_block_output(runtime, opened_project)
+    _write_workflow_and_plot(client, opened_project)
+
+    targets = client.get("/api/plots/targets", params={"workflow_id": "main"})
+    assert targets.status_code == 200, targets.text
+    body = targets.json()
+    assert body["count"] >= 1
+    target_id = body["targets"][0]["target_id"]
+
+    created = client.post(
+        "/api/plots",
+        json={
+            "plot_id": "quick_plot",
+            "target_id": target_id,
+            "title": "Quick Plot",
+            "language": "python",
+        },
+    )
+
+    assert created.status_code == 200, created.text
+    payload = created.json()
+    assert payload["plot_id"] == "quick_plot"
+    assert payload["manifest_path"] == "plots/quick_plot/plot.yaml"
+    assert payload["script_path"] == "plots/quick_plot/render.py"
+    manifest = opened_project / "plots" / "quick_plot" / "plot.yaml"
+    script = opened_project / "plots" / "quick_plot" / "render.py"
+    assert manifest.is_file()
+    assert script.is_file()
+    manifest_text = manifest.read_text(encoding="utf-8")
+    assert "id: quick_plot" in manifest_text
+    assert "title: Quick Plot" in manifest_text
+    assert "node_id:" in manifest_text
+    assert "def render(collection, context):" in script.read_text(encoding="utf-8")
+
+
 def test_plot_preview_resource_save_writes_export_to_user_selected_path(
     client: TestClient,
     runtime: ApiRuntime,

--- a/tests/api/test_previewers.py
+++ b/tests/api/test_previewers.py
@@ -526,6 +526,120 @@ def test_collection_resource_uses_descriptor_params(
     assert child["target"]["recorded_type"] == "DataFrame"
 
 
+def test_collection_image_child_resource_uses_catalog_storage(
+    client: TestClient,
+    runtime: ApiRuntime,
+    opened_project: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Collection item previews must route through the catalog-backed Image previewer."""
+    import numpy as np
+    import tifffile
+
+    imaging_ep = importlib.metadata.EntryPoint(
+        name="imaging",
+        value="scistudio_blocks_imaging.previewers:get_previewers",
+        group="scistudio.previewers",
+    )
+    real_entry_points = importlib.metadata.entry_points
+
+    def _entry_points(*args: object, **kwargs: object) -> object:
+        if kwargs.get("group") == "scistudio.previewers":
+            return (imaging_ep,)
+        return real_entry_points(*args, **kwargs)
+
+    monkeypatch.setattr(importlib.metadata, "entry_points", _entry_points)
+    runtime.refresh_preview_service()
+
+    image_path = opened_project / "images" / "child.tif"
+    image_path.parent.mkdir(parents=True, exist_ok=True)
+    tifffile.imwrite(image_path, np.arange(64, dtype=np.uint8).reshape(8, 8))
+    record = runtime.register_data_ref(
+        StorageReference(
+            backend="filesystem",
+            path=str(image_path),
+            format="tiff",
+            metadata={"type_chain": ["DataObject", "Array", "Image"], "axes": ["y", "x"]},
+        ),
+        type_name="Image",
+    )
+
+    resp = client.post(
+        "/api/previews/sessions",
+        json={
+            "target": {
+                "kind": "collection_ref",
+                "ref": "image-collection",
+                "recorded_type": "Image",
+                "type_chain": ["DataObject", "Array", "Image"],
+                "collection_item_type": "Image",
+            },
+            "query": {
+                "_collection_items": [{"data_ref": record.id, "type_name": "Image"}],
+                "_collection_count": 1,
+                "_collection_item_type": "Image",
+            },
+        },
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    resource = body["resources"][0]
+
+    res = client.get(
+        f"/api/previews/sessions/{body['session_id']}/resources/{resource['resource_id']}",
+        params={"params": json.dumps(resource["params"])},
+    )
+
+    assert res.status_code == 200
+    child = res.json()["data"]
+    assert child["session_id"]
+    assert child["session_id"] != body["session_id"]
+    assert child["previewer_id"] == "imaging.image.viewer"
+    assert child["kind"] == "array"
+    assert child["target"]["ref"] == record.id
+    assert child["target"]["recorded_type"] == "Image"
+    assert child["target"]["type_chain"] == ["DataObject", "Array", "Image"]
+    assert child["payload"]["shape"] == [8, 8]
+    assert str(child["payload"]["src"]).startswith("data:image/png;base64,")
+
+
+def test_imaging_previewer_asset_served_from_companion_package_entry_point(
+    client: TestClient,
+    runtime: ApiRuntime,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Imaging viewer assets remain available when previewer entry-point metadata is stale."""
+    block_ep = importlib.metadata.EntryPoint(
+        name="imaging",
+        value="scistudio_blocks_imaging:get_block_package",
+        group="scistudio.blocks",
+    )
+    real_entry_points = importlib.metadata.entry_points
+
+    def _entry_points(*args: object, **kwargs: object) -> object:
+        group = kwargs.get("group")
+        if group == "scistudio.previewers":
+            return ()
+        if group == "scistudio.blocks":
+            return (block_ep,)
+        if group == "scistudio.types":
+            return ()
+        return real_entry_points(*args, **kwargs)
+
+    monkeypatch.setattr(importlib.metadata, "entry_points", _entry_points)
+    runtime.refresh_preview_service()
+
+    spec = runtime.get_preview_service().registry.get("imaging.image.viewer")
+    assert spec is not None
+    assert spec.frontend_manifest is not None
+
+    resp = client.get("/api/previews/assets/imaging.image.viewer/viewer.js")
+
+    assert resp.status_code == 200
+    assert "text/javascript" in resp.headers["content-type"]
+    assert b"mount" in resp.content
+
+
 def test_composite_resource_uses_descriptor_params(
     client: TestClient,
     opened_project: Path,

--- a/tests/blocks/io/test_load_data.py
+++ b/tests/blocks/io/test_load_data.py
@@ -21,6 +21,7 @@ Covers:
 
 from __future__ import annotations
 
+import importlib.metadata
 import json
 import logging
 import pickle
@@ -35,6 +36,7 @@ from scistudio.blocks.io import LoadData
 from scistudio.blocks.io.loaders.load_data import _CORE_TYPE_MAP
 from scistudio.core.types.array import Array
 from scistudio.core.types.artifact import Artifact
+from scistudio.core.types.collection import Collection
 from scistudio.core.types.composite import CompositeData
 from scistudio.core.types.dataframe import DataFrame
 from scistudio.core.types.series import Series
@@ -126,6 +128,7 @@ def test_load_tsv_to_dataframe(tmp_path: Path) -> None:
 
     df = block.load(block.config)
 
+    assert isinstance(df, DataFrame)
     assert df.columns == ["a", "b"]
     assert df.row_count == 2
 
@@ -138,6 +141,7 @@ def test_load_json_records_to_dataframe(tmp_path: Path) -> None:
 
     df = block.load(block.config)
 
+    assert isinstance(df, DataFrame)
     assert set(df.columns or []) == {"x", "y"}
     assert df.row_count == 2
 
@@ -150,6 +154,7 @@ def test_load_json_columns_to_dataframe(tmp_path: Path) -> None:
 
     df = block.load(block.config)
 
+    assert isinstance(df, DataFrame)
     assert set(df.columns or []) == {"x", "y"}
     assert df.row_count == 3
 
@@ -163,6 +168,7 @@ def test_load_parquet_to_dataframe(tmp_path: Path) -> None:
     block = LoadData(config={"params": {"core_type": "DataFrame", "path": str(parquet_path)}})
     df = block.load(block.config)
 
+    assert isinstance(df, DataFrame)
     assert df.columns == ["col_a", "col_b"]
     assert df.row_count == 3
 
@@ -344,6 +350,7 @@ def test_load_artifact_with_sidecar_metadata(tmp_path: Path) -> None:
     block = LoadData(config={"params": {"core_type": "Artifact", "path": str(bin_path)}})
     art = block.load(block.config)
 
+    assert isinstance(art, Artifact)
     assert art.user["source"] == "instrument-A"
     assert art.user["version"] == 7
 
@@ -393,9 +400,10 @@ def test_load_composite_data_from_manifest(tmp_path: Path) -> None:
     assert isinstance(composite, CompositeData)
     assert set(composite.slot_names) == {"table", "notes", "signal"}
     assert isinstance(composite.get("table"), DataFrame)
-    assert isinstance(composite.get("notes"), Text)
+    notes = composite.get("notes")
+    assert isinstance(notes, Text)
     assert isinstance(composite.get("signal"), Array)
-    assert composite.get("notes").content == "hello composite"
+    assert notes.content == "hello composite"
 
 
 def test_load_composite_data_rejects_nested_composite(tmp_path: Path) -> None:
@@ -557,8 +565,6 @@ def test_load_data_multi_path_returns_collection(tmp_path: Path) -> None:
     block = LoadData(config={"params": {"core_type": "DataFrame", "path": [str(csv1), str(csv2)]}})
     result = block.load(block.config)
 
-    from scistudio.core.types.collection import Collection
-
     assert isinstance(result, Collection)
     assert len(result) == 2
     assert all(isinstance(item, DataFrame) for item in result)
@@ -575,8 +581,13 @@ def test_load_data_multi_path_collection_preserves_contents(tmp_path: Path) -> N
     block = LoadData(config={"params": {"core_type": "DataFrame", "path": [str(csv1), str(csv2)]}})
     result = block.load(block.config)
 
-    assert result[0].row_count == 2
-    assert result[1].row_count == 3
+    assert isinstance(result, Collection)
+    first = result[0]
+    second = result[1]
+    assert isinstance(first, DataFrame)
+    assert isinstance(second, DataFrame)
+    assert first.row_count == 2
+    assert second.row_count == 3
 
 
 def test_load_data_multi_path_single_element_list(tmp_path: Path) -> None:
@@ -586,8 +597,6 @@ def test_load_data_multi_path_single_element_list(tmp_path: Path) -> None:
 
     block = LoadData(config={"params": {"core_type": "DataFrame", "path": [str(csv1)]}})
     result = block.load(block.config)
-
-    from scistudio.core.types.collection import Collection
 
     assert isinstance(result, Collection)
     assert len(result) == 1
@@ -604,10 +613,60 @@ def test_load_data_multi_path_array(tmp_path: Path) -> None:
     block = LoadData(config={"params": {"core_type": "Array", "path": [str(npy1), str(npy2)]}})
     result = block.load(block.config)
 
+    assert isinstance(result, Collection)
     assert result.item_type is Array
     assert len(result) == 2
     np.testing.assert_array_equal(np.asarray(result[0]), arr)
     np.testing.assert_array_equal(np.asarray(result[1]), arr * 2)
+
+
+def test_load_data_multi_path_package_image(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Multi-path dispatch must resolve package Image loaders from a path list."""
+    tifffile = pytest.importorskip("tifffile")
+    pytest.importorskip("scistudio_blocks_imaging")
+    from scistudio_blocks_imaging.types import Image
+
+    block_ep = importlib.metadata.EntryPoint(
+        name="imaging",
+        value="scistudio_blocks_imaging:get_block_package",
+        group="scistudio.blocks",
+    )
+    type_ep = importlib.metadata.EntryPoint(
+        name="imaging",
+        value="scistudio_blocks_imaging:get_types",
+        group="scistudio.types",
+    )
+    entry_points = importlib.metadata.EntryPoints((block_ep, type_ep))
+
+    def _entry_points(*args: object, **kwargs: object) -> object:
+        group = kwargs.get("group")
+        if group == "scistudio.blocks":
+            return (block_ep,)
+        if group == "scistudio.types":
+            return (type_ep,)
+        return entry_points
+
+    monkeypatch.setattr(importlib.metadata, "entry_points", _entry_points)
+
+    p1 = tmp_path / "img1.tif"
+    p2 = tmp_path / "img2.tif"
+    tifffile.imwrite(p1, np.zeros((2, 3), dtype=np.uint8))
+    tifffile.imwrite(p2, np.ones((4, 5), dtype=np.uint8))
+    output_dir = tmp_path / "out"
+    output_dir.mkdir()
+
+    block = LoadData(config={"params": {"core_type": "Image", "path": [str(p1), str(p2)]}})
+    result = block.load(block.config, output_dir=str(output_dir))
+
+    assert isinstance(result, Collection)
+    assert result.item_type is Image
+    assert len(result) == 2
+    assert all(isinstance(item, Image) for item in result)
+    assert result[0].shape == (2, 3)
+    assert result[1].shape == (4, 5)
 
 
 def test_load_data_multi_path_get_effective_output_ports_is_collection(tmp_path: Path) -> None:

--- a/tests/previewers/test_preview_registry.py
+++ b/tests/previewers/test_preview_registry.py
@@ -2,6 +2,12 @@
 
 from __future__ import annotations
 
+import importlib.metadata
+import sys
+import types
+
+import pytest
+
 from scistudio.previewers.fallbacks import dataframe_previewer
 from scistudio.previewers.models import OwnerKind, PreviewerSpec
 from scistudio.previewers.registry import PreviewerRegistry
@@ -82,7 +88,7 @@ def test_raising_factory_is_diagnosed_not_fatal() -> None:
     assert any("raised" in d for d in reg.diagnostics)
 
 
-def test_monorepo_fallback_discovers_get_previewers(monkeypatch) -> None:
+def test_monorepo_fallback_discovers_get_previewers(monkeypatch: pytest.MonkeyPatch) -> None:
     """FR-030: a monorepo package exposing get_previewers() is discovered."""
     import sys
     import types
@@ -97,6 +103,41 @@ def test_monorepo_fallback_discovers_get_previewers(monkeypatch) -> None:
     # imaging package's own monorepo test); this proves the contract shape.
     reg._register_from_factory("scistudio_blocks_fake", fake_module.get_previewers)
     assert reg.get("pkg.fake.viewer") is not None
+    assert reg.diagnostics == []
+
+
+def test_companion_package_entry_point_discovers_get_previewers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Block/type packages can provide previewers even when previewer metadata is stale."""
+    fake_module = types.ModuleType("scistudio_blocks_fake")
+    fake_module.get_previewers = lambda: [_spec("pkg.fake.viewer")]  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "scistudio_blocks_fake", fake_module)
+
+    block_ep = importlib.metadata.EntryPoint(
+        name="fake",
+        value="scistudio_blocks_fake:get_block_package",
+        group="scistudio.blocks",
+    )
+    real_entry_points = importlib.metadata.entry_points
+
+    def _entry_points(*args: object, **kwargs: object) -> object:
+        group = kwargs.get("group")
+        if group == "scistudio.previewers":
+            return ()
+        if group == "scistudio.blocks":
+            return (block_ep,)
+        if group == "scistudio.types":
+            return ()
+        return real_entry_points(*args, **kwargs)
+
+    monkeypatch.setattr(importlib.metadata, "entry_points", _entry_points)
+
+    reg = PreviewerRegistry()
+    reg.load_packages(include_monorepo=False)
+
+    assert reg.get("pkg.fake.viewer") is not None
+    assert reg.diagnostics == []
 
 
 def test_project_default_declaration_roundtrips() -> None:


### PR DESCRIPTION
## Summary

This hotfix restores several user-visible SciStudio preview, plugin discovery, load, plot, and editor paths that regressed during the ADR-048 work.

The main fixes are:

- restore package block/type/previewer discovery visibility for installed SciStudio packages
- route Image previews to the package Image viewer instead of the generic Array viewer
- fix collection child preview handling and multi-image Load dispatch
- remove leaked ADR/development terminology from user-facing errors and plot templates
- add the New Plot UX with Python/R scaffolding, selected-node default binding, and a custom dialog
- allow `.R` plot scripts to open in the editor
- improve plot templates and image/plot preview UX
- add SciStudio plot `context` helper completion in the built-in editor
- collapse duplicate empty preview messages into one `Nothing to preview yet` state

## Root Cause

The regressions came from several connected integration gaps: previewer discovery was not fully aligned with installed package entry points, routed preview UI state was falling back to generic or stale render paths in several cases, plot authoring UX was only partially wired, and Monaco had no SciStudio-specific knowledge of plot render helpers.

## Validation

- Targeted backend previewer/load/plot/file tests were added or updated.
- Targeted frontend tests were added or updated for PreviewHost, DataPreview, NewPlotDialog, CodeEditor completions, ProjectTree, toolbar/API plot paths, and image/plot preview behavior.
- Frontend `npm run build` passed after the latest UI edits.
- The hotfix server was restarted on `localhost:8000` during live validation.

Closes #1655
