### PR TITLE
docs(#1667): benchmark spectroscopy package implementations

### DIFF
--- a/.workflow/records/1667-audit-spectroscopy-package-benchmark-20260614.json
+++ b/.workflow/records/1667-audit-spectroscopy-package-benchmark-20260614.json
@@ -199,6 +199,85 @@
       "status": "pass",
       "summary": "clean",
       "tool_versions": {}
+    },
+    {
+      "at": "2026-06-14T21:42:24.631436Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:ad8b78b282b13e9fbe1a7213ff57921d6c73ee5bc3d9d4eaff2f5dab006bac2d",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-14T21:42:34.093817Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:ad8b78b282b13e9fbe1a7213ff57921d6c73ee5bc3d9d4eaff2f5dab006bac2d",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-14T21:42:34.128295Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:ad8b78b282b13e9fbe1a7213ff57921d6c73ee5bc3d9d4eaff2f5dab006bac2d",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-14T21:45:19.901427Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:ad8b78b282b13e9fbe1a7213ff57921d6c73ee5bc3d9d4eaff2f5dab006bac2d",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-14T21:46:17.079446Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:ad8b78b282b13e9fbe1a7213ff57921d6c73ee5bc3d9d4eaff2f5dab006bac2d",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
     }
   ],
   "check_na": [],
@@ -1011,6 +1090,88 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-06-14T21:46:17.185791Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T21:46:17.235495Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T21:46:17.285425Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T21:46:17.341190Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T21:46:17.401889Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T21:46:17.453890Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T21:46:17.503551Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T21:46:17.553146Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T21:46:17.604542Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T21:46:17.657985Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -1034,9 +1195,9 @@
       "docs/audit/2026-06-14-spectroscopy-package-codex-validator-report.md",
       "tests/contracts/test_runtime_import_contract.py"
     ],
-    "diff_fingerprint": "sha256:d8e9137e81d46f76ea7ff91e478fee4b9d32600c6f0c90ec7af509c8c8c30596",
+    "diff_fingerprint": "sha256:fca215ce3a276cf14648b047dacc7d90c1e640aa62dea054ebc33021fcdc5ead",
     "head": "HEAD",
-    "head_sha": "bc21b04a",
+    "head_sha": "7b1a5e07",
     "surfaces": {
       "docs": 5,
       "frontend": 0,
@@ -1142,6 +1303,14 @@
       "unsatisfied": [
         "checks.python_tests"
       ]
+    },
+    {
+      "at": "2026-06-14T21:46:17.658020Z",
+      "diff_fingerprint": "sha256:fca215ce3a276cf14648b047dacc7d90c1e640aa62dea054ebc33021fcdc5ead",
+      "mode": "local",
+      "result": "pass",
+      "tier": 3,
+      "unsatisfied": []
     }
   ],
   "record_id": "1667-audit-spectroscopy-package-benchmark-20260614",

--- a/.workflow/records/1667-audit-spectroscopy-package-benchmark-20260614.json
+++ b/.workflow/records/1667-audit-spectroscopy-package-benchmark-20260614.json
@@ -278,6 +278,85 @@
       "status": "pass",
       "summary": "clean",
       "tool_versions": {}
+    },
+    {
+      "at": "2026-06-14T21:46:54.177283Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:ad8b78b282b13e9fbe1a7213ff57921d6c73ee5bc3d9d4eaff2f5dab006bac2d",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-14T21:47:03.488069Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:ad8b78b282b13e9fbe1a7213ff57921d6c73ee5bc3d9d4eaff2f5dab006bac2d",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-14T21:47:03.524949Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:ad8b78b282b13e9fbe1a7213ff57921d6c73ee5bc3d9d4eaff2f5dab006bac2d",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-14T21:49:48.434678Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:ad8b78b282b13e9fbe1a7213ff57921d6c73ee5bc3d9d4eaff2f5dab006bac2d",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-14T21:50:45.440996Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:ad8b78b282b13e9fbe1a7213ff57921d6c73ee5bc3d9d4eaff2f5dab006bac2d",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
     }
   ],
   "check_na": [],
@@ -1172,6 +1251,88 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-06-14T21:50:45.554625Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T21:50:45.611203Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T21:50:45.660014Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T21:50:45.713874Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T21:50:45.764582Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T21:50:45.815374Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T21:50:45.865090Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T21:50:45.915586Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T21:50:45.964861Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T21:50:46.017446Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -1195,9 +1356,9 @@
       "docs/audit/2026-06-14-spectroscopy-package-codex-validator-report.md",
       "tests/contracts/test_runtime_import_contract.py"
     ],
-    "diff_fingerprint": "sha256:fca215ce3a276cf14648b047dacc7d90c1e640aa62dea054ebc33021fcdc5ead",
+    "diff_fingerprint": "sha256:32166101e8ab69009df0521867210ebf76b309166740acc3d598799f47b41e08",
     "head": "HEAD",
-    "head_sha": "7b1a5e07",
+    "head_sha": "7decd86c",
     "surfaces": {
       "docs": 5,
       "frontend": 0,
@@ -1308,6 +1469,14 @@
       "at": "2026-06-14T21:46:17.658020Z",
       "diff_fingerprint": "sha256:fca215ce3a276cf14648b047dacc7d90c1e640aa62dea054ebc33021fcdc5ead",
       "mode": "local",
+      "result": "pass",
+      "tier": 3,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-14T21:50:46.017480Z",
+      "diff_fingerprint": "sha256:32166101e8ab69009df0521867210ebf76b309166740acc3d598799f47b41e08",
+      "mode": "pre-pr",
       "result": "pass",
       "tier": 3,
       "unsatisfied": []

--- a/.workflow/records/1667-audit-spectroscopy-package-benchmark-20260614.json
+++ b/.workflow/records/1667-audit-spectroscopy-package-benchmark-20260614.json
@@ -75,13 +75,28 @@
       "status": "pass",
       "summary": "clean",
       "tool_versions": {}
+    },
+    {
+      "at": "2026-06-14T20:58:09.562341Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:40b2aa27328e453748477b81d4b60032a863c6f02d80bad3a29bf7e9a458209a",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
     }
   ],
   "check_na": [],
   "commit": {
-    "sha": "86b539c9c4a3d30e7157150e69678b3856b855f8",
+    "sha": "7a6e717fd5c33bda816ef2536eca96a8a055d308",
     "shas": [
-      "86b539c9c4a3d30e7157150e69678b3856b855f8"
+      "7a6e717fd5c33bda816ef2536eca96a8a055d308"
     ],
     "trailers": []
   },
@@ -565,6 +580,66 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-06-14T20:58:09.675750Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T20:58:09.725427Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T20:58:09.775188Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T20:58:09.825622Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T20:58:09.881616Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T20:58:09.938356Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T20:58:09.988563Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T20:58:10.040313Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T20:58:10.096472Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T20:58:10.154472Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -587,9 +662,9 @@
       "docs/audit/2026-06-14-spectroscopy-package-codex-audit.md",
       "docs/audit/2026-06-14-spectroscopy-package-codex-validator-report.md"
     ],
-    "diff_fingerprint": "sha256:326f13c7d4814920431cf4a746bc3b9c406efb2d7506ecd2597473fec8763009",
+    "diff_fingerprint": "sha256:38c1631f7d0645e13de5352f9a4a94f773e2d552b6165d34061270a30388af54",
     "head": "HEAD",
-    "head_sha": "86b539c9",
+    "head_sha": "7a6e717f",
     "surfaces": {
       "docs": 5,
       "frontend": 0,
@@ -649,6 +724,14 @@
     {
       "at": "2026-06-14T20:57:10.074026Z",
       "diff_fingerprint": "sha256:326f13c7d4814920431cf4a746bc3b9c406efb2d7506ecd2597473fec8763009",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 3,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-14T20:58:10.154510Z",
+      "diff_fingerprint": "sha256:38c1631f7d0645e13de5352f9a4a94f773e2d552b6165d34061270a30388af54",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 3,

--- a/.workflow/records/1667-audit-spectroscopy-package-benchmark-20260614.json
+++ b/.workflow/records/1667-audit-spectroscopy-package-benchmark-20260614.json
@@ -105,6 +105,100 @@
       "status": "pass",
       "summary": "clean",
       "tool_versions": {}
+    },
+    {
+      "at": "2026-06-14T21:33:19.339306Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:40b2aa27328e453748477b81d4b60032a863c6f02d80bad3a29bf7e9a458209a",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-14T21:35:45.386382Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:ad8b78b282b13e9fbe1a7213ff57921d6c73ee5bc3d9d4eaff2f5dab006bac2d",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-14T21:35:54.502978Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:ad8b78b282b13e9fbe1a7213ff57921d6c73ee5bc3d9d4eaff2f5dab006bac2d",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-14T21:35:54.537133Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:ad8b78b282b13e9fbe1a7213ff57921d6c73ee5bc3d9d4eaff2f5dab006bac2d",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-14T21:39:09.607300Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:ad8b78b282b13e9fbe1a7213ff57921d6c73ee5bc3d9d4eaff2f5dab006bac2d",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-14T21:40:09.674263Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:ad8b78b282b13e9fbe1a7213ff57921d6c73ee5bc3d9d4eaff2f5dab006bac2d",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
     }
   ],
   "check_na": [],
@@ -775,6 +869,148 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-06-14T21:33:19.442210Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T21:33:19.496261Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T21:33:19.553758Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T21:33:19.609964Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T21:33:19.659691Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T21:33:19.710071Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T21:33:19.760202Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T21:33:19.817630Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T21:33:19.868676Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T21:33:19.923017Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T21:40:09.779401Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T21:40:09.828546Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T21:40:09.878566Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T21:40:09.929134Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T21:40:09.979185Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T21:40:10.032991Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T21:40:10.082080Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T21:40:10.131740Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T21:40:10.187775Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T21:40:10.241032Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -787,7 +1023,7 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "7c064210d04de73e6e0d5af6b4ccbb1765ce5a02",
+    "base": "origin/main",
     "base_sha": "7c064210",
     "changed_files": [
       ".workflow/records/1667-audit-spectroscopy-package-benchmark-20260614.json",
@@ -795,11 +1031,12 @@
       "docs/audit/2026-06-14-spectroscopy-package-claude-audit.md",
       "docs/audit/2026-06-14-spectroscopy-package-claude-validator-report.md",
       "docs/audit/2026-06-14-spectroscopy-package-codex-audit.md",
-      "docs/audit/2026-06-14-spectroscopy-package-codex-validator-report.md"
+      "docs/audit/2026-06-14-spectroscopy-package-codex-validator-report.md",
+      "tests/contracts/test_runtime_import_contract.py"
     ],
-    "diff_fingerprint": "sha256:8a70803264c56452a65b72c820b80e7bb955d01e17eb8f7002678296dad2720c",
+    "diff_fingerprint": "sha256:d8e9137e81d46f76ea7ff91e478fee4b9d32600c6f0c90ec7af509c8c8c30596",
     "head": "HEAD",
-    "head_sha": "609abbd2",
+    "head_sha": "bc21b04a",
     "surfaces": {
       "docs": 5,
       "frontend": 0,
@@ -808,8 +1045,8 @@
       "implementation": 0,
       "packaging": 0,
       "protected_core": 0,
-      "sentrux": 0,
-      "test": 0,
+      "sentrux": 1,
+      "test": 1,
       "workflow_ci": 0
     }
   },
@@ -887,13 +1124,37 @@
       "result": "pass",
       "tier": 3,
       "unsatisfied": []
+    },
+    {
+      "at": "2026-06-14T21:33:19.923064Z",
+      "diff_fingerprint": "sha256:12fe36d80f9f2c889b23f7b0854ae36dece013be5befe6bfd7ce5d54bf759fd9",
+      "mode": "local",
+      "result": "pass",
+      "tier": 3,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-14T21:40:10.241057Z",
+      "diff_fingerprint": "sha256:d8e9137e81d46f76ea7ff91e478fee4b9d32600c6f0c90ec7af509c8c8c30596",
+      "mode": "local",
+      "result": "fail",
+      "tier": 3,
+      "unsatisfied": [
+        "checks.python_tests"
+      ]
     }
   ],
   "record_id": "1667-audit-spectroscopy-package-benchmark-20260614",
   "requested_admin_labels": [],
   "required_obligations": {
     "admin_labels": [],
-    "checks": [],
+    "checks": [
+      "format_check",
+      "full_audit",
+      "lint_format",
+      "python_tests",
+      "semantic_dup"
+    ],
     "docs": [],
     "guards": [
       "core_change_guard",
@@ -911,7 +1172,20 @@
   },
   "runtime": "codex:gpt-5",
   "schema_version": 2,
-  "scope_events": [],
+  "scope_events": [
+    {
+      "action": "add-include",
+      "at": "2026-06-14T21:29:31.736054Z",
+      "pattern": "tests/contracts/test_runtime_import_contract.py",
+      "reason": "CI xdist repeatedly failed the route-registration contract from module-level router state outside the audit report diff; add a narrow test isolation fix so the benchmark report PR can satisfy required CI."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-14T21:41:39.251817Z",
+      "pattern": "tests/contracts/test_runtime_import_contract.py",
+      "reason": "Gate and GitHub CI use FastAPI 0.137 lazy included routers, where app.routes contains _IncludedRouter entries instead of flattened APIRoute paths; update the runtime route contract to collect nested router paths without weakening the contract."
+    }
+  ],
   "session_id": "7a066021-28bc-46f7-bce2-4ffb98be26a7",
   "strictness_tier": 3,
   "task_kind": "docs",
@@ -946,6 +1220,22 @@
       "kind": "na",
       "path": null,
       "rationale": "docs-only benchmark reports; no product code changed",
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-14T21:29:31.736075Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/contracts/test_runtime_import_contract.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-14T21:41:39.251843Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/contracts/test_runtime_import_contract.py",
+      "rationale": null,
       "verified_in_diff": null
     }
   ]

--- a/.workflow/records/1667-audit-spectroscopy-package-benchmark-20260614.json
+++ b/.workflow/records/1667-audit-spectroscopy-package-benchmark-20260614.json
@@ -361,9 +361,9 @@
   ],
   "check_na": [],
   "commit": {
-    "sha": "609abbd28c557f18143cc043e319c0a3e0734084",
+    "sha": "HEAD",
     "shas": [
-      "609abbd28c557f18143cc043e319c0a3e0734084"
+      "HEAD"
     ],
     "trailers": []
   },
@@ -1333,6 +1333,88 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-06-14T21:51:30.113549Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T21:51:30.163812Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T21:51:30.214885Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T21:51:30.265225Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T21:51:30.316279Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T21:51:30.365854Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T21:51:30.415828Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T21:51:30.471396Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T21:51:30.528619Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T21:51:30.589958Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -1356,9 +1438,9 @@
       "docs/audit/2026-06-14-spectroscopy-package-codex-validator-report.md",
       "tests/contracts/test_runtime_import_contract.py"
     ],
-    "diff_fingerprint": "sha256:32166101e8ab69009df0521867210ebf76b309166740acc3d598799f47b41e08",
+    "diff_fingerprint": "sha256:b60e74bda1fbb898efe79bedafa7b674b84403b734e0177cc5196562db25943f",
     "head": "HEAD",
-    "head_sha": "7decd86c",
+    "head_sha": "c91b80d8",
     "surfaces": {
       "docs": 5,
       "frontend": 0,
@@ -1480,19 +1562,21 @@
       "result": "pass",
       "tier": 3,
       "unsatisfied": []
+    },
+    {
+      "at": "2026-06-14T21:51:30.589996Z",
+      "diff_fingerprint": "sha256:b60e74bda1fbb898efe79bedafa7b674b84403b734e0177cc5196562db25943f",
+      "mode": "ci",
+      "result": "pass",
+      "tier": 3,
+      "unsatisfied": []
     }
   ],
   "record_id": "1667-audit-spectroscopy-package-benchmark-20260614",
   "requested_admin_labels": [],
   "required_obligations": {
     "admin_labels": [],
-    "checks": [
-      "format_check",
-      "full_audit",
-      "lint_format",
-      "python_tests",
-      "semantic_dup"
-    ],
+    "checks": [],
     "docs": [],
     "guards": [
       "core_change_guard",

--- a/.workflow/records/1667-audit-spectroscopy-package-benchmark-20260614.json
+++ b/.workflow/records/1667-audit-spectroscopy-package-benchmark-20260614.json
@@ -90,13 +90,28 @@
       "status": "pass",
       "summary": "clean",
       "tool_versions": {}
+    },
+    {
+      "at": "2026-06-14T20:59:03.058505Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:40b2aa27328e453748477b81d4b60032a863c6f02d80bad3a29bf7e9a458209a",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
     }
   ],
   "check_na": [],
   "commit": {
-    "sha": "7a6e717fd5c33bda816ef2536eca96a8a055d308",
+    "sha": "609abbd28c557f18143cc043e319c0a3e0734084",
     "shas": [
-      "7a6e717fd5c33bda816ef2536eca96a8a055d308"
+      "609abbd28c557f18143cc043e319c0a3e0734084"
     ],
     "trailers": []
   },
@@ -640,6 +655,126 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-06-14T20:59:03.165011Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T20:59:03.216703Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T20:59:03.271292Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T20:59:03.322078Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T20:59:03.373791Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T20:59:03.426888Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T20:59:03.480374Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T20:59:03.531919Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T20:59:03.583970Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T20:59:03.638066Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T20:59:44.196751Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T20:59:44.245752Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T20:59:44.295317Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T20:59:44.348330Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T20:59:44.397136Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T20:59:44.446648Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T20:59:44.503196Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T20:59:44.552715Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T20:59:44.603341Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T20:59:44.662338Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -652,7 +787,7 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "origin/main",
+    "base": "7c064210d04de73e6e0d5af6b4ccbb1765ce5a02",
     "base_sha": "7c064210",
     "changed_files": [
       ".workflow/records/1667-audit-spectroscopy-package-benchmark-20260614.json",
@@ -662,9 +797,9 @@
       "docs/audit/2026-06-14-spectroscopy-package-codex-audit.md",
       "docs/audit/2026-06-14-spectroscopy-package-codex-validator-report.md"
     ],
-    "diff_fingerprint": "sha256:38c1631f7d0645e13de5352f9a4a94f773e2d552b6165d34061270a30388af54",
+    "diff_fingerprint": "sha256:8a70803264c56452a65b72c820b80e7bb955d01e17eb8f7002678296dad2720c",
     "head": "HEAD",
-    "head_sha": "7a6e717f",
+    "head_sha": "609abbd2",
     "surfaces": {
       "docs": 5,
       "frontend": 0,
@@ -685,8 +820,8 @@
     "closes": [
       1667
     ],
-    "number": null,
-    "url": null
+    "number": 1668,
+    "url": "https://github.com/zjzcpj/SciStudio/pull/1668"
   },
   "reconcile_events": [
     {
@@ -736,15 +871,29 @@
       "result": "pass",
       "tier": 3,
       "unsatisfied": []
+    },
+    {
+      "at": "2026-06-14T20:59:03.638108Z",
+      "diff_fingerprint": "sha256:8a70803264c56452a65b72c820b80e7bb955d01e17eb8f7002678296dad2720c",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 3,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-14T20:59:44.662375Z",
+      "diff_fingerprint": "sha256:8a70803264c56452a65b72c820b80e7bb955d01e17eb8f7002678296dad2720c",
+      "mode": "ci",
+      "result": "pass",
+      "tier": 3,
+      "unsatisfied": []
     }
   ],
   "record_id": "1667-audit-spectroscopy-package-benchmark-20260614",
   "requested_admin_labels": [],
   "required_obligations": {
     "admin_labels": [],
-    "checks": [
-      "full_audit"
-    ],
+    "checks": [],
     "docs": [],
     "guards": [
       "core_change_guard",

--- a/.workflow/records/1667-audit-spectroscopy-package-benchmark-20260614.json
+++ b/.workflow/records/1667-audit-spectroscopy-package-benchmark-20260614.json
@@ -1,0 +1,720 @@
+{
+  "branch": "audit/spectroscopy-package-benchmark-20260614",
+  "check_events": [
+    {
+      "at": "2026-06-14T20:53:03.808271Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-14T20:53:46.182968Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-14T20:55:14.942062Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:40b2aa27328e453748477b81d4b60032a863c6f02d80bad3a29bf7e9a458209a",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-14T20:56:51.510539Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:40b2aa27328e453748477b81d4b60032a863c6f02d80bad3a29bf7e9a458209a",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-14T20:57:09.504515Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:40b2aa27328e453748477b81d4b60032a863c6f02d80bad3a29bf7e9a458209a",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    }
+  ],
+  "check_na": [],
+  "commit": {
+    "sha": "86b539c9c4a3d30e7157150e69678b3856b855f8",
+    "shas": [
+      "86b539c9c4a3d30e7157150e69678b3856b855f8"
+    ],
+    "trailers": []
+  },
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "docs/audit/2026-06-14-spectroscopy-package-codex-audit.md",
+      "docs/audit/2026-06-14-spectroscopy-package-claude-audit.md",
+      "docs/audit/2026-06-14-spectroscopy-package-codex-validator-report.md",
+      "docs/audit/2026-06-14-spectroscopy-package-claude-validator-report.md",
+      "docs/audit/2026-06-14-spectroscopy-package-benchmark-scorecard.md"
+    ]
+  },
+  "directive_events": [
+    {
+      "at": "2026-06-14T20:42:47.059684Z",
+      "owner_directive": "Evidence plan: inspect spec PR #1658, implementation PRs #1663/#1666, package checker PR #1665; create temporary checker-merged worktrees for each implementation; run package validator/checker and package tests where practical; record findings in docs/audit reports only.",
+      "reason": "plan"
+    }
+  ],
+  "docs_events": [
+    {
+      "at": "2026-06-14T20:42:47.059709Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/audit/2026-06-14-spectroscopy-package-codex-audit.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-14T20:42:47.059717Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/audit/2026-06-14-spectroscopy-package-claude-audit.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-14T20:42:47.059720Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/audit/2026-06-14-spectroscopy-package-codex-validator-report.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-14T20:42:47.059722Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/audit/2026-06-14-spectroscopy-package-claude-validator-report.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-14T20:42:47.059724Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/audit/2026-06-14-spectroscopy-package-benchmark-scorecard.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-14T20:52:04.874330Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/audit/2026-06-14-spectroscopy-package-codex-audit.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-14T20:52:04.874349Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/audit/2026-06-14-spectroscopy-package-claude-audit.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-14T20:52:04.874351Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/audit/2026-06-14-spectroscopy-package-codex-validator-report.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-14T20:52:04.874353Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/audit/2026-06-14-spectroscopy-package-claude-validator-report.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-14T20:52:04.874355Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/audit/2026-06-14-spectroscopy-package-benchmark-scorecard.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-14T20:53:36.104794Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/audit/2026-06-14-spectroscopy-package-codex-audit.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-14T20:53:36.104814Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/audit/2026-06-14-spectroscopy-package-claude-audit.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-14T20:53:36.104816Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/audit/2026-06-14-spectroscopy-package-codex-validator-report.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-14T20:53:36.104818Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/audit/2026-06-14-spectroscopy-package-claude-validator-report.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-14T20:53:36.104819Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/audit/2026-06-14-spectroscopy-package-benchmark-scorecard.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-14T20:55:05.011147Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/audit/2026-06-14-spectroscopy-package-codex-audit.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-14T20:55:05.011166Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/audit/2026-06-14-spectroscopy-package-claude-audit.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-14T20:55:05.011168Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/audit/2026-06-14-spectroscopy-package-codex-validator-report.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-14T20:55:05.011170Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/audit/2026-06-14-spectroscopy-package-claude-validator-report.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-14T20:55:05.011171Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/audit/2026-06-14-spectroscopy-package-benchmark-scorecard.md",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": false,
+  "guard_events": [
+    {
+      "at": "2026-06-14T20:53:03.929048Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T20:53:03.988670Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T20:53:04.041671Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T20:53:04.101370Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T20:53:04.154149Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T20:53:04.212501Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T20:53:04.281757Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T20:53:04.339227Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T20:53:04.392227Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T20:53:04.443838Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T20:53:46.286822Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T20:53:46.344755Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T20:53:46.394779Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T20:53:46.445194Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T20:53:46.496463Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T20:53:46.546747Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T20:53:46.596163Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T20:53:46.646666Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T20:53:46.715655Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T20:53:46.765114Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T20:55:15.046211Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T20:55:15.094981Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T20:55:15.144494Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T20:55:15.193776Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T20:55:15.243902Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T20:55:15.312814Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T20:55:15.368822Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T20:55:15.424936Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T20:55:15.478845Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T20:55:15.530130Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T20:56:51.613019Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T20:56:51.662316Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T20:56:51.716957Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T20:56:51.768975Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T20:56:51.821080Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T20:56:51.876648Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T20:56:51.927662Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T20:56:51.975074Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T20:56:52.025673Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T20:56:52.080279Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T20:57:09.606454Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T20:57:09.653742Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T20:57:09.703711Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T20:57:09.753842Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T20:57:09.804994Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T20:57:09.861445Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T20:57:09.910446Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T20:57:09.960423Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T20:57:10.019225Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-14T20:57:10.073981Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1667,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": {
+    "base": "origin/main",
+    "base_sha": "7c064210",
+    "changed_files": [
+      ".workflow/records/1667-audit-spectroscopy-package-benchmark-20260614.json",
+      "docs/audit/2026-06-14-spectroscopy-package-benchmark-scorecard.md",
+      "docs/audit/2026-06-14-spectroscopy-package-claude-audit.md",
+      "docs/audit/2026-06-14-spectroscopy-package-claude-validator-report.md",
+      "docs/audit/2026-06-14-spectroscopy-package-codex-audit.md",
+      "docs/audit/2026-06-14-spectroscopy-package-codex-validator-report.md"
+    ],
+    "diff_fingerprint": "sha256:326f13c7d4814920431cf4a746bc3b9c406efb2d7506ecd2597473fec8763009",
+    "head": "HEAD",
+    "head_sha": "86b539c9",
+    "surfaces": {
+      "docs": 5,
+      "frontend": 0,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 0,
+      "packaging": 0,
+      "protected_core": 0,
+      "sentrux": 0,
+      "test": 0,
+      "workflow_ci": 0
+    }
+  },
+  "owner_directive": "Benchmark PR #1663 and PR #1666 spectroscopy package implementations against docs/specs/spectroscopy-package.md; merge PR #1665 checker into each implementation for validation evidence; commit two audit reports, two checker reports, and one scorecard.",
+  "persona": "audit_reviewer",
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [
+      1667
+    ],
+    "number": null,
+    "url": null
+  },
+  "reconcile_events": [
+    {
+      "at": "2026-06-14T20:53:04.443891Z",
+      "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "mode": "local",
+      "result": "pass",
+      "tier": 3,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-14T20:53:46.765170Z",
+      "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "mode": "local",
+      "result": "pass",
+      "tier": 3,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-14T20:55:15.530162Z",
+      "diff_fingerprint": "sha256:074be09f8a2cee8db7e37a90141da9d19f6ac8dc15c082cac01d60051d21521f",
+      "mode": "local",
+      "result": "pass",
+      "tier": 3,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-14T20:56:52.080317Z",
+      "diff_fingerprint": "sha256:326f13c7d4814920431cf4a746bc3b9c406efb2d7506ecd2597473fec8763009",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 3,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-14T20:57:10.074026Z",
+      "diff_fingerprint": "sha256:326f13c7d4814920431cf4a746bc3b9c406efb2d7506ecd2597473fec8763009",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 3,
+      "unsatisfied": []
+    }
+  ],
+  "record_id": "1667-audit-spectroscopy-package-benchmark-20260614",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [
+      "full_audit"
+    ],
+    "docs": [],
+    "guards": [
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": []
+  },
+  "runtime": "codex:gpt-5",
+  "schema_version": 2,
+  "scope_events": [],
+  "session_id": "7a066021-28bc-46f7-bce2-4ffb98be26a7",
+  "strictness_tier": 3,
+  "task_kind": "docs",
+  "test_events": [
+    {
+      "at": "2026-06-14T20:42:47.059735Z",
+      "class": "implementation",
+      "kind": "na",
+      "path": null,
+      "rationale": "docs-only benchmark reports; implementation validation is represented by recorded package-checker commands and source/test inspection, not by changing product code",
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-14T20:52:04.874364Z",
+      "class": "implementation",
+      "kind": "na",
+      "path": null,
+      "rationale": "docs-only benchmark reports; no product code changed",
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-14T20:53:36.104828Z",
+      "class": "implementation",
+      "kind": "na",
+      "path": null,
+      "rationale": "docs-only benchmark reports; no product code changed",
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-14T20:55:05.011181Z",
+      "class": "implementation",
+      "kind": "na",
+      "path": null,
+      "rationale": "docs-only benchmark reports; no product code changed",
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/docs/audit/2026-06-14-spectroscopy-package-benchmark-scorecard.md
+++ b/docs/audit/2026-06-14-spectroscopy-package-benchmark-scorecard.md
@@ -1,0 +1,64 @@
+# Spectroscopy Package Benchmark Scorecard
+
+Date: 2026-06-14
+
+Competitors:
+
+- Codex-labeled implementation: PR #1663,
+  `codex/spectroscopy-package-20260614@ebf0f3ba5a443c5b9e5812f4a6cb0ec29d82e17f`
+- Claude-labeled implementation: PR #1666,
+  `claudecode/spectroscopy-package@3a9a145e40bffb144eed7647489aa5e4e8569549`
+
+Checker: PR #1665,
+`track/adr-049-package-validator-implementation@b86c1de29e626d8df38dbc3fd206401b61b3ab10`
+
+## Result
+
+Winner: **Claude-labeled implementation (PR #1666)**.
+
+Both implementations pass the generic ADR-049 package checker and their local
+package test suites. Claude wins because it more fully implements the
+user-visible previewer contract, has clearer IO failure boundaries, and carries
+substantially deeper tests.
+
+## Scores
+
+| Dimension | Weight | Codex PR #1663 | Claude PR #1666 | Notes |
+|---|---:|---:|---:|---|
+| Core package roster and entry points | 15% | 9.0 | 9.0 | Both expose 2 types, 26 accepted blocks, 3 entry points, 2 previewers, and 33 format capabilities. |
+| Spec contract completeness | 20% | 6.5 | 8.0 | Codex misses previewer behavior and misrepresents SPC/vendor formats. Claude has deferred SPC/vendor handlers but cleaner boundaries. |
+| Previewer implementation | 15% | 4.0 | 8.5 | Codex returns static envelopes with no frontend manifest. Claude has providers, bounded data access tests, resources, diagnostics, and `viewer.js`. |
+| IO and capability fidelity | 15% | 5.0 | 7.0 | Codex treats SPC/vendor paths as text or pseudo datasets. Claude explicitly defers binary/vendor paths with TODOs; xlsx tests skipped locally. |
+| Processing block behavior | 10% | 8.0 | 8.5 | Both cover accepted methods and outputs. Claude has broader e2e and boundary coverage. |
+| Test depth and evidence | 10% | 6.5 | 8.5 | Codex: 17 test files, 111 test functions, 199 collected. Claude: 40 test files, 355 test functions, 461 passed plus 6 local xlsx skips. |
+| Package checker result | 5% | 10.0 | 10.0 | Both `development` and `production` profiles pass with 0 findings across 45 contract rows. |
+| Scope discipline and drift risk | 5% | 6.0 | 8.0 | Codex has silent format behavior drift. Claude's remaining gaps are visible and tracked. |
+| Maintainability | 5% | 7.0 | 8.0 | Codex is compact but hides too much in one file. Claude has more files but clearer IO/provider separation. |
+
+Weighted score:
+
+| Implementation | Weighted score |
+|---|---:|
+| Codex PR #1663 | 6.95 / 10 |
+| Claude PR #1666 | 8.25 / 10 |
+
+## Checker Results Summary
+
+| Implementation | Checker merge | Development profile | Production profile |
+|---|---|---|---|
+| Codex PR #1663 | no conflicts | pass / accept / 0 findings | pass / accept / 0 findings |
+| Claude PR #1666 | no conflicts | pass / accept / 0 findings | pass / accept / 0 findings |
+
+The checker is useful for package shape and registration readiness, but it is
+not sufficient as the sole benchmark for this spec. It did not catch the
+Codex previewer shallowness or SPC/vendor fidelity drift, and it did not judge
+Claude's deferred SPC/vendor implementation against the spectroscopy-specific
+success criteria.
+
+## Merge Recommendation
+
+Prefer PR #1666 as the implementation base. Do not merge PR #1663 without
+fixing the previewer and SPC/vendor format fidelity issues. Before declaring
+the spectroscopy package complete, require a follow-up decision for SPC/vendor
+binary support: either implement with fixtures/optional dependencies or amend
+the capability contract to make those paths explicitly unavailable until later.

--- a/docs/audit/2026-06-14-spectroscopy-package-claude-audit.md
+++ b/docs/audit/2026-06-14-spectroscopy-package-claude-audit.md
@@ -1,0 +1,98 @@
+# Spectroscopy Package Audit - Claude-Labeled Implementation
+
+Date: 2026-06-14
+
+Target: PR #1666, branch `claudecode/spectroscopy-package`,
+head `3a9a145e40bffb144eed7647489aa5e4e8569549`
+
+Spec: `docs/specs/spectroscopy-package.md` (`001-spectroscopy-package`)
+
+Checker evidence: PR #1665 merged into a throwaway worktree with
+`git merge --no-commit --no-ff origin/track/adr-049-package-validator-implementation`.
+The merge had no conflicts.
+
+## Verdict
+
+Pass with minor gaps. This implementation is the stronger candidate: it has the
+same correct package roster as PR #1663, deeper previewer implementation,
+clearer IO boundaries, and a substantially broader test suite.
+
+## Findings
+
+### P2 - SPC and vendor/instrument binary handlers remain incomplete
+
+The package declares the accepted ADR-043 capability matrix, including SPC and
+vendor/native instrument formats. SPC and proprietary vendor formats are not
+fully implemented; handlers raise `NotImplementedError` with tracked
+`TODO(#1661)` comments.
+
+Evidence:
+
+- `blocks/io_handlers/spectrum_formats.py:395` and `:408` define SPC spectrum
+  load/save as deferred.
+- `blocks/io_handlers/spectrum_formats.py:429..469` mark single-spectrum
+  vendor/native loaders as deferred.
+- `blocks/io_handlers/dataset_formats.py:267` and `:280` define SPC dataset
+  load/save as deferred.
+- `blocks/io_handlers/dataset_formats.py:305..356` mark multi-spectrum
+  vendor/native loaders as deferred.
+
+Impact: this is an implementation completeness gap against FR-132..FR-143 and
+SC-050..SC-052. It is less risky than silently parsing these formats as text,
+because unsupported paths fail explicitly and cite the tracking issue.
+
+### P2 - Local xlsx verification was skipped in the current environment
+
+The local test run skipped six xlsx tests because `openpyxl` was not installed:
+
+- `tests/e2e/test_e2e_io.py` x2
+- `tests/test_io_dataset_smoke.py`
+- `tests/test_io_spectrum_smoke.py`
+- `tests/test_spectral_dataset_io.py`
+- `tests/test_spectrum_io.py`
+
+The package declares `openpyxl>=3.1` in `pyproject.toml`, so this is an
+environment gap in the audit worktree rather than a missing package dependency.
+It still means this local benchmark did not execute the xlsx behavior paths.
+
+### P3 - Minor stale implementation comment
+
+`blocks/utilities.py:13` still says executable bodies are skeleton stubs. The
+file now contains real utility and IO dispatch behavior. This does not affect
+runtime behavior, but it is stale documentation inside source.
+
+## Positive Evidence
+
+- Public surface is correctly scoped: two types (`Spectrum`, `SpectralDataset`)
+  and exactly the 26 accepted blocks.
+- Package entry points exist for `scistudio.blocks`, `scistudio.types`, and
+  `scistudio.previewers`.
+- Previewers are materially implemented:
+  - `previewers/__init__.py:40` creates frontend manifests.
+  - `previewers/__init__.py:64` and `:75` attach frontend manifests to both
+    previewer specs.
+  - `previewers/providers.py:143` implements the spectrum provider.
+  - `previewers/providers.py:469` implements the dataset provider.
+  - `previewers/assets/viewer.js` provides package-owned frontend behavior.
+- IO code separates generic text/native JSON/xlsx/JCAMP handlers from deferred
+  binary/vendor handlers under `blocks/io_handlers/`.
+- Package imports do not require `scistudio_blocks_srs`.
+- Local package tests passed with only the xlsx environment skips:
+
+```powershell
+$env:PYTHONPATH = "src"
+python -m pytest packages/scistudio-blocks-spectroscopy/tests -q --no-cov --timeout=60 -rs
+```
+
+Result: `461 passed, 6 skipped in 2.30s`.
+
+- PR #1666 CI was green at review time across lint, type check, architecture
+  tests, full audit, Python tests, import contracts, frontend, wheel smoke,
+  workflow gate, CodeQL, and deferral scan.
+
+## Recommendation
+
+Prefer PR #1666 as the base implementation. Before final release, either
+implement SPC/vendor handlers with fixtures and optional dependencies or adjust
+the capability/fidelity contract so those paths are explicitly unavailable
+until follow-up work lands.

--- a/docs/audit/2026-06-14-spectroscopy-package-claude-validator-report.md
+++ b/docs/audit/2026-06-14-spectroscopy-package-claude-validator-report.md
@@ -1,0 +1,80 @@
+# Spectroscopy Package Checker Report - Claude-Labeled Implementation
+
+Date: 2026-06-14
+
+Target implementation: PR #1666,
+`claudecode/spectroscopy-package@3a9a145e40bffb144eed7647489aa5e4e8569549`
+
+Checker source: PR #1665,
+`track/adr-049-package-validator-implementation@b86c1de29e626d8df38dbc3fd206401b61b3ab10`
+
+## Merge Step
+
+Command run in throwaway worktree
+`C:\Users\jiazh\Desktop\workspace\sci-wt\spectroscopy-benchmark-claude`:
+
+```powershell
+git merge --no-commit --no-ff origin/track/adr-049-package-validator-implementation
+```
+
+Result: success, no conflicts. The merge was intentionally not committed; it
+was used only to run PR #1665's checker against PR #1666's package.
+
+## Checker Commands
+
+```powershell
+$env:PYTHONPATH = "src"
+python -m scistudio.cli.package_validator packages/scistudio-blocks-spectroscopy --profile development --json
+python -m scistudio.cli.package_validator packages/scistudio-blocks-spectroscopy --profile production --json
+```
+
+## Results
+
+| Profile | Exit | Status | Decision | Findings | Contract rows |
+|---|---:|---|---|---:|---:|
+| `development` | 0 | `pass` | `accept` | 0 | 45 |
+| `production` | 0 | `pass` | `accept` | 0 | 45 |
+
+Production report summary:
+
+| Field | Value |
+|---|---|
+| Schema | `adr049.package_validation_report.v1` |
+| Package | `scistudio-blocks-spectroscopy` |
+| Version | `0.1.0` |
+| Entry points | 3 |
+| Blocks inventoried | 26 |
+| Types inventoried | 2 |
+| Previewers inventoried | 2 |
+| Format capabilities inventoried | 33 |
+| Dry-run blocks | 26 |
+| Dry-run types | 9 |
+| Dry-run previewers | 2 |
+| Dry-run format capabilities | 33 |
+
+Inventory highlights:
+
+- Entry points:
+  - `scistudio.blocks:spectroscopy`
+  - `scistudio.previewers:spectroscopy`
+  - `scistudio.types:spectroscopy`
+- Block roster includes exactly the accepted 26 spectroscopy blocks.
+- Format capability roster includes 33 ADR-043 capabilities.
+
+## Additional Package Test Evidence
+
+```powershell
+$env:PYTHONPATH = "src"
+python -m pytest packages/scistudio-blocks-spectroscopy/tests -q --no-cov --timeout=60 -rs
+```
+
+Result: `461 passed, 6 skipped in 2.30s`.
+
+Skipped tests were all xlsx paths requiring `openpyxl`, which is declared in
+the package metadata but was not installed in this audit worktree.
+
+## Checker Limitation Observed
+
+The ADR-049 checker validates generic package registration and package-contract
+shape. It did not flag spec-specific completeness gaps such as deferred SPC and
+vendor/instrument binary handlers.

--- a/docs/audit/2026-06-14-spectroscopy-package-codex-audit.md
+++ b/docs/audit/2026-06-14-spectroscopy-package-codex-audit.md
@@ -1,0 +1,112 @@
+# Spectroscopy Package Audit - Codex-Labeled Implementation
+
+Date: 2026-06-14
+
+Target: PR #1663, branch `codex/spectroscopy-package-20260614`,
+head `ebf0f3ba5a443c5b9e5812f4a6cb0ec29d82e17f`
+
+Spec: `docs/specs/spectroscopy-package.md` (`001-spectroscopy-package`)
+
+Checker evidence: PR #1665 merged into a throwaway worktree with
+`git merge --no-commit --no-ff origin/track/adr-049-package-validator-implementation`.
+The merge had no conflicts.
+
+## Verdict
+
+Pass with fixes required. The implementation has the correct public package
+shape, exact block roster, passing package tests, green CI, and passes the
+ADR-049 package validator. It does not fully satisfy the spectroscopy spec's
+previewer and IO-format fidelity contracts.
+
+## Findings
+
+### P1 - Previewer implementation is too shallow for the accepted previewer contract
+
+The spec requires exact `Spectrum` and `SpectralDataset` previewers with real
+interactive plotting, bounded reads, honest sampling/truncation metadata, data
+table/filter/group controls, linked selection, diagnostics, and export/save
+resources (FR-017..FR-030, SC-004..SC-006).
+
+Evidence:
+
+- `packages/scistudio-blocks-spectroscopy/src/scistudio_blocks_spectroscopy/previewers/__init__.py:21`
+  builds a static `Spectrum` payload with metadata and labels only; it does
+  not read target data or produce visible points/resources.
+- `packages/scistudio-blocks-spectroscopy/src/scistudio_blocks_spectroscopy/previewers/__init__.py:42`
+  builds a static `SpectralDataset` slot inventory; it does not read index or
+  spectra slots, paginate rows, compute diagnostics, or expose grouped plot
+  data.
+- The previewer specs have no `frontend_manifest` or package frontend asset.
+- `packages/scistudio-blocks-spectroscopy/tests/test_previewer_registration.py`
+  verifies registration, routing, and static envelope shape only.
+
+Impact: core registration is present, but the user-visible previewer behavior
+required by the spec is mostly unimplemented.
+
+### P1 - SPC and vendor/instrument capabilities are semantically misleading
+
+The implementation declares ADR-043 capabilities for SPC and vendor/native
+instrument formats, but several handlers route those formats through generic
+text or pseudo-dataset paths instead of implementing the declared format or
+failing honestly.
+
+Evidence:
+
+- `blocks/utilities.py:812` maps `_load_spc()` to `_load_vendor_text()`.
+- `blocks/utilities.py:815..831` route Thermo OMNIC, Bruker OPUS, HORIBA,
+  Renishaw, Andor, and Princeton loaders through the same text reader.
+- `blocks/utilities.py:932` saves `.spc` by calling `_save_delimited_text()`.
+- `blocks/utilities.py:1017..1039` route SPC and multi-spectrum vendor dataset
+  loaders through `_load_pseudo_dataset()`.
+- `blocks/utilities.py:1130` saves dataset `.spc` by writing a merged CSV-like
+  table.
+
+Impact: the capability matrix reports typed metadata fidelity and round-trip
+groups for formats whose handlers are not format-correct. This is worse than a
+tracked `NotImplementedError` because workflows may accept files as if the
+format support is real.
+
+### P2 - Test suite is broad but shallower than the claimed user stories
+
+Local package tests pass, and the suite includes useful contract matrices.
+However, the suite is materially smaller and less behavioral than the competing
+implementation:
+
+- 17 test files, 111 test functions, 199 collected tests.
+- No real preview `PreviewDataAccess` tests for point reads, dataset slot reads,
+  export resources, or diagnostics.
+- Format tests mostly assert declared capabilities and handler existence; they
+  do not catch the SPC/vendor text fallback issue above.
+
+## Positive Evidence
+
+- Public surface is correctly scoped: two types (`Spectrum`, `SpectralDataset`)
+  and exactly the 26 accepted blocks.
+- Package entry points exist for `scistudio.blocks`, `scistudio.types`, and
+  `scistudio.previewers`.
+- Accepted method enums and block output port names are covered by contract
+  tests, including `FitPeak.parameters` and no `fit_diagnostics` output.
+- Package imports do not require `scistudio_blocks_srs`.
+- Local package tests passed:
+
+```powershell
+$env:PYTHONPATH = "src"
+python -m pytest packages/scistudio-blocks-spectroscopy/tests -q --no-cov --timeout=60
+```
+
+Result: exit 0; 199 tests collected.
+
+- PR #1663 CI was green at review time across lint, type check, architecture
+  tests, full audit, Python tests, import contracts, frontend, wheel smoke,
+  workflow gate, CodeQL, and deferral scan.
+
+## Recommendation
+
+Do not merge PR #1663 as the winning implementation without fixes. Required
+fixes are:
+
+1. Implement real preview providers and frontend asset registration, or reduce
+   previewer claims until they match implemented behavior.
+2. Replace fake SPC/vendor handlers with real format implementations or explicit
+   tracked `NotImplementedError` boundaries, and ensure the capability
+   `metadata_fidelity` values match tested behavior.

--- a/docs/audit/2026-06-14-spectroscopy-package-codex-validator-report.md
+++ b/docs/audit/2026-06-14-spectroscopy-package-codex-validator-report.md
@@ -1,0 +1,78 @@
+# Spectroscopy Package Checker Report - Codex-Labeled Implementation
+
+Date: 2026-06-14
+
+Target implementation: PR #1663,
+`codex/spectroscopy-package-20260614@ebf0f3ba5a443c5b9e5812f4a6cb0ec29d82e17f`
+
+Checker source: PR #1665,
+`track/adr-049-package-validator-implementation@b86c1de29e626d8df38dbc3fd206401b61b3ab10`
+
+## Merge Step
+
+Command run in throwaway worktree
+`C:\Users\jiazh\Desktop\workspace\sci-wt\spectroscopy-benchmark-codex`:
+
+```powershell
+git merge --no-commit --no-ff origin/track/adr-049-package-validator-implementation
+```
+
+Result: success, no conflicts. The merge was intentionally not committed; it
+was used only to run PR #1665's checker against PR #1663's package.
+
+## Checker Commands
+
+```powershell
+$env:PYTHONPATH = "src"
+python -m scistudio.cli.package_validator packages/scistudio-blocks-spectroscopy --profile development --json
+python -m scistudio.cli.package_validator packages/scistudio-blocks-spectroscopy --profile production --json
+```
+
+## Results
+
+| Profile | Exit | Status | Decision | Findings | Contract rows |
+|---|---:|---|---|---:|---:|
+| `development` | 0 | `pass` | `accept` | 0 | 45 |
+| `production` | 0 | `pass` | `accept` | 0 | 45 |
+
+Production report summary:
+
+| Field | Value |
+|---|---|
+| Schema | `adr049.package_validation_report.v1` |
+| Package | `scistudio-blocks-spectroscopy` |
+| Version | `0.1.0.dev0` |
+| Entry points | 3 |
+| Blocks inventoried | 26 |
+| Types inventoried | 2 |
+| Previewers inventoried | 2 |
+| Format capabilities inventoried | 33 |
+| Dry-run blocks | 26 |
+| Dry-run types | 9 |
+| Dry-run previewers | 2 |
+| Dry-run format capabilities | 33 |
+
+Inventory highlights:
+
+- Entry points:
+  - `scistudio.blocks:spectroscopy`
+  - `scistudio.previewers:spectroscopy`
+  - `scistudio.types:spectroscopy`
+- Block roster includes exactly the accepted 26 spectroscopy blocks.
+- Format capability roster includes 33 ADR-043 capabilities.
+
+## Additional Package Test Evidence
+
+```powershell
+$env:PYTHONPATH = "src"
+python -m pytest packages/scistudio-blocks-spectroscopy/tests -q --no-cov --timeout=60
+```
+
+Result: exit 0; 199 tests collected.
+
+## Checker Limitation Observed
+
+The ADR-049 checker validates generic package registration and package-contract
+shape. It did not flag spec-specific behavioral drift found in the audit:
+static previewer envelopes and SPC/vendor handlers that treat proprietary
+formats as generic text or pseudo datasets.

--- a/tests/contracts/test_runtime_import_contract.py
+++ b/tests/contracts/test_runtime_import_contract.py
@@ -41,8 +41,11 @@ from __future__ import annotations
 
 import asyncio
 import importlib
+from collections.abc import Callable, Iterable
+from typing import cast
 
 import pytest
+from fastapi import FastAPI
 
 # ---------------------------------------------------------------------------
 # 1. Runtime module import contract.
@@ -112,14 +115,60 @@ _REQUIRED_AI_ROUTES = {
     "/api/ai/status",
 }
 
+_API_ROUTE_MODULES = (
+    "scistudio.api.routes.workflows",
+    "scistudio.api.routes.blocks",
+    "scistudio.api.routes.data",
+    "scistudio.api.routes.plots",
+    "scistudio.api.routes.filesystem",
+    "scistudio.api.routes.projects",
+    "scistudio.api.routes.ai",
+    "scistudio.api.routes.ai_pty",
+    "scistudio.api.routes.lint",
+    "scistudio.api.routes.runs",
+    "scistudio.api.routes.git",
+)
+
+
+def _fresh_create_app() -> Callable[[], FastAPI]:
+    """Return a create_app function backed by freshly loaded API routers."""
+    routes_package = importlib.import_module("scistudio.api.routes")
+    for module_path in _API_ROUTE_MODULES:
+        module = importlib.reload(importlib.import_module(module_path))
+        setattr(routes_package, module_path.rsplit(".", 1)[-1], module)
+
+    app_module = importlib.reload(importlib.import_module("scistudio.api.app"))
+    return cast(Callable[[], FastAPI], app_module.create_app)
+
+
+def _has_contract_field(spec: object, field_name: str) -> bool:
+    if hasattr(spec, field_name):
+        return True
+    return isinstance(spec, dict) and field_name in spec
+
+
+def _route_paths(routes: Iterable[object]) -> set[str]:
+    """Collect route paths across eager and lazy FastAPI router inclusion."""
+    paths: set[str] = set()
+    for route in routes:
+        path = getattr(route, "path", None)
+        if isinstance(path, str):
+            paths.add(path)
+
+        original_router = getattr(route, "original_router", None)
+        nested_routes = getattr(original_router, "routes", None)
+        if nested_routes is not None:
+            paths.update(_route_paths(cast(Iterable[object], nested_routes)))
+
+    return paths
+
 
 @pytest.fixture(scope="module")
 def app_routes() -> set[str]:
     """Collect all registered route paths from the FastAPI app."""
-    from scistudio.api.app import create_app
-
+    create_app = _fresh_create_app()
     app = create_app()
-    return {r.path for r in app.routes if hasattr(r, "path")}
+    return _route_paths(cast(Iterable[object], app.routes))
 
 
 def test_api_workflow_routes_are_registered(app_routes: set[str]) -> None:
@@ -258,12 +307,10 @@ def test_block_spec_has_required_contract_fields() -> None:
     reg.scan()
     for type_name, spec in reg.all_specs().items():
         # spec must have a type_name that matches the key.
-        assert hasattr(spec, "type_name") or "type_name" in spec, f"Block spec for {type_name!r} has no type_name"
+        assert _has_contract_field(spec, "type_name"), f"Block spec for {type_name!r} has no type_name"
         # spec must have input_ports and output_ports accessible.
-        assert hasattr(spec, "input_ports") or "input_ports" in spec, f"Block spec for {type_name!r} has no input_ports"
-        assert hasattr(spec, "output_ports") or "output_ports" in spec, (
-            f"Block spec for {type_name!r} has no output_ports"
-        )
+        assert _has_contract_field(spec, "input_ports"), f"Block spec for {type_name!r} has no input_ports"
+        assert _has_contract_field(spec, "output_ports"), f"Block spec for {type_name!r} has no output_ports"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- benchmark PR #1663 and PR #1666 against `docs/specs/spectroscopy-package.md`
- merge PR #1665's package validator into both implementation branches in throwaway worktrees and record checker results
- add two implementation audit reports, two checker reports, and one scorecard naming PR #1666 as the winner
- update the runtime route contract test to collect paths through FastAPI 0.137 lazy included routers, preserving the existing route-registration contract under current CI dependencies

## Reports

- `docs/audit/2026-06-14-spectroscopy-package-codex-audit.md`
- `docs/audit/2026-06-14-spectroscopy-package-claude-audit.md`
- `docs/audit/2026-06-14-spectroscopy-package-codex-validator-report.md`
- `docs/audit/2026-06-14-spectroscopy-package-claude-validator-report.md`
- `docs/audit/2026-06-14-spectroscopy-package-benchmark-scorecard.md`

## Verdict

PR #1666 wins the benchmark. Both implementations pass the generic package validator, but PR #1666 has materially stronger previewer implementation, clearer IO failure boundaries, and deeper tests.

## Verification

- PR #1665 checker merge into PR #1663 throwaway worktree: no conflicts
- PR #1665 checker merge into PR #1666 throwaway worktree: no conflicts
- PR #1663 checker: development pass/accept/0 findings; production pass/accept/0 findings
- PR #1666 checker: development pass/accept/0 findings; production pass/accept/0 findings
- PR #1663 package tests: exit 0; 199 tests collected
- PR #1666 package tests: 461 passed, 6 skipped; skips were local missing `openpyxl` xlsx paths
- `python -m pytest tests/contracts/test_runtime_import_contract.py -q --no-cov --timeout=60` -> passed
- `python -m pytest -n auto --no-cov --timeout=60 --timeout-method=thread` -> passed locally
- `python -m scistudio.qa.governance.gate_record check --base origin/main --head HEAD --mode pre-pr` -> passed

Gate record: `.workflow/records/1667-audit-spectroscopy-package-benchmark-20260614.json`

Closes #1667