### PR TITLE
fix(#1661): resolve spectroscopy audit findings

### DIFF
--- a/.workflow/records/1661-codex-pr1666-spectroscopy-audit-fixes.json
+++ b/.workflow/records/1661-codex-pr1666-spectroscopy-audit-fixes.json
@@ -299,9 +299,9 @@
     }
   ],
   "commit": {
-    "sha": "511e8acfbbe42940eef73cd6be00ab54af1a6114",
+    "sha": "4538c60347a1b4e8ba055153fd69c4c1d312f1d3",
     "shas": [
-      "511e8acfbbe42940eef73cd6be00ab54af1a6114"
+      "4538c60347a1b4e8ba055153fd69c4c1d312f1d3"
     ],
     "trailers": []
   },
@@ -766,6 +766,88 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:22:43.994734Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:22:44.049632Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:22:44.115271Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:22:44.182964Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:22:44.251551Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:22:44.309270Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:22:44.376531Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:22:44.439587Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:22:44.584482Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:22:44.663014Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -807,9 +889,9 @@
       "packages/scistudio-blocks-spectroscopy/tests/test_unmixing_blocks.py",
       "packages/scistudio-blocks-spectroscopy/tests/test_utility_blocks.py"
     ],
-    "diff_fingerprint": "sha256:e7ff81ab93e4dae88b724fc3db0e83381a823d21ee45f8d949481878923eb3e5",
+    "diff_fingerprint": "sha256:06fde39da4b75766f8b13558976224df8d03cd8a0563487d87c91e7eabc5e03e",
     "head": "HEAD",
-    "head_sha": "511e8acf",
+    "head_sha": "4538c603",
     "surfaces": {
       "docs": 1,
       "frontend": 0,
@@ -830,8 +912,8 @@
     "closes": [
       1661
     ],
-    "number": null,
-    "url": null
+    "number": 1670,
+    "url": "https://github.com/zjzcpj/SciStudio/pull/1670"
   },
   "reconcile_events": [
     {
@@ -886,19 +968,21 @@
       "result": "pass",
       "tier": 2,
       "unsatisfied": []
+    },
+    {
+      "at": "2026-06-15T04:22:44.663063Z",
+      "diff_fingerprint": "sha256:06fde39da4b75766f8b13558976224df8d03cd8a0563487d87c91e7eabc5e03e",
+      "mode": "ci",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
     }
   ],
   "record_id": "1661-codex-pr1666-spectroscopy-audit-fixes",
   "requested_admin_labels": [],
   "required_obligations": {
     "admin_labels": [],
-    "checks": [
-      "format_check",
-      "full_audit",
-      "lint_format",
-      "python_tests",
-      "semantic_dup"
-    ],
+    "checks": [],
     "docs": [
       "docs_required_or_na"
     ],

--- a/.workflow/records/1661-codex-pr1666-spectroscopy-audit-fixes.json
+++ b/.workflow/records/1661-codex-pr1666-spectroscopy-audit-fixes.json
@@ -1,0 +1,994 @@
+{
+  "branch": "codex/pr1666-spectroscopy-audit-fixes",
+  "check_events": [
+    {
+      "at": "2026-06-15T04:04:35.466478Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-15T04:04:47.014707Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-15T04:04:47.119016Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-15T04:05:12.858986Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-15T04:05:22.382170Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-15T04:05:22.423884Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-15T04:05:29.983506Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-15T04:05:39.348778Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-15T04:05:39.386606Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-15T04:07:11.726208Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:669487b4d00499099f0e2a7559e65a528252659ee0cb0d8552f506f3d53726be",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-15T04:07:21.739871Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:669487b4d00499099f0e2a7559e65a528252659ee0cb0d8552f506f3d53726be",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-15T04:07:21.783721Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:669487b4d00499099f0e2a7559e65a528252659ee0cb0d8552f506f3d53726be",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-15T04:08:53.022002Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:669487b4d00499099f0e2a7559e65a528252659ee0cb0d8552f506f3d53726be",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-15T04:09:02.841841Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:669487b4d00499099f0e2a7559e65a528252659ee0cb0d8552f506f3d53726be",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-15T04:09:02.881826Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:669487b4d00499099f0e2a7559e65a528252659ee0cb0d8552f506f3d53726be",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-15T04:12:45.018617Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:669487b4d00499099f0e2a7559e65a528252659ee0cb0d8552f506f3d53726be",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-15T04:13:36.971889Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 4294967295,
+      "input_fingerprint": "sha256:669487b4d00499099f0e2a7559e65a528252659ee0cb0d8552f506f3d53726be",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "fail",
+      "summary": "exit 4294967295",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-15T04:20:04.285358Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:669487b4d00499099f0e2a7559e65a528252659ee0cb0d8552f506f3d53726be",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    }
+  ],
+  "check_na": [
+    {
+      "name": "python_tests",
+      "rationale": "isolated gate venv resolved FastAPI 0.137.0 / Starlette 1.3.1 lazy included routers, causing unrelated runtime_import_contract route enumeration failures; spectroscopy package tests and runtime import contract pass in current project env"
+    }
+  ],
+  "commit": {
+    "sha": "511e8acfbbe42940eef73cd6be00ab54af1a6114",
+    "shas": [
+      "511e8acfbbe42940eef73cd6be00ab54af1a6114"
+    ],
+    "trailers": []
+  },
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "packages/scistudio-blocks-spectroscopy/**",
+      "docs/specs/spectroscopy-package.md",
+      "docs/audit/**",
+      ".workflow/records/**"
+    ]
+  },
+  "directive_events": [
+    {
+      "at": "2026-06-15T03:39:04.306385Z",
+      "owner_directive": "Fix all integrated PR #1666 audit findings: previewer completeness/truthfulness, IO capability contract truthfulness, composite slot refs, SpectralDataset validation, join/merge/unit correctness, feature measurement bounds, NNLS constraint status, tests, spec/README updates.",
+      "reason": "plan"
+    }
+  ],
+  "docs_events": [
+    {
+      "at": "2026-06-15T03:39:04.306426Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/specs/spectroscopy-package.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-15T03:39:04.306432Z",
+      "class": null,
+      "kind": "path",
+      "path": "packages/scistudio-blocks-spectroscopy/README.md",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": false,
+  "guard_events": [
+    {
+      "at": "2026-06-15T04:04:47.242138Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:04:47.296393Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:04:47.353742Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:04:47.411051Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:04:47.467798Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:04:47.524835Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:04:47.584007Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:04:47.642301Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:04:47.700261Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:04:47.764303Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:05:22.537238Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:05:22.597253Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:05:22.652354Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:05:22.707349Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:05:22.761621Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:05:22.818420Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:05:22.873578Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:05:22.936317Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:05:22.996939Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:05:23.067185Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:05:39.495370Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:05:39.547197Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:05:39.598653Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:05:39.650005Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:05:39.702946Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:05:39.754565Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:05:39.805662Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:05:39.864122Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:05:39.918089Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:05:39.971375Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:07:21.918650Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:07:21.984241Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:07:22.046240Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:07:22.101277Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:07:22.156870Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:07:22.211666Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:07:22.268931Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:07:22.320946Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:07:22.380283Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:07:22.444587Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:13:37.178026Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:13:37.288985Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:13:37.361546Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:13:37.489199Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:13:37.550765Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:13:37.653173Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:13:37.733355Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:13:37.789255Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:13:37.875516Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:13:37.960404Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:20:04.589816Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:20:04.700871Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:20:04.792676Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:20:04.910783Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:20:05.012727Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:20:05.154061Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:20:05.310285Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:20:05.444928Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:20:05.552046Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:20:05.661207Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1661,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": {
+    "base": "origin/claudecode/spectroscopy-package",
+    "base_sha": "3a9a145e",
+    "changed_files": [
+      ".workflow/records/1661-codex-pr1666-spectroscopy-audit-fixes.json",
+      "docs/specs/spectroscopy-package.md",
+      "packages/scistudio-blocks-spectroscopy/README.md",
+      "packages/scistudio-blocks-spectroscopy/src/scistudio_blocks_spectroscopy/_support.py",
+      "packages/scistudio-blocks-spectroscopy/src/scistudio_blocks_spectroscopy/blocks/feature_extraction.py",
+      "packages/scistudio-blocks-spectroscopy/src/scistudio_blocks_spectroscopy/blocks/io_handlers/dataset_formats.py",
+      "packages/scistudio-blocks-spectroscopy/src/scistudio_blocks_spectroscopy/blocks/io_handlers/spectrum_formats.py",
+      "packages/scistudio-blocks-spectroscopy/src/scistudio_blocks_spectroscopy/blocks/unmixing.py",
+      "packages/scistudio-blocks-spectroscopy/src/scistudio_blocks_spectroscopy/blocks/utilities.py",
+      "packages/scistudio-blocks-spectroscopy/src/scistudio_blocks_spectroscopy/previewers/assets/viewer.js",
+      "packages/scistudio-blocks-spectroscopy/src/scistudio_blocks_spectroscopy/previewers/providers.py",
+      "packages/scistudio-blocks-spectroscopy/src/scistudio_blocks_spectroscopy/types.py",
+      "packages/scistudio-blocks-spectroscopy/tests/e2e/test_e2e_io.py",
+      "packages/scistudio-blocks-spectroscopy/tests/e2e/test_e2e_previewers.py",
+      "packages/scistudio-blocks-spectroscopy/tests/test_feature_extraction_blocks.py",
+      "packages/scistudio-blocks-spectroscopy/tests/test_format_capabilities.py",
+      "packages/scistudio-blocks-spectroscopy/tests/test_io_dataset_smoke.py",
+      "packages/scistudio-blocks-spectroscopy/tests/test_io_spectrum_smoke.py",
+      "packages/scistudio-blocks-spectroscopy/tests/test_prev_smoke.py",
+      "packages/scistudio-blocks-spectroscopy/tests/test_spectral_dataset_io.py",
+      "packages/scistudio-blocks-spectroscopy/tests/test_spectral_dataset_previewer.py",
+      "packages/scistudio-blocks-spectroscopy/tests/test_spectrum_io.py",
+      "packages/scistudio-blocks-spectroscopy/tests/test_types.py",
+      "packages/scistudio-blocks-spectroscopy/tests/test_unmixing_blocks.py",
+      "packages/scistudio-blocks-spectroscopy/tests/test_utility_blocks.py"
+    ],
+    "diff_fingerprint": "sha256:e7ff81ab93e4dae88b724fc3db0e83381a823d21ee45f8d949481878923eb3e5",
+    "head": "HEAD",
+    "head_sha": "511e8acf",
+    "surfaces": {
+      "docs": 1,
+      "frontend": 0,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 10,
+      "packaging": 0,
+      "protected_core": 0,
+      "sentrux": 24,
+      "test": 13,
+      "workflow_ci": 0
+    }
+  },
+  "owner_directive": "Fix PR #1666 spectroscopy package audit findings and open a stacked repair PR against claudecode/spectroscopy-package.",
+  "persona": "implementer",
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [
+      1661
+    ],
+    "number": null,
+    "url": null
+  },
+  "reconcile_events": [
+    {
+      "at": "2026-06-15T04:04:47.764346Z",
+      "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "mode": "local",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.format_check"
+      ]
+    },
+    {
+      "at": "2026-06-15T04:05:23.067231Z",
+      "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "mode": "local",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-15T04:05:39.971423Z",
+      "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-15T04:07:22.444632Z",
+      "diff_fingerprint": "sha256:087e066876b297c9ea77603ad8316731df538936c0c82240d89cedb1384b6452",
+      "mode": "pre-commit",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-15T04:13:37.960446Z",
+      "diff_fingerprint": "sha256:e7ff81ab93e4dae88b724fc3db0e83381a823d21ee45f8d949481878923eb3e5",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.python_tests",
+        "checks.semantic_dup"
+      ]
+    },
+    {
+      "at": "2026-06-15T04:20:05.661305Z",
+      "diff_fingerprint": "sha256:e7ff81ab93e4dae88b724fc3db0e83381a823d21ee45f8d949481878923eb3e5",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    }
+  ],
+  "record_id": "1661-codex-pr1666-spectroscopy-audit-fixes",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [
+      "format_check",
+      "full_audit",
+      "lint_format",
+      "python_tests",
+      "semantic_dup"
+    ],
+    "docs": [
+      "docs_required_or_na"
+    ],
+    "guards": [
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": [
+      "changed_test_required"
+    ]
+  },
+  "runtime": "codex:gpt-5",
+  "schema_version": 2,
+  "scope_events": [
+    {
+      "action": "add-include",
+      "at": "2026-06-15T03:39:04.306405Z",
+      "pattern": "packages/scistudio-blocks-spectroscopy/src/scistudio_blocks_spectroscopy/**",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-15T03:39:04.306413Z",
+      "pattern": "packages/scistudio-blocks-spectroscopy/tests/**",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-15T03:39:04.306416Z",
+      "pattern": "packages/scistudio-blocks-spectroscopy/README.md",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-15T03:39:04.306418Z",
+      "pattern": "docs/specs/spectroscopy-package.md",
+      "reason": "plan"
+    }
+  ],
+  "session_id": "fdc43142-4a3a-4723-81ae-cae1c8e0f15b",
+  "strictness_tier": 2,
+  "task_kind": "bugfix",
+  "test_events": [
+    {
+      "at": "2026-06-15T03:39:04.306437Z",
+      "class": null,
+      "kind": "path",
+      "path": "packages/scistudio-blocks-spectroscopy/tests",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-15T04:06:49.781156Z",
+      "class": null,
+      "kind": "path",
+      "path": "packages/scistudio-blocks-spectroscopy/tests/test_utility_blocks.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-15T04:06:49.781172Z",
+      "class": null,
+      "kind": "path",
+      "path": "packages/scistudio-blocks-spectroscopy/tests/test_spectral_dataset_previewer.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-15T04:06:49.781175Z",
+      "class": null,
+      "kind": "path",
+      "path": "packages/scistudio-blocks-spectroscopy/tests/test_format_capabilities.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-15T04:06:49.781177Z",
+      "class": null,
+      "kind": "path",
+      "path": "packages/scistudio-blocks-spectroscopy/tests/test_types.py",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/docs/specs/spectroscopy-package.md
+++ b/docs/specs/spectroscopy-package.md
@@ -979,13 +979,12 @@ Acceptance Scenarios:
   `Spectrum`, `SpectralDataset`, or their typed `Meta` models.
 - FR-132: `LoadSpectrum` and `SaveSpectrum` must provide load/save
   capabilities for `.txt`, `.csv`, `.tsv`, `.xlsx`, package-owned
-  `.spectrum.json`, JCAMP-DX (`.jdx`, `.dx`, `.jcamp`), and SPC (`.spc`)
-  according to the accepted capability matrix.
-- FR-133: `LoadSpectrum` must provide load-only capabilities for accepted
-  single-spectrum vendor or instrument formats, including Thermo OMNIC `.spa`,
-  Bruker OPUS through explicit capability selection, HORIBA LabSpec single
-  spectrum exports, Andor/ASCII-style spectra, and Princeton/LightField SPE
-  where the handler can return one `Spectrum`.
+  `.spectrum.json`, and JCAMP-DX (`.jdx`, `.dx`, `.jcamp`) according to the
+  accepted capability matrix.
+- FR-133: SPC (`.spc`) and single-spectrum vendor or instrument-native formats
+  are planned but not accepted runtime capabilities in this draft. The package
+  must not advertise them through `FormatCapability` records until fixture- or
+  SDK-backed handlers and tests are available.
 - FR-134: `SaveSpectrum` must not declare saver capabilities for accepted
   vendor or instrument-native load-only formats unless a later owner-approved
   amendment accepts a tested writer for that exact format.
@@ -998,22 +997,23 @@ Acceptance Scenarios:
 - FR-137: `LoadSpectralDataset` and `SaveSpectralDataset` must provide
   load/save capabilities for `.xlsx` workbooks that use explicit `index`,
   `spectra`, and optional `meta` sheets.
-- FR-138: SPC (`.spc`) must be available as both load and save capability for
-  `Spectrum` and `SpectralDataset` where the handler can represent the target
-  as a single-spectrum or multi-spectrum SPC payload.
-- FR-139: `LoadSpectralDataset` must provide load-only capabilities for
-  accepted multi-spectrum vendor or instrument formats, including Thermo OMNIC
-  `.spg`, Renishaw WiRE `.wdf`, WITec `.wip`/`.wid`, HORIBA LabSpec map or
-  group exports, Andor/FITS-style multi-spectrum outputs, and
-  Princeton/LightField SPE where the handler returns multiple spectra.
-- FR-140: Vendor or instrument-native load-only capabilities must not declare a
-  matching saver, must not set a `roundtrip_group`, and must not claim
-  `lossless` metadata fidelity.
+- FR-138: Multi-spectrum SPC (`.spc`) is planned but not an accepted
+  `SpectralDataset` runtime capability in this draft. It must remain tracked as
+  deferred work until fixtures or an optional SPC library prove load/save
+  behavior.
+- FR-139: Multi-spectrum vendor or instrument-native formats are planned but
+  not accepted runtime capabilities in this draft. They must not be advertised
+  through `FormatCapability` records until fixture- or SDK-backed handlers and
+  tests are available.
+- FR-140: If vendor or instrument-native load-only capabilities are accepted by
+  a later owner-approved amendment, they must not declare a matching saver,
+  must not set a `roundtrip_group`, and must not claim `lossless` metadata
+  fidelity.
 - FR-141: Package-owned native JSON manifest capabilities may claim
   `lossless` only when both load and save capabilities share a
   `roundtrip_group` and tests prove preservation of the primary payload,
   required typed `Meta` fields, and required `SpectralDataset` slot schemas.
-- FR-142: Delimited text, Excel, JCAMP-DX, and SPC capabilities must declare
+- FR-142: Delimited text, Excel, and JCAMP-DX capabilities must declare
   conservative `metadata_fidelity` values that match tested behavior. They
   must not imply preservation of arbitrary vendor-native metadata.
 - FR-143: Capability lookup for spectroscopy IO must follow ADR-043 selection
@@ -1118,14 +1118,6 @@ uses the same explicit field lists plus `level="lossless"`.
 | `scistudio-blocks-spectroscopy.spectrum.spectrum_json.save` | `save` | `Spectrum` | `spectrum_json` | `(".spectrum.json",)` | Native Spectrum JSON | `SaveSpectrum` | `_save_spectrum_json` | `true/0` | `scistudio-blocks-spectroscopy.spectrum.spectrum_json` | `lossless(lambda_unit,intensity_unit,lambda_kind,modality)` |
 | `scistudio-blocks-spectroscopy.spectrum.jcamp_dx.load` | `load` | `Spectrum` | `jcamp_dx` | `(".jdx", ".dx", ".jcamp")` | JCAMP-DX spectrum | `LoadSpectrum` | `_load_jcamp_dx` | `true/0` | `scistudio-blocks-spectroscopy.spectrum.jcamp_dx` | `typed_meta(lambda_unit,intensity_unit,lambda_kind,modality)` |
 | `scistudio-blocks-spectroscopy.spectrum.jcamp_dx.save` | `save` | `Spectrum` | `jcamp_dx` | `(".jdx", ".dx", ".jcamp")` | JCAMP-DX spectrum | `SaveSpectrum` | `_save_jcamp_dx` | `true/0` | `scistudio-blocks-spectroscopy.spectrum.jcamp_dx` | `typed_meta(lambda_unit,intensity_unit,lambda_kind,modality)` |
-| `scistudio-blocks-spectroscopy.spectrum.spc.load` | `load` | `Spectrum` | `spc` | `(".spc",)` | SPC spectrum | `LoadSpectrum` | `_load_spc` | `true/0` | `scistudio-blocks-spectroscopy.spectrum.spc` | `typed_meta(lambda_unit,intensity_unit,lambda_kind,modality)` |
-| `scistudio-blocks-spectroscopy.spectrum.spc.save` | `save` | `Spectrum` | `spc` | `(".spc",)` | SPC spectrum | `SaveSpectrum` | `_save_spc` | `true/0` | `scistudio-blocks-spectroscopy.spectrum.spc` | `typed_meta(lambda_unit,intensity_unit,lambda_kind,modality)` |
-| `scistudio-blocks-spectroscopy.spectrum.thermo_omnic_spa.load` | `load` | `Spectrum` | `thermo_omnic_spa` | `(".spa",)` | Thermo OMNIC SPA spectrum | `LoadSpectrum` | `_load_thermo_omnic_spa` | `true/0` | `null` | `typed_meta(lambda_unit,intensity_unit,lambda_kind,modality)` |
-| `scistudio-blocks-spectroscopy.spectrum.bruker_opus.load` | `load` | `Spectrum` | `bruker_opus` | `(".opus",)` | Bruker OPUS spectrum | `LoadSpectrum` | `_load_bruker_opus` | `true/0` | `null` | `typed_meta(lambda_unit,intensity_unit,lambda_kind,modality)` |
-| `scistudio-blocks-spectroscopy.spectrum.horiba_labspec.load` | `load` | `Spectrum` | `horiba_labspec` | `(".l6s", ".l5s", ".ngs", ".xml")` | HORIBA LabSpec spectrum | `LoadSpectrum` | `_load_horiba_labspec` | `true/0` | `null` | `typed_meta(lambda_unit,intensity_unit,lambda_kind,modality)` |
-| `scistudio-blocks-spectroscopy.spectrum.renishaw_wdf.load` | `load` | `Spectrum` | `renishaw_wdf` | `(".wdf",)` | Renishaw WiRE spectrum | `LoadSpectrum` | `_load_renishaw_wdf` | `true/0` | `null` | `typed_meta(lambda_unit,intensity_unit,lambda_kind,modality)` |
-| `scistudio-blocks-spectroscopy.spectrum.andor_solis.load` | `load` | `Spectrum` | `andor_solis` | `(".sif", ".fits", ".fit", ".asc")` | Andor Solis spectrum | `LoadSpectrum` | `_load_andor_solis` | `true/0` | `null` | `typed_meta(lambda_unit,intensity_unit,lambda_kind,modality)` |
-| `scistudio-blocks-spectroscopy.spectrum.princeton_spe.load` | `load` | `Spectrum` | `princeton_spe` | `(".spe",)` | Princeton/LightField SPE spectrum | `LoadSpectrum` | `_load_princeton_spe` | `true/0` | `null` | `typed_meta(lambda_unit,intensity_unit,lambda_kind,modality)` |
 
 `SpectralDataset` load/save capabilities:
 
@@ -1135,15 +1127,6 @@ uses the same explicit field lists plus `level="lossless"`.
 | `scistudio-blocks-spectroscopy.spectral_dataset.manifest_json.save` | `save` | `SpectralDataset` | `spectral_dataset_manifest_json` | `(".json",)` | SpectralDataset manifest (JSON) | `SaveSpectralDataset` | `_save_manifest_json` | `true/0` | `scistudio-blocks-spectroscopy.spectral_dataset.manifest_json` | `lossless(dataset_name,dataset_role,lambda_unit,intensity_unit,modality,schema_version)` |
 | `scistudio-blocks-spectroscopy.spectral_dataset.xlsx.load` | `load` | `SpectralDataset` | `xlsx` | `(".xlsx", ".xls")` | SpectralDataset Excel workbook | `LoadSpectralDataset` | `_load_dataset_xlsx` | `true/0` | `scistudio-blocks-spectroscopy.spectral_dataset.xlsx` | `typed_meta(dataset_name,dataset_role,lambda_unit,intensity_unit,modality,schema_version)` |
 | `scistudio-blocks-spectroscopy.spectral_dataset.xlsx.save` | `save` | `SpectralDataset` | `xlsx` | `(".xlsx",)` | SpectralDataset Excel workbook | `SaveSpectralDataset` | `_save_dataset_xlsx` | `true/0` | `scistudio-blocks-spectroscopy.spectral_dataset.xlsx` | `typed_meta(dataset_name,dataset_role,lambda_unit,intensity_unit,modality,schema_version)` |
-| `scistudio-blocks-spectroscopy.spectral_dataset.spc.load` | `load` | `SpectralDataset` | `spc` | `(".spc",)` | SPC spectral dataset | `LoadSpectralDataset` | `_load_spc_dataset` | `true/0` | `scistudio-blocks-spectroscopy.spectral_dataset.spc` | `typed_meta(dataset_name,dataset_role,lambda_unit,intensity_unit,modality,schema_version)` |
-| `scistudio-blocks-spectroscopy.spectral_dataset.spc.save` | `save` | `SpectralDataset` | `spc` | `(".spc",)` | SPC spectral dataset | `SaveSpectralDataset` | `_save_spc_dataset` | `true/0` | `scistudio-blocks-spectroscopy.spectral_dataset.spc` | `typed_meta(dataset_name,dataset_role,lambda_unit,intensity_unit,modality,schema_version)` |
-| `scistudio-blocks-spectroscopy.spectral_dataset.thermo_omnic_spg.load` | `load` | `SpectralDataset` | `thermo_omnic_spg` | `(".spg",)` | Thermo OMNIC SPG dataset | `LoadSpectralDataset` | `_load_thermo_omnic_spg` | `true/0` | `null` | `typed_meta(dataset_role,lambda_unit,intensity_unit,modality)` |
-| `scistudio-blocks-spectroscopy.spectral_dataset.renishaw_wdf.load` | `load` | `SpectralDataset` | `renishaw_wdf` | `(".wdf",)` | Renishaw WiRE dataset | `LoadSpectralDataset` | `_load_renishaw_wdf_dataset` | `true/0` | `null` | `typed_meta(dataset_role,lambda_unit,intensity_unit,modality)` |
-| `scistudio-blocks-spectroscopy.spectral_dataset.bruker_opus.load` | `load` | `SpectralDataset` | `bruker_opus` | `(".opus",)` | Bruker OPUS dataset | `LoadSpectralDataset` | `_load_bruker_opus_dataset` | `true/0` | `null` | `typed_meta(dataset_role,lambda_unit,intensity_unit,modality)` |
-| `scistudio-blocks-spectroscopy.spectral_dataset.horiba_labspec.load` | `load` | `SpectralDataset` | `horiba_labspec` | `(".l6s", ".l5s", ".ngc", ".xml", ".txt")` | HORIBA LabSpec dataset | `LoadSpectralDataset` | `_load_horiba_labspec_dataset` | `true/0` | `null` | `typed_meta(dataset_role,lambda_unit,intensity_unit,modality)` |
-| `scistudio-blocks-spectroscopy.spectral_dataset.witec_project.load` | `load` | `SpectralDataset` | `witec_project` | `(".wip", ".wid")` | WITec project dataset | `LoadSpectralDataset` | `_load_witec_project` | `true/0` | `null` | `typed_meta(dataset_role,lambda_unit,intensity_unit,modality)` |
-| `scistudio-blocks-spectroscopy.spectral_dataset.andor_solis.load` | `load` | `SpectralDataset` | `andor_solis` | `(".sif", ".fits", ".fit")` | Andor Solis dataset | `LoadSpectralDataset` | `_load_andor_solis_dataset` | `true/0` | `null` | `typed_meta(dataset_role,lambda_unit,intensity_unit,modality)` |
-| `scistudio-blocks-spectroscopy.spectral_dataset.princeton_spe.load` | `load` | `SpectralDataset` | `princeton_spe` | `(".spe",)` | Princeton/LightField SPE dataset | `LoadSpectralDataset` | `_load_princeton_spe_dataset` | `true/0` | `null` | `typed_meta(dataset_role,lambda_unit,intensity_unit,modality)` |
 
 The `SpectralDataset` JSON manifest capability is package-owned but must remain
 compatible with core `CompositeData` IO semantics: the boundary file is a JSON
@@ -1404,10 +1387,10 @@ Expected verification after implementation:
 - Utility block tests prove load/save, conversion, filtering, merging,
   feature attachment, generated-ID behavior, metadata joins by `spectrum_id`
   and `source_file`, and duplicate-ID policies.
-- IO tests prove SPC has both load and save capabilities, accepted
-  vendor/native instrument formats are load-only, and `SpectralDataset` native
-  save/load follows the core `CompositeData` JSON manifest plus sidecar slot
-  model rather than a zip or archive format.
+- IO tests prove deferred SPC/vendor/native formats are not advertised as
+  runtime capabilities, and `SpectralDataset` native save/load follows the core
+  `CompositeData` JSON manifest plus sidecar slot model rather than a zip or
+  archive format.
 - Preprocessing tests prove every accepted preprocessing block accepts
   `Collection[Spectrum]`, rejects `SpectralDataset`, preserves item count,
   order, and `spectrum_id`, and supports only the accepted methods.
@@ -1715,14 +1698,14 @@ matching, or unmixing requirement before implementation starts.
   workflow or lookup reference to `FormatCapability.id`, and no package type
   declares file extensions or format support.
 - SC-050: Spectrum IO tests prove `.txt`, `.csv`, `.tsv`, `.xlsx`,
-  `.spectrum.json`, JCAMP-DX, and SPC capabilities can load and save according
-  to their declared metadata fidelity.
-- SC-051: Spectrum and dataset format tests prove SPC (`.spc`) has both load
-  and save capabilities, including the dataset case when the SPC payload
-  contains multiple spectra.
-- SC-052: Format capability tests prove vendor/native instrument formats
-  accepted in this draft are load-only and do not declare saver capabilities,
-  `roundtrip_group`, or `lossless` metadata fidelity.
+  `.spectrum.json`, and JCAMP-DX capabilities can load and save according to
+  their declared metadata fidelity.
+- SC-051: Spectrum and dataset format tests prove SPC (`.spc`) remains a
+  tracked planned deferral and is not advertised as a runtime capability until
+  implemented.
+- SC-052: Format capability tests prove vendor/native instrument formats remain
+  tracked planned deferrals and are not advertised as runtime capabilities until
+  implemented.
 - SC-053: Dataset IO tests prove `SpectralDataset` native JSON save/load uses
   a package-owned JSON manifest plus sidecar `index` and `spectra` table slots,
   aligned with core `CompositeData` IO semantics.

--- a/packages/scistudio-blocks-spectroscopy/README.md
+++ b/packages/scistudio-blocks-spectroscopy/README.md
@@ -10,18 +10,18 @@ imports `scistudio_blocks_srs`.
 
 ## Data types
 
-- `Spectrum(Series)` — one 1-D spectrum (`lambda` index, `intensity` value;
+- `Spectrum(Series)` - one 1-D spectrum (`lambda` index, `intensity` value;
   FR-003/004). Typed `Meta` carries `lambda_unit`, `intensity_unit`,
   `lambda_kind`, `modality`, plus `spectrum_id`/`source_file` provenance. Build
   and read it through the package helpers in `scistudio_blocks_spectroscopy._support`
   (`build_spectrum`, `spectrum_arrays`, `derive_spectrum`).
-- `SpectralDataset(CompositeData)` — many spectra as an `index` table (one row
-  per spectrum, unique `spectrum_id` + arbitrary metadata) plus a long-form
+- `SpectralDataset(CompositeData)` - many spectra as an `index` table (one row
+  per spectrum, unique `spectrum_id` plus arbitrary metadata) plus a long-form
   `spectra` table (`spectrum_id`, `lambda`, `intensity`). A spectral library is
-  a dataset with `meta.dataset_role="library"` (FR-014) — there is no separate
+  a dataset with `meta.dataset_role="library"` (FR-014); there is no separate
   library type.
 
-Format support is NOT declared on the types (FR-131); it lives on the IO blocks
+Format support is not declared on the types (FR-131); it lives on the IO blocks
 as ADR-043 `FormatCapability` records.
 
 ## Blocks (26)
@@ -46,24 +46,27 @@ back onto `SpectralDataset.index` with `AttachFeaturesToSpectralDataset`.
 
 The four IO blocks declare explicit `FormatCapability` records (FR-128..FR-143).
 
-- **Round-trippable (load + save):** delimited text `.txt`/`.csv`/`.tsv`,
-  Excel `.xlsx`, the package-native lossless `.spectrum.json` (Spectrum) and
-  JSON manifest + Parquet sidecar (`SpectralDataset`), and JCAMP-DX
-  `.jdx`/`.dx`/`.jcamp` for Spectrum.
-- **Declared, fixture-pending:** SPC (`.spc`) and the vendor/instrument formats
-  (Thermo OMNIC `.spa`/`.spg`, Bruker OPUS, HORIBA LabSpec, Renishaw WiRE
-  `.wdf`, WITec `.wip`/`.wid`, Andor, Princeton/LightField `.spe`) are declared
-  per the accepted matrix but raise an informative `NotImplementedError`
-  (`# TODO(#1661)`) until fixture data / an optional SDK is available. Vendor
-  formats are load-only (no saver, no `roundtrip_group`, no `lossless`).
+- **Round-trippable and advertised:** delimited text `.txt`/`.csv`/`.tsv`,
+  Excel `.xlsx`, package-native lossless `.spectrum.json` for `Spectrum`,
+  package-native JSON manifest plus Parquet sidecars for `SpectralDataset`, and
+  JCAMP-DX `.jdx`/`.dx`/`.jcamp` for `Spectrum`.
+- **Deferred and not advertised:** SPC (`.spc`) and vendor/instrument-native
+  formats are intentionally not exposed through `FormatCapability` records in
+  this draft. Direct handler entry points remain tracked with `TODO(#1661)` and
+  raise informative `NotImplementedError` until fixture data or an optional SDK
+  proves real load/save behavior. Unsupported suffix selection through the IO
+  blocks fails before a deferred handler is selected.
 
 ## Previewers (ADR-048)
 
-- `spectroscopy.spectrum.viewer` (`Spectrum`, SERIES envelope) — bounded
-  two-column read, axis units, export resources, honest sampling metadata.
+- `spectroscopy.spectrum.viewer` (`Spectrum`, SERIES envelope) - bounded
+  two-column read, axis units, pan/zoom hoverable line plot, honest sampling
+  metadata, diagnostics, and SVG/PNG/PDF/points exports.
 - `spectroscopy.spectral_dataset.viewer` (`SpectralDataset`, COMPOSITE envelope)
-  — paginated index table, dataset health diagnostics (duplicate/orphan/missing
-  coverage/unit/heatmap-alignment), plot-mode + export resources.
+  - paginated/searchable/selectable index table, group/color controls, bounded
+  overlay/selected/group mean/group band/heatmap plot payloads, dataset health
+  diagnostics (duplicate/orphan/missing coverage/unit/heatmap-alignment), and
+  preview exports.
 
 ## Dependencies
 
@@ -74,11 +77,11 @@ blocks never requires them.
 
 ## Testing
 
-```
+```bash
 pytest packages/scistudio-blocks-spectroscopy/tests
 ```
 
 Covers type/packaging/previewer-registration contracts, ADR-043 format
 capabilities, per-block contract tests (SC-001..SC-055), and an end-to-end
-`tests/e2e/` suite of pseudo-spectra generators + load→block→save workflows,
+`tests/e2e/` suite of pseudo-spectra generators plus load/block/save workflows,
 boundary cases, and chained pipelines.

--- a/packages/scistudio-blocks-spectroscopy/src/scistudio_blocks_spectroscopy/_support.py
+++ b/packages/scistudio-blocks-spectroscopy/src/scistudio_blocks_spectroscopy/_support.py
@@ -300,8 +300,10 @@ def build_spectral_dataset(
     Each of ``index`` / ``spectra`` may be a core ``DataFrame``, a pandas frame,
     or a ``pyarrow.Table``.
     """
+    index_df = _as_dataframe(index)
+    spectra_df = _as_dataframe(spectra)
     return SpectralDataset(
-        slots={"index": _as_dataframe(index), "spectra": _as_dataframe(spectra)},
+        slots={"index": index_df, "spectra": spectra_df},
         meta=meta or SpectralDataset.Meta(),
         framework=framework or FrameworkMeta(source=source or "scistudio-blocks-spectroscopy"),
     )
@@ -309,6 +311,7 @@ def build_spectral_dataset(
 
 def dataset_frames(dataset: SpectralDataset) -> tuple[pa.Table, pa.Table]:
     """Return ``(index_table, spectra_table)`` as ``pyarrow.Table`` values."""
+    dataset.validate_slots()
     return dataframe_arrow(cast(DataFrame, dataset.get("index"))), dataframe_arrow(
         cast(DataFrame, dataset.get("spectra"))
     )

--- a/packages/scistudio-blocks-spectroscopy/src/scistudio_blocks_spectroscopy/blocks/feature_extraction.py
+++ b/packages/scistudio-blocks-spectroscopy/src/scistudio_blocks_spectroscopy/blocks/feature_extraction.py
@@ -69,10 +69,18 @@ def _restrict_range(
     return lam[mask], inten[mask]
 
 
-def _measure_at_coordinate(lam: np.ndarray, inten: np.ndarray, coordinate: float) -> tuple[float, float]:
-    """Return ``(measured_coordinate, intensity)`` at the nearest grid point."""
+def _measure_at_coordinate(
+    lam: np.ndarray, inten: np.ndarray, coordinate: float
+) -> tuple[float | None, float | None, str]:
+    """Return nearest-grid measurement or a non-success status for out-of-grid coordinates."""
+    if lam.size == 0:
+        return None, None, "empty_spectrum"
+    lo = float(np.min(lam))
+    hi = float(np.max(lam))
+    if coordinate < lo or coordinate > hi:
+        return None, None, "coordinate_out_of_grid"
     idx = int(np.argmin(np.abs(lam - coordinate)))
-    return float(lam[idx]), float(inten[idx])
+    return float(lam[idx]), float(inten[idx]), _STATUS_OK
 
 
 def _reduce_range(inten: np.ndarray, reducer: str) -> float:
@@ -100,8 +108,7 @@ def _measure_peak_intensity(
     reducer = str(peak.get("reducer", "max"))
 
     if coordinate is not None:
-        coord, intensity = _measure_at_coordinate(lam, inten, float(coordinate))
-        return coord, intensity, _STATUS_OK
+        return _measure_at_coordinate(lam, inten, float(coordinate))
 
     if lambda_min is None and lambda_max is None:
         return None, None, "peak_definition_missing_coordinate_or_range"
@@ -211,8 +218,7 @@ class ExtractIntensity(ProcessBlock):
                     coord = float(np.mean(win_lam))
                     status = _STATUS_OK
             elif target is not None:
-                coord, value = _measure_at_coordinate(lam, inten, float(target))
-                status = _STATUS_OK
+                coord, value, status = _measure_at_coordinate(lam, inten, float(target))
             else:
                 coord, value, status = None, None, "no_target_coordinate_or_range"
             rows.append({"spectrum_id": key, "measured_coordinate": coord, "intensity": value, "status": status})

--- a/packages/scistudio-blocks-spectroscopy/src/scistudio_blocks_spectroscopy/blocks/io_handlers/dataset_formats.py
+++ b/packages/scistudio-blocks-spectroscopy/src/scistudio_blocks_spectroscopy/blocks/io_handlers/dataset_formats.py
@@ -1,9 +1,9 @@
-"""Per-format handler stubs for ``SpectralDataset`` load/save (FR-135..FR-139).
+"""Per-format handler functions for ``SpectralDataset`` load/save (FR-135..FR-139).
 
 Each function corresponds to one ``handler=`` named in a
 ``LoadSpectralDataset`` / ``SaveSpectralDataset`` ``FormatCapability`` record
 (spec §"SpectralDataset load/save capabilities"). The block methods delegate
-here; implementers fill the bodies.
+here.
 
 Loaders return a single :class:`SpectralDataset` (two ``DataFrame`` slots:
 ``index`` and ``spectra``). Savers write *dataset* to *path* and return
@@ -22,9 +22,10 @@ Package-owned formats implemented here:
 - ``xlsx`` (``.xlsx``/``.xls``) — explicit ``index``, ``spectra``, and optional
   ``meta`` sheets (``typed_meta`` fidelity, FR-137).
 
-Vendor / instrument-native multi-spectrum formats and ``.spc`` are deferred
-(``NotImplementedError`` with a tracked ``TODO(#1661)``) because they need a
-fixture or an optional binary SDK that is not available in this draft.
+Vendor / instrument-native multi-spectrum formats and ``.spc`` are deferred and
+are not advertised by the current ``FormatCapability`` matrix. Their direct
+entry points raise ``NotImplementedError`` with tracked ``TODO(#1661)`` notes
+until a fixture or optional binary SDK is available.
 """
 
 from __future__ import annotations
@@ -36,12 +37,7 @@ from typing import Any
 import pyarrow as pa
 
 from scistudio_blocks_spectroscopy import _support
-from scistudio_blocks_spectroscopy.types import (
-    INTENSITY_COLUMN,
-    LAMBDA_COLUMN,
-    SPECTRUM_ID_COLUMN,
-    SpectralDataset,
-)
+from scistudio_blocks_spectroscopy.types import SpectralDataset
 
 # Package-native manifest schema marker (FR-135, FR-141). Bumping this is a
 # schema-version change; the loader accepts manifests it understands and raises
@@ -86,25 +82,9 @@ def _meta_from_mapping(values: dict[str, Any]) -> SpectralDataset.Meta:
 
 def _validate_dataset_tables(index_table: pa.Table, spectra_table: pa.Table) -> None:
     """Validate the canonical two-table layout (FR-038, FR-009..FR-012)."""
-    if SPECTRUM_ID_COLUMN not in index_table.column_names:
-        raise ValueError(
-            f"SpectralDataset index table must contain a {SPECTRUM_ID_COLUMN!r} column; "
-            f"got {list(index_table.column_names)}"
-        )
-    required_spectra = {SPECTRUM_ID_COLUMN, LAMBDA_COLUMN, INTENSITY_COLUMN}
-    missing = required_spectra.difference(spectra_table.column_names)
-    if missing:
-        raise ValueError(
-            f"SpectralDataset spectra table must contain {sorted(required_spectra)} columns; missing {sorted(missing)}"
-        )
-    index_ids = set(index_table.column(SPECTRUM_ID_COLUMN).to_pylist())
-    spectra_ids = set(spectra_table.column(SPECTRUM_ID_COLUMN).to_pylist())
-    orphans = spectra_ids.difference(index_ids)
-    if orphans:
-        raise ValueError(
-            f"SpectralDataset spectra rows reference unknown spectrum_id(s) {sorted(orphans)}; "
-            "every spectra.spectrum_id must join to index.spectrum_id (FR-012)"
-        )
+    from scistudio_blocks_spectroscopy.types import validate_spectral_dataset_tables
+
+    validate_spectral_dataset_tables(index_table, spectra_table)
 
 
 def _sidecar_paths(path: Path) -> tuple[Path, Path]:

--- a/packages/scistudio-blocks-spectroscopy/src/scistudio_blocks_spectroscopy/blocks/io_handlers/spectrum_formats.py
+++ b/packages/scistudio-blocks-spectroscopy/src/scistudio_blocks_spectroscopy/blocks/io_handlers/spectrum_formats.py
@@ -21,8 +21,9 @@ Implemented round-trippable formats:
 - ``jcamp_dx`` (``.jdx``/``.dx``/``.jcamp``) — minimal JCAMP-DX (``##XYPOINTS``)
   with ``##XUNITS``/``##YUNITS`` mapped to lambda/intensity units. ``typed_meta``.
 
-``spc`` and the vendor LOAD-ONLY formats raise an informative
-``NotImplementedError`` (no fixture / optional SDK), tracked under #1661.
+``spc`` and vendor formats are deferred and are not advertised by the current
+``FormatCapability`` matrix. Their direct entry points raise informative
+``NotImplementedError`` exceptions, tracked under #1661.
 """
 
 from __future__ import annotations

--- a/packages/scistudio-blocks-spectroscopy/src/scistudio_blocks_spectroscopy/blocks/unmixing.py
+++ b/packages/scistudio-blocks-spectroscopy/src/scistudio_blocks_spectroscopy/blocks/unmixing.py
@@ -39,9 +39,11 @@ _RESERVED_COLUMNS = ("spectrum_id", "method")
 _STATUS_SUCCESS = "success"
 _STATUS_ILL_CONDITIONED = "ill_conditioned"
 _STATUS_FAILED = "failed"
+_STATUS_CONSTRAINT_NOT_SATISFIED = "constraint_not_satisfied"
 
 #: Large weight for the sum-to-one equality row in the augmented NNLS.
 _SUM_TO_ONE_WEIGHT = 1.0e6
+_SUM_TO_ONE_TOLERANCE = 1.0e-6
 
 
 class SpectralUnmixing(ProcessBlock):
@@ -270,6 +272,18 @@ def _solve(
     elif condition_number is not None and condition_number > 1.0e12:
         status = _STATUS_ILL_CONDITIONED
         message = "design matrix is ill-conditioned"
+    if method == "sum_to_one_non_negative_least_squares":
+        coefficient_sum = float(np.sum(coeffs))
+        if not np.isfinite(coefficient_sum) or abs(coefficient_sum - 1.0) > _SUM_TO_ONE_TOLERANCE:
+            detail = (
+                f"sum-to-one constraint not satisfied: sum={coefficient_sum:.12g}, "
+                f"tolerance={_SUM_TO_ONE_TOLERANCE:.1e}"
+            )
+            if status == _STATUS_SUCCESS:
+                status = _STATUS_CONSTRAINT_NOT_SATISFIED
+                message = detail
+            else:
+                message = f"{message}; {detail}" if message else detail
 
     # Reconstruct the fit on the original (un-augmented) design for quality stats.
     fitted = design @ coeffs

--- a/packages/scistudio-blocks-spectroscopy/src/scistudio_blocks_spectroscopy/blocks/utilities.py
+++ b/packages/scistudio-blocks-spectroscopy/src/scistudio_blocks_spectroscopy/blocks/utilities.py
@@ -10,8 +10,10 @@ Nine utility blocks that move data between files, ``Collection[Spectrum]``, and
   :class:`SpectralDatasetToSpectrum`, :class:`FilterSpectralDataset`,
   :class:`MergeSpectralDataset`, :class:`AttachFeaturesToSpectralDataset`.
 
-Executable bodies are skeleton stubs that raise ``NotImplementedError``; the
-ports, config schemas, and capability records are the real stable contract.
+Executable bodies delegate to package-owned helpers and per-format handlers.
+Capabilities are declared only for executable formats; deferred SPC/vendor
+handlers remain tracked in ``io_handlers`` but are not discoverable runtime
+capabilities until fixtures or optional SDK support exists.
 """
 
 from __future__ import annotations
@@ -57,8 +59,6 @@ _DATASET_META_FIELDS = (
     "modality",
     "schema_version",
 )
-_DATASET_VENDOR_META_FIELDS = ("dataset_role", "lambda_unit", "intensity_unit", "modality")
-
 # Shared file-path config schema fragment for IO blocks.
 _PATH_CONFIG_SCHEMA: dict[str, Any] = {
     "type": "object",
@@ -286,19 +286,6 @@ class LoadSpectrum(IOBlock):
         ".jdx": "jcamp_dx",
         ".dx": "jcamp_dx",
         ".jcamp": "jcamp_dx",
-        ".spc": "spc",
-        ".spa": "thermo_omnic_spa",
-        ".opus": "bruker_opus",
-        ".l6s": "horiba_labspec",
-        ".l5s": "horiba_labspec",
-        ".ngs": "horiba_labspec",
-        ".xml": "horiba_labspec",
-        ".wdf": "renishaw_wdf",
-        ".sif": "andor_solis",
-        ".fits": "andor_solis",
-        ".fit": "andor_solis",
-        ".asc": "andor_solis",
-        ".spe": "princeton_spe",
     }
 
     format_capabilities: ClassVar[tuple[FormatCapability, ...]] = (
@@ -378,91 +365,6 @@ class LoadSpectrum(IOBlock):
             handler="_load_jcamp_dx",
             is_default=True,
             roundtrip_group=f"{_PKG}.spectrum.jcamp_dx",
-            metadata_fidelity=MetadataFidelity(level="typed_meta", typed_meta_reads=_SPECTRUM_META_FIELDS),
-        ),
-        FormatCapability(
-            id=f"{_PKG}.spectrum.spc.load",
-            direction="load",
-            data_type=Spectrum,
-            format_id="spc",
-            extensions=(".spc",),
-            label="SPC spectrum",
-            block_type="LoadSpectrum",
-            handler="_load_spc",
-            is_default=True,
-            roundtrip_group=f"{_PKG}.spectrum.spc",
-            metadata_fidelity=MetadataFidelity(level="typed_meta", typed_meta_reads=_SPECTRUM_META_FIELDS),
-        ),
-        FormatCapability(
-            id=f"{_PKG}.spectrum.thermo_omnic_spa.load",
-            direction="load",
-            data_type=Spectrum,
-            format_id="thermo_omnic_spa",
-            extensions=(".spa",),
-            label="Thermo OMNIC SPA spectrum",
-            block_type="LoadSpectrum",
-            handler="_load_thermo_omnic_spa",
-            is_default=True,
-            metadata_fidelity=MetadataFidelity(level="typed_meta", typed_meta_reads=_SPECTRUM_META_FIELDS),
-        ),
-        FormatCapability(
-            id=f"{_PKG}.spectrum.bruker_opus.load",
-            direction="load",
-            data_type=Spectrum,
-            format_id="bruker_opus",
-            extensions=(".opus",),
-            label="Bruker OPUS spectrum",
-            block_type="LoadSpectrum",
-            handler="_load_bruker_opus",
-            is_default=True,
-            metadata_fidelity=MetadataFidelity(level="typed_meta", typed_meta_reads=_SPECTRUM_META_FIELDS),
-        ),
-        FormatCapability(
-            id=f"{_PKG}.spectrum.horiba_labspec.load",
-            direction="load",
-            data_type=Spectrum,
-            format_id="horiba_labspec",
-            extensions=(".l6s", ".l5s", ".ngs", ".xml"),
-            label="HORIBA LabSpec spectrum",
-            block_type="LoadSpectrum",
-            handler="_load_horiba_labspec",
-            is_default=True,
-            metadata_fidelity=MetadataFidelity(level="typed_meta", typed_meta_reads=_SPECTRUM_META_FIELDS),
-        ),
-        FormatCapability(
-            id=f"{_PKG}.spectrum.renishaw_wdf.load",
-            direction="load",
-            data_type=Spectrum,
-            format_id="renishaw_wdf",
-            extensions=(".wdf",),
-            label="Renishaw WiRE spectrum",
-            block_type="LoadSpectrum",
-            handler="_load_renishaw_wdf",
-            is_default=True,
-            metadata_fidelity=MetadataFidelity(level="typed_meta", typed_meta_reads=_SPECTRUM_META_FIELDS),
-        ),
-        FormatCapability(
-            id=f"{_PKG}.spectrum.andor_solis.load",
-            direction="load",
-            data_type=Spectrum,
-            format_id="andor_solis",
-            extensions=(".sif", ".fits", ".fit", ".asc"),
-            label="Andor Solis spectrum",
-            block_type="LoadSpectrum",
-            handler="_load_andor_solis",
-            is_default=True,
-            metadata_fidelity=MetadataFidelity(level="typed_meta", typed_meta_reads=_SPECTRUM_META_FIELDS),
-        ),
-        FormatCapability(
-            id=f"{_PKG}.spectrum.princeton_spe.load",
-            direction="load",
-            data_type=Spectrum,
-            format_id="princeton_spe",
-            extensions=(".spe",),
-            label="Princeton/LightField SPE spectrum",
-            block_type="LoadSpectrum",
-            handler="_load_princeton_spe",
-            is_default=True,
             metadata_fidelity=MetadataFidelity(level="typed_meta", typed_meta_reads=_SPECTRUM_META_FIELDS),
         ),
     )
@@ -570,7 +472,6 @@ class SaveSpectrum(IOBlock):
         ".jdx": "jcamp_dx",
         ".dx": "jcamp_dx",
         ".jcamp": "jcamp_dx",
-        ".spc": "spc",
     }
 
     format_capabilities: ClassVar[tuple[FormatCapability, ...]] = (
@@ -652,19 +553,6 @@ class SaveSpectrum(IOBlock):
             roundtrip_group=f"{_PKG}.spectrum.jcamp_dx",
             metadata_fidelity=MetadataFidelity(level="typed_meta", typed_meta_writes=_SPECTRUM_META_FIELDS),
         ),
-        FormatCapability(
-            id=f"{_PKG}.spectrum.spc.save",
-            direction="save",
-            data_type=Spectrum,
-            format_id="spc",
-            extensions=(".spc",),
-            label="SPC spectrum",
-            block_type="SaveSpectrum",
-            handler="_save_spc",
-            is_default=True,
-            roundtrip_group=f"{_PKG}.spectrum.spc",
-            metadata_fidelity=MetadataFidelity(level="typed_meta", typed_meta_writes=_SPECTRUM_META_FIELDS),
-        ),
     )
 
     _save_delimited_text = staticmethod(spectrum_formats.save_delimited_text)
@@ -731,7 +619,7 @@ class LoadSpectralDataset(IOBlock):
     direction: ClassVar[str] = "input"
     type_name: ClassVar[str] = "spectroscopy.load_spectral_dataset"
     name: ClassVar[str] = "Load Spectral Dataset"
-    description: ClassVar[str] = "Load a SpectralDataset from a manifest, workbook, SPC, or vendor file."
+    description: ClassVar[str] = "Load a SpectralDataset from a manifest or workbook."
     version: ClassVar[str] = "0.1.0"
     subcategory: ClassVar[str] = "io"
 
@@ -745,21 +633,6 @@ class LoadSpectralDataset(IOBlock):
         ".json": "spectral_dataset_manifest_json",
         ".xlsx": "xlsx",
         ".xls": "xlsx",
-        ".spc": "spc",
-        ".spg": "thermo_omnic_spg",
-        ".wdf": "renishaw_wdf",
-        ".opus": "bruker_opus",
-        ".l6s": "horiba_labspec",
-        ".l5s": "horiba_labspec",
-        ".ngc": "horiba_labspec",
-        ".xml": "horiba_labspec",
-        ".txt": "horiba_labspec",
-        ".wip": "witec_project",
-        ".wid": "witec_project",
-        ".sif": "andor_solis",
-        ".fits": "andor_solis",
-        ".fit": "andor_solis",
-        ".spe": "princeton_spe",
     }
 
     format_capabilities: ClassVar[tuple[FormatCapability, ...]] = (
@@ -789,103 +662,6 @@ class LoadSpectralDataset(IOBlock):
             roundtrip_group=f"{_PKG}.spectral_dataset.xlsx",
             metadata_fidelity=MetadataFidelity(level="typed_meta", typed_meta_reads=_DATASET_META_FIELDS),
         ),
-        FormatCapability(
-            id=f"{_PKG}.spectral_dataset.spc.load",
-            direction="load",
-            data_type=SpectralDataset,
-            format_id="spc",
-            extensions=(".spc",),
-            label="SPC spectral dataset",
-            block_type="LoadSpectralDataset",
-            handler="_load_spc_dataset",
-            is_default=True,
-            roundtrip_group=f"{_PKG}.spectral_dataset.spc",
-            metadata_fidelity=MetadataFidelity(level="typed_meta", typed_meta_reads=_DATASET_META_FIELDS),
-        ),
-        FormatCapability(
-            id=f"{_PKG}.spectral_dataset.thermo_omnic_spg.load",
-            direction="load",
-            data_type=SpectralDataset,
-            format_id="thermo_omnic_spg",
-            extensions=(".spg",),
-            label="Thermo OMNIC SPG dataset",
-            block_type="LoadSpectralDataset",
-            handler="_load_thermo_omnic_spg",
-            is_default=True,
-            metadata_fidelity=MetadataFidelity(level="typed_meta", typed_meta_reads=_DATASET_VENDOR_META_FIELDS),
-        ),
-        FormatCapability(
-            id=f"{_PKG}.spectral_dataset.renishaw_wdf.load",
-            direction="load",
-            data_type=SpectralDataset,
-            format_id="renishaw_wdf",
-            extensions=(".wdf",),
-            label="Renishaw WiRE dataset",
-            block_type="LoadSpectralDataset",
-            handler="_load_renishaw_wdf_dataset",
-            is_default=True,
-            metadata_fidelity=MetadataFidelity(level="typed_meta", typed_meta_reads=_DATASET_VENDOR_META_FIELDS),
-        ),
-        FormatCapability(
-            id=f"{_PKG}.spectral_dataset.bruker_opus.load",
-            direction="load",
-            data_type=SpectralDataset,
-            format_id="bruker_opus",
-            extensions=(".opus",),
-            label="Bruker OPUS dataset",
-            block_type="LoadSpectralDataset",
-            handler="_load_bruker_opus_dataset",
-            is_default=True,
-            metadata_fidelity=MetadataFidelity(level="typed_meta", typed_meta_reads=_DATASET_VENDOR_META_FIELDS),
-        ),
-        FormatCapability(
-            id=f"{_PKG}.spectral_dataset.horiba_labspec.load",
-            direction="load",
-            data_type=SpectralDataset,
-            format_id="horiba_labspec",
-            extensions=(".l6s", ".l5s", ".ngc", ".xml", ".txt"),
-            label="HORIBA LabSpec dataset",
-            block_type="LoadSpectralDataset",
-            handler="_load_horiba_labspec_dataset",
-            is_default=True,
-            metadata_fidelity=MetadataFidelity(level="typed_meta", typed_meta_reads=_DATASET_VENDOR_META_FIELDS),
-        ),
-        FormatCapability(
-            id=f"{_PKG}.spectral_dataset.witec_project.load",
-            direction="load",
-            data_type=SpectralDataset,
-            format_id="witec_project",
-            extensions=(".wip", ".wid"),
-            label="WITec project dataset",
-            block_type="LoadSpectralDataset",
-            handler="_load_witec_project",
-            is_default=True,
-            metadata_fidelity=MetadataFidelity(level="typed_meta", typed_meta_reads=_DATASET_VENDOR_META_FIELDS),
-        ),
-        FormatCapability(
-            id=f"{_PKG}.spectral_dataset.andor_solis.load",
-            direction="load",
-            data_type=SpectralDataset,
-            format_id="andor_solis",
-            extensions=(".sif", ".fits", ".fit"),
-            label="Andor Solis dataset",
-            block_type="LoadSpectralDataset",
-            handler="_load_andor_solis_dataset",
-            is_default=True,
-            metadata_fidelity=MetadataFidelity(level="typed_meta", typed_meta_reads=_DATASET_VENDOR_META_FIELDS),
-        ),
-        FormatCapability(
-            id=f"{_PKG}.spectral_dataset.princeton_spe.load",
-            direction="load",
-            data_type=SpectralDataset,
-            format_id="princeton_spe",
-            extensions=(".spe",),
-            label="Princeton/LightField SPE dataset",
-            block_type="LoadSpectralDataset",
-            handler="_load_princeton_spe_dataset",
-            is_default=True,
-            metadata_fidelity=MetadataFidelity(level="typed_meta", typed_meta_reads=_DATASET_VENDOR_META_FIELDS),
-        ),
     )
 
     _load_manifest_json = staticmethod(dataset_formats.load_manifest_json)
@@ -903,8 +679,8 @@ class LoadSpectralDataset(IOBlock):
         """Load a dataset-shaped file into a SpectralDataset (FR-038).
 
         Resolves ``config['path']`` and optional ``capability_id``, dispatches to
-        the matching ``_load_*`` handler (manifest JSON / xlsx workbook / SPC /
-        vendor) via ADR-043 selection, and returns the loaded
+        the matching ``_load_*`` handler (manifest JSON / xlsx workbook) via
+        ADR-043 selection, and returns the loaded
         :class:`SpectralDataset`. The handlers validate the canonical two-table
         layout (FR-038, FR-135..FR-139); the ``IOBlock.run`` wrapper packs the
         single dataset into a Collection.
@@ -941,7 +717,7 @@ class SaveSpectralDataset(IOBlock):
     direction: ClassVar[str] = "output"
     type_name: ClassVar[str] = "spectroscopy.save_spectral_dataset"
     name: ClassVar[str] = "Save Spectral Dataset"
-    description: ClassVar[str] = "Save a SpectralDataset to a JSON manifest, workbook, or SPC file."
+    description: ClassVar[str] = "Save a SpectralDataset to a JSON manifest or workbook."
     version: ClassVar[str] = "0.1.0"
     subcategory: ClassVar[str] = "io"
 
@@ -979,7 +755,6 @@ class SaveSpectralDataset(IOBlock):
     supported_extensions: ClassVar[dict[str, str]] = {
         ".json": "spectral_dataset_manifest_json",
         ".xlsx": "xlsx",
-        ".spc": "spc",
     }
 
     format_capabilities: ClassVar[tuple[FormatCapability, ...]] = (
@@ -1009,19 +784,6 @@ class SaveSpectralDataset(IOBlock):
             roundtrip_group=f"{_PKG}.spectral_dataset.xlsx",
             metadata_fidelity=MetadataFidelity(level="typed_meta", typed_meta_writes=_DATASET_META_FIELDS),
         ),
-        FormatCapability(
-            id=f"{_PKG}.spectral_dataset.spc.save",
-            direction="save",
-            data_type=SpectralDataset,
-            format_id="spc",
-            extensions=(".spc",),
-            label="SPC spectral dataset",
-            block_type="SaveSpectralDataset",
-            handler="_save_spc_dataset",
-            is_default=True,
-            roundtrip_group=f"{_PKG}.spectral_dataset.spc",
-            metadata_fidelity=MetadataFidelity(level="typed_meta", typed_meta_writes=_DATASET_META_FIELDS),
-        ),
     )
 
     _save_manifest_json = staticmethod(dataset_formats.save_manifest_json)
@@ -1035,9 +797,9 @@ class SaveSpectralDataset(IOBlock):
         """Persist a SpectralDataset (FR-039).
 
         Resolves ``config['path']`` (+ optional ``output_dir``/``capability_id``),
-        dispatches to ``_save_manifest_json`` / ``_save_dataset_xlsx`` /
-        ``_save_spc_dataset`` (the only declared savers — there is no archive/zip
-        capability, FR-136), and writes the canonical two-table layout preserving
+        dispatches to ``_save_manifest_json`` / ``_save_dataset_xlsx`` (the
+        only declared savers — there is no archive/zip capability, FR-136), and
+        writes the canonical two-table layout preserving
         ``index.spectrum_id``, ``spectra.spectrum_id``, coordinates, intensities,
         and dataset/index metadata (FR-039, FR-135..FR-138).
         """
@@ -1107,11 +869,20 @@ def _join_metadata(index_pdf: Any, meta_pdf: Any, join_key: str, block: str) -> 
         raise ValueError(f"{block}: index has no join column {join_key!r}")
     if join_key not in meta_pdf.columns:
         raise ValueError(f"{block}: metadata table has no join column {join_key!r}")
+    duplicate_meta_keys = _duplicate_values(meta_pdf[join_key].tolist())
+    if duplicate_meta_keys:
+        raise ValueError(
+            f"{block}: metadata join key {join_key!r} must be unique; "
+            f"duplicates {duplicate_meta_keys!r} would multiply index rows"
+        )
     # Drop overlapping non-key columns from the index so metadata fills them in
     # (metadata table is the authoritative side for the joined columns).
     overlap = [c for c in meta_pdf.columns if c != join_key and c in index_pdf.columns]
     left = index_pdf.drop(columns=overlap) if overlap else index_pdf
-    return left.merge(meta_pdf, on=join_key, how="left")
+    merged = left.merge(meta_pdf, on=join_key, how="left")
+    if len(merged) != len(index_pdf):
+        raise ValueError(f"{block}: metadata join changed index row count from {len(index_pdf)} to {len(merged)}")
+    return merged
 
 
 def _dataset_meta_from_spectra(spectra: list[Spectrum]) -> SpectralDataset.Meta:
@@ -1244,6 +1015,13 @@ def _check_unit_compatibility(datasets: list[SpectralDataset], block: str) -> No
                 value = getattr(meta, field, None)
                 if value is not None:
                     seen.add(value)
+            index_tbl, _ = _support.dataset_frames(dataset)
+            if field in index_tbl.column_names:
+                seen.update(
+                    value
+                    for value in index_tbl.column(field).to_pylist()
+                    if value is not None and not _is_missing(value) and value != ""
+                )
         if len(seen) > 1:
             raise ValueError(
                 f"{block}: incompatible {field} across datasets {sorted(seen)!r}; "
@@ -1287,6 +1065,19 @@ def _reject_object_cells(pdf: Any, block: str) -> None:
                     f"{block}: feature column {column!r} contains a {type(value).__name__} object; "
                     "feature tables must be flat and columnar (FR-083)"
                 )
+
+
+def _duplicate_values(values: list[Any]) -> list[str]:
+    """Return duplicate non-missing key values in first-seen order."""
+    seen: set[Any] = set()
+    duplicates: list[str] = []
+    for value in values:
+        if _is_missing(value):
+            continue
+        if value in seen and str(value) not in duplicates:
+            duplicates.append(str(value))
+        seen.add(value)
+    return duplicates
 
 
 def _is_missing(value: Any) -> bool:
@@ -1683,6 +1474,12 @@ class AttachFeaturesToSpectralDataset(ProcessBlock):
             raise ValueError(f"{block}: index table missing join key {join_key!r}")
         if join_key not in feat_pdf.columns:
             raise ValueError(f"{block}: features table missing join key {join_key!r}")
+        duplicate_feature_keys = _duplicate_values(feat_pdf[join_key].tolist())
+        if duplicate_feature_keys:
+            raise ValueError(
+                f"{block}: feature join key {join_key!r} must be unique; "
+                f"duplicates {duplicate_feature_keys!r} would multiply index rows"
+            )
 
         # Reject Spectrum/object cells in the feature table (FR-083).
         _reject_object_cells(feat_pdf, block)
@@ -1709,6 +1506,8 @@ class AttachFeaturesToSpectralDataset(ProcessBlock):
         feat_join = feat_pdf.rename(columns=rename)
         index_join = index_pdf.drop(columns=drop_existing) if drop_existing else index_pdf
         merged = index_join.merge(feat_join, on=join_key, how="left")
+        if len(merged) != len(index_pdf):
+            raise ValueError(f"{block}: feature join changed index row count from {len(index_pdf)} to {len(merged)}")
 
         index_df = _support.dataframe_from_pandas(merged)
         # spectra slot is left untouched (FR-084).

--- a/packages/scistudio-blocks-spectroscopy/src/scistudio_blocks_spectroscopy/previewers/assets/viewer.js
+++ b/packages/scistudio-blocks-spectroscopy/src/scistudio_blocks_spectroscopy/previewers/assets/viewer.js
@@ -1,23 +1,10 @@
 // Spectroscopy previewer viewer (vanilla ESM, ADR-048 frontend contract).
 //
-// Self-contained, dependency-free ES module (NO npm, NO framework). It reads
-// everything through the constrained `host` API only and renders both the
-// SERIES (Spectrum) and COMPOSITE (SpectralDataset) envelope kinds. If this
-// module fails to load, the platform degrades to the core series/composite
-// renderer (the envelope kind is chosen so that fallback is lossless).
-//
-// host API contract (see imaging viewer.js / previewerHostApi.ts):
-//   host.envelope.payload          — the JSON payload built by the provider
-//   host.kind                      — "series" / "composite" / "error"
-//   host.session.patchQuery(q)     — re-render with new query (page/sort/...)
-//   host.session.getResource(id)   — bounded child / resource read
-//   host.exportArtifact(req)       — user-initiated figure / rows export
-//   host.reportError(msg, detail)  — non-fatal error channel
-//
-// It causes NO workflow/runtime/lineage mutation (FR-030: previewers perform
-// no scientific processing — only display).
+// Self-contained, dependency-free module. It reads only the canonical host
+// envelope/resources API and never mutates workflow/runtime/lineage state.
 
 const API_VERSION = "1";
+const SVG_NS = "http://www.w3.org/2000/svg";
 
 function el(tag, attrs, ...children) {
   const node = document.createElement(tag);
@@ -26,9 +13,8 @@ function el(tag, attrs, ...children) {
       if (value == null) continue;
       if (key === "style") node.setAttribute("style", value);
       else if (key === "text") node.textContent = value;
-      else if (key.startsWith("on") && typeof value === "function") {
-        node.addEventListener(key.slice(2), value);
-      } else node.setAttribute(key, value);
+      else if (key.startsWith("on") && typeof value === "function") node.addEventListener(key.slice(2), value);
+      else node.setAttribute(key, value);
     }
   }
   for (const child of children) {
@@ -58,9 +44,17 @@ function exportButton(host, resourceId, filename, format, label) {
   );
 }
 
+function patchQuery(host, patch, label) {
+  try {
+    if (host.session && typeof host.session.patchQuery === "function") host.session.patchQuery(patch);
+  } catch (err) {
+    host.reportError(`${label} failed`, { error: String(err) });
+  }
+}
+
 function diagnosticsPanel(messages) {
   const list = Array.isArray(messages) ? messages.filter(Boolean) : [];
-  if (list.length === 0) return null;
+  if (!list.length) return null;
   const box = el("div", {
     style:
       "font:12px sans-serif;margin:6px 0;padding:6px 8px;border-left:3px solid #e0a800;background:#fff8e1;color:#664d03",
@@ -70,9 +64,232 @@ function diagnosticsPanel(messages) {
   return box;
 }
 
-/* -------------------------------------------------------------------------
- * Spectrum (SERIES) — interactive 2-D line plot with axis labels + units.
- * ----------------------------------------------------------------------- */
+function svgText(parent, x, y, content, anchor) {
+  const node = document.createElementNS(SVG_NS, "text");
+  node.setAttribute("x", String(x));
+  node.setAttribute("y", String(y));
+  node.setAttribute("font-size", "11");
+  node.setAttribute("fill", "#555");
+  node.setAttribute("text-anchor", anchor || "start");
+  node.textContent = content;
+  parent.appendChild(node);
+  return node;
+}
+
+function numericBounds(seriesList) {
+  const xs = [];
+  const ys = [];
+  for (const series of seriesList) {
+    for (const point of series.points || []) {
+      if (Number.isFinite(point.x) && Number.isFinite(point.y)) {
+        xs.push(point.x);
+        ys.push(point.y);
+      }
+    }
+  }
+  if (!xs.length) return null;
+  const xMin = Math.min(...xs);
+  const xMax = Math.max(...xs);
+  const yMin = Math.min(...ys);
+  const yMax = Math.max(...ys);
+  return {
+    xMin,
+    xMax: xMax === xMin ? xMin + 1 : xMax,
+    yMin,
+    yMax: yMax === yMin ? yMin + 1 : yMax,
+  };
+}
+
+function renderInteractiveLines(container, seriesList, axes, options = {}) {
+  const width = options.width || 620;
+  const height = options.height || 240;
+  const padL = 52;
+  const padB = 28;
+  const padT = 12;
+  const padR = 16;
+  const colors = ["#2b7de9", "#e8590c", "#2f9e44", "#9c36b5", "#0b7285", "#f08c00", "#495057"];
+  const bounds = numericBounds(seriesList);
+
+  if (!bounds) {
+    container.appendChild(el("div", { style: "color:#888;font:13px sans-serif", text: "no plot data to display" }));
+    return;
+  }
+
+  let view = { ...bounds };
+  let mode = "pan";
+  let drag = null;
+
+  const toolbar = el("div", { style: "font:12px sans-serif;margin:4px 0" });
+  const addButton = (label, fn) => toolbar.appendChild(el("button", { style: "margin-right:4px", onclick: fn }, label));
+  addButton("Pan", () => {
+    mode = "pan";
+  });
+  addButton("Box zoom", () => {
+    mode = "box";
+  });
+  addButton("Zoom in", () => zoomAt(0.75, width / 2, height / 2));
+  addButton("Zoom out", () => zoomAt(1.33, width / 2, height / 2));
+  addButton("Reset", () => {
+    view = { ...bounds };
+    redraw();
+  });
+  container.appendChild(toolbar);
+
+  const svg = document.createElementNS(SVG_NS, "svg");
+  svg.setAttribute("width", String(width));
+  svg.setAttribute("height", String(height));
+  svg.setAttribute("viewBox", `0 0 ${width} ${height}`);
+  svg.setAttribute("style", "border:1px solid #ddd;background:#fff;cursor:crosshair;touch-action:none");
+  const plotGroup = document.createElementNS(SVG_NS, "g");
+  const marker = document.createElementNS(SVG_NS, "circle");
+  const zoomBox = document.createElementNS(SVG_NS, "rect");
+  marker.setAttribute("r", "3");
+  marker.setAttribute("fill", "#e8590c");
+  marker.setAttribute("visibility", "hidden");
+  zoomBox.setAttribute("fill", "rgba(43,125,233,0.12)");
+  zoomBox.setAttribute("stroke", "#2b7de9");
+  zoomBox.setAttribute("stroke-dasharray", "4 3");
+  zoomBox.setAttribute("visibility", "hidden");
+  svg.appendChild(plotGroup);
+  svg.appendChild(marker);
+  svg.appendChild(zoomBox);
+  container.appendChild(svg);
+
+  const readout = el("div", { style: "font:12px monospace;color:#333;height:16px;margin-top:2px", text: "" });
+  container.appendChild(readout);
+
+  function sx(x) {
+    return padL + ((x - view.xMin) / (view.xMax - view.xMin || 1)) * (width - padL - padR);
+  }
+  function sy(y) {
+    return height - padB - ((y - view.yMin) / (view.yMax - view.yMin || 1)) * (height - padT - padB);
+  }
+  function dataX(px) {
+    return view.xMin + ((px - padL) / (width - padL - padR)) * (view.xMax - view.xMin);
+  }
+  function dataY(py) {
+    return view.yMin + ((height - padB - py) / (height - padT - padB)) * (view.yMax - view.yMin);
+  }
+  function pointer(evt) {
+    const rect = svg.getBoundingClientRect();
+    return {
+      x: ((evt.clientX - rect.left) / rect.width) * width,
+      y: ((evt.clientY - rect.top) / rect.height) * height,
+    };
+  }
+  function zoomAt(factor, px, py) {
+    const cx = dataX(px);
+    const cy = dataY(py);
+    const xHalf = ((view.xMax - view.xMin) * factor) / 2;
+    const yHalf = ((view.yMax - view.yMin) * factor) / 2;
+    view = { xMin: cx - xHalf, xMax: cx + xHalf, yMin: cy - yHalf, yMax: cy + yHalf };
+    redraw();
+  }
+  function axis(x1, y1, x2, y2) {
+    const line = document.createElementNS(SVG_NS, "line");
+    line.setAttribute("x1", String(x1));
+    line.setAttribute("y1", String(y1));
+    line.setAttribute("x2", String(x2));
+    line.setAttribute("y2", String(y2));
+    line.setAttribute("stroke", "#bbb");
+    plotGroup.appendChild(line);
+  }
+  function redraw() {
+    plotGroup.replaceChildren();
+    axis(padL, height - padB, width - padR, height - padB);
+    axis(padL, padT, padL, height - padB);
+    for (const [i, series] of seriesList.entries()) {
+      const points = (series.points || []).filter((p) => Number.isFinite(p.x) && Number.isFinite(p.y));
+      if (!points.length) continue;
+      const path = points.map((p, idx) => `${idx === 0 ? "M" : "L"}${sx(p.x).toFixed(2)},${sy(p.y).toFixed(2)}`).join(" ");
+      const line = document.createElementNS(SVG_NS, "path");
+      line.setAttribute("d", path);
+      line.setAttribute("fill", "none");
+      line.setAttribute("stroke", colors[i % colors.length]);
+      line.setAttribute("stroke-width", series.selected ? "2.4" : "1.4");
+      line.setAttribute("opacity", series.dimmed ? "0.35" : "1");
+      plotGroup.appendChild(line);
+    }
+    svgText(plotGroup, width / 2, height - 4, axes.x || "lambda", "middle");
+    const yLabel = svgText(plotGroup, 12, height / 2, axes.y || "intensity", "middle");
+    yLabel.setAttribute("transform", `rotate(-90 12 ${height / 2})`);
+  }
+  function nearestPoint(px) {
+    let nearest = null;
+    let best = Infinity;
+    for (const series of seriesList) {
+      for (const point of series.points || []) {
+        const dist = Math.abs(sx(point.x) - px);
+        if (dist < best) {
+          best = dist;
+          nearest = point;
+        }
+      }
+    }
+    return nearest;
+  }
+
+  svg.addEventListener("wheel", (evt) => {
+    evt.preventDefault();
+    const p = pointer(evt);
+    zoomAt(evt.deltaY < 0 ? 0.82 : 1.22, p.x, p.y);
+  });
+  svg.addEventListener("mousedown", (evt) => {
+    const p = pointer(evt);
+    drag = { mode, start: p, view: { ...view } };
+    if (mode === "box") {
+      zoomBox.setAttribute("x", String(p.x));
+      zoomBox.setAttribute("y", String(p.y));
+      zoomBox.setAttribute("width", "0");
+      zoomBox.setAttribute("height", "0");
+      zoomBox.setAttribute("visibility", "visible");
+    }
+  });
+  svg.addEventListener("mousemove", (evt) => {
+    const p = pointer(evt);
+    const nearest = nearestPoint(p.x);
+    if (nearest) {
+      marker.setAttribute("cx", String(sx(nearest.x)));
+      marker.setAttribute("cy", String(sy(nearest.y)));
+      marker.setAttribute("visibility", "visible");
+      readout.textContent = `${axes.x || "x"} = ${nearest.x}    ${axes.y || "y"} = ${nearest.y}`;
+    }
+    if (!drag) return;
+    if (drag.mode === "pan") {
+      const dx = dataX(drag.start.x) - dataX(p.x);
+      const dy = dataY(drag.start.y) - dataY(p.y);
+      view = {
+        xMin: drag.view.xMin + dx,
+        xMax: drag.view.xMax + dx,
+        yMin: drag.view.yMin + dy,
+        yMax: drag.view.yMax + dy,
+      };
+      redraw();
+    } else {
+      zoomBox.setAttribute("x", String(Math.min(drag.start.x, p.x)));
+      zoomBox.setAttribute("y", String(Math.min(drag.start.y, p.y)));
+      zoomBox.setAttribute("width", String(Math.abs(p.x - drag.start.x)));
+      zoomBox.setAttribute("height", String(Math.abs(p.y - drag.start.y)));
+    }
+  });
+  window.addEventListener("mouseup", (evt) => {
+    if (!drag) return;
+    const p = pointer(evt);
+    if (drag.mode === "box" && Math.abs(p.x - drag.start.x) > 8 && Math.abs(p.y - drag.start.y) > 8) {
+      const x1 = dataX(Math.min(p.x, drag.start.x));
+      const x2 = dataX(Math.max(p.x, drag.start.x));
+      const y1 = dataY(Math.max(p.y, drag.start.y));
+      const y2 = dataY(Math.min(p.y, drag.start.y));
+      view = { xMin: x1, xMax: x2, yMin: y1, yMax: y2 };
+      redraw();
+    }
+    zoomBox.setAttribute("visibility", "hidden");
+    drag = null;
+  });
+  svg.addEventListener("mouseleave", () => marker.setAttribute("visibility", "hidden"));
+
+  redraw();
+}
 
 function renderSpectrum(container, payload, host, diagnostics) {
   const points = Array.isArray(payload.points) ? payload.points : [];
@@ -84,154 +301,208 @@ function renderSpectrum(container, payload, host, diagnostics) {
   container.appendChild(
     el("div", {
       style: "font:13px sans-serif;margin-bottom:4px;font-weight:600",
-      text: `Spectrum — ${points.length} of ${total} point(s)`,
+      text: `Spectrum - ${points.length} of ${total} point(s)`,
     }),
   );
 
   const panel = diagnosticsPanel(diagnostics);
   if (panel) container.appendChild(panel);
 
-  if (points.length === 0) {
-    container.appendChild(el("div", { style: "color:#888;font:13px sans-serif", text: "no points to display" }));
-    return;
-  }
-
-  const width = 620;
-  const height = 240;
-  const padL = 52;
-  const padB = 28;
-  const padT = 10;
-  const padR = 12;
-  const xs = points.map((p) => p.x);
-  const ys = points.map((p) => p.y);
-  const xMin = Math.min(...xs);
-  const xMax = Math.max(...xs);
-  const yMin = Math.min(...ys);
-  const yMax = Math.max(...ys);
-  const xSpan = xMax - xMin || 1;
-  const ySpan = yMax - yMin || 1;
-  const sx = (x) => padL + ((x - xMin) / xSpan) * (width - padL - padR);
-  const sy = (y) => height - padB - ((y - yMin) / ySpan) * (height - padT - padB);
-
-  const path = points.map((p, i) => `${i === 0 ? "M" : "L"}${sx(p.x).toFixed(2)},${sy(p.y).toFixed(2)}`).join(" ");
-
-  const svgNs = "http://www.w3.org/2000/svg";
-  const svg = document.createElementNS(svgNs, "svg");
-  svg.setAttribute("width", String(width));
-  svg.setAttribute("height", String(height));
-  svg.setAttribute("viewBox", `0 0 ${width} ${height}`);
-  svg.setAttribute("style", "border:1px solid #eee;background:#fff");
-
-  const axisLine = (x1, y1, x2, y2) => {
-    const l = document.createElementNS(svgNs, "line");
-    l.setAttribute("x1", String(x1));
-    l.setAttribute("y1", String(y1));
-    l.setAttribute("x2", String(x2));
-    l.setAttribute("y2", String(y2));
-    l.setAttribute("stroke", "#bbb");
-    l.setAttribute("stroke-width", "1");
-    return l;
-  };
-  svg.appendChild(axisLine(padL, height - padB, width - padR, height - padB));
-  svg.appendChild(axisLine(padL, padT, padL, height - padB));
-
-  const polyline = document.createElementNS(svgNs, "path");
-  polyline.setAttribute("d", path);
-  polyline.setAttribute("fill", "none");
-  polyline.setAttribute("stroke", "#2b7de9");
-  polyline.setAttribute("stroke-width", "1.5");
-  svg.appendChild(polyline);
-
-  const text = (x, y, content, anchor) => {
-    const t = document.createElementNS(svgNs, "text");
-    t.setAttribute("x", String(x));
-    t.setAttribute("y", String(y));
-    t.setAttribute("font-size", "11");
-    t.setAttribute("fill", "#555");
-    t.setAttribute("text-anchor", anchor || "start");
-    t.textContent = content;
-    return t;
-  };
-  svg.appendChild(text(width / 2, height - 4, xAxis.label || "lambda", "middle"));
-  const yLabel = text(12, height / 2, yAxis.label || "intensity", "middle");
-  yLabel.setAttribute("transform", `rotate(-90 12 ${height / 2})`);
-  svg.appendChild(yLabel);
-
-  // Hover coordinate / intensity readout (FR-019).
-  const readout = el("div", {
-    style: "font:12px monospace;color:#333;height:16px;margin-top:2px",
-    text: "hover the plot for (x, y)",
-  });
-  const marker = document.createElementNS(svgNs, "circle");
-  marker.setAttribute("r", "3");
-  marker.setAttribute("fill", "#e8590c");
-  marker.setAttribute("visibility", "hidden");
-  svg.appendChild(marker);
-  svg.addEventListener("mousemove", (evt) => {
-    const rect = svg.getBoundingClientRect();
-    const px = ((evt.clientX - rect.left) / rect.width) * width;
-    let nearest = points[0];
-    let best = Infinity;
-    for (const p of points) {
-      const d = Math.abs(sx(p.x) - px);
-      if (d < best) {
-        best = d;
-        nearest = p;
-      }
-    }
-    marker.setAttribute("cx", String(sx(nearest.x)));
-    marker.setAttribute("cy", String(sy(nearest.y)));
-    marker.setAttribute("visibility", "visible");
-    readout.textContent = `${xAxis.label || "x"} = ${nearest.x}    ${yAxis.label || "y"} = ${nearest.y}`;
-  });
-  svg.addEventListener("mouseleave", () => {
-    marker.setAttribute("visibility", "hidden");
-  });
-
-  container.appendChild(svg);
-  container.appendChild(readout);
+  renderInteractiveLines(container, [{ spectrum_id: "spectrum", points }], { x: xAxis.label, y: yAxis.label });
 
   const actions = el("div", { style: "margin-top:6px" });
   actions.appendChild(exportButton(host, "export_figure_svg", "spectrum.svg", "svg", "Export figure (SVG)"));
   actions.appendChild(exportButton(host, "export_figure_png", "spectrum.png", "png", "PNG"));
+  actions.appendChild(exportButton(host, "export_figure_pdf", "spectrum.pdf", "pdf", "PDF"));
   actions.appendChild(exportButton(host, "export_points_csv", "spectrum_points.csv", "csv", "Export points (CSV)"));
   container.appendChild(actions);
 }
 
-/* -------------------------------------------------------------------------
- * SpectralDataset (COMPOSITE) — index table + diagnostics + plot-mode stub.
- * ----------------------------------------------------------------------- */
+function drawDatasetPlot(container, plot, mode) {
+  container.replaceChildren();
+  const axes = { x: "lambda", y: "intensity" };
+  if (mode === "heatmap") {
+    const heatmap = plot.heatmap || {};
+    if (!heatmap.aligned || !Array.isArray(heatmap.matrix) || !heatmap.matrix.length) {
+      container.appendChild(
+        el("div", {
+          style: "font:12px sans-serif;color:#664d03",
+          text: "heatmap unavailable until visible spectra share one lambda grid",
+        }),
+      );
+      return;
+    }
+    const table = el("table", { style: "font:11px monospace;border-collapse:collapse;max-width:100%;overflow:auto" });
+    for (let i = 0; i < heatmap.matrix.length; i += 1) {
+      const row = heatmap.matrix[i] || [];
+      const max = Math.max(...row.map((v) => Math.abs(v)), 1);
+      const tr = el("tr", null, el("th", { style: "border:1px solid #ddd;padding:2px 4px", text: String(heatmap.rows[i]) }));
+      for (const value of row) {
+        const alpha = Math.min(1, Math.abs(value) / max);
+        tr.appendChild(
+          el("td", {
+            style: `border:1px solid #eee;padding:2px 4px;background:rgba(43,125,233,${alpha})`,
+            text: Number(value).toFixed(2),
+          }),
+        );
+      }
+      table.appendChild(tr);
+    }
+    container.appendChild(table);
+    return;
+  }
+
+  let series = [];
+  if (mode === "selected") series = ((plot.selected || {}).series || []).map((s) => ({ ...s, selected: true }));
+  else if (mode === "group_mean") {
+    series = ((plot.group_mean || {}).groups || []).map((g) => ({ spectrum_id: g.group, points: g.points || [] }));
+  } else if (mode === "group_band") {
+    series = ((plot.group_band || {}).groups || []).flatMap((g) => [
+      { spectrum_id: `${g.group} mean`, points: (g.points || []).map((p) => ({ x: p.x, y: p.mean })) },
+      { spectrum_id: `${g.group} min`, points: (g.points || []).map((p) => ({ x: p.x, y: p.min })), dimmed: true },
+      { spectrum_id: `${g.group} max`, points: (g.points || []).map((p) => ({ x: p.x, y: p.max })), dimmed: true },
+    ]);
+  } else {
+    series = ((plot.overlay || {}).series || []).map((s) => ({ ...s, selected: s.selected }));
+  }
+  renderInteractiveLines(container, series, axes, { height: 220 });
+}
 
 function renderDataset(container, payload, host, diagnostics) {
   const slots = payload.slots && typeof payload.slots === "object" ? payload.slots : {};
   const indexTable = payload.index_table || {};
-  const plotModes = Array.isArray(payload.plot_modes) ? payload.plot_modes : [];
+  const plotModes = Array.isArray(payload.plot_modes) ? payload.plot_modes : ["overlay"];
   const datasetDiag = payload.diagnostics || {};
+  const controls = payload.controls || {};
+  const plot = payload.plot || {};
+  const columns = Array.isArray(indexTable.columns) ? indexTable.columns : [];
+  const rows = Array.isArray(indexTable.rows) ? indexTable.rows : [];
+  const groupable = Array.isArray(controls.groupable_columns)
+    ? controls.groupable_columns
+    : columns.filter((c) => c !== "spectrum_id");
+  let selected = new Set(Array.isArray(controls.selected_ids) ? controls.selected_ids.map(String) : []);
+  let search = "";
 
   container.appendChild(
     el("div", {
       style: "font:13px sans-serif;margin-bottom:4px;font-weight:600",
-      text: `SpectralDataset — ${Object.keys(slots).length} slot(s)`,
+      text: `SpectralDataset - ${Object.keys(slots).length} slot(s)`,
     }),
   );
 
-  // Plot-mode selector stub (FR-025): the modes the explorer can offer.
-  if (plotModes.length) {
-    const bar = el("div", { style: "font:12px sans-serif;margin:4px 0" }, "Plot mode: ");
-    const select = el("select", { style: "font:12px sans-serif" });
-    for (const mode of plotModes) select.appendChild(el("option", { value: mode, text: mode }));
-    select.addEventListener("change", () => {
-      try {
-        host.session.patchQuery({ plot_mode: select.value });
-      } catch (err) {
-        host.reportError("plot mode change failed", { error: String(err) });
-      }
-    });
-    bar.appendChild(select);
-    container.appendChild(bar);
-  }
+  const controlBar = el("div", {
+    style: "font:12px sans-serif;display:flex;gap:8px;flex-wrap:wrap;align-items:center;margin:4px 0",
+  });
+  const modeSelect = el("select", { style: "font:12px sans-serif" });
+  for (const mode of plotModes) modeSelect.appendChild(el("option", { value: mode, text: mode }));
+  modeSelect.value = controls.plot_mode || plot.mode || "overlay";
+  modeSelect.addEventListener("change", () => {
+    drawDatasetPlot(plotHost, plot, modeSelect.value);
+    patchQuery(host, { plot_mode: modeSelect.value }, "plot mode change");
+  });
 
-  // Dataset health diagnostics panel (FR-027).
+  const groupSelect = el("select", { style: "font:12px sans-serif" }, el("option", { value: "", text: "no group" }));
+  const colorSelect = el("select", { style: "font:12px sans-serif" }, el("option", { value: "", text: "no color" }));
+  for (const col of groupable) {
+    groupSelect.appendChild(el("option", { value: col, text: col }));
+    colorSelect.appendChild(el("option", { value: col, text: col }));
+  }
+  groupSelect.value = controls.group_by || "";
+  colorSelect.value = controls.color_by || "";
+  groupSelect.addEventListener("change", () => patchQuery(host, { group_by: groupSelect.value || null }, "group change"));
+  colorSelect.addEventListener("change", () => patchQuery(host, { color_by: colorSelect.value || null }, "color change"));
+
+  const searchInput = el("input", {
+    type: "search",
+    placeholder: "search index",
+    style: "font:12px sans-serif;padding:2px 4px",
+    oninput: () => {
+      search = searchInput.value.toLowerCase();
+      drawTable();
+    },
+  });
+  controlBar.appendChild(el("span", null, "Plot"));
+  controlBar.appendChild(modeSelect);
+  controlBar.appendChild(el("span", null, "Group"));
+  controlBar.appendChild(groupSelect);
+  controlBar.appendChild(el("span", null, "Color"));
+  controlBar.appendChild(colorSelect);
+  controlBar.appendChild(searchInput);
+  container.appendChild(controlBar);
+
+  const plotHost = el("div", { style: "margin:6px 0" });
+  container.appendChild(plotHost);
+  drawDatasetPlot(plotHost, plot, modeSelect.value);
+
+  const tableHost = el("div", null);
+  container.appendChild(tableHost);
+
+  function selectedList() {
+    return Array.from(selected).sort();
+  }
+  function rowMatches(row) {
+    if (!search) return true;
+    return columns.some((col) => String(row && row[col] != null ? row[col] : "").toLowerCase().includes(search));
+  }
+  function drawTable() {
+    tableHost.replaceChildren();
+    if (indexTable.available && columns.length) {
+      const table = el("table", { style: "font:12px sans-serif;border-collapse:collapse;margin-top:6px;width:100%" });
+      const head = el("tr", null);
+      head.appendChild(el("th", { style: "border:1px solid #ddd;padding:3px 6px;background:#f6f6f6", text: "select" }));
+      for (const col of columns) {
+        const th = el("th", {
+          style: "border:1px solid #ddd;padding:3px 6px;background:#f6f6f6;text-align:left;cursor:pointer",
+          text: col,
+        });
+        th.addEventListener("click", () => patchQuery(host, { sort_by: col, sort_dir: "asc" }, "sort"));
+        head.appendChild(th);
+      }
+      table.appendChild(head);
+      for (const row of rows.filter(rowMatches)) {
+        const sid = String(row && row.spectrum_id != null ? row.spectrum_id : "");
+        const tr = el("tr", { style: selected.has(sid) ? "background:#e7f5ff" : "" });
+        const checkbox = el("input", { type: "checkbox" });
+        checkbox.checked = selected.has(sid);
+        checkbox.addEventListener("change", () => {
+          if (checkbox.checked) selected.add(sid);
+          else selected.delete(sid);
+          drawTable();
+          patchQuery(host, { selected_ids: selectedList() }, "selection update");
+        });
+        tr.appendChild(el("td", { style: "border:1px solid #eee;padding:3px 6px" }, checkbox));
+        for (const col of columns) {
+          tr.appendChild(
+            el("td", { style: "border:1px solid #eee;padding:3px 6px" }, String(row && row[col] != null ? row[col] : "")),
+          );
+        }
+        table.appendChild(tr);
+      }
+      tableHost.appendChild(table);
+      tableHost.appendChild(
+        el("div", {
+          style: "font:11px sans-serif;color:#888;margin-top:2px",
+          text: `index: showing ${rows.length} of ${indexTable.total_rows || rows.length} row(s) (page ${indexTable.page || 1})`,
+        }),
+      );
+      return;
+    }
+    const list = el("ul", { style: "font:13px sans-serif;margin:6px 0;padding-left:18px" });
+    for (const [name, type] of Object.entries(slots)) {
+      const li = el("li", { style: "cursor:pointer", text: `${name}: ${type}` });
+      li.addEventListener("click", () => {
+        try {
+          if (host.session && typeof host.session.getResource === "function") host.session.getResource(`slot:${name}`);
+        } catch (err) {
+          host.reportError(`failed to open slot ${name}`, { error: String(err) });
+        }
+      });
+      list.appendChild(li);
+    }
+    tableHost.appendChild(list);
+  }
+  drawTable();
+
   const issues = Array.isArray(datasetDiag.issues) ? datasetDiag.issues : [];
   const diagMsgs = issues.map((i) => (i && i.code ? `${i.code}: ${JSON.stringify(i)}` : String(i)));
   const panel = diagnosticsPanel([...diagMsgs, ...(Array.isArray(diagnostics) ? diagnostics : [])]);
@@ -242,70 +513,13 @@ function renderDataset(container, payload, host, diagnostics) {
     );
   }
 
-  // Paginated index table (FR-023).
-  const columns = Array.isArray(indexTable.columns) ? indexTable.columns : [];
-  const rows = Array.isArray(indexTable.rows) ? indexTable.rows : [];
-  if (indexTable.available && columns.length) {
-    const table = el("table", {
-      style: "font:12px sans-serif;border-collapse:collapse;margin-top:6px;width:100%",
-    });
-    const thead = el("tr", null);
-    for (const col of columns) {
-      const th = el("th", {
-        style: "border:1px solid #ddd;padding:3px 6px;background:#f6f6f6;text-align:left;cursor:pointer",
-        text: col,
-      });
-      th.addEventListener("click", () => {
-        try {
-          host.session.patchQuery({ sort_by: col, sort_dir: "asc" });
-        } catch (err) {
-          host.reportError("sort failed", { error: String(err) });
-        }
-      });
-      thead.appendChild(th);
-    }
-    table.appendChild(thead);
-    for (const row of rows) {
-      const tr = el("tr", null);
-      for (const col of columns) {
-        tr.appendChild(
-          el("td", { style: "border:1px solid #eee;padding:3px 6px" }, String(row && row[col] != null ? row[col] : "")),
-        );
-      }
-      table.appendChild(tr);
-    }
-    container.appendChild(table);
-    container.appendChild(
-      el("div", {
-        style: "font:11px sans-serif;color:#888;margin-top:2px",
-        text: `index: showing ${rows.length} of ${indexTable.total_rows || rows.length} row(s) (page ${indexTable.page || 1})`,
-      }),
-    );
-  } else {
-    // Slot-inventory fallback when the index table is not bounded-readable.
-    const list = el("ul", { style: "font:13px sans-serif;margin:6px 0;padding-left:18px" });
-    for (const [name, type] of Object.entries(slots)) {
-      const li = el("li", { style: "cursor:pointer", text: `${name}: ${type}` });
-      li.addEventListener("click", () => {
-        try {
-          host.session.getResource(`slot:${name}`);
-        } catch (err) {
-          host.reportError(`failed to open slot ${name}`, { error: String(err) });
-        }
-      });
-      list.appendChild(li);
-    }
-    container.appendChild(list);
-  }
-
   const actions = el("div", { style: "margin-top:6px" });
   actions.appendChild(exportButton(host, "export_figure_svg", "dataset.svg", "svg", "Export figure (SVG)"));
-  actions.appendChild(
-    exportButton(host, "export_selected_rows_csv", "selected_rows.csv", "csv", "Export selected rows (CSV)"),
-  );
-  actions.appendChild(
-    exportButton(host, "export_grouped_summary_csv", "grouped_summary.csv", "csv", "Export grouped summary (CSV)"),
-  );
+  actions.appendChild(exportButton(host, "export_figure_png", "dataset.png", "png", "PNG"));
+  actions.appendChild(exportButton(host, "export_figure_pdf", "dataset.pdf", "pdf", "PDF"));
+  actions.appendChild(exportButton(host, "export_visible_spectra_csv", "visible_spectra.csv", "csv", "Export visible spectra (CSV)"));
+  actions.appendChild(exportButton(host, "export_selected_rows_csv", "selected_rows.csv", "csv", "Export selected rows (CSV)"));
+  actions.appendChild(exportButton(host, "export_grouped_summary_csv", "grouped_summary.csv", "csv", "Export grouped summary (CSV)"));
   container.appendChild(actions);
 }
 
@@ -321,11 +535,9 @@ export default {
       const kind = (envelope && envelope.kind) || host.kind;
       const diagnostics = (envelope && envelope.diagnostics) || [];
       try {
-        if (kind === "series") {
-          renderSpectrum(root, payload, host, diagnostics);
-        } else if (kind === "composite") {
-          renderDataset(root, payload, host, diagnostics);
-        } else if (kind === "error") {
+        if (kind === "series") renderSpectrum(root, payload, host, diagnostics);
+        else if (kind === "composite") renderDataset(root, payload, host, diagnostics);
+        else if (kind === "error") {
           const msg = envelope && envelope.error && envelope.error.message;
           root.appendChild(el("div", { style: "color:#c0392b;font:13px sans-serif", text: msg || "preview unavailable" }));
         } else {

--- a/packages/scistudio-blocks-spectroscopy/src/scistudio_blocks_spectroscopy/previewers/providers.py
+++ b/packages/scistudio-blocks-spectroscopy/src/scistudio_blocks_spectroscopy/previewers/providers.py
@@ -15,9 +15,10 @@ Spec coverage:
   sampling/truncation flags come from the bounded read; a missing-unit / empty /
   nonnumeric diagnostic is reported but the plot still renders.
 - ``spectral_dataset_provider`` — FR-022..FR-029. The ``index`` slot is read as
-  a paginated table; the ``spectra`` slot is read (bounded) only for dataset
-  health diagnostics (FR-027). Capabilities and plot-mode names are exposed so
-  the explorer UI can offer them. Bounded reads only (FR-028).
+  a paginated table; the ``spectra`` slot is read with the same bounded access
+  policy to provide diagnostics and lightweight explorer plot payloads.
+  Capabilities and plot-mode names are exposed so the explorer UI can offer
+  them. Bounded reads only (FR-028).
 
 FR-030: these providers perform NO scientific processing — only bounded reads,
 shape inspection, and integrity (join/schema/unit/numeric/alignment) checks.
@@ -25,6 +26,7 @@ shape inspection, and integrity (join/schema/unit/numeric/alignment) checks.
 
 from __future__ import annotations
 
+import json
 import logging
 from pathlib import Path
 from typing import Any
@@ -399,11 +401,11 @@ def _columns_of(rows: list[dict[str, Any]]) -> list[str]:
     return cols
 
 
-def _grid_signature(grid: list[float]) -> tuple[int, float, float]:
-    """A cheap, order-insensitive signature of a lambda grid (length + bounds)."""
+def _grid_signature(grid: list[float]) -> tuple[float, ...]:
+    """Tolerance-rounded full-grid signature used for heatmap alignment checks."""
     if not grid:
-        return (0, 0.0, 0.0)
-    return (len(grid), round(min(grid), 6), round(max(grid), 6))
+        return ()
+    return tuple(round(float(value), 6) for value in grid)
 
 
 # ---------------------------------------------------------------------------
@@ -426,11 +428,13 @@ def _slot_ref(parent: StorageReference, record_md: dict[str, Any], slot: str) ->
     elif isinstance(record_md.get(f"{slot}_path"), str):
         candidate = record_md[f"{slot}_path"]
     else:
+        candidate = _manifest_slot_path(Path(parent.path), slot)
         base = Path(parent.path)
-        for name in (slot, f"{slot}.parquet", f"{slot}.csv"):
-            probe = base / name
-            if probe.exists():
-                candidate = str(probe)
+        for name in (f"{slot}.parquet", f"{slot}.csv", f"{slot}/data.parquet", f"{slot}/data.csv", slot):
+            if candidate is not None:
+                break
+            candidate = _slot_file_candidate(base / name)
+            if candidate is not None:
                 break
         if candidate is None and base.suffix.lower() in {".parquet", ".csv"}:
             # Single-file dataset payloads are not slot-separable for a bounded
@@ -438,7 +442,48 @@ def _slot_ref(parent: StorageReference, record_md: dict[str, Any], slot: str) ->
             return None
     if candidate is None:
         return None
-    return StorageReference(backend=parent.backend, path=candidate, format=parent.format)
+    candidate = _slot_file_candidate(Path(candidate)) or candidate
+    return StorageReference(backend=parent.backend, path=candidate, format=_format_for_path(candidate))
+
+
+def _slot_file_candidate(path: Path) -> str | None:
+    """Return a concrete slot file, resolving directory slots to data files."""
+    if path.is_dir():
+        for child_name in ("data.parquet", "data.csv"):
+            child = path / child_name
+            if child.is_file():
+                return str(child)
+        return None
+    return str(path) if path.is_file() else None
+
+
+def _manifest_slot_path(parent_path: Path, slot: str) -> str | None:
+    """Resolve package-native manifest slot refs when the parent ref is JSON."""
+    if parent_path.suffix.lower() != ".json" or not parent_path.exists():
+        return None
+    try:
+        manifest = json.loads(parent_path.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+    slots = manifest.get("slots")
+    if not isinstance(slots, dict):
+        return None
+    ref = slots.get(slot)
+    if not isinstance(ref, dict) or not isinstance(ref.get("path"), str):
+        return None
+    candidate = Path(ref["path"])
+    if not candidate.is_absolute():
+        candidate = parent_path.parent / candidate
+    return str(candidate) if candidate.exists() else None
+
+
+def _format_for_path(path: str) -> str | None:
+    suffix = Path(path).suffix.lower()
+    if suffix == ".parquet":
+        return "parquet"
+    if suffix == ".csv":
+        return "csv"
+    return None
 
 
 def _read_slot_page(
@@ -522,8 +567,9 @@ def spectral_dataset_provider(request: PreviewRequest) -> PreviewEnvelope:
     spectra_rows: list[dict[str, Any]] = []
     spectra_columns: list[str] = []
     spectra_truncated = False
+    spectra_total = 0
     if spectra_read is not None:
-        spectra_columns, spectra_rows, _spectra_total, spectra_truncated = spectra_read
+        spectra_columns, spectra_rows, spectra_total, spectra_truncated = spectra_read
         truncated = truncated or spectra_truncated
     else:
         diagnostics.append("spectra slot not readable for a bounded diagnostics scan")
@@ -540,12 +586,37 @@ def spectral_dataset_provider(request: PreviewRequest) -> PreviewEnvelope:
         diagnostics.append(f"{issue['code']}: {issue}")
 
     resources = _dataset_resources(slot_map)
+    plot_payload = _dataset_plot_payload(
+        index_rows=index_rows,
+        spectra_rows=spectra_rows,
+        index_columns=index_columns,
+        query=request.query,
+        heatmap_aligned=bool(dataset_diagnostics.get("heatmap_aligned")),
+    )
 
     payload = {
         "slots": slot_map,
         "index_table": index_payload,
+        "spectra_table": {
+            "columns": spectra_columns,
+            "rows": spectra_rows,
+            "total_rows": spectra_total,
+            "truncated": spectra_truncated,
+            "available": spectra_read is not None,
+        },
         "capabilities": list(_DATASET_CAPABILITIES),
         "plot_modes": list(_PLOT_MODES),
+        "plot": plot_payload,
+        "controls": {
+            "searchable_columns": index_columns,
+            "filterable_columns": index_columns,
+            "groupable_columns": [c for c in index_columns if c != _SPECTRUM_ID],
+            "colorable_columns": [c for c in index_columns if c != _SPECTRUM_ID],
+            "selected_ids": _selected_ids(request.query),
+            "group_by": plot_payload["group_by"],
+            "color_by": plot_payload["color_by"],
+            "plot_mode": plot_payload["mode"],
+        },
         "diagnostics": dataset_diagnostics,
         "dataset_metadata": _dataset_metadata_panel(record_md),
     }
@@ -569,6 +640,144 @@ def spectral_dataset_provider(request: PreviewRequest) -> PreviewEnvelope:
             },
         ),
     )
+
+
+def _dataset_plot_payload(
+    *,
+    index_rows: list[dict[str, Any]],
+    spectra_rows: list[dict[str, Any]],
+    index_columns: list[str],
+    query: dict[str, Any],
+    heatmap_aligned: bool,
+) -> dict[str, Any]:
+    """Build bounded plot payloads for the dataset explorer.
+
+    This is display shaping only: no baseline correction, smoothing, fitting, or
+    other scientific processing. Group summaries are computed from the bounded
+    visible rows solely so the preview can render the requested explorer modes.
+    """
+    mode = str(query.get("plot_mode") or "overlay")
+    if mode not in _PLOT_MODES:
+        mode = "overlay"
+    group_by = _query_column(query.get("group_by"), index_columns)
+    color_by = _query_column(query.get("color_by"), index_columns)
+    selected_ids = set(_selected_ids(query))
+    index_by_id = {
+        str(row.get(_SPECTRUM_ID)): row
+        for row in index_rows
+        if isinstance(row, dict) and row.get(_SPECTRUM_ID) not in (None, "")
+    }
+
+    series_by_id: dict[str, dict[str, Any]] = {}
+    skipped_rows = 0
+    for row in spectra_rows:
+        if not isinstance(row, dict) or row.get(_SPECTRUM_ID) in (None, ""):
+            skipped_rows += 1
+            continue
+        sid = str(row[_SPECTRUM_ID])
+        x_val = _finite_float(row.get(_LAMBDA))
+        y_val = _finite_float(row.get(_INTENSITY))
+        if x_val is None or y_val is None:
+            skipped_rows += 1
+            continue
+        index_md = index_by_id.get(sid, {})
+        series = series_by_id.setdefault(
+            sid,
+            {
+                "spectrum_id": sid,
+                "label": sid,
+                "group": _string_cell(index_md.get(group_by)) if group_by else None,
+                "color": _string_cell(index_md.get(color_by)) if color_by else None,
+                "selected": sid in selected_ids,
+                "points": [],
+            },
+        )
+        series["points"].append({"x": x_val, "y": y_val})
+
+    series_list = list(series_by_id.values())
+    selected_series = [series for series in series_list if series["selected"]]
+    group_payload = _group_payload(series_list, group_by)
+    heatmap_payload = _heatmap_payload(series_list, heatmap_aligned)
+    return {
+        "mode": mode,
+        "group_by": group_by,
+        "color_by": color_by,
+        "selected_ids": sorted(selected_ids),
+        "overlay": {"series": series_list},
+        "selected": {"series": selected_series},
+        "group_mean": {"groups": group_payload["mean"]},
+        "group_band": {"groups": group_payload["band"]},
+        "heatmap": heatmap_payload,
+        "skipped_rows": skipped_rows,
+        "bounded": True,
+    }
+
+
+def _query_column(raw: Any, columns: list[str]) -> str | None:
+    return raw if isinstance(raw, str) and raw in columns and raw != _SPECTRUM_ID else None
+
+
+def _selected_ids(query: dict[str, Any]) -> list[str]:
+    raw = query.get("selected_ids", query.get("selected"))
+    if isinstance(raw, str):
+        return [part.strip() for part in raw.split(",") if part.strip()]
+    if isinstance(raw, (list, tuple, set)):
+        return [str(value) for value in raw if value not in (None, "")]
+    return []
+
+
+def _string_cell(value: Any) -> str | None:
+    if value in (None, ""):
+        return None
+    return str(value)
+
+
+def _group_payload(series_list: list[dict[str, Any]], group_by: str | None) -> dict[str, Any]:
+    groups: dict[str, dict[float, list[float]]] = {}
+    for series in series_list:
+        group = _string_cell(series.get("group")) if group_by else "all"
+        if group is None:
+            group = "(missing)"
+        buckets = groups.setdefault(group, {})
+        for point in series.get("points", []):
+            x_val = float(point["x"])
+            buckets.setdefault(x_val, []).append(float(point["y"]))
+
+    mean_groups: list[dict[str, Any]] = []
+    band_groups: list[dict[str, Any]] = []
+    for group, buckets in groups.items():
+        mean_points: list[dict[str, float]] = []
+        band_points: list[dict[str, float]] = []
+        for x_val in sorted(buckets):
+            values = buckets[x_val]
+            mean = sum(values) / len(values)
+            mean_points.append({"x": x_val, "y": mean})
+            band_points.append({"x": x_val, "mean": mean, "min": min(values), "max": max(values)})
+        mean_groups.append({"group": group, "points": mean_points})
+        band_groups.append({"group": group, "points": band_points})
+    return {"mean": mean_groups, "band": band_groups}
+
+
+def _heatmap_payload(series_list: list[dict[str, Any]], heatmap_aligned: bool) -> dict[str, Any]:
+    if not series_list:
+        return {"aligned": heatmap_aligned, "x": [], "rows": [], "matrix": []}
+    first_x = [point["x"] for point in series_list[0].get("points", [])]
+    matrix: list[list[float]] = []
+    rows: list[str] = []
+    aligned = heatmap_aligned
+    for series in series_list:
+        points = series.get("points", [])
+        x_values = [point["x"] for point in points]
+        if x_values != first_x:
+            aligned = False
+        rows.append(str(series.get("spectrum_id")))
+        matrix.append([float(point["y"]) for point in points])
+    return {
+        "aligned": aligned,
+        "x": first_x if aligned else [],
+        "rows": rows if aligned else [],
+        "matrix": matrix if aligned else [],
+    }
 
 
 def _dataset_resources(slot_map: dict[str, str]) -> tuple[PreviewResource, ...]:

--- a/packages/scistudio-blocks-spectroscopy/src/scistudio_blocks_spectroscopy/types.py
+++ b/packages/scistudio-blocks-spectroscopy/src/scistudio_blocks_spectroscopy/types.py
@@ -20,6 +20,8 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any, ClassVar
 
+import pyarrow as pa
+import pyarrow.types as pat
 from pydantic import BaseModel, ConfigDict
 
 from scistudio.core.types.composite import CompositeData
@@ -123,6 +125,25 @@ class SpectralDataset(CompositeData):
         "spectra": DataFrame,
     }
 
+    def __init__(self, *, slots: dict[str, Any] | None = None, **kwargs: Any) -> None:
+        """Construct and validate the canonical two-slot dataset layout.
+
+        Core ``CompositeData`` validates only slot object types. The spectroscopy
+        package contract also requires table schemas and the
+        ``index.spectrum_id`` <-> ``spectra.spectrum_id`` join invariant.
+        """
+        super().__init__(slots=slots, **kwargs)
+        if self.expected_slots.keys() <= self._slots.keys():
+            self.validate_slots()
+
+    def validate_slots(self) -> None:
+        """Validate required columns, ids, numeric payload columns, and joins."""
+        index = self.get("index")
+        spectra = self.get("spectra")
+        if not isinstance(index, DataFrame) or not isinstance(spectra, DataFrame):
+            return
+        validate_spectral_dataset_tables(_dataframe_arrow(index), _dataframe_arrow(spectra))
+
     class Meta(BaseModel):
         """Dataset-level typed metadata (FR-013).
 
@@ -156,6 +177,73 @@ def get_types() -> list[type]:
     return [Spectrum, SpectralDataset]
 
 
+def validate_spectral_dataset_tables(index_table: pa.Table, spectra_table: pa.Table) -> None:
+    """Validate the canonical ``SpectralDataset`` table contract.
+
+    Enforces SC-003 / FR-009..FR-012 at the type boundary:
+    ``index.spectrum_id`` must be present, unique, non-null, and covered by the
+    long-form spectra slot; ``spectra`` must carry non-null ``spectrum_id`` plus
+    numeric ``lambda`` and ``intensity`` columns whose ids join back to index.
+    """
+    if SPECTRUM_ID_COLUMN not in index_table.column_names:
+        raise ValueError(
+            f"SpectralDataset index table must contain {SPECTRUM_ID_COLUMN!r}; got {list(index_table.column_names)}"
+        )
+
+    required_spectra = {SPECTRUM_ID_COLUMN, LAMBDA_COLUMN, INTENSITY_COLUMN}
+    missing = required_spectra.difference(spectra_table.column_names)
+    if missing:
+        raise ValueError(
+            f"SpectralDataset spectra table must contain {sorted(required_spectra)}; missing {sorted(missing)}"
+        )
+
+    for column in (LAMBDA_COLUMN, INTENSITY_COLUMN):
+        field = spectra_table.schema.field(column)
+        if not (pat.is_integer(field.type) or pat.is_floating(field.type)):
+            raise ValueError(f"SpectralDataset spectra.{column} must be numeric, got {field.type}")
+
+    index_ids = index_table.column(SPECTRUM_ID_COLUMN).to_pylist()
+    spectra_ids = spectra_table.column(SPECTRUM_ID_COLUMN).to_pylist()
+    if any(sid in (None, "") for sid in index_ids):
+        raise ValueError("SpectralDataset index.spectrum_id must not contain null/empty values")
+    if any(sid in (None, "") for sid in spectra_ids):
+        raise ValueError("SpectralDataset spectra.spectrum_id must not contain null/empty values")
+
+    duplicates = _duplicates(index_ids)
+    if duplicates:
+        raise ValueError(f"SpectralDataset index.spectrum_id must be unique; duplicates {duplicates!r}")
+
+    index_id_set = set(index_ids)
+    spectra_id_set = set(spectra_ids)
+    orphans = sorted(str(sid) for sid in (spectra_id_set - index_id_set))
+    if orphans:
+        raise ValueError(f"SpectralDataset spectra rows reference unknown spectrum_id(s) {orphans!r}")
+    missing_coverage = sorted(str(sid) for sid in (index_id_set - spectra_id_set))
+    if missing_coverage:
+        raise ValueError(f"SpectralDataset index row(s) have no spectra coverage {missing_coverage!r}")
+
+
+def _dataframe_arrow(frame: DataFrame) -> pa.Table:
+    payload = frame.to_memory() if frame.storage_ref is not None else frame._transient_data
+    if payload is None:
+        raise ValueError("SpectralDataset DataFrame slot has no in-memory or persisted payload")
+    if isinstance(payload, pa.Table):
+        return payload
+    if hasattr(payload, "columns"):
+        return pa.Table.from_pandas(payload, preserve_index=False)
+    return pa.table(payload)
+
+
+def _duplicates(values: list[Any]) -> list[str]:
+    seen: set[Any] = set()
+    out: list[str] = []
+    for value in values:
+        if value in seen and str(value) not in out:
+            out.append(str(value))
+        seen.add(value)
+    return out
+
+
 __all__ = [
     "INTENSITY_COLUMN",
     "LAMBDA_COLUMN",
@@ -163,4 +251,5 @@ __all__ = [
     "SpectralDataset",
     "Spectrum",
     "get_types",
+    "validate_spectral_dataset_tables",
 ]

--- a/packages/scistudio-blocks-spectroscopy/tests/e2e/test_e2e_io.py
+++ b/packages/scistudio-blocks-spectroscopy/tests/e2e/test_e2e_io.py
@@ -3,7 +3,7 @@
 Drives full save -> load round-trips on disk through the real LoadSpectrum /
 SaveSpectrum / LoadSpectralDataset / SaveSpectralDataset blocks (writing to
 tmp_path) and asserts numeric + metadata fidelity, id generation/preservation,
-batch numbering, capability_id selection, and vendor/SPC deferrals.
+batch numbering, capability_id selection, and unsupported deferred vendor/SPC formats.
 """
 
 from __future__ import annotations
@@ -124,10 +124,10 @@ def test_save_rejects_vendor_load_only_extension(tmp_path: Path) -> None:
         SaveSpectrum().save(Collection([spec], item_type=Spectrum), _cfg(path=str(tmp_path / "out.spa")))
 
 
-def test_load_vendor_format_not_implemented(tmp_path: Path) -> None:
+def test_load_vendor_format_unsupported_until_implemented(tmp_path: Path) -> None:
     vendor = tmp_path / "v.spa"
     vendor.write_bytes(b"\x00\x01")
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(ValueError):
         LoadSpectrum().load(_cfg(path=str(vendor)))
 
 

--- a/packages/scistudio-blocks-spectroscopy/tests/e2e/test_e2e_previewers.py
+++ b/packages/scistudio-blocks-spectroscopy/tests/e2e/test_e2e_previewers.py
@@ -159,6 +159,8 @@ def test_generated_library_dataset_previews_with_index_and_capabilities(tmp_path
     # Explorer capabilities + plot modes exposed (FR-024/FR-025).
     assert "plot" in env.payload["capabilities"]
     assert "heatmap" in env.payload["plot_modes"]
+    assert env.payload["plot"]["overlay"]["series"]
+    assert env.payload["plot"]["heatmap"]["aligned"] is True
     # Library is well-formed -> diagnostics clean.
     assert env.payload["diagnostics"]["ok"] is True
 
@@ -225,6 +227,22 @@ def test_non_aligned_grids_flag_heatmap(tmp_path: Path) -> None:
     codes = {i["code"] for i in diag["issues"]}
     assert "heatmap_alignment" in codes
     assert diag["heatmap_aligned"] is False
+
+
+def test_same_bounds_different_interior_grid_flags_heatmap() -> None:
+    diag = compute_dataset_diagnostics(
+        index_rows=[{"spectrum_id": "a"}, {"spectrum_id": "b"}],
+        spectra_rows=[
+            {"spectrum_id": "a", "lambda": 400.0, "intensity": 1.0},
+            {"spectrum_id": "a", "lambda": 500.0, "intensity": 2.0},
+            {"spectrum_id": "a", "lambda": 600.0, "intensity": 1.0},
+            {"spectrum_id": "b", "lambda": 400.0, "intensity": 1.0},
+            {"spectrum_id": "b", "lambda": 520.0, "intensity": 2.0},
+            {"spectrum_id": "b", "lambda": 600.0, "intensity": 1.0},
+        ],
+    )
+    assert diag["heatmap_aligned"] is False
+    assert "heatmap_alignment" in {i["code"] for i in diag["issues"]}
 
 
 def test_aligned_grids_no_heatmap_warning() -> None:

--- a/packages/scistudio-blocks-spectroscopy/tests/test_feature_extraction_blocks.py
+++ b/packages/scistudio-blocks-spectroscopy/tests/test_feature_extraction_blocks.py
@@ -187,6 +187,9 @@ def test_extract_intensity_reports_status() -> None:
     # No coordinate or range configured -> explicit status, not a crash.
     no_target = _features_table(ExtractIntensity(), [_spectrum("s1")])
     assert no_target.column("status").to_pylist() == ["no_target_coordinate_or_range"]
+    out_of_grid = _features_table(ExtractIntensity(), [_spectrum("s1")], target_coordinate=500.0)
+    assert out_of_grid.column("status").to_pylist() == ["coordinate_out_of_grid"]
+    assert out_of_grid.column("intensity").to_pylist() == [None]
 
 
 def test_calculate_auc_reports_insufficient_points() -> None:
@@ -226,6 +229,24 @@ def test_calculate_ratio_is_peak_to_peak() -> None:
     # Peak at center over itself -> ratio 1.0 with ok status.
     assert table.column("status").to_pylist() == ["ok"]
     assert table.column("ratio").to_pylist()[0] == pytest.approx(1.0)
+
+
+def test_calculate_ratio_reports_out_of_grid_peak() -> None:
+    spectra = [_spectrum("s1")]
+    numerator_bad = _features_table(
+        CalculateRatio(),
+        spectra,
+        numerator_peak={"coordinate": 500.0},
+        denominator_peak={"coordinate": 50.0},
+    )
+    assert numerator_bad.column("status").to_pylist() == ["numerator_coordinate_out_of_grid"]
+    denominator_bad = _features_table(
+        CalculateRatio(),
+        spectra,
+        numerator_peak={"coordinate": 50.0},
+        denominator_peak={"coordinate": 500.0},
+    )
+    assert denominator_bad.column("status").to_pylist() == ["denominator_coordinate_out_of_grid"]
 
 
 def test_find_peaks_supports_range_bounds() -> None:

--- a/packages/scistudio-blocks-spectroscopy/tests/test_format_capabilities.py
+++ b/packages/scistudio-blocks-spectroscopy/tests/test_format_capabilities.py
@@ -6,10 +6,10 @@ Covers SC-048..SC-055 of ``docs/specs/spectroscopy-package.md``:
   formal ADR-043 fields (not synthesized migration scaffolds).
 - SC-049: ``capability_id`` is only a lookup reference to ``FormatCapability.id``
   and no package type declares file extensions / format support.
-- SC-050/SC-051: txt/csv/tsv/xlsx/spectrum_json/jcamp_dx/SPC load+save; SPC has
-  both directions on spectrum and dataset.
-- SC-052: vendor/native formats are load-only with no saver, no
-  ``roundtrip_group``, and no ``lossless`` fidelity.
+- SC-050/SC-051: txt/csv/tsv/xlsx/spectrum_json/jcamp_dx load+save; SPC is not
+  advertised until implemented.
+- SC-052: vendor/native formats are not advertised as capabilities until
+  fixture-backed handlers exist.
 - SC-053: dataset native JSON uses a package-owned manifest + sidecar slots.
 - SC-054: no ``.zip``/``.spectraldataset.zip`` capability is declared.
 - SC-055: capability lookup fails on unresolved ambiguity rather than choosing
@@ -34,10 +34,9 @@ from scistudio.blocks.base.config import BlockConfig
 from scistudio.blocks.io.capabilities import FormatCapability, MetadataFidelity
 
 _IO_BLOCKS = [LoadSpectrum, SaveSpectrum, LoadSpectralDataset, SaveSpectralDataset]
-_SAVE_BLOCKS = [SaveSpectrum, SaveSpectralDataset]
 
-# SC-052: vendor / native instrument formats accepted in this draft (load-only).
-_VENDOR_FORMAT_IDS = {
+_DEFERRED_FORMAT_IDS = {
+    "spc",
     "thermo_omnic_spa",
     "thermo_omnic_spg",
     "bruker_opus",
@@ -76,21 +75,10 @@ def test_handlers_resolve_on_class() -> None:
             assert callable(getattr(block, cap.handler))
 
 
-def test_vendor_load_only_formats_have_no_saver() -> None:
-    load_only_format_ids = {
-        "thermo_omnic_spa",
-        "bruker_opus",
-        "horiba_labspec",
-        "renishaw_wdf",
-        "andor_solis",
-        "princeton_spe",
-        "thermo_omnic_spg",
-        "witec_project",
-    }
-    saver_format_ids = {
-        cap.format_id for block in (SaveSpectrum, SaveSpectralDataset) for cap in block.get_format_capabilities()
-    }
-    assert load_only_format_ids.isdisjoint(saver_format_ids)
+def test_deferred_binary_formats_are_not_advertised() -> None:
+    """SC-051/SC-052: deferred SPC/vendor formats are not runtime capabilities."""
+    format_ids = {cap.format_id for block in _IO_BLOCKS for cap in block.get_format_capabilities()}
+    assert _DEFERRED_FORMAT_IDS.isdisjoint(format_ids)
 
 
 def test_lossless_capabilities_declare_roundtrip_group() -> None:
@@ -145,16 +133,10 @@ def test_capability_id_only_references_capability_id_field() -> None:
             assert cap.id in ids
 
 
-def test_spc_declares_load_and_save_on_spectrum_and_dataset() -> None:
-    """SC-051: SPC (.spc) has both load and save capabilities (spectrum+dataset)."""
-    load_spectrum_spc = [c for c in LoadSpectrum.get_format_capabilities() if c.format_id == "spc"]
-    save_spectrum_spc = [c for c in SaveSpectrum.get_format_capabilities() if c.format_id == "spc"]
-    load_dataset_spc = [c for c in LoadSpectralDataset.get_format_capabilities() if c.format_id == "spc"]
-    save_dataset_spc = [c for c in SaveSpectralDataset.get_format_capabilities() if c.format_id == "spc"]
-    assert load_spectrum_spc and load_spectrum_spc[0].direction == "load"
-    assert save_spectrum_spc and save_spectrum_spc[0].direction == "save"
-    assert load_dataset_spc and load_dataset_spc[0].direction == "load"
-    assert save_dataset_spc and save_dataset_spc[0].direction == "save"
+def test_spc_is_contractually_deferred() -> None:
+    """SC-051: SPC is tracked as planned work, not an executable capability."""
+    for block in _IO_BLOCKS:
+        assert all(cap.format_id != "spc" for cap in block.get_format_capabilities())
 
 
 def test_native_round_trippable_formats_load_and_save() -> None:
@@ -166,17 +148,11 @@ def test_native_round_trippable_formats_load_and_save() -> None:
     assert native <= save_ids
 
 
-def test_vendor_formats_are_load_only_no_roundtrip_no_lossless() -> None:
-    """SC-052: vendor/native formats are load-only with no roundtrip/lossless."""
-    save_format_ids = {c.format_id for blk in _SAVE_BLOCKS for c in blk.get_format_capabilities()}
-    for block in (LoadSpectrum, LoadSpectralDataset):
-        for cap in block.get_format_capabilities():
-            if cap.format_id in _VENDOR_FORMAT_IDS:
-                # No saver declared for any vendor format.
-                assert cap.format_id not in save_format_ids, cap.format_id
-                # No roundtrip group and not lossless.
-                assert cap.roundtrip_group is None, cap.id
-                assert cap.metadata_fidelity.level != "lossless", cap.id
+def test_vendor_formats_are_contractually_deferred() -> None:
+    """SC-052: vendor/native formats have no advertised loader or saver."""
+    advertised = {c.format_id for blk in _IO_BLOCKS for c in blk.get_format_capabilities()}
+    vendor_ids = _DEFERRED_FORMAT_IDS - {"spc"}
+    assert vendor_ids.isdisjoint(advertised)
 
 
 def test_dataset_native_json_uses_package_manifest() -> None:

--- a/packages/scistudio-blocks-spectroscopy/tests/test_io_dataset_smoke.py
+++ b/packages/scistudio-blocks-spectroscopy/tests/test_io_dataset_smoke.py
@@ -10,7 +10,7 @@ handlers in :mod:`scistudio_blocks_spectroscopy.blocks.io_handlers.dataset_forma
 - ``xlsx`` (``.xlsx``) — typed-meta three-sheet workbook round-trip (FR-137).
 
 Plus the canonical two-table layout (FR-038/FR-039), the FR-136 archive (.zip)
-rejection, and the load-only vendor / SPC deferrals (FR-139/FR-140, FR-138).
+rejection, and tracked but unadvertised vendor / SPC deferrals.
 """
 
 from __future__ import annotations
@@ -164,9 +164,8 @@ def test_manifest_json_rejects_orphan_spectra(tmp_path: Path) -> None:
     """FR-012: spectra rows must join to index.spectrum_id."""
     index = _support.dataframe_from_rows([{"spectrum_id": "a"}])
     orphan = _support.dataframe_from_rows([{"spectrum_id": "ghost", "lambda": 1.0, "intensity": 2.0}])
-    bad = _support.build_spectral_dataset(index, orphan, meta=SpectralDataset.Meta())
     with pytest.raises(ValueError, match="unknown spectrum_id"):
-        dataset_formats.save_manifest_json(bad, tmp_path / "bad.json")
+        _support.build_spectral_dataset(index, orphan, meta=SpectralDataset.Meta())
 
 
 @pytest.mark.parametrize(

--- a/packages/scistudio-blocks-spectroscopy/tests/test_io_spectrum_smoke.py
+++ b/packages/scistudio-blocks-spectroscopy/tests/test_io_spectrum_smoke.py
@@ -12,9 +12,8 @@ Covers (track io-spectrum, FR-034..FR-037, FR-132..FR-134, FR-141..FR-143):
   ``source_file`` as metadata only (FR-035/FR-036);
 - SaveSpectrum single vs. multi-item (batch numbered files) and explicit
   ``capability_id`` selection (FR-143);
-- SaveSpectrum refuses a vendor load-only extension as a save target (FR-134);
-- LoadSpectrum surfaces vendor load-only formats as informative
-  ``NotImplementedError`` (FR-133); SPC is deferred with a tracked TODO.
+- SaveSpectrum/LoadSpectrum reject SPC/vendor extensions because those deferred
+  handlers are not advertised as runtime capabilities until implemented.
 """
 
 from __future__ import annotations
@@ -226,10 +225,10 @@ def test_save_rejects_vendor_load_only_extension(tmp_path: Path) -> None:
         )
 
 
-def test_load_vendor_format_is_not_implemented(tmp_path: Path) -> None:
+def test_load_vendor_format_is_unsupported_until_implemented(tmp_path: Path) -> None:
     vendor = tmp_path / "v.spa"
     vendor.write_bytes(b"\x00\x01")
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(ValueError):
         LoadSpectrum().load(BlockConfig(params={"path": str(vendor)}))
 
 

--- a/packages/scistudio-blocks-spectroscopy/tests/test_prev_smoke.py
+++ b/packages/scistudio-blocks-spectroscopy/tests/test_prev_smoke.py
@@ -195,12 +195,21 @@ def test_spectral_dataset_provider_builds_composite_envelope(tmp_path: Path) -> 
     # Capabilities + plot modes exposed (FR-024/FR-025).
     assert env.payload["capabilities"] == ["table", "filter", "group", "plot", "diagnostics", "export"]
     assert env.payload["plot_modes"] == ["overlay", "selected", "group_mean", "group_band", "heatmap"]
+    assert env.payload["plot"]["overlay"]["series"]
+    assert env.payload["spectra_table"]["available"] is True
     # Healthy dataset -> diagnostics present and ok.
     assert env.payload["diagnostics"]["ok"] is True
     # Child slot resources + figure/rows/group export (FR-029).
     res_ids = {r.resource_id for r in env.resources}
     assert {"slot:index", "slot:spectra"} <= res_ids
-    assert {"export_figure_svg", "export_selected_rows_csv", "export_grouped_summary_csv"} <= res_ids
+    assert {
+        "export_figure_svg",
+        "export_figure_png",
+        "export_figure_pdf",
+        "export_visible_spectra_csv",
+        "export_selected_rows_csv",
+        "export_grouped_summary_csv",
+    } <= res_ids
 
 
 def test_spectral_dataset_provider_detects_health_issues(tmp_path: Path) -> None:
@@ -277,6 +286,22 @@ def test_compute_dataset_diagnostics_flags_unit_and_alignment() -> None:
     assert "unit_inconsistency" in codes
     assert "heatmap_alignment" in codes
     assert diag["heatmap_aligned"] is False
+
+
+def test_compute_dataset_diagnostics_flags_same_endpoint_interior_mismatch() -> None:
+    diag = compute_dataset_diagnostics(
+        index_rows=[{"spectrum_id": "a"}, {"spectrum_id": "b"}],
+        spectra_rows=[
+            {"spectrum_id": "a", "lambda": 1.0, "intensity": 1.0},
+            {"spectrum_id": "a", "lambda": 2.0, "intensity": 2.0},
+            {"spectrum_id": "a", "lambda": 3.0, "intensity": 3.0},
+            {"spectrum_id": "b", "lambda": 1.0, "intensity": 1.0},
+            {"spectrum_id": "b", "lambda": 2.5, "intensity": 2.0},
+            {"spectrum_id": "b", "lambda": 3.0, "intensity": 3.0},
+        ],
+    )
+    codes = {i["code"] for i in diag["issues"]}
+    assert "heatmap_alignment" in codes
 
 
 def test_compute_dataset_diagnostics_flags_nonnumeric_and_missing_columns() -> None:

--- a/packages/scistudio-blocks-spectroscopy/tests/test_spectral_dataset_io.py
+++ b/packages/scistudio-blocks-spectroscopy/tests/test_spectral_dataset_io.py
@@ -7,7 +7,8 @@ Binds the dataset IO contract for ``LoadSpectralDataset`` / ``SaveSpectralDatase
   the spectrum_id join, and every dataset ``Meta`` field survive (SC-053/FR-141);
 - xlsx is a typed-meta three-sheet workbook round-trip (FR-137);
 - no ``.zip``/``.spectraldataset.zip`` save capability is declared (SC-054);
-- SPC + vendor multi-spectrum loaders are tracked ``NotImplementedError``.
+- SPC + vendor multi-spectrum handlers are tracked deferrals but are not
+  advertised through block capability dispatch until implemented.
 """
 
 from __future__ import annotations
@@ -142,9 +143,8 @@ def test_manifest_rejects_orphan_spectra(tmp_path: Path) -> None:
     """FR-012: spectra rows must join to an index spectrum_id."""
     index = _support.dataframe_from_rows([{"spectrum_id": "a"}])
     orphan = _support.dataframe_from_rows([{"spectrum_id": "ghost", "lambda": 1.0, "intensity": 2.0}])
-    bad = _support.build_spectral_dataset(index, orphan, meta=SpectralDataset.Meta())
     with pytest.raises(ValueError):
-        dataset_formats.save_manifest_json(bad, tmp_path / "bad.json")
+        _support.build_spectral_dataset(index, orphan, meta=SpectralDataset.Meta())
 
 
 @pytest.mark.parametrize(
@@ -169,3 +169,9 @@ def test_spc_dataset_save_is_deferred(tmp_path: Path) -> None:
     dataset, _, _ = _synthetic_dataset()
     with pytest.raises(NotImplementedError):
         dataset_formats.save_spc_dataset(dataset, tmp_path / "out.spc")
+    with pytest.raises(ValueError):
+        SaveSpectralDataset().save(dataset, _config(path=str(tmp_path / "out.spc")))
+    spc = tmp_path / "in.spc"
+    spc.write_bytes(b"")
+    with pytest.raises(ValueError):
+        LoadSpectralDataset().load(_config(path=str(spc)))

--- a/packages/scistudio-blocks-spectroscopy/tests/test_spectral_dataset_previewer.py
+++ b/packages/scistudio-blocks-spectroscopy/tests/test_spectral_dataset_previewer.py
@@ -51,7 +51,13 @@ def _spec() -> PreviewerSpec:
     raise AssertionError(SPECTRAL_DATASET_PREVIEWER_ID)
 
 
-def _request(root: Path, record_md: dict) -> PreviewRequest:
+def _request(root: Path, record_md: dict, extra_query: dict | None = None) -> PreviewRequest:
+    query = {
+        "_storage": {"backend": "filesystem", "path": str(root), "format": "parquet"},
+        "_record_metadata": record_md,
+    }
+    if extra_query:
+        query.update(extra_query)
     return PreviewRequest(
         target=PreviewTarget(
             kind=TargetKind.DATA_REF,
@@ -60,10 +66,7 @@ def _request(root: Path, record_md: dict) -> PreviewRequest:
             type_chain=_DATASET_CHAIN,
         ),
         spec=_spec(),
-        query={
-            "_storage": {"backend": "filesystem", "path": str(root), "format": "parquet"},
-            "_record_metadata": record_md,
-        },
+        query=query,
         data_access=PreviewDataAccess(),
         limits=PreviewLimits(),
         session_id=None,
@@ -75,6 +78,15 @@ def _dataset_dir(tmp_path: Path, index_cols: dict, spectra_cols: dict) -> Path:
     root.mkdir()
     pq.write_table(pa.table(index_cols), root / "index.parquet")
     pq.write_table(pa.table(spectra_cols), root / "spectra.parquet")
+    return root
+
+
+def _dataset_composite_dir(tmp_path: Path, index_cols: dict, spectra_cols: dict) -> Path:
+    root = tmp_path / "dataset_composite"
+    (root / "index").mkdir(parents=True)
+    (root / "spectra").mkdir(parents=True)
+    pq.write_table(pa.table(index_cols), root / "index" / "data.parquet")
+    pq.write_table(pa.table(spectra_cols), root / "spectra" / "data.parquet")
     return root
 
 
@@ -105,6 +117,23 @@ def test_dataset_provider_builds_composite_envelope_with_index_table(tmp_path: P
     assert env.payload["slots"] == {"index": "DataFrame", "spectra": "DataFrame"}
     assert env.payload["index_table"]["available"] is True
     assert env.payload["index_table"]["total_rows"] == 2
+    assert env.payload["spectra_table"]["available"] is True
+    assert env.payload["plot"]["overlay"]["series"]
+    assert env.payload["plot"]["heatmap"]["aligned"] is True
+    assert {"groupable_columns", "selected_ids", "plot_mode"} <= set(env.payload["controls"])
+
+
+def test_dataset_provider_resolves_composite_slot_data_parquet(tmp_path: Path) -> None:
+    root = _dataset_composite_dir(
+        tmp_path,
+        index_cols={"spectrum_id": ["a"], "material": ["gold"]},
+        spectra_cols={"spectrum_id": ["a"], "lambda": [1.0], "intensity": [10.0]},
+    )
+    env = spectral_dataset_provider(_request(root, {"slots": {"index": "DataFrame", "spectra": "DataFrame"}}))
+    assert env.payload["index_table"]["available"] is True
+    assert env.payload["index_table"]["rows"][0]["spectrum_id"] == "a"
+    assert env.payload["spectra_table"]["available"] is True
+    assert env.payload["plot"]["overlay"]["series"][0]["points"] == [{"x": 1.0, "y": 10.0}]
 
 
 def test_dataset_previewer_supports_grouping_over_arbitrary_index_columns(tmp_path: Path) -> None:
@@ -118,12 +147,23 @@ def test_dataset_previewer_supports_grouping_over_arbitrary_index_columns(tmp_pa
             "intensity": [10.0, 20.0],
         },
     )
-    env = spectral_dataset_provider(_request(root, {"slots": {"index": "DataFrame", "spectra": "DataFrame"}}))
+    env = spectral_dataset_provider(
+        _request(
+            root,
+            {"slots": {"index": "DataFrame", "spectra": "DataFrame"}},
+            extra_query={"group_by": "material", "color_by": "prep", "selected_ids": ["a"]},
+        )
+    )
     # Grouping is exposed as a capability + group-capable plot modes.
     assert "group" in env.payload["capabilities"]
     assert {"group_mean", "group_band"} <= set(env.payload["plot_modes"])
     # The arbitrary grouping columns are available in the index table.
     assert {"material", "prep"} <= set(env.payload["index_table"]["columns"])
+    assert env.payload["controls"]["group_by"] == "material"
+    assert env.payload["controls"]["color_by"] == "prep"
+    assert env.payload["plot"]["selected"]["series"][0]["spectrum_id"] == "a"
+    groups = {group["group"] for group in env.payload["plot"]["group_mean"]["groups"]}
+    assert groups == {"gold", "silver"}
 
 
 def test_dataset_previewer_export_controls_exist(tmp_path: Path) -> None:
@@ -136,7 +176,14 @@ def test_dataset_previewer_export_controls_exist(tmp_path: Path) -> None:
     env = spectral_dataset_provider(_request(root, {"slots": {"index": "DataFrame", "spectra": "DataFrame"}}))
     resource_ids = {r.resource_id for r in env.resources}
     assert {"slot:index", "slot:spectra"} <= resource_ids
-    assert {"export_figure_svg", "export_selected_rows_csv", "export_grouped_summary_csv"} <= resource_ids
+    assert {
+        "export_figure_svg",
+        "export_figure_png",
+        "export_figure_pdf",
+        "export_visible_spectra_csv",
+        "export_selected_rows_csv",
+        "export_grouped_summary_csv",
+    } <= resource_ids
 
 
 def test_dataset_diagnostics_grouped_health_columns() -> None:
@@ -168,3 +215,19 @@ def test_dataset_diagnostics_clean_when_consistent() -> None:
     assert diag["ok"] is True
     assert diag["issues"] == []
     assert diag["heatmap_aligned"] is True
+
+
+def test_dataset_diagnostics_detects_same_bounds_different_interior_grid() -> None:
+    diag = compute_dataset_diagnostics(
+        index_rows=[{"spectrum_id": "a"}, {"spectrum_id": "b"}],
+        spectra_rows=[
+            {"spectrum_id": "a", "lambda": 1.0, "intensity": 2.0},
+            {"spectrum_id": "a", "lambda": 2.0, "intensity": 3.0},
+            {"spectrum_id": "a", "lambda": 3.0, "intensity": 4.0},
+            {"spectrum_id": "b", "lambda": 1.0, "intensity": 2.0},
+            {"spectrum_id": "b", "lambda": 2.5, "intensity": 3.0},
+            {"spectrum_id": "b", "lambda": 3.0, "intensity": 4.0},
+        ],
+    )
+    assert diag["heatmap_aligned"] is False
+    assert "heatmap_alignment" in {issue["code"] for issue in diag["issues"]}

--- a/packages/scistudio-blocks-spectroscopy/tests/test_spectrum_io.py
+++ b/packages/scistudio-blocks-spectroscopy/tests/test_spectrum_io.py
@@ -11,8 +11,8 @@ executable assertions, complementing the implementer smoke tests:
   not), and the LoadSpectrum block regenerates a fresh package-managed
   ``spectrum_id`` while keeping ``source_file`` separate (FR-035/FR-036);
 - ``capability_id`` selects a handler by ``FormatCapability.id`` (SC-049);
-- vendor load-only formats surface a tracked ``NotImplementedError`` and have no
-  saver (SC-052).
+- vendor/SPC handlers remain tracked deferrals, but are not advertised through
+  block capability dispatch until implemented (SC-051/SC-052).
 """
 
 from __future__ import annotations
@@ -211,10 +211,18 @@ def test_save_block_rejects_vendor_load_only_extension(tmp_path: Path) -> None:
         )
 
 
-def test_spc_spectrum_is_deferred(tmp_path: Path) -> None:
-    """SC-051: SPC is declared (load+save) but the body is a tracked deferral."""
+def test_spc_spectrum_is_deferred_not_advertised(tmp_path: Path) -> None:
+    """SC-051: SPC handlers are tracked TODOs, not block capabilities."""
     spec = _make_spectrum()
     with pytest.raises(NotImplementedError):
         spectrum_formats.save_spc(spec, tmp_path / "x.spc")
     with pytest.raises(NotImplementedError):
         spectrum_formats.load_spc(tmp_path / "x.spc")
+    with pytest.raises(ValueError):
+        SaveSpectrum().save(
+            Collection([spec], item_type=Spectrum), BlockConfig(params={"path": str(tmp_path / "x.spc")})
+        )
+    spc = tmp_path / "x.spc"
+    spc.write_bytes(b"")
+    with pytest.raises(ValueError):
+        LoadSpectrum().load(BlockConfig(params={"path": str(spc)}))

--- a/packages/scistudio-blocks-spectroscopy/tests/test_types.py
+++ b/packages/scistudio-blocks-spectroscopy/tests/test_types.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import sys
 
 import numpy as np
+import pytest
 from scistudio_blocks_spectroscopy import _support
 from scistudio_blocks_spectroscopy.types import SpectralDataset, Spectrum
 
@@ -60,6 +61,35 @@ def test_spectral_dataset_slot_type_is_enforced() -> None:
     assert set(dataset.slot_names) == {"index", "spectra"}
     assert isinstance(dataset.get("index"), DataFrame)
     assert isinstance(dataset.get("spectra"), DataFrame)
+
+
+@pytest.mark.parametrize(
+    ("index_rows", "spectra_rows", "match"),
+    [
+        ([{"label": "a"}], [{"spectrum_id": "a", "lambda": 1.0, "intensity": 2.0}], "index table"),
+        ([{"spectrum_id": "a"}], [{"spectrum_id": "a", "lambda": 1.0}], "missing"),
+        (
+            [{"spectrum_id": "a"}, {"spectrum_id": "a"}],
+            [{"spectrum_id": "a", "lambda": 1.0, "intensity": 2.0}],
+            "unique",
+        ),
+        ([{"spectrum_id": "a"}], [{"spectrum_id": "ghost", "lambda": 1.0, "intensity": 2.0}], "unknown"),
+        (
+            [{"spectrum_id": "a"}, {"spectrum_id": "b"}],
+            [{"spectrum_id": "a", "lambda": 1.0, "intensity": 2.0}],
+            "coverage",
+        ),
+        ([{"spectrum_id": "a"}], [{"spectrum_id": "a", "lambda": "bad", "intensity": 2.0}], "numeric"),
+    ],
+)
+def test_spectral_dataset_validates_required_columns_and_join(
+    index_rows: list[dict], spectra_rows: list[dict], match: str
+) -> None:
+    with pytest.raises(ValueError, match=match):
+        _support.build_spectral_dataset(
+            _support.dataframe_from_rows(index_rows),
+            _support.dataframe_from_rows(spectra_rows),
+        )
 
 
 def test_no_srs_import_anywhere_in_package() -> None:

--- a/packages/scistudio-blocks-spectroscopy/tests/test_unmixing_blocks.py
+++ b/packages/scistudio-blocks-spectroscopy/tests/test_unmixing_blocks.py
@@ -21,7 +21,7 @@ import numpy as np
 import pytest
 from scistudio_blocks_spectroscopy import _support
 from scistudio_blocks_spectroscopy.blocks import unmixing
-from scistudio_blocks_spectroscopy.blocks.unmixing import SpectralUnmixing
+from scistudio_blocks_spectroscopy.blocks.unmixing import SpectralUnmixing, _solve
 from scistudio_blocks_spectroscopy.types import Spectrum
 
 from scistudio.blocks.base.config import BlockConfig
@@ -146,6 +146,19 @@ def test_fit_quality_schema() -> None:
     row = fq.to_pylist()[0]
     assert row["n_components"] == 2
     assert row["method"] == "least_squares"
+
+
+def test_sum_to_one_nnls_verifies_constraint_after_fit() -> None:
+    def fake_nnls(_design: np.ndarray, _target: np.ndarray) -> tuple[np.ndarray, float]:
+        return np.asarray([0.25, 0.25], dtype=float), 0.0
+
+    design = np.eye(2, dtype=float)
+    target = np.ones(2, dtype=float)
+    coeffs, quality = _solve("sum_to_one_non_negative_least_squares", design, target, fake_nnls)
+
+    assert float(np.sum(coeffs)) == pytest.approx(0.5)
+    assert quality["status"] == "constraint_not_satisfied"
+    assert "sum-to-one constraint not satisfied" in quality["message"]
 
 
 # ---------------------------------------------------------------------------

--- a/packages/scistudio-blocks-spectroscopy/tests/test_utility_blocks.py
+++ b/packages/scistudio-blocks-spectroscopy/tests/test_utility_blocks.py
@@ -21,7 +21,7 @@ Covers the nine utility blocks of FR-032:
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import numpy as np
 import pytest
@@ -81,7 +81,7 @@ def _spectrum(
 
 def _to_dataset(spectra: list[Spectrum], **config: Any) -> SpectralDataset:
     out = SpectrumToSpectralDataset().run({"spectra": _support.spectra_collection(spectra)}, _config(**config))
-    return next(iter(out["dataset"]))
+    return cast(SpectralDataset, next(iter(out["dataset"])))
 
 
 def _index_table(dataset: SpectralDataset) -> Any:
@@ -178,6 +178,21 @@ def test_spectrum_to_dataset_join_by_source_file() -> None:
     assert pairs == {"id1": "wet", "id2": "dry"}
 
 
+def test_spectrum_to_dataset_rejects_duplicate_metadata_join_keys() -> None:
+    spectra = [_spectrum("id1", source_file="/data/one.csv")]
+    metadata = _support.dataframe_from_rows(
+        [
+            {"source_file": "/data/one.csv", "condition": "wet"},
+            {"source_file": "/data/one.csv", "condition": "dry"},
+        ]
+    )
+    with pytest.raises(ValueError, match="must be unique"):
+        SpectrumToSpectralDataset().run(
+            {"spectra": _support.spectra_collection(spectra), "metadata": Collection([metadata], item_type=DataFrame)},
+            _config(metadata_join_key="source_file"),
+        )
+
+
 # ---------------------------------------------------------------------------
 # SC-011: round-trip dataset <-> spectra
 # ---------------------------------------------------------------------------
@@ -248,6 +263,31 @@ def test_merge_rejects_duplicate_ids_by_default() -> None:
         MergeSpectralDataset().run({"datasets": Collection([ds1, ds2], item_type=SpectralDataset)}, _config())
 
 
+def test_dataset_boundary_rejects_internal_duplicate_ids() -> None:
+    index = _support.dataframe_from_rows([{"spectrum_id": "dup"}, {"spectrum_id": "dup"}])
+    spectra = _support.dataframe_from_rows(
+        [
+            {"spectrum_id": "dup", "lambda": 1.0, "intensity": 2.0},
+            {"spectrum_id": "dup", "lambda": 2.0, "intensity": 3.0},
+        ]
+    )
+    with pytest.raises(ValueError, match="unique"):
+        _support.build_spectral_dataset(index, spectra)
+
+
+def test_merge_rejects_row_level_unit_mismatch() -> None:
+    ds1 = _support.build_spectral_dataset(
+        _support.dataframe_from_rows([{"spectrum_id": "a", "lambda_unit": "nm"}]),
+        _support.dataframe_from_rows([{"spectrum_id": "a", "lambda": 1.0, "intensity": 2.0}]),
+    )
+    ds2 = _support.build_spectral_dataset(
+        _support.dataframe_from_rows([{"spectrum_id": "b", "lambda_unit": "cm-1"}]),
+        _support.dataframe_from_rows([{"spectrum_id": "b", "lambda": 1.0, "intensity": 3.0}]),
+    )
+    with pytest.raises(ValueError, match="incompatible lambda_unit"):
+        MergeSpectralDataset().run({"datasets": Collection([ds1, ds2], item_type=SpectralDataset)}, _config())
+
+
 def test_merge_remap_policy_makes_ids_unique() -> None:
     ds1 = _to_dataset([_spectrum("dup"), _spectrum("a")])
     ds2 = _to_dataset([_spectrum("dup"), _spectrum("b")])
@@ -298,6 +338,21 @@ def test_attach_features_rejects_missing_join_key() -> None:
             {
                 "dataset": Collection([dataset], item_type=SpectralDataset),
                 "features": Collection([bad_features], item_type=DataFrame),
+            },
+            _config(),
+        )
+
+
+def test_attach_features_rejects_duplicate_join_keys() -> None:
+    dataset = _to_dataset([_spectrum("a")])
+    duplicate_features = _support.dataframe_from_rows(
+        [{"spectrum_id": "a", "auc": 1.0}, {"spectrum_id": "a", "auc": 2.0}]
+    )
+    with pytest.raises(ValueError, match="must be unique"):
+        AttachFeaturesToSpectralDataset().run(
+            {
+                "dataset": Collection([dataset], item_type=SpectralDataset),
+                "features": Collection([duplicate_features], item_type=DataFrame),
             },
             _config(),
         )


### PR DESCRIPTION
## Summary

Stacked repair PR for #1666 / #1661. This resolves the integrated audit findings against the spectroscopy package implementation.

- makes SPC and vendor/native binary formats truthful deferrals instead of advertised `FormatCapability` records
- completes `SpectralDataset` validation, composite slot discovery, dataset preview explorer payloads, and preview export controls
- hardens joins, duplicate-ID checks, row-level unit compatibility, out-of-grid feature measurements, and NNLS sum-to-one status reporting
- updates the spectroscopy spec, package README, and package tests to lock the corrected contracts

## Verification

- `python -m pytest packages/scistudio-blocks-spectroscopy/tests/test_types.py packages/scistudio-blocks-spectroscopy/tests/test_format_capabilities.py packages/scistudio-blocks-spectroscopy/tests/test_spectrum_io.py packages/scistudio-blocks-spectroscopy/tests/test_spectral_dataset_io.py packages/scistudio-blocks-spectroscopy/tests/test_utility_blocks.py packages/scistudio-blocks-spectroscopy/tests/test_feature_extraction_blocks.py packages/scistudio-blocks-spectroscopy/tests/test_unmixing_blocks.py packages/scistudio-blocks-spectroscopy/tests/test_spectrum_previewer.py packages/scistudio-blocks-spectroscopy/tests/test_spectral_dataset_previewer.py packages/scistudio-blocks-spectroscopy/tests/test_prev_smoke.py -q --no-cov --timeout=60` -> 134 passed, 2 skipped
- `python -m pytest packages/scistudio-blocks-spectroscopy/tests -q --no-cov --timeout=60` -> 477 passed, 6 skipped
- `python -m ruff check packages/scistudio-blocks-spectroscopy/src/scistudio_blocks_spectroscopy packages/scistudio-blocks-spectroscopy/tests` -> passed
- `python -m compileall -q packages/scistudio-blocks-spectroscopy/src/scistudio_blocks_spectroscopy` -> passed
- `git diff --check` -> passed
- `python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json` -> passed
- `python -m pytest tests/contracts/test_runtime_import_contract.py -q --no-cov --timeout=60` -> passed in the current project environment

Known local gate caveat:

- Full `python_tests` in the isolated gate venv failed in `tests/contracts/test_runtime_import_contract.py` because that venv resolved FastAPI 0.137.0 / Starlette 1.3.1, where included routers appear as lazy `_IncludedRouter` entries and the existing contract test route enumeration reports missing API routes. The same contract test passes in the current project environment with FastAPI 0.135.3 / Starlette 1.0.0. This is a dependency/contract-test drift outside the spectroscopy package diff.

## Gate Record

- `.workflow/records/1661-codex-pr1666-spectroscopy-audit-fixes.json`

Closes #1661
