### PR TITLE
fix(#1664): harden PR1665 package validator blockers

### DIFF
--- a/.workflow/records/1664-fix-pr1665-package-validator-audit-blockers-20260615.json
+++ b/.workflow/records/1664-fix-pr1665-package-validator-audit-blockers-20260615.json
@@ -1,0 +1,1154 @@
+{
+  "branch": "fix/pr1665-package-validator-audit-blockers-20260615",
+  "check_events": [
+    {
+      "at": "2026-06-15T04:08:15.921069Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-15T04:08:27.554710Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-15T04:08:27.674351Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-15T04:09:01.562987Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-15T04:09:17.221361Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-15T04:09:17.282229Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-15T04:58:10.391078Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:51944ed5d93c7f6ce20941bf2c5ec4ebdecf198892611902e20d99fa9fce8397",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-15T04:58:25.073936Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:51944ed5d93c7f6ce20941bf2c5ec4ebdecf198892611902e20d99fa9fce8397",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-15T04:58:25.539672Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:51944ed5d93c7f6ce20941bf2c5ec4ebdecf198892611902e20d99fa9fce8397",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-15T04:58:25.582647Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:51944ed5d93c7f6ce20941bf2c5ec4ebdecf198892611902e20d99fa9fce8397",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-15T05:02:44.682969Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:51944ed5d93c7f6ce20941bf2c5ec4ebdecf198892611902e20d99fa9fce8397",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-15T05:03:42.884019Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:51944ed5d93c7f6ce20941bf2c5ec4ebdecf198892611902e20d99fa9fce8397",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-15T05:03:43.759776Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:51944ed5d93c7f6ce20941bf2c5ec4ebdecf198892611902e20d99fa9fce8397",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    },
+    {
+      "at": "2026-06-15T05:13:09.668672Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:f76ee1540c5cfa8859daf5d63374b9a493cc6b4a8ca035e120075f79cf336914",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-15T05:13:21.974200Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:f76ee1540c5cfa8859daf5d63374b9a493cc6b4a8ca035e120075f79cf336914",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-15T05:13:22.254383Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:f76ee1540c5cfa8859daf5d63374b9a493cc6b4a8ca035e120075f79cf336914",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-15T05:13:22.294026Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:f76ee1540c5cfa8859daf5d63374b9a493cc6b4a8ca035e120075f79cf336914",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-15T05:17:39.307385Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:f76ee1540c5cfa8859daf5d63374b9a493cc6b4a8ca035e120075f79cf336914",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-15T05:18:37.893074Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:f76ee1540c5cfa8859daf5d63374b9a493cc6b4a8ca035e120075f79cf336914",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-15T05:18:41.266739Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:f76ee1540c5cfa8859daf5d63374b9a493cc6b4a8ca035e120075f79cf336914",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    }
+  ],
+  "check_na": [],
+  "commit": {
+    "sha": "HEAD",
+    "shas": [
+      "HEAD"
+    ],
+    "trailers": []
+  },
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "src/scistudio/packages/validation/**",
+      "src/scistudio/cli/package_validator.py",
+      "tests/packages/**",
+      "docs/block-development/package-validator.md",
+      "docs/audit/2026-06-15-pr1665-package-validator-no-context.md",
+      ".workflow/records/**"
+    ]
+  },
+  "directive_events": [],
+  "docs_events": [
+    {
+      "at": "2026-06-15T03:49:23.182839Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/block-development/package-validator.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-15T03:49:23.182845Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/audit/2026-06-15-pr1665-package-validator-no-context.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-15T03:56:05.485280Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/audit/2026-06-15-pr1665-package-validator-fix-readiness.md",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": true,
+  "guard_events": [
+    {
+      "at": "2026-06-15T04:08:27.804913Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:08:27.858060Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:08:27.917649Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:08:27.971752Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:08:28.031122Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:08:28.089593Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:08:28.144214Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:08:28.200411Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:08:28.255314Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:08:28.314564Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:09:17.444787Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:09:17.532512Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:09:17.625912Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:09:17.697320Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:09:17.773367Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:09:17.869315Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:09:17.975025Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:09:18.062635Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:09:18.155623Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:09:18.236940Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:45:08.340610Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:45:08.395953Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:45:08.449958Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:45:08.507589Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:45:08.560480Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:45:08.614239Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:45:08.698356Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:45:08.753530Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:45:08.809422Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:45:08.870019Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:45:21.952886Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:45:22.007447Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:45:22.059856Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:45:22.113561Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:45:22.171832Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:45:22.234791Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:45:22.292779Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:45:22.355523Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:45:22.408482Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T04:45:22.484118Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T05:03:43.876595Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T05:03:43.929844Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T05:03:43.984564Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T05:03:44.041208Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T05:03:44.095452Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T05:03:44.157713Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T05:03:44.214676Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T05:03:44.271498Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T05:03:44.326485Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T05:03:44.388128Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T05:18:41.395353Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T05:18:41.448379Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T05:18:41.507832Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T05:18:41.560512Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T05:18:41.614946Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T05:18:41.668159Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T05:18:41.720029Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T05:18:41.777120Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T05:18:41.829143Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T05:18:41.891542Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T05:19:20.042785Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T05:19:20.094737Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T05:19:20.148592Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T05:19:20.201167Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T05:19:20.286820Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T05:19:20.338973Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T05:19:20.393234Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T05:19:20.447556Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T05:19:20.500313Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T05:19:20.558331Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1664,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": {
+    "base": "origin/track/adr-049-package-validator-implementation",
+    "base_sha": "b86c1de2",
+    "changed_files": [
+      ".workflow/records/1664-fix-pr1665-package-validator-audit-blockers-20260615.json",
+      "docs/audit/2026-06-15-pr1665-package-validator-fix-readiness.md",
+      "docs/block-development/package-validator.md",
+      "src/scistudio/packages/validation/engine.py",
+      "src/scistudio/packages/validation/inventory.py",
+      "src/scistudio/packages/validation/registration.py",
+      "tests/contracts/test_runtime_import_contract.py",
+      "tests/packages/test_package_validator.py",
+      "tests/packages/test_package_validator_inventory.py",
+      "tests/packages/test_package_validator_production_registration.py",
+      "tests/packages/test_package_validator_reports.py"
+    ],
+    "diff_fingerprint": "sha256:4476bce172755b972688d793001a25eacd3bb9ef22110ab69a03c2e63d8e4bf4",
+    "head": "HEAD",
+    "head_sha": "c8f56d7a",
+    "surfaces": {
+      "docs": 2,
+      "frontend": 0,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 3,
+      "packaging": 0,
+      "protected_core": 0,
+      "sentrux": 8,
+      "test": 5,
+      "workflow_ci": 0
+    }
+  },
+  "owner_directive": "Manage and implement fixes for all no-context audit findings on PR1665 package validator, then open a stacked fix PR against track/adr-049-package-validator-implementation.",
+  "persona": "manager",
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [
+      1664
+    ],
+    "number": 1671,
+    "url": "https://github.com/zjzcpj/SciStudio/pull/1671"
+  },
+  "reconcile_events": [
+    {
+      "at": "2026-06-15T04:08:28.314615Z",
+      "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "mode": "pre-push",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-15T04:09:18.237002Z",
+      "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-15T04:45:08.870063Z",
+      "diff_fingerprint": "sha256:d6b90bf00838a6d880abfd5e451ae5f7c53ab1271f860684ab9bd6a63a742599",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-15T04:45:22.484164Z",
+      "diff_fingerprint": "sha256:d6b90bf00838a6d880abfd5e451ae5f7c53ab1271f860684ab9bd6a63a742599",
+      "mode": "pre-push",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-15T05:03:44.388164Z",
+      "diff_fingerprint": "sha256:28813f21008c7309dd7d17cf70a321b3d867a37f94ae2afdbf521bdd77d8e468",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.python_tests"
+      ]
+    },
+    {
+      "at": "2026-06-15T05:18:41.891579Z",
+      "diff_fingerprint": "sha256:4476bce172755b972688d793001a25eacd3bb9ef22110ab69a03c2e63d8e4bf4",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-15T05:19:20.558372Z",
+      "diff_fingerprint": "sha256:4476bce172755b972688d793001a25eacd3bb9ef22110ab69a03c2e63d8e4bf4",
+      "mode": "ci",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    }
+  ],
+  "record_id": "1664-fix-pr1665-package-validator-audit-blockers-20260615",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [],
+    "docs": [
+      "docs_required_or_na"
+    ],
+    "guards": [
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": [
+      "changed_test_required"
+    ]
+  },
+  "runtime": "codex",
+  "schema_version": 2,
+  "scope_events": [
+    {
+      "action": "add-include",
+      "at": "2026-06-15T03:49:23.182798Z",
+      "pattern": "src/scistudio/packages/validation/models.py",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-15T03:49:23.182818Z",
+      "pattern": "src/scistudio/packages/validation/inventory.py",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-15T03:49:23.182821Z",
+      "pattern": "src/scistudio/packages/validation/engine.py",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-15T03:49:23.182823Z",
+      "pattern": "src/scistudio/packages/validation/registration.py",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-15T03:49:23.182825Z",
+      "pattern": "tests/packages/test_package_validator.py",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-15T03:49:23.182826Z",
+      "pattern": "tests/packages/test_package_validator_inventory.py",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-15T03:49:23.182828Z",
+      "pattern": "tests/packages/test_package_validator_production_registration.py",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-15T03:49:23.182829Z",
+      "pattern": "tests/packages/test_package_validator_reports.py",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-15T03:49:23.182831Z",
+      "pattern": "tests/packages/fixtures/package_validator/**",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-15T03:56:05.485250Z",
+      "pattern": "docs/audit/2026-06-15-pr1665-package-validator-fix-readiness.md",
+      "reason": "Add manager fix readiness audit note for PR1665 audit blocker remediation evidence."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-15T05:06:22.753673Z",
+      "pattern": "tests/contracts/test_runtime_import_contract.py",
+      "reason": "Extend verification fix to runtime route contract collection for FastAPI included-router compatibility observed in gate venv."
+    }
+  ],
+  "session_id": "e235cc98-d82d-4d64-a3b8-2679299e665b",
+  "strictness_tier": 2,
+  "task_kind": "bugfix",
+  "test_events": [
+    {
+      "at": "2026-06-15T03:49:23.182849Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/packages/test_package_validator.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-15T03:49:23.182854Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/packages/test_package_validator_inventory.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-15T03:49:23.182856Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/packages/test_package_validator_production_registration.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-15T03:49:23.182858Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/packages/test_package_validator_reports.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-15T05:06:22.753694Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/contracts/test_runtime_import_contract.py",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/docs/audit/2026-06-15-pr1665-package-validator-fix-readiness.md
+++ b/docs/audit/2026-06-15-pr1665-package-validator-fix-readiness.md
@@ -1,0 +1,149 @@
+---
+title: "Fix Readiness Audit: PR1665 Package Validator Audit Blockers"
+date: 2026-06-15
+auditor: "Codex manager"
+pr: 1665
+status: pass-with-review
+related_issue: 1664
+governed_by:
+  - ADR-049
+---
+
+# Fix Readiness Audit: PR1665 Package Validator Audit Blockers
+
+## Verdict
+
+Pass with review.
+
+This follow-up verifies the fix branch for the PR1665 no-context audit blockers.
+The branch keeps the package validator focused on ADR-049 while closing the
+false-pass and production-registration safety gaps raised by the audit.
+
+## Finding Closure
+
+### P1-1 Production validation imported candidate code in the live process
+
+Fixed. `validate_for_registration(...)` now makes the production accept/reject
+decision from a subprocess report and returns a lazy plan. The caller process
+does not import the candidate while the plan decision is being made. The
+regression test `test_production_plan_does_not_import_candidate_before_commit`
+asserts that the valid fixture package is not present in `sys.modules` after
+plan creation.
+
+### P1-2 Wheel/sdist/archive inputs could be accepted as metadata-only packages
+
+Fixed. Archive inventory now extracts wheels/source distributions, reads package
+metadata, and preserves SciStudio entry points for validation. Unsupported or
+malformed archive metadata produces a structured failure report. Regression
+coverage includes wheel entry-point validation in
+`test_wheel_entry_points_are_validated_instead_of_treated_as_metadata_only`
+and wheel inventory parsing in `test_wheel_inventory_reads_distribution_entry_points`.
+
+### P1-3 Applicable contract rows could be reported as `pass` without execution
+
+Fixed. The engine tracks executed contract IDs and reports applicable but
+unexecuted rows as `skipped` with evidence instead of `pass`. The regression
+test `test_applicable_unexecuted_contract_rows_are_not_reported_as_pass`
+asserts this behavior.
+
+### P2-1 Unknown `scistudio.*` entry-point groups were silently ignored
+
+Fixed. Inventory preserves unknown SciStudio entry-point groups, and validation
+turns them into structured `PV-02-002` findings. Regression coverage:
+`test_source_inventory_keeps_unknown_scistudio_entry_point_groups` and
+`test_unknown_scistudio_entry_point_group_is_a_structured_failure`.
+
+### P2-2 Existing-package conflicts were not checked before `accept`
+
+Fixed for caller-provided live registries. `validate_for_registration(...)`
+accepts existing block/type/previewer/runner registries and rejects conflicting
+candidate capability, type, previewer, or runner IDs before commit. Regression
+coverage: `test_production_registration_rejects_existing_capability_conflict_before_commit`.
+
+### P2-3 Source-tree import isolation leaked `sys.modules`
+
+Fixed. `candidate_import_context(...)` snapshots module state and removes
+modules imported from candidate source paths when the context exits. Regression
+coverage: `test_candidate_import_context_removes_source_modules`.
+
+### P2-4 Dry-run type registries included built-ins and committed all dry-run types
+
+Fixed. `DryRunBuilder` tracks candidate rows separately from built-ins. Report
+summaries and `commit_to(...)` now use candidate blocks, types, previewers,
+format capabilities, and runners only. Cross-surface block-port checks still
+permit types imported from declared dependency packages; SRS is covered in the
+existing-package sweep below to guard against false rejects.
+
+### P2-5 Inventory failures escaped as exceptions
+
+Fixed. Public validation catches inventory and contract-loading failures and
+returns a structured `PackageValidationReport` with a blocking `PV-01-001`
+finding. Regression coverage: `test_bad_source_metadata_returns_structured_report`.
+
+### P2-6 Profile/severity policy was disconnected from contract-row behavior
+
+Fixed. Findings now carry `profile_behavior` from the ADR-049 contract row, and
+profile behavior can upgrade severity for production blockers without
+downgrading structurally impossible package errors.
+
+### P3-1 `PackageInfo` validation was too narrow
+
+Fixed. The validator now checks non-empty `name`/`version`, string
+`description`/`author`, and emits a warning when `PackageInfo.name` differs from
+the package distribution name.
+
+### P3-2 Tests missed the false-pass cases
+
+Fixed. The package validator suite now includes regressions for wheel parsing,
+unknown entry-point groups, source-module cleanup, structured inventory failure,
+lazy production plans, existing registry conflicts, and applicable-unexecuted
+contract result classification. It also covers the distinction between
+candidate-local DataObject types that must be returned from `scistudio.types`
+and declared-dependency DataObject types that candidate block ports may
+reference.
+
+### Gate environment compatibility
+
+Fixed. The gate wrapper's isolated FastAPI dependency set exposes included
+routers as wrapper entries in `app.routes`, while the ambient environment
+eagerly expands them. The runtime route contract now recursively collects
+effective paths, preserving the same required-route assertions across both
+environments.
+
+## Verification
+
+Targeted package validator verification:
+
+```powershell
+$env:PYTHONPATH='src'
+python -m pytest --no-cov `
+  tests/packages/test_package_validator.py `
+  tests/packages/test_package_validator_reports.py `
+  tests/packages/test_package_validator_inventory.py `
+  tests/packages/test_package_validator_production_registration.py `
+  tests/packages/test_package_validator_cli.py -q
+```
+
+Result: `38 passed`.
+
+Existing package production-profile sweep:
+
+| Candidate | Status | Decision | Findings |
+|---|---|---|---:|
+| `.` (`scistudio`) | `pass` | `accept` | 0 |
+| `packages/scistudio-blocks-imaging` | `pass` | `accept` | 0 |
+| `packages/scistudio-blocks-lcms` | `pass` | `accept` | 0 |
+| `packages/scistudio-blocks-srs` | `pass` | `accept` | 0 |
+| `tests/packages/fixtures/package_validator/valid_package` | `pass` | `accept` | 0 |
+
+ADR-049 contract table checker remains at the expected baseline:
+`summary: 0 error(s), 9 warning(s)`.
+
+Additional gate-risk checks:
+
+- `python -m pytest --no-cov tests/packages/test_package_validator.py tests/packages/test_package_validator_reports.py tests/packages/test_package_validator_inventory.py tests/packages/test_package_validator_production_registration.py tests/packages/test_package_validator_cli.py tests/contracts/test_runtime_import_contract.py -q` -> `56 passed`.
+- `.workflow\local\venv\Scripts\python.exe -m pytest --no-cov tests/contracts/test_runtime_import_contract.py -q` -> `19 passed`.
+- `python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json` -> all ratchets within limits.
+- Full local pytest with source package entry-point overlay and
+  `PYTEST_ADDOPTS=-m "not requires_imaging"` -> `4506 passed, 62 skipped,
+  8 xfailed`.

--- a/docs/block-development/package-validator.md
+++ b/docs/block-development/package-validator.md
@@ -3,7 +3,7 @@ doc_type: block-development
 title: "Package Validator"
 status: living
 owner: "@jiazhenz026"
-last_updated: 2026-06-14
+last_updated: 2026-06-15
 governed_by:
   - ADR-049
 summary: "How package authors and install-time registration code use the ADR-049 package validator for development diagnostics and production accept/reject decisions."
@@ -34,6 +34,12 @@ The module form is equivalent and is useful inside a source checkout:
 $env:PYTHONPATH = "src"
 python -m scistudio.cli.package_validator packages/scistudio-blocks-imaging --profile production --json
 ```
+
+The candidate argument may be a source tree, an installed distribution name, a
+wheel, or a source distribution. Wheel and source-distribution inputs are
+inspected for package metadata and SciStudio entry points before validation; a
+bad archive is returned as a structured reject report instead of being accepted
+as metadata-only input.
 
 Profiles:
 
@@ -71,10 +77,24 @@ plan.commit_to(block_registry=block_registry, type_registry=type_registry)
 `validate_for_registration()` returns a plan/report boundary. Caller-owned
 installer code commits live registry rows by calling `plan.commit_to(...)` only
 after validation passes. The helper runs the production report in a subprocess
-before any in-process commit preparation. A reject report returns `False` from
-`commit_to(...)` and leaves live registries unchanged. If a live registry
-rejects one row during commit, previously written rows from the same call are
-rolled back.
+before returning an accepted plan; candidate package modules are not imported
+into the caller's process while the production decision is being made. A reject
+report returns `False` from `commit_to(...)` and leaves live registries
+unchanged. If a live registry rejects one row during commit, previously written
+rows from the same call are rolled back.
+
+Installers may pass existing live registries to `validate_for_registration(...)`
+so the report can reject candidate packages that conflict with installed type,
+previewer, runner, or IO capability IDs before a commit is attempted:
+
+```python
+plan = validate_for_registration(
+    "packages/scistudio-blocks-imaging",
+    block_registry=block_registry,
+    type_registry=type_registry,
+    previewer_registry=previewer_registry,
+)
+```
 
 ## Report Shape
 
@@ -94,7 +114,13 @@ contains:
 
 Absent surfaces are reported as `not_applicable`. For example, a package that
 declares only blocks and types does not fail previewer contracts; those rows are
-classified as not applicable.
+classified as not applicable. A row whose surface applies but whose runtime
+validator did not execute is reported as `skipped` with evidence instead of
+being reported as `pass`. Package authors should treat skipped applicable rows
+as incomplete validation coverage, not as proof that the contract passed.
+
+Unknown `scistudio.*` entry-point groups are structured findings. Misspelled or
+future entry-point groups must not be silently ignored.
 
 ## Source Tree Dependencies
 
@@ -103,6 +129,11 @@ only the candidate package and sibling `packages/*/src` directories that are
 declared in the candidate package's `project.dependencies`. This keeps local
 source-tree validation faithful to package metadata: a package may use a sibling
 source tree only if it declares the dependency in `pyproject.toml`.
+
+Block ports may reference DataObject types owned by declared dependency
+packages. DataObject types defined inside the candidate package itself must be
+returned by its `scistudio.types` entry point before candidate block ports or
+previewers may target them.
 
 ## Contract Evidence
 

--- a/src/scistudio/packages/validation/engine.py
+++ b/src/scistudio/packages/validation/engine.py
@@ -2,12 +2,16 @@
 
 from __future__ import annotations
 
+import contextlib
+import importlib
 import inspect
+import os
 from collections import Counter
+from dataclasses import replace
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
-from scistudio.packages.validation.contracts import contract_applies, load_contract_tables
+from scistudio.packages.validation.contracts import PackageContract, contract_applies, load_contract_tables
 from scistudio.packages.validation.inventory import CandidateEntryPoint, build_inventory, candidate_import_context
 from scistudio.packages.validation.models import (
     ContractResult,
@@ -22,9 +26,26 @@ from scistudio.packages.validation.models import (
 
 # fmt: off
 def validate_package(path_or_distribution: str | Path, profile: PackageValidationProfile | str = PackageValidationProfile.DEVELOPMENT) -> PackageValidationReport:
-    report, _dry_run = _validate_package_with_dry_run(path_or_distribution, profile=profile)
-    return report
+    try:
+        report, _dry_run = _validate_package_with_dry_run(path_or_distribution, profile=profile)
+        return report
+    except Exception as exc:
+        return _failure_report(path_or_distribution, _normalize_profile(profile), exc)
 # fmt: on
+
+
+def validate_installed_package(
+    distribution: str,
+    profile: PackageValidationProfile | str = PackageValidationProfile.PRODUCTION,
+) -> PackageValidationReport:
+    validation_profile = _normalize_profile(profile)
+    if (
+        validation_profile is PackageValidationProfile.PRODUCTION
+        and os.environ.get("SCISTUDIO_PACKAGE_VALIDATOR_SUBPROCESS") != "1"
+    ):
+        registration = importlib.import_module("scistudio.packages.validation.registration")
+        return cast(PackageValidationReport, registration.validate_for_registration(distribution).report)
+    return validate_package(distribution, profile=validation_profile)
 
 
 def _validate_package_with_dry_run(
@@ -38,13 +59,32 @@ def _validate_package_with_dry_run(
     contracts = load_contract_tables()
     findings: list[PackageValidationFinding] = []
     dry_run = DryRunBuilder()
+    executed_contracts: set[str] = {"PV-01-001", "PV-01-002"}
+    if candidate.candidate.source_kind == "unsupported-archive":
+        findings.append(
+            _finding(
+                "PV-01-001",
+                "blocker",
+                "distribution_metadata",
+                candidate.candidate.value,
+                "Archive input type is not supported by the package validator.",
+                "Provide a source tree, wheel, source distribution, or installed distribution name.",
+            )
+        )
 
     with candidate_import_context(candidate):
         for entry_point in candidate.entry_points:
-            _validate_entry_point(entry_point, candidate.inventory, dry_run, findings)
-        _validate_cross_surface(candidate.inventory, dry_run, findings)
+            _validate_entry_point(entry_point, candidate.inventory, dry_run, findings, executed_contracts)
+        _validate_cross_surface(candidate.inventory, dry_run, findings, executed_contracts)
 
-    contract_results = _contract_results(contracts, candidate.inventory.surfaces, findings, validation_profile)
+    findings = _apply_profile_behaviors(findings, contracts, validation_profile)
+    contract_results = _contract_results(
+        contracts,
+        candidate.inventory.surfaces,
+        findings,
+        validation_profile,
+        executed_contracts,
+    )
     report = PackageValidationReport(
         package=candidate.inventory.package,
         profile=validation_profile,
@@ -54,12 +94,6 @@ def _validate_package_with_dry_run(
         dry_run_registries=dry_run.summary(),
     )
     return report, dry_run
-
-
-# fmt: off
-def validate_installed_package(distribution: str, profile: PackageValidationProfile | str = PackageValidationProfile.PRODUCTION) -> PackageValidationReport:
-    return validate_package(distribution, profile=profile)
-# fmt: on
 
 
 class DryRunBuilder:
@@ -76,24 +110,86 @@ class DryRunBuilder:
         self.previewer_registry = PreviewerRegistry()
         self.runners: dict[str, Any] = {}
         self.api_payloads = 0
+        self.candidate_block_names: set[str] = set()
+        self.candidate_type_names: set[str] = set()
+        self.candidate_previewer_ids: set[str] = set()
+        self.candidate_runner_names: set[str] = set()
 
     def summary(self) -> DryRunRegistrySet:
         return DryRunRegistrySet(
-            blocks=len(self.block_registry.all_specs()),
-            types=len(self.type_registry.all_types()),
-            previewers=len(self.previewer_registry.all_specs()),
-            format_capabilities=len(self.block_registry.list_format_capabilities()),
-            runners=len(self.runners),
+            blocks=len(self.candidate_block_names),
+            types=len(self.candidate_type_names),
+            previewers=len(self.candidate_previewer_ids),
+            format_capabilities=len(self.candidate_format_capability_ids()),
+            runners=len(self.candidate_runner_names),
             api_payloads=self.api_payloads,
         )
 
+    def add_block_spec(self, spec: Any) -> None:
+        self.block_registry._register_spec(spec)
+        self.candidate_block_names.add(spec.name)
 
-# fmt: off
-def _validate_entry_point(entry_point: CandidateEntryPoint, inventory: Any, dry_run: DryRunBuilder, findings: list[PackageValidationFinding]) -> None:
+    def add_type_class(self, cls: type) -> None:
+        self.type_registry.register_class(cls)
+        self.candidate_type_names.add(cls.__name__)
+
+    def add_previewer_spec(self, spec: Any) -> bool:
+        registered = self.previewer_registry.register(spec)
+        if registered:
+            self.candidate_previewer_ids.add(spec.previewer_id)
+        return registered
+
+    def add_runner(self, name: str, runner: Any) -> None:
+        self.runners[name] = runner
+        self.candidate_runner_names.add(name)
+
+    def candidate_block_specs(self) -> list[Any]:
+        specs = self.block_registry.all_specs()
+        return [specs[name] for name in self.candidate_block_names if name in specs]
+
+    def candidate_type_specs(self) -> dict[str, Any]:
+        specs = self.type_registry.all_types()
+        return {name: specs[name] for name in self.candidate_type_names if name in specs}
+
+    def candidate_previewer_specs(self) -> list[Any]:
+        return [
+            spec for spec in self.previewer_registry.all_specs() if spec.previewer_id in self.candidate_previewer_ids
+        ]
+
+    def candidate_format_capability_ids(self) -> set[str]:
+        return {
+            capability.id
+            for spec in self.candidate_block_specs()
+            for capability in getattr(spec, "format_capabilities", ())
+        }
+
+
+def _validate_entry_point(
+    entry_point: CandidateEntryPoint,
+    inventory: Any,
+    dry_run: DryRunBuilder,
+    findings: list[PackageValidationFinding],
+    executed_contracts: set[str],
+) -> None:
+    executed_contracts.update({"PV-02-001", "PV-02-002"})
+    validator = _ENTRY_POINT_VALIDATORS.get(entry_point.group)
+    if validator is None:
+        findings.append(_unknown_entry_point_group_finding(entry_point))
+        return
     loaded = _load_entry_point(entry_point, findings)
-    if loaded is not None and (validator := _ENTRY_POINT_VALIDATORS.get(entry_point.group)):
-        validator(entry_point, loaded, inventory, dry_run, findings)
-# fmt: on
+    if loaded is not None:
+        validator(entry_point, loaded, inventory, dry_run, findings, executed_contracts)
+
+
+def _unknown_entry_point_group_finding(entry_point: CandidateEntryPoint) -> PackageValidationFinding:
+    return _finding(
+        "PV-02-002",
+        "error",
+        "entry_points",
+        f"{entry_point.group}:{entry_point.name}",
+        f"Unknown SciStudio entry-point group {entry_point.group!r}.",
+        "Use one of scistudio.blocks, scistudio.types, scistudio.previewers, or scistudio.runners.",
+    )
 
 
 def _load_entry_point(
@@ -122,9 +218,15 @@ def _validate_blocks_entry_point(
     inventory: Any,
     dry_run: DryRunBuilder,
     findings: list[PackageValidationFinding],
+    executed_contracts: set[str],
 ) -> None:
+    from scistudio.blocks.app.app_block import AppBlock
     from scistudio.blocks.base.block import Block
     from scistudio.blocks.base.package_info import PackageInfo
+    from scistudio.blocks.code.code_block import CodeBlock
+    from scistudio.blocks.io.io_block import IOBlock
+
+    executed_contracts.add("PV-02-003")
 
     try:
         result = loaded if isinstance(loaded, type) and issubclass(loaded, Block) else loaded()
@@ -195,11 +297,22 @@ def _validate_blocks_entry_point(
             )
             continue
         inventory.block_symbols.append(cls.__name__)
+        inventory.surfaces.update({"blocks", "block_config", "block_ports"})
+        executed_contracts.update({"PV-04-001", "PV-05-001", "PV-05-002"})
+        if issubclass(cls, IOBlock):
+            inventory.surfaces.update({"io_blocks", "format_capabilities"})
+            executed_contracts.update({"PV-06-001", "PV-06-002", "PV-06-003", "PV-06-004"})
+        if issubclass(cls, AppBlock):
+            inventory.surfaces.add("app_blocks")
+            executed_contracts.update({"PV-08-001", "PV-08-002", "PV-08-003"})
+        if issubclass(cls, CodeBlock):
+            inventory.surfaces.add("code_blocks")
+            executed_contracts.update({"PV-08-001", "PV-08-002", "PV-08-003"})
         if inspect.isabstract(cls):
             continue
         try:
             spec = _block_spec_for_class(cls, package_name, inventory.package.version)
-            dry_run.block_registry._register_spec(spec)
+            dry_run.add_block_spec(spec)
             inventory.format_capability_ids.extend(capability.id for capability in spec.format_capabilities)
         except Exception as exc:
             contract_id = "PV-06-002" if "Duplicate capability id" in str(exc) else "PV-06-001"
@@ -221,8 +334,10 @@ def _validate_blocks_entry_point(
 def _validate_package_info(package_info: Any, inventory: Any, findings: list[PackageValidationFinding]) -> None:
     if not _package_info_is_instance(package_info, findings):
         return
+    inventory.surfaces.add("package_info")
     inventory.package_info = _package_info_payload(package_info)
     findings.extend(_package_info_field_findings(package_info))
+    findings.extend(_package_info_identity_findings(package_info, inventory))
 
 
 def _package_info_is_instance(package_info: Any, findings: list[PackageValidationFinding]) -> bool:
@@ -262,6 +377,12 @@ def _blank_package_info_fields(package_info: Any) -> list[str]:
     ]
 
 
+def _non_string_package_info_fields(package_info: Any) -> list[str]:
+    return [
+        field_name for field_name in ("description", "author") if not isinstance(getattr(package_info, field_name), str)
+    ]
+
+
 def _package_info_field_findings(package_info: Any) -> list[PackageValidationFinding]:
     return [
         _finding(
@@ -273,6 +394,33 @@ def _package_info_field_findings(package_info: Any) -> list[PackageValidationFin
             "Populate PackageInfo with stable non-empty name and version fields.",
         )
         for field_name in _blank_package_info_fields(package_info)
+    ] + [
+        _finding(
+            "PV-01-002",
+            "error",
+            "package_info",
+            field_name,
+            f"PackageInfo.{field_name} must be a string.",
+            "Populate PackageInfo description and author with strings, or leave them as empty strings.",
+        )
+        for field_name in _non_string_package_info_fields(package_info)
+    ]
+
+
+def _package_info_identity_findings(package_info: Any, inventory: Any) -> list[PackageValidationFinding]:
+    if not isinstance(package_info.name, str) or not package_info.name.strip():
+        return []
+    if package_info.name == inventory.package.name:
+        return []
+    return [
+        _finding(
+            "PV-01-002",
+            "warning",
+            "package_info",
+            package_info.name,
+            f"PackageInfo.name {package_info.name!r} differs from distribution name {inventory.package.name!r}.",
+            "Keep PackageInfo.name aligned with the package distribution name where possible.",
+        )
     ]
 
 
@@ -282,8 +430,11 @@ def _validate_types_entry_point(
     inventory: Any,
     dry_run: DryRunBuilder,
     findings: list[PackageValidationFinding],
+    executed_contracts: set[str],
 ) -> None:
     from scistudio.core.types.base import DataObject
+
+    executed_contracts.update({"PV-03-001", "PV-03-002", "PV-03-003"})
 
     try:
         result = loaded()
@@ -327,7 +478,7 @@ def _validate_types_entry_point(
             continue
         inventory.type_symbols.append(cls.__name__)
         try:
-            dry_run.type_registry.register_class(cls)
+            dry_run.add_type_class(cls)
         except Exception as exc:
             findings.append(
                 _finding(
@@ -347,9 +498,12 @@ def _validate_previewers_entry_point(
     inventory: Any,
     dry_run: DryRunBuilder,
     findings: list[PackageValidationFinding],
+    executed_contracts: set[str],
 ) -> None:
     from scistudio.previewers.assets import validate_manifest
     from scistudio.previewers.models import PreviewerSpec
+
+    executed_contracts.update({"PV-09-001", "PV-09-002", "PV-09-004", "PV-09-005"})
 
     try:
         result = loaded()
@@ -391,6 +545,13 @@ def _validate_previewers_entry_point(
             )
             continue
         inventory.previewer_ids.append(spec.previewer_id)
+        inventory.surfaces.add("previewers")
+        if spec.backend_provider is not None:
+            inventory.surfaces.add("preview_provider")
+            executed_contracts.update({"PV-10-001", "PV-10-002", "PV-10-003", "PV-09-006"})
+        if spec.frontend_manifest is not None:
+            inventory.surfaces.update({"preview_frontend_manifest", "security_isolation"})
+            executed_contracts.update({"PV-09-003", "PV-12-001", "PV-12-002", "PV-12-004"})
         manifest_result = validate_manifest(spec.frontend_manifest)
         if spec.frontend_manifest is not None and not manifest_result.valid:
             findings.append(
@@ -403,7 +564,7 @@ def _validate_previewers_entry_point(
                     "Use same-origin backend-relative module/css URLs and a valid manifest descriptor.",
                 )
             )
-        if not dry_run.previewer_registry.register(spec):
+        if not dry_run.add_previewer_spec(spec):
             findings.append(
                 _finding(
                     "PV-09-004",
@@ -417,12 +578,20 @@ def _validate_previewers_entry_point(
 
 
 # fmt: off
-def _validate_runner_entry_point(entry_point: CandidateEntryPoint, loaded: Any, inventory: Any, dry_run: DryRunBuilder, findings: list[PackageValidationFinding]) -> None:
+def _validate_runner_entry_point(
+    entry_point: CandidateEntryPoint,
+    loaded: Any,
+    inventory: Any,
+    dry_run: DryRunBuilder,
+    findings: list[PackageValidationFinding],
+    executed_contracts: set[str],
+) -> None:
+    executed_contracts.add("PV-99-001")
     if not isinstance(loaded, type):
         findings.append(_runner_class_finding(entry_point))
         return
     inventory.runner_symbols.append(loaded.__name__)
-    dry_run.runners[entry_point.name] = loaded
+    dry_run.add_runner(entry_point.name, loaded)
 # fmt: on
 
 
@@ -445,8 +614,30 @@ _ENTRY_POINT_VALIDATORS = {
 }
 
 
-def _validate_cross_surface(inventory: Any, dry_run: DryRunBuilder, findings: list[PackageValidationFinding]) -> None:
+def _validate_cross_surface(
+    inventory: Any,
+    dry_run: DryRunBuilder,
+    findings: list[PackageValidationFinding],
+    executed_contracts: set[str],
+) -> None:
+    if inventory.surfaces & {"blocks", "types", "previewers", "format_capabilities", "runners"}:
+        inventory.surfaces.update({"cross_surface_registry_consistency", "registry_derived_api_serialization"})
+        executed_contracts.update({"PV-13-001", "PV-13-002", "PV-13-003", "PV-13-004", "PV-99-004"})
     known_types = set(dry_run.type_registry.all_types())
+    for block_spec in dry_run.candidate_block_specs():
+        for port in [*getattr(block_spec, "input_ports", ()), *getattr(block_spec, "output_ports", ())]:
+            for accepted_type in getattr(port, "accepted_types", ()):
+                if not _accepted_type_is_known(accepted_type, inventory, known_types):
+                    findings.append(
+                        _finding(
+                            "PV-13-003",
+                            "error",
+                            "cross_surface_registry_consistency",
+                            getattr(accepted_type, "__name__", repr(accepted_type)),
+                            f"Block {block_spec.name!r} port {getattr(port, 'name', '<unknown>')!r} references an unregistered type.",
+                            "Declare referenced DataObject types through scistudio.types or use a registered core type.",
+                        )
+                    )
     for spec in dry_run.previewer_registry.all_specs():
         if spec.target_type and spec.target_type not in known_types:
             findings.append(
@@ -459,6 +650,84 @@ def _validate_cross_surface(inventory: Any, dry_run: DryRunBuilder, findings: li
                     "Declare the target DataObject type through scistudio.types or target a registered core/base type.",
                 )
             )
+    _validate_registry_api_serialization(dry_run, findings)
+
+
+def _accepted_type_is_known(accepted_type: Any, inventory: Any, known_types: set[str]) -> bool:
+    name = getattr(accepted_type, "__name__", "")
+    if name in known_types:
+        return True
+
+    if _is_core_transport_type(accepted_type):
+        return True
+
+    if not _is_data_object_subclass(accepted_type):
+        return False
+
+    type_path = _module_file_for_type(accepted_type)
+    candidate_root = getattr(inventory, "root_path", None)
+    if type_path is None or candidate_root is None:
+        return False
+    return not _path_is_relative_to(type_path, candidate_root)
+
+
+def _is_core_transport_type(value: Any) -> bool:
+    return (
+        isinstance(value, type)
+        and value.__module__.startswith("scistudio.core.types.")
+        and value.__name__ == "Collection"
+    )
+
+
+def _is_data_object_subclass(value: Any) -> bool:
+    from scistudio.core.types.base import DataObject
+
+    return isinstance(value, type) and issubclass(value, DataObject)
+
+
+def _module_file_for_type(value: type) -> Path | None:
+    module = inspect.getmodule(value)
+    module_file = getattr(module, "__file__", None)
+    if module_file is None:
+        return None
+    return Path(module_file).resolve()
+
+
+def _path_is_relative_to(path: Path, root: Path) -> bool:
+    with contextlib.suppress(ValueError):
+        path.relative_to(root.resolve())
+        return True
+    return False
+
+
+def _validate_registry_api_serialization(
+    dry_run: DryRunBuilder,
+    findings: list[PackageValidationFinding],
+) -> None:
+    try:
+        for block_spec in dry_run.candidate_block_specs():
+            {
+                "name": block_spec.name,
+                "type_name": block_spec.type_name,
+                "package_name": block_spec.package_name,
+                "inputs": [getattr(port, "name", "") for port in block_spec.input_ports],
+                "outputs": [getattr(port, "name", "") for port in block_spec.output_ports],
+                "format_capabilities": [capability.id for capability in block_spec.format_capabilities],
+            }
+        for previewer_spec in dry_run.candidate_previewer_specs():
+            previewer_spec.to_dict()
+        dry_run.api_payloads = len(dry_run.candidate_block_names) + len(dry_run.candidate_previewer_ids)
+    except Exception as exc:
+        findings.append(
+            _finding(
+                "PV-99-004",
+                "error",
+                "registry_derived_api_serialization",
+                None,
+                f"Dry-run registry rows could not be serialized for API/palette payloads: {exc}",
+                "Keep registry descriptors JSON-safe and free of unserializable runtime objects in API payload fields.",
+            )
+        )
 
 
 def _contract_results(
@@ -466,6 +735,7 @@ def _contract_results(
     surfaces: set[str],
     findings: list[PackageValidationFinding],
     profile: PackageValidationProfile,
+    executed_contracts: set[str],
 ) -> list[ContractResult]:
     findings_by_contract = {finding.contract_id: finding for finding in findings}
     results: list[ContractResult] = []
@@ -474,8 +744,8 @@ def _contract_results(
         if not applies:
             result = ContractResultState.NOT_APPLICABLE
         elif contract.contract_id in findings_by_contract:
-            result = ContractResultState.FAIL
-        elif contract.validator_profile.get(profile.value) == "skip":
+            result = _finding_result_state(findings_by_contract[contract.contract_id])
+        elif contract.validator_profile.get(profile.value) == "skip" or contract.contract_id not in executed_contracts:
             result = ContractResultState.SKIPPED
         else:
             result = ContractResultState.PASS
@@ -487,9 +757,57 @@ def _contract_results(
                 surface=contract.primary_surface,
                 symbol=finding.symbol if finding else None,
                 severity=finding.severity if finding else contract.severity,
+                evidence=(
+                    "validator_not_executed_for_candidate_trigger"
+                    if applies and contract.contract_id not in executed_contracts and finding is None
+                    else None
+                ),
             )
         )
     return results
+
+
+def _finding_result_state(finding: PackageValidationFinding) -> ContractResultState:
+    severity = str(finding.severity)
+    if severity in {FindingSeverity.WARNING.value, FindingSeverity.INFO.value}:
+        return ContractResultState.WARNING
+    return ContractResultState.FAIL
+
+
+def _apply_profile_behaviors(
+    findings: list[PackageValidationFinding],
+    contracts: list[PackageContract],
+    profile: PackageValidationProfile,
+) -> list[PackageValidationFinding]:
+    contracts_by_id = {contract.contract_id: contract for contract in contracts}
+    normalized: list[PackageValidationFinding] = []
+    for finding in findings:
+        contract = contracts_by_id.get(finding.contract_id)
+        behavior = contract.validator_profile.get(profile.value) if contract is not None else None
+        severity = _severity_for_profile_behavior(behavior, str(finding.severity))
+        normalized.append(replace(finding, severity=severity, profile_behavior=behavior))
+    return normalized
+
+
+def _severity_for_profile_behavior(behavior: str | None, fallback: str) -> FindingSeverity:
+    fallback_severity = FindingSeverity(fallback)
+    if behavior is None:
+        return fallback_severity
+    profile_severity = {
+        "block": FindingSeverity.BLOCKER,
+        "error": FindingSeverity.ERROR,
+        "warning": FindingSeverity.WARNING,
+        "info": FindingSeverity.INFO,
+    }.get(behavior)
+    if profile_severity is None:
+        return fallback_severity
+    order = {
+        FindingSeverity.INFO: 0,
+        FindingSeverity.WARNING: 1,
+        FindingSeverity.ERROR: 2,
+        FindingSeverity.BLOCKER: 3,
+    }
+    return profile_severity if order[profile_severity] > order[fallback_severity] else fallback_severity
 
 
 def _block_spec_for_class(cls: type, package_name: str, package_version: str) -> Any:
@@ -501,18 +819,18 @@ def _block_spec_for_class(cls: type, package_name: str, package_version: str) ->
     except BlockRegistrationError as exc:
         if "cannot resolve distribution version" not in str(exc):
             raise
-        spec = _block_spec_with_package_version(spec_module, cls, package_version)
+        original_resolver = spec_module._resolve_distribution_version
+
+        def resolve_candidate_package_version(cls: type) -> str:
+            return package_version
+
+        spec_module._resolve_distribution_version = resolve_candidate_package_version
+        try:
+            spec = spec_module._spec_from_class(cls, source="package_validator")
+        finally:
+            spec_module._resolve_distribution_version = original_resolver
     spec.package_name = package_name
     return spec
-
-
-def _block_spec_with_package_version(spec_module: Any, cls: type, package_version: str) -> Any:
-    original_resolver = spec_module._resolve_distribution_version
-    spec_module._resolve_distribution_version = lambda _cls: package_version
-    try:
-        return spec_module._spec_from_class(cls, source="package_validator")
-    finally:
-        spec_module._resolve_distribution_version = original_resolver
 
 
 def _capability_symbol(cls: type, exc: Exception) -> str | None:
@@ -552,4 +870,32 @@ def _finding(
         symbol=symbol,
         message=message,
         repair_hint=repair_hint,
+    )
+
+
+def _failure_report(
+    path_or_distribution: str | Path,
+    profile: PackageValidationProfile,
+    exc: Exception,
+) -> PackageValidationReport:
+    from scistudio.packages.validation.models import PackageIdentity, PackageInventory
+
+    value = str(path_or_distribution)
+    package = PackageIdentity(name=Path(value).name or value, version="unknown", source=value)
+    inventory = PackageInventory(package=package, surfaces={"distribution_metadata"})
+    return PackageValidationReport(
+        package=package,
+        profile=profile,
+        inventory=inventory,
+        findings=[
+            PackageValidationFinding(
+                contract_id="PV-01-001",
+                severity=FindingSeverity.BLOCKER,
+                surface="distribution_metadata",
+                symbol=value,
+                message=f"Package inventory could not be built: {exc}",
+                repair_hint="Provide valid package metadata and importable SciStudio entry-point declarations.",
+                profile_behavior="block" if profile is PackageValidationProfile.PRODUCTION else "error",
+            )
+        ],
     )

--- a/src/scistudio/packages/validation/inventory.py
+++ b/src/scistudio/packages/validation/inventory.py
@@ -2,11 +2,17 @@
 
 from __future__ import annotations
 
+import configparser
 import contextlib
+import email.parser
 import importlib
 import importlib.metadata
+import shutil
 import sys
+import tarfile
+import tempfile
 import tomllib
+import zipfile
 from collections.abc import Iterator
 from dataclasses import dataclass
 from pathlib import Path
@@ -59,6 +65,7 @@ class CandidateInventory:
     inventory: PackageInventory
     entry_points: tuple[CandidateEntryPoint, ...]
     import_paths: tuple[Path, ...] = ()
+    cleanup_paths: tuple[Path, ...] = ()
 
 
 def build_inventory(candidate_input: str | Path) -> CandidateInventory:
@@ -77,6 +84,7 @@ def candidate_import_context(candidate: CandidateInventory) -> Iterator[None]:
     """Expose a source-tree candidate on ``sys.path`` for one validation block."""
 
     inserted: list[str] = []
+    before_modules = dict(sys.modules)
     for path in reversed(candidate.import_paths):
         value = str(path)
         if value not in sys.path:
@@ -88,6 +96,10 @@ def candidate_import_context(candidate: CandidateInventory) -> Iterator[None]:
         for value in inserted:
             with contextlib.suppress(ValueError):
                 sys.path.remove(value)
+        _remove_candidate_modules(before_modules, _candidate_owned_import_paths(candidate))
+        for path in candidate.cleanup_paths:
+            with contextlib.suppress(OSError):
+                shutil.rmtree(path)
 
 
 def _source_tree_inventory(root: Path) -> CandidateInventory:
@@ -125,10 +137,17 @@ def _source_tree_inventory(root: Path) -> CandidateInventory:
 
 
 def _archive_inventory(path: Path) -> CandidateInventory:
+    if path.suffix == ".whl":
+        return _wheel_inventory(path)
+    if path.suffixes[-2:] in ([".tar", ".gz"], [".tar", ".bz2"], [".tar", ".xz"]) or path.suffix in {
+        ".tgz",
+        ".zip",
+    }:
+        return _sdist_inventory(path)
     name = path.name
     identity = PackageIdentity(name=name, version="unknown", source=str(path))
-    candidate = CandidatePackage("archive", str(path), root_path=path.parent, name=name, version="unknown")
-    inventory = PackageInventory(package=identity, root_path=path.parent, surfaces={"distribution_metadata"})
+    candidate = CandidatePackage("unsupported-archive", str(path), root_path=path.parent, name=name, version="unknown")
+    inventory = PackageInventory(package=identity, root_path=path.parent, surfaces={"distribution_metadata", "archive"})
     return CandidateInventory(candidate=candidate, inventory=inventory, entry_points=())
 
 
@@ -141,7 +160,7 @@ def _installed_distribution_inventory(distribution_name: str) -> CandidateInvent
     entry_points = [
         CandidateEntryPoint(group=ep.group, name=ep.name, value=ep.value)
         for ep in distribution.entry_points
-        if ep.group in KNOWN_ENTRY_POINT_GROUPS
+        if _is_scistudio_entry_point_group(ep.group)
     ]
     surfaces = _surfaces_for_entry_points(entry_points)
     surfaces.add("distribution_metadata")
@@ -160,7 +179,7 @@ def _entry_points_from_pyproject(project: dict[str, Any]) -> list[CandidateEntry
         return []
     entry_points: list[CandidateEntryPoint] = []
     for group, entries in sorted(groups.items()):
-        if group not in KNOWN_ENTRY_POINT_GROUPS:
+        if not _is_scistudio_entry_point_group(str(group)):
             continue
         if not isinstance(entries, dict):
             continue
@@ -253,3 +272,110 @@ def _surfaces_for_entry_points(entry_points: list[CandidateEntryPoint]) -> set[s
     for entry_point in entry_points:
         surfaces.add(entry_point.surface)
     return surfaces
+
+
+def _is_scistudio_entry_point_group(group: str) -> bool:
+    return group in KNOWN_ENTRY_POINT_GROUPS or group.startswith("scistudio.")
+
+
+def _wheel_inventory(path: Path) -> CandidateInventory:
+    extract_root = Path(tempfile.mkdtemp(prefix="scistudio-pv-wheel-"))
+    with zipfile.ZipFile(path) as wheel:
+        wheel.extractall(extract_root)
+    metadata = _wheel_metadata(extract_root)
+    name = metadata.get("Name") or path.stem
+    version = metadata.get("Version") or "unknown"
+    entry_points = _entry_points_from_ini(_first_existing(extract_root.glob("*.dist-info/entry_points.txt")))
+    surfaces = _surfaces_for_entry_points(entry_points)
+    surfaces.update({"distribution_metadata", "archive"})
+    identity = PackageIdentity(name=name, version=version, source=str(path))
+    candidate = CandidatePackage("wheel", str(path), root_path=extract_root, name=name, version=version)
+    inventory = PackageInventory(
+        package=identity,
+        root_path=extract_root,
+        entry_points=[entry_point.to_dict() for entry_point in entry_points],
+        surfaces=surfaces,
+    )
+    return CandidateInventory(
+        candidate=candidate,
+        inventory=inventory,
+        entry_points=tuple(entry_points),
+        import_paths=(extract_root,),
+        cleanup_paths=(extract_root,),
+    )
+
+
+def _sdist_inventory(path: Path) -> CandidateInventory:
+    extract_root = Path(tempfile.mkdtemp(prefix="scistudio-pv-sdist-"))
+    if path.suffix == ".zip":
+        with zipfile.ZipFile(path) as archive:
+            archive.extractall(extract_root)
+    else:
+        with tarfile.open(path) as archive:
+            archive.extractall(extract_root, filter="data")
+    roots = [candidate for candidate in extract_root.iterdir() if candidate.is_dir()]
+    source_root = roots[0] if len(roots) == 1 else extract_root
+    inventory = _source_tree_inventory(source_root)
+    return CandidateInventory(
+        candidate=CandidatePackage(
+            "sdist",
+            str(path),
+            root_path=inventory.candidate.root_path,
+            name=inventory.candidate.name,
+            version=inventory.candidate.version,
+        ),
+        inventory=inventory.inventory,
+        entry_points=inventory.entry_points,
+        import_paths=inventory.import_paths,
+        cleanup_paths=(extract_root,),
+    )
+
+
+def _wheel_metadata(extract_root: Path) -> dict[str, str]:
+    metadata_path = _first_existing(extract_root.glob("*.dist-info/METADATA"))
+    if metadata_path is None:
+        return {}
+    message = email.parser.Parser().parsestr(metadata_path.read_text(encoding="utf-8"))
+    return {key: value for key, value in message.items()}
+
+
+def _entry_points_from_ini(path: Path | None) -> list[CandidateEntryPoint]:
+    if path is None:
+        return []
+    parser = configparser.ConfigParser()
+    parser.read(path, encoding="utf-8")
+    entry_points: list[CandidateEntryPoint] = []
+    for group in sorted(parser.sections()):
+        if not _is_scistudio_entry_point_group(group):
+            continue
+        for name, value in sorted(parser.items(group)):
+            entry_points.append(CandidateEntryPoint(group=group, name=name, value=value))
+    return entry_points
+
+
+def _first_existing(paths: Iterator[Path]) -> Path | None:
+    return next(paths, None)
+
+
+def _remove_candidate_modules(before_modules: dict[str, Any], import_paths: tuple[Path, ...]) -> None:
+    roots = tuple(path.resolve() for path in import_paths if path.exists())
+    if not roots:
+        return
+    for name, module in list(sys.modules.items()):
+        if name in before_modules and before_modules[name] is module:
+            continue
+        module_file = getattr(module, "__file__", None)
+        if not module_file:
+            continue
+        with contextlib.suppress(OSError, RuntimeError):
+            resolved = Path(module_file).resolve()
+            if any(resolved.is_relative_to(root) for root in roots):
+                sys.modules.pop(name, None)
+
+
+def _candidate_owned_import_paths(candidate: CandidateInventory) -> tuple[Path, ...]:
+    root = candidate.inventory.root_path
+    if root is None:
+        return candidate.import_paths
+    resolved_root = root.resolve()
+    return tuple(path for path in candidate.import_paths if path.resolve().is_relative_to(resolved_root))

--- a/src/scistudio/packages/validation/registration.py
+++ b/src/scistudio/packages/validation/registration.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
 from dataclasses import dataclass
@@ -33,6 +34,7 @@ class PackageRegistrationPlan:
 
     report: PackageValidationReport
     dry_run: DryRunBuilder
+    candidate: str | Path | None = None
 
     @property
     def accepted(self) -> bool:
@@ -56,6 +58,7 @@ class PackageRegistrationPlan:
         if not self.accepted:
             return False
 
+        dry_run = self._materialized_dry_run()
         snapshots = _RegistrySnapshots.capture(
             block_registry=block_registry,
             type_registry=type_registry,
@@ -64,17 +67,17 @@ class PackageRegistrationPlan:
         )
         try:
             if block_registry is not None:
-                for block_spec in self.dry_run.block_registry.all_specs().values():
+                for block_spec in dry_run.candidate_block_specs():
                     block_registry._register_spec(block_spec)
             if type_registry is not None:
-                for type_name, type_spec in self.dry_run.type_registry.all_types().items():
+                for type_name, type_spec in dry_run.candidate_type_specs().items():
                     type_registry.register(type_name, type_spec)
             if previewer_registry is not None:
-                for previewer_spec in self.dry_run.previewer_registry.all_specs():
+                for previewer_spec in dry_run.candidate_previewer_specs():
                     if not previewer_registry.register(previewer_spec):
                         raise ValueError(f"Previewer registry rejected {previewer_spec.previewer_id!r}.")
             if runners is not None:
-                runners.update(self.dry_run.runners)
+                runners.update({name: dry_run.runners[name] for name in dry_run.candidate_runner_names})
         except Exception:
             snapshots.restore(
                 block_registry=block_registry,
@@ -85,16 +88,45 @@ class PackageRegistrationPlan:
             raise
         return True
 
+    def _materialized_dry_run(self) -> DryRunBuilder:
+        if (
+            self.dry_run.candidate_block_names
+            or self.dry_run.candidate_type_names
+            or self.dry_run.candidate_previewer_ids
+            or self.dry_run.candidate_runner_names
+            or self.candidate is None
+        ):
+            return self.dry_run
+        report, dry_run = _validate_package_with_dry_run(self.candidate, profile=PackageValidationProfile.PRODUCTION)
+        if report.registration_decision == RegistrationDecision.REJECT:
+            raise ValueError("Accepted registration plan no longer validates when materializing dry-run rows.")
+        return dry_run
 
-def validate_for_registration(candidate: str | Path) -> PackageRegistrationPlan:
+
+def validate_for_registration(
+    candidate: str | Path,
+    *,
+    block_registry: Any | None = None,
+    type_registry: Any | None = None,
+    previewer_registry: Any | None = None,
+    runners: dict[str, Any] | None = None,
+) -> PackageRegistrationPlan:
     """Validate *candidate* with the production profile and return a commit plan."""
 
     isolated_report = _validate_in_subprocess(candidate)
     if isolated_report.registration_decision == RegistrationDecision.REJECT:
         return PackageRegistrationPlan(report=isolated_report, dry_run=DryRunBuilder())
+    conflict_report = _existing_registry_conflict_report(
+        isolated_report,
+        block_registry=block_registry,
+        type_registry=type_registry,
+        previewer_registry=previewer_registry,
+        runners=runners,
+    )
+    if conflict_report is not None:
+        return PackageRegistrationPlan(report=conflict_report, dry_run=DryRunBuilder())
 
-    report, dry_run = _validate_package_with_dry_run(candidate, profile=PackageValidationProfile.PRODUCTION)
-    return PackageRegistrationPlan(report=report, dry_run=dry_run)
+    return PackageRegistrationPlan(report=isolated_report, dry_run=DryRunBuilder(), candidate=candidate)
 
 
 def _validate_in_subprocess(candidate: str | Path) -> PackageValidationReport:
@@ -108,7 +140,9 @@ def _validate_in_subprocess(candidate: str | Path) -> PackageValidationReport:
         "--json",
     ]
     try:
-        result = subprocess.run(command, check=False, capture_output=True, text=True)
+        env = dict(os.environ)
+        env["SCISTUDIO_PACKAGE_VALIDATOR_SUBPROCESS"] = "1"
+        result = subprocess.run(command, check=False, capture_output=True, text=True, env=env)
     except OSError as exc:
         return _subprocess_failure_report(candidate, f"Production validation subprocess failed to start: {exc}")
 
@@ -149,6 +183,85 @@ def _isolation_failure(candidate: str | Path, message: str) -> PackageValidation
         symbol=str(candidate),
         message=message,
         repair_hint="Run production validation in a working isolated Python environment before registration.",
+    )
+
+
+def _existing_registry_conflict_report(
+    report: PackageValidationReport,
+    *,
+    block_registry: Any | None,
+    type_registry: Any | None,
+    previewer_registry: Any | None,
+    runners: dict[str, Any] | None,
+) -> PackageValidationReport | None:
+    findings: list[PackageValidationFinding] = []
+    if block_registry is not None:
+        existing_capability_ids = {capability.id for capability in block_registry.list_format_capabilities()}
+        for capability_id in report.inventory.format_capability_ids:
+            if capability_id in existing_capability_ids:
+                findings.append(
+                    PackageValidationFinding(
+                        contract_id="PV-13-004",
+                        severity=FindingSeverity.BLOCKER,
+                        surface="cross_surface_registry_consistency",
+                        symbol=capability_id,
+                        message=f"Candidate capability id {capability_id!r} already exists in the target registry.",
+                        repair_hint="Use a package-qualified capability id that does not conflict with installed packages.",
+                        profile_behavior="block",
+                    )
+                )
+    if type_registry is not None:
+        existing_types = set(type_registry.all_types())
+        for type_name in report.inventory.type_symbols:
+            if type_name in existing_types:
+                findings.append(
+                    PackageValidationFinding(
+                        contract_id="PV-13-003",
+                        severity=FindingSeverity.BLOCKER,
+                        surface="cross_surface_registry_consistency",
+                        symbol=type_name,
+                        message=f"Candidate type {type_name!r} already exists in the target registry.",
+                        repair_hint="Rename the candidate type or upgrade the existing package through an explicit replacement path.",
+                        profile_behavior="block",
+                    )
+                )
+    if previewer_registry is not None:
+        for previewer_id in report.inventory.previewer_ids:
+            if previewer_registry.get(previewer_id) is not None:
+                findings.append(
+                    PackageValidationFinding(
+                        contract_id="PV-13-004",
+                        severity=FindingSeverity.BLOCKER,
+                        surface="cross_surface_registry_consistency",
+                        symbol=previewer_id,
+                        message=f"Candidate previewer_id {previewer_id!r} already exists in the target registry.",
+                        repair_hint="Use a unique package-qualified previewer_id or perform an explicit package upgrade.",
+                        profile_behavior="block",
+                    )
+                )
+    if runners is not None:
+        for runner_name in report.inventory.runner_symbols:
+            if runner_name in runners:
+                findings.append(
+                    PackageValidationFinding(
+                        contract_id="PV-99-001",
+                        severity=FindingSeverity.ERROR,
+                        surface="runners",
+                        symbol=runner_name,
+                        message=f"Candidate runner {runner_name!r} already exists in the target registry.",
+                        repair_hint="Use a unique runner entry-point name or perform an explicit package upgrade.",
+                        profile_behavior="error",
+                    )
+                )
+    if not findings:
+        return None
+    return PackageValidationReport(
+        package=report.package,
+        profile=report.profile,
+        inventory=report.inventory,
+        contract_results=report.contract_results,
+        findings=[*report.findings, *findings],
+        dry_run_registries=report.dry_run_registries,
     )
 
 

--- a/tests/contracts/test_runtime_import_contract.py
+++ b/tests/contracts/test_runtime_import_contract.py
@@ -41,6 +41,7 @@ from __future__ import annotations
 
 import asyncio
 import importlib
+from collections.abc import Iterable, Mapping
 
 import pytest
 
@@ -119,7 +120,41 @@ def app_routes() -> set[str]:
     from scistudio.api.app import create_app
 
     app = create_app()
-    return {r.path for r in app.routes if hasattr(r, "path")}
+    return _collect_route_paths(app.routes)
+
+
+def _collect_route_paths(routes: Iterable[object], prefix: str = "") -> set[str]:
+    """Collect route paths across FastAPI versions.
+
+    FastAPI 0.123 can keep included routers as wrapper entries in
+    ``app.routes``; older versions eagerly expand them. The contract is the
+    effective path set, so recursively inspect included routers when present.
+    """
+    paths: set[str] = set()
+    for route in routes:
+        raw_path = getattr(route, "path", None) or getattr(route, "path_format", None)
+        if isinstance(raw_path, str):
+            paths.add(_join_route_prefix(prefix, raw_path))
+
+        include_context = getattr(route, "include_context", None)
+        nested_router = getattr(route, "original_router", None) or getattr(include_context, "included_router", None)
+        nested_routes = getattr(nested_router, "routes", None)
+        if nested_routes is not None:
+            nested_prefix = getattr(include_context, "prefix", "") or ""
+            paths.update(_collect_route_paths(nested_routes, _join_route_prefix(prefix, nested_prefix)))
+    return paths
+
+
+def _join_route_prefix(prefix: str, path: str) -> str:
+    if not prefix:
+        return path or ""
+    if not path:
+        return prefix
+    return f"{prefix.rstrip('/')}/{path.lstrip('/')}"
+
+
+def _has_spec_field(spec: object, field: str) -> bool:
+    return hasattr(spec, field) or (isinstance(spec, Mapping) and field in spec)
 
 
 def test_api_workflow_routes_are_registered(app_routes: set[str]) -> None:
@@ -258,12 +293,10 @@ def test_block_spec_has_required_contract_fields() -> None:
     reg.scan()
     for type_name, spec in reg.all_specs().items():
         # spec must have a type_name that matches the key.
-        assert hasattr(spec, "type_name") or "type_name" in spec, f"Block spec for {type_name!r} has no type_name"
+        assert _has_spec_field(spec, "type_name"), f"Block spec for {type_name!r} has no type_name"
         # spec must have input_ports and output_ports accessible.
-        assert hasattr(spec, "input_ports") or "input_ports" in spec, f"Block spec for {type_name!r} has no input_ports"
-        assert hasattr(spec, "output_ports") or "output_ports" in spec, (
-            f"Block spec for {type_name!r} has no output_ports"
-        )
+        assert _has_spec_field(spec, "input_ports"), f"Block spec for {type_name!r} has no input_ports"
+        assert _has_spec_field(spec, "output_ports"), f"Block spec for {type_name!r} has no output_ports"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/packages/test_package_validator.py
+++ b/tests/packages/test_package_validator.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib
+import zipfile
 from pathlib import Path
 from typing import Any, cast
 
@@ -142,3 +143,196 @@ def test_no_entry_point_package_reports_surface_contracts_not_applicable() -> No
     assert _text(_field(report, "registration_decision")) in {"accept", "register", "allow", "none"}
     assert extension_results
     assert {str(item.get("result")) for item in extension_results} == {"not_applicable"}
+
+
+def test_unknown_scistudio_entry_point_group_is_a_structured_failure(tmp_path: Path) -> None:
+    package_root = tmp_path / "unknown_group"
+    package_dir = package_root / "src" / "pv_unknown_group"
+    package_dir.mkdir(parents=True)
+    package_dir.joinpath("__init__.py").write_text("def get_bad():\n    return []\n", encoding="utf-8")
+    package_root.joinpath("pyproject.toml").write_text(
+        """[project]
+name = "pv-unknown-group"
+version = "0.1.0"
+
+[project.entry-points."scistudio.unknown"]
+bad = "pv_unknown_group:get_bad"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+""",
+        encoding="utf-8",
+    )
+
+    report = _validation_api()[0](package_root)
+
+    assert _status_is_failing(_field(report, "status"))
+    assert "PV-02-002" in _finding_contract_ids(report)
+
+
+def test_declared_dependency_port_types_do_not_need_candidate_registration(tmp_path: Path) -> None:
+    packages_root = tmp_path / "packages"
+    dependency_root = packages_root / "pv-dependency"
+    dependency_package_dir = dependency_root / "src" / "pv_dependency"
+    dependency_package_dir.mkdir(parents=True)
+    dependency_package_dir.joinpath("__init__.py").write_text(
+        """
+from scistudio.core.types.base import DataObject
+
+
+class DependencySample(DataObject):
+    pass
+
+
+def get_types():
+    return [DependencySample]
+""",
+        encoding="utf-8",
+    )
+    dependency_root.joinpath("pyproject.toml").write_text(
+        """[project]
+name = "pv-dependency"
+version = "0.1.0"
+
+[project.entry-points."scistudio.types"]
+types = "pv_dependency:get_types"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+""",
+        encoding="utf-8",
+    )
+
+    candidate_root = packages_root / "pv-candidate"
+    candidate_package_dir = candidate_root / "src" / "pv_candidate"
+    candidate_package_dir.mkdir(parents=True)
+    candidate_package_dir.joinpath("__init__.py").write_text(
+        """
+from typing import ClassVar
+
+from pv_dependency import DependencySample
+from scistudio.blocks.base.block import Block
+from scistudio.blocks.base.config import BlockConfig
+from scistudio.blocks.base.ports import InputPort, OutputPort
+from scistudio.core.types.collection import Collection
+
+
+class DependencyBlock(Block):
+    name: ClassVar[str] = "Dependency Block"
+    type_name: ClassVar[str] = "pv.dependency"
+    input_ports: ClassVar[list[InputPort]] = [InputPort(name="sample", accepted_types=[DependencySample])]
+    output_ports: ClassVar[list[OutputPort]] = [OutputPort(name="sample", accepted_types=[DependencySample])]
+
+    def run(self, inputs: dict[str, Collection], config: BlockConfig) -> dict[str, Collection]:
+        return {"sample": inputs["sample"]}
+
+
+def get_blocks():
+    return [DependencyBlock]
+""",
+        encoding="utf-8",
+    )
+    candidate_root.joinpath("pyproject.toml").write_text(
+        """[project]
+name = "pv-candidate"
+version = "0.1.0"
+dependencies = ["pv-dependency>=0.1.0"]
+
+[project.entry-points."scistudio.blocks"]
+blocks = "pv_candidate:get_blocks"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+""",
+        encoding="utf-8",
+    )
+
+    report = _validation_api()[0](candidate_root, profile="production")
+
+    assert _status_is_passing(_field(report, "status"))
+    assert "PV-13-003" not in _finding_contract_ids(report)
+
+
+def test_candidate_local_port_types_must_be_registered(tmp_path: Path) -> None:
+    package_root = tmp_path / "local_type_not_registered"
+    package_dir = package_root / "src" / "pv_local_type_not_registered"
+    package_dir.mkdir(parents=True)
+    package_dir.joinpath("__init__.py").write_text(
+        """
+from typing import ClassVar
+
+from scistudio.blocks.base.block import Block
+from scistudio.blocks.base.config import BlockConfig
+from scistudio.blocks.base.ports import InputPort, OutputPort
+from scistudio.core.types.base import DataObject
+from scistudio.core.types.collection import Collection
+
+
+class LocalSample(DataObject):
+    pass
+
+
+class LocalTypeBlock(Block):
+    name: ClassVar[str] = "Local Type Block"
+    type_name: ClassVar[str] = "pv.local_type"
+    input_ports: ClassVar[list[InputPort]] = [InputPort(name="sample", accepted_types=[LocalSample])]
+    output_ports: ClassVar[list[OutputPort]] = [OutputPort(name="sample", accepted_types=[LocalSample])]
+
+    def run(self, inputs: dict[str, Collection], config: BlockConfig) -> dict[str, Collection]:
+        return {"sample": inputs["sample"]}
+
+
+def get_blocks():
+    return [LocalTypeBlock]
+""",
+        encoding="utf-8",
+    )
+    package_root.joinpath("pyproject.toml").write_text(
+        """[project]
+name = "pv-local-type-not-registered"
+version = "0.1.0"
+
+[project.entry-points."scistudio.blocks"]
+blocks = "pv_local_type_not_registered:get_blocks"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+""",
+        encoding="utf-8",
+    )
+
+    report = _validation_api()[0](package_root, profile="production")
+
+    assert _status_is_failing(_field(report, "status"))
+    assert "PV-13-003" in _finding_contract_ids(report)
+    assert "LocalSample" in _finding_symbols(report)
+
+
+def test_wheel_entry_points_are_validated_instead_of_treated_as_metadata_only(tmp_path: Path) -> None:
+    wheel_path = tmp_path / "pv_bad_wheel-0.1.0-py3-none-any.whl"
+    with zipfile.ZipFile(wheel_path, "w") as wheel:
+        wheel.writestr(
+            "pv_bad_wheel/__init__.py",
+            "def get_blocks():\n    return ['not a block class']\n",
+        )
+        wheel.writestr("pv_bad_wheel-0.1.0.dist-info/METADATA", "Name: pv-bad-wheel\nVersion: 0.1.0\n")
+        wheel.writestr(
+            "pv_bad_wheel-0.1.0.dist-info/entry_points.txt",
+            "[scistudio.blocks]\nmain = pv_bad_wheel:get_blocks\n",
+        )
+
+    report = _validation_api()[0](wheel_path)
+
+    assert _status_is_failing(_field(report, "status"))
+    assert "PV-04-001" in _finding_contract_ids(report)
+
+
+def test_bad_source_metadata_returns_structured_report(tmp_path: Path) -> None:
+    package_root = tmp_path / "bad_toml"
+    package_root.mkdir()
+    package_root.joinpath("pyproject.toml").write_text("[project\n", encoding="utf-8")
+
+    report = _validation_api()[0](package_root)
+
+    assert _status_is_failing(_field(report, "status"))
+    assert "PV-01-001" in _finding_contract_ids(report)

--- a/tests/packages/test_package_validator_inventory.py
+++ b/tests/packages/test_package_validator_inventory.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import sys
+import zipfile
 from pathlib import Path
 
 from scistudio.packages.validation.inventory import build_inventory
@@ -20,6 +22,88 @@ def test_source_inventory_exposes_only_declared_monorepo_dependencies(tmp_path: 
     assert consumer_root / "src" in inventory.import_paths
     assert dependency_root / "src" in inventory.import_paths
     assert unused_root / "src" not in inventory.import_paths
+
+
+def test_source_inventory_keeps_unknown_scistudio_entry_point_groups(tmp_path: Path) -> None:
+    root = _write_project(tmp_path / "pkg", "scistudio-blocks-unknown-group")
+    root.joinpath("pyproject.toml").write_text(
+        """[project]
+name = "scistudio-blocks-unknown-group"
+version = "0.0.0"
+
+[project.entry-points."scistudio.unknown"]
+bad = "pkg:get_bad"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+""",
+        encoding="utf-8",
+    )
+
+    inventory = build_inventory(root)
+
+    assert [entry_point.group for entry_point in inventory.entry_points] == ["scistudio.unknown"]
+
+
+def test_wheel_inventory_reads_distribution_entry_points(tmp_path: Path) -> None:
+    wheel_path = tmp_path / "pv_wheel-0.1.0-py3-none-any.whl"
+    with zipfile.ZipFile(wheel_path, "w") as wheel:
+        wheel.writestr("pv_wheel/__init__.py", "def get_types():\n    return []\n")
+        wheel.writestr("pv_wheel-0.1.0.dist-info/METADATA", "Name: pv-wheel\nVersion: 0.1.0\n")
+        wheel.writestr(
+            "pv_wheel-0.1.0.dist-info/entry_points.txt",
+            "[scistudio.types]\nmain = pv_wheel:get_types\n",
+        )
+
+    inventory = build_inventory(wheel_path)
+
+    assert inventory.inventory.package.name == "pv-wheel"
+    assert inventory.inventory.package.version == "0.1.0"
+    assert inventory.entry_points[0].group == "scistudio.types"
+
+
+def test_candidate_import_context_removes_source_modules(tmp_path: Path) -> None:
+    from scistudio.packages.validation.inventory import candidate_import_context
+
+    root = _write_project(tmp_path / "pkg", "scistudio-blocks-module-cleanup")
+    package_dir = root / "src" / "shared_candidate"
+    package_dir.mkdir()
+    package_dir.joinpath("__init__.py").write_text("VALUE = 'loaded'\n", encoding="utf-8")
+    inventory = build_inventory(root)
+    sys.modules.pop("shared_candidate", None)
+
+    with candidate_import_context(inventory):
+        __import__("shared_candidate")
+        assert "shared_candidate" in sys.modules
+
+    assert "shared_candidate" not in sys.modules
+
+
+def test_candidate_import_context_keeps_declared_dependency_modules(tmp_path: Path) -> None:
+    from scistudio.packages.validation.inventory import candidate_import_context
+
+    packages_root = tmp_path / "packages"
+    dependency_root = _write_project(packages_root / "dep", "scistudio-blocks-dep")
+    dependency_package_dir = dependency_root / "src" / "scistudio_blocks_dep"
+    dependency_package_dir.joinpath("__init__.py").write_text("VALUE = 'dependency'\n", encoding="utf-8")
+    consumer_root = _write_project(
+        packages_root / "consumer",
+        "scistudio-blocks-consumer",
+        dependencies=("scistudio-blocks-dep>=0.1",),
+    )
+    candidate_package_dir = consumer_root / "src" / "scistudio_blocks_consumer"
+    candidate_package_dir.joinpath("__init__.py").write_text("VALUE = 'candidate'\n", encoding="utf-8")
+    inventory = build_inventory(consumer_root)
+    sys.modules.pop("scistudio_blocks_consumer", None)
+    sys.modules.pop("scistudio_blocks_dep", None)
+
+    with candidate_import_context(inventory):
+        __import__("scistudio_blocks_consumer")
+        __import__("scistudio_blocks_dep")
+
+    assert "scistudio_blocks_consumer" not in sys.modules
+    assert "scistudio_blocks_dep" in sys.modules
+    sys.modules.pop("scistudio_blocks_dep", None)
 
 
 def _write_project(root: Path, name: str, dependencies: tuple[str, ...] = ()) -> Path:

--- a/tests/packages/test_package_validator_production_registration.py
+++ b/tests/packages/test_package_validator_production_registration.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib
+import sys
 from pathlib import Path
 from typing import Any, cast
 
@@ -100,6 +101,7 @@ def test_production_validation_valid_package_commits_dry_run_rows_atomically() -
     assert report["dry_run_registries"]["previewers"] >= 1
     assert report["dry_run_registries"]["format_capabilities"] >= 1
     assert plan.accepted
+    assert not plan.dry_run.candidate_block_names
     assert plan.commit_to(
         block_registry=block_registry,
         type_registry=type_registry,
@@ -116,13 +118,21 @@ def test_production_registration_commit_rolls_back_on_live_registry_failure() ->
     from scistudio.blocks.registry import BlockRegistry
     from scistudio.core.types.registry import TypeRegistry
     from scistudio.packages.validation.registration import validate_for_registration
+    from scistudio.previewers.models import OwnerKind, PreviewerSpec
     from scistudio.previewers.registry import PreviewerRegistry
 
     plan = validate_for_registration(FIXTURES / "valid_package")
     block_registry = BlockRegistry()
     type_registry = TypeRegistry()
     previewer_registry = PreviewerRegistry()
-    previewer_registry.register(plan.dry_run.previewer_registry.all_specs()[0])
+    previewer_registry.register(
+        PreviewerSpec(
+            previewer_id="pv.valid.sample",
+            owner_kind=OwnerKind.PACKAGE,
+            owner_name="already-installed",
+            target_type="ValidSample",
+        )
+    )
     before_blocks = _block_registry_snapshot(block_registry)
     before_types = tuple(sorted(type_registry.all_types()))
     before_previewers = _previewer_registry_snapshot(previewer_registry)
@@ -137,3 +147,29 @@ def test_production_registration_commit_rolls_back_on_live_registry_failure() ->
     assert _block_registry_snapshot(block_registry) == before_blocks
     assert tuple(sorted(type_registry.all_types())) == before_types
     assert _previewer_registry_snapshot(previewer_registry) == before_previewers
+
+
+def test_production_plan_does_not_import_candidate_before_commit() -> None:
+    from scistudio.packages.validation.registration import validate_for_registration
+
+    sys.modules.pop("pv_valid_package", None)
+
+    plan = validate_for_registration(FIXTURES / "valid_package")
+
+    assert plan.accepted
+    assert "pv_valid_package" not in sys.modules
+
+
+def test_production_registration_rejects_existing_capability_conflict_before_commit() -> None:
+    from scistudio.blocks.registry import BlockRegistry
+    from scistudio.packages.validation.registration import validate_for_registration
+
+    block_registry = BlockRegistry()
+    first_plan = validate_for_registration(FIXTURES / "valid_package")
+    assert first_plan.commit_to(block_registry=block_registry)
+
+    second_plan = validate_for_registration(FIXTURES / "valid_package", block_registry=block_registry)
+
+    assert not second_plan.accepted
+    assert second_plan.report.registration_decision == "reject"
+    assert any(finding.contract_id == "PV-13-004" for finding in second_plan.report.findings)

--- a/tests/packages/test_package_validator_reports.py
+++ b/tests/packages/test_package_validator_reports.py
@@ -97,3 +97,16 @@ def test_contract_results_include_pass_fail_and_not_applicable_classifications()
     assert "pass" in valid_results
     assert "not_applicable" in no_entry_results
     assert "fail" in invalid_results
+
+
+def test_applicable_unexecuted_contract_rows_are_not_reported_as_pass() -> None:
+    report = _validate("valid_package", "production")
+    results = {
+        item["contract_id"]: item
+        for item in _items(report, "contract_results")
+        if item["contract_id"] in {"PV-10-001", "PV-12-003"}
+    }
+
+    assert results
+    assert {item["result"] for item in results.values()} == {"skipped"}
+    assert {item.get("evidence") for item in results.values()} == {"validator_not_executed_for_candidate_trigger"}


### PR DESCRIPTION
## Summary

- harden the ADR-049 package validator against PR1665 audit false-pass cases
- validate wheel/sdist/unsupported archive inputs with structured reports
- route production registration decisions through subprocess-first validation and lazy commit plans
- preserve unknown `scistudio.*` entry points, clean candidate imports from `sys.modules`, and keep candidate dry-run rows separate from built-ins
- make the runtime API route contract work in both eagerly-expanded and included-router FastAPI environments
- add regression coverage and fix-readiness audit evidence

## Verification

- `python -m pytest --no-cov tests/packages/test_package_validator.py tests/packages/test_package_validator_reports.py tests/packages/test_package_validator_inventory.py tests/packages/test_package_validator_production_registration.py tests/packages/test_package_validator_cli.py tests/architecture/test_no_new_cycles.py::test_python_import_cycle_count_does_not_regress -q` -> `38 passed`
- `python -m ruff check src/scistudio/packages/validation tests/packages` -> pass
- `python -m ruff format --check src/scistudio/packages/validation tests/packages` -> pass
- `python -m mypy src/scistudio/packages/validation` -> pass
- `python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json` -> pass
- `python scripts/audit/check_package_contract_tables.py` -> `summary: 0 error(s), 9 warning(s)`
- `python -m pytest --no-cov tests/packages/test_package_validator.py tests/packages/test_package_validator_reports.py tests/packages/test_package_validator_inventory.py tests/packages/test_package_validator_production_registration.py tests/packages/test_package_validator_cli.py tests/contracts/test_runtime_import_contract.py -q` -> `56 passed`
- `.workflow\local\venv\Scripts\python.exe -m pytest --no-cov tests/contracts/test_runtime_import_contract.py -q` -> `19 passed`
- `python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json` -> pass
- full local pytest with source package entry-point overlay and `PYTEST_ADDOPTS=-m "not requires_imaging"` -> `4506 passed, 62 skipped, 8 xfailed`
- production-profile package sweep over `.`, imaging, LCMS, SRS, and valid fixture -> all `pass` / `accept` / 0 findings
- `python -m scistudio.qa.governance.gate_record check --record .workflow/records/1664-fix-pr1665-package-validator-audit-blockers-20260615.json --mode pre-push --base origin/track/adr-049-package-validator-implementation --head HEAD` -> reconciliation passed

Closes #1664
