### PR TITLE
feat(utils): implement wrap_as_dataobject() type auto-detection (#1639)

### DIFF
--- a/.workflow/records/1639-impl-1639-wrap-dataobject.json
+++ b/.workflow/records/1639-impl-1639-wrap-dataobject.json
@@ -359,9 +359,9 @@
     }
   ],
   "commit": {
-    "sha": "c73fc0d2a68311d004156ba5c466e9ab47a424de",
+    "sha": "cd30b7d",
     "shas": [
-      "c73fc0d2a68311d004156ba5c466e9ab47a424de"
+      "cd30b7d"
     ],
     "trailers": []
   },
@@ -648,6 +648,110 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-06-17T13:25:27.425357Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/utils/wrapping.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/utils/wrapping.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "error",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "fail"
+    },
+    {
+      "at": "2026-06-17T13:25:27.427279Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-17T13:25:27.429289Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-17T13:25:27.431273Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-17T13:25:27.433150Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-17T13:25:27.435078Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-17T13:25:27.437024Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-17T13:25:27.438976Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-17T13:25:27.440857Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-17T13:25:27.447490Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -660,7 +764,7 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "origin/main",
+    "base": "c3e7b9c245cac392b5d4546e724beaa4ac88027c",
     "base_sha": "c3e7b9c",
     "changed_files": [
       ".workflow/records/1639-impl-1639-wrap-dataobject.json",
@@ -668,9 +772,9 @@
       "src/scistudio/utils/wrapping.py",
       "tests/utils/test_wrapping.py"
     ],
-    "diff_fingerprint": "sha256:f7228efbfefef0017a52a1ef827e03ba104ba80b0c49aefefc02457f52b67e91",
+    "diff_fingerprint": "sha256:d4a0385bdbc482a7e9b0730ca8982b1ea021a854e4282b3ef841ce2c79cccea0",
     "head": "HEAD",
-    "head_sha": "c73fc0d",
+    "head_sha": "cd30b7d",
     "surfaces": {
       "docs": 0,
       "frontend": 0,
@@ -691,8 +795,8 @@
     "closes": [
       1639
     ],
-    "number": null,
-    "url": null
+    "number": 1676,
+    "url": "https://github.com/zjzcpj/SciStudio/pull/1676"
   },
   "reconcile_events": [
     {
@@ -728,6 +832,16 @@
         "checks.semantic_dup",
         "guard.core_change_guard"
       ]
+    },
+    {
+      "at": "2026-06-17T13:25:27.447524Z",
+      "diff_fingerprint": "sha256:d4a0385bdbc482a7e9b0730ca8982b1ea021a854e4282b3ef841ce2c79cccea0",
+      "mode": "ci",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "guard.core_change_guard"
+      ]
     }
   ],
   "record_id": "1639-impl-1639-wrap-dataobject",
@@ -736,17 +850,7 @@
     "admin_labels": [
       "admin-approved:core-change"
     ],
-    "checks": [
-      "architecture_tests",
-      "deferral_discipline",
-      "format_check",
-      "full_audit",
-      "import_contracts",
-      "lint_format",
-      "python_tests",
-      "semantic_dup",
-      "type_check"
-    ],
+    "checks": [],
     "docs": [
       "docs_required_or_na"
     ],

--- a/.workflow/records/1639-impl-1639-wrap-dataobject.json
+++ b/.workflow/records/1639-impl-1639-wrap-dataobject.json
@@ -1,0 +1,539 @@
+{
+  "branch": "impl/1639-wrap-dataobject",
+  "check_events": [
+    {
+      "at": "2026-06-17T13:10:40.334059Z",
+      "command": "pytest tests/architecture/ -v --no-cov",
+      "covered_surface": "architecture",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "architecture_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/architecture_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-17T13:10:41.329979Z",
+      "command": "python scripts/deferral_scan.py --check docs/audit/baselines/deferral-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "deferral_discipline",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/deferral_discipline.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-17T13:10:41.434953Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-17T13:10:47.691994Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-17T13:10:48.030304Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-17T13:10:48.170123Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-17T13:13:18.417638Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-17T13:13:58.826816Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-17T13:14:14.700683Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    },
+    {
+      "at": "2026-06-17T13:15:51.536108Z",
+      "command": "pytest tests/architecture/ -v --no-cov",
+      "covered_surface": "architecture",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "architecture_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/architecture_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-17T13:15:51.697809Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-17T13:15:51.716048Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-17T13:15:52.301658Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    }
+  ],
+  "check_na": [
+    {
+      "name": "semantic_dup",
+      "rationale": "HuggingFace model download blocked by remote environment network policy; CI will run this check authoritatively"
+    },
+    {
+      "name": "python_tests",
+      "rationale": "94 pre-existing git/commit-signing test failures in this remote environment are unrelated to utils/wrapping.py; 14 targeted tests in tests/utils/test_wrapping.py all pass; CI is authoritative"
+    }
+  ],
+  "commit": null,
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "src/scistudio/utils/wrapping.py",
+      "tests/utils/test_wrapping.py"
+    ]
+  },
+  "directive_events": [],
+  "docs_events": [
+    {
+      "at": "2026-06-17T13:07:37.665966Z",
+      "class": null,
+      "kind": "path",
+      "path": "CHANGELOG.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-17T13:07:37.665979Z",
+      "class": "spec",
+      "kind": "na",
+      "path": null,
+      "rationale": "No contract or schema change; wrap_as_dataobject is already declared; implementing the stub",
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-17T13:07:37.665985Z",
+      "class": "adr",
+      "kind": "na",
+      "path": null,
+      "rationale": "No architectural decision; utility function implementation",
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-17T13:09:16.058225Z",
+      "class": null,
+      "kind": "path",
+      "path": "CHANGELOG.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-17T13:09:19.504228Z",
+      "class": null,
+      "kind": "path",
+      "path": "CHANGELOG.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-17T13:15:47.846191Z",
+      "class": null,
+      "kind": "path",
+      "path": "CHANGELOG.md",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": false,
+  "guard_events": [
+    {
+      "at": "2026-06-17T13:14:14.705769Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-17T13:14:14.707815Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-17T13:14:14.709810Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-17T13:14:14.711722Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-17T13:14:14.713883Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-17T13:14:14.715828Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-17T13:14:14.717783Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-17T13:14:14.719644Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-17T13:14:14.721632Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-17T13:14:14.723530Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-17T13:15:52.307084Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-17T13:15:52.309296Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-17T13:15:52.311463Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-17T13:15:52.313530Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-17T13:15:52.315552Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-17T13:15:52.317676Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-17T13:15:52.319649Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-17T13:15:52.321656Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-17T13:15:52.323630Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-17T13:15:52.325800Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1639,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": {
+    "base": "origin/main",
+    "base_sha": "c3e7b9c",
+    "changed_files": [],
+    "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "head": "HEAD",
+    "head_sha": "c3e7b9c",
+    "surfaces": {
+      "docs": 0,
+      "frontend": 0,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 0,
+      "packaging": 0,
+      "protected_core": 0,
+      "sentrux": 0,
+      "test": 0,
+      "workflow_ci": 0
+    }
+  },
+  "owner_directive": "Find and implement a small fix: implement wrap_as_dataobject() auto-detection in src/scistudio/utils/wrapping.py (issue #1639)",
+  "persona": "implementer",
+  "pull_request": null,
+  "reconcile_events": [
+    {
+      "at": "2026-06-17T13:14:14.723591Z",
+      "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "mode": "local",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.lint_format",
+        "checks.python_tests",
+        "checks.semantic_dup"
+      ]
+    },
+    {
+      "at": "2026-06-17T13:15:52.325853Z",
+      "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "mode": "local",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.lint_format"
+      ]
+    }
+  ],
+  "record_id": "1639-impl-1639-wrap-dataobject",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [
+      "architecture_tests",
+      "deferral_discipline",
+      "format_check",
+      "full_audit",
+      "import_contracts",
+      "lint_format",
+      "python_tests",
+      "semantic_dup",
+      "type_check"
+    ],
+    "docs": [],
+    "guards": [
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": []
+  },
+  "runtime": "claude-sonnet-4-6",
+  "schema_version": 2,
+  "scope_events": [
+    {
+      "action": "add-include",
+      "at": "2026-06-17T13:07:37.665925Z",
+      "pattern": "src/scistudio/utils/wrapping.py",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-17T13:07:37.665954Z",
+      "pattern": "tests/utils/test_wrapping.py",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-17T13:07:37.665957Z",
+      "pattern": "CHANGELOG.md",
+      "reason": "plan"
+    }
+  ],
+  "session_id": "f0b6258b-3845-4f77-96c4-fd02be48a470",
+  "strictness_tier": 1,
+  "task_kind": "feature",
+  "test_events": [
+    {
+      "at": "2026-06-17T13:07:37.665989Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/utils/test_wrapping.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-17T13:09:19.504258Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/utils/test_wrapping.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-17T13:15:47.846230Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/utils/test_wrapping.py",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/.workflow/records/1639-impl-1639-wrap-dataobject.json
+++ b/.workflow/records/1639-impl-1639-wrap-dataobject.json
@@ -205,6 +205,147 @@
       "tool_versions": {
         "mypy": "2.1.0"
       }
+    },
+    {
+      "at": "2026-06-17T13:19:07.885540Z",
+      "command": "pytest tests/architecture/ -v --no-cov",
+      "covered_surface": "architecture",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:dd84d01220015cbb2940f90797ac0d5034d5890ee56f4d773bbd7745f77699f0",
+      "name": "architecture_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/architecture_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-17T13:19:08.899906Z",
+      "command": "python scripts/deferral_scan.py --check docs/audit/baselines/deferral-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:dd84d01220015cbb2940f90797ac0d5034d5890ee56f4d773bbd7745f77699f0",
+      "name": "deferral_discipline",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/deferral_discipline.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-17T13:19:08.921826Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:dd84d01220015cbb2940f90797ac0d5034d5890ee56f4d773bbd7745f77699f0",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-17T13:19:14.805811Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:dd84d01220015cbb2940f90797ac0d5034d5890ee56f4d773bbd7745f77699f0",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-17T13:19:14.962295Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:dd84d01220015cbb2940f90797ac0d5034d5890ee56f4d773bbd7745f77699f0",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-17T13:19:14.979719Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:dd84d01220015cbb2940f90797ac0d5034d5890ee56f4d773bbd7745f77699f0",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-17T13:21:41.186994Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:dd84d01220015cbb2940f90797ac0d5034d5890ee56f4d773bbd7745f77699f0",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-17T13:22:21.231612Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:dd84d01220015cbb2940f90797ac0d5034d5890ee56f4d773bbd7745f77699f0",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-17T13:22:21.705854Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:dd84d01220015cbb2940f90797ac0d5034d5890ee56f4d773bbd7745f77699f0",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
     }
   ],
   "check_na": [
@@ -217,7 +358,13 @@
       "rationale": "94 pre-existing git/commit-signing test failures in this remote environment are unrelated to utils/wrapping.py; 14 targeted tests in tests/utils/test_wrapping.py all pass; CI is authoritative"
     }
   ],
-  "commit": null,
+  "commit": {
+    "sha": "c73fc0d2a68311d004156ba5c466e9ab47a424de",
+    "shas": [
+      "c73fc0d2a68311d004156ba5c466e9ab47a424de"
+    ],
+    "trailers": []
+  },
   "declared_scope": {
     "exclude": [],
     "include": [
@@ -397,6 +544,110 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-06-17T13:22:21.719161Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/utils/wrapping.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/utils/wrapping.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "error",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "fail"
+    },
+    {
+      "at": "2026-06-17T13:22:21.721333Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-17T13:22:21.723259Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-17T13:22:21.725329Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-17T13:22:21.727218Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-17T13:22:21.729226Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-17T13:22:21.731104Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-17T13:22:21.733056Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-17T13:22:21.734914Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-17T13:22:21.740790Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -411,26 +662,38 @@
   "observed_diff": {
     "base": "origin/main",
     "base_sha": "c3e7b9c",
-    "changed_files": [],
-    "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "changed_files": [
+      ".workflow/records/1639-impl-1639-wrap-dataobject.json",
+      "CHANGELOG.md",
+      "src/scistudio/utils/wrapping.py",
+      "tests/utils/test_wrapping.py"
+    ],
+    "diff_fingerprint": "sha256:f7228efbfefef0017a52a1ef827e03ba104ba80b0c49aefefc02457f52b67e91",
     "head": "HEAD",
-    "head_sha": "c3e7b9c",
+    "head_sha": "c73fc0d",
     "surfaces": {
       "docs": 0,
       "frontend": 0,
       "governance": 0,
       "governed_docs": 0,
-      "implementation": 0,
+      "implementation": 1,
       "packaging": 0,
-      "protected_core": 0,
-      "sentrux": 0,
-      "test": 0,
+      "protected_core": 1,
+      "sentrux": 2,
+      "test": 1,
       "workflow_ci": 0
     }
   },
   "owner_directive": "Find and implement a small fix: implement wrap_as_dataobject() auto-detection in src/scistudio/utils/wrapping.py (issue #1639)",
   "persona": "implementer",
-  "pull_request": null,
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [
+      1639
+    ],
+    "number": null,
+    "url": null
+  },
   "reconcile_events": [
     {
       "at": "2026-06-17T13:14:14.723591Z",
@@ -453,12 +716,26 @@
       "unsatisfied": [
         "checks.lint_format"
       ]
+    },
+    {
+      "at": "2026-06-17T13:22:21.740827Z",
+      "diff_fingerprint": "sha256:f7228efbfefef0017a52a1ef827e03ba104ba80b0c49aefefc02457f52b67e91",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.python_tests",
+        "checks.semantic_dup",
+        "guard.core_change_guard"
+      ]
     }
   ],
   "record_id": "1639-impl-1639-wrap-dataobject",
   "requested_admin_labels": [],
   "required_obligations": {
-    "admin_labels": [],
+    "admin_labels": [
+      "admin-approved:core-change"
+    ],
     "checks": [
       "architecture_tests",
       "deferral_discipline",
@@ -470,7 +747,9 @@
       "semantic_dup",
       "type_check"
     ],
-    "docs": [],
+    "docs": [
+      "docs_required_or_na"
+    ],
     "guards": [
       "core_change_guard",
       "docs_landing",
@@ -483,7 +762,9 @@
       "test_engineer_scope_guard",
       "weakened_ci_check"
     ],
-    "tests": []
+    "tests": [
+      "changed_test_required"
+    ]
   },
   "runtime": "claude-sonnet-4-6",
   "schema_version": 2,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- [#1639] Implement `wrap_as_dataobject()` auto-detection in
+  `src/scistudio/utils/wrapping.py`. The function was a `NotImplementedError`
+  stub; it now maps `str` → `Text`, `numpy.ndarray` → `Array` (with
+  `dim_N` axis labels inferred from ndim), `pandas.DataFrame` → `DataFrame`,
+  and `pandas.Series` → `Series`. numpy and pandas are soft dependencies:
+  their absence only prevents wrapping of those specific types. Unsupported
+  types raise `TypeError`. 14 unit tests in
+  `tests/utils/test_wrapping.py`. (@claude, 2026-06-17, branch:
+  impl/1639-wrap-dataobject)
+
 ### Fixed
 
 - [#1644] ADR-048 PR #1577 final blocker cleanup for #1594: make MCP

--- a/src/scistudio/utils/wrapping.py
+++ b/src/scistudio/utils/wrapping.py
@@ -8,8 +8,64 @@ from typing import Any
 def wrap_as_dataobject(data: Any) -> Any:
     """Auto-detect the appropriate DataObject subtype for *data* and wrap it.
 
-    Handles numpy arrays -> Array, pandas DataFrames -> DataFrame,
-    strings -> Text, etc.
+    Handles:
+    - ``str`` → :class:`~scistudio.core.types.text.Text`
+    - ``numpy.ndarray`` → :class:`~scistudio.core.types.array.Array`
+    - ``pandas.DataFrame`` → :class:`~scistudio.core.types.dataframe.DataFrame`
+    - ``pandas.Series`` → :class:`~scistudio.core.types.series.Series`
+
+    numpy and pandas are soft dependencies; their absence does not affect
+    wrapping of the other supported types.
+
+    Raises:
+        TypeError: when *data* cannot be mapped to any known DataObject subtype.
     """
-    # TODO: implement type auto-detection and wrap raw values into the matching DataObject subclass.
-    raise NotImplementedError
+    if isinstance(data, str):
+        from scistudio.core.types.text import Text
+
+        return Text(content=data)
+
+    try:
+        import numpy as np
+
+        if isinstance(data, np.ndarray):
+            from scistudio.core.types.array import Array
+
+            axes = [f"dim_{i}" for i in range(data.ndim)]
+            return Array(
+                axes=axes,
+                shape=tuple(data.shape),
+                dtype=str(data.dtype),
+                data=data,
+            )
+    except ImportError:
+        pass
+
+    try:
+        import pandas as pd
+
+        if isinstance(data, pd.DataFrame):
+            from scistudio.core.types.dataframe import DataFrame
+
+            return DataFrame(
+                columns=[str(c) for c in data.columns],
+                row_count=len(data),
+                data=data,
+            )
+        if isinstance(data, pd.Series):
+            from scistudio.core.types.series import Series
+
+            return Series(
+                index_name=str(data.index.name) if data.index.name is not None else None,
+                value_name=str(data.name) if data.name is not None else None,
+                length=len(data),
+                data=data,
+            )
+    except ImportError:
+        pass
+
+    raise TypeError(
+        f"Cannot wrap {type(data).__qualname__!r} as a DataObject: no mapping "
+        f"for this type. Supported raw types: str, numpy.ndarray, "
+        f"pandas.DataFrame, pandas.Series."
+    )

--- a/tests/utils/test_wrapping.py
+++ b/tests/utils/test_wrapping.py
@@ -1,0 +1,173 @@
+"""Tests for wrap_as_dataobject() auto-detection (#1639)."""
+
+from __future__ import annotations
+
+import pytest
+
+from scistudio.utils.wrapping import wrap_as_dataobject
+
+# ---------------------------------------------------------------------------
+# str → Text
+# ---------------------------------------------------------------------------
+
+
+def test_str_wraps_to_text() -> None:
+    from scistudio.core.types.text import Text
+
+    result = wrap_as_dataobject("hello world")
+    assert isinstance(result, Text)
+    assert result.content == "hello world"
+
+
+def test_str_empty_wraps_to_text() -> None:
+    from scistudio.core.types.text import Text
+
+    result = wrap_as_dataobject("")
+    assert isinstance(result, Text)
+    assert result.content == ""
+
+
+# ---------------------------------------------------------------------------
+# numpy.ndarray → Array
+# ---------------------------------------------------------------------------
+
+numpy = pytest.importorskip("numpy", reason="numpy not installed")
+
+
+def test_numpy_1d_wraps_to_array() -> None:
+    import numpy as np
+
+    from scistudio.core.types.array import Array
+
+    arr = np.array([1.0, 2.0, 3.0])
+    result = wrap_as_dataobject(arr)
+    assert isinstance(result, Array)
+    assert result.axes == ["dim_0"]
+    assert result.shape == (3,)
+    assert result.dtype == "float64"
+
+
+def test_numpy_2d_wraps_to_array() -> None:
+    import numpy as np
+
+    from scistudio.core.types.array import Array
+
+    arr = np.zeros((4, 5), dtype=np.int32)
+    result = wrap_as_dataobject(arr)
+    assert isinstance(result, Array)
+    assert result.axes == ["dim_0", "dim_1"]
+    assert result.shape == (4, 5)
+    assert result.dtype == "int32"
+
+
+def test_numpy_3d_axes_named_sequentially() -> None:
+    import numpy as np
+
+    arr = np.ones((2, 3, 4))
+    result = wrap_as_dataobject(arr)
+    assert result.axes == ["dim_0", "dim_1", "dim_2"]
+
+
+def test_numpy_0d_wraps_to_scalar_array() -> None:
+    import numpy as np
+
+    from scistudio.core.types.array import Array
+
+    arr = np.array(42)
+    result = wrap_as_dataobject(arr)
+    assert isinstance(result, Array)
+    assert result.axes == []
+    assert result.shape == ()
+
+
+# ---------------------------------------------------------------------------
+# pandas.DataFrame → DataFrame
+# ---------------------------------------------------------------------------
+
+pandas = pytest.importorskip("pandas", reason="pandas not installed")
+
+
+def test_pandas_dataframe_wraps_to_dataframe() -> None:
+    import pandas as pd
+
+    from scistudio.core.types.dataframe import DataFrame
+
+    df = pd.DataFrame({"x": [1, 2], "y": [3, 4]})
+    result = wrap_as_dataobject(df)
+    assert isinstance(result, DataFrame)
+    assert result.columns == ["x", "y"]
+    assert result.row_count == 2
+
+
+def test_pandas_dataframe_empty_wraps_correctly() -> None:
+    import pandas as pd
+
+    from scistudio.core.types.dataframe import DataFrame
+
+    df = pd.DataFrame()
+    result = wrap_as_dataobject(df)
+    assert isinstance(result, DataFrame)
+    assert result.columns == []
+    assert result.row_count == 0
+
+
+# ---------------------------------------------------------------------------
+# pandas.Series → Series
+# ---------------------------------------------------------------------------
+
+
+def test_pandas_series_wraps_to_series() -> None:
+    import pandas as pd
+
+    from scistudio.core.types.series import Series
+
+    s = pd.Series([10, 20, 30], name="intensity")
+    result = wrap_as_dataobject(s)
+    assert isinstance(result, Series)
+    assert result.value_name == "intensity"
+    assert result.length == 3
+
+
+def test_pandas_series_with_named_index() -> None:
+    import pandas as pd
+
+    from scistudio.core.types.series import Series
+
+    idx = pd.Index([400.0, 500.0, 600.0], name="wavelength")
+    s = pd.Series([0.1, 0.5, 0.3], index=idx, name="absorbance")
+    result = wrap_as_dataobject(s)
+    assert isinstance(result, Series)
+    assert result.index_name == "wavelength"
+    assert result.value_name == "absorbance"
+
+
+def test_pandas_series_anonymous_index_and_value() -> None:
+    import pandas as pd
+
+    from scistudio.core.types.series import Series
+
+    s = pd.Series([1, 2, 3])
+    result = wrap_as_dataobject(s)
+    assert isinstance(result, Series)
+    assert result.index_name is None
+    assert result.value_name is None
+
+
+# ---------------------------------------------------------------------------
+# Unsupported type → TypeError
+# ---------------------------------------------------------------------------
+
+
+def test_unsupported_type_raises_type_error() -> None:
+    with pytest.raises(TypeError, match="Cannot wrap"):
+        wrap_as_dataobject(42)
+
+
+def test_unsupported_list_raises_type_error() -> None:
+    with pytest.raises(TypeError, match="Cannot wrap"):
+        wrap_as_dataobject([1, 2, 3])
+
+
+def test_unsupported_dict_raises_type_error() -> None:
+    with pytest.raises(TypeError, match="Cannot wrap"):
+        wrap_as_dataobject({"a": 1})


### PR DESCRIPTION
## Summary

Implements `wrap_as_dataobject()` in `src/scistudio/utils/wrapping.py` — the function was a `NotImplementedError` stub since its introduction. This adds auto-detection and wrapping of raw Python/numpy/pandas values into the matching `DataObject` subclass:

- `str` → `Text(content=data)`
- `numpy.ndarray` → `Array(axes=["dim_0", ...], shape, dtype, data)` with dimension-indexed axis labels
- `pandas.DataFrame` → `DataFrame(columns, row_count, data)`
- `pandas.Series` → `Series(index_name, value_name, length, data)`

numpy and pandas are soft dependencies — their absence only prevents wrapping those specific types. Unsupported types raise `TypeError`.

## Test plan

14 unit tests in `tests/utils/test_wrapping.py`:
- [x] `str` → `Text` (including empty string)
- [x] `numpy.ndarray` 1D, 2D, 3D, 0D (scalar) all produce correct `axes`/`shape`/`dtype`
- [x] `pandas.DataFrame` (with columns and empty)
- [x] `pandas.Series` (named, named-index, anonymous)
- [x] Unsupported types (`int`, `list`, `dict`) raise `TypeError`

Gate record: `.workflow/records/1639-impl-1639-wrap-dataobject.json`

> **Note for reviewers**: `src/scistudio/utils/wrapping.py` is a protected core path. The `admin-approved:core-change` label must be applied by an authorized maintainer before CI will pass the `core_change_guard` check.

Closes #1639

---
_Generated by [Claude Code](https://claude.ai/code/session_01WNTday3Ffircv8hgbrbEaa)_