### PR TITLE
docs(#1659): add ADR-049 package validator contracts

### DIFF
--- a/.workflow/records/design-package-validator-contract-survey-design-package-validator-contract-survey.json
+++ b/.workflow/records/design-package-validator-contract-survey-design-package-validator-contract-survey.json
@@ -1,0 +1,1609 @@
+{
+  "branch": "design/package-validator-contract-survey",
+  "check_events": [
+    {
+      "at": "2026-06-14T06:58:06.028653Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-14T07:28:43.433862Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-14T07:29:33.701593Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-14T07:30:01.052695Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-14T07:40:50.427578Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-14T07:41:28.075836Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-14T07:43:54.334071Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-14T07:45:36.416500Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-14T07:46:05.905360Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-14T07:46:56.210436Z",
+      "command": "pytest tests/architecture/ -v --no-cov",
+      "covered_surface": "architecture",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:a256c64035de25b10bedaa99bbd238ddd71241bc4ae9df9aa1c3da8b4cf330e6",
+      "name": "architecture_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/architecture_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-14T07:46:57.069058Z",
+      "command": "python scripts/deferral_scan.py --check docs/audit/baselines/deferral-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:a256c64035de25b10bedaa99bbd238ddd71241bc4ae9df9aa1c3da8b4cf330e6",
+      "name": "deferral_discipline",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/deferral_discipline.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-14T07:46:57.107927Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:a256c64035de25b10bedaa99bbd238ddd71241bc4ae9df9aa1c3da8b4cf330e6",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-14T07:47:09.781971Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:a256c64035de25b10bedaa99bbd238ddd71241bc4ae9df9aa1c3da8b4cf330e6",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-14T07:47:10.035811Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:a256c64035de25b10bedaa99bbd238ddd71241bc4ae9df9aa1c3da8b4cf330e6",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-14T07:47:10.072446Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:a256c64035de25b10bedaa99bbd238ddd71241bc4ae9df9aa1c3da8b4cf330e6",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-14T07:51:09.002225Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:a256c64035de25b10bedaa99bbd238ddd71241bc4ae9df9aa1c3da8b4cf330e6",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-14T07:52:13.436902Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:a256c64035de25b10bedaa99bbd238ddd71241bc4ae9df9aa1c3da8b4cf330e6",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-14T07:52:14.232509Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:a256c64035de25b10bedaa99bbd238ddd71241bc4ae9df9aa1c3da8b4cf330e6",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    }
+  ],
+  "check_na": [],
+  "commit": {
+    "sha": "f5b7b3e52c4f92919ecfde40ecfba0efc5413e87",
+    "shas": [
+      "f5b7b3e52c4f92919ecfde40ecfba0efc5413e87"
+    ],
+    "trailers": []
+  },
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "docs/planning/package-validator-contract-survey-draft.md",
+      "docs/planning/adr-049-package-validator-checklist.md",
+      "docs/planning/adr-049-package-validator/contracts/**",
+      "scripts/audit/check_package_contract_tables.py"
+    ]
+  },
+  "directive_events": [
+    {
+      "at": "2026-06-14T06:37:27.709020Z",
+      "owner_directive": "Use five subagents. Each writes one disjoint machine-verifiable JSON contract table under docs/planning/adr-049-package-validator/contracts/. Manager writes scripts/audit/check_package_contract_tables.py and corrects tables based on checker output.",
+      "reason": "plan"
+    },
+    {
+      "at": "2026-06-14T07:43:17.905916Z",
+      "owner_directive": "Owner requested ADR-049, machine-verifiable contract checker, implementation spec, and PR submission",
+      "reason": "Declare governance touch for package contract checker under scripts/audit"
+    }
+  ],
+  "docs_events": [
+    {
+      "at": "2026-06-14T06:37:27.709043Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/planning/package-validator-contract-survey-draft.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-14T06:37:27.709052Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/planning/adr-049-package-validator-checklist.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-14T06:37:41.367411Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/planning/adr-049-package-validator-checklist.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-14T06:55:58.006762Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/planning/adr-049-package-validator/contracts/pv-a1-sections-01-03.json",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-14T06:55:58.006782Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/planning/adr-049-package-validator/contracts/pv-a2-sections-04-06.json",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-14T06:55:58.006784Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/planning/adr-049-package-validator/contracts/pv-a3-sections-07-09.json",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-14T06:55:58.006786Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/planning/adr-049-package-validator/contracts/pv-a4-sections-10-12.json",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-14T06:55:58.006788Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/planning/adr-049-package-validator/contracts/pv-a5-section-13-omissions.json",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-14T06:57:08.209565Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/planning/package-validator-contract-survey-draft.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-14T06:57:08.209584Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/planning/adr-049-package-validator-checklist.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-14T06:57:08.209586Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/planning/adr-049-package-validator/contracts/pv-a1-sections-01-03.json",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-14T06:57:08.209588Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/planning/adr-049-package-validator/contracts/pv-a2-sections-04-06.json",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-14T06:57:08.209589Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/planning/adr-049-package-validator/contracts/pv-a3-sections-07-09.json",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-14T06:57:08.209591Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/planning/adr-049-package-validator/contracts/pv-a4-sections-10-12.json",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-14T06:57:08.209592Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/planning/adr-049-package-validator/contracts/pv-a5-section-13-omissions.json",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-14T07:00:46.675153Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/adr/ADR-049.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-14T07:00:46.675158Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/planning/adr-049-package-validator/contracts/contract-table.schema.json",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-14T07:05:49.186576Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/adr/ADR-049.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-14T07:05:49.186595Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/planning/adr-049-package-validator-checklist.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-14T07:28:14.892441Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/adr/ADR-049.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-14T07:28:14.892445Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/planning/package-validator-contract-survey-draft.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-14T07:28:14.892447Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/planning/adr-049-package-validator-checklist.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-14T07:28:31.872597Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/adr/ADR-049.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-14T07:28:31.872616Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/planning/package-validator-contract-survey-draft.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-14T07:28:31.872619Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/planning/adr-049-package-validator-checklist.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-14T07:29:15.061719Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/planning/adr-049-package-validator-checklist.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-14T07:29:48.568186Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/planning/adr-049-package-validator-checklist.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-14T07:40:14.879898Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/specs/adr-049-package-validator-implementation.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-14T07:40:14.879902Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/adr/ADR-049.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-14T07:40:14.879904Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/planning/adr-049-package-validator/contracts/contract-table.schema.json",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-14T07:40:34.149581Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/adr/ADR-049.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-14T07:40:34.149599Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/specs/adr-049-package-validator-implementation.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-14T07:40:34.149602Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/planning/package-validator-contract-survey-draft.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-14T07:40:34.149603Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/planning/adr-049-package-validator-checklist.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-14T07:41:16.956062Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/planning/adr-049-package-validator-checklist.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-14T07:41:16.956082Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/specs/adr-049-package-validator-implementation.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-14T07:43:43.070219Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/adr/ADR-049.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-14T07:43:43.070238Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/specs/adr-049-package-validator-implementation.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-14T07:43:43.070241Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/planning/package-validator-contract-survey-draft.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-14T07:43:43.070242Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/planning/adr-049-package-validator-checklist.md",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": true,
+  "guard_events": [
+    {
+      "at": "2026-06-14T06:58:06.147689Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T06:58:06.221875Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T06:58:06.289110Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T06:58:06.349944Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "issue_link",
+          "git_evidence": null,
+          "id": "issue_link.missing",
+          "line": null,
+          "message": "at least one linked issue is required",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "issue_link.missing",
+          "severity": "error",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "issue_link",
+      "status": "fail"
+    },
+    {
+      "at": "2026-06-14T06:58:06.418734Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T06:58:06.488581Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T06:58:06.570782Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T06:58:06.630283Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T06:58:06.681312Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T06:58:06.734121Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:28:43.554466Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:28:43.609965Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:28:43.663035Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:28:43.719704Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:28:43.776790Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:28:43.835414Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:28:43.904116Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:28:43.956990Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:28:44.014488Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:28:44.065895Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:29:33.831620Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:29:33.883327Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:29:33.942914Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:29:33.998808Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:29:34.058832Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:29:34.120011Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:29:34.191765Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:29:34.244532Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:29:34.297186Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:29:34.373757Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:30:01.184975Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:30:01.239492Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:30:01.292118Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:30:01.351573Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:30:01.423920Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:30:01.476877Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:30:01.529030Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:30:01.585475Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:30:01.645695Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:30:01.700432Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:40:50.564573Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:40:50.625292Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:40:50.682273Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:40:50.735548Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:40:50.790751Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:40:50.863608Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:40:50.917273Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:40:50.987068Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:40:51.055201Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:40:51.142706Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:41:28.190684Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:41:28.249107Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:41:28.305674Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:41:28.356591Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:41:28.407826Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:41:28.465092Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:41:28.536008Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:41:28.589311Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:41:28.649869Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:41:28.701207Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:43:54.458157Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:43:54.510983Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:43:54.571116Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:43:54.630514Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:43:54.688322Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:43:54.740161Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:43:54.791948Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:43:54.850195Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:43:54.917988Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:43:54.971924Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:45:36.557665Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:45:36.614365Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:45:36.687183Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:45:36.776968Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:45:36.834643Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:45:36.897326Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:45:36.964297Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:45:37.023095Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:45:37.088035Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:45:37.149703Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:46:06.020309Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:46:06.075511Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:46:06.130894Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:46:06.186583Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:46:06.242417Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:46:06.298262Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:46:06.360076Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:46:06.422597Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:46:06.479822Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:46:06.543849Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:52:14.367376Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:52:14.423970Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:52:14.480450Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:52:14.537414Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:52:14.609776Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:52:14.665931Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:52:14.756381Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:52:14.817842Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:52:14.882612Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:52:14.958965Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1659,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": {
+    "base": "origin/main",
+    "base_sha": "7c064210",
+    "changed_files": [
+      ".workflow/records/design-package-validator-contract-survey-design-package-validator-contract-survey.json",
+      "docs/adr/ADR-049.md",
+      "docs/planning/adr-049-package-validator-checklist.md",
+      "docs/planning/adr-049-package-validator/contracts/contract-table.schema.json",
+      "docs/planning/adr-049-package-validator/contracts/pv-a1-sections-01-03.json",
+      "docs/planning/adr-049-package-validator/contracts/pv-a2-sections-04-06.json",
+      "docs/planning/adr-049-package-validator/contracts/pv-a3-sections-07-09.json",
+      "docs/planning/adr-049-package-validator/contracts/pv-a4-sections-10-12.json",
+      "docs/planning/adr-049-package-validator/contracts/pv-a5-section-13-omissions.json",
+      "docs/planning/adr-049-package-validator/prompts/pv-a1-sections-01-03.md",
+      "docs/planning/adr-049-package-validator/prompts/pv-a2-sections-04-06.md",
+      "docs/planning/adr-049-package-validator/prompts/pv-a3-sections-07-09.md",
+      "docs/planning/adr-049-package-validator/prompts/pv-a4-sections-10-12.md",
+      "docs/planning/adr-049-package-validator/prompts/pv-a5-section-13-omissions.md",
+      "docs/planning/package-validator-contract-survey-draft.md",
+      "docs/specs/adr-049-package-validator-implementation.md",
+      "scripts/audit/check_package_contract_tables.py"
+    ],
+    "diff_fingerprint": "sha256:a1ca0e240a7ffa5b0fda06811a4a9bb36371388cce928325472bad9eb6caf925",
+    "head": "HEAD",
+    "head_sha": "f5b7b3e5",
+    "surfaces": {
+      "docs": 15,
+      "frontend": 0,
+      "governance": 1,
+      "governed_docs": 0,
+      "implementation": 0,
+      "packaging": 0,
+      "protected_core": 0,
+      "sentrux": 2,
+      "test": 0,
+      "workflow_ci": 0
+    }
+  },
+  "owner_directive": "Coordinate five subagents to derive ADR-049 package validator contract tables from code-first evidence; write QA consistency checker; correct tables for ADR drafting.",
+  "persona": "adr_author",
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [
+      1659
+    ],
+    "number": null,
+    "url": null
+  },
+  "reconcile_events": [
+    {
+      "at": "2026-06-14T06:58:06.734189Z",
+      "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "mode": "local",
+      "result": "fail",
+      "tier": 3,
+      "unsatisfied": [
+        "guard.issue_link"
+      ]
+    },
+    {
+      "at": "2026-06-14T07:28:44.065970Z",
+      "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "mode": "local",
+      "result": "pass",
+      "tier": 3,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-14T07:29:34.373830Z",
+      "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 3,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-14T07:30:01.700506Z",
+      "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 3,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-14T07:40:51.142817Z",
+      "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "mode": "local",
+      "result": "pass",
+      "tier": 3,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-14T07:41:28.701313Z",
+      "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 3,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-14T07:43:54.971999Z",
+      "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "mode": "local",
+      "result": "fail",
+      "tier": 3,
+      "unsatisfied": [
+        "checks.full_audit"
+      ]
+    },
+    {
+      "at": "2026-06-14T07:45:37.149817Z",
+      "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 3,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-14T07:46:06.543952Z",
+      "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 3,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-14T07:52:14.959010Z",
+      "diff_fingerprint": "sha256:a1ca0e240a7ffa5b0fda06811a4a9bb36371388cce928325472bad9eb6caf925",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    }
+  ],
+  "record_id": "design-package-validator-contract-survey-design-package-validator-contract-survey",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [
+      "architecture_tests",
+      "deferral_discipline",
+      "format_check",
+      "full_audit",
+      "import_contracts",
+      "lint_format",
+      "python_tests",
+      "semantic_dup",
+      "type_check"
+    ],
+    "docs": [
+      "docs_required_or_na"
+    ],
+    "guards": [
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": []
+  },
+  "runtime": "codex",
+  "schema_version": 2,
+  "scope_events": [
+    {
+      "action": "add-include",
+      "at": "2026-06-14T06:37:41.367387Z",
+      "pattern": "docs/planning/adr-049-package-validator/prompts/**",
+      "reason": "Add saved dispatch prompts for five package-validator contract agents"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-14T07:00:46.675131Z",
+      "pattern": "docs/adr/ADR-049.md",
+      "reason": "Owner requested ADR-049 draft from corrected package validator contract tables"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-14T07:28:14.892320Z",
+      "pattern": "docs/adr/ADR-049.md",
+      "reason": "Link ADR-049 package validator issue for PR readiness"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-14T07:28:14.892338Z",
+      "pattern": "docs/planning/package-validator-contract-survey-draft.md",
+      "reason": "Link ADR-049 package validator issue for PR readiness"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-14T07:28:14.892340Z",
+      "pattern": "docs/planning/adr-049-package-validator-checklist.md",
+      "reason": "Link ADR-049 package validator issue for PR readiness"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-14T07:28:14.892342Z",
+      "pattern": "docs/planning/adr-049-package-validator/contracts/**",
+      "reason": "Link ADR-049 package validator issue for PR readiness"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-14T07:28:14.892343Z",
+      "pattern": "docs/planning/adr-049-package-validator/prompts/**",
+      "reason": "Link ADR-049 package validator issue for PR readiness"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-14T07:28:14.892345Z",
+      "pattern": "scripts/audit/check_package_contract_tables.py",
+      "reason": "Link ADR-049 package validator issue for PR readiness"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-14T07:40:14.879874Z",
+      "pattern": "docs/specs/adr-049-package-validator-implementation.md",
+      "reason": "Add ADR-049 implementation spec and explicit contract applicability metadata"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-14T07:40:14.879892Z",
+      "pattern": "docs/planning/adr-049-package-validator/contracts/contract-table.schema.json",
+      "reason": "Add ADR-049 implementation spec and explicit contract applicability metadata"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-14T07:43:17.905932Z",
+      "pattern": "scripts/audit/check_package_contract_tables.py",
+      "reason": "Declare governance touch for package contract checker under scripts/audit"
+    }
+  ],
+  "session_id": "388bdc02-5a03-4ae2-a164-68dd78cd849e",
+  "strictness_tier": 1,
+  "task_kind": "manager",
+  "test_events": [
+    {
+      "at": "2026-06-14T06:37:27.709056Z",
+      "class": null,
+      "kind": "path",
+      "path": "scripts/audit/check_package_contract_tables.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-14T06:55:58.006792Z",
+      "class": null,
+      "kind": "path",
+      "path": "scripts/audit/check_package_contract_tables.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-14T06:57:08.209595Z",
+      "class": null,
+      "kind": "path",
+      "path": "scripts/audit/check_package_contract_tables.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-14T07:00:46.675161Z",
+      "class": null,
+      "kind": "path",
+      "path": "scripts/audit/check_package_contract_tables.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-14T07:05:49.186599Z",
+      "class": null,
+      "kind": "path",
+      "path": "scripts/audit/check_package_contract_tables.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-14T07:28:14.892450Z",
+      "class": null,
+      "kind": "path",
+      "path": "scripts/audit/check_package_contract_tables.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-14T07:28:31.872623Z",
+      "class": null,
+      "kind": "path",
+      "path": "scripts/audit/check_package_contract_tables.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-14T07:40:14.879907Z",
+      "class": null,
+      "kind": "path",
+      "path": "scripts/audit/check_package_contract_tables.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-14T07:40:34.149607Z",
+      "class": null,
+      "kind": "path",
+      "path": "scripts/audit/check_package_contract_tables.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-14T07:43:43.070246Z",
+      "class": null,
+      "kind": "path",
+      "path": "scripts/audit/check_package_contract_tables.py",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/.workflow/records/design-package-validator-contract-survey-design-package-validator-contract-survey.json
+++ b/.workflow/records/design-package-validator-contract-survey-design-package-validator-contract-survey.json
@@ -276,13 +276,154 @@
       "tool_versions": {
         "mypy": "2.1.0"
       }
+    },
+    {
+      "at": "2026-06-14T07:53:16.703124Z",
+      "command": "pytest tests/architecture/ -v --no-cov",
+      "covered_surface": "architecture",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:a256c64035de25b10bedaa99bbd238ddd71241bc4ae9df9aa1c3da8b4cf330e6",
+      "name": "architecture_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/architecture_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-14T07:53:17.608569Z",
+      "command": "python scripts/deferral_scan.py --check docs/audit/baselines/deferral-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:a256c64035de25b10bedaa99bbd238ddd71241bc4ae9df9aa1c3da8b4cf330e6",
+      "name": "deferral_discipline",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/deferral_discipline.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-14T07:53:17.651542Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:a256c64035de25b10bedaa99bbd238ddd71241bc4ae9df9aa1c3da8b4cf330e6",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-14T07:53:31.627479Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:a256c64035de25b10bedaa99bbd238ddd71241bc4ae9df9aa1c3da8b4cf330e6",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-14T07:53:32.069880Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:a256c64035de25b10bedaa99bbd238ddd71241bc4ae9df9aa1c3da8b4cf330e6",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-14T07:53:32.113276Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:a256c64035de25b10bedaa99bbd238ddd71241bc4ae9df9aa1c3da8b4cf330e6",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-14T07:57:30.912861Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:a256c64035de25b10bedaa99bbd238ddd71241bc4ae9df9aa1c3da8b4cf330e6",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-14T07:58:37.284745Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:a256c64035de25b10bedaa99bbd238ddd71241bc4ae9df9aa1c3da8b4cf330e6",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-14T07:58:38.125566Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:a256c64035de25b10bedaa99bbd238ddd71241bc4ae9df9aa1c3da8b4cf330e6",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
     }
   ],
   "check_na": [],
   "commit": {
-    "sha": "f5b7b3e52c4f92919ecfde40ecfba0efc5413e87",
+    "sha": "6a89c2d6f25cd1c33202b64d0b6dc14d8b5713ca",
     "shas": [
-      "f5b7b3e52c4f92919ecfde40ecfba0efc5413e87"
+      "6a89c2d6f25cd1c33202b64d0b6dc14d8b5713ca"
     ],
     "trailers": []
   },
@@ -1274,6 +1415,170 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:58:38.261251Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:58:38.328702Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:58:38.399330Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:58:38.460597Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:58:38.520813Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:58:38.586870Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:58:38.652323Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:58:38.711677Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:58:38.766880Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:58:38.827052Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:59:21.853366Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:59:21.917706Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:59:21.973076Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:59:22.026444Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:59:22.081640Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:59:22.145110Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:59:22.209215Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:59:22.270688Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:59:22.325962Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T07:59:22.381624Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -1286,8 +1591,8 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "origin/main",
-    "base_sha": "7c064210",
+    "base": "25c0176e2584d5bf8bc8ca48c95ca9145702c1c1",
+    "base_sha": "25c0176e",
     "changed_files": [
       ".workflow/records/design-package-validator-contract-survey-design-package-validator-contract-survey.json",
       "docs/adr/ADR-049.md",
@@ -1307,9 +1612,9 @@
       "docs/specs/adr-049-package-validator-implementation.md",
       "scripts/audit/check_package_contract_tables.py"
     ],
-    "diff_fingerprint": "sha256:a1ca0e240a7ffa5b0fda06811a4a9bb36371388cce928325472bad9eb6caf925",
+    "diff_fingerprint": "sha256:2b8c6be5d6acd66359cb72994bbec47d5962620751256484f740865b814d5212",
     "head": "HEAD",
-    "head_sha": "f5b7b3e5",
+    "head_sha": "6a89c2d6",
     "surfaces": {
       "docs": 15,
       "frontend": 0,
@@ -1330,8 +1635,8 @@
     "closes": [
       1659
     ],
-    "number": null,
-    "url": null
+    "number": 1662,
+    "url": "https://github.com/zjzcpj/SciStudio/pull/1662"
   },
   "reconcile_events": [
     {
@@ -1417,23 +1722,29 @@
       "result": "pass",
       "tier": 1,
       "unsatisfied": []
+    },
+    {
+      "at": "2026-06-14T07:58:38.827088Z",
+      "diff_fingerprint": "sha256:2b8c6be5d6acd66359cb72994bbec47d5962620751256484f740865b814d5212",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-14T07:59:22.381659Z",
+      "diff_fingerprint": "sha256:2b8c6be5d6acd66359cb72994bbec47d5962620751256484f740865b814d5212",
+      "mode": "ci",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
     }
   ],
   "record_id": "design-package-validator-contract-survey-design-package-validator-contract-survey",
   "requested_admin_labels": [],
   "required_obligations": {
     "admin_labels": [],
-    "checks": [
-      "architecture_tests",
-      "deferral_discipline",
-      "format_check",
-      "full_audit",
-      "import_contracts",
-      "lint_format",
-      "python_tests",
-      "semantic_dup",
-      "type_check"
-    ],
+    "checks": [],
     "docs": [
       "docs_required_or_na"
     ],

--- a/docs/adr/ADR-049.md
+++ b/docs/adr/ADR-049.md
@@ -1,0 +1,619 @@
+---
+adr: 49
+title: "Package Validator System And Machine-Verifiable Extension Contracts"
+status: Proposed
+date_created: 2026-06-14
+date_accepted: null
+date_superseded: null
+
+supersedes: []
+superseded_by: null
+related: [17, 20, 22, 25, 26, 27, 28, 29, 30, 31, 37, 38, 41, 43, 44, 47, 48]
+closes_issues: [1659]
+tracking_issue: 1659
+
+is_code_implementation: true
+governs:
+  modules:
+    - scistudio.blocks.registry
+    - scistudio.blocks.io.capabilities
+    - scistudio.blocks.code.validation
+    - scistudio.core.types.registry
+    - scistudio.previewers
+    - scistudio.testing
+    - scistudio.workflow.validator
+  contracts:
+    - scistudio.blocks.base.package_info.PackageInfo
+    - scistudio.blocks.registry.BlockRegistry
+    - scistudio.blocks.registry.BlockSpec
+    - scistudio.blocks.registry.MissingCapabilityError
+    - scistudio.blocks.registry.AmbiguousCapabilityError
+    - scistudio.blocks.io.capabilities.FormatCapability
+    - scistudio.blocks.io.capabilities.MetadataFidelity
+    - scistudio.blocks.code.validation.validate_codeblock_config
+    - scistudio.core.types.registry.TypeRegistry
+    - scistudio.previewers.registry.PreviewerRegistry
+    - scistudio.previewers.router.PreviewRouter
+    - scistudio.previewers.models.PreviewerSpec
+    - scistudio.previewers.models.FrontendManifest
+    - scistudio.previewers.data_access.PreviewDataAccess
+    - scistudio.previewers.assets.validate_manifest
+    - scistudio.previewers.assets.resolve_asset
+    - scistudio.testing.harness.BlockTestHarness
+    - scistudio.workflow.validator.validate_workflow
+  entry_points:
+    - scistudio.blocks
+    - scistudio.types
+    - scistudio.previewers
+    - scistudio.runners
+  files:
+    - docs/adr/ADR-049.md
+    - docs/specs/adr-049-package-validator-implementation.md
+    - docs/planning/adr-049-package-validator/**
+    - docs/planning/package-validator-contract-survey-draft.md
+    - scripts/audit/check_package_contract_tables.py
+    - pyproject.toml
+    - packages/scistudio-blocks-*/pyproject.toml
+    - packages/scistudio-blocks-*/src/**
+    - packages/scistudio-blocks-*/tests/**
+    - src/scistudio/blocks/registry/**
+    - src/scistudio/blocks/io/**
+    - src/scistudio/blocks/code/validation.py
+    - src/scistudio/core/types/registry.py
+    - src/scistudio/previewers/**
+    - src/scistudio/testing/**
+    - src/scistudio/workflow/validator.py
+  excludes:
+    - docs/audit/**
+planned_governs:
+  modules:
+    - scistudio.packages.validation
+    - scistudio.cli.package_validator
+  contracts:
+    - scistudio.packages.validation.PackageValidationReport
+    - scistudio.packages.validation.PackageValidationFinding
+    - scistudio.packages.validation.PackageValidationProfile
+    - scistudio.packages.validation.validate_package
+    - scistudio.packages.validation.validate_installed_package
+  entry_points: []
+  files:
+    - src/scistudio/packages/validation/**
+    - src/scistudio/cli/package_validator.py
+    - tests/packages/**
+  excludes: []
+
+tests:
+  - scripts/audit/check_package_contract_tables.py
+  - tests/testing/test_harness.py
+  - tests/blocks/test_registry.py
+  - tests/blocks/test_block_registry_capabilities.py
+  - tests/blocks/io/test_format_capabilities.py
+  - tests/contracts/test_io_capability_contract.py
+  - tests/workflow/test_io_boundary_validation.py
+  - tests/previewers/test_preview_registry.py
+  - tests/previewers/test_preview_routing.py
+  - packages/scistudio-blocks-imaging/tests/test_previewer_registration.py
+  - tests/packages/test_package_validator.py
+  - tests/packages/test_package_validator_reports.py
+agent_editable: false
+assisted_by:
+  - "Codex:gpt-5"
+
+phase: planning
+tags:
+  - package-validator
+  - plugin-contracts
+  - contract-testing
+  - machine-verifiable-contracts
+  - architecture
+owner: "@jiazhenz026"
+co_authors:
+  - "@codex"
+language_source: en
+translations: []
+---
+
+# ADR-049: Package Validator System And Machine-Verifiable Extension Contracts
+
+## 1. Decision Summary
+
+SciStudio will introduce a package validator system that validates extension
+packages during development and before production registration. The validator
+uses code-first, machine-verifiable contract tables as the authoritative package
+contract inventory. ADR text and older ADRs remain important design evidence,
+but implementation evidence wins when they disagree.
+
+The validator has two profiles:
+
+- **Development validation** helps package authors find invalid or inconsistent
+  package contracts before release. It returns structured findings and may
+  classify weak or legacy-compatible behavior as warnings.
+- **Production install validation** protects running SciStudio instances. A
+  package with blocking findings is not registered into live block, type,
+  previewer, IO capability, runner, or API-facing registries.
+
+The complete machine-verifiable contract set for this ADR is the JSON table set
+listed in Section 4. The Markdown tables in Section 5 are an ADR-readable index;
+the JSON files carry the complete evidence rows and are checked by
+`scripts/audit/check_package_contract_tables.py`.
+
+### 1.1 Problems Addressed
+
+| Problem | Risk | ADR response | Detailed section |
+|---|---|---|---|
+| Package-facing contracts are scattered across registries, tests, ADRs, docs, and package examples | Package authors and AI agents can implement plausible but invalid packages | Define one package validator system and one machine-verifiable contract table family | Section 3 and Section 4 |
+| Development validation and production install behavior need different failure policy | A warning-friendly authoring helper is either too weak for production or too strict for local iteration | Define explicit development and production profiles with shared contract IDs but different severities | Section 3 |
+| Current registry scans are intentionally tolerant | Invalid packages may be skipped or partially registered instead of rejected with actionable findings | Require isolated dry-run validation and atomic production registration | Section 6 |
+| ADRs may be stale relative to code | Generated or agent-authored code may satisfy current implementation but drift from architecture intent | Make code evidence errors blocking and ADR drift machine-visible warnings | Section 4 and Section 8 |
+| Extension surfaces beyond blocks/types/previewers can be missed | Validator scope omits runners, API serialization, scaffold fixtures, or generated public facts | Include omitted/discovered contracts and require mechanical inventory coverage | Section 5 and Section 7 |
+
+## 2. Context
+
+SciStudio extension packages currently contribute behavior through Python entry
+points, package modules, in-repo monorepo fallbacks, registries, and package
+tests. The main extension surfaces are blocks, DataObject types, IO format
+capabilities, previewers, preview frontend assets, plot jobs, runner backends,
+and registry-derived API payloads.
+
+Current implementation already contains local validation pieces:
+
+- `BlockTestHarness` validates basic block and package callable shape.
+- `TypeRegistry` validates type class shape and selected `Meta` constraints.
+- `BlockRegistry` validates dynamic ports, distribution version resolution, and
+  IO capability registration.
+- `FormatCapability` and `MetadataFidelity` validate IO capability fields.
+- `PreviewerRegistry`, `PreviewRouter`, and preview asset helpers validate
+  parts of previewer declaration, routing, and asset safety.
+- Workflow validation checks selected AppBlock, CodeBlock, variadic-port, and
+  IO boundary conditions.
+
+Those pieces are not a production package validator. Many scans log and skip
+invalid surfaces so application startup remains resilient. ADR-049 keeps that
+runtime resilience but adds a stricter package validation path.
+
+## 3. Validation System And Environment Behavior
+
+### 3.1 Shared Validation Pipeline
+
+Development and production validation use the same contract IDs and the same
+evidence model. A validator run MUST:
+
+1. Build a mechanical package inventory from code and package metadata.
+2. Load candidate entry points in an isolated validation context.
+3. Build dry-run type, block, previewer, IO capability, and runner registries.
+4. Validate every contract row relevant to the candidate package.
+5. Validate cross-surface consistency after each individual surface is parsed.
+6. Optionally run smoke fixtures when the package provides test data or fixture
+   declarations.
+7. Emit a structured `PackageValidationReport`.
+8. Avoid mutating live application registries until production validation
+   passes.
+
+### 3.2 Development Profile
+
+Development validation is author-facing. It SHOULD be exposed as a CLI and test
+helper, planned under `scistudio.packages.validation` and
+`scistudio.cli.package_validator`.
+
+Development behavior:
+
+- It SHOULD report all findings in one run instead of fail-fast.
+- It MAY treat compatibility paths as warnings when current runtime accepts
+  them.
+- It SHOULD include repair hints and source locations.
+- It SHOULD allow optional dependency checks to be marked skipped when the
+  package declares why a dependency is optional.
+- It MUST still treat malformed, non-importable, or structurally impossible
+  contracts as errors.
+
+### 3.3 Production Install Profile
+
+Production validation is install-facing. It runs before package registration
+into live registries.
+
+Production behavior:
+
+- It MUST run in an isolated validation process or future per-plugin
+  environment. Candidate package code MUST NOT be imported directly into the
+  live engine process for validation.
+- It MUST build dry-run registries and commit validated registry rows only
+  after all blocking checks pass.
+- It MUST reject package registration when a contract row with production
+  profile `block` or `error` fails.
+- It MUST quarantine or ignore the invalid distribution as a whole unless a
+  later ADR explicitly defines safe partial-surface registration.
+- It MUST return deterministic structured diagnostics that can be displayed in
+  desktop, CLI, and logs.
+
+### 3.4 Severity Semantics
+
+| Severity | Development meaning | Production meaning |
+|---|---|---|
+| `blocker` | The package cannot be trusted to run validation safely | Do not install or register |
+| `error` | Package author must fix before release | Do not register when production profile is `block` or `error` |
+| `warning` | Accepted or tolerated locally, but not clean release quality | May block when production profile says `error`; otherwise register with diagnostic |
+| `info` | Informational compatibility or documentation signal | Non-blocking diagnostic |
+
+### 3.5 What The Validator Actually Checks
+
+This section is the human-readable checklist for the runtime validator. For
+every candidate package, the validator checks only the surfaces that the
+candidate package exposes. Repository examples such as `Image`, `SRSImage`, or
+`PeakTable` are evidence that the contract exists today; they are not required
+names for a new package.
+
+| Candidate surface | When checked | Required checks |
+|---|---|---|
+| Python distribution metadata | Development and production | Distribution name and version resolve; package can be located; package version is not `"unknown"` where registry lineage needs it; future `[tool.scistudio]` fields are validated when that manifest is active |
+| `PackageInfo` | When `scistudio.blocks` returns package metadata | Value is a `PackageInfo`; `name` and `version` are non-empty strings; `description` and `author` are strings; package identity is consistent with the distribution where possible |
+| Entry points | For each declared `scistudio.*` entry point | Entry point group is known; module target imports in validation isolation; target is callable or accepted class form; callable returns the expected surface payload; errors become structured findings |
+| `scistudio.types` payload | When package declares types | Payload is a list/tuple of `DataObject` subclasses; each type can be registered in a dry-run `TypeRegistry`; `Meta` is a Pydantic model when present; no `PrivateAttr`; metadata can JSON round-trip when constructible; duplicate or unloadable type names are findings |
+| `scistudio.blocks` payload | When package declares blocks | Payload resolves to concrete `Block` subclasses; each block has valid `name`, `input_ports`, `output_ports`, and callable execution path; port names and port types are valid; package block specs can be built in a dry-run `BlockRegistry` |
+| Block config, dynamic ports, and variadic ports | For every candidate block | `config_schema` can be merged and serialized; `dynamic_ports` descriptor shape is valid; effective ports can be computed from representative config; variadic min/max and configured port lists are coherent |
+| IO blocks and format capabilities | For every candidate `IOBlock` or declared `FormatCapability` | Capability is explicit unless compatibility profile allows legacy synthesis; ID is stable/package-qualified/unique; direction matches IO block role; handler exists; extensions normalize; metadata fidelity is valid; defaults do not conflict; lookup is deterministic |
+| Runtime data boundary smoke | Development profile and production only when safe fixtures exist | Smoke execution returns a mapping of output port names to `Collection` values; returned objects crossing process/storage boundaries are reference-based; ordinary data objects have `storage_ref`; `Artifact` objects have `file_path`; hidden raw payload backdoors are findings |
+| AppBlock and CodeBlock boundaries | For candidate `AppBlock` / `CodeBlock` subclasses or configs | File exchange declarations are valid; input materialization resolves saver capabilities; output reconstruction resolves loader capabilities; output extensions are not ambiguous; CodeBlock paths are project-local and use supported script extensions |
+| `scistudio.previewers` payload | When package declares previewers | Payload is a list/tuple of `PreviewerSpec`; `previewer_id` is non-empty and unique; `owner_kind`/`owner_name` match the package; `target_type` resolves in the dry-run type registry; priority and collection support are deterministic; router ambiguity is a finding |
+| Preview frontend manifest | When a previewer declares frontend assets | Manifest IDs match the previewer; module and CSS URLs are same-origin/backend-relative; version/API version are checked; asset root is backend-only; served asset paths remain confined under `asset_root` |
+| Preview provider | When previewer has a backend provider | Provider is callable or importable dotted path; routine provider failures return typed error envelopes; provider uses bounded `PreviewDataAccess` in smoke/instrumented checks where available |
+| Plot jobs and examples | Only when package ships project examples or plot templates | Plot manifests are project-local and schema-valid; target references resolve in the example project; scripts stay path-confined; outputs use allowed formats; plot execution is preview-only |
+| Security and isolation | Production always; development where practical | Candidate package code is evaluated in validation isolation; live registries are not mutated before validation passes; remote frontend assets and path traversal are rejected; unsafe subprocess or filesystem assumptions are findings |
+| Cross-surface consistency | After all candidate surfaces are loaded into dry-run registries | Block port types resolve to registered types; IO capability data types match effective IO ports; previewer target types resolve; capability IDs do not conflict with existing packages; registry-derived API/palette payloads serialize cleanly |
+
+Production validation MUST NOT require a candidate package to define a concrete
+type, block, previewer, capability, or runner merely because that symbol appears
+in ADR-049 evidence tables. Production validation checks the candidate package's
+own declared surfaces against the generic contracts above.
+
+### 3.6 Candidate Selection And Runtime Triggers
+
+The validator does not decide that every installed Python distribution is a
+SciStudio package. A caller supplies one candidate package at a time, and the
+validator derives the package's SciStudio surfaces from distribution metadata,
+entry points, manifests, and package-owned modules.
+
+Valid candidate inputs are:
+
+- a source tree path during local package development;
+- a built wheel or source distribution before publish;
+- an installed Python distribution name;
+- an importable module only when wrapped with distribution metadata;
+- a package installer, enable, upgrade, reload, or startup scan event that
+  identifies the distribution being considered for registration.
+
+Development triggers are explicit: CLI validation, package CI, package scaffold
+tests, or a test helper call. Production triggers are install-facing: package
+install, enable, upgrade, reload, or application startup entry-point discovery
+before live registration.
+
+The runtime validator MUST classify every contract row for a candidate as
+`pass`, `fail`, `warning`, `skipped`, or `not_applicable`. `not_applicable`
+means the candidate did not expose the surface named by the row's
+`applicability` metadata. It is not a validation failure.
+
+## 4. Machine-Verifiable Contract System
+
+### 4.1 Normative Contract Manifest
+
+The following manifest is normative. The checker MUST be able to validate the
+contract tables and ADR coverage from this repository state.
+
+```json
+{
+  "schema_version": "adr049.package_validator_contract_manifest.v1",
+  "adr": "docs/adr/ADR-049.md",
+  "contract_schema": "docs/planning/adr-049-package-validator/contracts/contract-table.schema.json",
+  "contract_tables": [
+    "docs/planning/adr-049-package-validator/contracts/pv-a1-sections-01-03.json",
+    "docs/planning/adr-049-package-validator/contracts/pv-a2-sections-04-06.json",
+    "docs/planning/adr-049-package-validator/contracts/pv-a3-sections-07-09.json",
+    "docs/planning/adr-049-package-validator/contracts/pv-a4-sections-10-12.json",
+    "docs/planning/adr-049-package-validator/contracts/pv-a5-section-13-omissions.json"
+  ],
+  "checker": "scripts/audit/check_package_contract_tables.py",
+  "inventory_command": "python scripts/audit/check_package_contract_tables.py --dump-inventory",
+  "validation_command": "python scripts/audit/check_package_contract_tables.py",
+  "current_expected_result": {
+    "errors": 0,
+    "warnings": 9,
+    "warning_contract_ids": [
+      "PV-02-002",
+      "PV-03-002",
+      "PV-04-001",
+      "PV-07-001",
+      "PV-08-003",
+      "PV-12-004",
+      "PV-99-001",
+      "PV-99-003",
+      "PV-99-004"
+    ]
+  }
+}
+```
+
+### 4.2 Contract Row Rules
+
+Every contract row MUST use schema version
+`adr049.package_contract_table.v1`. Each row records:
+
+- stable contract ID;
+- one of the ADR-049 contract sections;
+- contract title and normative contract text;
+- implementation status;
+- severity and development/production profile behavior;
+- applicability metadata, including candidate surfaces, trigger condition, and
+  the `not_applicable` result for absent surfaces;
+- code evidence, ADR evidence, and test evidence;
+- ADR alignment classification;
+- validator implication.
+
+The checker enforces these rules:
+
+- code evidence mismatch is an error;
+- uncovered required inventory anchor is an error;
+- duplicate contract IDs are errors;
+- ADR evidence mismatch is a warning;
+- `adr_missing`, `adr_drift`, and `adr_planned` rows are warnings when code
+  evidence passes;
+- if this ADR exists, it must name every contract ID and every contract table.
+
+## 5. Validation Contract Master Table
+
+The following table is the ADR-readable contract index. The JSON tables named in
+Section 4 are the complete machine-readable contract source.
+
+| ID | Section | Contract | Status | Dev | Prod | ADR alignment | Machine table |
+|---|---|---|---|---|---|---|---|
+| PV-01-001 | 01 package metadata distribution | PackageInfo is the package metadata envelope | implemented | error | block | aligned | pv-a1-sections-01-03 |
+| PV-01-002 | 01 package metadata distribution | PackageInfo fields are structurally validated | implemented | error | block | aligned | pv-a1-sections-01-03 |
+| PV-02-001 | 02 entry points | Block package entry points expose package metadata plus block classes | implemented | error | block | aligned | pv-a1-sections-01-03 |
+| PV-02-002 | 02 entry points | Core distribution declares block and CodeBlock runner entry points | implemented | error | block | adr_missing | pv-a1-sections-01-03 |
+| PV-02-003 | 02 entry points | Development harness validates scistudio.blocks callable return shape | implemented | error | block | aligned | pv-a1-sections-01-03 |
+| PV-03-001 | 03 type contracts | Type entry points return plugin DataObject type classes | implemented | error | block | aligned | pv-a1-sections-01-03 |
+| PV-03-002 | 03 type contracts | TypeRegistry validates and registers type classes | partial | warning | error | adr_drift | pv-a1-sections-01-03 |
+| PV-03-003 | 03 type contracts | Current plugin packages ship concrete type payloads | implemented | error | block | aligned | pv-a1-sections-01-03 |
+| PV-04-001 | 04 block contracts | BlockTestHarness reports SDK block contract errors | partial | warning | skip | adr_drift | pv-a2-sections-04-06 |
+| PV-05-001 | 05 config dynamic variadic | Config schema and dynamic-port descriptors are registry-spec contracts | implemented | block | block | aligned | pv-a2-sections-04-06 |
+| PV-05-002 | 05 config dynamic variadic | Effective and variadic ports are instance-aware validation surfaces | implemented | block | block | aligned | pv-a2-sections-04-06 |
+| PV-06-001 | 06 IO format capability | FormatCapability and MetadataFidelity constructors enforce field validity | implemented | block | block | aligned | pv-a2-sections-04-06 |
+| PV-06-002 | 06 IO format capability | Registry registration validates class-owned capabilities | partial | block | error | aligned | pv-a2-sections-04-06 |
+| PV-06-003 | 06 IO format capability | Capability lookup is deterministic and typed-error based | implemented | block | block | aligned | pv-a2-sections-04-06 |
+| PV-06-004 | 06 IO format capability | Boundary ports validate by IO capability lookup | implemented | error | error | aligned | pv-a2-sections-04-06 |
+| PV-07-001 | 07 data transport runtime boundary | Smoke tests execute Block.run directly and propagate failures | implemented | block | skip | adr_missing | pv-a3-sections-07-09 |
+| PV-07-002 | 07 data transport runtime boundary | Collection transport remains runtime-specific at external boundaries | implemented | warning | warning | aligned | pv-a3-sections-07-09 |
+| PV-08-001 | 08 AppBlock and CodeBlock boundaries | CodeBlock v2 persisted config validation is strict for concrete CodeBlock specs | implemented | block | block | aligned | pv-a3-sections-07-09 |
+| PV-08-002 | 08 AppBlock and CodeBlock boundaries | Workflow validation enforces AppBlock output ambiguity and CodeBlock strictness | implemented | block | block | aligned | pv-a3-sections-07-09 |
+| PV-08-003 | 08 AppBlock and CodeBlock boundaries | Concrete AppBlock and CodeBlock subclasses inherit boundary contracts with drift-sensitive checks | partial | warning | warning | adr_drift | pv-a3-sections-07-09 |
+| PV-09-001 | 09 previewer contracts | Previewer entry points return PreviewerSpec lists and registry failures are diagnostic | implemented | warning | warning | aligned | pv-a3-sections-07-09 |
+| PV-09-002 | 09 previewer contracts | PreviewerSpec and FrontendManifest define the public previewer declaration shape | implemented | error | error | aligned | pv-a3-sections-07-09 |
+| PV-09-003 | 09 previewer contracts | Frontend manifest validation separates blocking invalidity from diagnostics | implemented | block | block | aligned | pv-a3-sections-07-09 |
+| PV-09-004 | 09 previewer contracts | PreviewRouter selection is deterministic and ambiguous matches are strict errors | implemented | block | block | aligned | pv-a3-sections-07-09 |
+| PV-09-005 | 09 previewer contracts | Core and imaging package PreviewerSpec declarations establish fallback and package ownership | implemented | info | info | aligned | pv-a3-sections-07-09 |
+| PV-09-006 | 09 previewer contracts | Session rendering stamps manifests and turns provider failures into error envelopes | implemented | error | error | aligned | pv-a3-sections-07-09 |
+| PV-10-001 | 10 preview provider behavior | Preview providers use the bounded data-access surface | implemented | error | block | aligned | pv-a4-sections-10-12 |
+| PV-10-002 | 10 preview provider behavior | Preview session invocation converts routine provider failure to typed envelopes | implemented | error | block | aligned | pv-a4-sections-10-12 |
+| PV-10-003 | 10 preview provider behavior | Preview resource reads remain session-scoped and bounded | implemented | error | block | aligned | pv-a4-sections-10-12 |
+| PV-11-001 | 11 plot jobs | Plot jobs are strict project-local manifests bound by stable output identity | implemented | error | skip | aligned | pv-a4-sections-10-12 |
+| PV-11-002 | 11 plot jobs | Plot execution is preview-only and writes only display cache state | implemented | error | block | aligned | pv-a4-sections-10-12 |
+| PV-11-003 | 11 plot jobs | Plot runtime clamps subprocess execution, output, file, and log limits | implemented | error | block | aligned | pv-a4-sections-10-12 |
+| PV-11-004 | 11 plot jobs | Successful plot artifacts route through PlotPreviewer; failures return no data_ref | implemented | error | block | aligned | pv-a4-sections-10-12 |
+| PV-12-001 | 12 security isolation | Preview frontend manifests are same-origin and hide backend asset roots | implemented | error | block | aligned | pv-a4-sections-10-12 |
+| PV-12-002 | 12 security isolation | Preview asset serving is manifest-validated and path-confined | implemented | error | block | aligned | pv-a4-sections-10-12 |
+| PV-12-003 | 12 security isolation | Plot SVG display and export are sanitized and bounded | implemented | error | block | aligned | pv-a4-sections-10-12 |
+| PV-12-004 | 12 security isolation | Subprocess isolation exists for plot rendering; broader plugin validation isolation is unresolved | partial | warning | error | adr_planned | pv-a4-sections-10-12 |
+| PV-13-001 | 13 cross-surface registry consistency | Block registry descriptors preserve package identity | partial | error | block | aligned | pv-a5-section-13-omissions |
+| PV-13-002 | 13 cross-surface registry consistency | Block entry-point scans are tolerant runtime discovery, not install validation | partial | error | block | aligned | pv-a5-section-13-omissions |
+| PV-13-003 | 13 cross-surface registry consistency | Type registry discovery must reconcile package types with blocks and previewers | partial | error | block | aligned | pv-a5-section-13-omissions |
+| PV-13-004 | 13 cross-surface registry consistency | Previewer package discovery must feed cross-surface target validation | partial | error | block | aligned | pv-a5-section-13-omissions |
+| PV-99-001 | 99 omitted or discovered contracts | Code runner entry-point and language registry contract is not owned by sections 1-13 | partial | warning | error | adr_missing | pv-a5-section-13-omissions |
+| PV-99-002 | 99 omitted or discovered contracts | Scaffold-generated package fixtures are a package contract | implemented | warning | skip | aligned | pv-a5-section-13-omissions |
+| PV-99-003 | 99 omitted or discovered contracts | Generated public symbol facts are an API/package compatibility contract | implemented | info | skip | adr_missing | pv-a5-section-13-omissions |
+| PV-99-004 | 99 omitted or discovered contracts | Registry-derived API serialization is a package-facing contract | partial | error | block | adr_missing | pv-a5-section-13-omissions |
+
+### 5.1 Section Coverage
+
+| Section | Required ADR-049 coverage |
+|---|---|
+| 01 package metadata distribution | Distribution metadata, `PackageInfo`, package version, package display identity |
+| 02 entry points | `scistudio.blocks`, `scistudio.types`, `scistudio.previewers`, current `scistudio.runners`, callable shapes, importability |
+| 03 type contracts | DataObject subclass payloads, TypeRegistry registration, `Meta` validation, type reconstruction implications |
+| 04 block contracts | Block subclass shape, ports, names, run/smoke behavior, SDK harness limitations |
+| 05 config dynamic variadic | MRO schema merge, dynamic-port descriptors, effective ports, variadic cardinality |
+| 06 IO format capability | `FormatCapability`, metadata fidelity, handler/class consistency, lookup determinism, boundary capability validation |
+| 07 data transport runtime boundary | Collection transport, reference-only boundary, smoke-test limits |
+| 08 AppBlock and CodeBlock boundaries | File exchange config, project-local script paths, duplicate extensions, capability resolution |
+| 09 previewer contracts | `PreviewerSpec`, manifest validation, routing determinism, package/core previewer ownership |
+| 10 preview provider behavior | `PreviewDataAccess`, provider invocation, resource reads, typed error envelopes |
+| 11 plot jobs | Project-local plot manifests, preview-only execution, bounded subprocess, artifact routing |
+| 12 security isolation | Same-origin frontend assets, path confinement, SVG sanitization, future package validation isolation |
+| 13 cross-surface registry consistency | Dry-run registries, package identity, type/block/previewer/capability reconciliation |
+| 99 omitted or discovered contracts | Runner entry points, scaffold fixtures, generated facts, registry-derived API serialization |
+
+## 6. Validator Architecture
+
+ADR-049 defines a planned validator module, not yet implemented:
+
+- `PackageValidationProfile`: enum with `development` and `production`.
+- `PackageValidationFinding`: structured finding with contract ID, severity,
+  source path, evidence, profile behavior, message, and repair hint.
+- `PackageValidationReport`: package identity, profile, inventory, findings,
+  dry-run registry summaries, warnings, and final registration decision.
+- `validate_package(path_or_distribution, profile)`: development-oriented
+  validation for source trees, wheels, and installed distributions.
+- `validate_installed_package(distribution, profile="production")`: install
+  validation used by desktop/server package registration.
+
+The minimum report envelope is:
+
+```json
+{
+  "schema_version": "adr049.package_validation_report.v1",
+  "package": {
+    "name": "scistudio-blocks-spectroscopy",
+    "version": "0.1.0",
+    "source": "installed-distribution-or-source-tree"
+  },
+  "profile": "production",
+  "status": "fail",
+  "registration_decision": "reject",
+  "inventory": {
+    "entry_points": ["scistudio.blocks", "scistudio.types"],
+    "surfaces": ["blocks", "types"]
+  },
+  "contract_results": [
+    {
+      "contract_id": "PV-03-001",
+      "result": "pass",
+      "surface": "types"
+    },
+    {
+      "contract_id": "PV-09-001",
+      "result": "not_applicable",
+      "surface": "previewers"
+    }
+  ],
+  "findings": [
+    {
+      "contract_id": "PV-04-001",
+      "severity": "error",
+      "surface": "blocks",
+      "symbol": "spectroscopy.blocks.BadBlock",
+      "message": "Block registry spec cannot be built.",
+      "repair_hint": "Declare valid input_ports, output_ports, and execution contract."
+    }
+  ],
+  "dry_run_registries": {
+    "blocks": 0,
+    "types": 1,
+    "previewers": 0,
+    "format_capabilities": 0
+  }
+}
+```
+
+Production validation MUST be atomic:
+
+1. validate in isolation;
+2. build dry-run registries;
+3. produce a report;
+4. commit validated rows into live registries only when blocking findings are
+   absent.
+
+Current runtime registry scans may remain tolerant for ordinary startup. The
+production package validator is stricter and must not silently skip invalid
+package surfaces.
+
+## 7. Omitted And Newly Discovered Surfaces
+
+The investigation found four extension-facing surfaces not fully captured by
+the original thirteen-section sketch:
+
+| Omission | Required ADR-049 response |
+|---|---|
+| `scistudio.runners` / runner registry | Add runner entry-point importability and language registry validation to package validation scope |
+| Scaffold-generated package fixtures | Treat scaffold output as a conformance fixture or explicitly mark it dev-only |
+| Generated public symbol facts | Decide whether package validator reports must reference generated facts when claiming public API compatibility |
+| Registry-derived API serialization | Validate that candidate registry descriptors serialize consistently for palette/API/MCP surfaces |
+
+These omissions are captured by PV-99-001, PV-99-002, PV-99-003, and PV-99-004.
+
+## 8. ADR Drift Handling
+
+ADR-049 adopts this drift rule:
+
+- If a contract table row disagrees with current code evidence, the table is
+  wrong and the checker reports an error.
+- If code evidence passes but ADR evidence is missing, planned, or drifted, the
+  checker reports a warning.
+- ADR-049 implementation planning MUST either update stale ADRs/docs or record
+  an intentional compatibility policy for the drift.
+
+Current warnings are:
+
+| Contract ID | Meaning |
+|---|---|
+| PV-02-002 | `scistudio.runners` is code-backed but not governed by ADR-025 |
+| PV-03-002 | `Meta.frozen` is ADR/docs-required but not hard-enforced by current `TypeRegistry` |
+| PV-04-001 | Block harness is useful but shallow relative to full block contract requirements |
+| PV-07-001 | Smoke-test contract is implemented in harness but not fully governed by older ADR text |
+| PV-08-003 | Concrete AppBlock/CodeBlock subclasses can drift from CodeBlock v2 boundary expectations |
+| PV-12-004 | Plot subprocess isolation exists, but broader package validation isolation is planned |
+| PV-99-001 | Runner entry-point validation lacks a dedicated ADR section |
+| PV-99-003 | Generated public facts are not yet tied to package validation claims |
+| PV-99-004 | Registry-derived API serialization is package-facing but not fully specified in earlier ADRs |
+
+## 9. Verification
+
+ADR-049 verification starts with contract-table verification:
+
+```bash
+python scripts/audit/check_package_contract_tables.py
+```
+
+The checker MUST:
+
+- parse all `pv-*.json` contract tables;
+- verify code evidence patterns against repository files;
+- verify ADR evidence patterns as warnings;
+- verify required inventory anchors are covered;
+- verify this ADR names every contract ID and table path;
+- return nonzero when any code-evidence or coverage error exists.
+
+Implementation PRs for the validator MUST add direct package-validator tests
+under the planned `tests/package_validation/**` surface. At minimum, those tests
+must include:
+
+- invalid block package rejected in development and production profiles;
+- invalid type `Meta` surfaced with profile-appropriate severity;
+- invalid IO capability rejected before registration;
+- invalid previewer spec and manifest rejected or diagnosed as specified;
+- cross-surface mismatch between type, block port, capability, and previewer
+  target detected by dry-run registries;
+- production install path refuses live registration when blocking findings
+  exist;
+- development path reports all findings in one structured report.
+
+## 10. Consequences
+
+Positive consequences:
+
+- Package authors receive one explicit validation surface instead of learning
+  registry behavior by failure.
+- Production package install can reject invalid packages before live registry
+  mutation.
+- AI-generated package work gets a mechanical contract source, reducing
+  hallucinated or ADR-only implementations.
+- Drift between ADRs and code becomes visible instead of hidden.
+
+Costs and risks:
+
+- The validator must import or execute some package code to inspect entry-point
+  payloads, so isolation is required for production.
+- The contract table set must be maintained when package-facing code changes.
+- Existing packages may need migration if production profile treats current
+  compatibility behavior as invalid.
+- Partial package registration is intentionally out of scope until a future ADR
+  defines safe quarantine semantics.
+
+## 11. Alternatives Considered
+
+| Alternative | Decision | Reason |
+|---|---|---|
+| Keep using tolerant registries as the only validator | Rejected | Startup resilience is not install-time validation; warning/skip behavior hides invalid packages |
+| ADR-only contract prose | Rejected | ADRs can drift and are hard to mechanically compare to code |
+| Test-only package validation | Rejected | Package install needs a runtime report and registration decision, not only pytest failures |
+| Validate only blocks/types/previewers | Rejected | IO capabilities, runners, preview assets, API serialization, and security boundaries are package-facing too |
+| Allow partial production registration by default | Deferred | It requires explicit quarantine semantics and user messaging that are not designed here |
+
+## 12. Open Questions
+
+- Should the first production implementation reject the whole distribution on
+  any blocking finding, or can a later quarantine design safely disable only
+  invalid entry-point groups?
+- What is the exact location and CLI spelling for the planned validator module?
+- When ADR-037 desktop plugin manifests become active, which manifest fields
+  are hard production blockers versus user-visible warnings?
+- Should `Meta.frozen` become a hard code-enforced requirement, or should ADR
+  text be relaxed to match current registry behavior?
+- Should generated public symbol facts become required evidence for every
+  package validator release report?

--- a/docs/planning/adr-049-package-validator-checklist.md
+++ b/docs/planning/adr-049-package-validator-checklist.md
@@ -1,0 +1,223 @@
+---
+title: "ADR-049 Package Validator Agent Dispatch Checklist"
+status: Draft
+owners:
+  - "@jiazhenz026"
+related_adrs:
+  - 49
+language_source: en
+---
+
+# ADR-049 Package Validator Agent Dispatch Checklist
+
+> Mandatory tracking file for the ADR-049 package validator contract survey.
+> Source template:
+> `docs/ai-developer/templates/agent-dispatch-checklist-template.md`
+
+## 1. Change Summary
+
+- Owner request: derive strict package validator contracts for ADR-049 from
+  code-first evidence, using ADRs as secondary evidence.
+- Task kind: `manager`
+- Manager persona: `test_engineer`
+- Issue: #1659
+- Gate record:
+  `.workflow/records/design-package-validator-contract-survey-design-package-validator-contract-survey.json`
+- Branch/worktree plan: manager branch
+  `design/package-validator-contract-survey` in
+  `C:/Users/jiazh/Desktop/workspace/sci-wt/package-validator-design`;
+  subagents write disjoint JSON tables only.
+- Protected branch: `main`
+- Umbrella branch: local manager branch for ADR/design PR submission.
+- Umbrella PR: pending until gate-aware PR wrapper completes.
+- Umbrella PR title: `[DO NOT MERGE] ADR-049 package validator contract survey`
+- Final PR target: `main` when owner asks to submit ADR-049.
+- Dispatch prompt templates:
+  - Work: `docs/ai-developer/templates/agent-dispatch-prompt-template.md`
+  - Saved prompts: `docs/planning/adr-049-package-validator/prompts/*.md`
+
+## 2. Scope
+
+- In scope:
+  - `docs/planning/package-validator-contract-survey-draft.md`
+  - `docs/adr/ADR-049.md`
+  - `docs/specs/adr-049-package-validator-implementation.md`
+  - `docs/planning/adr-049-package-validator-checklist.md`
+  - `docs/planning/adr-049-package-validator/contracts/**`
+  - `docs/planning/adr-049-package-validator/prompts/**`
+  - `scripts/audit/check_package_contract_tables.py`
+- Out of scope:
+  - Production runtime changes under `src/scistudio/**`
+  - Frontend changes
+  - Runtime validator implementation
+- Protected paths:
+  - `docs/ai-developer/**` is read-only for this task.
+- Deferred work:
+  - N/A for this investigation pass.
+
+## 3. Conventions
+
+- `[ ]` not started
+- `[~]` in progress
+- `[x]` done
+- `[!]` blocked
+- Every completed row MUST include an artifact path, command, or check result.
+- Code evidence is authoritative. ADR evidence is secondary and may be stale.
+- A contract row with failing code evidence is an error in the table.
+- A contract row with passing code evidence but failing ADR evidence is an ADR
+  drift warning.
+
+## 4. Manager Preflight
+
+- [x] Dedicated manager branch and worktree created.
+  -> `design/package-validator-contract-survey`
+- [x] Gate record started.
+  -> `.workflow/records/design-package-validator-contract-survey-design-package-validator-contract-survey.json`
+- [x] Scope include/exclude recorded in the gate record.
+  -> `gate_record init` / `gate_record amend`
+- [x] Dispatch checklist copied from the template.
+  -> `docs/planning/adr-049-package-validator-checklist.md`
+- [x] Dispatch prompt paths assigned.
+  -> `docs/planning/adr-049-package-validator/prompts/*.md`
+- [x] Five subagents dispatched.
+  -> PV-A1 `019ec4e0-3020-7141-ab8f-608c9dfe8b4d`,
+  PV-A2 `019ec4e0-5829-7ef3-8277-3b48f591ba94`,
+  PV-A3 `019ec4e0-82e8-7353-8f3e-cabd9840eb66`,
+  PV-A4 `019ec4e0-ab38-72a3-829a-500d27741939`,
+  PV-A5 `019ec4e0-d7f8-7bb2-88c2-66616587d7b5`
+- [x] Five subagent JSON contract tables landed.
+  -> `docs/planning/adr-049-package-validator/contracts/pv-a*.json`
+- [x] Consistency checker implemented.
+  -> `scripts/audit/check_package_contract_tables.py`
+- [x] Consistency checker run and errors corrected.
+  -> `python scripts/audit/check_package_contract_tables.py`
+  returned `summary: 0 error(s), 9 warning(s)`
+- [x] ADR-049 draft created.
+  -> `docs/adr/ADR-049.md`
+- [x] ADR-049 implementation spec created.
+  -> `docs/specs/adr-049-package-validator-implementation.md`
+- [x] ADR frontmatter lint passed.
+  -> `$env:PYTHONPATH='src'; python -m scistudio.qa.audit.frontmatter_lint docs/adr/ADR-049.md --repo-root . --format text`
+
+## 5. Local Gate Hook Bypass Evidence
+
+- Authorized bypass label: N/A
+- Owner authorization source: N/A
+- Reason: N/A
+
+| Hook | Command | Bypass label | Status | Evidence |
+|---|---|---|---|---|
+| Pre-commit | `python -m scistudio.qa.governance.gate_record check --mode pre-commit` | N/A | `[ ]` | pending |
+| Commit message | `python -m scistudio.qa.governance.gate_record check --mode commit-msg` | N/A | `[ ]` | pending |
+| Pre-push | `python -m scistudio.qa.governance.gate_record check --mode pre-push --base origin/main --head HEAD` | N/A | `[ ]` | pending |
+| Pre-PR reconcile | `python -m scistudio.qa.governance.gate_record check --mode pre-pr --pr-body-file .workflow/local/pr-body.md` | N/A | `[x]` | `mode=pre-pr tier=3 checks=['full_audit']; reconciliation passed` |
+
+## 5.1 Docs Impact Check
+
+- Wrapper/hook/gate-record/receipt/CI/runtime behavior changed: no
+- AI docs checked: N/A, no AI workflow docs edited.
+- Updated docs or N/A rationale:
+  `docs/planning/package-validator-contract-survey-draft.md`,
+  `docs/specs/adr-049-package-validator-implementation.md`,
+  `docs/planning/adr-049-package-validator-checklist.md`,
+  `docs/planning/adr-049-package-validator/contracts/**`
+
+## 6. Dispatch Matrix
+
+| Agent | Persona | Audit mode | Prompt | Task | Branch | Worktree | Write set | Out of scope | Issue/PR | Status |
+|---|---|---|---|---|---|---|---|---|---|---|
+| PV-A1 | test_engineer | N/A | `docs/planning/adr-049-package-validator/prompts/pv-a1-sections-01-03.md` | Sections 1-3: package metadata, entry points, types | local subagent fork | subagent-isolated | `contracts/pv-a1-sections-01-03.json` | production code | pending/N/A | `[x]` |
+| PV-A2 | test_engineer | N/A | `docs/planning/adr-049-package-validator/prompts/pv-a2-sections-04-06.md` | Sections 4-6: blocks, config/dynamic/variadic, IO capabilities | local subagent fork | subagent-isolated | `contracts/pv-a2-sections-04-06.json` | production code | pending/N/A | `[x]` |
+| PV-A3 | test_engineer | N/A | `docs/planning/adr-049-package-validator/prompts/pv-a3-sections-07-09.md` | Sections 7-9: data boundary, AppBlock/CodeBlock, previewers | local subagent fork | subagent-isolated | `contracts/pv-a3-sections-07-09.json` | production code | pending/N/A | `[x]` |
+| PV-A4 | test_engineer | N/A | `docs/planning/adr-049-package-validator/prompts/pv-a4-sections-10-12.md` | Sections 10-12: preview provider behavior, plot jobs, security/isolation | local subagent fork | subagent-isolated | `contracts/pv-a4-sections-10-12.json` | production code | pending/N/A | `[x]` |
+| PV-A5 | test_engineer | N/A | `docs/planning/adr-049-package-validator/prompts/pv-a5-section-13-omissions.md` | Section 13 and omitted contracts | local subagent fork | subagent-isolated | `contracts/pv-a5-section-13-omissions.json` | production code | pending/N/A | `[x]` |
+
+## 7. Track: Contract Table Survey
+
+### 7.1 Track Scope
+
+- Owner: manager / test_engineer
+- In scope:
+  - Code-first contract extraction.
+  - ADR drift annotation.
+  - JSON contract tables suitable for ADR-049 subsections.
+- Out of scope:
+  - Runtime validator implementation.
+  - Final ADR prose until tables are corrected.
+- Required docs:
+  - Contract tables under `docs/planning/adr-049-package-validator/contracts/`.
+- Required tests:
+  - `python scripts/audit/check_package_contract_tables.py`
+
+### 7.2 Dispatch
+
+- [x] PV-A1 prompt dispatched.
+  -> agent `019ec4e0-3020-7141-ab8f-608c9dfe8b4d`
+- [x] PV-A2 prompt dispatched.
+  -> agent `019ec4e0-5829-7ef3-8277-3b48f591ba94`
+- [x] PV-A3 prompt dispatched.
+  -> agent `019ec4e0-82e8-7353-8f3e-cabd9840eb66`
+- [x] PV-A4 prompt dispatched.
+  -> agent `019ec4e0-ab38-72a3-829a-500d27741939`
+- [x] PV-A5 prompt dispatched.
+  -> agent `019ec4e0-d7f8-7bb2-88c2-66616587d7b5`
+
+### 7.3 Implementation
+
+- [x] PV-A1 contract table landed.
+  -> `contracts/pv-a1-sections-01-03.json`
+- [x] PV-A2 contract table landed.
+  -> `contracts/pv-a2-sections-04-06.json`
+- [x] PV-A3 contract table landed.
+  -> `contracts/pv-a3-sections-07-09.json`
+- [x] PV-A4 contract table landed.
+  -> `contracts/pv-a4-sections-10-12.json`
+- [x] PV-A5 contract table landed.
+  -> `contracts/pv-a5-section-13-omissions.json`
+- [x] Checker script landed.
+  -> `scripts/audit/check_package_contract_tables.py`
+- [x] Tables corrected until checker reports zero errors.
+  -> full checker `0 error(s), 9 warning(s)`
+
+### 7.4 Audit
+
+- [x] Manager reviewed every JSON table.
+  -> contract summary extracted with Python JSON scan
+- [x] Manager reviewed checker diagnostics.
+  -> full checker `0 error(s), 9 warning(s)`
+- [x] ADR drift warnings recorded or explained.
+  -> warnings are declared `adr_missing`, `adr_drift`, or `adr_planned`
+
+### 7.5 Integration
+
+- [x] Corrected contract tables are ready to become ADR-049 subsections.
+  -> five corrected JSON tables under `contracts/`
+
+## 8. Verification Evidence
+
+| Check | Command or tool | Status | Evidence |
+|---|---|---|---|
+| Contract table checker | `python scripts/audit/check_package_contract_tables.py` | `[x]` | `summary: 0 error(s), 9 warning(s)` |
+| ADR/spec frontmatter lint | `$env:PYTHONPATH='src'; python -m scistudio.qa.audit.frontmatter_lint docs/adr/ADR-049.md docs/specs/adr-049-package-validator-implementation.md --repo-root . --format text` | `[x]` | pass |
+| Python compile | `python -m py_compile scripts/audit/check_package_contract_tables.py` | `[x]` | pass |
+| Gate ledger check | `$env:PYTHONPATH='src'; python -m scistudio.qa.governance.gate_record check --mode local --base origin/main --head HEAD` | `[x]` | `mode=local tier=3 checks=['full_audit']; reconciliation passed` |
+
+## 9. Drift Log
+
+Append only.
+
+| Date | Agent | Drift | Action | Follow-up |
+|---|---|---|---|---|
+| 2026-06-14 | manager | No issue/umbrella PR opened for local owner-directed investigation pass. | Recorded as pending/N/A; final PR flow will need issue linkage before submission. | Owner decides when ADR-049 moves to PR. |
+| 2026-06-14 | manager | `gate_record check --mode local` failed on `guard.issue_link`. | Kept as expected blocker for non-PR investigation; checker and py_compile passed. | Link issue before PR readiness. |
+| 2026-06-14 | manager | ADR-049 is currently `is_code_implementation: false` to satisfy frontmatter without a tracking issue. | Kept `planned_governs` and implementation plan in ADR. | Switch to `true` and add tracking issue before implementation PR. |
+| 2026-06-14 | manager | Owner requested PR submission. | Created #1659, restored ADR implementation tracking, and moved gate evidence to PR-ready flow. | Open PR with gate-aware wrapper. |
+| 2026-06-14 | manager | Owner requested an executable ADR-049 implementation spec before PR submission. | Added `docs/specs/adr-049-package-validator-implementation.md` and explicit contract applicability metadata. | Re-run contract checker, frontmatter lint, and gate checks before push. |
+
+## 10. Final Readiness
+
+- [x] All dispatched agents have final outputs.
+- [x] Manager reviewed every changed file.
+- [x] Checker reports zero errors.
+- [x] ADR drift warnings are understood.
+- [x] Gate record includes final local checks.

--- a/docs/planning/adr-049-package-validator/contracts/contract-table.schema.json
+++ b/docs/planning/adr-049-package-validator/contracts/contract-table.schema.json
@@ -1,0 +1,183 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://scistudio.local/schemas/adr049.package_contract_table.v1.json",
+  "title": "ADR-049 Package Validator Contract Table",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "agent_id",
+    "generated_at",
+    "source_priority",
+    "agent_scope",
+    "contracts"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "adr049.package_contract_table.v1"
+    },
+    "agent_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "generated_at": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+    },
+    "source_priority": {
+      "const": "code-primary-adr-secondary"
+    },
+    "agent_scope": {
+      "type": "object",
+      "required": ["sections", "summary"],
+      "properties": {
+        "sections": {
+          "type": "array",
+          "items": {"type": "string"},
+          "minItems": 1
+        },
+        "summary": {"type": "string"}
+      },
+      "additionalProperties": false
+    },
+    "contracts": {
+      "type": "array",
+      "minItems": 1,
+      "items": {"$ref": "#/$defs/contract"}
+    },
+    "omissions": {
+      "type": "array",
+      "items": {"$ref": "#/$defs/omission"}
+    }
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "evidence": {
+      "type": "object",
+      "required": ["path", "kind", "pattern"],
+      "properties": {
+        "path": {"type": "string", "minLength": 1},
+        "kind": {"enum": ["contains", "regex"]},
+        "pattern": {"type": "string", "minLength": 1},
+        "symbol": {"type": "string"},
+        "notes": {"type": "string"}
+      },
+      "additionalProperties": false
+    },
+    "contract": {
+      "type": "object",
+      "required": [
+        "id",
+        "section",
+        "title",
+        "contract",
+        "status",
+        "severity",
+        "environments",
+        "validator_profile",
+        "applicability",
+        "code_evidence",
+        "adr_evidence",
+        "tests",
+        "adr_alignment",
+        "validator_implication"
+      ],
+      "properties": {
+        "id": {"type": "string", "pattern": "^PV-[0-9]{2}-[0-9]{3}$"},
+        "section": {
+          "enum": [
+            "01_package_metadata_distribution",
+            "02_entry_points",
+            "03_type_contracts",
+            "04_block_contracts",
+            "05_config_dynamic_variadic",
+            "06_io_format_capability",
+            "07_data_transport_runtime_boundary",
+            "08_app_code_block_boundaries",
+            "09_previewer_contracts",
+            "10_preview_provider_behavior",
+            "11_plot_jobs",
+            "12_security_isolation",
+            "13_cross_surface_registry_consistency",
+            "99_omitted_or_discovered_contracts"
+          ]
+        },
+        "title": {"type": "string", "minLength": 1},
+        "contract": {"type": "string", "minLength": 1},
+        "status": {
+          "enum": ["implemented", "partial", "planned", "not_implemented", "deprecated"]
+        },
+        "severity": {
+          "enum": ["blocker", "error", "warning", "info"]
+        },
+        "environments": {
+          "type": "array",
+          "items": {"enum": ["development", "production"]},
+          "minItems": 1,
+          "uniqueItems": true
+        },
+        "validator_profile": {
+          "type": "object",
+          "required": ["development", "production"],
+          "properties": {
+            "development": {"enum": ["block", "error", "warning", "info", "skip"]},
+            "production": {"enum": ["block", "error", "warning", "info", "skip"]}
+          },
+          "additionalProperties": false
+        },
+        "applicability": {
+          "$ref": "#/$defs/applicability"
+        },
+        "code_evidence": {
+          "type": "array",
+          "items": {"$ref": "#/$defs/evidence"},
+          "minItems": 1
+        },
+        "adr_evidence": {
+          "type": "array",
+          "items": {"$ref": "#/$defs/evidence"}
+        },
+        "tests": {
+          "type": "array",
+          "items": {"$ref": "#/$defs/evidence"}
+        },
+        "adr_alignment": {
+          "enum": ["aligned", "adr_missing", "adr_drift", "adr_planned", "unknown"]
+        },
+        "notes": {"type": "string"},
+        "validator_implication": {"type": "string", "minLength": 1}
+      },
+      "additionalProperties": false
+    },
+    "applicability": {
+      "type": "object",
+      "required": ["candidate_surfaces", "trigger", "not_applicable_result"],
+      "properties": {
+        "candidate_surfaces": {
+          "type": "array",
+          "items": {"type": "string", "minLength": 1},
+          "minItems": 1,
+          "uniqueItems": true
+        },
+        "trigger": {"type": "string", "minLength": 1},
+        "not_applicable_result": {"const": "not_applicable"}
+      },
+      "additionalProperties": false
+    },
+    "omission": {
+      "type": "object",
+      "required": ["id", "title", "evidence", "recommended_section"],
+      "properties": {
+        "id": {"type": "string", "pattern": "^OM-[0-9]{3}$"},
+        "title": {"type": "string", "minLength": 1},
+        "evidence": {
+          "type": "array",
+          "items": {"$ref": "#/$defs/evidence"},
+          "minItems": 1
+        },
+        "recommended_section": {"type": "string", "minLength": 1},
+        "notes": {"type": "string"}
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/docs/planning/adr-049-package-validator/contracts/pv-a1-sections-01-03.json
+++ b/docs/planning/adr-049-package-validator/contracts/pv-a1-sections-01-03.json
@@ -1,0 +1,932 @@
+{
+  "schema_version": "adr049.package_contract_table.v1",
+  "agent_id": "PV-A1",
+  "generated_at": "2026-06-14",
+  "source_priority": "code-primary-adr-secondary",
+  "agent_scope": {
+    "sections": [
+      "01_package_metadata_distribution",
+      "02_entry_points",
+      "03_type_contracts"
+    ],
+    "summary": "Code-first package validator contracts for package metadata, block/runner entry points, and type registration."
+  },
+  "contracts": [
+    {
+      "id": "PV-01-001",
+      "section": "01_package_metadata_distribution",
+      "title": "PackageInfo is the package metadata envelope",
+      "contract": "A SciStudio block package metadata envelope is a frozen PackageInfo dataclass with a required name and optional description, author, and version fields. Package authors use this envelope to give the registry package-level display and grouping metadata.",
+      "status": "implemented",
+      "severity": "error",
+      "environments": [
+        "development",
+        "production"
+      ],
+      "validator_profile": {
+        "development": "error",
+        "production": "block"
+      },
+      "applicability": {
+        "candidate_surfaces": [
+          "distribution_metadata",
+          "package_info"
+        ],
+        "trigger": "always_for_candidate_package; PackageInfo checks run when the candidate scistudio.blocks payload returns package metadata",
+        "not_applicable_result": "not_applicable"
+      },
+      "code_evidence": [
+        {
+          "path": "src/scistudio/blocks/base/package_info.py",
+          "symbol": "PackageInfo",
+          "kind": "contains",
+          "pattern": "class PackageInfo:"
+        },
+        {
+          "path": "src/scistudio/blocks/base/package_info.py",
+          "symbol": "PackageInfo",
+          "kind": "contains",
+          "pattern": "@dataclass(frozen=True)"
+        }
+      ],
+      "adr_evidence": [
+        {
+          "path": "docs/adr/ADR-025.md",
+          "symbol": "PackageInfo",
+          "kind": "contains",
+          "pattern": "Block packages may also provide package-level metadata through"
+        },
+        {
+          "path": "docs/block-development/publishing.md",
+          "symbol": "PackageInfo",
+          "kind": "contains",
+          "pattern": "`PackageInfo` is a frozen dataclass that describes your package to the"
+        }
+      ],
+      "tests": [
+        {
+          "path": "tests/blocks/test_registry.py",
+          "symbol": "TestPackageInfo",
+          "kind": "contains",
+          "pattern": "class TestPackageInfo:"
+        },
+        {
+          "path": "tests/blocks/test_registry.py",
+          "symbol": "test_frozen",
+          "kind": "contains",
+          "pattern": "def test_frozen(self) -> None:"
+        }
+      ],
+      "adr_alignment": "aligned",
+      "notes": "This row covers the public metadata class itself; field-level validation is covered by PV-01-002.",
+      "validator_implication": "A package validator should require any provided package metadata to be a PackageInfo instance and should treat mutation-prone or ad hoc metadata envelopes as invalid for production install."
+    },
+    {
+      "id": "PV-01-002",
+      "section": "01_package_metadata_distribution",
+      "title": "PackageInfo fields are structurally validated",
+      "contract": "PackageInfo validation requires an actual PackageInfo instance, a non-empty string name, string description and author fields, and a non-empty string version. Description and author may be empty strings.",
+      "status": "implemented",
+      "severity": "error",
+      "environments": [
+        "development",
+        "production"
+      ],
+      "validator_profile": {
+        "development": "error",
+        "production": "block"
+      },
+      "applicability": {
+        "candidate_surfaces": [
+          "distribution_metadata",
+          "package_info"
+        ],
+        "trigger": "always_for_candidate_package; PackageInfo checks run when the candidate scistudio.blocks payload returns package metadata",
+        "not_applicable_result": "not_applicable"
+      },
+      "code_evidence": [
+        {
+          "path": "src/scistudio/testing/harness.py",
+          "symbol": "validate_package_info",
+          "kind": "contains",
+          "pattern": "def validate_package_info(self, info: Any) -> list[str]:"
+        },
+        {
+          "path": "src/scistudio/testing/harness.py",
+          "symbol": "validate_package_info",
+          "kind": "contains",
+          "pattern": "PackageInfo.version must be a non-empty string."
+        }
+      ],
+      "adr_evidence": [
+        {
+          "path": "docs/adr/ADR-026.md",
+          "symbol": "validate_package_info",
+          "kind": "contains",
+          "pattern": "generated entry-point metadata, harness block"
+        },
+        {
+          "path": "docs/block-development/testing.md",
+          "symbol": "validate_package_info",
+          "kind": "contains",
+          "pattern": "- If `PackageInfo` is present, validates its fields (non-empty `name`,"
+        }
+      ],
+      "tests": [
+        {
+          "path": "tests/testing/test_harness.py",
+          "symbol": "TestValidatePackageInfo",
+          "kind": "contains",
+          "pattern": "class TestValidatePackageInfo:"
+        },
+        {
+          "path": "tests/testing/test_harness.py",
+          "symbol": "test_empty_version",
+          "kind": "contains",
+          "pattern": "def test_empty_version(self) -> None:"
+        }
+      ],
+      "adr_alignment": "aligned",
+      "notes": "The harness validates PackageInfo structure but does not compare PackageInfo.version against installed distribution metadata.",
+      "validator_implication": "Development validation can report PackageInfo field errors through the harness; production install validation should block packages with malformed metadata and may add distribution-version consistency checks in a later row."
+    },
+    {
+      "id": "PV-02-001",
+      "section": "02_entry_points",
+      "title": "Block package entry points expose package metadata plus block classes",
+      "contract": "Installed block packages declare a scistudio.blocks entry-point group. Runtime accepts a callable returning (PackageInfo, list[type[Block]]), a callable returning list[type[Block]], or a direct Block class; the monorepo package fallback prefers get_block_package() and then get_blocks(). Current in-repo plugin pyprojects point installed scistudio.blocks entries at get_block_package(), while each package also exposes get_blocks() as a plain block-list helper.",
+      "status": "implemented",
+      "severity": "error",
+      "environments": [
+        "development",
+        "production"
+      ],
+      "validator_profile": {
+        "development": "error",
+        "production": "block"
+      },
+      "applicability": {
+        "candidate_surfaces": [
+          "entry_points"
+        ],
+        "trigger": "when_candidate_distribution_declares_a_scistudio_entry_point",
+        "not_applicable_result": "not_applicable"
+      },
+      "code_evidence": [
+        {
+          "path": "packages/scistudio-blocks-imaging/pyproject.toml",
+          "symbol": "scistudio.blocks",
+          "kind": "contains",
+          "pattern": "[project.entry-points.\"scistudio.blocks\"]"
+        },
+        {
+          "path": "packages/scistudio-blocks-imaging/pyproject.toml",
+          "symbol": "scistudio.blocks:imaging",
+          "kind": "contains",
+          "pattern": "imaging = \"scistudio_blocks_imaging:get_block_package\""
+        },
+        {
+          "path": "packages/scistudio-blocks-imaging/src/scistudio_blocks_imaging/__init__.py",
+          "symbol": "get_blocks",
+          "kind": "contains",
+          "pattern": "def get_blocks() -> list[type]:"
+        },
+        {
+          "path": "packages/scistudio-blocks-imaging/src/scistudio_blocks_imaging/__init__.py",
+          "symbol": "get_block_package",
+          "kind": "contains",
+          "pattern": "def get_block_package() -> tuple[PackageInfo, list[type]]:"
+        },
+        {
+          "path": "packages/scistudio-blocks-lcms/pyproject.toml",
+          "symbol": "scistudio.blocks",
+          "kind": "contains",
+          "pattern": "[project.entry-points.\"scistudio.blocks\"]"
+        },
+        {
+          "path": "packages/scistudio-blocks-lcms/pyproject.toml",
+          "symbol": "scistudio.blocks:lcms",
+          "kind": "contains",
+          "pattern": "lcms = \"scistudio_blocks_lcms:get_block_package\""
+        },
+        {
+          "path": "packages/scistudio-blocks-lcms/src/scistudio_blocks_lcms/__init__.py",
+          "symbol": "get_blocks",
+          "kind": "contains",
+          "pattern": "def get_blocks() -> list[type]:"
+        },
+        {
+          "path": "packages/scistudio-blocks-lcms/src/scistudio_blocks_lcms/__init__.py",
+          "symbol": "get_block_package",
+          "kind": "contains",
+          "pattern": "def get_block_package() -> tuple[PackageInfo, list[type]]:"
+        },
+        {
+          "path": "packages/scistudio-blocks-srs/pyproject.toml",
+          "symbol": "scistudio.blocks",
+          "kind": "contains",
+          "pattern": "[project.entry-points.\"scistudio.blocks\"]"
+        },
+        {
+          "path": "packages/scistudio-blocks-srs/pyproject.toml",
+          "symbol": "scistudio.blocks:srs",
+          "kind": "contains",
+          "pattern": "srs = \"scistudio_blocks_srs:get_block_package\""
+        },
+        {
+          "path": "packages/scistudio-blocks-srs/src/scistudio_blocks_srs/__init__.py",
+          "symbol": "get_blocks",
+          "kind": "contains",
+          "pattern": "def get_blocks() -> list[type]:"
+        },
+        {
+          "path": "packages/scistudio-blocks-srs/src/scistudio_blocks_srs/__init__.py",
+          "symbol": "get_block_package",
+          "kind": "contains",
+          "pattern": "def get_block_package() -> tuple[PackageInfo, list[type]]:"
+        },
+        {
+          "path": "src/scistudio/blocks/registry/_scan.py",
+          "symbol": "_scan_tier2",
+          "kind": "contains",
+          "pattern": "def _scan_tier2(registry: BlockRegistry) -> None:"
+        },
+        {
+          "path": "src/scistudio/blocks/registry/_scan.py",
+          "symbol": "_scan_monorepo_packages",
+          "kind": "contains",
+          "pattern": "prefer ``get_block_package() -> (PackageInfo, list[type[Block]])``"
+        }
+      ],
+      "adr_evidence": [
+        {
+          "path": "docs/adr/ADR-025.md",
+          "symbol": "scistudio.blocks",
+          "kind": "contains",
+          "pattern": "| `scistudio.blocks` | Discover block classes and optional package metadata | Active |"
+        },
+        {
+          "path": "docs/adr/ADR-025.md",
+          "symbol": "PackageInfo",
+          "kind": "contains",
+          "pattern": "(PackageInfo(...), [BlockClassA, BlockClassB])"
+        },
+        {
+          "path": "docs/block-development/publishing.md",
+          "symbol": "get_block_package",
+          "kind": "contains",
+          "pattern": "returns a plain `list[type]`, a `get_block_package()` callable, or a direct"
+        }
+      ],
+      "tests": [
+        {
+          "path": "tests/blocks/test_registry.py",
+          "symbol": "TestScanTier2CallableProtocol",
+          "kind": "contains",
+          "pattern": "class TestScanTier2CallableProtocol:"
+        },
+        {
+          "path": "packages/scistudio-blocks-imaging/tests/test_packaging.py",
+          "symbol": "test_get_block_package_returns_package_info_and_blocks",
+          "kind": "contains",
+          "pattern": "def test_get_block_package_returns_package_info_and_blocks() -> None:"
+        },
+        {
+          "path": "packages/scistudio-blocks-imaging/tests/test_packaging.py",
+          "symbol": "test_pyproject_declares_release_entry_points",
+          "kind": "contains",
+          "pattern": "scistudio_blocks_imaging:get_block_package"
+        }
+      ],
+      "adr_alignment": "aligned",
+      "notes": "The active ADR aligns with the tuple/list return contract. The current publishing guide prefers get_blocks() returning the tuple for new packages, while current in-repo plugin pyprojects still use get_block_package() for installed discovery.",
+      "validator_implication": "A validator should load the scistudio.blocks entry point in an isolated context, accept the runtime-compatible shapes, validate PackageInfo when present, validate every concrete Block subclass, and report legacy callable naming as a development warning rather than a production block until migration policy changes."
+    },
+    {
+      "id": "PV-02-002",
+      "section": "02_entry_points",
+      "title": "Core distribution declares block and CodeBlock runner entry points",
+      "contract": "The root SciStudio distribution declares built-in scistudio.blocks entries for core block classes and a scistudio.runners entry-point group for CodeBlock runner backends. Each entry-point reference must resolve to an importable module attribute.",
+      "status": "implemented",
+      "severity": "error",
+      "environments": [
+        "development",
+        "production"
+      ],
+      "validator_profile": {
+        "development": "error",
+        "production": "block"
+      },
+      "applicability": {
+        "candidate_surfaces": [
+          "entry_points"
+        ],
+        "trigger": "when_candidate_distribution_declares_a_scistudio_entry_point",
+        "not_applicable_result": "not_applicable"
+      },
+      "code_evidence": [
+        {
+          "path": "pyproject.toml",
+          "symbol": "scistudio.blocks",
+          "kind": "contains",
+          "pattern": "[project.entry-points.\"scistudio.blocks\"]"
+        },
+        {
+          "path": "pyproject.toml",
+          "symbol": "scistudio.blocks:load_data",
+          "kind": "contains",
+          "pattern": "load_data = \"scistudio.blocks.io.loaders.load_data:LoadData\""
+        },
+        {
+          "path": "pyproject.toml",
+          "symbol": "scistudio.blocks:save_data",
+          "kind": "contains",
+          "pattern": "save_data = \"scistudio.blocks.io.savers.save_data:SaveData\""
+        },
+        {
+          "path": "pyproject.toml",
+          "symbol": "scistudio.blocks:process_merge",
+          "kind": "contains",
+          "pattern": "process_merge = \"scistudio.blocks.process.builtins.merge:MergeBlock\""
+        },
+        {
+          "path": "pyproject.toml",
+          "symbol": "scistudio.blocks:process_split",
+          "kind": "contains",
+          "pattern": "process_split = \"scistudio.blocks.process.builtins.split:SplitBlock\""
+        },
+        {
+          "path": "pyproject.toml",
+          "symbol": "scistudio.blocks:code_block",
+          "kind": "contains",
+          "pattern": "code_block = \"scistudio.blocks.code:CodeBlock\""
+        },
+        {
+          "path": "pyproject.toml",
+          "symbol": "scistudio.blocks:app_block",
+          "kind": "contains",
+          "pattern": "app_block = \"scistudio.blocks.app:AppBlock\""
+        },
+        {
+          "path": "pyproject.toml",
+          "symbol": "scistudio.blocks:ai_block",
+          "kind": "contains",
+          "pattern": "ai_block = \"scistudio.blocks.ai:AIBlock\""
+        },
+        {
+          "path": "pyproject.toml",
+          "symbol": "scistudio.blocks:subworkflow_block",
+          "kind": "contains",
+          "pattern": "subworkflow_block = \"scistudio.blocks.subworkflow:SubWorkflowBlock\""
+        },
+        {
+          "path": "pyproject.toml",
+          "symbol": "scistudio.blocks:merge_collection",
+          "kind": "contains",
+          "pattern": "merge_collection = \"scistudio.blocks.process.builtins.merge_collection:MergeCollection\""
+        },
+        {
+          "path": "pyproject.toml",
+          "symbol": "scistudio.blocks:split_collection",
+          "kind": "contains",
+          "pattern": "split_collection = \"scistudio.blocks.process.builtins.split_collection:SplitCollection\""
+        },
+        {
+          "path": "pyproject.toml",
+          "symbol": "scistudio.blocks:filter_collection",
+          "kind": "contains",
+          "pattern": "filter_collection = \"scistudio.blocks.process.builtins.filter_collection:FilterCollection\""
+        },
+        {
+          "path": "pyproject.toml",
+          "symbol": "scistudio.blocks:slice_collection",
+          "kind": "contains",
+          "pattern": "slice_collection = \"scistudio.blocks.process.builtins.slice_collection:SliceCollection\""
+        },
+        {
+          "path": "pyproject.toml",
+          "symbol": "scistudio.blocks:data_router",
+          "kind": "contains",
+          "pattern": "data_router = \"scistudio.blocks.process.builtins.data_router:DataRouter\""
+        },
+        {
+          "path": "pyproject.toml",
+          "symbol": "scistudio.blocks:pair_editor",
+          "kind": "contains",
+          "pattern": "pair_editor = \"scistudio.blocks.process.builtins.pair_editor:PairEditor\""
+        },
+        {
+          "path": "pyproject.toml",
+          "symbol": "scistudio.runners",
+          "kind": "contains",
+          "pattern": "[project.entry-points.\"scistudio.runners\"]"
+        },
+        {
+          "path": "pyproject.toml",
+          "symbol": "scistudio.runners:python",
+          "kind": "contains",
+          "pattern": "python = \"scistudio.blocks.code.runners.python_runner:PythonRunner\""
+        },
+        {
+          "path": "pyproject.toml",
+          "symbol": "scistudio.runners:r",
+          "kind": "contains",
+          "pattern": "r = \"scistudio.blocks.code.runners.r_runner:RRunner\""
+        },
+        {
+          "path": "pyproject.toml",
+          "symbol": "scistudio.runners:julia",
+          "kind": "contains",
+          "pattern": "julia = \"scistudio.blocks.code.runners.julia_runner:JuliaRunner\""
+        },
+        {
+          "path": "tests/architecture/test_registries.py",
+          "symbol": "test_entry_point_resolves_to_class",
+          "kind": "contains",
+          "pattern": "def test_entry_point_resolves_to_class("
+        }
+      ],
+      "adr_evidence": [
+        {
+          "path": "docs/adr/ADR-025.md",
+          "symbol": "scistudio.blocks",
+          "kind": "contains",
+          "pattern": "| `scistudio.blocks` | Discover block classes and optional package metadata | Active |"
+        },
+        {
+          "path": "docs/architecture/ARCHITECTURE.md",
+          "symbol": "scistudio.runners",
+          "kind": "contains",
+          "pattern": "| `scistudio.runners` | Registers CodeBlock runner backends for additional script execution environments. |"
+        }
+      ],
+      "tests": [
+        {
+          "path": "tests/architecture/test_registries.py",
+          "symbol": "test_entry_point_resolves_to_class",
+          "kind": "contains",
+          "pattern": "Every entry-point must reference an importable module AND an existing class."
+        }
+      ],
+      "adr_alignment": "adr_missing",
+      "notes": "ADR-025 governs scistudio.blocks and scistudio.types but does not mention scistudio.runners; the runner group is documented in ARCHITECTURE.md and implemented in root pyproject.toml.",
+      "validator_implication": "A package validator should validate importability and attribute resolution for every declared SciStudio entry-point group. Runner validation should be tracked as architecture-backed until a dedicated ADR/spec row governs runner package semantics."
+    },
+    {
+      "id": "PV-02-003",
+      "section": "02_entry_points",
+      "title": "Development harness validates scistudio.blocks callable return shape",
+      "contract": "The development harness validates scistudio.blocks callable results as either (PackageInfo, list[type[Block]]) or list[type[Block]], validates PackageInfo when present, rejects empty block lists, rejects non-class and non-Block items, and delegates each candidate block to block contract validation.",
+      "status": "implemented",
+      "severity": "error",
+      "environments": [
+        "development",
+        "production"
+      ],
+      "validator_profile": {
+        "development": "error",
+        "production": "block"
+      },
+      "applicability": {
+        "candidate_surfaces": [
+          "entry_points"
+        ],
+        "trigger": "when_candidate_distribution_declares_a_scistudio_entry_point",
+        "not_applicable_result": "not_applicable"
+      },
+      "code_evidence": [
+        {
+          "path": "src/scistudio/testing/harness.py",
+          "symbol": "validate_entry_point_callable",
+          "kind": "contains",
+          "pattern": "def validate_entry_point_callable(self, callable_result: Any) -> list[str]:"
+        },
+        {
+          "path": "src/scistudio/testing/harness.py",
+          "symbol": "validate_entry_point_callable",
+          "kind": "contains",
+          "pattern": "Entry-point callable must return (PackageInfo, list[Block])"
+        }
+      ],
+      "adr_evidence": [
+        {
+          "path": "docs/adr/ADR-026.md",
+          "symbol": "BlockTestHarness",
+          "kind": "contains",
+          "pattern": "Block authors need contract checks before distribution"
+        },
+        {
+          "path": "docs/block-development/testing.md",
+          "symbol": "validate_entry_point_callable",
+          "kind": "contains",
+          "pattern": "Per ADR-025, the entry-point callable must return either:"
+        }
+      ],
+      "tests": [
+        {
+          "path": "tests/testing/test_harness.py",
+          "symbol": "TestValidateEntryPointCallable",
+          "kind": "contains",
+          "pattern": "class TestValidateEntryPointCallable:"
+        },
+        {
+          "path": "tests/testing/test_harness.py",
+          "symbol": "test_empty_block_list",
+          "kind": "contains",
+          "pattern": "def test_empty_block_list(self) -> None:"
+        }
+      ],
+      "adr_alignment": "aligned",
+      "notes": "The harness is stricter than BlockRegistry runtime compatibility for direct class entry points; direct class compatibility is covered as runtime behavior in PV-02-001.",
+      "validator_implication": "A development validator can surface harness errors directly. A production install validator should include the runtime-compatible direct-class path only if compatibility policy keeps it active."
+    },
+    {
+      "id": "PV-03-001",
+      "section": "03_type_contracts",
+      "title": "Type entry points return plugin DataObject type classes",
+      "contract": "Packages register semantic DataObject subclasses through scistudio.types entry points. The callable returns a list of exported type classes, and the root SciStudio package intentionally contributes no built-in domain types through its empty scistudio.types group.",
+      "status": "implemented",
+      "severity": "error",
+      "environments": [
+        "development",
+        "production"
+      ],
+      "validator_profile": {
+        "development": "error",
+        "production": "block"
+      },
+      "applicability": {
+        "candidate_surfaces": [
+          "types"
+        ],
+        "trigger": "when_candidate_declares_scistudio.types",
+        "not_applicable_result": "not_applicable"
+      },
+      "code_evidence": [
+        {
+          "path": "pyproject.toml",
+          "symbol": "scistudio.types",
+          "kind": "contains",
+          "pattern": "[project.entry-points.\"scistudio.types\"]"
+        },
+        {
+          "path": "packages/scistudio-blocks-imaging/pyproject.toml",
+          "symbol": "scistudio.types",
+          "kind": "contains",
+          "pattern": "[project.entry-points.\"scistudio.types\"]"
+        },
+        {
+          "path": "packages/scistudio-blocks-imaging/pyproject.toml",
+          "symbol": "scistudio.types:imaging",
+          "kind": "contains",
+          "pattern": "imaging = \"scistudio_blocks_imaging:get_types\""
+        },
+        {
+          "path": "packages/scistudio-blocks-imaging/src/scistudio_blocks_imaging/__init__.py",
+          "symbol": "get_types",
+          "kind": "contains",
+          "pattern": "def get_types() -> list[type]:"
+        },
+        {
+          "path": "packages/scistudio-blocks-lcms/pyproject.toml",
+          "symbol": "scistudio.types",
+          "kind": "contains",
+          "pattern": "[project.entry-points.\"scistudio.types\"]"
+        },
+        {
+          "path": "packages/scistudio-blocks-lcms/pyproject.toml",
+          "symbol": "scistudio.types:lcms",
+          "kind": "contains",
+          "pattern": "lcms = \"scistudio_blocks_lcms:get_types\""
+        },
+        {
+          "path": "packages/scistudio-blocks-lcms/src/scistudio_blocks_lcms/types.py",
+          "symbol": "get_types",
+          "kind": "contains",
+          "pattern": "def get_types() -> list[type]:"
+        },
+        {
+          "path": "packages/scistudio-blocks-srs/pyproject.toml",
+          "symbol": "scistudio.types",
+          "kind": "contains",
+          "pattern": "[project.entry-points.\"scistudio.types\"]"
+        },
+        {
+          "path": "packages/scistudio-blocks-srs/pyproject.toml",
+          "symbol": "scistudio.types:srs",
+          "kind": "contains",
+          "pattern": "srs = \"scistudio_blocks_srs:get_types\""
+        },
+        {
+          "path": "packages/scistudio-blocks-srs/src/scistudio_blocks_srs/types.py",
+          "symbol": "get_types",
+          "kind": "contains",
+          "pattern": "def get_types() -> list[type]:"
+        }
+      ],
+      "adr_evidence": [
+        {
+          "path": "docs/adr/ADR-025.md",
+          "symbol": "scistudio.types",
+          "kind": "contains",
+          "pattern": "| `scistudio.types` | Discover custom `DataObject` subclasses | Active |"
+        },
+        {
+          "path": "docs/block-development/custom-types.md",
+          "symbol": "get_types",
+          "kind": "contains",
+          "pattern": "def get_types() -> list[type]:"
+        }
+      ],
+      "tests": [
+        {
+          "path": "packages/scistudio-blocks-imaging/tests/test_packaging.py",
+          "symbol": "test_get_types_returns_exported_imaging_types",
+          "kind": "contains",
+          "pattern": "def test_get_types_returns_exported_imaging_types() -> None:"
+        },
+        {
+          "path": "packages/scistudio-blocks-lcms/tests/test_types.py",
+          "symbol": "test_get_types_returns_all_four_classes",
+          "kind": "contains",
+          "pattern": "def test_get_types_returns_all_four_classes() -> None:"
+        },
+        {
+          "path": "packages/scistudio-blocks-srs/tests/test_types.py",
+          "symbol": "test_get_types_returns_srsimage",
+          "kind": "contains",
+          "pattern": "def test_get_types_returns_srsimage() -> None:"
+        }
+      ],
+      "adr_alignment": "aligned",
+      "notes": "The root scistudio.types group is present but empty by design because domain types live in plugin packages.",
+      "validator_implication": "A validator should invoke scistudio.types callables, require a list or tuple payload, and validate every returned item as a DataObject subclass before registration."
+    },
+    {
+      "id": "PV-03-002",
+      "section": "03_type_contracts",
+      "title": "TypeRegistry validates and registers type classes",
+      "contract": "TypeRegistry is the runtime authority for DataObject type registration. register_class() validates a class before storing a TypeSpec, _scan_entrypoint_types() loads scistudio.types callables, skips malformed entry points with warnings, rejects non-DataObject items, and calls _validate_meta_class() for Meta constraints.",
+      "status": "partial",
+      "severity": "warning",
+      "environments": [
+        "development",
+        "production"
+      ],
+      "validator_profile": {
+        "development": "warning",
+        "production": "error"
+      },
+      "applicability": {
+        "candidate_surfaces": [
+          "types"
+        ],
+        "trigger": "when_candidate_declares_scistudio.types",
+        "not_applicable_result": "not_applicable"
+      },
+      "code_evidence": [
+        {
+          "path": "src/scistudio/core/types/registry.py",
+          "symbol": "TypeRegistry",
+          "kind": "contains",
+          "pattern": "class TypeRegistry:"
+        },
+        {
+          "path": "src/scistudio/core/types/registry.py",
+          "symbol": "_validate_meta_class",
+          "kind": "contains",
+          "pattern": "def _validate_meta_class(self, cls: type) -> None:"
+        },
+        {
+          "path": "src/scistudio/core/types/registry.py",
+          "symbol": "_scan_entrypoint_types",
+          "kind": "contains",
+          "pattern": "eps = importlib.metadata.entry_points(group=\"scistudio.types\")"
+        },
+        {
+          "path": "src/scistudio/core/types/registry.py",
+          "symbol": "_validate_meta_class",
+          "kind": "contains",
+          "pattern": "``frozen=True`` on ``model_config`` is *recommended*"
+        }
+      ],
+      "adr_evidence": [
+        {
+          "path": "docs/adr/ADR-027.md",
+          "symbol": "TypeRegistry",
+          "kind": "contains",
+          "pattern": "Worker subprocesses must scan registered types before reconstructing payloads."
+        },
+        {
+          "path": "docs/adr/ADR-031.md",
+          "symbol": "Meta",
+          "kind": "contains",
+          "pattern": "- Frozen, no `PrivateAttr`, all fields must round-trip through `model_dump_json` / `model_validate_json`"
+        },
+        {
+          "path": "docs/block-development/custom-types.md",
+          "symbol": "Meta",
+          "kind": "contains",
+          "pattern": "1. **`model_config = ConfigDict(frozen=True)`** -- Immutability is required."
+        }
+      ],
+      "tests": [
+        {
+          "path": "tests/core/test_type_registry_resolve_and_meta.py",
+          "symbol": "TestValidateMetaClass",
+          "kind": "contains",
+          "pattern": "class TestValidateMetaClass:"
+        },
+        {
+          "path": "tests/core/test_type_registry_resolve_and_meta.py",
+          "symbol": "test_register_class_with_meta_having_private_attr_raises",
+          "kind": "contains",
+          "pattern": "def test_register_class_with_meta_having_private_attr_raises(self) -> None:"
+        },
+        {
+          "path": "tests/architecture/test_registries.py",
+          "symbol": "test_type_registry_has_required_interface",
+          "kind": "contains",
+          "pattern": "def test_type_registry_has_required_interface() -> None:"
+        }
+      ],
+      "adr_alignment": "adr_drift",
+      "notes": "Code enforces BaseModel inheritance, no PrivateAttr, and best-effort JSON round-trip. It explicitly treats frozen=True as recommended rather than required, while ADR/docs describe frozen Meta as required.",
+      "validator_implication": "A unified package validator should preserve current registry validation for installed compatibility, but ADR-049 should decide whether frozen Meta becomes a production-blocking validator rule or remains a development warning."
+    },
+    {
+      "id": "PV-03-003",
+      "section": "03_type_contracts",
+      "title": "Current plugin packages ship concrete type payloads",
+      "contract": "The imaging, LC-MS, and SRS packages contribute concrete DataObject subtype payloads through their scistudio.types callables. The payload includes direct base-class subtypes such as Image, Label, Transform, MSRawFile, PeakTable, MIDTable, and SampleMetadata, plus indirect plugin subtypes such as Mask and SRSImage that must still be validated because they are returned by get_types().",
+      "status": "implemented",
+      "severity": "error",
+      "environments": [
+        "development",
+        "production"
+      ],
+      "validator_profile": {
+        "development": "error",
+        "production": "block"
+      },
+      "applicability": {
+        "candidate_surfaces": [
+          "types"
+        ],
+        "trigger": "when_candidate_declares_scistudio.types",
+        "not_applicable_result": "not_applicable"
+      },
+      "code_evidence": [
+        {
+          "path": "packages/scistudio-blocks-imaging/src/scistudio_blocks_imaging/types.py",
+          "symbol": "Image",
+          "kind": "contains",
+          "pattern": "class Image(Array):"
+        },
+        {
+          "path": "packages/scistudio-blocks-imaging/src/scistudio_blocks_imaging/types.py",
+          "symbol": "Mask",
+          "kind": "contains",
+          "pattern": "class Mask(Image):"
+        },
+        {
+          "path": "packages/scistudio-blocks-imaging/src/scistudio_blocks_imaging/types.py",
+          "symbol": "Label",
+          "kind": "contains",
+          "pattern": "class Label(CompositeData):"
+        },
+        {
+          "path": "packages/scistudio-blocks-imaging/src/scistudio_blocks_imaging/types.py",
+          "symbol": "Transform",
+          "kind": "contains",
+          "pattern": "class Transform(Array):"
+        },
+        {
+          "path": "packages/scistudio-blocks-imaging/src/scistudio_blocks_imaging/__init__.py",
+          "symbol": "get_types",
+          "kind": "contains",
+          "pattern": "return list(_IMAGING_TYPES)"
+        },
+        {
+          "path": "packages/scistudio-blocks-lcms/src/scistudio_blocks_lcms/types.py",
+          "symbol": "MSRawFile",
+          "kind": "contains",
+          "pattern": "class MSRawFile(Artifact):"
+        },
+        {
+          "path": "packages/scistudio-blocks-lcms/src/scistudio_blocks_lcms/types.py",
+          "symbol": "PeakTable",
+          "kind": "contains",
+          "pattern": "class PeakTable(DataFrame):"
+        },
+        {
+          "path": "packages/scistudio-blocks-lcms/src/scistudio_blocks_lcms/types.py",
+          "symbol": "MIDTable",
+          "kind": "contains",
+          "pattern": "class MIDTable(DataFrame):"
+        },
+        {
+          "path": "packages/scistudio-blocks-lcms/src/scistudio_blocks_lcms/types.py",
+          "symbol": "SampleMetadata",
+          "kind": "contains",
+          "pattern": "class SampleMetadata(DataFrame):"
+        },
+        {
+          "path": "packages/scistudio-blocks-lcms/src/scistudio_blocks_lcms/types.py",
+          "symbol": "get_types",
+          "kind": "contains",
+          "pattern": "return [MSRawFile, PeakTable, MIDTable, SampleMetadata]"
+        },
+        {
+          "path": "packages/scistudio-blocks-srs/src/scistudio_blocks_srs/types.py",
+          "symbol": "SRSImage",
+          "kind": "contains",
+          "pattern": "class SRSImage(Image):"
+        },
+        {
+          "path": "packages/scistudio-blocks-srs/src/scistudio_blocks_srs/types.py",
+          "symbol": "get_types",
+          "kind": "contains",
+          "pattern": "return [SRSImage]"
+        }
+      ],
+      "adr_evidence": [
+        {
+          "path": "docs/adr/ADR-027.md",
+          "symbol": "plugin-owned domain types",
+          "kind": "contains",
+          "pattern": "Core contains only base data types. Domain subtypes such as image, spectral,"
+        },
+        {
+          "path": "docs/specs/phase11-imaging-block-spec.md",
+          "symbol": "Image",
+          "kind": "contains",
+          "pattern": "| T-IMG-001 | Types module (Image / Mask / Label / Transform)"
+        },
+        {
+          "path": "docs/specs/phase11-lcms-block-spec.md",
+          "symbol": "MSRawFile",
+          "kind": "contains",
+          "pattern": "\"\"\"LC-MS plugin types: MSRawFile, PeakTable, MIDTable, SampleMetadata.\"\"\""
+        },
+        {
+          "path": "docs/specs/phase11-srs-block-spec.md",
+          "symbol": "SRSImage",
+          "kind": "contains",
+          "pattern": "### T-SRS-001 — `SRSImage` type + `Meta` model"
+        }
+      ],
+      "tests": [
+        {
+          "path": "packages/scistudio-blocks-imaging/tests/test_packaging.py",
+          "symbol": "test_get_types_returns_exported_imaging_types",
+          "kind": "contains",
+          "pattern": "assert get_types() == [Image, Mask, Label, Transform]"
+        },
+        {
+          "path": "packages/scistudio-blocks-lcms/tests/test_types.py",
+          "symbol": "test_get_types_returns_all_four_classes",
+          "kind": "contains",
+          "pattern": "assert get_types() == [MSRawFile, PeakTable, MIDTable, SampleMetadata]"
+        },
+        {
+          "path": "packages/scistudio-blocks-srs/tests/test_types.py",
+          "symbol": "test_get_types_returns_srsimage",
+          "kind": "contains",
+          "pattern": "assert get_types() == [SRSImage]"
+        }
+      ],
+      "adr_alignment": "aligned",
+      "notes": "The mechanical inventory only classifies direct subclasses of known base names as type_class items; a validator must still validate indirect subclasses returned by get_types().",
+      "validator_implication": "A validator should validate the returned type payload itself rather than relying only on static class-base inventory, so indirect DataObject subclasses cannot escape type contract checks."
+    }
+  ],
+  "omissions": [
+    {
+      "id": "OM-001",
+      "title": "Indirect DataObject subclasses are not classified as type_class inventory items",
+      "evidence": [
+        {
+          "path": "packages/scistudio-blocks-imaging/src/scistudio_blocks_imaging/types.py",
+          "symbol": "Mask",
+          "kind": "contains",
+          "pattern": "class Mask(Image):"
+        },
+        {
+          "path": "packages/scistudio-blocks-srs/src/scistudio_blocks_srs/types.py",
+          "symbol": "SRSImage",
+          "kind": "contains",
+          "pattern": "class SRSImage(Image):"
+        },
+        {
+          "path": "packages/scistudio-blocks-imaging/tests/test_packaging.py",
+          "symbol": "get_types",
+          "kind": "contains",
+          "pattern": "assert get_types() == [Image, Mask, Label, Transform]"
+        }
+      ],
+      "recommended_section": "03_type_contracts",
+      "notes": "The current inventory detects direct bases in TYPE_BASE_NAMES, so classes inheriting through plugin type bases are only visible through get_types payload evidence."
+    }
+  ]
+}

--- a/docs/planning/adr-049-package-validator/contracts/pv-a2-sections-04-06.json
+++ b/docs/planning/adr-049-package-validator/contracts/pv-a2-sections-04-06.json
@@ -1,0 +1,619 @@
+{
+  "schema_version": "adr049.package_contract_table.v1",
+  "agent_id": "PV-A2",
+  "generated_at": "2026-06-14",
+  "source_priority": "code-primary-adr-secondary",
+  "agent_scope": {
+    "sections": [
+      "04_block_contracts",
+      "05_config_dynamic_variadic",
+      "06_io_format_capability"
+    ],
+    "summary": "Code-first contracts for block harness validation, config/dynamic/variadic ports, and IO format capability registration and lookup."
+  },
+  "contracts": [
+    {
+      "id": "PV-04-001",
+      "section": "04_block_contracts",
+      "title": "BlockTestHarness reports SDK block contract errors",
+      "contract": "BlockTestHarness.validate_block reports errors for non-Block candidates, abstract classes, malformed input_ports/output_ports declarations, missing run attributes, and missing/default block names. It returns an error list and is a test-helper surface rather than an automatic production registration gate.",
+      "status": "partial",
+      "severity": "warning",
+      "environments": [
+        "development",
+        "production"
+      ],
+      "validator_profile": {
+        "development": "warning",
+        "production": "skip"
+      },
+      "applicability": {
+        "candidate_surfaces": [
+          "blocks"
+        ],
+        "trigger": "when_candidate_declares_scistudio.blocks",
+        "not_applicable_result": "not_applicable"
+      },
+      "code_evidence": [
+        {
+          "path": "src/scistudio/testing/harness.py",
+          "kind": "contains",
+          "pattern": "class BlockTestHarness:",
+          "symbol": "BlockTestHarness"
+        },
+        {
+          "path": "src/scistudio/testing/harness.py",
+          "kind": "contains",
+          "pattern": "def validate_block(self) -> list[str]:",
+          "symbol": "validate_block"
+        },
+        {
+          "path": "src/scistudio/testing/harness.py",
+          "kind": "contains",
+          "pattern": "if not (isinstance(cls, type) and issubclass(cls, Block)):"
+        },
+        {
+          "path": "src/scistudio/testing/harness.py",
+          "kind": "contains",
+          "pattern": "run_method = getattr(cls, \"run\", None)"
+        }
+      ],
+      "adr_evidence": [
+        {
+          "path": "docs/adr/ADR-026.md",
+          "kind": "contains",
+          "pattern": "`BlockTestHarness` is the public SDK test surface. It validates:"
+        }
+      ],
+      "tests": [
+        {
+          "path": "tests/testing/test_harness.py",
+          "kind": "contains",
+          "pattern": "class TestValidateBlock:"
+        }
+      ],
+      "adr_alignment": "adr_drift",
+      "notes": "ADR-026 describes a public validation surface; code evidence shows a narrower helper that reports diagnostics and does not inspect run signature.",
+      "validator_implication": "Package validator may reuse these predicates, but production blocking should come from explicit package-validator and registry checks."
+    },
+    {
+      "id": "PV-05-001",
+      "section": "05_config_dynamic_variadic",
+      "title": "Config schema and dynamic-port descriptors are registry-spec contracts",
+      "contract": "The registry spec builder merges config_schema along the MRO with child properties winning and output-direction inherited IO path fields rewritten to directory_browser. It also calls BlockRegistry._validate_dynamic_ports, which permits None and otherwise requires a dict with non-empty source_config_key plus exactly one of output_port_mapping/input_port_mapping shaped as port-name -> enum-value -> list of non-empty type-name strings. Dynamic-port shape failures are strict ValueError scan/spec-time errors.",
+      "status": "implemented",
+      "severity": "error",
+      "environments": [
+        "development",
+        "production"
+      ],
+      "validator_profile": {
+        "development": "block",
+        "production": "block"
+      },
+      "applicability": {
+        "candidate_surfaces": [
+          "blocks",
+          "block_config",
+          "block_ports"
+        ],
+        "trigger": "for_each_candidate_block_with_config_schema_dynamic_ports_or_variadic_ports",
+        "not_applicable_result": "not_applicable"
+      },
+      "code_evidence": [
+        {
+          "path": "src/scistudio/blocks/registry/_spec.py",
+          "kind": "contains",
+          "pattern": "def _merge_config_schema(cls: type) -> dict[str, Any]:",
+          "symbol": "_merge_config_schema"
+        },
+        {
+          "path": "src/scistudio/blocks/registry/_spec.py",
+          "kind": "contains",
+          "pattern": "for klass in reversed(cls.__mro__):"
+        },
+        {
+          "path": "src/scistudio/blocks/registry/_spec.py",
+          "kind": "contains",
+          "pattern": "BlockRegistry._validate_dynamic_ports(cls)"
+        },
+        {
+          "path": "src/scistudio/blocks/registry/__init__.py",
+          "kind": "contains",
+          "pattern": "def _validate_dynamic_ports(cls: type) -> None:",
+          "symbol": "_validate_dynamic_ports"
+        },
+        {
+          "path": "src/scistudio/blocks/registry/_capability.py",
+          "kind": "contains",
+          "pattern": "def _validate_dynamic_ports(cls: type) -> None:",
+          "symbol": "_validate_dynamic_ports"
+        },
+        {
+          "path": "src/scistudio/blocks/registry/_capability.py",
+          "kind": "contains",
+          "pattern": "must declare exactly one of"
+        }
+      ],
+      "adr_evidence": [
+        {
+          "path": "docs/block-development/block-contract.md",
+          "kind": "contains",
+          "pattern": "Config schema MRO merge (ADR-030)"
+        },
+        {
+          "path": "docs/adr/ADR-028.md",
+          "kind": "contains",
+          "pattern": "`BlockRegistry._validate_dynamic_ports()` validates descriptor shape"
+        }
+      ],
+      "tests": [
+        {
+          "path": "tests/blocks/test_dynamic_ports.py",
+          "kind": "contains",
+          "pattern": "class TestValidateDynamicPorts:"
+        }
+      ],
+      "adr_alignment": "aligned",
+      "notes": "Current dynamic-port validation is strict for shape but does not resolve mapped type names or prove source_config_key is an enum config field.",
+      "validator_implication": "Package validator should block malformed dynamic_ports and can add cross-surface checks for enum/type-name consistency."
+    },
+    {
+      "id": "PV-05-002",
+      "section": "05_config_dynamic_variadic",
+      "title": "Effective and variadic ports are instance-aware validation surfaces",
+      "contract": "Framework code that needs instance port shape must read get_effective_input_ports/get_effective_output_ports. LoadData maps core_type to output_port_mapping, SaveData maps core_type to input_port_mapping, and workflow validation uses instantiated effective ports when possible. Variadic flags, allowed type lists, and min/max port count limits are serialized into BlockSpec and workflow validation enforces count limits only when the corresponding variadic flag is true.",
+      "status": "implemented",
+      "severity": "error",
+      "environments": [
+        "development",
+        "production"
+      ],
+      "validator_profile": {
+        "development": "block",
+        "production": "block"
+      },
+      "applicability": {
+        "candidate_surfaces": [
+          "blocks",
+          "block_config",
+          "block_ports"
+        ],
+        "trigger": "for_each_candidate_block_with_config_schema_dynamic_ports_or_variadic_ports",
+        "not_applicable_result": "not_applicable"
+      },
+      "code_evidence": [
+        {
+          "path": "src/scistudio/blocks/base/block.py",
+          "kind": "contains",
+          "pattern": "def get_effective_input_ports(self) -> list[InputPort]:",
+          "symbol": "get_effective_input_ports"
+        },
+        {
+          "path": "src/scistudio/blocks/base/block.py",
+          "kind": "contains",
+          "pattern": "variadic_inputs: ClassVar[bool] = False",
+          "symbol": "Block.variadic_inputs"
+        },
+        {
+          "path": "src/scistudio/blocks/registry/_spec.py",
+          "kind": "contains",
+          "pattern": "variadic_inputs=bool(getattr(cls, \"variadic_inputs\", False))",
+          "symbol": "_spec_from_class"
+        },
+        {
+          "path": "src/scistudio/workflow/validator.py",
+          "kind": "contains",
+          "pattern": "return list(instance.get_effective_input_ports()), list(instance.get_effective_output_ports())",
+          "symbol": "_effective_ports_for_node"
+        },
+        {
+          "path": "src/scistudio/workflow/validator.py",
+          "kind": "contains",
+          "pattern": "if spec.variadic_inputs:",
+          "symbol": "validate_workflow"
+        },
+        {
+          "path": "src/scistudio/blocks/io/loaders/load_data.py",
+          "kind": "contains",
+          "pattern": "\"output_port_mapping\": {",
+          "symbol": "LoadData.dynamic_ports"
+        },
+        {
+          "path": "src/scistudio/blocks/io/savers/save_data.py",
+          "kind": "contains",
+          "pattern": "\"input_port_mapping\": {",
+          "symbol": "SaveData.dynamic_ports"
+        }
+      ],
+      "adr_evidence": [
+        {
+          "path": "docs/adr/ADR-028.md",
+          "kind": "contains",
+          "pattern": "Workflow validation constructs block instances and reads effective ports."
+        },
+        {
+          "path": "docs/adr/ADR-029.md",
+          "kind": "contains",
+          "pattern": "Variadic block authors declare:"
+        }
+      ],
+      "tests": [
+        {
+          "path": "tests/workflow/test_validator_dynamic_ports.py",
+          "kind": "contains",
+          "pattern": "class TestValidatorDynamicPortsCompatible:"
+        },
+        {
+          "path": "tests/workflow/test_validator.py",
+          "kind": "contains",
+          "pattern": "class TestValidatorVariadicCardinality:"
+        }
+      ],
+      "adr_alignment": "aligned",
+      "validator_implication": "Package validator should validate the effective BlockSpec/API surface and should not infer dynamic or variadic validity from static ClassVar ports alone."
+    },
+    {
+      "id": "PV-06-001",
+      "section": "06_io_format_capability",
+      "title": "FormatCapability and MetadataFidelity constructors enforce field validity",
+      "contract": "MetadataFidelity validates allowed levels, normalizes field tuples, rejects contradictory field declarations, and verifies typed-meta fields against the DataObject.Meta model. FormatCapability requires stable non-empty fields, load/save direction, a DataObject subclass, normalized non-empty extensions, a MetadataFidelity instance, and roundtrip_group for lossless capabilities.",
+      "status": "implemented",
+      "severity": "error",
+      "environments": [
+        "development",
+        "production"
+      ],
+      "validator_profile": {
+        "development": "block",
+        "production": "block"
+      },
+      "applicability": {
+        "candidate_surfaces": [
+          "io_blocks",
+          "format_capabilities"
+        ],
+        "trigger": "for_each_candidate_IOBlock_or_declared_FormatCapability",
+        "not_applicable_result": "not_applicable"
+      },
+      "code_evidence": [
+        {
+          "path": "src/scistudio/blocks/io/capabilities.py",
+          "kind": "contains",
+          "pattern": "class MetadataFidelity:",
+          "symbol": "MetadataFidelity"
+        },
+        {
+          "path": "src/scistudio/blocks/io/capabilities.py",
+          "kind": "contains",
+          "pattern": "class FormatCapability:",
+          "symbol": "FormatCapability"
+        },
+        {
+          "path": "src/scistudio/blocks/io/capabilities.py",
+          "kind": "contains",
+          "pattern": "lossless capabilities must declare roundtrip_group."
+        },
+        {
+          "path": "src/scistudio/blocks/io/capabilities.py",
+          "kind": "contains",
+          "pattern": "self.metadata_fidelity.validate_typed_meta_fields(self.data_type)"
+        }
+      ],
+      "adr_evidence": [
+        {
+          "path": "docs/specs/adr-043-io-format-capability-registry.md",
+          "kind": "contains",
+          "pattern": "FR-001: The system MUST define `FormatCapability`"
+        },
+        {
+          "path": "docs/specs/adr-043-io-format-capability-registry.md",
+          "kind": "contains",
+          "pattern": "FR-002: The system MUST define `MetadataFidelity`"
+        }
+      ],
+      "tests": [
+        {
+          "path": "tests/contracts/test_io_capability_contract.py",
+          "kind": "contains",
+          "pattern": "test_registered_io_capabilities_expose_stable_replay_fields"
+        }
+      ],
+      "adr_alignment": "aligned",
+      "validator_implication": "Package validator should instantiate capability declarations to force normalization and constructor-level validation."
+    },
+    {
+      "id": "PV-06-002",
+      "section": "06_io_format_capability",
+      "title": "Registry registration validates class-owned capabilities",
+      "contract": "_format_capabilities_from_class extracts FormatCapability records only from IOBlock subclasses and validates each record. _validate_class_capability checks direction against IO direction, block_type against the class name, handler callability, and package-qualified id. Registry registration then rejects duplicate ids within a spec, ids already declared by other specs, and conflicting defaults for the same direction/type/extension. Legacy supported_extensions and SimpleLoader/SimpleSaver synthesis remain migration scaffolding.",
+      "status": "partial",
+      "severity": "error",
+      "environments": [
+        "development",
+        "production"
+      ],
+      "validator_profile": {
+        "development": "block",
+        "production": "error"
+      },
+      "applicability": {
+        "candidate_surfaces": [
+          "io_blocks",
+          "format_capabilities"
+        ],
+        "trigger": "for_each_candidate_IOBlock_or_declared_FormatCapability",
+        "not_applicable_result": "not_applicable"
+      },
+      "code_evidence": [
+        {
+          "path": "src/scistudio/blocks/registry/_spec.py",
+          "kind": "contains",
+          "pattern": "def _validate_class_capability(cls: type, capability: FormatCapability) -> None:",
+          "symbol": "_validate_class_capability"
+        },
+        {
+          "path": "src/scistudio/blocks/registry/_spec.py",
+          "kind": "contains",
+          "pattern": "def _format_capabilities_from_class(cls: type) -> list[FormatCapability]:",
+          "symbol": "_format_capabilities_from_class"
+        },
+        {
+          "path": "src/scistudio/blocks/registry/__init__.py",
+          "kind": "contains",
+          "pattern": "def _validate_capability_registration(self, spec: BlockSpec) -> None:",
+          "symbol": "_validate_capability_registration"
+        },
+        {
+          "path": "src/scistudio/blocks/registry/_scan.py",
+          "kind": "contains",
+          "pattern": "def _validate_capability_registration(registry: BlockRegistry, spec: BlockSpec) -> None:",
+          "symbol": "_validate_capability_registration"
+        },
+        {
+          "path": "src/scistudio/blocks/registry/_capability.py",
+          "kind": "contains",
+          "pattern": "must be stable and package-qualified",
+          "symbol": "_validate_capability_id"
+        },
+        {
+          "path": "src/scistudio/blocks/registry/_scan.py",
+          "kind": "contains",
+          "pattern": "Conflicting default IO format capabilities"
+        },
+        {
+          "path": "src/scistudio/blocks/io/io_block.py",
+          "kind": "contains",
+          "pattern": "supported_extensions`` synthesis exists only as migration"
+        }
+      ],
+      "adr_evidence": [
+        {
+          "path": "docs/specs/adr-043-io-format-capability-registry.md",
+          "kind": "contains",
+          "pattern": "FR-009: The registry MUST validate handler existence"
+        },
+        {
+          "path": "docs/specs/adr-043-io-format-capability-registry.md",
+          "kind": "contains",
+          "pattern": "FR-016: Existing `supported_extensions` declarations MAY synthesize"
+        }
+      ],
+      "tests": [
+        {
+          "path": "tests/blocks/test_block_registry_capabilities.py",
+          "kind": "contains",
+          "pattern": "test_scan_time_validation_rejects_missing_handler"
+        },
+        {
+          "path": "tests/blocks/test_block_registry_capabilities.py",
+          "kind": "contains",
+          "pattern": "test_scan_time_validation_rejects_default_conflict"
+        }
+      ],
+      "adr_alignment": "aligned",
+      "notes": "Strict for class-local and registry conflicts; partial for final published-package compliance because migration synthesis remains allowed.",
+      "validator_implication": "Package validator should run capability extraction in registry context and distinguish explicit package-author declarations from synthesized compatibility records."
+    },
+    {
+      "id": "PV-06-003",
+      "section": "06_io_format_capability",
+      "title": "Capability lookup is deterministic and typed-error based",
+      "contract": "list_format_capabilities filters by direction, data type compatibility, format id, and normalized extension with compound-to-single fallback. find_loader_capability and find_saver_capability prefer explicit capability_id, then unique match, single default, type specificity, and priority. Misses and unresolved ambiguity raise typed lookup errors instead of falling back to registration order.",
+      "status": "implemented",
+      "severity": "error",
+      "environments": [
+        "development",
+        "production"
+      ],
+      "validator_profile": {
+        "development": "block",
+        "production": "block"
+      },
+      "applicability": {
+        "candidate_surfaces": [
+          "io_blocks",
+          "format_capabilities"
+        ],
+        "trigger": "for_each_candidate_IOBlock_or_declared_FormatCapability",
+        "not_applicable_result": "not_applicable"
+      },
+      "code_evidence": [
+        {
+          "path": "src/scistudio/blocks/registry/__init__.py",
+          "kind": "contains",
+          "pattern": "def list_format_capabilities(",
+          "symbol": "list_format_capabilities"
+        },
+        {
+          "path": "src/scistudio/blocks/registry/__init__.py",
+          "kind": "contains",
+          "pattern": "def find_loader_capability(",
+          "symbol": "find_loader_capability"
+        },
+        {
+          "path": "src/scistudio/blocks/registry/__init__.py",
+          "kind": "contains",
+          "pattern": "def find_saver_capability(",
+          "symbol": "find_saver_capability"
+        },
+        {
+          "path": "src/scistudio/blocks/registry/_capability.py",
+          "kind": "contains",
+          "pattern": "def list_format_capabilities(",
+          "symbol": "list_format_capabilities"
+        },
+        {
+          "path": "src/scistudio/blocks/registry/_capability.py",
+          "kind": "contains",
+          "pattern": "def find_loader_capability(",
+          "symbol": "find_loader_capability"
+        },
+        {
+          "path": "src/scistudio/blocks/registry/_capability.py",
+          "kind": "contains",
+          "pattern": "def find_saver_capability(",
+          "symbol": "find_saver_capability"
+        },
+        {
+          "path": "src/scistudio/blocks/registry/_capability.py",
+          "kind": "contains",
+          "pattern": "if capability_id is not None:"
+        },
+        {
+          "path": "src/scistudio/blocks/registry/_capability.py",
+          "kind": "contains",
+          "pattern": "raise AmbiguousCapabilityError("
+        }
+      ],
+      "adr_evidence": [
+        {
+          "path": "docs/specs/adr-043-io-format-capability-registry.md",
+          "kind": "contains",
+          "pattern": "FR-007: Capability lookup MUST prefer explicit"
+        },
+        {
+          "path": "docs/specs/adr-043-io-format-capability-registry.md",
+          "kind": "contains",
+          "pattern": "FR-008: Capability lookup MUST fail on unresolved"
+        }
+      ],
+      "tests": [
+        {
+          "path": "tests/blocks/test_block_registry_capabilities.py",
+          "kind": "contains",
+          "pattern": "test_ambiguous_capability_raises_typed_error_without_registration_order_dispatch"
+        }
+      ],
+      "adr_alignment": "aligned",
+      "validator_implication": "Package validator should fail missing or ambiguous capability lookups unless a valid explicit capability_id or unique/default candidate resolves the query."
+    },
+    {
+      "id": "PV-06-004",
+      "section": "06_io_format_capability",
+      "title": "Boundary ports validate by IO capability lookup",
+      "contract": "Workflow validation treats AppBlock and CodeBlock boundary ports as IO boundary declarations. Configured input_ports with declared type plus extension must resolve a saver capability; configured output_ports with declared type plus extension must resolve a loader capability; explicit capability_id is verified as semantic truth. Duplicate output extensions on variadic-output blocks are rejected as file-binning ambiguity. Artifact outputs without capability_id are currently skipped.",
+      "status": "partial",
+      "severity": "error",
+      "environments": [
+        "development",
+        "production"
+      ],
+      "validator_profile": {
+        "development": "error",
+        "production": "error"
+      },
+      "applicability": {
+        "candidate_surfaces": [
+          "io_blocks",
+          "format_capabilities"
+        ],
+        "trigger": "for_each_candidate_IOBlock_or_declared_FormatCapability",
+        "not_applicable_result": "not_applicable"
+      },
+      "code_evidence": [
+        {
+          "path": "src/scistudio/workflow/validator.py",
+          "kind": "contains",
+          "pattern": "Check 10: ADR-043 boundary IO capabilities",
+          "symbol": "validate_workflow"
+        },
+        {
+          "path": "src/scistudio/workflow/validator.py",
+          "kind": "contains",
+          "pattern": "registry.find_saver_capability("
+        },
+        {
+          "path": "src/scistudio/workflow/validator.py",
+          "kind": "contains",
+          "pattern": "registry.find_loader_capability("
+        },
+        {
+          "path": "src/scistudio/workflow/validator.py",
+          "kind": "contains",
+          "pattern": "Duplicate extension"
+        }
+      ],
+      "adr_evidence": [
+        {
+          "path": "docs/specs/adr-043-io-format-capability-registry.md",
+          "kind": "contains",
+          "pattern": "FR-012: AppBlock and CodeBlock input ports with declared type and extension"
+        },
+        {
+          "path": "docs/specs/adr-043-io-format-capability-registry.md",
+          "kind": "contains",
+          "pattern": "FR-013: AppBlock and CodeBlock output ports with declared"
+        }
+      ],
+      "tests": [
+        {
+          "path": "tests/contracts/test_io_capability_contract.py",
+          "kind": "contains",
+          "pattern": "test_boundary_validation_uses_capability_id_not_extension_hint_as_contract"
+        },
+        {
+          "path": "tests/workflow/test_validator.py",
+          "kind": "contains",
+          "pattern": "class TestValidatorAppBlockDuplicateExtensions:"
+        }
+      ],
+      "adr_alignment": "aligned",
+      "notes": "Implemented in workflow validation, not yet a standalone package-validator entry point. Artifact no-capability output remains a current exception.",
+      "validator_implication": "Package validator should mirror the boundary lookup semantics and explicitly decide whether the Artifact exception remains allowed in package mode."
+    }
+  ],
+  "omissions": [
+    {
+      "id": "OM-001",
+      "title": "Dynamic-port source config enum and mapped type-name resolution are not scan-time enforced",
+      "evidence": [
+        {
+          "path": "src/scistudio/blocks/registry/_capability.py",
+          "kind": "contains",
+          "pattern": "def _validate_dynamic_ports(cls: type) -> None:"
+        }
+      ],
+      "recommended_section": "05_config_dynamic_variadic",
+      "notes": "Shape is strict, but cross-surface consistency with config_schema enum values and TypeRegistry names is a package-validator opportunity."
+    },
+    {
+      "id": "OM-002",
+      "title": "Published-package IO compliance is stricter than current migration scaffolding",
+      "evidence": [
+        {
+          "path": "src/scistudio/blocks/io/io_block.py",
+          "kind": "contains",
+          "pattern": "supported_extensions`` synthesis exists only as migration"
+        },
+        {
+          "path": "tests/contracts/test_io_capability_contract.py",
+          "kind": "contains",
+          "pattern": "current core IO declarations have save-only Series JSON roundtrip drift"
+        }
+      ],
+      "recommended_section": "06_io_format_capability",
+      "notes": "Package mode should define when synthesized capabilities and known roundtrip drift become blockers."
+    }
+  ]
+}

--- a/docs/planning/adr-049-package-validator/contracts/pv-a3-sections-07-09.json
+++ b/docs/planning/adr-049-package-validator/contracts/pv-a3-sections-07-09.json
@@ -1,0 +1,959 @@
+{
+  "schema_version": "adr049.package_contract_table.v1",
+  "agent_id": "PV-A3",
+  "generated_at": "2026-06-14",
+  "source_priority": "code-primary-adr-secondary",
+  "agent_scope": {
+    "sections": [
+      "07_data_transport_runtime_boundary",
+      "08_app_code_block_boundaries",
+      "09_previewer_contracts"
+    ],
+    "summary": "Contracts for package-validator behavior around direct smoke execution, AppBlock and CodeBlock boundary validation, and previewer registration, routing, manifests, assets, and session stamping."
+  },
+  "contracts": [
+    {
+      "id": "PV-07-001",
+      "section": "07_data_transport_runtime_boundary",
+      "title": "Smoke tests execute Block.run directly and propagate failures",
+      "contract": "A package validator smoke test for runtime transport must instantiate only Block subclasses, pass optional params through BlockConfig params, call instance.run(inputs, config), and return that output mapping. Non-Block classes are strict TypeError failures, and any exception raised by run() propagates to the caller. This helper observes a block boundary; it does not by itself prove worker serialization, lineage, or storage durability.",
+      "status": "implemented",
+      "severity": "error",
+      "environments": [
+        "development"
+      ],
+      "validator_profile": {
+        "development": "block",
+        "production": "skip"
+      },
+      "applicability": {
+        "candidate_surfaces": [
+          "blocks",
+          "runtime_smoke"
+        ],
+        "trigger": "when_candidate_block_has_safe_fixture_or_profile_requires_safe_smoke_validation",
+        "not_applicable_result": "not_applicable"
+      },
+      "code_evidence": [
+        {
+          "path": "src/scistudio/testing/harness.py",
+          "kind": "contains",
+          "pattern": "def smoke_test(",
+          "symbol": "smoke_test",
+          "notes": "Required inventory item for section 07."
+        },
+        {
+          "path": "src/scistudio/testing/harness.py",
+          "kind": "contains",
+          "pattern": "return instance.run(inputs, config)",
+          "notes": "The harness directly executes the block runtime boundary."
+        },
+        {
+          "path": "src/scistudio/testing/harness.py",
+          "kind": "contains",
+          "pattern": "raise TypeError(f\"{cls!r} is not a subclass of Block. Cannot run smoke test.\")",
+          "notes": "Non-Block targets are strict failures."
+        }
+      ],
+      "adr_evidence": [],
+      "tests": [
+        {
+          "path": "tests/testing/test_harness.py",
+          "kind": "contains",
+          "pattern": "def test_smoke_test_returns_outputs",
+          "notes": "Smoke test returns the block output mapping."
+        },
+        {
+          "path": "tests/testing/test_harness.py",
+          "kind": "contains",
+          "pattern": "def test_smoke_test_propagates_errors",
+          "notes": "Runtime exceptions propagate."
+        },
+        {
+          "path": "tests/testing/test_harness.py",
+          "kind": "contains",
+          "pattern": "def test_smoke_test_rejects_non_block",
+          "notes": "Non-Block targets are rejected."
+        }
+      ],
+      "adr_alignment": "adr_missing",
+      "notes": "ADR-020 governs the broader runtime transport model, but no ADR found in this pass defines BlockTestHarness.smoke_test itself.",
+      "validator_implication": "Block package validation can use smoke_test as a development-time executable check and should treat raised exceptions as blocking smoke failures."
+    },
+    {
+      "id": "PV-07-002",
+      "section": "07_data_transport_runtime_boundary",
+      "title": "Collection transport remains runtime-specific at external boundaries",
+      "contract": "Package validation must not reduce data transport to a single metadata-only rule. AppBlock unwraps Collection inputs for tool-specific file exchange and rewraps collected artifacts as Collections; CodeBlock v2 materializes declared file-exchange ports, writes a manifest, invokes a backend, and reconstructs declared outputs. A validator may inspect declarations statically, but executable transport proof requires a smoke or runtime test.",
+      "status": "implemented",
+      "severity": "warning",
+      "environments": [
+        "development",
+        "production"
+      ],
+      "validator_profile": {
+        "development": "warning",
+        "production": "warning"
+      },
+      "applicability": {
+        "candidate_surfaces": [
+          "blocks",
+          "runtime_smoke"
+        ],
+        "trigger": "when_candidate_block_has_safe_fixture_or_profile_requires_safe_smoke_validation",
+        "not_applicable_result": "not_applicable"
+      },
+      "code_evidence": [
+        {
+          "path": "src/scistudio/blocks/app/app_block.py",
+          "kind": "contains",
+          "pattern": "if isinstance(value, Collection):",
+          "symbol": "AppBlock",
+          "notes": "AppBlock unpacks Collection inputs before file exchange."
+        },
+        {
+          "path": "src/scistudio/blocks/app/app_block.py",
+          "kind": "contains",
+          "pattern": "collection_results[key] = Collection([value], item_type=Artifact)",
+          "symbol": "AppBlock",
+          "notes": "Legacy AppBlock collection wrapping behavior."
+        },
+        {
+          "path": "src/scistudio/blocks/code/code_block.py",
+          "kind": "contains",
+          "pattern": "manifest = prepare_codeblock_exchange(",
+          "symbol": "CodeBlock",
+          "notes": "CodeBlock materializes declared exchange inputs."
+        },
+        {
+          "path": "src/scistudio/blocks/code/code_block.py",
+          "kind": "contains",
+          "pattern": "outputs = collect_codeblock_outputs(",
+          "symbol": "CodeBlock",
+          "notes": "CodeBlock reconstructs declared exchange outputs."
+        }
+      ],
+      "adr_evidence": [
+        {
+          "path": "docs/adr/ADR-020.md",
+          "kind": "contains",
+          "pattern": "### 7.2 CodeBlock Boundary",
+          "notes": "ADR-020 describes CodeBlock collection boundary behavior."
+        },
+        {
+          "path": "docs/adr/ADR-020.md",
+          "kind": "contains",
+          "pattern": "### 7.3 AppBlock And External Tool Boundary",
+          "notes": "ADR-020 delegates AppBlock exchange shape to the external tool block."
+        }
+      ],
+      "tests": [
+        {
+          "path": "tests/blocks/code/test_codeblock_exchange.py",
+          "kind": "contains",
+          "pattern": "CodeBlockExchangePort",
+          "notes": "CodeBlock file-exchange port tests cover boundary artifacts."
+        }
+      ],
+      "adr_alignment": "aligned",
+      "notes": "Static package validation can identify likely boundary declarations, but current implementation makes actual data movement a runtime concern.",
+      "validator_implication": "Emit a warning when only static declarations were inspected; block only when an executable smoke/runtime check or strict boundary validator fails."
+    },
+    {
+      "id": "PV-08-001",
+      "section": "08_app_code_block_boundaries",
+      "title": "CodeBlock v2 persisted config validation is strict for concrete CodeBlock specs",
+      "contract": "CodeBlock package validation must use the concrete CodeBlock v2 config contract: strip runtime-only keys, reject legacy inline/function/runner fields, require project-local paths, require supported script extensions, validate port direction/name/exchange_folder/data_type/capability lookup, and return CodeBlockValidationDiagnostic entries whose default severity is error.",
+      "status": "implemented",
+      "severity": "error",
+      "environments": [
+        "development",
+        "production"
+      ],
+      "validator_profile": {
+        "development": "block",
+        "production": "block"
+      },
+      "applicability": {
+        "candidate_surfaces": [
+          "app_blocks",
+          "code_blocks"
+        ],
+        "trigger": "when_candidate_declares_AppBlock_or_CodeBlock_surfaces_or_configs",
+        "not_applicable_result": "not_applicable"
+      },
+      "code_evidence": [
+        {
+          "path": "src/scistudio/blocks/code/validation.py",
+          "kind": "contains",
+          "pattern": "def validate_codeblock_config(",
+          "symbol": "validate_codeblock_config",
+          "notes": "Required inventory item for section 08."
+        },
+        {
+          "path": "src/scistudio/blocks/code/validation.py",
+          "kind": "contains",
+          "pattern": "diagnostics.extend(_port_diagnostics(parsed, registry=registry))",
+          "notes": "Port declarations participate in strict validation."
+        },
+        {
+          "path": "src/scistudio/blocks/code/config.py",
+          "kind": "contains",
+          "pattern": "Inline CodeBlock configs are not valid CodeBlock v2 configs.",
+          "notes": "Legacy inline configs become migration errors."
+        },
+        {
+          "path": "src/scistudio/blocks/code/config.py",
+          "kind": "contains",
+          "pattern": "CodeBlock v2 does not call SciStudio entry functions; scripts must use file exchange.",
+          "notes": "Entry-function script configs are rejected by the v2 config model."
+        }
+      ],
+      "adr_evidence": [
+        {
+          "path": "docs/adr/ADR-005.md",
+          "kind": "contains",
+          "pattern": "CodeBlock v2 is narrowed by ADR-041 toward project-local script file exchange",
+          "notes": "ADR-005 records the current CodeBlock v2 narrowing."
+        },
+        {
+          "path": "docs/adr/ADR-005.md",
+          "kind": "contains",
+          "pattern": "CodeBlock exchange and workflow-validator tests cover the current v2 script",
+          "notes": "ADR verification references strict v2 diagnostics."
+        }
+      ],
+      "tests": [
+        {
+          "path": "tests/workflow/test_validator_codeblock_v2.py",
+          "kind": "contains",
+          "pattern": "def test_validate_workflow_reports_node_scoped_codeblock_diagnostics",
+          "notes": "Workflow validator renders CodeBlock v2 errors."
+        },
+        {
+          "path": "tests/workflow/test_validator_codeblock_v2.py",
+          "kind": "contains",
+          "pattern": "def test_validate_workflow_reports_legacy_inline_migration",
+          "notes": "Legacy inline configs are reported as errors."
+        }
+      ],
+      "adr_alignment": "aligned",
+      "notes": "The current code treats these as diagnostics objects internally, then workflow validation renders error-severity diagnostics as save-time errors.",
+      "validator_implication": "A package validator should block concrete CodeBlock declarations that produce error-severity CodeBlockValidationDiagnostic entries."
+    },
+    {
+      "id": "PV-08-002",
+      "section": "08_app_code_block_boundaries",
+      "title": "Workflow validation enforces AppBlock output ambiguity and CodeBlock strictness",
+      "contract": "When a registry is provided, validate_workflow enforces boundary checks for variadic cardinality, AppBlock duplicate output-port extensions, and concrete CodeBlock v2 declarations. Duplicate AppBlock extensions and CodeBlock error diagnostics are strict errors. Unknown block types are returned as warning strings and skip deeper type and CodeBlock validation.",
+      "status": "implemented",
+      "severity": "error",
+      "environments": [
+        "development",
+        "production"
+      ],
+      "validator_profile": {
+        "development": "block",
+        "production": "block"
+      },
+      "applicability": {
+        "candidate_surfaces": [
+          "app_blocks",
+          "code_blocks"
+        ],
+        "trigger": "when_candidate_declares_AppBlock_or_CodeBlock_surfaces_or_configs",
+        "not_applicable_result": "not_applicable"
+      },
+      "code_evidence": [
+        {
+          "path": "src/scistudio/workflow/validator.py",
+          "kind": "contains",
+          "pattern": "def validate_workflow(",
+          "symbol": "validate_workflow",
+          "notes": "Required inventory item for section 08."
+        },
+        {
+          "path": "src/scistudio/workflow/validator.py",
+          "kind": "contains",
+          "pattern": "Check 8: AppBlock duplicate output-port extensions",
+          "notes": "AppBlock duplicate extension check is a workflow boundary validator."
+        },
+        {
+          "path": "src/scistudio/workflow/validator.py",
+          "kind": "contains",
+          "pattern": "diagnostic.render(node_id=node.id) for diagnostic in diagnostics if diagnostic.severity == \"error\"",
+          "notes": "Only error-severity CodeBlock diagnostics become workflow errors."
+        },
+        {
+          "path": "src/scistudio/workflow/validator.py",
+          "kind": "contains",
+          "pattern": "Warning: block type",
+          "notes": "Unknown registry specs are diagnostic warnings, not deep validation failures."
+        }
+      ],
+      "adr_evidence": [
+        {
+          "path": "docs/adr/ADR-006.md",
+          "kind": "contains",
+          "pattern": "`AppBlock` is the external-software block category.",
+          "notes": "ADR-006 identifies AppBlock as the external tool boundary."
+        },
+        {
+          "path": "docs/adr/ADR-005.md",
+          "kind": "contains",
+          "pattern": "CodeBlock is the block category for user-provided code.",
+          "notes": "ADR-005 identifies CodeBlock as the user-code boundary."
+        }
+      ],
+      "tests": [
+        {
+          "path": "tests/workflow/test_validator.py",
+          "kind": "contains",
+          "pattern": "class TestValidatorAppBlockDuplicateExtensions",
+          "notes": "AppBlock duplicate extension workflow checks."
+        },
+        {
+          "path": "tests/workflow/test_validator.py",
+          "kind": "contains",
+          "pattern": "def test_duplicate_extension_under_params_envelope",
+          "notes": "Validator reads frontend-style params.output_ports."
+        },
+        {
+          "path": "tests/workflow/test_validator.py",
+          "kind": "contains",
+          "pattern": "class TestIsCodeBlockSpecNarrowing",
+          "notes": "CodeBlock validation applies only to concrete CodeBlock specs."
+        },
+        {
+          "path": "tests/workflow/test_validator_codeblock_v2.py",
+          "kind": "contains",
+          "pattern": "def test_validate_workflow_preserves_unknown_block_warning",
+          "notes": "Unknown block registry entries remain warnings."
+        }
+      ],
+      "adr_alignment": "aligned",
+      "notes": "Current implementation returns all messages as strings; consumers distinguish warnings by message text, while CodeBlock diagnostic severity is explicit before rendering.",
+      "validator_implication": "Block package validation should block duplicate AppBlock output extensions and concrete CodeBlock error diagnostics, but report unknown or unavailable registry entries as diagnostics unless the package contract requires full registry resolution."
+    },
+    {
+      "id": "PV-08-003",
+      "section": "08_app_code_block_boundaries",
+      "title": "Concrete AppBlock and CodeBlock subclasses inherit boundary contracts with drift-sensitive checks",
+      "contract": "Concrete package subclasses of AppBlock and CodeBlock should be inspected as boundary participants. AppBlock subclasses that override run() must preserve extension-based output routing when output_ports are configured. CodeBlock subclasses delegating to CodeBlock.run must provide v2 file-exchange config and must not rely on legacy language, mode, or entry_function fields unless the package validator classifies that as a migration failure.",
+      "status": "partial",
+      "severity": "warning",
+      "environments": [
+        "development",
+        "production"
+      ],
+      "validator_profile": {
+        "development": "warning",
+        "production": "warning"
+      },
+      "applicability": {
+        "candidate_surfaces": [
+          "app_blocks",
+          "code_blocks"
+        ],
+        "trigger": "when_candidate_declares_AppBlock_or_CodeBlock_surfaces_or_configs",
+        "not_applicable_result": "not_applicable"
+      },
+      "code_evidence": [
+        {
+          "path": "packages/scistudio-blocks-imaging/src/scistudio_blocks_imaging/interactive/fiji_block.py",
+          "kind": "contains",
+          "pattern": "class FijiBlock(AppBlock):",
+          "symbol": "FijiBlock",
+          "notes": "Non-required inventory AppBlock subclass."
+        },
+        {
+          "path": "packages/scistudio-blocks-imaging/src/scistudio_blocks_imaging/interactive/fiji_block.py",
+          "kind": "contains",
+          "pattern": "return self._bin_outputs_by_extension(output_files, config)",
+          "notes": "Override preserves configured output-port binning."
+        },
+        {
+          "path": "packages/scistudio-blocks-imaging/src/scistudio_blocks_imaging/interactive/napari_block.py",
+          "kind": "contains",
+          "pattern": "class NapariBlock(AppBlock):",
+          "symbol": "NapariBlock",
+          "notes": "Non-required inventory AppBlock subclass."
+        },
+        {
+          "path": "packages/scistudio-blocks-lcms/src/scistudio_blocks_lcms/external/elmaven_block.py",
+          "kind": "contains",
+          "pattern": "class ElMAVENBlock(_LCMSBlockMixin, AppBlock):",
+          "symbol": "ElMAVENBlock",
+          "notes": "Non-required inventory AppBlock subclass."
+        },
+        {
+          "path": "packages/scistudio-blocks-lcms/src/scistudio_blocks_lcms/external/accucor_r.py",
+          "kind": "contains",
+          "pattern": "class AccuCorR(_LCMSBlockMixin, CodeBlock):",
+          "symbol": "AccuCorR",
+          "notes": "Non-required inventory CodeBlock subclass."
+        },
+        {
+          "path": "packages/scistudio-blocks-lcms/src/scistudio_blocks_lcms/external/accucor_r.py",
+          "kind": "contains",
+          "pattern": "patched_params[\"entry_function\"] = \"run_accucor\"",
+          "notes": "Implementation currently patches a field that CodeBlock v2 rejects."
+        }
+      ],
+      "adr_evidence": [
+        {
+          "path": "docs/adr/ADR-005.md",
+          "kind": "contains",
+          "pattern": "ADR-041 rejects inline execution in CodeBlock v2",
+          "notes": "ADR-005 records the v2 rejection of framework-shaped CodeBlock configs."
+        },
+        {
+          "path": "docs/adr/ADR-006.md",
+          "kind": "contains",
+          "pattern": "AppBlock tests verify file-exchange preparation and output reconstruction.",
+          "notes": "ADR-006 aligns with AppBlock file-exchange subclass behavior."
+        }
+      ],
+      "tests": [
+        {
+          "path": "packages/scistudio-blocks-lcms/tests/test_external/test_accucor_r.py",
+          "kind": "contains",
+          "pattern": "monkeypatch.setattr(CodeBlock, \"run\", fake_run)",
+          "notes": "Existing AccuCorR run test bypasses actual CodeBlock.run validation."
+        },
+        {
+          "path": "tests/plugins/test_phase11_skeleton.py",
+          "kind": "contains",
+          "pattern": "(AccuCorR, CodeBlock)",
+          "notes": "Skeleton test confirms CodeBlock subclass identity."
+        }
+      ],
+      "adr_alignment": "adr_drift",
+      "notes": "Drift is code-first: AccuCorR patches entry_function/language/mode before delegating, while CodeBlock v2 validation rejects entry_function and legacy runner fields. The current AccuCorR run test monkeypatches CodeBlock.run, so it does not exercise the real v2 delegate.",
+      "validator_implication": "Package validation should at least warn on CodeBlock subclasses that synthesize legacy fields; it should block when the concrete runtime config is passed through validate_codeblock_config and produces error diagnostics."
+    },
+    {
+      "id": "PV-09-001",
+      "section": "09_previewer_contracts",
+      "title": "Previewer entry points return PreviewerSpec lists and registry failures are diagnostic",
+      "contract": "A package previewer surface is declared with the scistudio.previewers entry-point group. The entry point resolves to a zero-argument factory returning a list or tuple of PreviewerSpec objects. PreviewerRegistry loads core specs, entry-point specs, and optional monorepo package specs; duplicate IDs, empty IDs, broken factories, non-list returns, and non-PreviewerSpec items are recorded as diagnostics or skipped instead of crashing the registry.",
+      "status": "implemented",
+      "severity": "warning",
+      "environments": [
+        "development",
+        "production"
+      ],
+      "validator_profile": {
+        "development": "warning",
+        "production": "warning"
+      },
+      "applicability": {
+        "candidate_surfaces": [
+          "previewers",
+          "preview_frontend_manifest"
+        ],
+        "trigger": "when_candidate_declares_scistudio.previewers",
+        "not_applicable_result": "not_applicable"
+      },
+      "code_evidence": [
+        {
+          "path": "packages/scistudio-blocks-imaging/pyproject.toml",
+          "kind": "contains",
+          "pattern": "[project.entry-points.\"scistudio.previewers\"]",
+          "symbol": "scistudio.previewers",
+          "notes": "Required inventory entry-point group."
+        },
+        {
+          "path": "packages/scistudio-blocks-imaging/src/scistudio_blocks_imaging/previewers/__init__.py",
+          "kind": "contains",
+          "pattern": "def get_previewers() -> list[PreviewerSpec]:",
+          "symbol": "get_previewers",
+          "notes": "Required inventory package entry-point factory."
+        },
+        {
+          "path": "src/scistudio/previewers/registry.py",
+          "kind": "contains",
+          "pattern": "class PreviewerRegistry:",
+          "symbol": "PreviewerRegistry",
+          "notes": "Required inventory registry class."
+        },
+        {
+          "path": "src/scistudio/previewers/registry.py",
+          "kind": "contains",
+          "pattern": "PREVIEWER_ENTRY_POINT_GROUP = \"scistudio.previewers\"",
+          "notes": "Registry uses the package entry-point group."
+        },
+        {
+          "path": "src/scistudio/previewers/registry.py",
+          "kind": "contains",
+          "pattern": "previewer factory '{source}' returned non-PreviewerSpec item; skipping",
+          "notes": "Factory item mismatches are diagnostics."
+        }
+      ],
+      "adr_evidence": [
+        {
+          "path": "docs/adr/ADR-048.md",
+          "kind": "contains",
+          "pattern": "A previewer may be supplied by core, an installed package",
+          "notes": "ADR-048 defines package/project previewers."
+        },
+        {
+          "path": "docs/specs/adr-048-preview-system.md",
+          "kind": "contains",
+          "pattern": "package previewers from `scistudio.previewers` entry points",
+          "notes": "Spec declares entry-point loading."
+        }
+      ],
+      "tests": [
+        {
+          "path": "tests/previewers/test_preview_registry.py",
+          "kind": "contains",
+          "pattern": "def test_duplicate_previewer_id_is_rejected_with_diagnostic",
+          "notes": "Duplicate IDs are diagnostic."
+        },
+        {
+          "path": "tests/previewers/test_preview_registry.py",
+          "kind": "contains",
+          "pattern": "def test_factory_returning_non_list_is_diagnosed",
+          "notes": "Bad factory return type is diagnostic."
+        },
+        {
+          "path": "packages/scistudio-blocks-imaging/tests/test_previewer_registration.py",
+          "kind": "contains",
+          "pattern": "def test_pyproject_declares_installed_previewer_entry_point",
+          "notes": "Imaging package entry point is pinned."
+        }
+      ],
+      "adr_alignment": "aligned",
+      "notes": "Current registry behavior is diagnostic-first. A future package validator may choose to escalate diagnostics for publish-time validation, but that is stricter than the runtime registry.",
+      "validator_implication": "Report registry diagnostics and malformed factories; block only when the package-validation profile explicitly requires a clean previewer registry."
+    },
+    {
+      "id": "PV-09-002",
+      "section": "09_previewer_contracts",
+      "title": "PreviewerSpec and FrontendManifest define the public previewer declaration shape",
+      "contract": "PreviewerSpec declares previewer_id, owner_kind, owner_name, target_type, supports_collection, priority, capabilities, backend_provider, optional frontend_manifest, and api_version. FrontendManifest declares previewer_id, module_url, export_name, css, version, api_version, and backend-only asset_root. The public wire shape must omit asset_root; value validity is enforced by registry and asset validators rather than dataclass construction.",
+      "status": "implemented",
+      "severity": "error",
+      "environments": [
+        "development",
+        "production"
+      ],
+      "validator_profile": {
+        "development": "error",
+        "production": "error"
+      },
+      "applicability": {
+        "candidate_surfaces": [
+          "previewers",
+          "preview_frontend_manifest"
+        ],
+        "trigger": "when_candidate_declares_scistudio.previewers",
+        "not_applicable_result": "not_applicable"
+      },
+      "code_evidence": [
+        {
+          "path": "src/scistudio/previewers/models.py",
+          "kind": "contains",
+          "pattern": "class FrontendManifest:",
+          "symbol": "FrontendManifest",
+          "notes": "Required inventory manifest model."
+        },
+        {
+          "path": "src/scistudio/previewers/models.py",
+          "kind": "contains",
+          "pattern": "class PreviewerSpec:",
+          "symbol": "PreviewerSpec",
+          "notes": "Required inventory previewer model."
+        },
+        {
+          "path": "src/scistudio/previewers/models.py",
+          "kind": "contains",
+          "pattern": "Wire shape sent to the frontend. ``asset_root`` is intentionally omitted.",
+          "notes": "FrontendManifest.to_dict omits backend-only asset_root."
+        },
+        {
+          "path": "src/scistudio/previewers/models.py",
+          "kind": "contains",
+          "pattern": "PreviewerSpecList = list[PreviewerSpec]",
+          "notes": "Entry-point canonical return shape alias."
+        }
+      ],
+      "adr_evidence": [
+        {
+          "path": "docs/adr/ADR-048.md",
+          "kind": "contains",
+          "pattern": "| `previewer_id` | Stable globally unique ID",
+          "notes": "ADR-048 lists PreviewerSpec fields."
+        },
+        {
+          "path": "docs/adr/ADR-048.md",
+          "kind": "contains",
+          "pattern": "The manifest must name the previewer ID",
+          "notes": "ADR-048 lists manifest fields."
+        }
+      ],
+      "tests": [
+        {
+          "path": "packages/scistudio-blocks-imaging/tests/test_previewer_registration.py",
+          "kind": "contains",
+          "pattern": "assert \"asset_root\" not in manifest.to_dict()",
+          "notes": "Backend-only asset_root is not serialized."
+        },
+        {
+          "path": "tests/previewers/test_preview_session_manifest.py",
+          "kind": "contains",
+          "pattern": "assert \"asset_root\" not in envelope.frontend_manifest.to_dict()",
+          "notes": "Session envelope manifest wire shape omits asset_root."
+        }
+      ],
+      "adr_alignment": "aligned",
+      "notes": "The dataclasses are frozen declaration models, not full validators. Empty IDs and remote URLs are handled by registry/assets.",
+      "validator_implication": "Validate the declaration shape, then delegate value-level checks to PreviewerRegistry and validate_manifest/resolve_asset."
+    },
+    {
+      "id": "PV-09-003",
+      "section": "09_previewer_contracts",
+      "title": "Frontend manifest validation separates blocking invalidity from diagnostics",
+      "contract": "validate_manifest returns ManifestValidation. A missing manifest, missing previewer_id, missing module_url, remote module_url, remote css URL, or missing export_name makes the manifest invalid. An api_version mismatch and missing version are diagnostics; api_version mismatch sets api_version_ok false but does not by itself flip valid to false. resolve_asset is stricter: it raises MissingBundleError for missing asset_root, remote asset URLs, path traversal outside asset_root, disallowed suffixes, or absent files, and returns ServedAsset only for path-confined allowed files.",
+      "status": "implemented",
+      "severity": "error",
+      "environments": [
+        "development",
+        "production"
+      ],
+      "validator_profile": {
+        "development": "block",
+        "production": "block"
+      },
+      "applicability": {
+        "candidate_surfaces": [
+          "previewers",
+          "preview_frontend_manifest"
+        ],
+        "trigger": "when_candidate_declares_scistudio.previewers",
+        "not_applicable_result": "not_applicable"
+      },
+      "code_evidence": [
+        {
+          "path": "src/scistudio/previewers/assets.py",
+          "kind": "contains",
+          "pattern": "def validate_manifest(manifest: FrontendManifest | None) -> ManifestValidation:",
+          "symbol": "validate_manifest",
+          "notes": "Required inventory manifest validator."
+        },
+        {
+          "path": "src/scistudio/previewers/assets.py",
+          "kind": "contains",
+          "pattern": "def resolve_asset(manifest: FrontendManifest, relative_path: str) -> ServedAsset:",
+          "symbol": "resolve_asset",
+          "notes": "Required inventory asset resolver."
+        },
+        {
+          "path": "src/scistudio/previewers/assets.py",
+          "kind": "contains",
+          "pattern": "api_version_ok = manifest.api_version == PREVIEWER_API_VERSION",
+          "notes": "API version mismatch is tracked separately from validity."
+        },
+        {
+          "path": "src/scistudio/previewers/assets.py",
+          "kind": "contains",
+          "pattern": "asset path escapes confinement root",
+          "notes": "Path confinement failure is a strict MissingBundleError."
+        }
+      ],
+      "adr_evidence": [
+        {
+          "path": "docs/adr/ADR-048.md",
+          "kind": "contains",
+          "pattern": "Package and project frontend modules are loaded only through backend-validated",
+          "notes": "ADR-048 requires backend-validated same-origin manifests."
+        },
+        {
+          "path": "docs/specs/adr-048-preview-system.md",
+          "kind": "contains",
+          "pattern": "FR-024: Package-owned frontend assets must be wheel-packaged",
+          "notes": "Spec requires path-confined validated assets."
+        }
+      ],
+      "tests": [
+        {
+          "path": "packages/scistudio-blocks-imaging/tests/test_previewer_registration.py",
+          "kind": "contains",
+          "pattern": "def test_manifests_pass_asset_validation_and_resolve_to_a_real_file",
+          "notes": "Positive manifest and asset resolution coverage."
+        },
+        {
+          "path": "packages/scistudio-blocks-imaging/tests/test_previewer_registration.py",
+          "kind": "contains",
+          "pattern": "assert result.api_version_ok",
+          "notes": "Current imaging manifest has matching API version."
+        }
+      ],
+      "adr_alignment": "aligned",
+      "notes": "Current code distinguishes invalid manifests from diagnostic-compatible API-version drift. resolve_asset is exception-based and should be treated as strict.",
+      "validator_implication": "Block remote, path-escaping, missing-root, missing-file, and invalid required-field cases; warn on API-version mismatch unless the validation profile escalates compatibility drift."
+    },
+    {
+      "id": "PV-09-004",
+      "section": "09_previewer_contracts",
+      "title": "PreviewRouter selection is deterministic and ambiguous matches are strict errors",
+      "contract": "PreviewRouter must resolve a PreviewTarget by collection-aware type specificity and owner tier: project exact, package exact, project parent, package parent, core collection fallback, core base fallback, then unknown/error. Highest priority wins within a bucket. Unresolved priority ties raise RoutingAmbiguityError, and no-match cases raise UnknownTargetError. A project default may resolve a tie for its target type.",
+      "status": "implemented",
+      "severity": "error",
+      "environments": [
+        "development",
+        "production"
+      ],
+      "validator_profile": {
+        "development": "block",
+        "production": "block"
+      },
+      "applicability": {
+        "candidate_surfaces": [
+          "previewers",
+          "preview_frontend_manifest"
+        ],
+        "trigger": "when_candidate_declares_scistudio.previewers",
+        "not_applicable_result": "not_applicable"
+      },
+      "code_evidence": [
+        {
+          "path": "src/scistudio/previewers/router.py",
+          "kind": "contains",
+          "pattern": "class PreviewRouter:",
+          "symbol": "PreviewRouter",
+          "notes": "Required inventory router class."
+        },
+        {
+          "path": "src/scistudio/previewers/router.py",
+          "kind": "contains",
+          "pattern": "raise RoutingAmbiguityError(",
+          "notes": "Ambiguous candidates are strict typed errors."
+        },
+        {
+          "path": "src/scistudio/previewers/router.py",
+          "kind": "contains",
+          "pattern": "raise UnknownTargetError(",
+          "notes": "No previewer match is a strict typed error."
+        },
+        {
+          "path": "src/scistudio/previewers/router.py",
+          "kind": "contains",
+          "pattern": "default_id = self._registry.project_default_for(type_name)",
+          "notes": "Project defaults can resolve priority ties."
+        }
+      ],
+      "adr_evidence": [
+        {
+          "path": "docs/adr/ADR-048.md",
+          "kind": "contains",
+          "pattern": "Resolution order is:",
+          "notes": "ADR-048 defines previewer resolution order."
+        },
+        {
+          "path": "docs/specs/adr-048-preview-system.md",
+          "kind": "contains",
+          "pattern": "FR-004: Within the same precedence tier and type specificity",
+          "notes": "Spec defines priority and ambiguity behavior."
+        }
+      ],
+      "tests": [
+        {
+          "path": "tests/previewers/test_preview_routing.py",
+          "kind": "contains",
+          "pattern": "def test_unresolved_priority_tie_raises_ambiguity",
+          "notes": "Ambiguous tie raises RoutingAmbiguityError."
+        },
+        {
+          "path": "tests/previewers/test_preview_routing.py",
+          "kind": "contains",
+          "pattern": "def test_collection_with_item_previewer_and_no_core_raises",
+          "notes": "Collection targets do not fall through to item-only previewers."
+        },
+        {
+          "path": "tests/previewers/test_preview_routing.py",
+          "kind": "contains",
+          "pattern": "def test_project_default_resolves_tie",
+          "notes": "Project default resolves ties."
+        }
+      ],
+      "adr_alignment": "aligned",
+      "notes": "PreviewSessionManager converts PreviewError from routing into error envelopes for one-shot rendering, but the router itself is strict exception-based.",
+      "validator_implication": "Block package configurations that would produce unresolved routing ambiguity; report UnknownTargetError only when the validation scenario expects a previewer to exist."
+    },
+    {
+      "id": "PV-09-005",
+      "section": "09_previewer_contracts",
+      "title": "Core and imaging package PreviewerSpec declarations establish fallback and package ownership",
+      "contract": "Core previewer specs are registered unconditionally for DataFrame, Array, Series, Text, Artifact, CompositeData, Collection, PlotArtifact, and DataObject fallback targets. The imaging package get_previewers factory returns Image and Label package-owned specs with positive priority, backend providers, capabilities, and same-origin frontend manifests so package exact matches can beat core fallbacks while core remains available when imaging is absent.",
+      "status": "implemented",
+      "severity": "info",
+      "environments": [
+        "development",
+        "production"
+      ],
+      "validator_profile": {
+        "development": "info",
+        "production": "info"
+      },
+      "applicability": {
+        "candidate_surfaces": [
+          "previewers",
+          "preview_frontend_manifest"
+        ],
+        "trigger": "when_candidate_declares_scistudio.previewers",
+        "not_applicable_result": "not_applicable"
+      },
+      "code_evidence": [
+        {
+          "path": "src/scistudio/previewers/fallbacks.py",
+          "kind": "contains",
+          "pattern": "def core_previewer_specs() -> list[PreviewerSpec]:",
+          "symbol": "PreviewerSpec",
+          "notes": "Core fallback specs are concrete PreviewerSpec declarations."
+        },
+        {
+          "path": "src/scistudio/previewers/fallbacks.py",
+          "kind": "contains",
+          "pattern": "previewer_id=\"core.base.fallback\"",
+          "notes": "Universal core base fallback."
+        },
+        {
+          "path": "packages/scistudio-blocks-imaging/src/scistudio_blocks_imaging/previewers/__init__.py",
+          "kind": "contains",
+          "pattern": "previewer_id=IMAGE_PREVIEWER_ID,",
+          "symbol": "PreviewerSpec",
+          "notes": "Imaging Image spec declaration."
+        },
+        {
+          "path": "packages/scistudio-blocks-imaging/src/scistudio_blocks_imaging/previewers/__init__.py",
+          "kind": "contains",
+          "pattern": "frontend_manifest=_frontend_manifest(IMAGE_PREVIEWER_ID),",
+          "symbol": "FrontendManifest",
+          "notes": "Imaging package spec declares a frontend manifest."
+        }
+      ],
+      "adr_evidence": [
+        {
+          "path": "docs/specs/adr-048-preview-system.md",
+          "kind": "contains",
+          "pattern": "FR-012: Core must provide fallback previewers for DataFrame",
+          "notes": "Spec requires core fallback previewers."
+        },
+        {
+          "path": "docs/specs/adr-048-preview-system.md",
+          "kind": "contains",
+          "pattern": "FR-025: `scistudio-blocks-imaging` must register package previewers for",
+          "notes": "Spec requires package-owned imaging previewers."
+        }
+      ],
+      "tests": [
+        {
+          "path": "tests/previewers/test_preview_registry.py",
+          "kind": "contains",
+          "pattern": "def test_core_specs_load_unconditionally",
+          "notes": "Core fallback registry coverage."
+        },
+        {
+          "path": "packages/scistudio-blocks-imaging/tests/test_previewer_registration.py",
+          "kind": "contains",
+          "pattern": "def test_get_previewers_returns_image_and_label_package_specs",
+          "notes": "Imaging package PreviewerSpec coverage."
+        },
+        {
+          "path": "packages/scistudio-blocks-imaging/tests/test_previewer_registration.py",
+          "kind": "contains",
+          "pattern": "def test_image_falls_back_to_core_array_when_imaging_absent",
+          "notes": "Core fallback remains available without imaging."
+        }
+      ],
+      "adr_alignment": "aligned",
+      "notes": "This row covers non-required concrete PreviewerSpec declarations from the inventory so package-validator design does not focus only on registry classes.",
+      "validator_implication": "Use info-level reporting for discovered fallback/package spec inventories, escalating only for malformed IDs, missing providers where required, or routing ambiguity."
+    },
+    {
+      "id": "PV-09-006",
+      "section": "09_previewer_contracts",
+      "title": "Session rendering stamps manifests and turns provider failures into error envelopes",
+      "contract": "PreviewSessionManager resolves a spec, invokes its backend provider, converts PreviewError and unexpected provider exceptions into PreviewEnvelope error responses, and stamps the resolved spec frontend_manifest onto the envelope when the provider did not set one. A provider-set frontend_manifest has precedence over the spec default.",
+      "status": "implemented",
+      "severity": "error",
+      "environments": [
+        "development",
+        "production"
+      ],
+      "validator_profile": {
+        "development": "error",
+        "production": "error"
+      },
+      "applicability": {
+        "candidate_surfaces": [
+          "previewers",
+          "preview_frontend_manifest"
+        ],
+        "trigger": "when_candidate_declares_scistudio.previewers",
+        "not_applicable_result": "not_applicable"
+      },
+      "code_evidence": [
+        {
+          "path": "src/scistudio/previewers/session.py",
+          "kind": "contains",
+          "pattern": "except PreviewError as exc:",
+          "notes": "Typed provider/routing errors become error envelopes."
+        },
+        {
+          "path": "src/scistudio/previewers/session.py",
+          "kind": "contains",
+          "pattern": "except Exception as exc:",
+          "notes": "Unexpected provider exceptions are also converted."
+        },
+        {
+          "path": "src/scistudio/previewers/session.py",
+          "kind": "contains",
+          "pattern": "if envelope.frontend_manifest is None and spec.frontend_manifest is not None:",
+          "symbol": "PreviewerSpec",
+          "notes": "Spec manifest stamping behavior."
+        },
+        {
+          "path": "src/scistudio/previewers/session.py",
+          "kind": "contains",
+          "pattern": "return PreviewerSpec(",
+          "symbol": "PreviewerSpec",
+          "notes": "Missing-spec helper is a concrete PreviewerSpec declaration from the inventory."
+        }
+      ],
+      "adr_evidence": [
+        {
+          "path": "docs/adr/ADR-048.md",
+          "kind": "contains",
+          "pattern": "The session manager stamps the resolved previewer's `frontend_manifest`",
+          "notes": "ADR-048 defines first-class manifest stamping."
+        },
+        {
+          "path": "docs/specs/adr-048-preview-system.md",
+          "kind": "contains",
+          "pattern": "FR-029: The implementation must add deterministic diagnostic payloads",
+          "notes": "Spec requires deterministic diagnostics."
+        }
+      ],
+      "tests": [
+        {
+          "path": "tests/previewers/test_preview_session_manifest.py",
+          "kind": "contains",
+          "pattern": "def test_spec_manifest_is_auto_injected_when_provider_sets_none",
+          "notes": "Spec manifest is stamped when provider omits one."
+        },
+        {
+          "path": "tests/previewers/test_preview_session_manifest.py",
+          "kind": "contains",
+          "pattern": "def test_provider_set_manifest_is_not_overwritten",
+          "notes": "Provider manifest precedence is tested."
+        }
+      ],
+      "adr_alignment": "aligned",
+      "notes": "Session behavior makes previewer provider failures non-fatal to the API surface even when the underlying router/provider raises typed or unexpected exceptions.",
+      "validator_implication": "Validate manifest ownership at the spec/session seam and classify provider exceptions as typed error-envelope behavior rather than process crashes."
+    }
+  ]
+}

--- a/docs/planning/adr-049-package-validator/contracts/pv-a4-sections-10-12.json
+++ b/docs/planning/adr-049-package-validator/contracts/pv-a4-sections-10-12.json
@@ -1,0 +1,939 @@
+{
+  "schema_version": "adr049.package_contract_table.v1",
+  "agent_id": "PV-A4",
+  "generated_at": "2026-06-14",
+  "source_priority": "code-primary-adr-secondary",
+  "agent_scope": {
+    "sections": [
+      "10_preview_provider_behavior",
+      "11_plot_jobs",
+      "12_security_isolation"
+    ],
+    "summary": "Preview provider bounded-read and failure contracts, preview-only plot-job contracts, and same-origin/path/subprocess isolation contracts."
+  },
+  "contracts": [
+    {
+      "id": "PV-10-001",
+      "section": "10_preview_provider_behavior",
+      "title": "Preview providers use the bounded data-access surface",
+      "contract": "Package and project preview providers must read data through PreviewDataAccess bounded helpers instead of arbitrary eager materialization or direct frontend-visible storage paths. The validator should flag providers that bypass the PreviewRequest.data_access surface for DataFrame, Array, Series, Text, Artifact, CompositeData, or Collection previews.",
+      "status": "implemented",
+      "severity": "error",
+      "environments": [
+        "development",
+        "production"
+      ],
+      "validator_profile": {
+        "development": "error",
+        "production": "block"
+      },
+      "applicability": {
+        "candidate_surfaces": [
+          "previewers",
+          "preview_provider"
+        ],
+        "trigger": "when_candidate_previewer_declares_a_backend_provider",
+        "not_applicable_result": "not_applicable"
+      },
+      "code_evidence": [
+        {
+          "path": "src/scistudio/previewers/data_access.py",
+          "kind": "contains",
+          "pattern": "Bounded data-access helpers for previewers",
+          "symbol": "data_access",
+          "notes": "Required inventory module item; module documents the bounded preview data-access surface."
+        },
+        {
+          "path": "src/scistudio/previewers/data_access.py",
+          "kind": "contains",
+          "pattern": "class PreviewDataAccess:",
+          "symbol": "PreviewDataAccess",
+          "notes": "Required inventory class item; public class is the provider read boundary."
+        },
+        {
+          "path": "src/scistudio/previewers/data_access.py",
+          "kind": "contains",
+          "pattern": "DEFAULT_MAX_BYTES = 8 * 1024 * 1024",
+          "notes": "Default byte budget mirrors the bounded MCP preview cap."
+        },
+        {
+          "path": "src/scistudio/previewers/fallbacks.py",
+          "kind": "contains",
+          "pattern": "request.data_access.dataframe_page",
+          "notes": "Fallback providers consume the injected bounded access object."
+        },
+        {
+          "path": "src/scistudio/previewers/fallbacks.py",
+          "kind": "contains",
+          "pattern": "request.data_access.array_plane",
+          "notes": "Array fallback reads through PreviewDataAccess rather than directly materializing storage."
+        }
+      ],
+      "adr_evidence": [
+        {
+          "path": "docs/specs/adr-048-preview-system.md",
+          "kind": "contains",
+          "pattern": "FR-009: `PreviewDataAccess` must provide bounded helpers for DataFrame,"
+        },
+        {
+          "path": "docs/specs/adr-048-preview-system.md",
+          "kind": "contains",
+          "pattern": "FR-010: Previewers must not call eager materialization helpers on large data"
+        },
+        {
+          "path": "docs/planning/package-validator-contract-survey-draft.md",
+          "kind": "contains",
+          "pattern": "Backend providers must use `PreviewDataAccess` for bounded reads"
+        }
+      ],
+      "tests": [
+        {
+          "path": "tests/previewers/test_preview_data_access.py",
+          "kind": "contains",
+          "pattern": "def test_array_plane_does_not_materialize_full_zarr"
+        },
+        {
+          "path": "tests/previewers/test_preview_data_access.py",
+          "kind": "contains",
+          "pattern": "assert selector[0] == 3"
+        },
+        {
+          "path": "tests/previewers/test_preview_data_access.py",
+          "kind": "contains",
+          "pattern": "def test_artifact_metadata_no_data_uri_for_large_file"
+        }
+      ],
+      "adr_alignment": "aligned",
+      "validator_implication": "Development validation should report a provider-bypass error; production install validation should block previewers that cannot demonstrate bounded PreviewDataAccess use or equivalent typed bounded helpers."
+    },
+    {
+      "id": "PV-10-002",
+      "section": "10_preview_provider_behavior",
+      "title": "Preview session invocation converts routine provider failure to typed envelopes",
+      "contract": "The preview session manager must resolve callable or dotted backend providers, inject PreviewRequest with PreviewDataAccess, and convert missing providers, routed PreviewError instances, and unexpected provider exceptions into deterministic error envelopes instead of API crashes or workflow/data mutations.",
+      "status": "implemented",
+      "severity": "error",
+      "environments": [
+        "development",
+        "production"
+      ],
+      "validator_profile": {
+        "development": "error",
+        "production": "block"
+      },
+      "applicability": {
+        "candidate_surfaces": [
+          "previewers",
+          "preview_provider"
+        ],
+        "trigger": "when_candidate_previewer_declares_a_backend_provider",
+        "not_applicable_result": "not_applicable"
+      },
+      "code_evidence": [
+        {
+          "path": "src/scistudio/previewers/session.py",
+          "kind": "contains",
+          "pattern": "Provider calls are wrapped defensively",
+          "symbol": "session",
+          "notes": "Required inventory module item; session module documents provider invocation and error conversion."
+        },
+        {
+          "path": "src/scistudio/previewers/session.py",
+          "kind": "contains",
+          "pattern": "request = PreviewRequest(",
+          "notes": "Session manager injects target, spec, query, data access, limits, and session id into providers."
+        },
+        {
+          "path": "src/scistudio/previewers/session.py",
+          "kind": "contains",
+          "pattern": "PreviewErrorCode.MISSING_BUNDLE",
+          "notes": "Missing backend provider becomes a typed preview error."
+        },
+        {
+          "path": "src/scistudio/previewers/session.py",
+          "kind": "contains",
+          "pattern": "PreviewErrorCode.PROVIDER_EXCEPTION",
+          "notes": "Unexpected provider exceptions become provider_exception envelopes."
+        }
+      ],
+      "adr_evidence": [
+        {
+          "path": "docs/specs/adr-048-preview-system.md",
+          "kind": "contains",
+          "pattern": "provider exceptions return preview errors without API crashes"
+        },
+        {
+          "path": "docs/specs/adr-048-preview-system.md",
+          "kind": "contains",
+          "pattern": "The preview API is session-oriented."
+        },
+        {
+          "path": "docs/planning/package-validator-contract-survey-draft.md",
+          "kind": "contains",
+          "pattern": "Preview failures must not mutate workflows, DataObjects, lineage, or"
+        }
+      ],
+      "tests": [
+        {
+          "path": "tests/api/test_previewers.py",
+          "kind": "contains",
+          "pattern": "def test_create_session_unknown_target_returns_error_envelope"
+        },
+        {
+          "path": "tests/api/test_previewers.py",
+          "kind": "contains",
+          "pattern": "assert body[\"kind\"] in {\"error\", \"artifact\"}"
+        }
+      ],
+      "adr_alignment": "aligned",
+      "validator_implication": "The package validator should statically or smoke-test backend_provider importability/callability and require failure behavior to degrade into typed preview envelopes, with production blocking missing or unimportable providers for declared previewers."
+    },
+    {
+      "id": "PV-10-003",
+      "section": "10_preview_provider_behavior",
+      "title": "Preview resource reads remain session-scoped and bounded",
+      "contract": "Follow-up preview resources must be served through PreviewSessionManager.read_resource using the existing session, public query parameters, and PreviewDataAccess limits. Providers must not expose arbitrary resource identifiers or private query enrichment keys back to client-controlled resource reads.",
+      "status": "implemented",
+      "severity": "error",
+      "environments": [
+        "development",
+        "production"
+      ],
+      "validator_profile": {
+        "development": "error",
+        "production": "block"
+      },
+      "applicability": {
+        "candidate_surfaces": [
+          "previewers",
+          "preview_provider"
+        ],
+        "trigger": "when_candidate_previewer_declares_a_backend_provider",
+        "not_applicable_result": "not_applicable"
+      },
+      "code_evidence": [
+        {
+          "path": "src/scistudio/previewers/session.py",
+          "kind": "contains",
+          "pattern": "def read_resource(self, session_id: str, resource_id: str, params: dict[str, Any] | None = None) -> dict[str, Any]:"
+        },
+        {
+          "path": "src/scistudio/previewers/session.py",
+          "kind": "contains",
+          "pattern": "merged.update(_public_resource_params(params or {}))"
+        },
+        {
+          "path": "src/scistudio/previewers/session.py",
+          "kind": "contains",
+          "pattern": "access = self._data_access_factory(session.limits)"
+        },
+        {
+          "path": "src/scistudio/previewers/session.py",
+          "kind": "contains",
+          "pattern": "raise ProviderError("
+        }
+      ],
+      "adr_evidence": [
+        {
+          "path": "docs/specs/adr-048-preview-system.md",
+          "kind": "contains",
+          "pattern": "`GET` | `/api/previews/sessions/{session_id}/resources/{resource_id}` | Fetch bounded provider resource data."
+        },
+        {
+          "path": "docs/specs/adr-048-preview-system.md",
+          "kind": "contains",
+          "pattern": "all preview reads, including table pagination/sort and array"
+        }
+      ],
+      "tests": [
+        {
+          "path": "tests/api/test_previewers.py",
+          "kind": "contains",
+          "pattern": "def test_array_session_resource_tile"
+        },
+        {
+          "path": "tests/api/test_previewers.py",
+          "kind": "contains",
+          "pattern": "assert \"matrix\" in res.json()[\"data\"]"
+        }
+      ],
+      "adr_alignment": "aligned",
+      "validator_implication": "Previewer validation should treat resource handlers as part of the provider contract and flag packages whose resources cannot be reached through session-scoped bounded reads."
+    },
+    {
+      "id": "PV-11-001",
+      "section": "11_plot_jobs",
+      "title": "Plot jobs are strict project-local manifests bound by stable output identity",
+      "contract": "A plot job is not a package registry surface; it is a project-local plots/<plot_id>/plot.yaml plus render script. When validator coverage includes project packages or examples, it must require schema_version 1, a safe single-segment plot_id, strict manifest fields, a stable workflow_path/node_id/output_port binding, and script.path confinement under the plot directory.",
+      "status": "implemented",
+      "severity": "error",
+      "environments": [
+        "development"
+      ],
+      "validator_profile": {
+        "development": "error",
+        "production": "skip"
+      },
+      "applicability": {
+        "candidate_surfaces": [
+          "plot_jobs",
+          "project_examples"
+        ],
+        "trigger": "when_candidate_ships_plot_manifest_plot_template_or_project_example",
+        "not_applicable_result": "not_applicable"
+      },
+      "code_evidence": [
+        {
+          "path": "src/scistudio/ai/agent/mcp/tools_plot/models.py",
+          "kind": "contains",
+          "pattern": "class PlotManifest(BaseModel):",
+          "notes": "Strict Pydantic manifest root for plot.yaml."
+        },
+        {
+          "path": "src/scistudio/ai/agent/mcp/tools_plot/models.py",
+          "kind": "contains",
+          "pattern": "schema_version: int = Field(description=\"Manifest schema version; must be 1.\")"
+        },
+        {
+          "path": "src/scistudio/ai/agent/mcp/tools_plot/scaffold.py",
+          "kind": "contains",
+          "pattern": "_PLOT_ID_RE = re.compile(r\"^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$\")"
+        },
+        {
+          "path": "src/scistudio/ai/agent/mcp/tools_plot/targets.py",
+          "kind": "contains",
+          "pattern": "raw = f\"{norm_path}|{node_id}|{output_port}\".encode()"
+        },
+        {
+          "path": "src/scistudio/ai/agent/mcp/tools_plot/validation.py",
+          "kind": "contains",
+          "pattern": "def resolve_script_path(plot_dir: Path, script_path: str, *, root: Path | None = None) -> Path:"
+        },
+        {
+          "path": "src/scistudio/ai/agent/mcp/tools_plot/validation.py",
+          "kind": "contains",
+          "pattern": "resolved.relative_to(plot_dir.resolve())"
+        }
+      ],
+      "adr_evidence": [
+        {
+          "path": "docs/specs/adr-048-ai-plot-tools.md",
+          "kind": "contains",
+          "pattern": "FR-021: `validate_plot` must validate manifest schema, path confinement,"
+        },
+        {
+          "path": "docs/block-development/previewers-and-plots.md",
+          "kind": "contains",
+          "pattern": "Bind a plot to a stable **workflow path + node id + output port**, never to a"
+        },
+        {
+          "path": "docs/planning/package-validator-contract-survey-draft.md",
+          "kind": "contains",
+          "pattern": "Plot jobs are project-local preview-only artifacts, not package registry"
+        }
+      ],
+      "tests": [
+        {
+          "path": "tests/ai/test_mcp_tools_plot.py",
+          "kind": "contains",
+          "pattern": "def test_scaffold_rejects_path_traversal_plot_id"
+        },
+        {
+          "path": "tests/ai/test_mcp_tools_plot.py",
+          "kind": "contains",
+          "pattern": "def test_read_rejects_manifest_script_path_traversal"
+        },
+        {
+          "path": "tests/ai/test_mcp_tools_plot.py",
+          "kind": "contains",
+          "pattern": "def test_validate_broken_target"
+        }
+      ],
+      "adr_alignment": "aligned",
+      "validator_implication": "Package-install validation should not treat plots as package entry points; development/project validation may validate plot.yaml and render script confinement before allowing run_plot_job."
+    },
+    {
+      "id": "PV-11-002",
+      "section": "11_plot_jobs",
+      "title": "Plot execution is preview-only and writes only display cache state",
+      "contract": "run_plot_job must never register workflow nodes, edit workflow YAML, mutate scheduler outputs, create downstream collections, or claim lineage. It may read the bound target's recorded scheduler output and write current.* plus current.json under .scistudio/previews/<workflow>/<node>/<port>/<plot>/, overwriting previous current artifacts and recording failures there.",
+      "status": "implemented",
+      "severity": "error",
+      "environments": [
+        "development",
+        "production"
+      ],
+      "validator_profile": {
+        "development": "error",
+        "production": "block"
+      },
+      "applicability": {
+        "candidate_surfaces": [
+          "plot_jobs",
+          "project_examples"
+        ],
+        "trigger": "when_candidate_ships_plot_manifest_plot_template_or_project_example",
+        "not_applicable_result": "not_applicable"
+      },
+      "code_evidence": [
+        {
+          "path": "src/scistudio/ai/agent/mcp/tools_plot/runtime.py",
+          "kind": "contains",
+          "pattern": "Hard invariant (FR-025, verified by tests): a plot run NEVER registers a workflow"
+        },
+        {
+          "path": "src/scistudio/ai/agent/mcp/tools_plot/runtime.py",
+          "kind": "contains",
+          "pattern": "root / _PREVIEW_ROOT / _safe_seg(workflow_id) / _safe_seg(node_id) / _safe_seg(output_port) / _safe_seg(plot_id)"
+        },
+        {
+          "path": "src/scistudio/ai/agent/mcp/tools_plot/runtime.py",
+          "kind": "contains",
+          "pattern": "_clear_current_artifacts(cache_dir)"
+        },
+        {
+          "path": "src/scistudio/ai/agent/mcp/tools_plot/runtime.py",
+          "kind": "contains",
+          "pattern": "metadata_path.write_text(json.dumps(record, indent=2), encoding=\"utf-8\")"
+        },
+        {
+          "path": "src/scistudio/api/routes/plots.py",
+          "kind": "contains",
+          "pattern": "A plot job remains PREVIEW-ONLY"
+        }
+      ],
+      "adr_evidence": [
+        {
+          "path": "docs/specs/adr-048-ai-plot-tools.md",
+          "kind": "contains",
+          "pattern": "FR-025: Plot execution must not register workflow nodes, edit workflow YAML,"
+        },
+        {
+          "path": "docs/specs/adr-048-ai-plot-tools.md",
+          "kind": "contains",
+          "pattern": "FR-026: Plot execution must write display-only artifacts to"
+        },
+        {
+          "path": "docs/block-development/previewers-and-plots.md",
+          "kind": "contains",
+          "pattern": "The preview cache is"
+        }
+      ],
+      "tests": [
+        {
+          "path": "tests/api/test_preview_plot_jobs.py",
+          "kind": "contains",
+          "pattern": "def test_plot_run_does_not_mutate_workflow_or_scheduler_or_lineage"
+        },
+        {
+          "path": "tests/api/test_preview_plot_jobs.py",
+          "kind": "contains",
+          "pattern": "assert scistudio_children == {\"previews\"}"
+        },
+        {
+          "path": "tests/api/test_preview_plot_jobs.py",
+          "kind": "contains",
+          "pattern": "def test_failed_rerun_records_failure"
+        }
+      ],
+      "adr_alignment": "aligned",
+      "validator_implication": "Any validator or smoke harness that runs plots must assert no workflow, scheduler, lineage, or downstream data diff escapes the preview cache."
+    },
+    {
+      "id": "PV-11-003",
+      "section": "11_plot_jobs",
+      "title": "Plot runtime clamps subprocess execution, output, file, and log limits",
+      "contract": "Plot rendering must run through the CodeBlock subprocess primitive in a confined working directory and enforce timeout, max output bytes, max file count, stdout/stderr truncation, allowed output formats, and sanitized error reporting. Hand-edited manifests may tighten but not raise absolute execution caps.",
+      "status": "implemented",
+      "severity": "error",
+      "environments": [
+        "development",
+        "production"
+      ],
+      "validator_profile": {
+        "development": "error",
+        "production": "block"
+      },
+      "applicability": {
+        "candidate_surfaces": [
+          "plot_jobs",
+          "project_examples"
+        ],
+        "trigger": "when_candidate_ships_plot_manifest_plot_template_or_project_example",
+        "not_applicable_result": "not_applicable"
+      },
+      "code_evidence": [
+        {
+          "path": "src/scistudio/ai/agent/mcp/tools_plot/models.py",
+          "kind": "contains",
+          "pattern": "ABSOLUTE_MAX_TIMEOUT_SECONDS: float = 300.0"
+        },
+        {
+          "path": "src/scistudio/ai/agent/mcp/tools_plot/runtime.py",
+          "kind": "contains",
+          "pattern": "def _clamp_limits(manifest: PlotManifest) -> tuple[float, int, int]:"
+        },
+        {
+          "path": "src/scistudio/ai/agent/mcp/tools_plot/runtime.py",
+          "kind": "contains",
+          "pattern": "work_dir = cache_dir / \"_work\""
+        },
+        {
+          "path": "src/scistudio/ai/agent/mcp/tools_plot/runtime.py",
+          "kind": "contains",
+          "pattern": "proc = run_codeblock_process(argv=argv, cwd=work_dir, env_delta={}, timeout_seconds=timeout)"
+        },
+        {
+          "path": "src/scistudio/ai/agent/mcp/tools_plot/runtime.py",
+          "kind": "contains",
+          "pattern": "errors.append(f\"plot wrote {len(on_disk)} files; max_files cap is {max_files}.\")"
+        },
+        {
+          "path": "src/scistudio/ai/agent/mcp/tools_plot/runtime.py",
+          "kind": "contains",
+          "pattern": "def _sanitize_error(message: str, root: Path) -> str:"
+        }
+      ],
+      "adr_evidence": [
+        {
+          "path": "docs/specs/adr-048-ai-plot-tools.md",
+          "kind": "contains",
+          "pattern": "FR-024: `run_plot_job` must reuse existing CodeBlock runner primitives where"
+        },
+        {
+          "path": "docs/specs/adr-048-ai-plot-tools.md",
+          "kind": "contains",
+          "pattern": "FR-029: `run_plot_job` must enforce timeout, output-size cap, file-count cap,"
+        },
+        {
+          "path": "docs/block-development/previewers-and-plots.md",
+          "kind": "contains",
+          "pattern": "Running renders the figure preview-side in a bounded subprocess"
+        }
+      ],
+      "tests": [
+        {
+          "path": "tests/ai/test_mcp_tools_plot.py",
+          "kind": "contains",
+          "pattern": "def test_run_enforces_file_count_cap"
+        },
+        {
+          "path": "tests/ai/test_mcp_tools_plot.py",
+          "kind": "contains",
+          "pattern": "def test_run_timeout"
+        },
+        {
+          "path": "tests/ai/test_mcp_tools_plot.py",
+          "kind": "contains",
+          "pattern": "def test_run_python_sanitized_failure"
+        }
+      ],
+      "adr_alignment": "aligned",
+      "validator_implication": "A plot validation profile should reject manifests or runners that exceed absolute caps, escape the confined work directory, write unsupported formats, or leak project paths in errors."
+    },
+    {
+      "id": "PV-11-004",
+      "section": "11_plot_jobs",
+      "title": "Successful plot artifacts route through PlotPreviewer; failures return no data_ref",
+      "contract": "A successful plot run must register the first display artifact as a PlotArtifact catalog record with plot_artifact metadata so the preview session API routes it to core.plot.basic. Failed or empty plot runs must return failure status and errors without minting a data_ref that would open an empty preview.",
+      "status": "implemented",
+      "severity": "error",
+      "environments": [
+        "development",
+        "production"
+      ],
+      "validator_profile": {
+        "development": "error",
+        "production": "block"
+      },
+      "applicability": {
+        "candidate_surfaces": [
+          "plot_jobs",
+          "project_examples"
+        ],
+        "trigger": "when_candidate_ships_plot_manifest_plot_template_or_project_example",
+        "not_applicable_result": "not_applicable"
+      },
+      "code_evidence": [
+        {
+          "path": "src/scistudio/api/routes/plots.py",
+          "kind": "contains",
+          "pattern": "record = runtime.register_plot_artifact("
+        },
+        {
+          "path": "src/scistudio/api/routes/plots.py",
+          "kind": "contains",
+          "pattern": "if result.status == \"succeeded\" and result.artifact_paths:"
+        },
+        {
+          "path": "src/scistudio/api/runtime/_data.py",
+          "kind": "contains",
+          "pattern": "record_metadata[\"plot_artifact\"] = True"
+        },
+        {
+          "path": "src/scistudio/api/runtime/_data.py",
+          "kind": "contains",
+          "pattern": "return TargetKind.PLOT_ARTIFACT"
+        },
+        {
+          "path": "src/scistudio/previewers/fallbacks.py",
+          "kind": "contains",
+          "pattern": "previewer_id=\"core.plot.basic\""
+        }
+      ],
+      "adr_evidence": [
+        {
+          "path": "docs/specs/adr-048-ai-plot-tools.md",
+          "kind": "contains",
+          "pattern": "FR-031: Successful plot artifacts must be consumable by the core"
+        },
+        {
+          "path": "docs/specs/adr-048-preview-system.md",
+          "kind": "contains",
+          "pattern": "FR-018: Core `PlotPreviewer` must display PNG, JPEG, SVG, and PDF artifacts"
+        }
+      ],
+      "tests": [
+        {
+          "path": "tests/api/test_plot_preview_wiring.py",
+          "kind": "contains",
+          "pattern": "def test_plot_run_route_registers_artifact_and_preview_session_renders_plot"
+        },
+        {
+          "path": "tests/api/test_plot_preview_wiring.py",
+          "kind": "contains",
+          "pattern": "assert env[\"previewer_id\"] == \"core.plot.basic\""
+        },
+        {
+          "path": "tests/api/test_plot_preview_wiring.py",
+          "kind": "contains",
+          "pattern": "def test_failed_plot_run_returns_status_without_data_ref"
+        }
+      ],
+      "adr_alignment": "aligned",
+      "validator_implication": "Validator smoke tests for plot examples should assert both producer-to-PlotPreviewer wiring on success and no catalog data_ref on failure."
+    },
+    {
+      "id": "PV-12-001",
+      "section": "12_security_isolation",
+      "title": "Preview frontend manifests are same-origin and hide backend asset roots",
+      "contract": "Previewer frontend manifests must use backend-relative same-origin module and CSS URLs; remote http, https, protocol-relative, data, and file URLs are rejected. Backend-only asset_root may be used for serving but must never be serialized to the frontend envelope.",
+      "status": "implemented",
+      "severity": "blocker",
+      "environments": [
+        "development",
+        "production"
+      ],
+      "validator_profile": {
+        "development": "error",
+        "production": "block"
+      },
+      "applicability": {
+        "candidate_surfaces": [
+          "security_isolation",
+          "preview_frontend_manifest",
+          "plot_jobs"
+        ],
+        "trigger": "production_always_and_development_when_candidate_declares_assets_subprocesses_or_filesystem_access",
+        "not_applicable_result": "not_applicable"
+      },
+      "code_evidence": [
+        {
+          "path": "src/scistudio/previewers/assets.py",
+          "kind": "contains",
+          "pattern": "Package- and project-owned previewers ship a JavaScript ESM module",
+          "symbol": "assets",
+          "notes": "Required inventory module item for preview asset security."
+        },
+        {
+          "path": "src/scistudio/previewers/assets.py",
+          "kind": "contains",
+          "pattern": "def is_remote_url(url: str) -> bool:",
+          "symbol": "is_remote_url",
+          "notes": "Required inventory validator function item for same-origin rejection."
+        },
+        {
+          "path": "src/scistudio/previewers/assets.py",
+          "kind": "contains",
+          "pattern": "_REMOTE_PREFIXES = (\"http://\", \"https://\", \"//\", \"data:\", \"file:\")"
+        },
+        {
+          "path": "src/scistudio/previewers/assets.py",
+          "kind": "contains",
+          "pattern": "manifest module_url is remote and rejected"
+        },
+        {
+          "path": "src/scistudio/previewers/models.py",
+          "kind": "contains",
+          "pattern": "Wire shape sent to the frontend. ``asset_root`` is intentionally omitted."
+        }
+      ],
+      "adr_evidence": [
+        {
+          "path": "docs/specs/adr-048-preview-system.md",
+          "kind": "contains",
+          "pattern": "FR-022: Frontend extension modules must be loaded only from backend-validated"
+        },
+        {
+          "path": "docs/specs/adr-048-preview-system.md",
+          "kind": "contains",
+          "pattern": "FR-024: Package-owned frontend assets must be wheel-packaged, fingerprinted or"
+        },
+        {
+          "path": "docs/block-development/previewers-and-plots.md",
+          "kind": "contains",
+          "pattern": "`module_url` must be a **backend-relative**, same-origin URL."
+        }
+      ],
+      "tests": [
+        {
+          "path": "tests/previewers/test_preview_session_manifest.py",
+          "kind": "contains",
+          "pattern": "assert \"asset_root\" not in envelope.frontend_manifest.to_dict()"
+        },
+        {
+          "path": "tests/api/test_previewers.py",
+          "kind": "contains",
+          "pattern": "assert \"asset_root\" not in created[\"frontend_manifest\"]"
+        }
+      ],
+      "adr_alignment": "aligned",
+      "validator_implication": "Production package validation must block previewer frontend manifests with remote URLs or frontend-visible asset roots; development validation should return precise manifest diagnostics."
+    },
+    {
+      "id": "PV-12-002",
+      "section": "12_security_isolation",
+      "title": "Preview asset serving is manifest-validated and path-confined",
+      "contract": "The backend asset route may serve only files under the previewer's declared asset_root after validate_manifest succeeds. Asset requests that lack asset_root, point off-origin, escape the root, use a disallowed suffix, or reference a missing file must fail without exposing arbitrary filesystem contents.",
+      "status": "implemented",
+      "severity": "blocker",
+      "environments": [
+        "development",
+        "production"
+      ],
+      "validator_profile": {
+        "development": "error",
+        "production": "block"
+      },
+      "applicability": {
+        "candidate_surfaces": [
+          "security_isolation",
+          "preview_frontend_manifest",
+          "plot_jobs"
+        ],
+        "trigger": "production_always_and_development_when_candidate_declares_assets_subprocesses_or_filesystem_access",
+        "not_applicable_result": "not_applicable"
+      },
+      "code_evidence": [
+        {
+          "path": "src/scistudio/previewers/assets.py",
+          "kind": "contains",
+          "pattern": "def resolve_asset(manifest: FrontendManifest, relative_path: str) -> ServedAsset:"
+        },
+        {
+          "path": "src/scistudio/previewers/assets.py",
+          "kind": "contains",
+          "pattern": "candidate.relative_to(root)"
+        },
+        {
+          "path": "src/scistudio/previewers/assets.py",
+          "kind": "contains",
+          "pattern": "_ALLOWED_ASSET_SUFFIXES = {\".js\", \".mjs\", \".css\", \".map\", \".json\", \".svg\", \".woff\", \".woff2\"}"
+        },
+        {
+          "path": "src/scistudio/api/routes/data.py",
+          "kind": "contains",
+          "pattern": "async def serve_preview_asset(previewer_id: str, asset_path: str, runtime: RuntimeDep) -> FileResponse:"
+        },
+        {
+          "path": "src/scistudio/api/routes/data.py",
+          "kind": "contains",
+          "pattern": "served = resolve_asset(spec.frontend_manifest, asset_path)"
+        }
+      ],
+      "adr_evidence": [
+        {
+          "path": "docs/specs/adr-048-preview-system.md",
+          "kind": "contains",
+          "pattern": "`GET` | `/api/previews/assets/{asset_id}` | Serve validated same-origin frontend assets."
+        },
+        {
+          "path": "docs/block-development/previewers-and-plots.md",
+          "kind": "contains",
+          "pattern": "`asset_root` is the filesystem directory the backend path-confines reads"
+        },
+        {
+          "path": "docs/planning/package-validator-contract-survey-draft.md",
+          "kind": "contains",
+          "pattern": "`previewers.assets.validate_manifest` checks same-origin frontend manifest"
+        }
+      ],
+      "tests": [],
+      "adr_alignment": "aligned",
+      "validator_implication": "Validator checks should verify packaged asset roots exist, asset paths resolve under that root, and only allowed frontend asset suffixes are exposed by package previewers."
+    },
+    {
+      "id": "PV-12-003",
+      "section": "12_security_isolation",
+      "title": "Plot SVG display and export are sanitized and bounded",
+      "contract": "PlotPreviewer must sanitize SVG content before inline display, mark SVG payloads sandboxed, strip scripts/event handlers/remote active hrefs, and expose export/save only for the artifact's supported format within preview byte budgets.",
+      "status": "implemented",
+      "severity": "blocker",
+      "environments": [
+        "development",
+        "production"
+      ],
+      "validator_profile": {
+        "development": "error",
+        "production": "block"
+      },
+      "applicability": {
+        "candidate_surfaces": [
+          "security_isolation",
+          "preview_frontend_manifest",
+          "plot_jobs"
+        ],
+        "trigger": "production_always_and_development_when_candidate_declares_assets_subprocesses_or_filesystem_access",
+        "not_applicable_result": "not_applicable"
+      },
+      "code_evidence": [
+        {
+          "path": "src/scistudio/previewers/fallbacks.py",
+          "kind": "contains",
+          "pattern": "def plot_previewer(request: PreviewRequest) -> PreviewEnvelope:"
+        },
+        {
+          "path": "src/scistudio/previewers/fallbacks.py",
+          "kind": "contains",
+          "pattern": "payload[\"sandboxed\"] = True"
+        },
+        {
+          "path": "src/scistudio/previewers/fallbacks.py",
+          "kind": "contains",
+          "pattern": "def sanitize_svg(svg_text: str) -> tuple[str, bool]:"
+        },
+        {
+          "path": "src/scistudio/previewers/session.py",
+          "kind": "contains",
+          "pattern": "if session.target.kind is not TargetKind.PLOT_ARTIFACT and session.previewer_id != \"core.plot.basic\":"
+        },
+        {
+          "path": "src/scistudio/previewers/session.py",
+          "kind": "contains",
+          "pattern": "if len(payload) > session.limits.max_bytes:"
+        }
+      ],
+      "adr_evidence": [
+        {
+          "path": "docs/specs/adr-048-preview-system.md",
+          "kind": "contains",
+          "pattern": "FR-019: SVG rendering must be sanitized or sandboxed so script execution and"
+        },
+        {
+          "path": "docs/specs/adr-048-preview-system.md",
+          "kind": "contains",
+          "pattern": "SC-007: SVG and PDF plot artifacts render through `PlotPreviewer` and expose"
+        },
+        {
+          "path": "docs/block-development/previewers-and-plots.md",
+          "kind": "contains",
+          "pattern": "SVG is sanitized before display."
+        }
+      ],
+      "tests": [
+        {
+          "path": "tests/previewers/test_preview_security.py",
+          "kind": "contains",
+          "pattern": "def test_sanitize_svg_strips_well_formed_script"
+        },
+        {
+          "path": "tests/previewers/test_preview_security.py",
+          "kind": "contains",
+          "pattern": "def test_sanitize_svg_strips_event_handlers_and_active_hrefs"
+        },
+        {
+          "path": "tests/api/test_plot_preview_wiring.py",
+          "kind": "contains",
+          "pattern": "assert any(r[\"resource_id\"] == \"export\" for r in env[\"resources\"])"
+        }
+      ],
+      "adr_alignment": "aligned",
+      "validator_implication": "Validator fixtures that accept plot SVG examples should include active-content cases and fail packages or examples that bypass sanitizer/sandbox/export budget behavior."
+    },
+    {
+      "id": "PV-12-004",
+      "section": "12_security_isolation",
+      "title": "Subprocess isolation exists for plot rendering; broader plugin validation isolation is unresolved",
+      "contract": "Plot rendering is isolated through the CodeBlock subprocess primitive and an auto-generated harness that avoids importing SciStudio inside the render subprocess. A broader package-validator production policy for executing arbitrary package entry points in an isolated validation subprocess or per-plugin environment remains a design gap and should not be claimed as implemented.",
+      "status": "partial",
+      "severity": "warning",
+      "environments": [
+        "development",
+        "production"
+      ],
+      "validator_profile": {
+        "development": "warning",
+        "production": "error"
+      },
+      "applicability": {
+        "candidate_surfaces": [
+          "security_isolation",
+          "preview_frontend_manifest",
+          "plot_jobs"
+        ],
+        "trigger": "production_always_and_development_when_candidate_declares_assets_subprocesses_or_filesystem_access",
+        "not_applicable_result": "not_applicable"
+      },
+      "code_evidence": [
+        {
+          "path": "src/scistudio/ai/agent/mcp/tools_plot/runtime.py",
+          "kind": "contains",
+          "pattern": "CodeBlock subprocess primitive"
+        },
+        {
+          "path": "src/scistudio/ai/agent/mcp/tools_plot/runtime.py",
+          "kind": "contains",
+          "pattern": "run_codeblock_process(argv=argv, cwd=work_dir, env_delta={}, timeout_seconds=timeout)"
+        },
+        {
+          "path": "src/scistudio/ai/agent/mcp/tools_plot/_harness.py",
+          "kind": "contains",
+          "pattern": "subprocess never imports SciStudio, only stdlib + (optionally) pandas/matplotlib"
+        }
+      ],
+      "adr_evidence": [
+        {
+          "path": "docs/planning/package-validator-contract-survey-draft.md",
+          "kind": "contains",
+          "pattern": "Should install-time validation execute package code in the main SciStudio"
+        },
+        {
+          "path": "docs/planning/package-validator-contract-survey-draft.md",
+          "kind": "contains",
+          "pattern": "Optional heavy dependencies and per-plugin venv isolation need explicit"
+        },
+        {
+          "path": "docs/specs/adr-048-ai-plot-tools.md",
+          "kind": "contains",
+          "pattern": "FR-024: `run_plot_job` must reuse existing CodeBlock runner primitives where"
+        }
+      ],
+      "tests": [
+        {
+          "path": "tests/ai/test_mcp_tools_plot.py",
+          "kind": "contains",
+          "pattern": "def test_run_timeout"
+        },
+        {
+          "path": "tests/api/test_plot_preview_wiring.py",
+          "kind": "contains",
+          "pattern": "def test_plot_run_offloads_blocking_job_off_the_event_loop"
+        }
+      ],
+      "adr_alignment": "adr_planned",
+      "notes": "Code evidence proves the plot-rendering subprocess boundary, not a general package-install isolation runner. The survey draft explicitly leaves package validation isolation policy open.",
+      "validator_implication": "ADR-049 should avoid claiming a general plugin-validation sandbox until a concrete isolated runner or per-plugin environment contract is selected; production profiles should error on validators that execute untrusted package code in-process."
+    }
+  ],
+  "omissions": []
+}

--- a/docs/planning/adr-049-package-validator/contracts/pv-a5-section-13-omissions.json
+++ b/docs/planning/adr-049-package-validator/contracts/pv-a5-section-13-omissions.json
@@ -1,0 +1,698 @@
+{
+  "schema_version": "adr049.package_contract_table.v1",
+  "agent_id": "PV-A5",
+  "generated_at": "2026-06-14",
+  "source_priority": "code-primary-adr-secondary",
+  "agent_scope": {
+    "sections": [
+      "13_cross_surface_registry_consistency",
+      "99_omitted_or_discovered_contracts"
+    ],
+    "summary": "Section 13 registry consistency contracts plus discovered package-facing omissions not cleanly owned by sections 1-13."
+  },
+  "contracts": [
+    {
+      "id": "PV-13-001",
+      "section": "13_cross_surface_registry_consistency",
+      "title": "Block registry descriptors preserve package identity",
+      "contract": "A package validator must derive block-package consistency from BlockRegistry descriptors, not live class references: entry-point blocks must produce BlockSpec rows with stable module/class identity, package_name, type_name aliases, and package metadata exposed through packages() and specs_by_package().",
+      "status": "partial",
+      "severity": "error",
+      "environments": [
+        "development",
+        "production"
+      ],
+      "validator_profile": {
+        "development": "error",
+        "production": "block"
+      },
+      "applicability": {
+        "candidate_surfaces": [
+          "cross_surface_registry_consistency"
+        ],
+        "trigger": "after_candidate_declared_surfaces_are_loaded_into_dry_run_registries",
+        "not_applicable_result": "not_applicable"
+      },
+      "code_evidence": [
+        {
+          "path": "src/scistudio/blocks/registry/__init__.py",
+          "kind": "contains",
+          "pattern": "class BlockSpec:",
+          "symbol": "BlockSpec",
+          "notes": "BlockSpec is the descriptor row used by registry consumers."
+        },
+        {
+          "path": "src/scistudio/blocks/registry/__init__.py",
+          "kind": "contains",
+          "pattern": "class BlockRegistry:",
+          "symbol": "BlockRegistry",
+          "notes": "BlockRegistry owns package metadata and grouped spec accessors."
+        },
+        {
+          "path": "src/scistudio/blocks/registry/__init__.py",
+          "kind": "contains",
+          "pattern": "def _scan_tier2(self) -> None:",
+          "symbol": "_scan_tier2",
+          "notes": "Public registry method delegates to the entry-point scan implementation."
+        },
+        {
+          "path": "src/scistudio/blocks/registry/__init__.py",
+          "kind": "contains",
+          "pattern": "def specs_by_package(self) -> dict[str, list[BlockSpec]]:",
+          "symbol": "BlockRegistry",
+          "notes": "Registry exposes package grouping derived from BlockSpec.package_name."
+        }
+      ],
+      "adr_evidence": [
+        {
+          "path": "docs/planning/package-validator-contract-survey-draft.md",
+          "kind": "contains",
+          "pattern": "BlockRegistry` entry-point scan accepts package tuples, plain block lists,",
+          "notes": "Draft records current BlockRegistry package scan behavior."
+        },
+        {
+          "path": "docs/planning/package-validator-contract-survey-draft.md",
+          "kind": "contains",
+          "pattern": "package metadata vs entry-point owner names need one combined pass.",
+          "notes": "Draft identifies package metadata cross-surface consistency as incomplete."
+        }
+      ],
+      "tests": [
+        {
+          "path": "tests/blocks/test_registry.py",
+          "kind": "contains",
+          "pattern": "def test_tuple_return_with_package_info(self) -> None:",
+          "notes": "Tests package tuple scan behavior."
+        },
+        {
+          "path": "tests/blocks/test_registry.py",
+          "kind": "contains",
+          "pattern": "def test_specs_by_package_groups_correctly(self) -> None:",
+          "notes": "Tests registry grouping by package_name."
+        }
+      ],
+      "adr_alignment": "aligned",
+      "notes": "The registry implements the raw descriptor surface, but there is no unified package validation report that checks package metadata consistency before registration.",
+      "validator_implication": "Development should report inconsistent package metadata and missing package grouping as errors; production install should block packages whose block descriptors cannot be reconciled with package metadata."
+    },
+    {
+      "id": "PV-13-002",
+      "section": "13_cross_surface_registry_consistency",
+      "title": "Block entry-point scans are tolerant runtime discovery, not install validation",
+      "contract": "The package validator must run block entry-point discovery in an isolated dry-run registry and convert unsupported return shapes, non-Block items, abstract blocks, duplicate capabilities, and callable failures into structured validation findings instead of relying on live startup warning-and-skip behavior.",
+      "status": "partial",
+      "severity": "error",
+      "environments": [
+        "development",
+        "production"
+      ],
+      "validator_profile": {
+        "development": "error",
+        "production": "block"
+      },
+      "applicability": {
+        "candidate_surfaces": [
+          "cross_surface_registry_consistency"
+        ],
+        "trigger": "after_candidate_declared_surfaces_are_loaded_into_dry_run_registries",
+        "not_applicable_result": "not_applicable"
+      },
+      "code_evidence": [
+        {
+          "path": "src/scistudio/blocks/registry/_scan.py",
+          "kind": "contains",
+          "pattern": "def _scan_tier2(registry: BlockRegistry) -> None:",
+          "symbol": "_scan",
+          "notes": "Mechanical inventory records the block registry scan module as the scan surface."
+        },
+        {
+          "path": "src/scistudio/blocks/registry/_scan.py",
+          "kind": "contains",
+          "pattern": "block_eps: Any = (",
+          "symbol": "_scan_tier2",
+          "notes": "Tier-2 scan selects the scistudio.blocks entry-point group."
+        },
+        {
+          "path": "src/scistudio/blocks/registry/_scan.py",
+          "kind": "contains",
+          "pattern": "Entry-point '%s' returned unsupported type: %s",
+          "symbol": "_scan_tier2",
+          "notes": "Invalid runtime entry points are logged and skipped."
+        },
+        {
+          "path": "src/scistudio/blocks/registry/_scan.py",
+          "kind": "contains",
+          "pattern": "def _scan_monorepo_packages(registry: BlockRegistry) -> None:",
+          "symbol": "_scan",
+          "notes": "Development fallback mirrors package entry-point callable protocol."
+        }
+      ],
+      "adr_evidence": [
+        {
+          "path": "docs/planning/package-validator-contract-survey-draft.md",
+          "kind": "contains",
+          "pattern": "Registry scan is tolerant by design.",
+          "notes": "Draft distinguishes runtime tolerance from production install validation."
+        },
+        {
+          "path": "docs/planning/package-validator-contract-survey-draft.md",
+          "kind": "contains",
+          "pattern": "isolated dry-run registry and atomic commit/quarantine semantics.",
+          "notes": "Draft calls out dry-run registry requirement."
+        }
+      ],
+      "tests": [
+        {
+          "path": "tests/blocks/test_registry.py",
+          "kind": "contains",
+          "pattern": "def test_entry_point_load_failure_logs_warning",
+          "notes": "Runtime behavior currently logs and continues."
+        },
+        {
+          "path": "tests/blocks/test_registry.py",
+          "kind": "contains",
+          "pattern": "def test_abstract_block_entry_point_logs_precise_warning",
+          "notes": "Abstract blocks are skipped with a precise warning."
+        }
+      ],
+      "adr_alignment": "aligned",
+      "notes": "Current code is deliberately resilient at app startup; the package validator must be stricter and side-effect-free.",
+      "validator_implication": "Validator implementations should instantiate temporary registries and classify each skipped entry point as a package validation finding, with production blocking invalid required package surfaces."
+    },
+    {
+      "id": "PV-13-003",
+      "section": "13_cross_surface_registry_consistency",
+      "title": "Type registry discovery must reconcile package types with blocks and previewers",
+      "contract": "A package validator must scan scistudio.types entry points into a dry-run TypeRegistry, validate returned DataObject subclasses and Meta constraints, and then use that registry to verify block port types, IO capability data_type values, and previewer target_type references.",
+      "status": "partial",
+      "severity": "error",
+      "environments": [
+        "development",
+        "production"
+      ],
+      "validator_profile": {
+        "development": "error",
+        "production": "block"
+      },
+      "applicability": {
+        "candidate_surfaces": [
+          "cross_surface_registry_consistency"
+        ],
+        "trigger": "after_candidate_declared_surfaces_are_loaded_into_dry_run_registries",
+        "not_applicable_result": "not_applicable"
+      },
+      "code_evidence": [
+        {
+          "path": "src/scistudio/core/types/registry.py",
+          "kind": "contains",
+          "pattern": "class TypeRegistry:",
+          "symbol": "registry",
+          "notes": "Mechanical inventory records the type registry module as the scan surface."
+        },
+        {
+          "path": "src/scistudio/core/types/registry.py",
+          "kind": "contains",
+          "pattern": "def _scan_entrypoint_types(self) -> None:",
+          "symbol": "_scan_entrypoint_types",
+          "notes": "Type entry-point discovery is the package type scan hook."
+        },
+        {
+          "path": "src/scistudio/core/types/registry.py",
+          "kind": "contains",
+          "pattern": "eps = importlib.metadata.entry_points(group=\"scistudio.types\")",
+          "symbol": "_scan_entrypoint_types",
+          "notes": "Registry scans the scistudio.types entry-point group."
+        },
+        {
+          "path": "src/scistudio/core/types/registry.py",
+          "kind": "contains",
+          "pattern": "Entry-point '%s' type %r has a Meta class that violates",
+          "symbol": "_scan_entrypoint_types",
+          "notes": "Bad type Meta declarations are warning/skipped at runtime."
+        }
+      ],
+      "adr_evidence": [
+        {
+          "path": "docs/planning/package-validator-contract-survey-draft.md",
+          "kind": "contains",
+          "pattern": "`scistudio.types`: callable returns `list`/`tuple` of `DataObject`",
+          "notes": "Draft records the package type entry-point protocol."
+        },
+        {
+          "path": "docs/planning/package-validator-contract-survey-draft.md",
+          "kind": "contains",
+          "pattern": "block port types vs package type entry points, previewer target types vs",
+          "notes": "Draft identifies type registry cross-surface gaps."
+        }
+      ],
+      "tests": [
+        {
+          "path": "tests/core/test_type_registry_resolve_and_meta.py",
+          "kind": "contains",
+          "pattern": "class TestValidateMetaClass:",
+          "notes": "Tests type Meta validation behavior."
+        },
+        {
+          "path": "tests/core/test_type_registry_scan_dirs.py",
+          "kind": "contains",
+          "pattern": "A DataObject subclass in a scanned dir is registered by scan_all.",
+          "notes": "Tests registry scan behavior for drop-in types."
+        }
+      ],
+      "adr_alignment": "aligned",
+      "notes": "The type registry validates individual type classes, but current package validation does not yet perform a combined block/type/previewer consistency pass.",
+      "validator_implication": "The validator should load candidate package types first, then reject package blocks, capabilities, or previewers that reference unresolved or inconsistent type names."
+    },
+    {
+      "id": "PV-13-004",
+      "section": "13_cross_surface_registry_consistency",
+      "title": "Previewer package discovery must feed cross-surface target validation",
+      "contract": "A package validator must scan scistudio.previewers factories, reject malformed PreviewerSpec lists, duplicate or empty previewer_id values, unresolved target_type references, and owner/package mismatches, then reconcile previewer specs with the type registry and package metadata.",
+      "status": "partial",
+      "severity": "error",
+      "environments": [
+        "development",
+        "production"
+      ],
+      "validator_profile": {
+        "development": "error",
+        "production": "block"
+      },
+      "applicability": {
+        "candidate_surfaces": [
+          "cross_surface_registry_consistency"
+        ],
+        "trigger": "after_candidate_declared_surfaces_are_loaded_into_dry_run_registries",
+        "not_applicable_result": "not_applicable"
+      },
+      "code_evidence": [
+        {
+          "path": "src/scistudio/previewers/registry.py",
+          "kind": "contains",
+          "pattern": "class PreviewerRegistry:",
+          "symbol": "registry",
+          "notes": "Mechanical inventory records the previewer registry module as the scan surface."
+        },
+        {
+          "path": "src/scistudio/previewers/registry.py",
+          "kind": "contains",
+          "pattern": "def load_packages(self, *, include_monorepo: bool = False) -> None:",
+          "symbol": "load_packages",
+          "notes": "Package previewers load through this registry method."
+        },
+        {
+          "path": "src/scistudio/previewers/registry.py",
+          "kind": "contains",
+          "pattern": "def _scan_entry_points(self) -> None:",
+          "symbol": "_scan_entry_points",
+          "notes": "Entry-point scan covers the scistudio.previewers group."
+        },
+        {
+          "path": "src/scistudio/previewers/registry.py",
+          "kind": "contains",
+          "pattern": "previewer factory '{source}' returned {type(specs).__name__}, expected list[PreviewerSpec]",
+          "symbol": "registry",
+          "notes": "Malformed factories are diagnostics, not hard install failures today."
+        }
+      ],
+      "adr_evidence": [
+        {
+          "path": "docs/planning/package-validator-contract-survey-draft.md",
+          "kind": "contains",
+          "pattern": "`scistudio.previewers`: callable returns `list[PreviewerSpec]`.",
+          "notes": "Draft records the previewer entry-point protocol."
+        },
+        {
+          "path": "docs/planning/package-validator-contract-survey-draft.md",
+          "kind": "contains",
+          "pattern": "Previewer spec validation is the weakest surface:",
+          "notes": "Draft calls out missing previewer package validation."
+        }
+      ],
+      "tests": [
+        {
+          "path": "tests/previewers/test_preview_registry.py",
+          "kind": "contains",
+          "pattern": "def test_duplicate_previewer_id_is_rejected_with_diagnostic() -> None:",
+          "notes": "Tests duplicate previewer diagnostics."
+        },
+        {
+          "path": "tests/previewers/test_preview_registry.py",
+          "kind": "contains",
+          "pattern": "def test_factory_returning_non_list_is_diagnosed() -> None:",
+          "notes": "Tests malformed factory diagnostics."
+        }
+      ],
+      "adr_alignment": "aligned",
+      "notes": "PreviewerRegistry has coarse validation, but registry diagnostics currently do not resolve target_type or owner consistency against package metadata and TypeRegistry.",
+      "validator_implication": "Production package validation should block malformed previewer specs and unresolved package previewer targets instead of allowing them to degrade to runtime diagnostics."
+    },
+    {
+      "id": "PV-99-001",
+      "section": "99_omitted_or_discovered_contracts",
+      "title": "Code runner entry-point and language registry contract is not owned by sections 1-13",
+      "contract": "The scistudio.runners entry-point group and RunnerRegistry language mapping are package-facing extension surfaces. A package validator needs an explicit contract for runner class importability, language-key normalization, required runner protocol methods, duplicate language handling, and production compatibility.",
+      "status": "partial",
+      "severity": "warning",
+      "environments": [
+        "development",
+        "production"
+      ],
+      "validator_profile": {
+        "development": "warning",
+        "production": "error"
+      },
+      "applicability": {
+        "candidate_surfaces": [
+          "runners",
+          "entry_points"
+        ],
+        "trigger": "when_candidate_declares_scistudio.runners_or_runner_language_registry_entries",
+        "not_applicable_result": "not_applicable"
+      },
+      "code_evidence": [
+        {
+          "path": "pyproject.toml",
+          "kind": "contains",
+          "pattern": "[project.entry-points.\"scistudio.runners\"]",
+          "symbol": "scistudio.runners",
+          "notes": "The root package declares a runner entry-point group."
+        },
+        {
+          "path": "src/scistudio/blocks/code/runner_registry.py",
+          "kind": "contains",
+          "pattern": "class RunnerRegistry:",
+          "symbol": "RunnerRegistry",
+          "notes": "RunnerRegistry is the public language-to-runner registry."
+        },
+        {
+          "path": "src/scistudio/blocks/code/runner_registry.py",
+          "kind": "contains",
+          "pattern": "self._runners[language.lower()] = runner_class",
+          "symbol": "RunnerRegistry",
+          "notes": "Registry normalizes language keys but does not validate a package runner protocol."
+        }
+      ],
+      "adr_evidence": [],
+      "tests": [
+        {
+          "path": "tests/blocks/test_runner_registry.py",
+          "kind": "contains",
+          "pattern": "class TestRunnerRegistry:",
+          "notes": "Tests runner registry behavior but not external package validation."
+        }
+      ],
+      "adr_alignment": "adr_missing",
+      "notes": "The survey draft focuses on blocks, types, previewers, IO, and preview surfaces. Runner entry points exist in package metadata but do not yet have a validator section.",
+      "validator_implication": "Add a validator section or explicit section-02 subprofile for scistudio.runners before external runner packages are accepted in production."
+    },
+    {
+      "id": "PV-99-002",
+      "section": "99_omitted_or_discovered_contracts",
+      "title": "Scaffold-generated package fixtures are a package contract",
+      "contract": "The init-block-package scaffold generates pyproject metadata, scistudio.blocks entry-point wiring, a get_blocks() callable returning PackageInfo plus block classes, and package-local tests. The package validator should either consume scaffold smoke fixtures or declare scaffold validation out of scope.",
+      "status": "implemented",
+      "severity": "warning",
+      "environments": [
+        "development"
+      ],
+      "validator_profile": {
+        "development": "warning",
+        "production": "skip"
+      },
+      "applicability": {
+        "candidate_surfaces": [
+          "scaffold_fixtures",
+          "package_examples"
+        ],
+        "trigger": "when_candidate_is_generated_from_or_claims_scaffold_fixture_conformance",
+        "not_applicable_result": "not_applicable"
+      },
+      "code_evidence": [
+        {
+          "path": "src/scistudio/cli/_scaffold.py",
+          "kind": "contains",
+          "pattern": "\"pyproject.toml.tpl\": \"pyproject.toml\"",
+          "symbol": "scaffold_block_package",
+          "notes": "Scaffold creates package metadata and source/test files."
+        },
+        {
+          "path": "src/scistudio/cli/templates/block_package/pyproject.toml.tpl",
+          "kind": "contains",
+          "pattern": "[project.entry-points.\"scistudio.blocks\"]",
+          "symbol": "block_package_pyproject_template",
+          "notes": "Template declares the block package entry point."
+        },
+        {
+          "path": "src/scistudio/cli/templates/block_package/__init__.py.tpl",
+          "kind": "contains",
+          "pattern": "def get_blocks() -> tuple[PackageInfo, list[type]]:",
+          "symbol": "block_package_init_template",
+          "notes": "Template emits the preferred package callable protocol."
+        },
+        {
+          "path": "src/scistudio/cli/templates/block_package/test_block.py.tpl",
+          "kind": "contains",
+          "pattern": "class TestEntryPoint:",
+          "symbol": "block_package_test_template",
+          "notes": "Template emits package-local entry-point tests."
+        }
+      ],
+      "adr_evidence": [
+        {
+          "path": "docs/planning/package-validator-contract-survey-draft.md",
+          "kind": "contains",
+          "pattern": "docs/scaffold",
+          "notes": "Draft notes scaffold guidance and tests as existing coverage."
+        }
+      ],
+      "tests": [
+        {
+          "path": "tests/cli/test_new_block_package.py",
+          "kind": "contains",
+          "pattern": "def test_generated_init_callable_protocol",
+          "notes": "Tests generated get_blocks callable shape."
+        },
+        {
+          "path": "tests/cli/test_new_block_package.py",
+          "kind": "contains",
+          "pattern": "def test_generated_entry_points_correct",
+          "notes": "Tests generated entry-point metadata."
+        }
+      ],
+      "adr_alignment": "aligned",
+      "notes": "Sections 1-13 cover the runtime surfaces that scaffold output targets, but not the scaffold-as-contract artifact itself.",
+      "validator_implication": "Development validation should smoke-test scaffolded packages or reuse scaffold fixtures as conformance examples; production package validation can skip scaffold-only checks."
+    },
+    {
+      "id": "PV-99-003",
+      "section": "99_omitted_or_discovered_contracts",
+      "title": "Generated public symbol facts are an API/package compatibility contract",
+      "contract": "The generated facts pipeline records public Python symbols with griffe. Because package validators may claim API compatibility or public extension surfaces, ADR-049 should decide whether validator output must reference or update generated symbol facts for package-facing API drift.",
+      "status": "implemented",
+      "severity": "info",
+      "environments": [
+        "development"
+      ],
+      "validator_profile": {
+        "development": "info",
+        "production": "skip"
+      },
+      "applicability": {
+        "candidate_surfaces": [
+          "generated_public_facts",
+          "public_api_compatibility"
+        ],
+        "trigger": "when_candidate_claims_public_API_compatibility_against_generated_facts",
+        "not_applicable_result": "not_applicable"
+      },
+      "code_evidence": [
+        {
+          "path": "src/scistudio/qa/audit/griffe_facts.py",
+          "kind": "contains",
+          "pattern": "def extract_symbol_facts(",
+          "symbol": "extract_symbol_facts",
+          "notes": "Public symbol facts are extracted from Python package surfaces."
+        },
+        {
+          "path": "src/scistudio/qa/audit/griffe_facts.py",
+          "kind": "contains",
+          "pattern": "if name.startswith(\"_\"):",
+          "symbol": "extract_symbol_facts",
+          "notes": "Private symbols are excluded from generated public facts."
+        },
+        {
+          "path": "scripts/audit/generate_facts.py",
+          "kind": "contains",
+          "pattern": "parser.add_argument(\"--check\", action=\"store_true\", help=\"Fail if docs/facts/generated.yaml is stale\")",
+          "symbol": "generate_facts",
+          "notes": "Generated facts have an explicit stale-check command."
+        }
+      ],
+      "adr_evidence": [],
+      "tests": [
+        {
+          "path": "tests/qa/test_griffe_facts.py",
+          "kind": "contains",
+          "pattern": "def test_extract_symbol_facts_from_temporary_package",
+          "notes": "Tests generated symbol fact extraction."
+        },
+        {
+          "path": "tests/qa/test_generate_facts_cli.py",
+          "kind": "contains",
+          "pattern": "def test_generate_facts_check_reports_stale_file",
+          "notes": "Tests stale generated facts detection."
+        }
+      ],
+      "adr_alignment": "adr_missing",
+      "notes": "Generated facts are governance evidence rather than a plugin runtime, but they are package-facing when validator claims mention public APIs.",
+      "validator_implication": "Keep generated facts out of production install blocking unless ADR-049 explicitly adopts them; in development, surface drift as informational validator context."
+    },
+    {
+      "id": "PV-99-004",
+      "section": "99_omitted_or_discovered_contracts",
+      "title": "Registry-derived API serialization is a package-facing contract",
+      "contract": "Block and previewer registries feed HTTP and MCP schema payloads. Package validation should verify candidate registry descriptors are JSON-serializable and remain consistent across palette, schema, connection-validation, preview capability, and MCP schema surfaces before committing them to live registries.",
+      "status": "partial",
+      "severity": "error",
+      "environments": [
+        "development",
+        "production"
+      ],
+      "validator_profile": {
+        "development": "error",
+        "production": "block"
+      },
+      "applicability": {
+        "candidate_surfaces": [
+          "registry_derived_api_serialization"
+        ],
+        "trigger": "after_candidate_dry_run_registries_emit_API_palette_or_MCP_payloads",
+        "not_applicable_result": "not_applicable"
+      },
+      "code_evidence": [
+        {
+          "path": "src/scistudio/api/routes/blocks.py",
+          "kind": "contains",
+          "pattern": "@router.get(\"/\", response_model=BlockListResponse)",
+          "symbol": "list_blocks",
+          "notes": "Block registry descriptors are serialized into the palette API."
+        },
+        {
+          "path": "src/scistudio/api/routes/blocks.py",
+          "kind": "contains",
+          "pattern": "@router.get(\"/{block_type}/schema\", response_model=BlockSchemaResponse)",
+          "symbol": "get_block_schema",
+          "notes": "Block registry descriptors are serialized into per-block schema APIs."
+        },
+        {
+          "path": "src/scistudio/api/schemas.py",
+          "kind": "contains",
+          "pattern": "class PreviewerSpecModel(BaseModel):",
+          "symbol": "PreviewerSpecModel",
+          "notes": "Previewer specs have a dedicated API wire model."
+        }
+      ],
+      "adr_evidence": [],
+      "tests": [
+        {
+          "path": "tests/contracts/test_block_schema_contract.py",
+          "kind": "contains",
+          "pattern": "def test_schema_payload_exposes_stable_contract_fields",
+          "notes": "Tests stable API schema fields."
+        },
+        {
+          "path": "tests/api/test_previewers.py",
+          "kind": "contains",
+          "pattern": "def test_image_session_serializes_first_class_frontend_manifest",
+          "notes": "Tests previewer manifest API serialization."
+        }
+      ],
+      "adr_alignment": "adr_missing",
+      "notes": "Sections 1-13 describe registry and previewer contracts but do not make API wire serialization an explicit package validation row.",
+      "validator_implication": "Production package validation should reject registry descriptors that cannot be converted into stable API/MCP payloads, especially non-serializable config schema, format capability, and previewer manifest fields."
+    }
+  ],
+  "omissions": [
+    {
+      "id": "OM-001",
+      "title": "scistudio.runners lacks a package-validator section",
+      "evidence": [
+        {
+          "path": "pyproject.toml",
+          "kind": "contains",
+          "pattern": "[project.entry-points.\"scistudio.runners\"]",
+          "symbol": "scistudio.runners"
+        },
+        {
+          "path": "src/scistudio/blocks/code/runner_registry.py",
+          "kind": "contains",
+          "pattern": "class RunnerRegistry:",
+          "symbol": "RunnerRegistry"
+        }
+      ],
+      "recommended_section": "Add section 14 or extend section 02 with a code-runner entry-point subprofile.",
+      "notes": "The entry-point group exists, but sections 1-13 do not define an external runner package contract."
+    },
+    {
+      "id": "OM-002",
+      "title": "Scaffold templates define a conformance fixture outside the runtime sections",
+      "evidence": [
+        {
+          "path": "src/scistudio/cli/templates/block_package/__init__.py.tpl",
+          "kind": "contains",
+          "pattern": "def get_blocks() -> tuple[PackageInfo, list[type]]:",
+          "symbol": "block_package_init_template"
+        },
+        {
+          "path": "src/scistudio/cli/templates/block_package/test_block.py.tpl",
+          "kind": "contains",
+          "pattern": "class TestEntryPoint:",
+          "symbol": "block_package_test_template"
+        }
+      ],
+      "recommended_section": "Add a development-only scaffold conformance subsection under section 99 or section 02.",
+      "notes": "Generated package tests are package-facing but not an install-time runtime surface."
+    },
+    {
+      "id": "OM-003",
+      "title": "Generated public symbol facts are not linked to package validation claims",
+      "evidence": [
+        {
+          "path": "src/scistudio/qa/audit/griffe_facts.py",
+          "kind": "contains",
+          "pattern": "def extract_symbol_facts(",
+          "symbol": "extract_symbol_facts"
+        },
+        {
+          "path": "scripts/audit/generate_facts.py",
+          "kind": "contains",
+          "pattern": "parser.add_argument(\"--check\", action=\"store_true\", help=\"Fail if docs/facts/generated.yaml is stale\")",
+          "symbol": "generate_facts"
+        }
+      ],
+      "recommended_section": "Keep as governance-only context or add a development validation evidence subsection.",
+      "notes": "Facts are not a runtime package validator dependency today, but they constrain public API drift claims."
+    },
+    {
+      "id": "OM-004",
+      "title": "Registry-derived API serialization is not explicit in sections 1-13",
+      "evidence": [
+        {
+          "path": "src/scistudio/api/routes/blocks.py",
+          "kind": "contains",
+          "pattern": "@router.get(\"/{block_type}/schema\", response_model=BlockSchemaResponse)",
+          "symbol": "get_block_schema"
+        },
+        {
+          "path": "src/scistudio/api/schemas.py",
+          "kind": "contains",
+          "pattern": "class PreviewerSpecModel(BaseModel):",
+          "symbol": "PreviewerSpecModel"
+        }
+      ],
+      "recommended_section": "Add a cross-surface API serialization subsection under section 13 or section 99.",
+      "notes": "Package descriptors must remain safe for API and MCP payloads, not only valid inside registries."
+    }
+  ]
+}

--- a/docs/planning/adr-049-package-validator/prompts/pv-a1-sections-01-03.md
+++ b/docs/planning/adr-049-package-validator/prompts/pv-a1-sections-01-03.md
@@ -1,0 +1,76 @@
+[DISPATCH-TEMPLATE-V1: test_engineer]
+
+## Task Identity
+
+- Repository: SciStudio
+- Owner request: derive ADR-049 package validator contracts from code-first evidence.
+- Task kind: manager
+- Persona: test_engineer
+- Issue: pending / owner-directed local investigation
+- Protected branch: main
+- Agent label: PV-A1
+- Gate record:
+  `.workflow/records/design-package-validator-contract-survey-design-package-validator-contract-survey.json`
+- Checklist: `docs/planning/adr-049-package-validator-checklist.md`
+
+## Required Rules
+
+Read and follow:
+
+- `AGENTS.md`
+- `docs/ai-developer/rules.md`
+- `docs/ai-developer/specific_rules/test-engineering.md`
+- `docs/ai-developer/personas/test-engineer.md`
+
+## Scope
+
+You own only:
+
+- `docs/planning/adr-049-package-validator/contracts/pv-a1-sections-01-03.json`
+
+You must not touch:
+
+- Production code under `src/scistudio/**`
+- Other agents' contract tables
+- `docs/planning/adr-049-package-validator-checklist.md`
+- `scripts/audit/check_package_contract_tables.py`
+
+## Work To Do
+
+1. Run the mechanical inventory:
+   `python scripts/audit/check_package_contract_tables.py --dump-inventory --sections 1,2,3 --output .workflow/local/adr049-inventory-a1.json`
+2. Use the inventory as the starting point. Cover every `required: true`
+   item with at least one contract row and inspect the non-required items for
+   omissions. The checker treats uncovered required inventory items as errors.
+3. Investigate implementation first, ADRs second. ADRs may be stale.
+4. Write the JSON contract table for:
+   - `01_package_metadata_distribution`
+   - `02_entry_points`
+   - `03_type_contracts`
+5. Each contract row must include code evidence with exact `path`, `symbol`,
+   `kind`, and `pattern`. ADR evidence may be empty only when ADR is missing;
+   set `adr_alignment` accordingly.
+
+## Machine Format
+
+Use schema version `adr049.package_contract_table.v1`.
+Top-level fields:
+
+- `schema_version`
+- `agent_id`
+- `generated_at`
+- `source_priority`
+- `agent_scope`
+- `contracts`
+- optional `omissions`
+
+Every contract row must satisfy
+`docs/planning/adr-049-package-validator/contracts/contract-table.schema.json`.
+
+## Required Check
+
+After writing your table, run:
+
+`python scripts/audit/check_package_contract_tables.py --sections 1,2,3`
+
+Report changed file paths, checker result, and any ADR drift warnings.

--- a/docs/planning/adr-049-package-validator/prompts/pv-a2-sections-04-06.md
+++ b/docs/planning/adr-049-package-validator/prompts/pv-a2-sections-04-06.md
@@ -1,0 +1,66 @@
+[DISPATCH-TEMPLATE-V1: test_engineer]
+
+## Task Identity
+
+- Repository: SciStudio
+- Owner request: derive ADR-049 package validator contracts from code-first evidence.
+- Task kind: manager
+- Persona: test_engineer
+- Issue: pending / owner-directed local investigation
+- Protected branch: main
+- Agent label: PV-A2
+- Gate record:
+  `.workflow/records/design-package-validator-contract-survey-design-package-validator-contract-survey.json`
+- Checklist: `docs/planning/adr-049-package-validator-checklist.md`
+
+## Required Rules
+
+Read and follow:
+
+- `AGENTS.md`
+- `docs/ai-developer/rules.md`
+- `docs/ai-developer/specific_rules/test-engineering.md`
+- `docs/ai-developer/personas/test-engineer.md`
+
+## Scope
+
+You own only:
+
+- `docs/planning/adr-049-package-validator/contracts/pv-a2-sections-04-06.json`
+
+You must not touch:
+
+- Production code under `src/scistudio/**`
+- Other agents' contract tables
+- `docs/planning/adr-049-package-validator-checklist.md`
+- `scripts/audit/check_package_contract_tables.py`
+
+## Work To Do
+
+1. Run the mechanical inventory:
+   `python scripts/audit/check_package_contract_tables.py --dump-inventory --sections 4,5,6 --output .workflow/local/adr049-inventory-a2.json`
+2. Use the inventory as the starting point. Cover every `required: true`
+   item with at least one contract row and inspect the non-required block,
+   dynamic-port, variadic, and capability items for omissions. The checker
+   treats uncovered required inventory items as errors.
+3. Investigate implementation first, ADRs second. ADRs may be stale.
+4. Write the JSON contract table for:
+   - `04_block_contracts`
+   - `05_config_dynamic_variadic`
+   - `06_io_format_capability`
+5. Include current implementation behavior, including whether it is strict,
+   warning/skip, partial, or only represented in tests.
+
+## Machine Format
+
+Use schema version `adr049.package_contract_table.v1`.
+Every contract row must satisfy
+`docs/planning/adr-049-package-validator/contracts/contract-table.schema.json`.
+
+## Required Check
+
+After writing your table, run:
+
+`python scripts/audit/check_package_contract_tables.py --sections 4,5,6`
+
+Report changed file paths, checker result, and any ADR drift warnings.

--- a/docs/planning/adr-049-package-validator/prompts/pv-a3-sections-07-09.md
+++ b/docs/planning/adr-049-package-validator/prompts/pv-a3-sections-07-09.md
@@ -1,0 +1,65 @@
+[DISPATCH-TEMPLATE-V1: test_engineer]
+
+## Task Identity
+
+- Repository: SciStudio
+- Owner request: derive ADR-049 package validator contracts from code-first evidence.
+- Task kind: manager
+- Persona: test_engineer
+- Issue: pending / owner-directed local investigation
+- Protected branch: main
+- Agent label: PV-A3
+- Gate record:
+  `.workflow/records/design-package-validator-contract-survey-design-package-validator-contract-survey.json`
+- Checklist: `docs/planning/adr-049-package-validator-checklist.md`
+
+## Required Rules
+
+Read and follow:
+
+- `AGENTS.md`
+- `docs/ai-developer/rules.md`
+- `docs/ai-developer/specific_rules/test-engineering.md`
+- `docs/ai-developer/personas/test-engineer.md`
+
+## Scope
+
+You own only:
+
+- `docs/planning/adr-049-package-validator/contracts/pv-a3-sections-07-09.json`
+
+You must not touch:
+
+- Production code under `src/scistudio/**`
+- Other agents' contract tables
+- `docs/planning/adr-049-package-validator-checklist.md`
+- `scripts/audit/check_package_contract_tables.py`
+
+## Work To Do
+
+1. Run the mechanical inventory:
+   `python scripts/audit/check_package_contract_tables.py --dump-inventory --sections 7,8,9 --output .workflow/local/adr049-inventory-a3.json`
+2. Use the inventory as the starting point. Cover every `required: true`
+   item with at least one contract row and inspect the non-required data
+   boundary, AppBlock/CodeBlock, and previewer items for omissions. The
+   checker treats uncovered required inventory items as errors.
+3. Investigate implementation first, ADRs second. ADRs may be stale.
+4. Write the JSON contract table for:
+   - `07_data_transport_runtime_boundary`
+   - `08_app_code_block_boundaries`
+   - `09_previewer_contracts`
+5. Include current implementation behavior for strict errors versus diagnostics.
+
+## Machine Format
+
+Use schema version `adr049.package_contract_table.v1`.
+Every contract row must satisfy
+`docs/planning/adr-049-package-validator/contracts/contract-table.schema.json`.
+
+## Required Check
+
+After writing your table, run:
+
+`python scripts/audit/check_package_contract_tables.py --sections 7,8,9`
+
+Report changed file paths, checker result, and any ADR drift warnings.

--- a/docs/planning/adr-049-package-validator/prompts/pv-a4-sections-10-12.md
+++ b/docs/planning/adr-049-package-validator/prompts/pv-a4-sections-10-12.md
@@ -1,0 +1,66 @@
+[DISPATCH-TEMPLATE-V1: test_engineer]
+
+## Task Identity
+
+- Repository: SciStudio
+- Owner request: derive ADR-049 package validator contracts from code-first evidence.
+- Task kind: manager
+- Persona: test_engineer
+- Issue: pending / owner-directed local investigation
+- Protected branch: main
+- Agent label: PV-A4
+- Gate record:
+  `.workflow/records/design-package-validator-contract-survey-design-package-validator-contract-survey.json`
+- Checklist: `docs/planning/adr-049-package-validator-checklist.md`
+
+## Required Rules
+
+Read and follow:
+
+- `AGENTS.md`
+- `docs/ai-developer/rules.md`
+- `docs/ai-developer/specific_rules/test-engineering.md`
+- `docs/ai-developer/personas/test-engineer.md`
+
+## Scope
+
+You own only:
+
+- `docs/planning/adr-049-package-validator/contracts/pv-a4-sections-10-12.json`
+
+You must not touch:
+
+- Production code under `src/scistudio/**`
+- Other agents' contract tables
+- `docs/planning/adr-049-package-validator-checklist.md`
+- `scripts/audit/check_package_contract_tables.py`
+
+## Work To Do
+
+1. Run the mechanical inventory:
+   `python scripts/audit/check_package_contract_tables.py --dump-inventory --sections 10,11,12 --output .workflow/local/adr049-inventory-a4.json`
+2. Use the inventory as the starting point. Cover every `required: true`
+   item with at least one contract row and inspect related code/tests for
+   omissions. The checker treats uncovered required inventory items as errors.
+3. Investigate implementation first, ADRs second. ADRs may be stale.
+4. Write the JSON contract table for:
+   - `10_preview_provider_behavior`
+   - `11_plot_jobs`
+   - `12_security_isolation`
+5. Pay special attention to routine provider failures, bounded access,
+   plot-job preview-only semantics, same-origin assets, path confinement, and
+   subprocess/plugin isolation boundaries.
+
+## Machine Format
+
+Use schema version `adr049.package_contract_table.v1`.
+Every contract row must satisfy
+`docs/planning/adr-049-package-validator/contracts/contract-table.schema.json`.
+
+## Required Check
+
+After writing your table, run:
+
+`python scripts/audit/check_package_contract_tables.py --sections 10,11,12`
+
+Report changed file paths, checker result, and any ADR drift warnings.

--- a/docs/planning/adr-049-package-validator/prompts/pv-a5-section-13-omissions.md
+++ b/docs/planning/adr-049-package-validator/prompts/pv-a5-section-13-omissions.md
@@ -1,0 +1,70 @@
+[DISPATCH-TEMPLATE-V1: test_engineer]
+
+## Task Identity
+
+- Repository: SciStudio
+- Owner request: derive ADR-049 package validator contracts from code-first evidence.
+- Task kind: manager
+- Persona: test_engineer
+- Issue: pending / owner-directed local investigation
+- Protected branch: main
+- Agent label: PV-A5
+- Gate record:
+  `.workflow/records/design-package-validator-contract-survey-design-package-validator-contract-survey.json`
+- Checklist: `docs/planning/adr-049-package-validator-checklist.md`
+
+## Required Rules
+
+Read and follow:
+
+- `AGENTS.md`
+- `docs/ai-developer/rules.md`
+- `docs/ai-developer/specific_rules/test-engineering.md`
+- `docs/ai-developer/personas/test-engineer.md`
+
+## Scope
+
+You own only:
+
+- `docs/planning/adr-049-package-validator/contracts/pv-a5-section-13-omissions.json`
+
+You must not touch:
+
+- Production code under `src/scistudio/**`
+- Other agents' contract tables
+- `docs/planning/adr-049-package-validator-checklist.md`
+- `scripts/audit/check_package_contract_tables.py`
+
+## Work To Do
+
+1. Run the mechanical inventory:
+   `python scripts/audit/check_package_contract_tables.py --dump-inventory --sections 13,99 --output .workflow/local/adr049-inventory-a5.json`
+2. Also run a broad inventory without filter:
+   `python scripts/audit/check_package_contract_tables.py --dump-inventory --output .workflow/local/adr049-inventory-all.json`
+3. Use the inventory as the starting point. Cover every section-13
+   `required: true` item with at least one contract row.
+   The checker treats uncovered required inventory items as errors.
+4. Investigate implementation first, ADRs second. ADRs may be stale.
+5. Write the JSON contract table for:
+   - `13_cross_surface_registry_consistency`
+   - `99_omitted_or_discovered_contracts`
+6. Extra duty: search for package-facing contracts omitted by sections 1-13.
+   Check entry point groups, public registries, API serialization, package
+   tests, scaffold templates, docs, and generated facts. Add omissions under
+   both `contracts` section `99_omitted_or_discovered_contracts` and the
+   top-level `omissions` array when warranted.
+
+## Machine Format
+
+Use schema version `adr049.package_contract_table.v1`.
+Every contract row must satisfy
+`docs/planning/adr-049-package-validator/contracts/contract-table.schema.json`.
+
+## Required Check
+
+After writing your table, run:
+
+`python scripts/audit/check_package_contract_tables.py --sections 13,99`
+
+Report changed file paths, checker result, omitted contracts found, and any ADR
+drift warnings.

--- a/docs/planning/package-validator-contract-survey-draft.md
+++ b/docs/planning/package-validator-contract-survey-draft.md
@@ -1,0 +1,293 @@
+# Package Validator Contract Survey Draft
+
+Status: working scratchpad.
+
+Purpose: collect ADR/spec/architecture-derived obligations for a package
+development-time and install-time validator. This is not yet a formal spec.
+
+## Scope
+
+- Validate package contracts during development.
+- Validate installed packages before production registration.
+- Focus on extension surfaces: package metadata, entry points, DataObject types,
+  blocks, IO capabilities, previewers, preview assets, and runtime registration
+  consistency.
+
+## Source Index
+
+- ADR-017: subprocess isolation and reference-oriented worker boundary.
+- ADR-020: Collection transport, homogeneous item type, no engine-level
+  per-item scheduling.
+- ADR-022: resource hints are CPU/GPU declarations and memory is OS-observed,
+  not a package RAM estimate contract.
+- ADR-025: package distribution through `scistudio.blocks` and
+  `scistudio.types`; `PackageInfo` and package grouping.
+- ADR-026: SDK scaffolding and `BlockTestHarness` contract validation.
+- ADR-027: plugin-owned domain types, type registry, typed worker
+  reconstruction, axis/Meta constraints.
+- ADR-028: `IOBlock` replaces central adapters; dynamic ports and effective
+  port hooks.
+- ADR-029: variadic port count through node config and effective ports.
+- ADR-030: config schema MRO merge and direction-aware IO path field injection.
+- ADR-031: reference-only DataObject boundary; IOBlock loaders persist through
+  storage refs; no cross-boundary `_data` / `_arrow_table` backdoors.
+- ADR-037: desktop/plugin distribution; future `[tool.scistudio]` plugin
+  manifest, API version, min/max core version, permissions/resources, PyPI
+  naming/classifier, per-plugin venv.
+- ADR-038: lineage records block version from package distribution and rejects
+  `"unknown"` versions; recipe/environment tracking, not raw-data retention.
+- ADR-041: CodeBlock v2 as AppBlock file exchange; capability-aware type +
+  extension boundary validation.
+- ADR-043: IO format capability registry and explicit package validity rules.
+- ADR-044: SubWorkflowBlock authoring-only container; generic ports are a
+  legitimate exception there, scheduler sees flattened DAG.
+- ADR-047: BlockRegistry subpackage split; `find_*_capability` is canonical,
+  legacy IO finder API removed.
+- ADR-048: `scistudio.previewers`, `PreviewerSpec`, deterministic routing,
+  same-origin manifests, bounded `PreviewDataAccess`, plot jobs.
+- `docs/architecture/ARCHITECTURE.md`: stable architecture overview for
+  plugin ecosystem, package installation, user-wide extension paths, and
+  extension philosophy.
+- `docs/block-development/**`: current author-facing package contract:
+  publishing, block contract, custom types, previewers/plots, testing,
+  memory safety, architecture for block developers.
+
+## Discovered Obligations
+
+### Package Metadata And Distribution
+
+- Installed package should expose standard Python package metadata:
+  distribution name, version, requires-python, dependencies, and entry points.
+- New package names should use the documented block/plugin convention
+  (`scistudio-blocks-*` or future `scistudio-plugin-*`) and classifier
+  `Framework :: SciStudio` when the desktop/plugin-browser model is in scope.
+- Preferred block package callable is
+  `get_blocks() -> (PackageInfo, list[type[Block]])`; plain list and direct
+  class shapes are compatibility, not ideal production compliance.
+- `PackageInfo.name` and version must be non-empty and should agree with the
+  installed distribution metadata.
+- Package version must be resolvable; registry/lineage must not stamp
+  `"unknown"`.
+- Future `[tool.scistudio]` manifest needs validation if ADR-037 is activated:
+  plugin API version, min/max SciStudio version, resource declarations,
+  permission declarations, heavy dependency URL, and compatibility range.
+
+### Entry Points
+
+- `scistudio.blocks`: callable returns package metadata plus block classes, or
+  accepted legacy forms in compatibility mode.
+- `scistudio.types`: callable returns `list`/`tuple` of `DataObject`
+  subclasses.
+- `scistudio.previewers`: callable returns `list[PreviewerSpec]`.
+- The three surfaces are independent; importing one surface should not require
+  unnecessarily importing heavy or unrelated surfaces when avoidable.
+- Historical `scistudio.adapters` is superseded and must not be accepted as a
+  current package contract.
+
+### Type Contracts
+
+- Plugin domain types belong outside core and must subclass a core
+  `DataObject` base type.
+- Custom type `Meta` must be a Pydantic model, frozen, no `PrivateAttr`, and
+  JSON-round-trippable.
+- Array subclasses must respect required/allowed/canonical axes when declared.
+- CompositeData subclasses must validate expected slots and slot object types.
+- Types that add constructor-required fields may need
+  `_reconstruct_extra_kwargs` and `_serialise_extra_metadata` round-trip hooks.
+- Type names/type chains must be concrete enough to support port validation
+  and preview routing.
+
+### Block Contracts
+
+- Every block class must be a concrete `Block` subclass with non-empty `name`,
+  `input_ports: list[InputPort]`, `output_ports: list[OutputPort]`, and a
+  usable `run()` path.
+- `OutputPort` uses `accepted_types`; any `produced_type` guidance is invalid.
+- Ports should use the most specific registered `DataObject` type available.
+  Empty `accepted_types` is runtime-valid but should be deliberate; generic
+  exceptions include SubWorkflow/generic utilities.
+- Port names should be unique within each direction and stable because
+  workflows and lineage refer to them.
+- `run(inputs, config)` returns `dict[str, Collection]`; values crossing block
+  boundaries should be DataObject refs inside homogeneous Collections.
+- `ProcessBlock.process_item` should use the current
+  `(self, item, config, state=None)` shape for new code.
+- `setup(config)` must not depend on inputs; `teardown(state)` should release
+  resources.
+- Resource declarations are advisory CPU/GPU/palette metadata, not memory
+  reservation or reproducibility truth.
+
+### Data Transport And Runtime Boundary
+
+- Blocks execute in subprocesses by default; engine passes JSON-friendly
+  config and storage references, not raw scientific payloads.
+- Collections are homogeneous transport wrappers; a single item is still a
+  length-one Collection.
+- DataObject instances crossing boundaries must be reference-only:
+  `storage_ref` for ordinary persisted data or `file_path` for Artifact.
+- Cross-boundary `_data` and `_arrow_table` monkey-patched payloads are invalid.
+- IOBlock loaders should persist directly via `persist_array` /
+  `persist_table`; auto-flush is a safety net, not a published package pattern.
+
+### IOBlock And FormatCapability
+
+- External formats are boundary capabilities, not DataObject attributes.
+- Published IO packages should declare explicit `FormatCapability` records;
+  legacy `supported_extensions` synthesis is migration scaffolding only.
+- Capability fields: stable package-qualified id, direction, data_type,
+  format_id, normalized lowercase dot extensions, label, block_type, handler,
+  default/priority, roundtrip_group, metadata_fidelity.
+- Capability validation must check referenced IOBlock exists, handler exists,
+  direction matches block role, type is compatible with effective port, ids are
+  globally stable/unique, defaults do not conflict, roundtrip claims have both
+  sides, and typed_meta fields exist on the type Meta model.
+- Capability lookup must be deterministic and fail on ambiguity unless an
+  explicit capability_id or valid default resolves it.
+- `find_loader_capability`, `find_saver_capability`, and
+  `list_format_capabilities` are canonical; legacy finder names are removed.
+
+### Dynamic, Variadic, And Config Schema
+
+- Dynamic ports are fixed-name ports whose type changes from a config enum.
+  Registry must validate descriptor shape and runtime must use effective ports.
+- Variadic ports store user-declared port lists in node config; allowed type
+  lists and min/max constraints must be exposed and enforced.
+- Config schemas are MRO-merged by the registry; child property overrides are
+  atomic, `required` is unioned/deduped, and IO path widget is direction-aware.
+
+### AppBlock And CodeBlock Boundaries
+
+- AppBlock/CodeBlock file exchange uses type + extension + optional
+  capability_id; extension alone is never semantic truth.
+- Inputs require saver capability resolution before external process/script
+  start.
+- Outputs require loader capability resolution before execution when the port
+  contract is known, and required output folders fail if no matching files are
+  produced.
+- Duplicate output extensions on the same variadic output block are invalid
+  because file binning would be ambiguous.
+- Script paths for CodeBlock must be project-local for lineage/git portability.
+
+### Previewer Contracts
+
+- Package previewers register through `scistudio.previewers` and return
+  `PreviewerSpec` records.
+- `PreviewerSpec` needs globally unique stable id, correct owner_kind,
+  owner_name, target_type, collection support flag, priority, capabilities,
+  backend_provider, optional frontend_manifest, and API version.
+- `target_type` should resolve against registered type chains; routing depends
+  on exact type, parent type, collection support, owner tier, priority, and
+  project defaults.
+- Routing must fail with typed ambiguity, not registration-order selection.
+- Backend providers must use `PreviewDataAccess` for bounded reads and return
+  typed error envelopes for routine failures.
+- Frontend manifests must be same-origin/backend-relative, versioned or
+  fingerprinted, API-version compatible, path-confined by asset_root, and
+  excluded from leaking backend filesystem paths to the frontend.
+- Package wheel must include previewer Python modules and frontend assets when
+  it ships a custom UI.
+- Preview failures must not mutate workflows, DataObjects, lineage, or
+  downstream outputs.
+
+### Plot Jobs
+
+- Plot jobs are project-local preview-only artifacts, not package registry
+  surfaces and not workflow nodes.
+- If validator later covers project packages/examples, `plot.yaml` requires
+  stable workflow path, node id, output port, script entrypoint, allowed output
+  format, target reachability, path traversal checks, and render smoke test.
+
+## Existing Coverage
+
+- `BlockTestHarness` validates a single block subclass, non-abstract status,
+  `input_ports` / `output_ports` list shapes, port object classes, non-empty
+  block name, `PackageInfo`, entry-point return shape, and basic smoke
+  execution.
+- `BlockRegistry` entry-point scan accepts package tuples, plain block lists,
+  and legacy direct block classes. Invalid entry points, abstract blocks, and
+  bad payload items are logged/skipped instead of returned as a structured
+  package report.
+- `BlockRegistry` spec construction validates dynamic-port descriptor shape,
+  distribution version resolution, IO capability declaration type, capability
+  direction, `block_type`, handler existence, package-qualified capability IDs,
+  duplicate capability IDs, and conflicting default capabilities.
+- `FormatCapability` / `MetadataFidelity` validate non-empty fields,
+  normalized extensions, valid direction and fidelity level, `lossless`
+  roundtrip-group requirement, and typed-meta field existence.
+- Capability lookup already uses deterministic matching and raises typed
+  missing/ambiguous capability errors rather than falling back to registration
+  order.
+- `TypeRegistry` validates plugin `Meta` classes for Pydantic inheritance,
+  no `PrivateAttr`, and best-effort JSON round-trip. Bad type entry points or
+  bad type classes are warning/skipped, not install-blocking.
+- `PreviewerRegistry` validates only coarse factory shape, item type, empty ID,
+  and duplicate ID. Broken previewer entry points are diagnostics/skips.
+- `previewers.assets.validate_manifest` checks same-origin frontend manifest
+  shape, rejects remote module/CSS URLs, reports API-version mismatch, and
+  requires version/fingerprint. `resolve_asset` path-confines asset serving.
+- `PreviewRouter` and tests cover deterministic previewer routing, priority
+  ties, project defaults, and ambiguity behavior.
+- Workflow validation already checks dynamic/effective port connections,
+  variadic cardinality, AppBlock duplicate output extensions, CodeBlock v2
+  declarations, and ADR-043 boundary capability resolution for
+  AppBlock/CodeBlock.
+- Contract tests exist for core IO capabilities, registry capability lookup,
+  package capability declarations, previewer registration, docs/scaffold
+  guidance, and wheel asset packaging in current in-repo packages.
+
+## Current Gaps For A Unified Package Validator
+
+- There is no single validator entry point that evaluates one candidate
+  package and returns a structured `PackageValidationReport`.
+- Registry scan is tolerant by design. Most broken package surfaces become
+  warnings, diagnostics, or skipped registrations; this is acceptable for app
+  startup resilience but insufficient for production install refusal.
+- Registry scan mutates live registries while scanning. Install validation
+  needs an isolated dry-run registry and atomic commit/quarantine semantics.
+- Current checks are split by surface. Cross-surface consistency is partial:
+  block port types vs package type entry points, previewer target types vs
+  registered type chains, IO capability types vs effective IO ports, and
+  package metadata vs entry-point owner names need one combined pass.
+- Previewer spec validation is the weakest surface: target type resolution,
+  owner_kind/owner_name consistency, api_version compatibility,
+  backend-provider importability, provider callable protocol, manifest
+  ID/spec ID consistency, and wheel asset inclusion are not enforced at
+  registry registration.
+- Type validation does not hard-enforce `Meta` frozen configuration, and it
+  only best-effort checks required-field Meta JSON round-trip.
+- Block contract validation is shallow: it does not fully validate run
+  signature, return value shape, Collection/reference-only output contract,
+  unique port names, accepted type registration, config schema widget
+  contracts, ProcessBlock hook signatures, or IOBlock load/save signatures.
+- ADR-043 migration scaffolding remains a policy question: synthesized
+  capabilities from legacy `supported_extensions` can still exist in
+  compatibility paths, but published packages should be explicit.
+- AppBlock/CodeBlock boundary validation is workflow-node scoped. A package
+  validator needs package-level static checks plus optional fixture-based
+  smoke checks for candidate AppBlock/CodeBlock templates/examples.
+- Runtime reference-only and subprocess-boundary guarantees cannot be proven
+  statically. They require smoke fixtures or instrumented execution against
+  temporary storage to catch returned `_data`, `_arrow_table`, missing
+  `storage_ref`, malformed `Collection`, and non-JSON metadata.
+- ADR-037 `[tool.scistudio]` plugin manifest is documented as a future desktop
+  contract. Validator design should include it, but activation needs an owner
+  decision on version/permission/resource enforcement timing.
+- Optional heavy dependencies and per-plugin venv isolation need explicit
+  policy: dev validation can allow skipped optional checks; production install
+  should validate within the same isolated environment used for execution.
+
+## Open Questions
+
+- Should production install reject legacy-but-loadable package shapes, or allow
+  with warnings under a compatibility profile?
+- Should install-time validation execute package code in the main SciStudio
+  process, an isolated validation subprocess, or the per-plugin venv worker
+  path from ADR-037?
+- Should invalid package validation disable the entire distribution or only the
+  invalid entry-point surface/specs?
+- How should validator handle packages with optional heavy dependencies absent
+  at validation time?
+- Should previewer provider importability be hard-required at install time, or
+  can backend-only provider absence degrade to a diagnostic until first use?
+- What is the migration policy for existing in-repo packages that still rely on
+  ADR-043 compatibility synthesis?

--- a/docs/specs/adr-049-package-validator-implementation.md
+++ b/docs/specs/adr-049-package-validator-implementation.md
@@ -1,0 +1,357 @@
+---
+spec_id: adr-049-package-validator-implementation
+title: "ADR-049 Package Validator Implementation Specification"
+status: Planned
+feature_branch: design/package-validator-contract-survey
+created: 2026-06-14
+input: "Owner request: define an executable implementation plan for the ADR-049 package validator that validates package contracts during development and before production registration."
+owners:
+  - "@jiazhenz026"
+related_adrs:
+  - 49
+related_specs: []
+scope:
+  in:
+    - Runtime package validator models, report schema, validation profiles, and candidate package inventory.
+    - Development CLI and test helper entry points for source trees, wheels, and installed distributions.
+    - Production install-time validation before live type, block, previewer, IO capability, runner, or API-facing registry mutation.
+    - Contract applicability selection from ADR-049 contract table rows.
+    - Dry-run registries for candidate types, blocks, previewers, format capabilities, runner declarations, and registry-derived API payloads.
+    - Structured validation report output for CLI, desktop, logs, and CI.
+    - Package fixture tests that prove invalid packages are rejected and valid packages are registered atomically.
+  out:
+    - Shipping a third-party package marketplace.
+    - Defining remote plugin sandboxing beyond the local isolation process required for validation.
+    - Partial production registration or quarantine UI beyond a structured reject report.
+    - Migrating every existing package contract warning to a production blocker in the first implementation PR.
+    - Rewriting tolerant startup scans that are not package-install validation paths.
+governs:
+  modules:
+    - scistudio.blocks.registry
+    - scistudio.blocks.io.capabilities
+    - scistudio.core.types.registry
+    - scistudio.previewers
+  contracts:
+    - scistudio.blocks.base.package_info.PackageInfo
+    - scistudio.blocks.registry.BlockRegistry
+    - scistudio.blocks.io.capabilities.FormatCapability
+    - scistudio.core.types.registry.TypeRegistry
+    - scistudio.previewers.registry.PreviewerRegistry
+    - scistudio.previewers.models.PreviewerSpec
+  entry_points:
+    - scistudio.blocks
+    - scistudio.types
+    - scistudio.previewers
+    - scistudio.runners
+  files:
+    - docs/adr/ADR-049.md
+    - docs/specs/adr-049-package-validator-implementation.md
+    - docs/planning/adr-049-package-validator/contracts/**
+    - scripts/audit/check_package_contract_tables.py
+    - pyproject.toml
+    - packages/scistudio-blocks-*/pyproject.toml
+    - packages/scistudio-blocks-*/src/**
+    - packages/scistudio-blocks-*/tests/**
+planned_governs:
+  modules:
+    - scistudio.packages.validation
+    - scistudio.cli.package_validator
+  contracts:
+    - scistudio.packages.validation.PackageValidationProfile
+    - scistudio.packages.validation.CandidatePackage
+    - scistudio.packages.validation.PackageInventory
+    - scistudio.packages.validation.ContractApplicability
+    - scistudio.packages.validation.PackageValidationFinding
+    - scistudio.packages.validation.PackageValidationReport
+    - scistudio.packages.validation.validate_package
+    - scistudio.packages.validation.validate_installed_package
+  entry_points: []
+  files:
+    - src/scistudio/packages/validation/**
+    - src/scistudio/cli/package_validator.py
+    - tests/packages/test_package_validator.py
+    - tests/packages/test_package_validator_reports.py
+    - tests/packages/fixtures/package_validator/**
+tests:
+  - tests/packages/test_package_validator.py
+  - tests/packages/test_package_validator_reports.py
+  - tests/packages/test_package_validator_cli.py
+  - tests/packages/test_package_validator_production_registration.py
+acceptance_source: adr
+language_source: en
+---
+
+# ADR-049 Package Validator Implementation Specification
+
+## 1. Change Summary
+
+This spec turns ADR-049 into an executable implementation plan. The package
+validator must validate SciStudio extension packages during development and
+before production registration. It must use ADR-049 contract tables as the
+machine-readable contract inventory, derive the candidate package's declared
+surfaces, apply only relevant contract rows, and return a structured validation
+report.
+
+The implementation has two profiles:
+
+- development validation for package authors, CI, scaffolds, and local test
+  helpers;
+- production validation for install, enable, upgrade, reload, and startup
+  package-registration paths.
+
+The production validator must be stricter than current tolerant registry scans:
+invalid packages are not registered into live registries when blocking findings
+exist.
+
+## 2. User Scenarios & Testing
+
+### User Story 1 - Package Author Validates Before Release (Priority: P1)
+
+As a package author, I can run a validator against a source tree, wheel, or
+installed distribution and receive all contract findings in one report.
+
+Why this priority: invalid packages should be caught before they enter a user
+environment.
+
+Independent Test: run the validator CLI against valid and invalid fixture
+packages and assert deterministic JSON report statuses and findings.
+
+Acceptance Scenarios:
+
+- Given a fixture package with an invalid block, when development validation
+  runs, then the report includes the block contract ID, source symbol, severity,
+  and repair hint.
+- Given a fixture package with only blocks and types, when validation runs, then
+  previewer contracts are reported as `not_applicable`, not failures.
+- Given a valid package, when development validation runs, then the final status
+  is `pass` or `pass_with_warnings` according to ADR-049 severity policy.
+
+### User Story 2 - Production Rejects Invalid Packages (Priority: P1)
+
+As SciStudio runtime, I can validate a package before registration and reject it
+without mutating live registries when blocking findings exist.
+
+Why this priority: production registration must not allow a bad extension to
+partially poison block, type, previewer, IO capability, or runner registries.
+
+Independent Test: run production validation through a fake installer or package
+registration harness and assert live registries are unchanged on failure.
+
+Acceptance Scenarios:
+
+- Given a package with an invalid previewer registry payload, when production
+  install validation runs, then registration is rejected and no previewer is
+  added to the live registry.
+- Given a package whose block ports reference an unknown type, when production
+  validation runs, then cross-surface consistency fails and no block is
+  registered.
+- Given a valid package, when production validation runs, then dry-run registry
+  rows are committed atomically to live registries.
+
+### User Story 3 - Agent And CI Drift Checks Stay Mechanical (Priority: P2)
+
+As a maintainer using AI agents, I can check that contract rows, ADR text, and
+code evidence stay aligned mechanically.
+
+Why this priority: ADR-049 is only useful if contract drift and omitted surfaces
+are visible before implementation or release.
+
+Independent Test: run `scripts/audit/check_package_contract_tables.py` and
+assert code evidence mismatches fail while ADR drift remains warning-level.
+
+Acceptance Scenarios:
+
+- Given a contract row whose code evidence no longer matches, when the checker
+  runs, then it exits with an error.
+- Given a contract row whose code evidence passes but ADR evidence is stale,
+  when the checker runs, then it emits a warning.
+- Given a contract row without applicability metadata, when the checker runs,
+  then it fails the table shape check.
+
+### Edge Cases
+
+- A package declares no SciStudio entry points: report package metadata checks
+  and mark extension-surface rows `not_applicable`.
+- A package import raises before inventory completes: report `blocker` and do
+  not attempt live registration.
+- A package depends on optional extras that are unavailable: development may
+  report `skipped` only when the optional dependency is declared; production
+  must reject if the missing dependency is required for a declared surface.
+- Two packages declare conflicting capability IDs: production validation must
+  reject the candidate package before live mutation.
+- A previewer has frontend assets but no provider: frontend manifest contracts
+  apply; provider contracts are `not_applicable`.
+
+## 3. Requirements
+
+### Functional Requirements
+
+- FR-001: The validator MUST accept candidate inputs as source tree path, wheel,
+  source distribution, installed distribution name, or installer-provided
+  distribution object.
+- FR-002: The validator MUST build a `PackageInventory` from distribution
+  metadata, entry points, manifests, and package-owned modules.
+- FR-003: The validator MUST classify each ADR-049 contract row as `pass`,
+  `fail`, `warning`, `skipped`, or `not_applicable`.
+- FR-004: The validator MUST use contract row `applicability` metadata to decide
+  whether a row applies to the candidate package.
+- FR-005: The validator MUST load candidate entry points in an isolated
+  validation context before touching live registries.
+- FR-006: The validator MUST build dry-run registries for candidate types,
+  blocks, previewers, format capabilities, runners, and registry-derived API
+  payloads.
+- FR-007: The validator MUST validate cross-surface consistency after all
+  candidate surfaces are loaded into dry-run registries.
+- FR-008: The development profile MUST return all findings in one report and
+  include repair hints where possible.
+- FR-009: The production profile MUST reject registration when a row with
+  production behavior `block` or `error` fails.
+- FR-010: Production validation MUST commit rows into live registries only after
+  blocking findings are absent.
+- FR-011: Production validation MUST leave live registries unchanged when
+  validation fails.
+- FR-012: The validator MUST emit `PackageValidationReport` JSON compatible with
+  ADR-049's report envelope.
+- FR-013: The CLI MUST support JSON output and a nonzero exit code when the
+  selected profile fails.
+- FR-014: The test helper MUST let package tests assert report status,
+  findings, and contract IDs without depending on CLI output text.
+- FR-015: The implementation MUST keep tolerant startup discovery separate from
+  install-facing production validation unless the startup path is registering a
+  candidate package.
+
+### Key Entities
+
+| Entity | Description | Required attributes |
+|---|---|---|
+| `PackageValidationProfile` | Validation profile enum | `development`, `production` |
+| `CandidatePackage` | Caller-supplied candidate package identity | source kind, path or distribution name, version, root path, installer context |
+| `PackageInventory` | Mechanical package surface inventory | metadata, entry points, declared surfaces, symbols, manifests, examples |
+| `ContractApplicability` | Runtime applicability model for one contract row | candidate surfaces, trigger, `not_applicable` result |
+| `ContractResult` | Per-contract execution result | contract ID, result, surface, symbol, severity, evidence |
+| `PackageValidationFinding` | Human and machine-readable problem | contract ID, severity, surface, source path, symbol, message, repair hint |
+| `PackageValidationReport` | Validator output envelope | schema version, package identity, profile, status, decision, inventory, results, findings |
+| `DryRunRegistrySet` | Non-live registries used during validation | type, block, previewer, IO capability, runner, API serialization summaries |
+
+## 4. Implementation Plan
+
+### 4.1 Technical Approach
+
+Create `src/scistudio/packages/validation/` as the package validator module. The
+module owns candidate discovery, contract table loading, applicability
+selection, dry-run registry construction, report generation, and production
+registration decisions. Existing registries remain the source of truth for
+their domain-specific checks; the validator orchestrates them in isolation and
+normalizes failures into `PackageValidationFinding` records.
+
+The validator must not import candidate package code into live registries before
+validation succeeds. The first implementation may use an in-process isolated
+context for development and a subprocess boundary for production validation.
+Production registration receives either a passing report plus dry-run registry
+rows or a reject report. It must not receive partially registered live state.
+
+Contract rows are loaded from
+`docs/planning/adr-049-package-validator/contracts/*.json` until they graduate
+to a runtime package-contract manifest location. Runtime rules must preserve the
+same contract IDs so reports are traceable to ADR-049.
+
+### 4.2 Affected Files
+
+| File or glob | Action | Rationale |
+|---|---|---|
+| `src/scistudio/packages/validation/models.py` | create | Pydantic or dataclass models for candidate, inventory, result, finding, report, profile |
+| `src/scistudio/packages/validation/contracts.py` | create | Load ADR-049 contract tables and expose applicability metadata |
+| `src/scistudio/packages/validation/inventory.py` | create | Build candidate package inventory from metadata, entry points, manifests, and modules |
+| `src/scistudio/packages/validation/engine.py` | create | Execute contract rows, dry-run registries, and cross-surface checks |
+| `src/scistudio/packages/validation/registration.py` | create | Atomic production registration handoff and reject behavior |
+| `src/scistudio/packages/validation/__init__.py` | create | Public validator API exports |
+| `src/scistudio/cli/package_validator.py` | create | CLI wrapper for development and production-style validation |
+| `src/scistudio/blocks/registry/**` | modify | Add dry-run or clone support only where existing APIs cannot validate without live mutation |
+| `src/scistudio/core/types/registry.py` | modify | Add dry-run support if current registration cannot be isolated by composition |
+| `src/scistudio/previewers/**` | modify | Add dry-run support and normalized provider validation hooks |
+| `pyproject.toml` | modify | Add CLI script or module entry, if needed |
+| `tests/packages/fixtures/package_validator/**` | create | Valid and invalid package fixtures |
+| `tests/packages/test_package_validator.py` | create | Core validation engine tests |
+| `tests/packages/test_package_validator_reports.py` | create | Report schema and result classification tests |
+| `tests/packages/test_package_validator_cli.py` | create | CLI behavior and exit-code tests |
+| `tests/packages/test_package_validator_production_registration.py` | create | Atomic production registration tests |
+| `docs/block-development/package-validator.md` | create | Author-facing package validation usage docs after runtime exists |
+
+### 4.3 Implementation Sequence
+
+| Task | Depends on | Work | Verification |
+|---|---|---|---|
+| T-001 | none | Add validation models and report JSON serialization | Unit tests for model round-trip and status derivation |
+| T-002 | T-001 | Add contract table loader and applicability normalization | Fixture contract table tests, missing applicability fails |
+| T-003 | T-001 | Add candidate package source parsing and inventory builder | Source tree, wheel, installed dist, and no-entry-point fixtures |
+| T-004 | T-002, T-003 | Implement per-surface validation dispatch and `not_applicable` classification | Contract result matrix tests |
+| T-005 | T-004 | Build dry-run type, block, previewer, IO capability, and runner registries | Valid package fixture registers in dry-run only |
+| T-006 | T-005 | Add cross-surface consistency checks | Unknown type, conflicting capability, invalid previewer target fixtures |
+| T-007 | T-006 | Add production registration handoff with atomic commit or reject | Live registry unchanged on failure |
+| T-008 | T-004 | Add CLI and test helper API | CLI JSON output and exit-code tests |
+| T-009 | T-008 | Add author-facing docs and sample command output | Docs link and frontmatter checks |
+| T-010 | T-009 | Wire package install/enable/reload call sites to production validator | Integration tests around installer or registration harness |
+
+### 4.4 Verification Plan
+
+- Run `python scripts/audit/check_package_contract_tables.py` before and after
+  implementation to keep ADR-049 contract rows aligned.
+- Add unit tests for `PackageValidationReport` schema, result classification,
+  and status derivation.
+- Add fixture package tests for invalid block, invalid type `Meta`, invalid
+  previewer payload, invalid frontend manifest, conflicting capability ID, and
+  unknown cross-surface target type.
+- Add production registration tests proving live registries remain unchanged on
+  reject and update atomically on pass.
+- Add CLI tests for source tree, installed distribution, JSON output, and exit
+  codes.
+- Run gate-selected repository checks through `gate_record check`.
+
+### 4.5 Risks And Rollback
+
+- Registry APIs may not currently support cheap dry-run cloning. Mitigation:
+  compose temporary registry instances first; only add clone APIs where tests
+  prove composition is insufficient.
+- Candidate imports may run package code. Mitigation: production validation must
+  use an isolation boundary before live mutation.
+- Contract tables currently live under `docs/planning`. Mitigation: first
+  implementation may load them there; a later cleanup can move generated
+  runtime manifests if needed while preserving contract IDs.
+- Existing packages may fail stricter production rules. Mitigation: development
+  profile reports warnings first; production blocker adoption can be staged by
+  contract row profile.
+- Rollback is to disable production registration enforcement while keeping the
+  CLI/report validator available for development checks.
+
+## 5. Success Criteria
+
+### Measurable Outcomes
+
+- SC-001: A valid fixture package passes development and production validation
+  with no blocking findings.
+- SC-002: At least five invalid fixture packages fail with the expected contract
+  IDs and source symbols.
+- SC-003: Previewer contracts are `not_applicable` for a package that declares
+  only blocks and types.
+- SC-004: Production validation rejects an invalid package and leaves live
+  registries unchanged in tests.
+- SC-005: The CLI returns JSON output and exits nonzero for a failing production
+  profile run.
+- SC-006: `PackageValidationReport` JSON includes package identity, profile,
+  status, registration decision, inventory, contract results, findings, and
+  dry-run registry summaries.
+- SC-007: `scripts/audit/check_package_contract_tables.py` still reports zero
+  errors for the ADR-049 contract tables.
+
+## 6. Assumptions
+
+- The first implementation can use the ADR-049 planning contract tables as the
+  runtime contract source until a generated runtime manifest is introduced.
+- The production validator can begin with local process isolation and does not
+  need remote sandboxing in the first implementation.
+- Existing tolerant discovery paths remain valid for startup resilience when
+  they are not making an install-time registration decision.
+- Package registration call sites can pass a candidate distribution or source
+  descriptor to the validator before live registry mutation.
+- Partial registration remains out of scope until a later ADR defines
+  quarantine semantics.

--- a/scripts/audit/check_package_contract_tables.py
+++ b/scripts/audit/check_package_contract_tables.py
@@ -1,0 +1,819 @@
+"""Check ADR-049 package-validator contract tables against code and ADRs.
+
+The checker has two jobs:
+
+1. Extract a mechanical inventory of package-extension interfaces from the
+   repository code (`--dump-inventory`). Agents use this inventory as their
+   starting point so contract tables are anchored in code instead of memory.
+2. Validate each JSON contract row. Code evidence mismatches are errors because
+   the table no longer matches implementation. ADR evidence mismatches are
+   warnings because ADRs may lag the implementation.
+
+The script intentionally uses only the Python standard library so agents can run
+it in fresh worktrees without installing test dependencies.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import re
+import tomllib
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "adr049.package_contract_table.v1"
+DEFAULT_CONTRACT_DIR = Path("docs/planning/adr-049-package-validator/contracts")
+
+SECTION_ALIASES = {
+    "01": "01_package_metadata_distribution",
+    "02": "02_entry_points",
+    "03": "03_type_contracts",
+    "04": "04_block_contracts",
+    "05": "05_config_dynamic_variadic",
+    "06": "06_io_format_capability",
+    "07": "07_data_transport_runtime_boundary",
+    "08": "08_app_code_block_boundaries",
+    "09": "09_previewer_contracts",
+    "10": "10_preview_provider_behavior",
+    "11": "11_plot_jobs",
+    "12": "12_security_isolation",
+    "13": "13_cross_surface_registry_consistency",
+    "99": "99_omitted_or_discovered_contracts",
+}
+VALID_SECTIONS = set(SECTION_ALIASES.values())
+
+BLOCK_BASE_NAMES = {
+    "Block",
+    "ProcessBlock",
+    "IOBlock",
+    "CodeBlock",
+    "AppBlock",
+    "AIBlock",
+    "SubWorkflowBlock",
+}
+TYPE_BASE_NAMES = {
+    "DataObject",
+    "Array",
+    "Series",
+    "DataFrame",
+    "Text",
+    "Artifact",
+    "CompositeData",
+}
+PUBLIC_CONTRACT_SYMBOLS = {
+    "PackageInfo": "01_package_metadata_distribution",
+    "BlockTestHarness": "04_block_contracts",
+    "TypeRegistry": "03_type_contracts",
+    "BlockRegistry": "13_cross_surface_registry_consistency",
+    "BlockSpec": "13_cross_surface_registry_consistency",
+    "FormatCapability": "06_io_format_capability",
+    "MetadataFidelity": "06_io_format_capability",
+    "PreviewerRegistry": "09_previewer_contracts",
+    "PreviewRouter": "09_previewer_contracts",
+    "PreviewerSpec": "09_previewer_contracts",
+    "FrontendManifest": "09_previewer_contracts",
+    "PreviewDataAccess": "10_preview_provider_behavior",
+}
+VALIDATOR_FUNCTIONS = {
+    "_validate_meta_class": "03_type_contracts",
+    "validate_entry_point_callable": "02_entry_points",
+    "validate_block": "04_block_contracts",
+    "validate_package_info": "01_package_metadata_distribution",
+    "smoke_test": "07_data_transport_runtime_boundary",
+    "_validate_dynamic_ports": "05_config_dynamic_variadic",
+    "_validate_capability_registration": "06_io_format_capability",
+    "_validate_class_capability": "06_io_format_capability",
+    "_format_capabilities_from_class": "06_io_format_capability",
+    "list_format_capabilities": "06_io_format_capability",
+    "find_loader_capability": "06_io_format_capability",
+    "find_saver_capability": "06_io_format_capability",
+    "validate_codeblock_config": "08_app_code_block_boundaries",
+    "validate_workflow": "08_app_code_block_boundaries",
+    "validate_manifest": "09_previewer_contracts",
+    "resolve_asset": "09_previewer_contracts",
+    "is_remote_url": "12_security_isolation",
+    "load_packages": "13_cross_surface_registry_consistency",
+    "_scan_entry_points": "13_cross_surface_registry_consistency",
+    "_scan_entrypoint_types": "13_cross_surface_registry_consistency",
+    "_scan_tier2": "13_cross_surface_registry_consistency",
+}
+
+
+@dataclass(frozen=True)
+class InventoryItem:
+    section: str
+    kind: str
+    path: str
+    line: int
+    symbol: str
+    required: bool
+    reason: str
+
+
+@dataclass
+class Diagnostic:
+    level: str
+    table: str
+    contract_id: str
+    message: str
+
+
+def relpath(path: Path, root: Path) -> str:
+    return path.resolve().relative_to(root.resolve()).as_posix()
+
+
+def ast_name(node: ast.AST | None) -> str:
+    if node is None:
+        return ""
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        parent = ast_name(node.value)
+        return f"{parent}.{node.attr}" if parent else node.attr
+    if isinstance(node, ast.Subscript):
+        return ast_name(node.value)
+    if isinstance(node, ast.Call):
+        return ast_name(node.func)
+    if isinstance(node, ast.Constant):
+        return str(node.value)
+    return ""
+
+
+def assigned_names(stmt: ast.stmt) -> set[str]:
+    names: set[str] = set()
+    if isinstance(stmt, ast.Assign):
+        targets = stmt.targets
+    elif isinstance(stmt, ast.AnnAssign):
+        targets = [stmt.target]
+    else:
+        return names
+    for target in targets:
+        if isinstance(target, ast.Name):
+            names.add(target.id)
+        elif isinstance(target, ast.Attribute):
+            names.add(target.attr)
+    return names
+
+
+def add_item(
+    items: list[InventoryItem],
+    *,
+    section: str,
+    kind: str,
+    path: str,
+    line: int,
+    symbol: str,
+    required: bool,
+    reason: str,
+) -> None:
+    if section not in VALID_SECTIONS:
+        raise ValueError(f"unknown inventory section: {section}")
+    items.append(
+        InventoryItem(
+            section=section,
+            kind=kind,
+            path=path,
+            line=line,
+            symbol=symbol,
+            required=required,
+            reason=reason,
+        )
+    )
+
+
+def parse_py_file(path: Path, root: Path, items: list[InventoryItem]) -> None:
+    rel = relpath(path, root)
+    try:
+        text = path.read_text(encoding="utf-8")
+        tree = ast.parse(text, filename=rel)
+    except (OSError, SyntaxError, UnicodeDecodeError):
+        return
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef):
+            base_names = {ast_name(base).split(".")[-1] for base in node.bases}
+            if node.name in PUBLIC_CONTRACT_SYMBOLS:
+                add_item(
+                    items,
+                    section=PUBLIC_CONTRACT_SYMBOLS[node.name],
+                    kind="public_contract_class",
+                    path=rel,
+                    line=node.lineno,
+                    symbol=node.name,
+                    required=True,
+                    reason="public class forms part of package validator contract surface",
+                )
+            if base_names & TYPE_BASE_NAMES and node.name not in TYPE_BASE_NAMES:
+                add_item(
+                    items,
+                    section="03_type_contracts",
+                    kind="type_class",
+                    path=rel,
+                    line=node.lineno,
+                    symbol=node.name,
+                    required=False,
+                    reason="DataObject subtype candidate discovered from class bases",
+                )
+            if base_names & BLOCK_BASE_NAMES and node.name not in BLOCK_BASE_NAMES:
+                block_section = "04_block_contracts"
+                if "IOBlock" in base_names:
+                    block_section = "06_io_format_capability"
+                elif {"CodeBlock", "AppBlock"} & base_names:
+                    block_section = "08_app_code_block_boundaries"
+                add_item(
+                    items,
+                    section=block_section,
+                    kind="block_class",
+                    path=rel,
+                    line=node.lineno,
+                    symbol=node.name,
+                    required=False,
+                    reason="Block subtype candidate discovered from class bases",
+                )
+            for stmt in node.body:
+                names = assigned_names(stmt)
+                for name in sorted(names & {"config_schema", "dynamic_ports"}):
+                    add_item(
+                        items,
+                        section="05_config_dynamic_variadic",
+                        kind=f"classvar_{name}",
+                        path=rel,
+                        line=getattr(stmt, "lineno", node.lineno),
+                        symbol=f"{node.name}.{name}",
+                        required=False,
+                        reason=f"{name} participates in package validator contract",
+                    )
+                if names & {
+                    "variadic_inputs",
+                    "variadic_outputs",
+                    "min_input_ports",
+                    "max_input_ports",
+                    "min_output_ports",
+                    "max_output_ports",
+                }:
+                    add_item(
+                        items,
+                        section="05_config_dynamic_variadic",
+                        kind="classvar_variadic_port_contract",
+                        path=rel,
+                        line=getattr(stmt, "lineno", node.lineno),
+                        symbol=node.name,
+                        required=False,
+                        reason="variadic port declarations participate in package validator contract",
+                    )
+                if "format_capabilities" in names or "supported_extensions" in names:
+                    add_item(
+                        items,
+                        section="06_io_format_capability",
+                        kind="classvar_io_capability_contract",
+                        path=rel,
+                        line=getattr(stmt, "lineno", node.lineno),
+                        symbol=node.name,
+                        required=False,
+                        reason="IO capability declarations participate in package validator contract",
+                    )
+        elif isinstance(node, ast.FunctionDef):
+            if node.name in VALIDATOR_FUNCTIONS:
+                add_item(
+                    items,
+                    section=VALIDATOR_FUNCTIONS[node.name],
+                    kind="validator_function",
+                    path=rel,
+                    line=node.lineno,
+                    symbol=node.name,
+                    required=True,
+                    reason="validator or registry function that encodes package contract behavior",
+                )
+            if node.name in {"get_blocks", "get_block_package", "get_types", "get_previewers"}:
+                section = "02_entry_points"
+                if node.name == "get_types":
+                    section = "03_type_contracts"
+                elif node.name == "get_previewers":
+                    section = "09_previewer_contracts"
+                add_item(
+                    items,
+                    section=section,
+                    kind="entry_point_factory",
+                    path=rel,
+                    line=node.lineno,
+                    symbol=node.name,
+                    required=True,
+                    reason="package entry-point factory discovered in code",
+                )
+            if node.name in {"run", "load", "save", "setup", "teardown", "process_item", "get_format_capabilities"}:
+                section = "04_block_contracts"
+                if node.name in {"load", "save", "get_format_capabilities"}:
+                    section = "06_io_format_capability"
+                add_item(
+                    items,
+                    section=section,
+                    kind="block_hook",
+                    path=rel,
+                    line=node.lineno,
+                    symbol=node.name,
+                    required=False,
+                    reason="block hook signature candidate",
+                )
+        elif isinstance(node, ast.Call):
+            call_name = ast_name(node.func).split(".")[-1]
+            if call_name == "FormatCapability":
+                add_item(
+                    items,
+                    section="06_io_format_capability",
+                    kind="format_capability_call",
+                    path=rel,
+                    line=node.lineno,
+                    symbol="FormatCapability",
+                    required=False,
+                    reason="concrete FormatCapability declaration",
+                )
+            elif call_name == "PreviewerSpec":
+                add_item(
+                    items,
+                    section="09_previewer_contracts",
+                    kind="previewer_spec_call",
+                    path=rel,
+                    line=node.lineno,
+                    symbol="PreviewerSpec",
+                    required=False,
+                    reason="concrete PreviewerSpec declaration",
+                )
+            elif call_name == "FrontendManifest":
+                add_item(
+                    items,
+                    section="09_previewer_contracts",
+                    kind="frontend_manifest_call",
+                    path=rel,
+                    line=node.lineno,
+                    symbol="FrontendManifest",
+                    required=False,
+                    reason="frontend preview manifest declaration",
+                )
+
+
+def parse_pyproject(path: Path, root: Path, items: list[InventoryItem]) -> None:
+    rel = relpath(path, root)
+    try:
+        data = tomllib.loads(path.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError, UnicodeDecodeError):
+        return
+    project = data.get("project", {})
+    entry_points = project.get("entry-points", {})
+    for group, value in sorted(entry_points.items()):
+        if group.startswith("scistudio."):
+            section = "02_entry_points"
+            if group == "scistudio.types":
+                section = "03_type_contracts"
+            elif group == "scistudio.previewers":
+                section = "09_previewer_contracts"
+            elif group == "scistudio.adapters":
+                section = "02_entry_points"
+            add_item(
+                items,
+                section=section,
+                kind="entry_point_group",
+                path=rel,
+                line=1,
+                symbol=group,
+                required=True,
+                reason=f"pyproject declares {group} entry-point group",
+            )
+            if isinstance(value, dict):
+                for name in sorted(value):
+                    add_item(
+                        items,
+                        section=section,
+                        kind="entry_point_name",
+                        path=rel,
+                        line=1,
+                        symbol=f"{group}:{name}",
+                        required=False,
+                        reason="specific package entry-point declaration",
+                    )
+    tool = data.get("tool", {})
+    if isinstance(tool, dict) and "scistudio" in tool:
+        add_item(
+            items,
+            section="01_package_metadata_distribution",
+            kind="tool_scistudio_manifest",
+            path=rel,
+            line=1,
+            symbol="[tool.scistudio]",
+            required=True,
+            reason="ADR-037 package manifest declaration",
+        )
+
+
+def add_known_file_items(root: Path, items: list[InventoryItem]) -> None:
+    known = {
+        "src/scistudio/previewers/data_access.py": (
+            "10_preview_provider_behavior",
+            "preview_data_access_module",
+            "PreviewDataAccess bounded data access surface",
+        ),
+        "src/scistudio/previewers/session.py": (
+            "10_preview_provider_behavior",
+            "preview_session_provider_invocation",
+            "Preview provider invocation and exception handling",
+        ),
+        "src/scistudio/api/preview_plot_jobs.py": (
+            "11_plot_jobs",
+            "plot_job_api",
+            "Plot job API contract",
+        ),
+        "src/scistudio/previewers/assets.py": (
+            "12_security_isolation",
+            "preview_asset_security",
+            "Same-origin/path-confined preview asset serving",
+        ),
+        "src/scistudio/engine/worker.py": (
+            "12_security_isolation",
+            "worker_boundary",
+            "Subprocess worker boundary",
+        ),
+        "src/scistudio/blocks/registry/_scan.py": (
+            "13_cross_surface_registry_consistency",
+            "block_registry_scan",
+            "Block package registry scan and live mutation behavior",
+        ),
+        "src/scistudio/core/types/registry.py": (
+            "13_cross_surface_registry_consistency",
+            "type_registry_scan",
+            "Type package registry scan behavior",
+        ),
+        "src/scistudio/previewers/registry.py": (
+            "13_cross_surface_registry_consistency",
+            "previewer_registry_scan",
+            "Previewer package registry scan behavior",
+        ),
+    }
+    for rel, (section, kind, reason) in known.items():
+        path = root / rel
+        if path.exists():
+            add_item(
+                items,
+                section=section,
+                kind=kind,
+                path=rel,
+                line=1,
+                symbol=Path(rel).stem,
+                required=True,
+                reason=reason,
+            )
+
+
+def extract_inventory(root: Path) -> list[InventoryItem]:
+    items: list[InventoryItem] = []
+    for base in (root / "src", root / "packages"):
+        if base.exists():
+            for py_file in sorted(base.rglob("*.py")):
+                parts = set(py_file.parts)
+                if parts & {".venv", "node_modules", "__pycache__"}:
+                    continue
+                parse_py_file(py_file, root, items)
+    for pyproject in sorted([root / "pyproject.toml", *(root / "packages").glob("*/pyproject.toml")]):
+        if pyproject.exists():
+            parse_pyproject(pyproject, root, items)
+    add_known_file_items(root, items)
+
+    dedup: dict[tuple[str, str, str, int, str], InventoryItem] = {}
+    for item in items:
+        key = (item.section, item.kind, item.path, item.line, item.symbol)
+        dedup[key] = item
+    return sorted(dedup.values(), key=lambda item: (item.section, item.path, item.line, item.kind, item.symbol))
+
+
+def normalize_sections(raw: str | None) -> set[str] | None:
+    if not raw:
+        return None
+    result: set[str] = set()
+    for part in raw.split(","):
+        key = part.strip()
+        if not key:
+            continue
+        alias_key = key.zfill(2) if key.isdigit() else key
+        result.add(SECTION_ALIASES.get(alias_key, key))
+    unknown = result - VALID_SECTIONS
+    if unknown:
+        raise SystemExit(f"unknown section filter(s): {sorted(unknown)}")
+    return result
+
+
+def text_matches(text: str, kind: str, pattern: str) -> bool:
+    if kind == "contains":
+        return pattern in text
+    if kind == "regex":
+        return re.search(pattern, text, flags=re.MULTILINE | re.DOTALL) is not None
+    raise ValueError(f"unknown evidence kind: {kind}")
+
+
+def evidence_matches(root: Path, evidence: dict[str, Any]) -> tuple[bool, str]:
+    evidence_path = evidence.get("path")
+    if not isinstance(evidence_path, str) or not evidence_path:
+        return False, "evidence path must be a non-empty string"
+    path = root / evidence_path
+    if not path.is_file():
+        return False, f"path not found: {evidence_path}"
+    try:
+        text = path.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        return False, f"path is not UTF-8 text: {evidence_path}"
+    kind = evidence.get("kind")
+    pattern = evidence.get("pattern")
+    if not isinstance(kind, str) or not isinstance(pattern, str):
+        return False, f"evidence kind and pattern must be strings for {evidence_path}"
+    try:
+        matched = text_matches(text, kind, pattern)
+    except re.error as exc:
+        return False, f"invalid regex for {evidence_path}: {exc}"
+    if not matched:
+        return False, f"pattern not found in {evidence.get('path')}: {pattern!r}"
+    return True, ""
+
+
+def validate_contract_table_shape(table: dict[str, Any], table_path: Path) -> list[Diagnostic]:
+    diagnostics: list[Diagnostic] = []
+    table_name = table_path.as_posix()
+    required = {"schema_version", "agent_id", "generated_at", "source_priority", "agent_scope", "contracts"}
+    missing = sorted(required - set(table))
+    for key in missing:
+        diagnostics.append(Diagnostic("error", table_name, "<table>", f"missing top-level field {key!r}"))
+    if table.get("schema_version") != SCHEMA_VERSION:
+        diagnostics.append(Diagnostic("error", table_name, "<table>", f"schema_version must be {SCHEMA_VERSION!r}"))
+    if table.get("source_priority") != "code-primary-adr-secondary":
+        diagnostics.append(
+            Diagnostic("error", table_name, "<table>", "source_priority must be code-primary-adr-secondary")
+        )
+    contracts = table.get("contracts")
+    if not isinstance(contracts, list) or not contracts:
+        diagnostics.append(Diagnostic("error", table_name, "<table>", "contracts must be a non-empty list"))
+        return diagnostics
+    seen_ids: set[str] = set()
+    for index, contract in enumerate(contracts):
+        cid = contract.get("id", f"<contract[{index}]>") if isinstance(contract, dict) else f"<contract[{index}]>"
+        if not isinstance(contract, dict):
+            diagnostics.append(Diagnostic("error", table_name, cid, "contract row must be an object"))
+            continue
+        for key in {
+            "id",
+            "section",
+            "title",
+            "contract",
+            "status",
+            "severity",
+            "environments",
+            "validator_profile",
+            "applicability",
+            "code_evidence",
+            "adr_evidence",
+            "tests",
+            "adr_alignment",
+            "validator_implication",
+        }:
+            if key not in contract:
+                diagnostics.append(Diagnostic("error", table_name, cid, f"missing contract field {key!r}"))
+        if cid in seen_ids:
+            diagnostics.append(Diagnostic("error", table_name, cid, "duplicate contract id"))
+        seen_ids.add(cid)
+        if contract.get("section") not in VALID_SECTIONS:
+            diagnostics.append(Diagnostic("error", table_name, cid, f"unknown section {contract.get('section')!r}"))
+        if not isinstance(contract.get("code_evidence"), list) or not contract.get("code_evidence"):
+            diagnostics.append(Diagnostic("error", table_name, cid, "code_evidence must be a non-empty list"))
+        applicability = contract.get("applicability")
+        if not isinstance(applicability, dict):
+            diagnostics.append(Diagnostic("error", table_name, cid, "applicability must be an object"))
+        else:
+            surfaces = applicability.get("candidate_surfaces")
+            if not isinstance(surfaces, list) or not surfaces or not all(isinstance(s, str) and s for s in surfaces):
+                diagnostics.append(
+                    Diagnostic(
+                        "error", table_name, cid, "applicability.candidate_surfaces must be a non-empty string list"
+                    )
+                )
+            if not isinstance(applicability.get("trigger"), str) or not applicability.get("trigger"):
+                diagnostics.append(
+                    Diagnostic("error", table_name, cid, "applicability.trigger must be a non-empty string")
+                )
+            if applicability.get("not_applicable_result") != "not_applicable":
+                diagnostics.append(
+                    Diagnostic(
+                        "error",
+                        table_name,
+                        cid,
+                        "applicability.not_applicable_result must be 'not_applicable'",
+                    )
+                )
+    return diagnostics
+
+
+def load_tables(contract_dir: Path) -> tuple[list[tuple[Path, dict[str, Any]]], list[Diagnostic]]:
+    diagnostics: list[Diagnostic] = []
+    tables: list[tuple[Path, dict[str, Any]]] = []
+    for path in sorted(contract_dir.glob("*.json")):
+        if path.name == "contract-table.schema.json":
+            continue
+        try:
+            table = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            diagnostics.append(Diagnostic("error", path.as_posix(), "<table>", f"cannot parse JSON: {exc}"))
+            continue
+        if not isinstance(table, dict):
+            diagnostics.append(Diagnostic("error", path.as_posix(), "<table>", "table root must be an object"))
+            continue
+        diagnostics.extend(validate_contract_table_shape(table, path))
+        tables.append((path, table))
+    return tables, diagnostics
+
+
+def check_tables(
+    root: Path, contract_dir: Path, sections: set[str] | None
+) -> tuple[list[Diagnostic], list[Diagnostic]]:
+    errors: list[Diagnostic] = []
+    warnings: list[Diagnostic] = []
+    tables, shape_diags = load_tables(contract_dir)
+    for diag in shape_diags:
+        (errors if diag.level == "error" else warnings).append(diag)
+
+    covered_symbols: set[tuple[str, str]] = set()
+    global_ids: dict[str, str] = {}
+    for table_path, table in tables:
+        for contract in table.get("contracts", []):
+            if not isinstance(contract, dict):
+                continue
+            section = contract.get("section")
+            if sections is not None and section not in sections:
+                continue
+            cid = contract.get("id", "<unknown>")
+            previous_table = global_ids.get(cid)
+            if previous_table is not None:
+                errors.append(
+                    Diagnostic(
+                        "error",
+                        table_path.as_posix(),
+                        cid,
+                        f"duplicate contract id also appears in {previous_table}",
+                    )
+                )
+            else:
+                global_ids[cid] = table_path.as_posix()
+            code_ok = True
+            for evidence in contract.get("code_evidence", []):
+                if not isinstance(evidence, dict):
+                    errors.append(Diagnostic("error", table_path.as_posix(), cid, "code evidence must be object"))
+                    code_ok = False
+                    continue
+                ok, message = evidence_matches(root, evidence)
+                if not ok:
+                    errors.append(Diagnostic("error", table_path.as_posix(), cid, f"code evidence mismatch: {message}"))
+                    code_ok = False
+                symbol = evidence.get("symbol")
+                ev_path = evidence.get("path")
+                if isinstance(symbol, str) and isinstance(ev_path, str):
+                    covered_symbols.add((ev_path, symbol))
+
+            if code_ok:
+                alignment = contract.get("adr_alignment")
+                if alignment in {"adr_drift", "adr_missing", "adr_planned"}:
+                    warnings.append(
+                        Diagnostic(
+                            "warning",
+                            table_path.as_posix(),
+                            cid,
+                            f"contract declares {alignment}; code evidence passed but ADR/spec text is not fully aligned",
+                        )
+                    )
+                adr_evidence = contract.get("adr_evidence", [])
+                if not adr_evidence and contract.get("adr_alignment") in {"aligned", "adr_drift"}:
+                    warnings.append(
+                        Diagnostic("warning", table_path.as_posix(), cid, "no ADR evidence for claimed ADR alignment")
+                    )
+                for evidence in adr_evidence:
+                    if not isinstance(evidence, dict):
+                        warnings.append(
+                            Diagnostic("warning", table_path.as_posix(), cid, "ADR evidence must be object")
+                        )
+                        continue
+                    ok, message = evidence_matches(root, evidence)
+                    if not ok:
+                        warnings.append(
+                            Diagnostic("warning", table_path.as_posix(), cid, f"ADR evidence mismatch: {message}")
+                        )
+
+                for evidence in contract.get("tests", []):
+                    if not isinstance(evidence, dict):
+                        warnings.append(
+                            Diagnostic("warning", table_path.as_posix(), cid, "test evidence must be object")
+                        )
+                        continue
+                    ok, message = evidence_matches(root, evidence)
+                    if not ok:
+                        warnings.append(
+                            Diagnostic("warning", table_path.as_posix(), cid, f"test evidence mismatch: {message}")
+                        )
+
+    inventory = extract_inventory(root)
+    if sections is not None:
+        inventory = [item for item in inventory if item.section in sections]
+    for item in inventory:
+        if not item.required:
+            continue
+        if (item.path, item.symbol) in covered_symbols:
+            continue
+        errors.append(
+            Diagnostic(
+                "error",
+                "<inventory>",
+                item.symbol,
+                (
+                    f"required inventory item not explicitly covered: section={item.section} "
+                    f"kind={item.kind} path={item.path}:{item.line} reason={item.reason}"
+                ),
+            )
+        )
+    if sections is None:
+        check_adr_coverage(root, tables, errors)
+    return errors, warnings
+
+
+def check_adr_coverage(
+    root: Path,
+    tables: list[tuple[Path, dict[str, Any]]],
+    errors: list[Diagnostic],
+) -> None:
+    """Verify ADR-049 names the machine-verifiable contract artifacts."""
+
+    adr_path = root / "docs/adr/ADR-049.md"
+    if not adr_path.exists():
+        return
+    text = adr_path.read_text(encoding="utf-8")
+    required_snippets = [
+        "scripts/audit/check_package_contract_tables.py",
+        "docs/planning/adr-049-package-validator/contracts/contract-table.schema.json",
+    ]
+    for table_path, table in tables:
+        required_snippets.append(relpath(table_path, root))
+        for contract in table.get("contracts", []):
+            if isinstance(contract, dict) and isinstance(contract.get("id"), str):
+                required_snippets.append(contract["id"])
+    for snippet in sorted(set(required_snippets)):
+        if snippet not in text:
+            errors.append(
+                Diagnostic(
+                    "error",
+                    relpath(adr_path, root),
+                    "ADR-049",
+                    f"ADR does not include required contract artifact or id: {snippet}",
+                )
+            )
+
+
+def print_diagnostics(errors: list[Diagnostic], warnings: list[Diagnostic]) -> None:
+    for diag in errors:
+        print(f"ERROR {diag.table} {diag.contract_id}: {diag.message}")
+    for diag in warnings:
+        print(f"WARNING {diag.table} {diag.contract_id}: {diag.message}")
+    print(f"summary: {len(errors)} error(s), {len(warnings)} warning(s)")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", default=".", help="Repository root. Defaults to cwd.")
+    parser.add_argument("--contracts-dir", default=str(DEFAULT_CONTRACT_DIR), help="Contract table directory.")
+    parser.add_argument("--sections", help="Comma-separated section numbers or names to filter.")
+    parser.add_argument(
+        "--dump-inventory", action="store_true", help="Print mechanical code interface inventory as JSON."
+    )
+    parser.add_argument("--output", help="Write --dump-inventory JSON to this path instead of stdout.")
+    args = parser.parse_args(argv)
+
+    root = Path(args.repo_root).resolve()
+    sections = normalize_sections(args.sections)
+
+    if args.dump_inventory:
+        inventory = extract_inventory(root)
+        if sections is not None:
+            inventory = [item for item in inventory if item.section in sections]
+        payload = {
+            "schema_version": "adr049.package_interface_inventory.v1",
+            "generated_by": "scripts/audit/check_package_contract_tables.py",
+            "items": [asdict(item) for item in inventory],
+        }
+        text = json.dumps(payload, indent=2, sort_keys=True)
+        if args.output:
+            output = root / args.output
+            output.parent.mkdir(parents=True, exist_ok=True)
+            output.write_text(text + "\n", encoding="utf-8")
+        else:
+            print(text)
+        return 0
+
+    errors, warnings = check_tables(root, root / args.contracts_dir, sections)
+    print_diagnostics(errors, warnings)
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- add ADR-049 for the package validator system, including development-time and production install-time validation behavior
- add machine-verifiable package contract tables, schema, subagent prompts, and survey scratchpad evidence
- add an executable ADR-049 implementation spec with models, APIs, trigger paths, implementation sequence, and test plan
- add `scripts/audit/check_package_contract_tables.py` to compare contract tables against code inventory and ADR drift annotations
- clarify that concrete existing symbols in evidence tables are inventory anchors, not required symbols for every newly installed package

## Verification

- `python scripts/audit/check_package_contract_tables.py` -> `summary: 0 error(s), 9 warning(s)`
- `python -m py_compile scripts/audit/check_package_contract_tables.py`
- `$env:PYTHONPATH='src'; python -m scistudio.qa.audit.frontmatter_lint docs/adr/ADR-049.md docs/specs/adr-049-package-validator-implementation.md --repo-root . --format text`
- `$env:PYTHONPATH='src'; python -m scistudio.qa.governance.gate_record check --mode local --base origin/main --head HEAD` -> `reconciliation passed`

Gate record: `.workflow/records/design-package-validator-contract-survey-design-package-validator-contract-survey.json`

Closes #1659
