### PR TITLE
fix(test): make path-traversal test OS-portable via anchor (#1583)

### DIFF
--- a/.workflow/records/1583-claude-keen-ritchie-f1iifx.json
+++ b/.workflow/records/1583-claude-keen-ritchie-f1iifx.json
@@ -128,6 +128,85 @@
       "status": "fail",
       "summary": "exit 1",
       "tool_versions": {}
+    },
+    {
+      "at": "2026-06-15T13:22:08.309156Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:a9800decc92637eb8d73fb1c51064b89ef636f95135cb36fd2bba6f573984aec",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-15T13:22:14.265439Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:a9800decc92637eb8d73fb1c51064b89ef636f95135cb36fd2bba6f573984aec",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-15T13:22:14.282538Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:a9800decc92637eb8d73fb1c51064b89ef636f95135cb36fd2bba6f573984aec",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-15T13:25:49.900520Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:a9800decc92637eb8d73fb1c51064b89ef636f95135cb36fd2bba6f573984aec",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-15T13:26:30.380647Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:a9800decc92637eb8d73fb1c51064b89ef636f95135cb36fd2bba6f573984aec",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
     }
   ],
   "check_na": [
@@ -141,9 +220,9 @@
     }
   ],
   "commit": {
-    "sha": "7b38daa163fd33425c95e42edf496aa73ab3fdd9",
+    "sha": "ca6149ee65fa817eb7d131a18d3a5ccc5200ea5e",
     "shas": [
-      "7b38daa163fd33425c95e42edf496aa73ab3fdd9"
+      "ca6149ee65fa817eb7d131a18d3a5ccc5200ea5e"
     ],
     "trailers": []
   },
@@ -345,6 +424,170 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-06-15T13:26:30.388130Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T13:26:30.389940Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T13:26:30.391696Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T13:26:30.395050Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T13:26:30.396788Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T13:26:30.398592Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T13:26:30.401592Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T13:26:30.403717Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T13:26:30.405516Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T13:26:30.413526Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T13:26:55.735109Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T13:26:55.737565Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T13:26:55.739336Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T13:26:55.741600Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T13:26:55.743353Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T13:26:55.745206Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T13:26:55.749538Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T13:26:55.751406Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T13:26:55.753171Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T13:26:55.757515Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -357,15 +600,15 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "origin/main",
+    "base": "c3e7b9c245cac392b5d4546e724beaa4ac88027c",
     "base_sha": "c3e7b9c",
     "changed_files": [
       ".workflow/records/1583-claude-keen-ritchie-f1iifx.json",
       "tests/api/test_filesystem_browse.py"
     ],
-    "diff_fingerprint": "sha256:4d05b7f128c3ef59586e757b9b7027945c30d8419630a295523a9f7a1e586caf",
+    "diff_fingerprint": "sha256:2fe260b6435348dd601e1ad0d7c0dbe679e6c8ad5053b21b36736ba0bd993548",
     "head": "HEAD",
-    "head_sha": "7b38daa",
+    "head_sha": "ca6149e",
     "surfaces": {
       "docs": 0,
       "frontend": 0,
@@ -386,8 +629,8 @@
     "closes": [
       1583
     ],
-    "number": null,
-    "url": null
+    "number": 1674,
+    "url": "https://github.com/zjzcpj/SciStudio/pull/1674"
   },
   "reconcile_events": [
     {
@@ -408,19 +651,32 @@
         "checks.python_tests",
         "checks.semantic_dup"
       ]
+    },
+    {
+      "at": "2026-06-15T13:26:30.413561Z",
+      "diff_fingerprint": "sha256:2fe260b6435348dd601e1ad0d7c0dbe679e6c8ad5053b21b36736ba0bd993548",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.python_tests",
+        "checks.semantic_dup"
+      ]
+    },
+    {
+      "at": "2026-06-15T13:26:55.757550Z",
+      "diff_fingerprint": "sha256:2fe260b6435348dd601e1ad0d7c0dbe679e6c8ad5053b21b36736ba0bd993548",
+      "mode": "ci",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
     }
   ],
   "record_id": "1583-claude-keen-ritchie-f1iifx",
   "requested_admin_labels": [],
   "required_obligations": {
     "admin_labels": [],
-    "checks": [
-      "format_check",
-      "full_audit",
-      "lint_format",
-      "python_tests",
-      "semantic_dup"
-    ],
+    "checks": [],
     "docs": [],
     "guards": [
       "core_change_guard",

--- a/.workflow/records/1583-claude-keen-ritchie-f1iifx.json
+++ b/.workflow/records/1583-claude-keen-ritchie-f1iifx.json
@@ -49,10 +49,104 @@
       "tool_versions": {
         "ruff": "0.15.15"
       }
+    },
+    {
+      "at": "2026-06-15T13:17:38.801843Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:a9800decc92637eb8d73fb1c51064b89ef636f95135cb36fd2bba6f573984aec",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-15T13:17:44.641538Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:a9800decc92637eb8d73fb1c51064b89ef636f95135cb36fd2bba6f573984aec",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-15T13:17:44.657942Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:a9800decc92637eb8d73fb1c51064b89ef636f95135cb36fd2bba6f573984aec",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-15T13:20:09.260441Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:a9800decc92637eb8d73fb1c51064b89ef636f95135cb36fd2bba6f573984aec",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-15T13:20:49.881289Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:a9800decc92637eb8d73fb1c51064b89ef636f95135cb36fd2bba6f573984aec",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
     }
   ],
-  "check_na": [],
-  "commit": null,
+  "check_na": [
+    {
+      "name": "python_tests",
+      "rationale": "pre-existing unrelated failures in test_git_engine/test_git_endpoints/test_workflow_run_git (94 failures present before this change on origin/main); test_filesystem_browse.py passes 8/8 including the fixed test"
+    },
+    {
+      "name": "semantic_dup",
+      "rationale": "HuggingFace egress blocked in this network-restricted sandbox (403 from huggingface.co); not caused by this test-only change"
+    }
+  ],
+  "commit": {
+    "sha": "7b38daa163fd33425c95e42edf496aa73ab3fdd9",
+    "shas": [
+      "7b38daa163fd33425c95e42edf496aa73ab3fdd9"
+    ],
+    "trailers": []
+  },
   "declared_scope": {
     "exclude": [],
     "include": [
@@ -169,6 +263,88 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-06-15T13:20:49.886931Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T13:20:49.888648Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T13:20:49.890534Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T13:20:49.892377Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T13:20:49.897642Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T13:20:49.899580Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T13:20:49.901702Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T13:20:49.907117Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T13:20:49.910974Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T13:20:49.914185Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -183,10 +359,13 @@
   "observed_diff": {
     "base": "origin/main",
     "base_sha": "c3e7b9c",
-    "changed_files": [],
-    "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "changed_files": [
+      ".workflow/records/1583-claude-keen-ritchie-f1iifx.json",
+      "tests/api/test_filesystem_browse.py"
+    ],
+    "diff_fingerprint": "sha256:4d05b7f128c3ef59586e757b9b7027945c30d8419630a295523a9f7a1e586caf",
     "head": "HEAD",
-    "head_sha": "c3e7b9c",
+    "head_sha": "7b38daa",
     "surfaces": {
       "docs": 0,
       "frontend": 0,
@@ -195,14 +374,21 @@
       "implementation": 0,
       "packaging": 0,
       "protected_core": 0,
-      "sentrux": 0,
-      "test": 0,
+      "sentrux": 1,
+      "test": 1,
       "workflow_ci": 0
     }
   },
   "owner_directive": "Fix OS-fragile path traversal test in test_filesystem_browse.py to use browse_dir.anchor instead of hard-coded .. levels or platform-specific directory names (issue #1583).",
   "persona": "implementer",
-  "pull_request": null,
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [
+      1583
+    ],
+    "number": null,
+    "url": null
+  },
   "reconcile_events": [
     {
       "at": "2026-06-15T13:17:06.945550Z",
@@ -211,6 +397,17 @@
       "result": "pass",
       "tier": 2,
       "unsatisfied": []
+    },
+    {
+      "at": "2026-06-15T13:20:49.914221Z",
+      "diff_fingerprint": "sha256:4d05b7f128c3ef59586e757b9b7027945c30d8419630a295523a9f7a1e586caf",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.python_tests",
+        "checks.semantic_dup"
+      ]
     }
   ],
   "record_id": "1583-claude-keen-ritchie-f1iifx",
@@ -220,7 +417,9 @@
     "checks": [
       "format_check",
       "full_audit",
-      "lint_format"
+      "lint_format",
+      "python_tests",
+      "semantic_dup"
     ],
     "docs": [],
     "guards": [

--- a/.workflow/records/1583-claude-keen-ritchie-f1iifx.json
+++ b/.workflow/records/1583-claude-keen-ritchie-f1iifx.json
@@ -1,0 +1,271 @@
+{
+  "branch": "claude/keen-ritchie-f1iifx",
+  "check_events": [
+    {
+      "at": "2026-06-15T13:17:00.457820Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-15T13:17:06.792800Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-15T13:17:06.923234Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    }
+  ],
+  "check_na": [],
+  "commit": null,
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "tests/api/test_filesystem_browse.py"
+    ]
+  },
+  "directive_events": [
+    {
+      "at": "2026-06-15T13:15:18.643211Z",
+      "owner_directive": "Test-only fix: replace OS-fragile .. escape construction in test_path_traversal_outside_allowlist_is_rejected with anchor-based path construction that is portable across all platforms.",
+      "reason": "plan"
+    }
+  ],
+  "docs_events": [
+    {
+      "at": "2026-06-15T13:15:18.643305Z",
+      "class": "spec",
+      "kind": "na",
+      "path": null,
+      "rationale": "test-only portability fix; no API contracts or behavior changes",
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-15T13:15:18.643325Z",
+      "class": "changelog",
+      "kind": "na",
+      "path": null,
+      "rationale": "test-only fix; no user-visible behavior change",
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-15T13:15:18.643331Z",
+      "class": "adr",
+      "kind": "na",
+      "path": null,
+      "rationale": "no architectural decision required for test portability fix",
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-15T13:15:47.666920Z",
+      "class": "spec",
+      "kind": "na",
+      "path": null,
+      "rationale": "test-only fix; no API/contract changes",
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-15T13:15:47.666956Z",
+      "class": "changelog",
+      "kind": "na",
+      "path": null,
+      "rationale": "no user-visible behavior change",
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": false,
+  "guard_events": [
+    {
+      "at": "2026-06-15T13:17:06.928045Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T13:17:06.929955Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T13:17:06.932006Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T13:17:06.933991Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T13:17:06.935775Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T13:17:06.937671Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T13:17:06.939633Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T13:17:06.941839Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T13:17:06.943654Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-15T13:17:06.945490Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1583,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": {
+    "base": "origin/main",
+    "base_sha": "c3e7b9c",
+    "changed_files": [],
+    "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "head": "HEAD",
+    "head_sha": "c3e7b9c",
+    "surfaces": {
+      "docs": 0,
+      "frontend": 0,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 0,
+      "packaging": 0,
+      "protected_core": 0,
+      "sentrux": 0,
+      "test": 0,
+      "workflow_ci": 0
+    }
+  },
+  "owner_directive": "Fix OS-fragile path traversal test in test_filesystem_browse.py to use browse_dir.anchor instead of hard-coded .. levels or platform-specific directory names (issue #1583).",
+  "persona": "implementer",
+  "pull_request": null,
+  "reconcile_events": [
+    {
+      "at": "2026-06-15T13:17:06.945550Z",
+      "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "mode": "local",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    }
+  ],
+  "record_id": "1583-claude-keen-ritchie-f1iifx",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [
+      "format_check",
+      "full_audit",
+      "lint_format"
+    ],
+    "docs": [],
+    "guards": [
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": []
+  },
+  "runtime": "claude-sonnet-4-6",
+  "schema_version": 2,
+  "scope_events": [
+    {
+      "action": "add-include",
+      "at": "2026-06-15T13:15:18.643287Z",
+      "pattern": "tests/api/test_filesystem_browse.py",
+      "reason": "plan"
+    }
+  ],
+  "session_id": "6cb8dd13-5eb8-4625-a15b-2b74d10ed0ca",
+  "strictness_tier": 2,
+  "task_kind": "bugfix",
+  "test_events": [
+    {
+      "at": "2026-06-15T13:15:18.643336Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/api/test_filesystem_browse.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-15T13:15:47.666963Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/api/test_filesystem_browse.py",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/tests/api/test_filesystem_browse.py
+++ b/tests/api/test_filesystem_browse.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import os
 from pathlib import Path
 
 import pytest
@@ -88,10 +87,11 @@ class TestBrowseFilesystem:
         assert resp.status_code == 400
 
     def test_path_traversal_outside_allowlist_is_rejected(self, client: TestClient, browse_dir: Path) -> None:
-        # A ``..`` escape that canonicalises outside the allowlist is rejected
-        # by the realpath+commonpath guard, not silently followed.
-        escaped_dir = "Windows" if os.name == "nt" else "etc"
-        escape = browse_dir.joinpath(*([".."] * (len(browse_dir.resolve().parts) - 1)), escaped_dir)
+        # Use the filesystem/drive root (browse_dir.anchor) so the escape is
+        # guaranteed to be outside the home/temp allowlist on every OS,
+        # regardless of tmp_path depth or how tempdir nests under home (Windows).
+        # The guard fires before any existence check so the name never needs to exist.
+        escape = Path(browse_dir.anchor) / "scistudio_nonexistent_outside_allowlist"
         resp = client.get(
             "/api/filesystem/browse",
             params={"path": str(escape)},


### PR DESCRIPTION
## Summary

Fix `test_path_traversal_outside_allowlist_is_rejected` to be OS-portable on all platforms (Linux, macOS, Windows).

## Root Cause

The test previously used OS-specific directory names (`etc` on POSIX, `Windows` on NT) combined with a dynamic `..`-level climb from `tmp_path`. On Windows, `gettempdir()` nests under `expanduser("~")` (`C:\Users\...\AppData\Local\Temp`), meaning a fixed `..` count could land back inside the home allowlist and return 404 instead of 400. The endpoint is correct; the test construction was not portable.

## Fix

Replace the platform-detection approach (`os.name == "nt"`) and `..`-level joinpath with a direct anchor-based construction:

```python
escape = Path(browse_dir.anchor) / "scistudio_nonexistent_outside_allowlist"
```

The filesystem root (`/` on POSIX, `C:\` on Windows) is always outside the home/temp allowlist on every OS. The allowlist guard fires before any existence check, so the name never needs to actually exist. Also removes the now-unused `import os`.

## Scope

Test-only portability fix. No production code, API contracts, or user-visible behaviour changed. No spec/ADR/changelog update required.

## Test Evidence

`tests/api/test_filesystem_browse.py` — 8/8 tests pass including the fixed `test_path_traversal_outside_allowlist_is_rejected`.

Gate record: `.workflow/records/1583-claude-keen-ritchie-f1iifx.json`

Closes #1583

---
_Generated by [Claude Code](https://claude.ai/code/session_01W174ipNZ9vDSqfbyYSVRUC)_