### PR TITLE
fix(#1661): address PR1666 spectroscopy audit findings

### DIFF
--- a/.workflow/records/1661-pr1666-spectroscopy-quality-fixes.json
+++ b/.workflow/records/1661-pr1666-spectroscopy-quality-fixes.json
@@ -98,9 +98,93 @@
       "tool_versions": {
         "ruff": "0.15.15"
       }
+    },
+    {
+      "at": "2026-06-15T06:23:35.971004Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cd2595a28d67565cff1f491c698498f4daadba730ba35e951b02d6602d17bf8a",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-15T06:23:45.367500Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cd2595a28d67565cff1f491c698498f4daadba730ba35e951b02d6602d17bf8a",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-15T06:23:45.405150Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cd2595a28d67565cff1f491c698498f4daadba730ba35e951b02d6602d17bf8a",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-15T06:27:21.525813Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:cd2595a28d67565cff1f491c698498f4daadba730ba35e951b02d6602d17bf8a",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-15T06:28:16.500662Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cd2595a28d67565cff1f491c698498f4daadba730ba35e951b02d6602d17bf8a",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
     }
   ],
-  "check_na": [],
+  "check_na": [
+    {
+      "name": "python_tests",
+      "rationale": "local gate venv dependency drift; CI remains authoritative for full repository python_tests"
+    }
+  ],
   "commit": null,
   "declared_scope": {
     "exclude": [],
@@ -247,6 +331,88 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-06-15T06:28:16.670952Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T06:28:16.728036Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T06:28:16.784244Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T06:28:16.838587Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T06:28:16.893486Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T06:28:16.990593Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T06:28:17.044234Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T06:28:17.106618Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T06:28:17.198907Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T06:28:17.253521Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -261,20 +427,29 @@
   "observed_diff": {
     "base": "origin/claudecode/spectroscopy-package",
     "base_sha": "04e4b342",
-    "changed_files": [],
-    "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "changed_files": [
+      ".workflow/records/1661-pr1666-spectroscopy-quality-fixes.json",
+      "packages/scistudio-blocks-spectroscopy/src/scistudio_blocks_spectroscopy/blocks/library_matching.py",
+      "packages/scistudio-blocks-spectroscopy/src/scistudio_blocks_spectroscopy/previewers/assets/viewer.js",
+      "packages/scistudio-blocks-spectroscopy/src/scistudio_blocks_spectroscopy/previewers/providers.py",
+      "packages/scistudio-blocks-spectroscopy/src/scistudio_blocks_spectroscopy/types.py",
+      "packages/scistudio-blocks-spectroscopy/tests/test_library_matching_blocks.py",
+      "packages/scistudio-blocks-spectroscopy/tests/test_spectral_dataset_previewer.py",
+      "packages/scistudio-blocks-spectroscopy/tests/test_types.py"
+    ],
+    "diff_fingerprint": "sha256:f35bcd53571dfa31cd7c00514682fe5e6045aceb2dd479fec5ca154472e8033d",
     "head": "HEAD",
-    "head_sha": "04e4b342",
+    "head_sha": "54d513a8",
     "surfaces": {
       "docs": 0,
       "frontend": 0,
       "governance": 0,
       "governed_docs": 0,
-      "implementation": 0,
+      "implementation": 4,
       "packaging": 0,
       "protected_core": 0,
-      "sentrux": 0,
-      "test": 0,
+      "sentrux": 7,
+      "test": 3,
       "workflow_ci": 0
     }
   },
@@ -299,6 +474,16 @@
       "result": "pass",
       "tier": 2,
       "unsatisfied": []
+    },
+    {
+      "at": "2026-06-15T06:28:17.253545Z",
+      "diff_fingerprint": "sha256:f35bcd53571dfa31cd7c00514682fe5e6045aceb2dd479fec5ca154472e8033d",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.python_tests"
+      ]
     }
   ],
   "record_id": "1661-pr1666-spectroscopy-quality-fixes",
@@ -308,9 +493,13 @@
     "checks": [
       "format_check",
       "full_audit",
-      "lint_format"
+      "lint_format",
+      "python_tests",
+      "semantic_dup"
     ],
-    "docs": [],
+    "docs": [
+      "docs_required_or_na"
+    ],
     "guards": [
       "core_change_guard",
       "docs_landing",
@@ -323,7 +512,9 @@
       "test_engineer_scope_guard",
       "weakened_ci_check"
     ],
-    "tests": []
+    "tests": [
+      "changed_test_required"
+    ]
   },
   "runtime": "codex",
   "schema_version": 2,

--- a/.workflow/records/1661-pr1666-spectroscopy-quality-fixes.json
+++ b/.workflow/records/1661-pr1666-spectroscopy-quality-fixes.json
@@ -1,0 +1,360 @@
+{
+  "branch": "codex/pr1666-spectroscopy-quality-fixes",
+  "check_events": [
+    {
+      "at": "2026-06-15T06:20:35.395494Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-15T06:20:46.297065Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-15T06:20:46.385117Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-15T06:21:05.489482Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-15T06:21:15.226563Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-15T06:21:15.264930Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    }
+  ],
+  "check_na": [],
+  "commit": null,
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "packages/scistudio-blocks-spectroscopy/src/scistudio_blocks_spectroscopy/types.py",
+      "packages/scistudio-blocks-spectroscopy/src/scistudio_blocks_spectroscopy/previewers/providers.py",
+      "packages/scistudio-blocks-spectroscopy/src/scistudio_blocks_spectroscopy/previewers/assets/viewer.js",
+      "packages/scistudio-blocks-spectroscopy/src/scistudio_blocks_spectroscopy/blocks/library_matching.py",
+      "packages/scistudio-blocks-spectroscopy/tests/test_types.py",
+      "packages/scistudio-blocks-spectroscopy/tests/test_spectral_dataset_previewer.py",
+      "packages/scistudio-blocks-spectroscopy/tests/test_library_matching_blocks.py",
+      ".workflow/records/1661-pr1666-spectroscopy-quality-fixes.json"
+    ]
+  },
+  "directive_events": [],
+  "docs_events": [
+    {
+      "at": "2026-06-15T06:15:24.387372Z",
+      "class": "No docs update",
+      "kind": "na",
+      "path": null,
+      "rationale": "implementation now satisfies the existing spectroscopy package spec and previewer contract.",
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": false,
+  "guard_events": [
+    {
+      "at": "2026-06-15T06:20:46.503980Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T06:20:46.559707Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T06:20:46.620450Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T06:20:46.688336Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T06:20:46.747358Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T06:20:46.811494Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T06:20:46.870009Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T06:20:46.927698Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T06:20:46.987663Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T06:20:47.051756Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T06:21:15.376214Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T06:21:15.468309Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T06:21:15.521522Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T06:21:15.575295Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T06:21:15.628286Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T06:21:15.687375Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T06:21:15.771591Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T06:21:15.825376Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T06:21:15.912154Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T06:21:16.003643Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1661,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": {
+    "base": "origin/claudecode/spectroscopy-package",
+    "base_sha": "04e4b342",
+    "changed_files": [],
+    "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "head": "HEAD",
+    "head_sha": "04e4b342",
+    "surfaces": {
+      "docs": 0,
+      "frontend": 0,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 0,
+      "packaging": 0,
+      "protected_core": 0,
+      "sentrux": 0,
+      "test": 0,
+      "workflow_ci": 0
+    }
+  },
+  "owner_directive": "Fix PR1666 audit P1 plus three P2 spectroscopy package findings and open a stacked PR.",
+  "persona": "implementer",
+  "pull_request": null,
+  "reconcile_events": [
+    {
+      "at": "2026-06-15T06:20:47.051811Z",
+      "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "mode": "local",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.format_check"
+      ]
+    },
+    {
+      "at": "2026-06-15T06:21:16.003690Z",
+      "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "mode": "local",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    }
+  ],
+  "record_id": "1661-pr1666-spectroscopy-quality-fixes",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [
+      "format_check",
+      "full_audit",
+      "lint_format"
+    ],
+    "docs": [],
+    "guards": [
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": []
+  },
+  "runtime": "codex",
+  "schema_version": 2,
+  "scope_events": [],
+  "session_id": "5e961cfc-241d-4c22-923c-2ea23ed87a36",
+  "strictness_tier": 2,
+  "task_kind": "bugfix",
+  "test_events": [
+    {
+      "at": "2026-06-15T06:15:24.387392Z",
+      "class": null,
+      "kind": "path",
+      "path": "packages/scistudio-blocks-spectroscopy/tests/test_types.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-15T06:15:24.387398Z",
+      "class": null,
+      "kind": "path",
+      "path": "packages/scistudio-blocks-spectroscopy/tests/test_spectral_dataset_previewer.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-15T06:15:24.387401Z",
+      "class": null,
+      "kind": "path",
+      "path": "packages/scistudio-blocks-spectroscopy/tests/test_library_matching_blocks.py",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/.workflow/records/1661-pr1666-spectroscopy-quality-fixes.json
+++ b/.workflow/records/1661-pr1666-spectroscopy-quality-fixes.json
@@ -264,7 +264,13 @@
       "rationale": "local gate venv dependency drift; CI remains authoritative for full repository python_tests"
     }
   ],
-  "commit": null,
+  "commit": {
+    "sha": "HEAD",
+    "shas": [
+      "HEAD"
+    ],
+    "trailers": []
+  },
   "declared_scope": {
     "exclude": [],
     "include": [
@@ -574,6 +580,88 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-06-15T06:38:50.327757Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T06:38:50.381050Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T06:38:50.435299Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T06:38:50.489671Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T06:38:50.542993Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T06:38:50.596669Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T06:38:50.649218Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T06:38:50.701350Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T06:38:50.754809Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T06:38:50.810734Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -598,9 +686,9 @@
       "packages/scistudio-blocks-spectroscopy/tests/test_spectral_dataset_previewer.py",
       "packages/scistudio-blocks-spectroscopy/tests/test_types.py"
     ],
-    "diff_fingerprint": "sha256:893a45cfd89fa6144bb4882941c0e11cb015f23d422f317d20a154c15a56176a",
+    "diff_fingerprint": "sha256:a83a253c20940f88c597207f36a0fd38cf7e29ad735bd5c704b0fcc8d6ded5c8",
     "head": "HEAD",
-    "head_sha": "24ae6496",
+    "head_sha": "9f6d7a09",
     "surfaces": {
       "docs": 0,
       "frontend": 0,
@@ -616,7 +704,14 @@
   },
   "owner_directive": "Fix PR1666 audit P1 plus three P2 spectroscopy package findings and open a stacked PR.",
   "persona": "implementer",
-  "pull_request": null,
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [
+      1661
+    ],
+    "number": 1672,
+    "url": "https://github.com/zjzcpj/SciStudio/pull/1672"
+  },
   "reconcile_events": [
     {
       "at": "2026-06-15T06:20:47.051811Z",
@@ -655,19 +750,21 @@
       "unsatisfied": [
         "checks.python_tests"
       ]
+    },
+    {
+      "at": "2026-06-15T06:38:50.810769Z",
+      "diff_fingerprint": "sha256:a83a253c20940f88c597207f36a0fd38cf7e29ad735bd5c704b0fcc8d6ded5c8",
+      "mode": "ci",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
     }
   ],
   "record_id": "1661-pr1666-spectroscopy-quality-fixes",
   "requested_admin_labels": [],
   "required_obligations": {
     "admin_labels": [],
-    "checks": [
-      "format_check",
-      "full_audit",
-      "lint_format",
-      "python_tests",
-      "semantic_dup"
-    ],
+    "checks": [],
     "docs": [
       "docs_required_or_na"
     ],

--- a/.workflow/records/1661-pr1666-spectroscopy-quality-fixes.json
+++ b/.workflow/records/1661-pr1666-spectroscopy-quality-fixes.json
@@ -177,6 +177,85 @@
       "status": "pass",
       "summary": "clean",
       "tool_versions": {}
+    },
+    {
+      "at": "2026-06-15T06:32:58.393136Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cd2595a28d67565cff1f491c698498f4daadba730ba35e951b02d6602d17bf8a",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-15T06:33:07.825947Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cd2595a28d67565cff1f491c698498f4daadba730ba35e951b02d6602d17bf8a",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-15T06:33:07.862556Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cd2595a28d67565cff1f491c698498f4daadba730ba35e951b02d6602d17bf8a",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-15T06:36:24.902990Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:cd2595a28d67565cff1f491c698498f4daadba730ba35e951b02d6602d17bf8a",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-15T06:37:19.774056Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cd2595a28d67565cff1f491c698498f4daadba730ba35e951b02d6602d17bf8a",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
     }
   ],
   "check_na": [
@@ -413,6 +492,88 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-06-15T06:37:19.874730Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T06:37:19.921774Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T06:37:19.972545Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T06:37:20.023012Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T06:37:20.080771Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T06:37:20.161006Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T06:37:20.206795Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T06:37:20.252833Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T06:37:20.298964Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T06:37:20.347188Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -437,9 +598,9 @@
       "packages/scistudio-blocks-spectroscopy/tests/test_spectral_dataset_previewer.py",
       "packages/scistudio-blocks-spectroscopy/tests/test_types.py"
     ],
-    "diff_fingerprint": "sha256:f35bcd53571dfa31cd7c00514682fe5e6045aceb2dd479fec5ca154472e8033d",
+    "diff_fingerprint": "sha256:893a45cfd89fa6144bb4882941c0e11cb015f23d422f317d20a154c15a56176a",
     "head": "HEAD",
-    "head_sha": "54d513a8",
+    "head_sha": "24ae6496",
     "surfaces": {
       "docs": 0,
       "frontend": 0,
@@ -479,6 +640,16 @@
       "at": "2026-06-15T06:28:17.253545Z",
       "diff_fingerprint": "sha256:f35bcd53571dfa31cd7c00514682fe5e6045aceb2dd479fec5ca154472e8033d",
       "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.python_tests"
+      ]
+    },
+    {
+      "at": "2026-06-15T06:37:20.347205Z",
+      "diff_fingerprint": "sha256:893a45cfd89fa6144bb4882941c0e11cb015f23d422f317d20a154c15a56176a",
+      "mode": "local",
       "result": "fail",
       "tier": 2,
       "unsatisfied": [

--- a/packages/scistudio-blocks-spectroscopy/src/scistudio_blocks_spectroscopy/blocks/library_matching.py
+++ b/packages/scistudio-blocks-spectroscopy/src/scistudio_blocks_spectroscopy/blocks/library_matching.py
@@ -245,7 +245,7 @@ class MatchSpectralLibrary(ProcessBlock):
             }
             for rank, (lib_id, score) in enumerate(ranked, start=1)
         ]
-        return rows
+        return rows + incompatible
 
     @staticmethod
     def _query_units(query: Spectrum) -> tuple[str | None, str | None]:

--- a/packages/scistudio-blocks-spectroscopy/src/scistudio_blocks_spectroscopy/previewers/assets/viewer.js
+++ b/packages/scistudio-blocks-spectroscopy/src/scistudio_blocks_spectroscopy/previewers/assets/viewer.js
@@ -380,6 +380,9 @@ function renderDataset(container, payload, host, diagnostics) {
   const groupable = Array.isArray(controls.groupable_columns)
     ? controls.groupable_columns
     : columns.filter((c) => c !== "spectrum_id");
+  const filterable = Array.isArray(controls.filterable_columns) ? controls.filterable_columns : columns;
+  const activeFilters = Array.isArray(controls.active_filters) ? controls.active_filters : [];
+  const firstFilter = activeFilters.length ? activeFilters[0] : {};
   let selected = new Set(Array.isArray(controls.selected_ids) ? controls.selected_ids.map(String) : []);
   let search = "";
 
@@ -412,6 +415,37 @@ function renderDataset(container, payload, host, diagnostics) {
   groupSelect.addEventListener("change", () => patchQuery(host, { group_by: groupSelect.value || null }, "group change"));
   colorSelect.addEventListener("change", () => patchQuery(host, { color_by: colorSelect.value || null }, "color change"));
 
+  const filterSelect = el("select", { style: "font:12px sans-serif" }, el("option", { value: "", text: "no filter" }));
+  for (const col of filterable) filterSelect.appendChild(el("option", { value: col, text: col }));
+  filterSelect.value = firstFilter.column || "";
+  const filterInput = el("input", {
+    type: "search",
+    placeholder: "filter value",
+    value: firstFilter.value || "",
+    style: "font:12px sans-serif;padding:2px 4px;width:120px",
+  });
+  const applyFilter = () =>
+    patchQuery(
+      host,
+      {
+        filter_column: filterSelect.value || null,
+        filter_value: filterSelect.value && filterInput.value ? filterInput.value : null,
+      },
+      "filter update",
+    );
+  filterInput.addEventListener("keydown", (evt) => {
+    if (evt.key === "Enter") applyFilter();
+  });
+  const filterButton = el("button", { style: "font:12px sans-serif", onclick: applyFilter }, "Apply");
+  const clearFilterButton = el("button", {
+    style: "font:12px sans-serif",
+    onclick: () => {
+      filterSelect.value = "";
+      filterInput.value = "";
+      patchQuery(host, { filter_column: null, filter_value: null, filters: null }, "filter clear");
+    },
+  }, "Clear");
+
   const searchInput = el("input", {
     type: "search",
     placeholder: "search index",
@@ -427,6 +461,11 @@ function renderDataset(container, payload, host, diagnostics) {
   controlBar.appendChild(groupSelect);
   controlBar.appendChild(el("span", null, "Color"));
   controlBar.appendChild(colorSelect);
+  controlBar.appendChild(el("span", null, "Filter"));
+  controlBar.appendChild(filterSelect);
+  controlBar.appendChild(filterInput);
+  controlBar.appendChild(filterButton);
+  controlBar.appendChild(clearFilterButton);
   controlBar.appendChild(searchInput);
   container.appendChild(controlBar);
 

--- a/packages/scistudio-blocks-spectroscopy/src/scistudio_blocks_spectroscopy/previewers/providers.py
+++ b/packages/scistudio-blocks-spectroscopy/src/scistudio_blocks_spectroscopy/previewers/providers.py
@@ -443,7 +443,9 @@ def _slot_ref(parent: StorageReference, record_md: dict[str, Any], slot: str) ->
     if candidate is None:
         return None
     candidate = _slot_file_candidate(Path(candidate)) or candidate
-    return StorageReference(backend=parent.backend, path=candidate, format=_format_for_path(candidate))
+    fmt = _format_for_path(candidate)
+    backend = "filesystem" if parent.backend == "composite" and fmt in {"parquet", "csv"} else parent.backend
+    return StorageReference(backend=backend, path=candidate, format=fmt)
 
 
 def _slot_file_candidate(path: Path) -> str | None:
@@ -511,6 +513,68 @@ def _read_slot_page(
     return list(page_obj.columns), rows, total, truncated
 
 
+def _index_filters(query: dict[str, Any], columns: list[str]) -> list[dict[str, str]]:
+    """Normalize provider-side index filters from query params."""
+    valid_columns = set(columns)
+    filters: list[dict[str, str]] = []
+
+    def add(column: Any, value: Any, op: Any = "contains") -> None:
+        if not isinstance(column, str) or column not in valid_columns or value in (None, ""):
+            return
+        operation = str(op or "contains").lower()
+        if operation not in {"contains", "equals"}:
+            operation = "contains"
+        filters.append({"column": column, "value": str(value), "op": operation})
+
+    raw_filters = query.get("filters")
+    if isinstance(raw_filters, str):
+        try:
+            raw_filters = json.loads(raw_filters)
+        except Exception:
+            raw_filters = None
+    if isinstance(raw_filters, dict):
+        for column, value in raw_filters.items():
+            add(column, value, "equals")
+    elif isinstance(raw_filters, list):
+        for item in raw_filters:
+            if isinstance(item, dict):
+                add(item.get("column"), item.get("value"), item.get("op", "contains"))
+
+    add(query.get("filter_column"), query.get("filter_value"), query.get("filter_op", "contains"))
+    return filters
+
+
+def _row_matches_filters(row: dict[str, Any], filters: list[dict[str, str]]) -> bool:
+    for spec in filters:
+        cell = "" if row.get(spec["column"]) is None else str(row.get(spec["column"]))
+        needle = spec["value"]
+        if spec["op"] == "equals":
+            if cell != needle:
+                return False
+        elif needle.lower() not in cell.lower():
+            return False
+    return True
+
+
+def _apply_index_filters(
+    index_rows: list[dict[str, Any]],
+    spectra_rows: list[dict[str, Any]],
+    filters: list[dict[str, str]],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    if not filters:
+        return index_rows, spectra_rows
+    filtered_index = [row for row in index_rows if _row_matches_filters(row, filters)]
+    visible_ids = {
+        str(row.get(_SPECTRUM_ID))
+        for row in filtered_index
+        if isinstance(row, dict) and row.get(_SPECTRUM_ID) not in (None, "")
+    }
+    filtered_spectra = [
+        row for row in spectra_rows if isinstance(row, dict) and str(row.get(_SPECTRUM_ID)) in visible_ids
+    ]
+    return filtered_index, filtered_spectra
+
+
 def spectral_dataset_provider(request: PreviewRequest) -> PreviewEnvelope:
     """Preview a ``SpectralDataset`` as a metadata-aware spectral explorer.
 
@@ -547,6 +611,7 @@ def spectral_dataset_provider(request: PreviewRequest) -> PreviewEnvelope:
     }
     index_rows: list[dict[str, Any]] = []
     index_columns: list[str] = []
+    index_total = 0
     index_truncated = False
     if index_read is not None:
         index_columns, index_rows, index_total, index_truncated = index_read
@@ -573,6 +638,20 @@ def spectral_dataset_provider(request: PreviewRequest) -> PreviewEnvelope:
         truncated = truncated or spectra_truncated
     else:
         diagnostics.append("spectra slot not readable for a bounded diagnostics scan")
+
+    active_filters = _index_filters(request.query, index_columns)
+    if active_filters:
+        index_unfiltered_total = index_total
+        index_rows, spectra_rows = _apply_index_filters(index_rows, spectra_rows, active_filters)
+        index_payload.update(
+            rows=index_rows,
+            total_rows=len(index_rows),
+            filtered=True,
+            unfiltered_total_rows=index_unfiltered_total,
+        )
+        spectra_total = len(spectra_rows)
+        if index_truncated or spectra_truncated:
+            diagnostics.append("filters applied to bounded preview rows; additional off-page matches may exist")
 
     dataset_diagnostics = compute_dataset_diagnostics(
         index_rows,
@@ -613,6 +692,7 @@ def spectral_dataset_provider(request: PreviewRequest) -> PreviewEnvelope:
             "groupable_columns": [c for c in index_columns if c != _SPECTRUM_ID],
             "colorable_columns": [c for c in index_columns if c != _SPECTRUM_ID],
             "selected_ids": _selected_ids(request.query),
+            "active_filters": active_filters,
             "group_by": plot_payload["group_by"],
             "color_by": plot_payload["color_by"],
             "plot_mode": plot_payload["mode"],

--- a/packages/scistudio-blocks-spectroscopy/src/scistudio_blocks_spectroscopy/types.py
+++ b/packages/scistudio-blocks-spectroscopy/src/scistudio_blocks_spectroscopy/types.py
@@ -132,9 +132,19 @@ class SpectralDataset(CompositeData):
         package contract also requires table schemas and the
         ``index.spectrum_id`` <-> ``spectra.spectrum_id`` join invariant.
         """
+        slot_names = set(slots or {})
+        expected = set(self.expected_slots)
+        if slot_names != expected:
+            missing = sorted(expected - slot_names)
+            extra = sorted(slot_names - expected)
+            details: list[str] = []
+            if missing:
+                details.append(f"missing required slot(s) {missing!r}")
+            if extra:
+                details.append(f"unexpected slot(s) {extra!r}")
+            raise ValueError(f"SpectralDataset requires exactly slots {sorted(expected)!r}; " + "; ".join(details))
         super().__init__(slots=slots, **kwargs)
-        if self.expected_slots.keys() <= self._slots.keys():
-            self.validate_slots()
+        self.validate_slots()
 
     def validate_slots(self) -> None:
         """Validate required columns, ids, numeric payload columns, and joins."""

--- a/packages/scistudio-blocks-spectroscopy/tests/test_library_matching_blocks.py
+++ b/packages/scistudio-blocks-spectroscopy/tests/test_library_matching_blocks.py
@@ -11,7 +11,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, cast
 
 import numpy as np
 from scistudio_blocks_spectroscopy import _support
@@ -38,7 +38,7 @@ def _spectrum(sid: str, *, lam: Any, inten: Any) -> Spectrum:
 
 def _library(spectra: list[Spectrum]) -> SpectralDataset:
     out = SpectrumToSpectralDataset().run({"spectra": _support.spectra_collection(spectra)}, _config())
-    return next(iter(out["dataset"]))
+    return cast(SpectralDataset, next(iter(out["dataset"])))
 
 
 def _matches(query: list[Spectrum], lib: SpectralDataset, **params: Any) -> Any:
@@ -112,3 +112,22 @@ def test_incompatible_grid_is_non_success_by_default() -> None:
     # Default grid_policy="error": no success row for the incompatible grid.
     assert "success" not in statuses
     assert any(s != "success" for s in statuses)
+
+
+def test_mixed_compatible_and_incompatible_library_rows_are_reported() -> None:
+    query_grid = np.linspace(0.0, 10.0, 11)
+    incompatible_grid = np.linspace(0.0, 10.0, 21)
+    lib = _library(
+        [
+            _spectrum("compatible", lam=query_grid, inten=query_grid),
+            _spectrum("incompatible", lam=incompatible_grid, inten=incompatible_grid),
+        ]
+    )
+    query = _spectrum("q1", lam=query_grid, inten=query_grid)
+    table = _matches([query], lib, method="cosine_similarity", top_k=1)
+    rows = {row["library_spectrum_id"]: row for row in table.to_pylist()}
+
+    assert rows["compatible"]["status"] == "success"
+    assert rows["compatible"]["rank"] == 1
+    assert rows["incompatible"]["status"] == "incompatible_grid"
+    assert rows["incompatible"]["rank"] == 0

--- a/packages/scistudio-blocks-spectroscopy/tests/test_spectral_dataset_previewer.py
+++ b/packages/scistudio-blocks-spectroscopy/tests/test_spectral_dataset_previewer.py
@@ -26,10 +26,12 @@ from scistudio_blocks_spectroscopy.previewers import (
     get_previewers,
 )
 from scistudio_blocks_spectroscopy.previewers.providers import (
+    _slot_ref,
     compute_dataset_diagnostics,
     spectral_dataset_provider,
 )
 
+from scistudio.core.storage.ref import StorageReference
 from scistudio.previewers.data_access import PreviewDataAccess
 from scistudio.previewers.models import (
     EnvelopeKind,
@@ -51,9 +53,15 @@ def _spec() -> PreviewerSpec:
     raise AssertionError(SPECTRAL_DATASET_PREVIEWER_ID)
 
 
-def _request(root: Path, record_md: dict, extra_query: dict | None = None) -> PreviewRequest:
+def _request(
+    root: Path,
+    record_md: dict,
+    extra_query: dict | None = None,
+    *,
+    storage_backend: str = "filesystem",
+) -> PreviewRequest:
     query = {
-        "_storage": {"backend": "filesystem", "path": str(root), "format": "parquet"},
+        "_storage": {"backend": storage_backend, "path": str(root), "format": "parquet"},
         "_record_metadata": record_md,
     }
     if extra_query:
@@ -129,11 +137,51 @@ def test_dataset_provider_resolves_composite_slot_data_parquet(tmp_path: Path) -
         index_cols={"spectrum_id": ["a"], "material": ["gold"]},
         spectra_cols={"spectrum_id": ["a"], "lambda": [1.0], "intensity": [10.0]},
     )
-    env = spectral_dataset_provider(_request(root, {"slots": {"index": "DataFrame", "spectra": "DataFrame"}}))
+    index_ref = _slot_ref(StorageReference(backend="composite", path=str(root), format="composite"), {}, "index")
+    assert index_ref is not None
+    assert index_ref.backend == "filesystem"
+    assert index_ref.format == "parquet"
+
+    env = spectral_dataset_provider(
+        _request(root, {"slots": {"index": "DataFrame", "spectra": "DataFrame"}}, storage_backend="composite")
+    )
     assert env.payload["index_table"]["available"] is True
     assert env.payload["index_table"]["rows"][0]["spectrum_id"] == "a"
     assert env.payload["spectra_table"]["available"] is True
     assert env.payload["plot"]["overlay"]["series"][0]["points"] == [{"x": 1.0, "y": 10.0}]
+
+
+def test_dataset_previewer_filters_index_and_spectra_by_index_column(tmp_path: Path) -> None:
+    root = _dataset_dir(
+        tmp_path,
+        index_cols={
+            "spectrum_id": ["a", "b", "c"],
+            "material": ["gold", "silver", "gold"],
+            "prep": ["wet", "dry", "dry"],
+        },
+        spectra_cols={
+            "spectrum_id": ["a", "a", "b", "b", "c", "c"],
+            "lambda": [1.0, 2.0, 1.0, 2.0, 1.0, 2.0],
+            "intensity": [10.0, 11.0, 20.0, 21.0, 30.0, 31.0],
+        },
+    )
+    env = spectral_dataset_provider(
+        _request(
+            root,
+            {"slots": {"index": "DataFrame", "spectra": "DataFrame"}},
+            extra_query={"filter_column": "material", "filter_value": "gold"},
+        )
+    )
+
+    index_ids = [row["spectrum_id"] for row in env.payload["index_table"]["rows"]]
+    spectra_ids = {row["spectrum_id"] for row in env.payload["spectra_table"]["rows"]}
+    plot_ids = {series["spectrum_id"] for series in env.payload["plot"]["overlay"]["series"]}
+    assert index_ids == ["a", "c"]
+    assert spectra_ids == {"a", "c"}
+    assert plot_ids == {"a", "c"}
+    assert env.payload["index_table"]["filtered"] is True
+    assert env.payload["index_table"]["unfiltered_total_rows"] == 3
+    assert env.payload["controls"]["active_filters"] == [{"column": "material", "value": "gold", "op": "contains"}]
 
 
 def test_dataset_previewer_supports_grouping_over_arbitrary_index_columns(tmp_path: Path) -> None:

--- a/packages/scistudio-blocks-spectroscopy/tests/test_types.py
+++ b/packages/scistudio-blocks-spectroscopy/tests/test_types.py
@@ -63,6 +63,24 @@ def test_spectral_dataset_slot_type_is_enforced() -> None:
     assert isinstance(dataset.get("spectra"), DataFrame)
 
 
+def test_spectral_dataset_requires_exact_slots_at_construction() -> None:
+    # FR-008 / SC-003: empty, partial, or extra slots are invalid datasets.
+    spectra = _support.dataframe_from_rows([{"spectrum_id": "a", "lambda": 1.0, "intensity": 2.0}])
+    index = _support.dataframe_from_rows([{"spectrum_id": "a"}])
+    extra = _support.dataframe_from_rows([{"spectrum_id": "a"}])
+
+    bad_slots = [
+        None,
+        {},
+        {"index": index},
+        {"spectra": spectra},
+        {"index": index, "spectra": spectra, "metadata": extra},
+    ]
+    for slots in bad_slots:
+        with pytest.raises(ValueError, match="exactly slots"):
+            SpectralDataset(slots=slots)
+
+
 @pytest.mark.parametrize(
     ("index_rows", "spectra_rows", "match"),
     [


### PR DESCRIPTION
## Summary

Stacked on PR #1666 (`claudecode/spectroscopy-package`) to address the PR1666 package-quality audit blockers:

- enforce the exact `SpectralDataset` slot contract at construction time;
- resolve concrete composite child slot files as table-readable filesystem refs;
- apply SpectralDataset preview filters in the provider before shaping table, spectra, diagnostics, and plot payloads;
- keep `incompatible_grid` library rows visible even when compatible ranked matches also exist.

## Tests

- `python -m pytest packages/scistudio-blocks-spectroscopy/tests/test_types.py packages/scistudio-blocks-spectroscopy/tests/test_spectral_dataset_previewer.py packages/scistudio-blocks-spectroscopy/tests/test_library_matching_blocks.py -q --no-cov --timeout=60`
- `python -m pytest packages/scistudio-blocks-spectroscopy/tests -q --no-cov --timeout=60`
- `node --check packages/scistudio-blocks-spectroscopy/src/scistudio_blocks_spectroscopy/previewers/assets/viewer.js`
- `python -m scistudio.qa.governance.gate_record check --record .workflow/records/1661-pr1666-spectroscopy-quality-fixes.json --base origin/claudecode/spectroscopy-package --head HEAD --mode local`
- `python -m pytest tests/contracts/test_runtime_import_contract.py::test_api_workflow_routes_are_registered tests/contracts/test_runtime_import_contract.py::test_api_block_routes_are_registered tests/contracts/test_runtime_import_contract.py::test_api_filesystem_routes_are_registered tests/contracts/test_runtime_import_contract.py::test_api_ai_routes_are_registered -q --no-cov`

## Gate Note

`gate_record check --mode pre-pr` reached the full-repo `python_tests` step and failed only inside the gate isolated venv. That venv resolved `fastapi 0.137.0` / `starlette 1.3.1`; in that environment the runtime import contract route tests fail because `FastAPI.include_router()` does not expose the expected route paths. The same four route contract assertions pass in the ambient repo environment, and the spectroscopy package test suite passes.

Gate record: `.workflow/records/1661-pr1666-spectroscopy-quality-fixes.json`

Closes #1661
