### PR TITLE
feat(#1684): implement context-free plot collection API

### DIFF
--- a/.workflow/records/1684-plot-render-collection-api.json
+++ b/.workflow/records/1684-plot-render-collection-api.json
@@ -1,0 +1,1227 @@
+{
+  "branch": "feat/1684-plot-render-collection-api",
+  "check_events": [
+    {
+      "at": "2026-06-18T07:36:48.723602Z",
+      "command": "pytest tests/architecture/ -v --no-cov",
+      "covered_surface": "architecture",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "architecture_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/architecture_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T07:36:49.603886Z",
+      "command": "python scripts/deferral_scan.py --check docs/audit/baselines/deferral-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "deferral_discipline",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/deferral_discipline.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T07:36:49.708476Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-18T07:37:01.905654Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T07:37:02.149705Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T07:37:02.194855Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-18T07:42:35.723731Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T07:43:35.191283Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T07:43:35.981387Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    },
+    {
+      "at": "2026-06-18T07:50:20.152110Z",
+      "command": "pytest tests/architecture/ -v --no-cov",
+      "covered_surface": "architecture",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "architecture_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/architecture_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T07:50:21.038737Z",
+      "command": "python scripts/deferral_scan.py --check docs/audit/baselines/deferral-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "deferral_discipline",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/deferral_discipline.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T07:50:21.089234Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-18T07:50:30.924778Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T07:50:31.164556Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T07:50:31.203252Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-18T07:53:46.821826Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T07:54:43.623735Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T07:54:44.806667Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    },
+    {
+      "at": "2026-06-18T07:55:20.792901Z",
+      "command": "pytest tests/architecture/ -v --no-cov",
+      "covered_surface": "architecture",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "architecture_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/architecture_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T07:55:21.687175Z",
+      "command": "python scripts/deferral_scan.py --check docs/audit/baselines/deferral-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "deferral_discipline",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/deferral_discipline.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T07:55:21.725572Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-18T07:55:31.608707Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T07:55:31.831425Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T07:55:31.868868Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-18T07:58:48.026928Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T07:59:43.673131Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T07:59:44.378514Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    },
+    {
+      "at": "2026-06-18T08:03:03.341403Z",
+      "command": "pytest tests/architecture/ -v --no-cov",
+      "covered_surface": "architecture",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "architecture_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/architecture_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T08:03:04.199035Z",
+      "command": "python scripts/deferral_scan.py --check docs/audit/baselines/deferral-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "deferral_discipline",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/deferral_discipline.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T08:03:04.240583Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-18T08:03:14.160635Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T08:03:14.392353Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T08:03:14.430402Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-18T08:07:08.111392Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T08:08:02.924402Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T08:08:05.958706Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    },
+    {
+      "at": "2026-06-18T08:08:38.705825Z",
+      "command": "pytest tests/architecture/ -v --no-cov",
+      "covered_surface": "architecture",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "architecture_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/architecture_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T08:08:39.542227Z",
+      "command": "python scripts/deferral_scan.py --check docs/audit/baselines/deferral-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "deferral_discipline",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/deferral_discipline.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T08:08:39.580458Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-18T08:08:49.491964Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T08:08:49.716434Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T08:08:49.751103Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-18T08:12:03.345055Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T08:12:58.248046Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T08:12:58.938046Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    }
+  ],
+  "check_na": [],
+  "commit": null,
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "docs/specs/adr-048-plot-render-collection-ux.md",
+      "docs/specs/adr-048-ai-plot-tools.md",
+      "docs/block-development/previewers-and-plots.md",
+      "src/scistudio/ai/agent/mcp/tools_plot/_harness.py",
+      "src/scistudio/ai/agent/mcp/tools_plot/runtime.py",
+      "src/scistudio/ai/agent/mcp/tools_plot/validation.py",
+      "src/scistudio/ai/agent/mcp/tools_plot/scaffold.py",
+      "src/scistudio/ai/agent/mcp/tools_plot/examples.py",
+      "src/scistudio/_skills/scistudio/scistudio-write-plot/SKILL.md",
+      "tests/ai/test_mcp_tools_plot.py",
+      "tests/api/test_preview_plot_jobs.py"
+    ]
+  },
+  "directive_events": [
+    {
+      "at": "2026-06-18T07:13:33.480819Z",
+      "owner_directive": "Complete #1684 per spec: context-free render API for Python/R, no compatibility layer, core-base collection helpers, native conversions, memory guard, docs/tests updated.",
+      "reason": "plan"
+    }
+  ],
+  "docs_events": [
+    {
+      "at": "2026-06-18T07:13:33.480840Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/specs/adr-048-plot-render-collection-ux.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-18T07:13:33.480849Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/specs/adr-048-ai-plot-tools.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-18T07:13:33.480852Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/block-development/previewers-and-plots.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-18T07:13:33.480854Z",
+      "class": null,
+      "kind": "path",
+      "path": "src/scistudio/_skills/scistudio/scistudio-write-plot/SKILL.md",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": false,
+  "guard_events": [
+    {
+      "at": "2026-06-18T07:43:36.248443Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T07:43:36.320719Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T07:43:36.388041Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T07:43:36.450337Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T07:43:36.511241Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T07:43:36.571964Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T07:43:36.629755Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T07:43:36.685380Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T07:43:36.740561Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T07:43:36.841886Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T07:54:44.944887Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T07:54:45.010160Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T07:54:45.071654Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T07:54:45.145860Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T07:54:45.236149Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T07:54:45.298715Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T07:54:45.363911Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T07:54:45.423345Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T07:54:45.482185Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T07:54:45.538543Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T07:59:44.497604Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T07:59:44.553531Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T07:59:44.613869Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T07:59:44.673408Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T07:59:44.728930Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T07:59:44.792030Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T07:59:44.850843Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T07:59:44.927545Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T07:59:44.996145Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T07:59:45.055005Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T08:08:06.073200Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T08:08:06.134277Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T08:08:06.188059Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T08:08:06.241413Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T08:08:06.302872Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T08:08:06.356623Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T08:08:06.409874Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T08:08:06.462554Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T08:08:06.514819Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T08:08:06.567434Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T08:12:59.050198Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T08:12:59.105707Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T08:12:59.166119Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T08:12:59.228651Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T08:12:59.283382Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T08:12:59.337916Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T08:12:59.392195Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T08:12:59.452199Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T08:12:59.555185Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T08:12:59.618166Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1684,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": {
+    "base": "b6083ceabb7b390a30d5d111c49491d9c8bd60cb",
+    "base_sha": "b6083cea",
+    "changed_files": [],
+    "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "head": "HEAD",
+    "head_sha": "b6083cea",
+    "surfaces": {
+      "docs": 0,
+      "frontend": 0,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 0,
+      "packaging": 0,
+      "protected_core": 0,
+      "sentrux": 0,
+      "test": 0,
+      "workflow_ci": 0
+    }
+  },
+  "owner_directive": "Implement issue #1684 completely from docs/specs/adr-048-plot-render-collection-ux.md: remove plot context API, add context-free collection wrappers for Python and R, native conversions, memory guard, docs, tests, gate, and PR. Do not use issue1654.",
+  "persona": "implementer",
+  "pull_request": null,
+  "reconcile_events": [
+    {
+      "at": "2026-06-18T07:43:36.841937Z",
+      "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.format_check",
+        "checks.python_tests",
+        "checks.semantic_dup"
+      ]
+    },
+    {
+      "at": "2026-06-18T07:54:45.538602Z",
+      "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-18T07:59:45.055063Z",
+      "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-18T08:08:06.567480Z",
+      "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.full_audit"
+      ]
+    },
+    {
+      "at": "2026-06-18T08:12:59.618221Z",
+      "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    }
+  ],
+  "record_id": "1684-plot-render-collection-api",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [
+      "architecture_tests",
+      "deferral_discipline",
+      "format_check",
+      "full_audit",
+      "import_contracts",
+      "lint_format",
+      "python_tests",
+      "semantic_dup",
+      "type_check"
+    ],
+    "docs": [],
+    "guards": [
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": []
+  },
+  "runtime": "codex",
+  "schema_version": 2,
+  "scope_events": [
+    {
+      "action": "add-include",
+      "at": "2026-06-18T07:33:26.203748Z",
+      "pattern": "src/scistudio/ai/agent/mcp/tools_plot/models.py",
+      "reason": "Add PlotManifestLimits model update for max_input_bytes scope."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-18T07:45:01.746563Z",
+      "pattern": "tests/api/test_plot_preview_wiring.py",
+      "reason": "Add API plot preview wiring regression tests updated for context-free render API."
+    }
+  ],
+  "session_id": "4ec3190d-1a3a-4451-9e43-4d85cd93c7fc",
+  "strictness_tier": 1,
+  "task_kind": "feature",
+  "test_events": [
+    {
+      "at": "2026-06-18T07:13:33.480859Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/ai/test_mcp_tools_plot.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-18T07:13:33.480863Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/api/test_preview_plot_jobs.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-18T07:45:01.746616Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/api/test_plot_preview_wiring.py",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/.workflow/records/1684-plot-render-collection-api.json
+++ b/.workflow/records/1684-plot-render-collection-api.json
@@ -987,6 +987,147 @@
       "tool_versions": {
         "mypy": "2.1.0"
       }
+    },
+    {
+      "at": "2026-06-18T18:03:25.982087Z",
+      "command": "pytest tests/architecture/ -v --no-cov",
+      "covered_surface": "architecture",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:ac04c47e9ea3b1910cf9550b3f3a5b75a0cf272ff0176d442cffd22698834651",
+      "name": "architecture_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/architecture_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T18:03:26.691054Z",
+      "command": "python scripts/deferral_scan.py --check docs/audit/baselines/deferral-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:ac04c47e9ea3b1910cf9550b3f3a5b75a0cf272ff0176d442cffd22698834651",
+      "name": "deferral_discipline",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/deferral_discipline.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T18:03:27.307462Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:ac04c47e9ea3b1910cf9550b3f3a5b75a0cf272ff0176d442cffd22698834651",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-18T18:03:31.285751Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:ac04c47e9ea3b1910cf9550b3f3a5b75a0cf272ff0176d442cffd22698834651",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T18:03:31.837171Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:ac04c47e9ea3b1910cf9550b3f3a5b75a0cf272ff0176d442cffd22698834651",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T18:03:31.888153Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:ac04c47e9ea3b1910cf9550b3f3a5b75a0cf272ff0176d442cffd22698834651",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-18T18:05:28.187865Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:ac04c47e9ea3b1910cf9550b3f3a5b75a0cf272ff0176d442cffd22698834651",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T18:07:26.704307Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:ac04c47e9ea3b1910cf9550b3f3a5b75a0cf272ff0176d442cffd22698834651",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T18:07:34.714079Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:ac04c47e9ea3b1910cf9550b3f3a5b75a0cf272ff0176d442cffd22698834651",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
     }
   ],
   "check_na": [],
@@ -1017,6 +1158,16 @@
     {
       "at": "2026-06-18T07:13:33.480819Z",
       "owner_directive": "Complete #1684 per spec: context-free render API for Python/R, no compatibility layer, core-base collection helpers, native conversions, memory guard, docs/tests updated.",
+      "reason": "plan"
+    },
+    {
+      "at": "2026-06-18T17:56:52.900378Z",
+      "owner_directive": "Fix the two Codex review comments on PR 1685 and push one commit back to the PR branch.",
+      "reason": "Address PR 1685 Codex review threads: enforce cumulative collection.items.open() input cap in Python/R and avoid blank R base-device artifact for path returns."
+    },
+    {
+      "at": "2026-06-18T17:56:53.079209Z",
+      "owner_directive": "Implement PR 1685 Codex review fixes in the plot harness with regression coverage.",
       "reason": "plan"
     }
   ],
@@ -1051,6 +1202,22 @@
       "kind": "path",
       "path": "src/scistudio/_skills/scistudio/scistudio-write-plot/SKILL.md",
       "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-18T17:56:52.900654Z",
+      "class": "review-fix",
+      "kind": "na",
+      "path": null,
+      "rationale": "No documentation change; this tightens the existing documented memory cap and artifact promotion behavior.",
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-18T17:56:53.079369Z",
+      "class": "review-fix",
+      "kind": "na",
+      "path": null,
+      "rationale": "No public contract text changes required for these review fixes.",
       "verified_in_diff": null
     }
   ],
@@ -1601,6 +1768,88 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-06-18T18:07:34.790791Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T18:07:34.801954Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T18:07:34.812618Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T18:07:34.823231Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T18:07:34.833401Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T18:07:34.844158Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T18:07:34.854997Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T18:07:34.869401Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T18:07:34.881467Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T18:07:34.902483Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -1613,7 +1862,7 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "b6083ceabb7b390a30d5d111c49491d9c8bd60cb",
+    "base": "origin/main",
     "base_sha": "b6083cea",
     "changed_files": [
       ".workflow/records/1684-plot-render-collection-api.json",
@@ -1631,9 +1880,9 @@
       "tests/api/test_plot_preview_wiring.py",
       "tests/api/test_preview_plot_jobs.py"
     ],
-    "diff_fingerprint": "sha256:b759834a46fe77f95515c9a9ab826f5798a62013a470dff009eb2789f454e786",
+    "diff_fingerprint": "sha256:012bd235c01edf715d3956b4abc53ba3cd666cff53d8a843c9c4c3dd97d85c72",
     "head": "HEAD",
-    "head_sha": "4d5f2560",
+    "head_sha": "104b3112",
     "surfaces": {
       "docs": 3,
       "frontend": 0,
@@ -1727,13 +1976,31 @@
       "result": "pass",
       "tier": 1,
       "unsatisfied": []
+    },
+    {
+      "at": "2026-06-18T18:07:34.902529Z",
+      "diff_fingerprint": "sha256:012bd235c01edf715d3956b4abc53ba3cd666cff53d8a843c9c4c3dd97d85c72",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
     }
   ],
   "record_id": "1684-plot-render-collection-api",
   "requested_admin_labels": [],
   "required_obligations": {
     "admin_labels": [],
-    "checks": [],
+    "checks": [
+      "architecture_tests",
+      "deferral_discipline",
+      "format_check",
+      "full_audit",
+      "import_contracts",
+      "lint_format",
+      "python_tests",
+      "semantic_dup",
+      "type_check"
+    ],
     "docs": [
       "docs_required_or_na"
     ],
@@ -1767,6 +2034,30 @@
       "at": "2026-06-18T07:45:01.746563Z",
       "pattern": "tests/api/test_plot_preview_wiring.py",
       "reason": "Add API plot preview wiring regression tests updated for context-free render API."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-18T17:56:52.900631Z",
+      "pattern": "src/scistudio/ai/agent/mcp/tools_plot/_harness.py",
+      "reason": "Address PR 1685 Codex review threads: enforce cumulative collection.items.open() input cap in Python/R and avoid blank R base-device artifact for path returns."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-18T17:56:52.900637Z",
+      "pattern": "tests/ai/test_mcp_tools_plot.py",
+      "reason": "Address PR 1685 Codex review threads: enforce cumulative collection.items.open() input cap in Python/R and avoid blank R base-device artifact for path returns."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-18T17:56:53.079354Z",
+      "pattern": "src/scistudio/ai/agent/mcp/tools_plot/_harness.py",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-18T17:56:53.079360Z",
+      "pattern": "tests/ai/test_mcp_tools_plot.py",
+      "reason": "plan"
     }
   ],
   "session_id": "4ec3190d-1a3a-4451-9e43-4d85cd93c7fc",
@@ -1794,6 +2085,22 @@
       "class": null,
       "kind": "path",
       "path": "tests/api/test_plot_preview_wiring.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-18T17:56:52.900925Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/ai/test_mcp_tools_plot.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-18T17:56:53.079377Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/ai/test_mcp_tools_plot.py",
       "rationale": null,
       "verified_in_diff": null
     }

--- a/.workflow/records/1684-plot-render-collection-api.json
+++ b/.workflow/records/1684-plot-render-collection-api.json
@@ -705,10 +705,157 @@
       "tool_versions": {
         "mypy": "2.1.0"
       }
+    },
+    {
+      "at": "2026-06-18T08:17:08.494469Z",
+      "command": "pytest tests/architecture/ -v --no-cov",
+      "covered_surface": "architecture",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:ac04c47e9ea3b1910cf9550b3f3a5b75a0cf272ff0176d442cffd22698834651",
+      "name": "architecture_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/architecture_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T08:17:09.346684Z",
+      "command": "python scripts/deferral_scan.py --check docs/audit/baselines/deferral-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:ac04c47e9ea3b1910cf9550b3f3a5b75a0cf272ff0176d442cffd22698834651",
+      "name": "deferral_discipline",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/deferral_discipline.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T08:17:09.386073Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:ac04c47e9ea3b1910cf9550b3f3a5b75a0cf272ff0176d442cffd22698834651",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-18T08:17:19.896345Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:ac04c47e9ea3b1910cf9550b3f3a5b75a0cf272ff0176d442cffd22698834651",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T08:17:20.138663Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:ac04c47e9ea3b1910cf9550b3f3a5b75a0cf272ff0176d442cffd22698834651",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T08:17:20.178672Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:ac04c47e9ea3b1910cf9550b3f3a5b75a0cf272ff0176d442cffd22698834651",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-18T08:21:13.990600Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:ac04c47e9ea3b1910cf9550b3f3a5b75a0cf272ff0176d442cffd22698834651",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T08:22:08.350421Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:ac04c47e9ea3b1910cf9550b3f3a5b75a0cf272ff0176d442cffd22698834651",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T08:22:09.052908Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:ac04c47e9ea3b1910cf9550b3f3a5b75a0cf272ff0176d442cffd22698834651",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
     }
   ],
   "check_na": [],
-  "commit": null,
+  "commit": {
+    "sha": "55bdd653258099d864f301412b3d327eb3db3da9",
+    "shas": [
+      "55bdd653258099d864f301412b3d327eb3db3da9"
+    ],
+    "trailers": []
+  },
   "declared_scope": {
     "exclude": [],
     "include": [
@@ -1067,6 +1214,88 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-06-18T08:22:09.172954Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T08:22:09.226373Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T08:22:09.283463Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T08:22:09.338443Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T08:22:09.401149Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T08:22:09.457685Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T08:22:09.514188Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T08:22:09.583713Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T08:22:09.648762Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T08:22:09.721754Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -1081,26 +1310,48 @@
   "observed_diff": {
     "base": "b6083ceabb7b390a30d5d111c49491d9c8bd60cb",
     "base_sha": "b6083cea",
-    "changed_files": [],
-    "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "changed_files": [
+      ".workflow/records/1684-plot-render-collection-api.json",
+      "docs/block-development/previewers-and-plots.md",
+      "docs/specs/adr-048-ai-plot-tools.md",
+      "docs/specs/adr-048-plot-render-collection-ux.md",
+      "src/scistudio/_skills/scistudio/scistudio-write-plot/SKILL.md",
+      "src/scistudio/ai/agent/mcp/tools_plot/_harness.py",
+      "src/scistudio/ai/agent/mcp/tools_plot/examples.py",
+      "src/scistudio/ai/agent/mcp/tools_plot/models.py",
+      "src/scistudio/ai/agent/mcp/tools_plot/runtime.py",
+      "src/scistudio/ai/agent/mcp/tools_plot/scaffold.py",
+      "src/scistudio/ai/agent/mcp/tools_plot/validation.py",
+      "tests/ai/test_mcp_tools_plot.py",
+      "tests/api/test_plot_preview_wiring.py",
+      "tests/api/test_preview_plot_jobs.py"
+    ],
+    "diff_fingerprint": "sha256:0ff1ec57e0654314448325e372a60e664aba3a9bf4d6397dc03a5af48d493448",
     "head": "HEAD",
-    "head_sha": "b6083cea",
+    "head_sha": "55bdd653",
     "surfaces": {
-      "docs": 0,
+      "docs": 3,
       "frontend": 0,
       "governance": 0,
       "governed_docs": 0,
-      "implementation": 0,
+      "implementation": 7,
       "packaging": 0,
       "protected_core": 0,
-      "sentrux": 0,
-      "test": 0,
+      "sentrux": 12,
+      "test": 3,
       "workflow_ci": 0
     }
   },
   "owner_directive": "Implement issue #1684 completely from docs/specs/adr-048-plot-render-collection-ux.md: remove plot context API, add context-free collection wrappers for Python and R, native conversions, memory guard, docs, tests, gate, and PR. Do not use issue1654.",
   "persona": "implementer",
-  "pull_request": null,
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [
+      1684
+    ],
+    "number": null,
+    "url": null
+  },
   "reconcile_events": [
     {
       "at": "2026-06-18T07:43:36.841937Z",
@@ -1147,6 +1398,14 @@
       "result": "pass",
       "tier": 1,
       "unsatisfied": []
+    },
+    {
+      "at": "2026-06-18T08:22:09.721790Z",
+      "diff_fingerprint": "sha256:0ff1ec57e0654314448325e372a60e664aba3a9bf4d6397dc03a5af48d493448",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
     }
   ],
   "record_id": "1684-plot-render-collection-api",
@@ -1164,7 +1423,9 @@
       "semantic_dup",
       "type_check"
     ],
-    "docs": [],
+    "docs": [
+      "docs_required_or_na"
+    ],
     "guards": [
       "core_change_guard",
       "docs_landing",
@@ -1177,7 +1438,9 @@
       "test_engineer_scope_guard",
       "weakened_ci_check"
     ],
-    "tests": []
+    "tests": [
+      "changed_test_required"
+    ]
   },
   "runtime": "codex",
   "schema_version": 2,

--- a/.workflow/records/1684-plot-render-collection-api.json
+++ b/.workflow/records/1684-plot-render-collection-api.json
@@ -846,13 +846,154 @@
       "tool_versions": {
         "mypy": "2.1.0"
       }
+    },
+    {
+      "at": "2026-06-18T08:23:28.238405Z",
+      "command": "pytest tests/architecture/ -v --no-cov",
+      "covered_surface": "architecture",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:ac04c47e9ea3b1910cf9550b3f3a5b75a0cf272ff0176d442cffd22698834651",
+      "name": "architecture_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/architecture_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T08:23:29.079027Z",
+      "command": "python scripts/deferral_scan.py --check docs/audit/baselines/deferral-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:ac04c47e9ea3b1910cf9550b3f3a5b75a0cf272ff0176d442cffd22698834651",
+      "name": "deferral_discipline",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/deferral_discipline.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T08:23:29.117255Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:ac04c47e9ea3b1910cf9550b3f3a5b75a0cf272ff0176d442cffd22698834651",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-18T08:23:38.550183Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:ac04c47e9ea3b1910cf9550b3f3a5b75a0cf272ff0176d442cffd22698834651",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T08:23:38.777909Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:ac04c47e9ea3b1910cf9550b3f3a5b75a0cf272ff0176d442cffd22698834651",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T08:23:38.814593Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:ac04c47e9ea3b1910cf9550b3f3a5b75a0cf272ff0176d442cffd22698834651",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-18T08:26:57.054132Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:ac04c47e9ea3b1910cf9550b3f3a5b75a0cf272ff0176d442cffd22698834651",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T08:27:51.352362Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:ac04c47e9ea3b1910cf9550b3f3a5b75a0cf272ff0176d442cffd22698834651",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T08:27:52.039763Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:ac04c47e9ea3b1910cf9550b3f3a5b75a0cf272ff0176d442cffd22698834651",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
     }
   ],
   "check_na": [],
   "commit": {
-    "sha": "55bdd653258099d864f301412b3d327eb3db3da9",
+    "sha": "4d5f2560",
     "shas": [
-      "55bdd653258099d864f301412b3d327eb3db3da9"
+      "4d5f2560"
     ],
     "trailers": []
   },
@@ -1296,6 +1437,170 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-06-18T08:27:52.164545Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T08:27:52.222386Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T08:27:52.278716Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T08:27:52.341344Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T08:27:52.397493Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T08:27:52.454222Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T08:27:52.508949Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T08:27:52.575403Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T08:27:52.643245Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T08:27:52.721708Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T08:28:16.540898Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T08:28:16.594115Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T08:28:16.649929Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T08:28:16.709122Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T08:28:16.762421Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T08:28:16.816690Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T08:28:16.871358Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T08:28:16.924372Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T08:28:16.976857Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T08:28:17.043958Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -1326,9 +1631,9 @@
       "tests/api/test_plot_preview_wiring.py",
       "tests/api/test_preview_plot_jobs.py"
     ],
-    "diff_fingerprint": "sha256:0ff1ec57e0654314448325e372a60e664aba3a9bf4d6397dc03a5af48d493448",
+    "diff_fingerprint": "sha256:b759834a46fe77f95515c9a9ab826f5798a62013a470dff009eb2789f454e786",
     "head": "HEAD",
-    "head_sha": "55bdd653",
+    "head_sha": "4d5f2560",
     "surfaces": {
       "docs": 3,
       "frontend": 0,
@@ -1349,7 +1654,7 @@
     "closes": [
       1684
     ],
-    "number": null,
+    "number": 1685,
     "url": null
   },
   "reconcile_events": [
@@ -1406,23 +1711,29 @@
       "result": "pass",
       "tier": 1,
       "unsatisfied": []
+    },
+    {
+      "at": "2026-06-18T08:27:52.721742Z",
+      "diff_fingerprint": "sha256:b759834a46fe77f95515c9a9ab826f5798a62013a470dff009eb2789f454e786",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-18T08:28:17.043995Z",
+      "diff_fingerprint": "sha256:b759834a46fe77f95515c9a9ab826f5798a62013a470dff009eb2789f454e786",
+      "mode": "ci",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
     }
   ],
   "record_id": "1684-plot-render-collection-api",
   "requested_admin_labels": [],
   "required_obligations": {
     "admin_labels": [],
-    "checks": [
-      "architecture_tests",
-      "deferral_discipline",
-      "format_check",
-      "full_audit",
-      "import_contracts",
-      "lint_format",
-      "python_tests",
-      "semantic_dup",
-      "type_check"
-    ],
+    "checks": [],
     "docs": [
       "docs_required_or_na"
     ],

--- a/docs/block-development/previewers-and-plots.md
+++ b/docs/block-development/previewers-and-plots.md
@@ -400,7 +400,7 @@ outputs:
 runtime:
   timeout_seconds: 30
 limits:
-  max_rows: 10000
+  max_input_bytes: 67108864
   max_output_bytes: 10485760    # 10 MiB
   max_files: 8
 ```
@@ -414,36 +414,82 @@ hand-edited manifest cannot raise the caps beyond the safe envelope
 
 ## The render contract (Python and R)
 
-The render script exposes a single `render(collection, context)` entry point.
+The render script exposes a single context-free entry point. `context` is not a
+plot authoring API.
 
-**Python** — `render(collection, context)`:
+**Python** - `render(collection)`:
 
 ```python
-def render(collection, context):
-    df = context.to_dataframe(collection, max_rows=10000)
-    fig, ax = context.plt.subplots()
+def render(collection):
+    import matplotlib.pyplot as plt
+
+    df = collection.items.open_one()
+    fig, ax = plt.subplots()
     ax.scatter(df["x"], df["y"], s=6)
-    return context.save_figure(fig, "figure.svg")
+    return fig
 ```
 
-**R** — `render <- function(collection, context)`:
+**R** - `render <- function(collection)`:
 
 ```r
-render <- function(collection, context) {
-  df <- context$to_dataframe(collection, max_rows = 10000)
-  p <- ggplot2::ggplot(df, ggplot2::aes(x = x, y = y)) +
+render <- function(collection) {
+  df <- collection$items$open_one()
+  ggplot2::ggplot(df, ggplot2::aes(x = x, y = y)) +
     ggplot2::geom_point()
-  context$save_plot(p, "figure.pdf")
 }
 ```
 
-`context` helpers are preview-only — there are **no** workflow-mutation APIs:
+Python collection helpers:
 
-- `context.to_dataframe(collection, max_rows=...)` — bounded DataFrame.
-- `context.items(collection, max_items=...)` — bounded iteration over refs.
-- `context.plt` — `matplotlib.pyplot` (Agg backend).
-- `context.save_figure(fig, "figure.svg")` / `context.save_plot(...)` — save a
-  PNG / JPEG / SVG / PDF artifact. SVG is sanitized before display.
+| API | Result |
+|---|---|
+| `collection.types` | `tuple[str, ...]` of normalized core base types. |
+| `collection.items` | Sequence-like item wrapper. |
+| `len(collection.items)` | Number of items. |
+| `for item in collection.items` | Iterate item wrappers. |
+| `collection.items[index]` | One item wrapper. |
+| `collection.items[start:stop]` | List of item wrappers. |
+| `collection.items.open()` | List of native Python values. |
+| `collection.items.open(max_items=n)` | List of at most `n` native Python values. |
+| `collection.items.open_one()` | First native Python value. |
+| `item.type` | One normalized core base type name. |
+| `item.metadata` | Read-only non-storage metadata mapping. |
+| `item.open()` | One native Python value. |
+
+R collection helpers:
+
+| API | Result |
+|---|---|
+| `collection$types` | Character vector of normalized core base types. |
+| `collection$items` | Sequence-like item wrapper. |
+| `length(collection$items)` | Number of items. |
+| `collection$items[[index]]` | One item wrapper. |
+| `collection$items$open()` | List of native R values. |
+| `collection$items$open(max_items = n)` | List of at most `n` native R values. |
+| `collection$items$open_one()` | First native R value. |
+| `collection$items[[index]]$type` | One normalized core base type name. |
+| `collection$items[[index]]$metadata` | Non-storage metadata list. |
+| `collection$items[[index]]$open()` | One native R value. |
+
+Native conversion table:
+
+| Core base type | Python `open()` result | R `open()` result |
+|---|---|---|
+| `Array` | `numpy.ndarray` | `matrix` for 2-D data, `array` otherwise |
+| `DataFrame` | `pandas.DataFrame` | `data.frame` |
+| `Series` | `pandas.Series` | atomic vector |
+| `Text` | `str` | character scalar |
+| `Artifact` | `pathlib.Path` | character scalar path |
+| `CompositeData` | `dict[str, native]` recursively | named list recursively |
+
+Package-defined subclasses are folded back to the nearest supported core base
+type before user code sees them. For example, package `Image` and `Mask`
+subclasses of core `Array` appear as `Array` and open as arrays.
+
+`open()` is explicit materialization, not lazy loading. Before reading, it uses
+metadata or storage size to enforce the plot input memory cap. If the input is
+too large, `open()` fails and the user should write an explicit storage-aware
+reader for that plot.
 
 seaborn works when the project environment provides it; ggplot2 works when R +
 ggplot2 are installed. Only `svg`, `pdf`, `png`, `jpeg` are accepted output

--- a/docs/specs/adr-048-ai-plot-tools.md
+++ b/docs/specs/adr-048-ai-plot-tools.md
@@ -114,9 +114,9 @@ Acceptance Scenarios:
 
 1. Given a valid target ID, when `scaffold_plot` runs with `language=python`,
    then it creates `plots/<plot_id>/plot.yaml` and `render.py`.
-2. Given the scaffolded script uses `context.plt.subplots()` and
-   `context.save_figure(fig, "figure.svg")`, when `run_plot_job` runs, then it
-   returns success and an SVG artifact path.
+2. Given the scaffolded script opens data with `collection.items.open_one()`
+   and returns a matplotlib figure, when `run_plot_job` runs, then it returns
+   success and an SVG artifact path.
 3. Given the plot is rerun, when a new artifact is written, then the
    `current.*` files are overwritten and `current.json` records the new run.
 
@@ -126,14 +126,14 @@ As a user with R installed, I need the same plot-job workflow to support
 ggplot2 and vector PDF/SVG output.
 
 Independent Test: Scaffold an R plot, validate the entrypoint, run it through an
-R-capable runner when available, and verify PDF output. In CI environments
+R-capable runner when available, and verify plot output. In CI environments
 without R, runner integration may be skipped with explicit skip reason while
 manifest validation remains tested.
 
 Acceptance Scenarios:
 
 1. Given `language=r`, when `scaffold_plot` runs, then it creates `render.R`
-   with `render <- function(collection, context)`.
+   with `render <- function(collection)`.
 2. Given R and ggplot2 are available, when `run_plot_job` runs, then it writes a
    PDF, SVG, PNG, or JPEG artifact accepted by `PlotPreviewer`.
 3. Given R is unavailable, when validation runs, then it can still validate the
@@ -223,19 +223,20 @@ Acceptance Scenarios:
   title, target, script, outputs, runtime, and limits fields.
 - FR-011: The manifest target must store workflow path, stable node ID, and
   output port. Human labels may be stored only as display metadata.
-- FR-012: Python render scripts must expose `render(collection, context)`.
-- FR-013: R render scripts must expose `render <- function(collection, context)`.
-- FR-014: The Python context must support matplotlib through `context.plt` and
-  must allow seaborn usage when the project environment provides it.
-- FR-015: The R context must support ggplot2 plot saving when R and ggplot2 are
-  available.
+- FR-012: Python render scripts must expose exactly `render(collection)`.
+- FR-013: R render scripts must expose exactly `render <- function(collection)`.
+- FR-014: Python scripts must open data through the collection helper surface
+  and may use familiar libraries such as matplotlib or seaborn directly.
+- FR-015: R scripts must open data through the collection helper surface and
+  may use familiar libraries such as base R plotting or ggplot2 directly.
 - FR-016: Plot scripts must receive the selected block output collection and
   must not receive direct workflow mutation APIs.
-- FR-017: Plot context helpers must include bounded conversions such as
-  `to_dataframe(collection, max_rows=...)` and bounded iteration over collection
-  items.
-- FR-018: Plot context helpers must include save functions for PNG, JPEG, SVG,
-  and PDF outputs.
+- FR-017: Collection helpers must include `collection.items.open()`,
+  `collection.items.open_one()`, item indexing, item metadata, and equivalent
+  R helpers.
+- FR-018: Plot outputs must be produced by returning a matplotlib figure,
+  ggplot object, path string, or list of supported return values. R base plots
+  may be captured from the active device.
 - FR-019: `list_plot_examples` must return curated examples for matplotlib,
   seaborn, and ggplot2.
 - FR-020: `read_plot_source` must read either by `plot_id` or manifest path, but
@@ -320,7 +321,7 @@ outputs:
 runtime:
   timeout_seconds: 30
 limits:
-  max_rows: 10000
+  max_input_bytes: 67108864
   max_output_bytes: 10485760
   max_files: 8
 ```
@@ -328,21 +329,22 @@ limits:
 Python template:
 
 ```python
-def render(collection, context):
-    df = context.to_dataframe(collection, max_rows=10000)
-    fig, ax = context.plt.subplots()
+def render(collection):
+    import matplotlib.pyplot as plt
+
+    df = collection.items.open_one()
+    fig, ax = plt.subplots()
     ax.scatter(df["x"], df["y"], s=4)
-    return context.save_figure(fig, "figure.svg")
+    return fig
 ```
 
 R template:
 
 ```r
-render <- function(collection, context) {
-  df <- context$to_dataframe(collection, max_rows = 10000)
-  p <- ggplot2::ggplot(df, ggplot2::aes(x = x, y = y)) +
+render <- function(collection) {
+  df <- collection$items$open_one()
+  ggplot2::ggplot(df, ggplot2::aes(x = x, y = y)) +
     ggplot2::geom_point()
-  context$save_plot(p, "figure.pdf")
 }
 ```
 

--- a/docs/specs/adr-048-plot-render-collection-ux.md
+++ b/docs/specs/adr-048-plot-render-collection-ux.md
@@ -1,0 +1,410 @@
+---
+spec_id: adr-048-plot-render-collection-ux
+title: "ADR-048 Plot Render Collection UX Refactor Specification"
+status: Draft
+feature_branch: feat/1684-plot-render-collection-api
+created: 2026-06-18
+input: "Owner directive: replace the plot render user API with a context-free collection API, persist the refactor plan as a small spec, and list every user-facing API."
+owners:
+  - "@jiazhenz026"
+related_adrs:
+  - 48
+related_specs:
+  - adr-048-ai-plot-tools
+  - adr-048-preview-system
+  - adr-048-developer-docs-refresh
+scope:
+  in:
+    - Breaking replacement of the plot render signature from `render(collection, context)` to `render(collection)`.
+    - Python and R user-facing collection wrappers for opening plot input data as native scientific objects.
+    - Core-base-type normalization for package-defined subclasses before data reaches the user-facing API.
+    - Native conversion rules for Array, DataFrame, Series, Text, Artifact, and CompositeData inputs.
+    - Return-value-based artifact collection for Python and R plot jobs.
+    - Plot scaffold, examples, validation, tests, and human-facing author documentation for the new API.
+  out:
+    - Any compatibility layer for `render(collection, context)`.
+    - User-facing storage format APIs such as `item.format`, backend names, or storage paths.
+    - New workflow nodes, scheduler-visible DAG work, downstream collections, or scientific lineage outputs.
+    - Package-specific plot APIs for domain subclasses such as Image or Mask.
+    - New frontend previewer behavior beyond consuming the existing plot artifact preview path.
+governs:
+  modules:
+    - scistudio.ai.agent.mcp.tools_plot
+  contracts:
+    - scistudio.ai.agent.mcp.tools_plot.runtime.run_plot_job
+    - scistudio.ai.agent.mcp.tools_plot.validation.validate_plot
+  entry_points: []
+  files:
+    - docs/specs/adr-048-plot-render-collection-ux.md
+    - docs/specs/adr-048-ai-plot-tools.md
+    - docs/block-development/previewers-and-plots.md
+    - src/scistudio/ai/agent/mcp/tools_plot/_harness.py
+    - src/scistudio/ai/agent/mcp/tools_plot/runtime.py
+    - src/scistudio/ai/agent/mcp/tools_plot/validation.py
+    - src/scistudio/ai/agent/mcp/tools_plot/scaffold.py
+    - src/scistudio/ai/agent/mcp/tools_plot/examples.py
+    - src/scistudio/_skills/scistudio/scistudio-write-plot/SKILL.md
+tests:
+  - tests/ai/test_mcp_tools_plot.py
+  - tests/api/test_preview_plot_jobs.py
+acceptance_source: manual
+language_source: en
+---
+
+# ADR-048 Plot Render Collection UX Refactor Specification
+
+## 1. Change Summary
+
+This spec defines a pre-alpha breaking replacement for the preview-side plot
+render API. The current API gives user scripts `render(collection, context)`.
+The `context` argument is not a user-natural concept and mixes data access,
+matplotlib access, and artifact saving into a helper object.
+
+The planned API removes `context` completely. A plot script receives exactly
+one SciStudio-provided object:
+
+```python
+def render(collection):
+    arrays = collection.items.open()
+
+    import matplotlib.pyplot as plt
+
+    fig, ax = plt.subplots()
+    ax.imshow(arrays[0], cmap="gray")
+    return fig
+```
+
+The new model is:
+
+1. open data from `collection.items`;
+2. plot with familiar Python or R libraries;
+3. return, or in R draw, a plot artifact.
+
+Because SciStudio is pre-alpha and has no external plot users, the
+implementation must not keep a compatibility path for the old two-argument
+contract.
+
+## 2. User Scenarios & Testing
+
+### User Story 1 - Python user opens array-like output data (Priority: P1)
+
+As a Python user, I need a collection of package-defined array subclasses to
+open as normal NumPy arrays without knowing the package subclass name or storage
+format.
+
+Independent Test: Given a collection whose items are package-defined subclasses
+of core `Array` and are stored through zarr-backed refs, when a plot script
+calls `collection.items.open()`, then it receives `list[numpy.ndarray]`.
+
+Acceptance Scenarios:
+
+1. Given a collection of ten package-defined image-like items, when the script
+   reads `collection.types`, then it reports `("Array",)`.
+2. Given the same collection, when the script calls `collection.items.open()`,
+   then it receives ten `numpy.ndarray` objects.
+3. Given one item, when the script calls `collection.items[0].open()`, then it
+   receives the first item as one `numpy.ndarray`.
+
+### User Story 2 - Python user opens table output data (Priority: P1)
+
+As a Python user, I need table output data to open as pandas dataframes without
+calling a SciStudio context helper.
+
+Independent Test: Given a DataFrame collection, when the script calls
+`collection.items.open()`, then it receives `list[pandas.DataFrame]`.
+
+Acceptance Scenarios:
+
+1. Given a DataFrame collection, when `collection.types` is read, then it
+   reports `("DataFrame",)`.
+2. Given the same collection, when `collection.items.open_one()` is called,
+   then it returns the first table as a `pandas.DataFrame`.
+3. Given a normal matplotlib figure is returned, when the plot job succeeds,
+   then the runtime saves it using the manifest's preferred allowed format.
+
+### User Story 3 - R user opens native output data (Priority: P1)
+
+As an R user, I need the same collection model to open data as R-native objects
+and to work with base R plotting or ggplot2.
+
+Independent Test: Given a DataFrame collection, when an R render function calls
+`collection$items$open()`, then it receives a list of `data.frame` values.
+
+Acceptance Scenarios:
+
+1. Given a DataFrame collection, when R reads `collection$types`, then it
+   reports `c("DataFrame")`.
+2. Given a DataFrame item, when R calls `collection$items[[1]]$open()`, then it
+   receives a `data.frame`.
+3. Given an R render function draws a base R plot to the active device, when
+   the plot job succeeds, then the device output is promoted as the plot
+   artifact.
+4. Given an R render function returns a ggplot object, when the plot job
+   succeeds, then the ggplot object is saved as the plot artifact.
+
+### User Story 4 - Old context API is rejected (Priority: P1)
+
+As a maintainer, I need the pre-alpha API to be clean, with no compatibility
+branch for an unused public contract.
+
+Independent Test: A script that defines `render(collection, context)` fails
+validation before execution.
+
+Acceptance Scenarios:
+
+1. Given a Python script with `def render(collection, context):`, when
+   `validate_plot` runs, then it fails with a signature error.
+2. Given an R script with `render <- function(collection, context)`, when
+   `validate_plot` runs, then it fails with a signature error.
+3. Given old `context.to_dataframe`, `context.items`, or `context.save_figure`
+   references in scaffold or examples, when docs tests scan the plot docs, then
+   the stale references are rejected.
+
+### Edge Cases
+
+- Collection contains zero items.
+- Collection contains mixed core base types.
+- Item metadata has a package-specific type chain but no supported core base.
+- Item storage exists but cannot be read by the native reader.
+- Python `render()` returns `None`.
+- Python `render()` returns an unsupported object.
+- R render returns an unsupported object and does not draw to the active device.
+- Returned artifact path escapes the confined plot working directory.
+- Render writes too many artifacts or too many bytes.
+- `open()` would materialize more input data than the plot runtime memory cap.
+- A package subclass has the same leaf name as a core base type.
+
+## 3. Requirements
+
+### Functional Requirements
+
+- FR-001: Python plot scripts must define exactly `render(collection)`.
+  `render(collection, context)` is invalid.
+- FR-002: R plot scripts must define exactly `render <- function(collection)`.
+  A second formal argument is invalid.
+- FR-003: No compatibility layer, deprecation warning, fallback call path, or
+  automatic migration shim may be implemented for the old context API.
+- FR-004: The user-facing `collection` must be a plot-runtime wrapper. It must
+  not expose or subclass `scistudio.core.types.collection.Collection`.
+- FR-005: The plot runtime must normalize package-defined subclasses to the
+  nearest supported SciStudio core base type before exposing type information
+  to user scripts.
+- FR-006: The supported user-facing core base types are `Array`, `DataFrame`,
+  `Series`, `Text`, `Artifact`, and `CompositeData`.
+- FR-007: User-facing APIs must not expose storage format or backend details.
+  Normal user code must not see `item.format`, backend names, zarr, parquet,
+  tiff, CSV, storage refs, or storage paths as helper fields.
+- FR-008: Storage backend, storage format, and storage path may remain internal
+  reader-dispatch fields and may appear in sanitized error diagnostics when
+  needed to debug unreadable data.
+- FR-009: The Python collection wrapper must expose exactly the helper surface
+  listed in section 3.2 unless a later spec expands it.
+- FR-010: The R collection wrapper must expose exactly the helper surface listed
+  in section 3.3 unless a later spec expands it.
+- FR-011: `collection.types` and `collection$types` must report normalized core
+  base type names only.
+- FR-012: Item metadata exposed to users must be read-only and must exclude
+  storage backend, storage format, and raw storage paths.
+- FR-013: Python `open()` conversion must follow the table in section 3.4.
+- FR-014: R `open()` conversion must follow the table in section 3.4.
+- FR-015: Python `render()` may return a matplotlib figure, a path string, a
+  `pathlib.Path`, or a list or tuple containing those supported values.
+- FR-016: Python `render()` returning `None` is invalid.
+- FR-017: R render may draw to the active graphics device, return a ggplot
+  object, return an artifact path string, or return a list of supported plot
+  values.
+- FR-018: The Python harness must not scan the working directory for arbitrary
+  artifacts. Artifacts must come from the render return value.
+- FR-019: The R harness may promote the configured active graphics device output
+  when the render function draws a base R plot.
+- FR-020: Plot jobs must remain preview-only: no workflow YAML edits, no
+  scheduler DAG mutation, no downstream collection creation, and no scientific
+  lineage output.
+- FR-021: Scaffolded Python and R scripts must use the new one-argument render
+  API and must contain no `context` references.
+- FR-022: Human-facing plot author docs must list every user-facing collection
+  helper and every core base type conversion for Python and R.
+- FR-023: `item.open()` and collection-level `open()` calls must perform an
+  implementation-defined memory guard before materializing data. If the
+  estimated or known materialized size exceeds the runtime cap, the call must
+  fail with a clear error instead of loading the payload.
+- FR-024: This spec must not add lazy-loading, selection, row-window, or
+  chunk-iteration helpers to the user API. Users who need to plot data larger
+  than the memory guard allows must author their own explicit storage-aware
+  reading strategy outside the SciStudio collection helper surface.
+
+### 3.2 Python User-Facing API
+
+The complete Python API is:
+
+| API | Result | Notes |
+|---|---|---|
+| `render(collection)` | entrypoint | Exactly one argument. |
+| `collection.types` | `tuple[str, ...]` | Normalized core base type names only. |
+| `collection.items` | `PlotItems` | Sequence-like item wrapper. |
+| `len(collection.items)` | `int` | Number of items in the collection. |
+| `for item in collection.items` | iterator | Iterates `PlotItem` wrappers. |
+| `collection.items[index]` | `PlotItem` | Zero-based item access. |
+| `collection.items[start:stop]` | `list[PlotItem]` | Slice access. |
+| `collection.items.open()` | `list[Any]` | Opens all items as native Python values. |
+| `collection.items.open(max_items=n)` | `list[Any]` | Opens at most `n` items. |
+| `collection.items.open_one()` | `Any` | Opens the first item. Fails on empty collection. |
+| `item.type` | `str` | One normalized core base type name. |
+| `item.metadata` | read-only mapping | Non-storage metadata only. |
+| `item.open()` | `Any` | Opens one item as a native Python value. |
+
+No other Python helper is part of this spec. In particular, there is no
+`context`, `context.plt`, `context.to_dataframe`, `context.items`,
+`context.save_figure`, `item.format`, or `item.path` user API. The `open()`
+helpers are explicit materialization calls, not lazy readers. They may fail
+before reading when the runtime memory guard predicts an unsafe load.
+
+### 3.3 R User-Facing API
+
+The complete R API is:
+
+| API | Result | Notes |
+|---|---|---|
+| `render <- function(collection)` | entrypoint | Exactly one argument. |
+| `collection$types` | character vector | Normalized core base type names only. |
+| `collection$items` | item wrapper object | Sequence-like item wrapper. |
+| `length(collection$items)` | integer | Number of items in the collection. |
+| `collection$items[[index]]` | item wrapper | One-based R item access. |
+| `collection$items$open()` | list | Opens all items as native R values. |
+| `collection$items$open(max_items = n)` | list | Opens at most `n` items. |
+| `collection$items$open_one()` | native value | Opens the first item. Fails on empty collection. |
+| `collection$items[[index]]$type` | character scalar | One normalized core base type name. |
+| `collection$items[[index]]$metadata` | named list | Non-storage metadata only. |
+| `collection$items[[index]]$open()` | native value | Opens one item as a native R value. |
+
+No other R helper is part of this spec. In particular, there is no `context`,
+`context$to_dataframe`, `context$save_plot`, storage-format helper, or raw
+storage-path helper. The `open()` helpers are explicit materialization calls,
+not lazy readers. They may fail before reading when the runtime memory guard
+predicts an unsafe load.
+
+### 3.4 Core Base Type Conversion Table
+
+All package-specific subclasses must be folded back to the nearest supported
+core base type before opening.
+
+| Core base type | Python `open()` result | R `open()` result |
+|---|---|---|
+| `Array` | `numpy.ndarray` | `matrix` for 2-D data, `array` otherwise |
+| `DataFrame` | `pandas.DataFrame` | `data.frame` |
+| `Series` | `pandas.Series` | atomic vector, named when index labels are available |
+| `Text` | `str` | character scalar |
+| `Artifact` | `pathlib.Path` | character scalar path |
+| `CompositeData` | `dict[str, native]` recursively | named list recursively |
+| unsupported `DataObject` | clear error | clear error |
+
+Examples:
+
+- A package-defined `Image` subclass of `Array` opens as `numpy.ndarray` in
+  Python and as `matrix` or `array` in R.
+- A package-defined `Mask` subclass of `Array` opens as `numpy.ndarray` in
+  Python and as `matrix` or `array` in R.
+- A package-defined table subclass of `DataFrame` opens as `pandas.DataFrame`
+  in Python and as `data.frame` in R.
+
+## 4. Implementation Plan
+
+### 4.1 Technical Approach
+
+`run_plot_job` should write an input envelope that contains internal storage
+refs and normalized core base type names. The harness should build wrapper
+objects from that envelope and should keep storage details private.
+
+The Python harness should contain:
+
+- `_PlotCollection`
+- `_PlotItems`
+- `_PlotItem`
+- native reader dispatch for supported core base types
+- return-value artifact collection
+
+The R harness should contain equivalent collection, items, item, native reader,
+and artifact handling objects/functions.
+
+### 4.2 Affected Files
+
+| Path | Action | Rationale |
+|---|---|---|
+| `src/scistudio/ai/agent/mcp/tools_plot/_harness.py` | modify | Remove context, add Python/R collection wrappers and native readers. |
+| `src/scistudio/ai/agent/mcp/tools_plot/runtime.py` | modify | Write normalized input envelope and collect returned artifacts. |
+| `src/scistudio/ai/agent/mcp/tools_plot/validation.py` | modify | Enforce one-argument Python/R render signatures. |
+| `src/scistudio/ai/agent/mcp/tools_plot/scaffold.py` | modify | Generate context-free Python/R templates. |
+| `src/scistudio/ai/agent/mcp/tools_plot/examples.py` | modify | Replace context examples with collection API examples. |
+| `src/scistudio/_skills/scistudio/scistudio-write-plot/SKILL.md` | modify | Teach AI agents the new render contract. |
+| `docs/block-development/previewers-and-plots.md` | modify | Document the user-facing helper API and conversion table. |
+| `tests/ai/test_mcp_tools_plot.py` | modify | Validate signatures, scaffolds, examples, and runtime behavior. |
+| `tests/api/test_preview_plot_jobs.py` | modify | Verify preview cache behavior and no workflow mutation. |
+
+### 4.3 Implementation Sequence
+
+1. Add the normalized input envelope in `runtime.py`.
+2. Replace `_Collection` and `_Context` in the Python harness with
+   `_PlotCollection`, `_PlotItems`, and `_PlotItem`.
+3. Add Python native readers for the supported core base types.
+4. Replace `context.save_figure` with Python return-value artifact collection.
+5. Replace R context construction with R collection wrappers and native readers.
+6. Add R graphics-device handling for base R plots and ggplot return handling.
+7. Tighten validation so two-argument render functions fail.
+8. Rewrite scaffolds, examples, skill guidance, and human-facing docs.
+9. Replace old context tests with new one-argument API tests.
+
+### 4.4 Verification Plan
+
+Tests must verify:
+
+- Python `render(collection)` succeeds.
+- Python `render(collection, context)` fails validation.
+- R `render <- function(collection)` succeeds.
+- R `render <- function(collection, context)` fails validation.
+- Package-defined `Array` subclasses normalize to `Array`.
+- `collection.types` and `collection$types` expose only core base types.
+- `collection.items.open()` and `collection$items$open()` return the native
+  values listed in section 3.4.
+- Storage format and backend are not exposed as user helper fields.
+- `open()` refuses payloads that exceed the runtime memory guard and does not
+  materialize them.
+- Python `None` return fails.
+- Python matplotlib figure returns are saved as allowed artifacts.
+- R base plots and ggplot returns are saved as allowed artifacts.
+- Plot runs remain preview-only and do not mutate workflow YAML, scheduler
+  outputs, DAG state, downstream data, or lineage.
+
+### 4.5 Risks And Rollback
+
+The main risk is that the harness duplicates some native read logic already
+available in other SciStudio layers. This is acceptable because the plot
+subprocess intentionally runs with a narrow user-facing wrapper and should not
+expose core runtime objects directly.
+
+Rollback is a normal pre-alpha revert of the new spec and implementation PR.
+No compatibility migration is required because the old plot API has no external
+user commitment.
+
+## 5. Success Criteria
+
+### Measurable Outcomes
+
+- SC-001: New Python and R plot scaffolds contain no `context` references.
+- SC-002: The plot docs include the full Python helper table, R helper table,
+  and core base type conversion table from this spec.
+- SC-003: A package-defined array subclass collection can be plotted in Python
+  with `collection.items.open()` and no storage-format knowledge.
+- SC-004: A DataFrame collection can be plotted in R with
+  `collection$items$open()` and no context helper.
+- SC-005: Validation rejects every two-argument render function fixture.
+- SC-006: No test preserves `render(collection, context)` as a valid behavior.
+- SC-007: Oversized input fixtures fail at `open()` with a memory-guard error
+  before the full payload is materialized.
+
+## 6. Assumptions
+
+- SciStudio is pre-alpha and has no external plot API compatibility obligation.
+- Core base types are the user-facing abstraction boundary for plot authoring.
+- Package subclasses remain meaningful for routing and internal metadata, but
+  they are not the normal plot authoring API.
+- Storage backend and format remain implementation details, not user helpers.

--- a/src/scistudio/_skills/scistudio/scistudio-write-plot/SKILL.md
+++ b/src/scistudio/_skills/scistudio/scistudio-write-plot/SKILL.md
@@ -1,25 +1,25 @@
 ---
 name: scistudio-write-plot
 description: |
-  Use when the user wants a QUICK PREVIEW PLOT — a matplotlib, seaborn, or
-  ggplot2 figure drawn from a block OUTPUT collection and shown in the
+  Use when the user wants a QUICK PREVIEW PLOT: a matplotlib, seaborn, base R,
+  or ggplot2 figure drawn from a block OUTPUT collection and shown in the
   preview panel (e.g. "scatter the measurements from my segment-cells node",
   "show me a histogram of that output"). A plot job lives in
   ``<project>/plots/<plot_id>/`` and renders a display-only artifact.
 
-  NOT for authoring a reusable processing BLOCK — that is
-  scistudio-write-block (a Python class under ``blocks/<name>.py`` that
-  becomes a workflow node). NOT for adding a node to a workflow YAML — that
-  is scistudio-build-workflow. A plot job NEVER becomes a workflow DAG node,
-  NEVER edits workflow YAML, and NEVER produces downstream data or lineage.
+  NOT for authoring a reusable processing BLOCK: that is scistudio-write-block
+  (a Python class under ``blocks/<name>.py`` that becomes a workflow node).
+  NOT for adding a node to a workflow YAML: that is scistudio-build-workflow.
+  A plot job NEVER becomes a workflow DAG node, NEVER edits workflow YAML, and
+  NEVER produces downstream data or lineage.
 ---
 
 # scistudio-write-plot
 
 A **plot job** is a preview-only figure. You bind it to one block **output
-port**, write a `render(collection, context)` script, run it, and the
-resulting PNG / JPEG / SVG / PDF appears in the preview panel through the core
-`PlotPreviewer`. It is **not** a workflow block and **not** a DAG node.
+port**, write a `render(collection)` script, run it, and the resulting PNG /
+JPEG / SVG / PDF appears in the preview panel through the core `PlotPreviewer`.
+It is **not** a workflow block and **not** a DAG node.
 
 The single most important rule: **never bind a plot by a human block label.**
 Block labels repeat and drift. Always discover a stable `target_id` with
@@ -38,7 +38,7 @@ mcp__scistudio__list_plot_examples(language="python", library="matplotlib")
 
 mcp__scistudio__scaffold_plot(
     plot_id="cell_scatter",
-    target_id="tgt_...",          # from list_plot_targets — NOT a label
+    target_id="tgt_...",          # from list_plot_targets; NOT a label
     language="python"             # or "r"
 )
 # Creates plots/cell_scatter/plot.yaml + render.py (or render.R).
@@ -48,14 +48,15 @@ mcp__scistudio__scaffold_plot(
 
 mcp__scistudio__validate_plot(plot_id="cell_scatter")
 # Catches broken targets, schema errors, path traversal, bad output formats,
-# missing entrypoint. R runner unavailability is a WARNING, not an error.
+# missing or wrong render(collection) entrypoint. R runner unavailability is a
+# WARNING, not an error.
 
 mcp__scistudio__run_plot_job(plot_id="cell_scatter")
 # Renders preview-side, writes current.* + current.json to the preview cache.
-# Re-running OVERWRITES current.* — it never appends a workflow node.
+# Re-running OVERWRITES current.*; it never appends a workflow node.
 ```
 
-## 2. plot.yaml — the manifest
+## 2. plot.yaml: the manifest
 
 Strict, versioned. Binding identity is `target.node_id` + `target.output_port`;
 `display_label` is metadata only.
@@ -67,7 +68,7 @@ title: Cell Scatter
 target:
   workflow_path: workflows/main.yaml
   workflow_id: main
-  node_id: node_8f3a2c          # the binding key — never a label
+  node_id: node_8f3a2c          # the binding key; never a label
   output_port: measurements
   display_label: Segment Cells / measurements
 script:
@@ -80,41 +81,82 @@ outputs:
 runtime:
   timeout_seconds: 30
 limits:
-  max_rows: 10000
+  max_input_bytes: 67108864
   max_output_bytes: 10485760    # 10 MiB
   max_files: 8
 ```
 
 ## 3. The render contract
 
-**Python** — `render(collection, context)`:
+**Python** - `render(collection)`:
 
 ```python
-def render(collection, context):
-    df = context.to_dataframe(collection, max_rows=10000)
-    fig, ax = context.plt.subplots()
+def render(collection):
+    import matplotlib.pyplot as plt
+
+    df = collection.items.open_one()
+    fig, ax = plt.subplots()
     ax.scatter(df["x"], df["y"], s=6)
-    return context.save_figure(fig, "figure.svg")
+    return fig
 ```
 
-**R** — `render <- function(collection, context)`:
+**R** - `render <- function(collection)`:
 
 ```r
-render <- function(collection, context) {
-  df <- context$to_dataframe(collection, max_rows = 10000)
-  p <- ggplot2::ggplot(df, ggplot2::aes(x = x, y = y)) +
+render <- function(collection) {
+  df <- collection$items$open_one()
+  ggplot2::ggplot(df, ggplot2::aes(x = x, y = y)) +
     ggplot2::geom_point()
-  context$save_plot(p, "figure.pdf")
 }
 ```
 
-`context` helpers (preview-only — there are **no** workflow-mutation APIs):
+Collection helpers are preview-only; there are **no** workflow-mutation APIs.
 
-- `context.to_dataframe(collection, max_rows=...)` — bounded DataFrame.
-- `context.items(collection, max_items=...)` — bounded iteration over refs.
-- `context.plt` — `matplotlib.pyplot` (Agg backend).
-- `context.save_figure(fig, "figure.svg")` / `context.save_plot(...)` —
-  save PNG / JPEG / SVG / PDF. SVG is sanitized before display.
+Python helpers:
+
+- `collection.types`
+- `collection.items`
+- `len(collection.items)`
+- `for item in collection.items`
+- `collection.items[index]`
+- `collection.items[start:stop]`
+- `collection.items.open()`
+- `collection.items.open(max_items=n)`
+- `collection.items.open_one()`
+- `item.type`
+- `item.metadata`
+- `item.open()`
+
+R helpers:
+
+- `collection$types`
+- `collection$items`
+- `length(collection$items)`
+- `collection$items[[index]]`
+- `collection$items$open()`
+- `collection$items$open(max_items = n)`
+- `collection$items$open_one()`
+- `collection$items[[index]]$type`
+- `collection$items[[index]]$metadata`
+- `collection$items[[index]]$open()`
+
+Core base conversions:
+
+| Core base type | Python `open()` result | R `open()` result |
+|---|---|---|
+| `Array` | `numpy.ndarray` | `matrix` for 2-D data, `array` otherwise |
+| `DataFrame` | `pandas.DataFrame` | `data.frame` |
+| `Series` | `pandas.Series` | atomic vector |
+| `Text` | `str` | character scalar |
+| `Artifact` | `pathlib.Path` | character scalar path |
+| `CompositeData` | `dict[str, native]` recursively | named list recursively |
+
+Package subclasses are folded back to supported core base types before user
+code sees them. For example, package `Image` and `Mask` subclasses of `Array`
+appear as `Array`.
+
+`open()` materializes data and has a memory guard. It is not lazy loading. For
+large inputs, write an explicit storage-aware reader in the plot script.
 
 seaborn works when the project environment provides it (`import seaborn`).
 ggplot2 works when R + ggplot2 are installed.
@@ -125,13 +167,13 @@ ggplot2 works when R + ggplot2 are installed.
 
 ```
 .scistudio/previews/<workflow_id>/<node_id>/<output_port>/<plot_id>/
-    current.svg        # (or current.png / current.pdf / current.jpeg)
+    current.svg        # or current.png / current.pdf / current.jpeg
     current.json       # run record: manifest, script hash, target, inputs,
                        # run id, runner, created time, outputs, status, error
 ```
 
 Re-running overwrites `current.*` and `current.json`. The preview cache is
-**not** a scientific result path — to keep a figure, export/save it explicitly.
+**not** a scientific result path; to keep a figure, export/save it explicitly.
 
 ## 5. Mandatory rules
 
@@ -148,9 +190,11 @@ Re-running overwrites `current.*` and `current.json`. The preview cache is
 ## 6. Anti-patterns
 
 - Binding a plot by block label instead of a discovered `target_id`.
+- Writing old `render(collection, context)` scripts. There is no compatibility
+  layer for the removed context API.
 - Treating a plot job as a workflow block (use `scistudio-write-block`) or a
   workflow node (use `scistudio-build-workflow`).
-- Editing `workflows/*.yaml` from a plot task — plots never touch the DAG.
+- Editing `workflows/*.yaml` from a plot task; plots never touch the DAG.
 - Saving an unsupported format (only svg / pdf / png / jpeg are accepted).
 - Skipping `validate_plot` and running a plot bound to a deleted node/port.
-- Expecting `current.*` to persist as a result — it is overwritten on re-run.
+- Expecting `current.*` to persist as a result; it is overwritten on re-run.

--- a/src/scistudio/ai/agent/mcp/tools_plot/_harness.py
+++ b/src/scistudio/ai/agent/mcp/tools_plot/_harness.py
@@ -130,6 +130,52 @@ def _guard_file_or_dir(path, limit, label):
         _guard_nbytes(_directory_size(p), limit, label)
 
 
+def _path_nbytes(path):
+    if not path:
+        return None
+    p = Path(path)
+    if p.is_file():
+        return p.stat().st_size
+    if p.is_dir():
+        return _directory_size(p)
+    return None
+
+
+def _ref_nbytes(ref):
+    typ = ref.get("type") or "DataObject"
+    if typ == "Artifact":
+        return 0
+    if typ == "CompositeData":
+        md = ref.get("metadata")
+        slots = md.get("slots") if isinstance(md, dict) else None
+        if not isinstance(slots, dict):
+            return 0
+        total = 0
+        found = False
+        for slot_ref in slots.values():
+            if isinstance(slot_ref, dict):
+                nbytes = _ref_nbytes(slot_ref)
+                if nbytes is not None:
+                    total += int(nbytes)
+                    found = True
+        return total if found else None
+    estimated = _metadata_estimated_nbytes(ref)
+    if estimated is not None:
+        return estimated
+    if typ in {"Array", "DataFrame", "Series", "Text"}:
+        return _path_nbytes(ref.get("_path"))
+    return None
+
+
+def _guard_collection_nbytes(refs, limit, label):
+    total = 0
+    for ref in refs:
+        nbytes = _ref_nbytes(ref)
+        if nbytes is not None:
+            total += int(nbytes)
+            _guard_nbytes(total, limit, label)
+
+
 def _read_array(ref, limit):
     raw_path = ref.get("_path")
     if not raw_path:
@@ -295,6 +341,7 @@ class _PlotItem:
 class _PlotItems:
     def __init__(self, refs, max_input_bytes):
         self._items = [_PlotItem(ref, max_input_bytes) for ref in refs]
+        self._max_input_bytes = int(max_input_bytes)
 
     def __len__(self):
         return len(self._items)
@@ -309,6 +356,7 @@ class _PlotItems:
         items = self._items
         if max_items is not None:
             items = items[: int(max_items)]
+        _guard_collection_nbytes([item._ref for item in items], self._max_input_bytes, "collection.items.open()")
         return [item.open() for item in items]
 
     def open_one(self):
@@ -462,9 +510,20 @@ guard_bytes <- function(nbytes, label) {
 }
 
 guard_path <- function(path, label) {
-  if (file.exists(path) && !dir.exists(path)) {
-    guard_bytes(file.info(path)$size, label)
+  guard_bytes(path_nbytes(path), label)
+}
+
+path_nbytes <- function(path) {
+  if (is.null(path) || !file.exists(path)) return(NA_real_)
+  if (dir.exists(path)) {
+    files <- list.files(path, recursive = TRUE, full.names = TRUE, all.files = TRUE, no.. = TRUE)
+    files <- files[file.exists(files) & !dir.exists(files)]
+    if (length(files) == 0) return(0)
+    sizes <- file.info(files)$size
+    if (all(is.na(sizes))) return(NA_real_)
+    return(sum(sizes, na.rm = TRUE))
   }
+  file.info(path)$size
 }
 
 dtype_size <- function(dtype) {
@@ -493,6 +552,42 @@ metadata_nbytes <- function(ref) {
 
 guard_ref <- function(ref, label) {
   guard_bytes(metadata_nbytes(ref), label)
+}
+
+ref_nbytes <- function(ref) {
+  typ <- ref$type
+  if (is.null(typ)) typ <- "DataObject"
+  if (typ == "Artifact") return(0)
+  if (typ == "CompositeData") {
+    slots <- ref$metadata$slots
+    if (is.null(slots) || !is.list(slots)) return(0)
+    total <- 0
+    found <- FALSE
+    for (name in names(slots)) {
+      nbytes <- ref_nbytes(slots[[name]])
+      if (!is.na(nbytes)) {
+        total <- total + nbytes
+        found <- TRUE
+      }
+    }
+    if (found) return(total)
+    return(NA_real_)
+  }
+  estimated <- metadata_nbytes(ref)
+  if (!is.na(estimated)) return(estimated)
+  if (typ %in% c("Array", "DataFrame", "Series", "Text")) return(path_nbytes(ref$`_path`))
+  NA_real_
+}
+
+guard_refs <- function(refs, label) {
+  total <- 0
+  for (ref in refs) {
+    nbytes <- ref_nbytes(ref)
+    if (!is.na(nbytes)) {
+      total <- total + nbytes
+      guard_bytes(total, label)
+    }
+  }
 }
 
 public_metadata <- function(ref) {
@@ -583,8 +678,10 @@ make_items <- function(refs) {
   hidden <- lapply(refs, make_item)
   items$._items <- hidden
   items$open <- function(max_items = NULL) {
-    selected <- hidden
-    if (!is.null(max_items)) selected <- selected[seq_len(min(as.integer(max_items), length(hidden)))]
+    selected_indices <- seq_along(hidden)
+    if (!is.null(max_items)) selected_indices <- seq_len(min(as.integer(max_items), length(hidden)))
+    selected <- hidden[selected_indices]
+    guard_refs(refs[selected_indices], "collection$items$open()")
     lapply(selected, function(item) item$open())
   }
   items$open_one <- function() {
@@ -611,10 +708,14 @@ make_collection <- function(envelope) {
   if (is.null(left)) right else left
 }
 
+normalise_existing_path <- function(path) {
+  tryCatch(normalizePath(path, mustWork = TRUE, winslash = "/"), error = function(e) NA_character_)
+}
+
 safe_artifact_path <- function(path) {
   candidate <- if (grepl("^([A-Za-z]:)?[\\\\/]", path)) path else file.path(out_dir, path)
-  resolved <- normalizePath(candidate, mustWork = TRUE, winslash = "/", unset = NA)
-  root <- normalizePath(out_dir, mustWork = TRUE, winslash = "/", unset = NA)
+  resolved <- normalise_existing_path(candidate)
+  root <- normalise_existing_path(out_dir)
   if (is.na(resolved) || !startsWith(resolved, root)) {
     stop("returned artifact path escapes the plot working directory")
   }
@@ -654,6 +755,11 @@ device_filename <- function() {
   paste0("figure.", suffix)
 }
 
+device_temp_filename <- function() {
+  suffix <- if (preferred == "jpeg") "jpg" else preferred
+  paste0(".scistudio-base-device.", suffix)
+}
+
 open_device <- function(path) {
   ext <- check_format(path)
   if (ext == "svg") grDevices::svg(path)
@@ -662,21 +768,35 @@ open_device <- function(path) {
   else grDevices::jpeg(path)
 }
 
+close_device <- function(device_id) {
+  devices <- grDevices::dev.list()
+  if (!is.null(devices) && device_id %in% as.integer(devices)) {
+    grDevices::dev.off(device_id)
+  }
+}
+
 result <- tryCatch({
   envelope <- jsonlite::fromJSON(inputs_json, simplifyVector = FALSE)
   collection <- make_collection(envelope)
   source(script_name, local = TRUE)
   render_fn <- get(entrypoint)
 
-  device_file <- file.path(out_dir, device_filename())
+  device_file <- file.path(out_dir, device_temp_filename())
   open_device(device_file)
-  before_pages <- grDevices::dev.cur()
+  base_device <- grDevices::dev.cur()
   rendered <- render_fn(collection)
-  grDevices::dev.off()
+  close_device(base_device)
 
   artifacts <- collect_returned(rendered)
   if (length(artifacts) == 0 && file.exists(device_file) && file.info(device_file)$size > 0) {
-    artifacts <- basename(device_file)
+    final_device_file <- file.path(out_dir, device_filename())
+    if (!file.rename(device_file, final_device_file)) {
+      file.copy(device_file, final_device_file, overwrite = TRUE)
+      unlink(device_file)
+    }
+    artifacts <- basename(final_device_file)
+  } else if (file.exists(device_file)) {
+    unlink(device_file)
   }
   if (length(artifacts) == 0) stop("render(collection) produced no plot artifact")
   list(ok = TRUE, artifacts = artifacts)

--- a/src/scistudio/ai/agent/mcp/tools_plot/_harness.py
+++ b/src/scistudio/ai/agent/mcp/tools_plot/_harness.py
@@ -1,15 +1,13 @@
-"""Embedded render-harness sources for preview-side plot jobs (ADR-048 SPEC 2).
+"""Embedded render-harness sources for preview-side plot jobs (ADR-048).
 
-The harness is the *outer* program the plot subprocess runs. It builds the
-``context`` object (FR-014..FR-018), loads the bound collection from the
-``inputs.json`` the runtime wrote, imports the user's render script, calls
-``render(collection, context)``, and prints a single JSON result line on stdout
-that the runtime parses.
+The harness is the outer program the plot subprocess runs. It loads the
+runtime-written input envelope, builds a context-free plot ``collection`` user
+object, imports the user's render script, calls ``render(collection)``, and
+prints a single JSON result line on stdout for the runtime to parse.
 
-These are stored as string templates rather than real modules so the runtime can
-write them next to the user script inside the confined working directory — the
-subprocess never imports SciStudio, only stdlib + (optionally) pandas/matplotlib
-from the project environment.
+These are stored as string templates rather than importable SciStudio modules so
+the subprocess only depends on the project environment's ordinary Python/R
+scientific packages.
 """
 
 from __future__ import annotations
@@ -19,19 +17,22 @@ from __future__ import annotations
 # ---------------------------------------------------------------------------
 #
 # Contract with the runtime:
-#   argv: python _plot_harness.py <script_name> <entrypoint> <inputs_json> <out_dir> <max_rows> <allowed_csv>
+#   argv: python _plot_harness.py <script_name> <entrypoint> <inputs_json>
+#         <out_dir> <preferred_format> <allowed_csv> <max_input_bytes>
 #   stdout: exactly one JSON line  {"ok": true, "artifacts": ["figure.svg", ...]}
-#                                  {"ok": false, "error": "<sanitized message>"}
-#
-# The harness writes artifacts into <out_dir> (the confined working dir). The
-# runtime then promotes the chosen artifact to the preview cache as current.*.
+#                                  {"ok": false, "error": "<message>"}
 
 PYTHON_HARNESS = r'''"""Auto-generated plot harness (ADR-048). Do not edit; regenerated each run."""
 import importlib.util
 import json
+import math
 import sys
 import traceback
 from pathlib import Path
+from types import MappingProxyType
+
+
+SUPPORTED_TYPES = {"Array", "DataFrame", "Series", "Text", "Artifact", "CompositeData"}
 
 
 def _load_render(script_name, entrypoint):
@@ -46,101 +47,343 @@ def _load_render(script_name, entrypoint):
     return fn
 
 
-class _Collection:
-    """Bounded view over the input data refs the runtime resolved."""
+def _normalise_ext(value):
+    ext = Path(str(value)).suffix.lower().lstrip(".")
+    if ext == "jpg":
+        return "jpeg"
+    return ext
 
-    def __init__(self, refs):
-        self._refs = list(refs)
 
-    @property
-    def refs(self):
-        return list(self._refs)
+def _check_allowed(path, allowed):
+    ext = _normalise_ext(path)
+    if ext not in {"svg", "pdf", "png", "jpeg"}:
+        raise ValueError("unsupported output format: ." + ext)
+    if allowed and ext not in allowed:
+        raise ValueError("format ." + ext + " not in manifest allowed_formats")
+    return ext
+
+
+def _dtype_size(dtype_value):
+    if dtype_value is None:
+        return None
+    try:
+        import numpy as np
+
+        return int(np.dtype(dtype_value).itemsize)
+    except Exception:
+        return None
+
+
+def _shape_size(shape_value):
+    if not isinstance(shape_value, (list, tuple)):
+        return None
+    total = 1
+    try:
+        for raw in shape_value:
+            total *= int(raw)
+    except Exception:
+        return None
+    return max(0, total)
+
+
+def _metadata_estimated_nbytes(ref):
+    md = ref.get("metadata") if isinstance(ref, dict) else None
+    if not isinstance(md, dict):
+        return None
+    shape = md.get("shape")
+    if shape is None:
+        shape = md.get("array_shape")
+    dtype = md.get("dtype")
+    if dtype is None:
+        dtype = md.get("array_dtype")
+    count = _shape_size(shape)
+    itemsize = _dtype_size(dtype)
+    if count is None or itemsize is None:
+        return None
+    return count * itemsize
+
+
+def _directory_size(path):
+    total = 0
+    for child in Path(path).rglob("*"):
+        if child.is_file():
+            total += child.stat().st_size
+    return total
+
+
+def _guard_nbytes(nbytes, limit, label):
+    if nbytes is None:
+        return
+    if int(nbytes) > int(limit):
+        raise MemoryError(
+            label + " would materialize " + str(int(nbytes)) + " bytes, "
+            "exceeding the plot input memory cap of " + str(int(limit)) + " bytes. "
+            "Use an explicit storage-aware reader for large plot inputs."
+        )
+
+
+def _guard_file_or_dir(path, limit, label):
+    p = Path(path)
+    if p.is_file():
+        _guard_nbytes(p.stat().st_size, limit, label)
+    elif p.is_dir():
+        _guard_nbytes(_directory_size(p), limit, label)
+
+
+def _read_array(ref, limit):
+    raw_path = ref.get("_path")
+    if not raw_path:
+        raise ValueError("Array item has no readable storage path")
+    path = Path(raw_path)
+    _guard_nbytes(_metadata_estimated_nbytes(ref), limit, "Array item")
+    suffix = path.suffix.lower()
+    backend = str(ref.get("_backend") or "").lower()
+    fmt = str(ref.get("_format") or "").lower()
+
+    import numpy as np
+
+    if backend == "zarr" or fmt == "zarr" or suffix == ".zarr" or path.is_dir():
+        import zarr
+
+        node = zarr.open(str(path), mode="r")
+        handle = node if isinstance(node, zarr.Array) else node.get("data")
+        if handle is None:
+            raise ValueError("Zarr Array item has no top-level array or 'data' dataset")
+        shape = getattr(handle, "shape", None)
+        dtype = getattr(handle, "dtype", None)
+        count = _shape_size(shape)
+        itemsize = _dtype_size(dtype)
+        if count is not None and itemsize is not None:
+            _guard_nbytes(count * itemsize, limit, "Array item")
+        return np.asarray(handle[...])
+
+    if suffix == ".npy":
+        arr = np.load(path, mmap_mode="r")
+        _guard_nbytes(arr.size * arr.dtype.itemsize, limit, "Array item")
+        return np.asarray(arr)
+
+    if suffix == ".npz":
+        _guard_file_or_dir(path, limit, "Array item")
+        loaded = np.load(path)
+        first_key = loaded.files[0] if loaded.files else None
+        if first_key is None:
+            raise ValueError("NPZ Array item contains no arrays")
+        return np.asarray(loaded[first_key])
+
+    if suffix in {".tif", ".tiff"}:
+        _guard_file_or_dir(path, limit, "Array item")
+        import tifffile
+
+        return np.asarray(tifffile.imread(str(path)))
+
+    if suffix in {".png", ".jpeg", ".jpg"}:
+        _guard_file_or_dir(path, limit, "Array item")
+        from PIL import Image
+
+        with Image.open(path) as img:
+            return np.asarray(img)
+
+    if suffix in {".csv", ".tsv", ".txt"}:
+        _guard_file_or_dir(path, limit, "Array item")
+        delimiter = "\t" if suffix == ".tsv" else ","
+        return np.loadtxt(path, delimiter=delimiter)
+
+    raise ValueError("unsupported Array storage for plot open(): " + path.name)
+
+
+def _read_dataframe(ref, limit):
+    raw_path = ref.get("_path")
+    if not raw_path:
+        raise ValueError("DataFrame item has no readable storage path")
+    path = Path(raw_path)
+    _guard_nbytes(_metadata_estimated_nbytes(ref), limit, "DataFrame item")
+    _guard_file_or_dir(path, limit, "DataFrame item")
+    suffix = path.suffix.lower()
+
+    import pandas as pd
+
+    if suffix in {".parquet", ".pq"}:
+        return pd.read_parquet(path)
+    if suffix in {".csv", ".txt"}:
+        return pd.read_csv(path)
+    if suffix == ".tsv":
+        return pd.read_csv(path, sep="\t")
+    if suffix == ".json":
+        return pd.read_json(path)
+    raise ValueError("unsupported DataFrame storage for plot open(): " + path.name)
+
+
+def _read_series(ref, limit):
+    value = _read_dataframe(ref, limit)
+    if hasattr(value, "iloc"):
+        if len(value.columns) == 0:
+            raise ValueError("Series item table has no columns")
+        return value.iloc[:, 0]
+    raise ValueError("unsupported Series storage for plot open()")
+
+
+def _read_text(ref, limit):
+    raw_path = ref.get("_path")
+    if not raw_path:
+        raise ValueError("Text item has no readable storage path")
+    path = Path(raw_path)
+    _guard_file_or_dir(path, limit, "Text item")
+    return path.read_text(encoding="utf-8")
+
+
+def _read_artifact(ref, limit):
+    raw_path = ref.get("_path")
+    if not raw_path:
+        raise ValueError("Artifact item has no readable storage path")
+    path = Path(raw_path)
+    return path
+
+
+def _read_composite(ref, limit):
+    md = ref.get("metadata")
+    if not isinstance(md, dict):
+        return {}
+    slots = md.get("slots")
+    if not isinstance(slots, dict):
+        return {}
+    result = {}
+    for name, slot_ref in slots.items():
+        if isinstance(slot_ref, dict):
+            result[str(name)] = _PlotItem(slot_ref, limit).open()
+    return result
+
+
+def _open_ref(ref, limit):
+    typ = ref.get("type") or "DataObject"
+    if typ == "Array":
+        return _read_array(ref, limit)
+    if typ == "DataFrame":
+        return _read_dataframe(ref, limit)
+    if typ == "Series":
+        return _read_series(ref, limit)
+    if typ == "Text":
+        return _read_text(ref, limit)
+    if typ == "Artifact":
+        return _read_artifact(ref, limit)
+    if typ == "CompositeData":
+        return _read_composite(ref, limit)
+    raise ValueError("unsupported plot collection item type: " + str(typ))
+
+
+def _public_metadata(ref):
+    md = ref.get("metadata") if isinstance(ref, dict) else {}
+    if not isinstance(md, dict):
+        return {}
+    return {
+        str(key): value
+        for key, value in md.items()
+        if key not in {"backend", "format", "path", "storage_ref", "storage", "type_chain", "item_type", "slots"}
+    }
+
+
+class _PlotItem:
+    def __init__(self, ref, max_input_bytes):
+        self._ref = dict(ref)
+        self._max_input_bytes = int(max_input_bytes)
+        self.type = str(ref.get("type") or "DataObject")
+        self.metadata = MappingProxyType(_public_metadata(ref))
+
+    def open(self):
+        return _open_ref(self._ref, self._max_input_bytes)
+
+
+class _PlotItems:
+    def __init__(self, refs, max_input_bytes):
+        self._items = [_PlotItem(ref, max_input_bytes) for ref in refs]
 
     def __len__(self):
-        return len(self._refs)
+        return len(self._items)
 
     def __iter__(self):
-        return iter(self._refs)
+        return iter(self._items)
+
+    def __getitem__(self, index):
+        return self._items[index]
+
+    def open(self, max_items=None):
+        items = self._items
+        if max_items is not None:
+            items = items[: int(max_items)]
+        return [item.open() for item in items]
+
+    def open_one(self):
+        if not self._items:
+            raise IndexError("collection is empty; cannot open_one()")
+        return self._items[0].open()
 
 
-class _Context:
-    def __init__(self, out_dir, max_rows, allowed_formats):
-        self._out_dir = Path(out_dir)
-        self._max_rows = int(max_rows)
-        self._allowed = set(allowed_formats)
-        self._saved = []
-        import matplotlib
+class _PlotCollection:
+    def __init__(self, envelope, max_input_bytes):
+        collection = envelope.get("collection") if isinstance(envelope, dict) else None
+        if not isinstance(collection, dict):
+            collection = {"types": [], "items": []}
+        refs = collection.get("items")
+        if not isinstance(refs, list):
+            refs = []
+        types = collection.get("types")
+        if not isinstance(types, list):
+            types = []
+        self.types = tuple(str(t) for t in types)
+        self.items = _PlotItems(refs, max_input_bytes)
 
-        matplotlib.use("Agg")
+
+def _artifact_name(index, preferred):
+    suffix = "jpg" if preferred == "jpeg" else preferred
+    return "figure." + suffix if index == 0 else "figure_" + str(index) + "." + suffix
+
+
+def _save_matplotlib_figure(fig, out_dir, preferred, allowed, index):
+    _check_allowed("figure." + preferred, allowed)
+    out = Path(out_dir) / _artifact_name(index, preferred)
+    fmt = "jpg" if preferred == "jpeg" else preferred
+    fig.savefig(out, format=fmt, bbox_inches="tight")
+    try:
         import matplotlib.pyplot as plt
 
-        self.plt = plt
+        plt.close(fig)
+    except Exception:
+        pass
+    return out.name
 
-    # --- data access (FR-017) ------------------------------------------
-    def items(self, collection, max_items=None):
-        refs = collection.refs if isinstance(collection, _Collection) else list(collection)
-        if max_items is not None:
-            refs = refs[: int(max_items)]
-        return refs
 
-    def to_dataframe(self, collection, max_rows=None):
-        import pandas as pd
+def _collect_path(value, out_dir, allowed):
+    raw = Path(value)
+    candidate = raw if raw.is_absolute() else (Path(out_dir) / raw)
+    resolved = candidate.resolve()
+    root = Path(out_dir).resolve()
+    try:
+        resolved.relative_to(root)
+    except ValueError as exc:
+        raise PermissionError("returned artifact path escapes the plot working directory") from exc
+    if not resolved.is_file():
+        raise FileNotFoundError("returned artifact path does not exist: " + str(raw))
+    _check_allowed(resolved, allowed)
+    return resolved.name
 
-        cap = int(max_rows) if max_rows is not None else self._max_rows
-        cap = min(cap, self._max_rows)
-        refs = collection.refs if isinstance(collection, _Collection) else list(collection)
-        frames = []
-        remaining = cap
-        for ref in refs:
-            if remaining <= 0:
-                break
-            path = ref.get("path") if isinstance(ref, dict) else None
-            if not path:
-                continue
-            suffix = Path(path).suffix.lower()
-            if suffix in (".parquet", ".pq"):
-                df = pd.read_parquet(path)
-                df = df.head(remaining)
-            elif suffix in (".csv", ".tsv", ".txt"):
-                sep = "\t" if suffix == ".tsv" else ","
-                df = pd.read_csv(path, sep=sep, nrows=remaining)
-            elif suffix in (".json",):
-                df = pd.read_json(path)
-                df = df.head(remaining)
-            else:
-                continue
-            frames.append(df)
-            remaining -= len(df)
-        if not frames:
-            return pd.DataFrame()
-        return pd.concat(frames, ignore_index=True).head(cap)
 
-    # --- saving (FR-018) -----------------------------------------------
-    def _check_format(self, filename):
-        ext = Path(filename).suffix.lower().lstrip(".")
-        if ext == "jpg":
-            ext = "jpeg"
-        if ext not in {"svg", "pdf", "png", "jpeg"}:
-            raise ValueError("unsupported output format: ." + ext)
-        if self._allowed and ext not in self._allowed:
-            raise ValueError("format ." + ext + " not in manifest allowed_formats")
-        return ext
-
-    def save_figure(self, fig, filename):
-        ext = self._check_format(filename)
-        out = self._out_dir / Path(filename).name
-        fig.savefig(out, format=ext if ext != "jpeg" else "jpg", bbox_inches="tight")
-        self.plt.close(fig)
-        self._saved.append(out.name)
-        return str(out)
-
-    # Alias so Python scripts can use the same name as R's save_plot.
-    def save_plot(self, fig, filename):
-        return self.save_figure(fig, filename)
-
-    @property
-    def saved(self):
-        return list(self._saved)
+def _collect_artifacts(value, out_dir, preferred, allowed):
+    if value is None:
+        raise ValueError("render(collection) must return a figure, artifact path, or list of artifacts")
+    values = list(value) if isinstance(value, (list, tuple)) else [value]
+    artifacts = []
+    fig_index = 0
+    for one in values:
+        if one is None:
+            raise ValueError("render(collection) returned an unsupported None artifact")
+        if isinstance(one, (str, Path)):
+            artifacts.append(_collect_path(one, out_dir, allowed))
+            continue
+        if hasattr(one, "savefig"):
+            artifacts.append(_save_matplotlib_figure(one, out_dir, preferred, allowed, fig_index))
+            fig_index += 1
+            continue
+        raise TypeError("unsupported render return value: " + type(one).__name__)
+    return artifacts
 
 
 def main():
@@ -148,22 +391,20 @@ def main():
     entrypoint = sys.argv[2]
     inputs_json = sys.argv[3]
     out_dir = sys.argv[4]
-    max_rows = sys.argv[5]
+    preferred = sys.argv[5]
     allowed = [s for s in sys.argv[6].split(",") if s]
+    max_input_bytes = int(sys.argv[7])
     try:
-        refs = json.loads(Path(inputs_json).read_text(encoding="utf-8"))
-        collection = _Collection(refs)
-        context = _Context(out_dir, max_rows, allowed)
+        import matplotlib
+
+        matplotlib.use("Agg")
+        envelope = json.loads(Path(inputs_json).read_text(encoding="utf-8"))
+        collection = _PlotCollection(envelope, max_input_bytes)
         render = _load_render(script_name, entrypoint)
-        render(collection, context)
-        artifacts = context.saved
-        if not artifacts:
-            # Scan the out dir for any produced image as a fallback.
-            for child in sorted(Path(out_dir).iterdir()):
-                if child.suffix.lower().lstrip(".") in {"svg", "pdf", "png", "jpeg", "jpg"}:
-                    artifacts.append(child.name)
+        result = render(collection)
+        artifacts = _collect_artifacts(result, out_dir, preferred, allowed)
         print(json.dumps({"ok": True, "artifacts": artifacts}))
-    except Exception as exc:  # noqa: BLE001 - sanitized below
+    except Exception as exc:  # noqa: BLE001 - sanitized by parent runtime
         tb = traceback.format_exc(limit=4)
         print(json.dumps({"ok": False, "error": str(exc), "trace": tb}))
         sys.exit(1)
@@ -179,7 +420,8 @@ if __name__ == "__main__":
 # ---------------------------------------------------------------------------
 #
 # argv passed to Rscript: _plot_harness.R <script.R> <entrypoint> <inputs.json>
-#                         <out_dir> <max_rows> <allowed_csv>
+#                         <out_dir> <preferred_format> <allowed_csv>
+#                         <max_input_bytes>
 # stdout: one JSON line, same contract as the Python harness.
 
 R_HARNESS = r"""# Auto-generated plot harness (ADR-048). Do not edit; regenerated each run.
@@ -188,67 +430,260 @@ script_name <- args[[1]]
 entrypoint  <- args[[2]]
 inputs_json <- args[[3]]
 out_dir     <- args[[4]]
-max_rows    <- as.integer(args[[5]])
+preferred   <- args[[5]]
 allowed     <- strsplit(args[[6]], ",")[[1]]
+allowed     <- allowed[nzchar(allowed)]
+max_input_bytes <- as.numeric(args[[7]])
 
 emit <- function(obj) {
   cat(jsonlite::toJSON(obj, auto_unbox = TRUE), "\n", sep = "")
 }
 
-result <- tryCatch({
-  refs <- jsonlite::fromJSON(inputs_json, simplifyVector = FALSE)
-  saved <- character(0)
-
-  check_format <- function(filename) {
-    ext <- tolower(tools::file_ext(filename))
-    if (ext == "jpg") ext <- "jpeg"
-    if (!(ext %in% c("svg", "pdf", "png", "jpeg"))) stop(paste0("unsupported output format: .", ext))
-    if (length(allowed) > 0 && !(ext %in% allowed)) stop(paste0("format .", ext, " not in allowed_formats"))
-    ext
+check_format <- function(filename) {
+  ext <- tolower(tools::file_ext(filename))
+  if (ext == "jpg") ext <- "jpeg"
+  if (!(ext %in% c("svg", "pdf", "png", "jpeg"))) {
+    stop(paste0("unsupported output format: .", ext))
   }
+  if (length(allowed) > 0 && !(ext %in% allowed)) {
+    stop(paste0("format .", ext, " not in manifest allowed_formats"))
+  }
+  ext
+}
 
-  context <- list(
-    to_dataframe = function(collection, max_rows = NULL) {
-      cap <- if (is.null(max_rows)) max_rows else min(as.integer(max_rows), max_rows)
-      cap <- if (is.null(cap)) get("max_rows", envir = globalenv()) else cap
-      frames <- list()
-      for (ref in refs) {
-        path <- ref$path
-        if (is.null(path)) next
-        ext <- tolower(tools::file_ext(path))
-        if (ext %in% c("csv", "txt")) {
-          frames[[length(frames) + 1]] <- utils::read.csv(path, nrows = cap)
-        } else if (ext == "tsv") {
-          frames[[length(frames) + 1]] <- utils::read.delim(path, nrows = cap)
-        }
-      }
-      if (length(frames) == 0) return(data.frame())
-      df <- do.call(rbind, frames)
-      utils::head(df, cap)
-    },
-    save_plot = function(plot, filename) {
-      ext <- check_format(filename)
-      out <- file.path(out_dir, basename(filename))
-      if (requireNamespace("ggplot2", quietly = TRUE) && inherits(plot, "ggplot")) {
-        ggplot2::ggsave(out, plot = plot, device = if (ext == "jpeg") "jpeg" else ext)
-      } else {
-        dev_fn <- switch(ext, svg = grDevices::svg, pdf = grDevices::pdf,
-                         png = grDevices::png, jpeg = grDevices::jpeg)
-        dev_fn(out)
-        print(plot)
-        grDevices::dev.off()
-      }
-      saved <<- c(saved, basename(out))
-      out
+guard_bytes <- function(nbytes, label) {
+  if (!is.na(nbytes) && nbytes > max_input_bytes) {
+    stop(paste0(
+      label, " would materialize ", nbytes,
+      " bytes, exceeding the plot input memory cap of ",
+      max_input_bytes, " bytes. Use an explicit storage-aware reader for large plot inputs."
+    ))
+  }
+}
+
+guard_path <- function(path, label) {
+  if (file.exists(path) && !dir.exists(path)) {
+    guard_bytes(file.info(path)$size, label)
+  }
+}
+
+dtype_size <- function(dtype) {
+  if (is.null(dtype)) return(NA_real_)
+  dtype <- tolower(as.character(dtype))
+  if (grepl("float64|double|int64|uint64", dtype)) return(8)
+  if (grepl("float32|single|int32|uint32", dtype)) return(4)
+  if (grepl("float16|int16|uint16", dtype)) return(2)
+  if (grepl("bool|int8|uint8", dtype)) return(1)
+  NA_real_
+}
+
+metadata_nbytes <- function(ref) {
+  md <- ref$metadata
+  if (is.null(md) || !is.list(md)) return(NA_real_)
+  shape <- md$shape
+  if (is.null(shape)) shape <- md$array_shape
+  dtype <- md$dtype
+  if (is.null(dtype)) dtype <- md$array_dtype
+  if (is.null(shape)) return(NA_real_)
+  count <- prod(as.numeric(unlist(shape)))
+  itemsize <- dtype_size(dtype)
+  if (is.na(count) || is.na(itemsize)) return(NA_real_)
+  count * itemsize
+}
+
+guard_ref <- function(ref, label) {
+  guard_bytes(metadata_nbytes(ref), label)
+}
+
+public_metadata <- function(ref) {
+  md <- ref$metadata
+  if (is.null(md) || !is.list(md)) return(list())
+  md$backend <- NULL
+  md$format <- NULL
+  md$path <- NULL
+  md$storage <- NULL
+  md$storage_ref <- NULL
+  md$type_chain <- NULL
+  md$item_type <- NULL
+  md$slots <- NULL
+  md
+}
+
+read_dataframe <- function(ref) {
+  path <- ref$`_path`
+  if (is.null(path)) stop("DataFrame item has no readable storage path")
+  guard_ref(ref, "DataFrame item")
+  guard_path(path, "DataFrame item")
+  ext <- tolower(tools::file_ext(path))
+  if (ext %in% c("csv", "txt")) return(utils::read.csv(path))
+  if (ext == "tsv") return(utils::read.delim(path))
+  if (ext == "json") return(as.data.frame(jsonlite::fromJSON(path)))
+  if (ext %in% c("parquet", "pq") && requireNamespace("arrow", quietly = TRUE)) {
+    return(as.data.frame(arrow::read_parquet(path)))
+  }
+  stop(paste0("unsupported DataFrame storage for plot open(): ", basename(path)))
+}
+
+read_array <- function(ref) {
+  path <- ref$`_path`
+  if (is.null(path)) stop("Array item has no readable storage path")
+  guard_ref(ref, "Array item")
+  guard_path(path, "Array item")
+  ext <- tolower(tools::file_ext(path))
+  if (ext %in% c("csv", "txt")) return(as.matrix(utils::read.csv(path, header = FALSE)))
+  if (ext == "tsv") return(as.matrix(utils::read.delim(path, header = FALSE)))
+  if (ext == "json") return(as.array(jsonlite::fromJSON(path)))
+  stop(paste0("unsupported Array storage for R plot open(): ", basename(path)))
+}
+
+read_series <- function(ref) {
+  df <- read_dataframe(ref)
+  if (ncol(df) < 1) stop("Series item table has no columns")
+  df[[1]]
+}
+
+read_text <- function(ref) {
+  path <- ref$`_path`
+  if (is.null(path)) stop("Text item has no readable storage path")
+  guard_ref(ref, "Text item")
+  guard_path(path, "Text item")
+  paste(readLines(path, warn = FALSE), collapse = "\n")
+}
+
+open_ref <- function(ref) {
+  typ <- ref$type
+  if (is.null(typ)) typ <- "DataObject"
+  if (typ == "Array") return(read_array(ref))
+  if (typ == "DataFrame") return(read_dataframe(ref))
+  if (typ == "Series") return(read_series(ref))
+  if (typ == "Text") return(read_text(ref))
+  if (typ == "Artifact") return(ref$`_path`)
+  if (typ == "CompositeData") {
+    slots <- ref$metadata$slots
+    if (is.null(slots) || !is.list(slots)) return(list())
+    opened <- list()
+    for (name in names(slots)) {
+      opened[[name]] <- open_ref(slots[[name]])
     }
-  )
-  context$save_figure <- context$save_plot
+    return(opened)
+  }
+  stop(paste0("unsupported plot collection item type: ", typ))
+}
 
+make_item <- function(ref) {
+  item <- new.env(parent = emptyenv())
+  item$type <- if (is.null(ref$type)) "DataObject" else ref$type
+  item$metadata <- public_metadata(ref)
+  item$open <- function() open_ref(ref)
+  item
+}
+
+make_items <- function(refs) {
+  items <- new.env(parent = emptyenv())
+  hidden <- lapply(refs, make_item)
+  items$._items <- hidden
+  items$open <- function(max_items = NULL) {
+    selected <- hidden
+    if (!is.null(max_items)) selected <- selected[seq_len(min(as.integer(max_items), length(hidden)))]
+    lapply(selected, function(item) item$open())
+  }
+  items$open_one <- function() {
+    if (length(hidden) == 0) stop("collection is empty; cannot open_one()")
+    hidden[[1]]$open()
+  }
+  class(items) <- "PlotItems"
+  items
+}
+
+length.PlotItems <- function(x) length(x$._items)
+`[[.PlotItems` <- function(x, i) x$._items[[i]]
+
+make_collection <- function(envelope) {
+  raw_collection <- envelope$collection
+  if (is.null(raw_collection)) raw_collection <- list(types = character(0), items = list())
+  collection <- new.env(parent = emptyenv())
+  collection$types <- unlist(raw_collection$types %||% character(0), use.names = FALSE)
+  collection$items <- make_items(raw_collection$items %||% list())
+  collection
+}
+
+`%||%` <- function(left, right) {
+  if (is.null(left)) right else left
+}
+
+safe_artifact_path <- function(path) {
+  candidate <- if (grepl("^([A-Za-z]:)?[\\\\/]", path)) path else file.path(out_dir, path)
+  resolved <- normalizePath(candidate, mustWork = TRUE, winslash = "/", unset = NA)
+  root <- normalizePath(out_dir, mustWork = TRUE, winslash = "/", unset = NA)
+  if (is.na(resolved) || !startsWith(resolved, root)) {
+    stop("returned artifact path escapes the plot working directory")
+  }
+  check_format(resolved)
+  basename(resolved)
+}
+
+save_ggplot <- function(plot, index) {
+  ext <- check_format(paste0("figure.", preferred))
+  suffix <- if (preferred == "jpeg") "jpg" else preferred
+  filename <- if (index == 0) paste0("figure.", suffix) else paste0("figure_", index, ".", suffix)
+  out <- file.path(out_dir, filename)
+  ggplot2::ggsave(out, plot = plot, device = if (ext == "jpeg") "jpeg" else ext)
+  basename(out)
+}
+
+collect_returned <- function(value) {
+  if (is.null(value)) return(character(0))
+  values <- if (is.list(value) && !inherits(value, "ggplot")) value else list(value)
+  out <- character(0)
+  gg_index <- 0
+  for (one in values) {
+    if (is.character(one) && length(one) == 1) {
+      out <- c(out, safe_artifact_path(one))
+    } else if (requireNamespace("ggplot2", quietly = TRUE) && inherits(one, "ggplot")) {
+      out <- c(out, save_ggplot(one, gg_index))
+      gg_index <- gg_index + 1
+    } else if (!is.null(one)) {
+      stop(paste0("unsupported render return value: ", paste(class(one), collapse = "/")))
+    }
+  }
+  out
+}
+
+device_filename <- function() {
+  suffix <- if (preferred == "jpeg") "jpg" else preferred
+  paste0("figure.", suffix)
+}
+
+open_device <- function(path) {
+  ext <- check_format(path)
+  if (ext == "svg") grDevices::svg(path)
+  else if (ext == "pdf") grDevices::pdf(path)
+  else if (ext == "png") grDevices::png(path)
+  else grDevices::jpeg(path)
+}
+
+result <- tryCatch({
+  envelope <- jsonlite::fromJSON(inputs_json, simplifyVector = FALSE)
+  collection <- make_collection(envelope)
   source(script_name, local = TRUE)
   render_fn <- get(entrypoint)
-  render_fn(refs, context)
-  list(ok = TRUE, artifacts = saved)
+
+  device_file <- file.path(out_dir, device_filename())
+  open_device(device_file)
+  before_pages <- grDevices::dev.cur()
+  rendered <- render_fn(collection)
+  grDevices::dev.off()
+
+  artifacts <- collect_returned(rendered)
+  if (length(artifacts) == 0 && file.exists(device_file) && file.info(device_file)$size > 0) {
+    artifacts <- basename(device_file)
+  }
+  if (length(artifacts) == 0) stop("render(collection) produced no plot artifact")
+  list(ok = TRUE, artifacts = artifacts)
 }, error = function(e) {
+  while (grDevices::dev.cur() > 1) {
+    try(grDevices::dev.off(), silent = TRUE)
+  }
   list(ok = FALSE, error = conditionMessage(e))
 })
 

--- a/src/scistudio/ai/agent/mcp/tools_plot/examples.py
+++ b/src/scistudio/ai/agent/mcp/tools_plot/examples.py
@@ -1,60 +1,62 @@
 """Curated plot examples for matplotlib / seaborn / ggplot2 (ADR-048 SPEC 2 FR-019).
 
-Each example is a complete ``render`` function an agent can adapt. The Python
-examples target the ``context.plt`` / ``context.save_figure`` helpers; the R
-example targets ``context$to_dataframe`` / ``context$save_plot`` (FR-014, FR-015,
-FR-018).
+Each example is a complete ``render`` function an agent can adapt. Examples use
+the context-free collection wrapper, open data into ordinary scientific objects,
+and return familiar matplotlib / ggplot2 plot objects.
 """
 
 from __future__ import annotations
 
 from scistudio.ai.agent.mcp.tools_plot.models import PlotExample
 
-_MATPLOTLIB_SCATTER = '''def render(collection, context):
-    """Scatter plot with matplotlib (FR-014)."""
-    df = context.to_dataframe(collection, max_rows=10000)
-    fig, ax = context.plt.subplots()
+_MATPLOTLIB_SCATTER = '''def render(collection):
+    """Scatter plot with matplotlib."""
+    import matplotlib.pyplot as plt
+
+    df = collection.items.open_one()
+    fig, ax = plt.subplots()
     ax.scatter(df["x"], df["y"], s=6)
     ax.set_xlabel("x")
     ax.set_ylabel("y")
-    return context.save_figure(fig, "figure.svg")
+    return fig
 '''
 
-_MATPLOTLIB_HIST = '''def render(collection, context):
+_MATPLOTLIB_HIST = '''def render(collection):
     """Histogram of one numeric column with matplotlib."""
-    df = context.to_dataframe(collection, max_rows=10000)
-    fig, ax = context.plt.subplots()
+    import matplotlib.pyplot as plt
+
+    df = collection.items.open_one()
+    fig, ax = plt.subplots()
     ax.hist(df["value"], bins=30)
     ax.set_xlabel("value")
     ax.set_ylabel("count")
-    return context.save_figure(fig, "figure.png")
+    return fig
 '''
 
-_SEABORN_BOX = '''def render(collection, context):
-    """Boxplot with seaborn (uses the project environment's seaborn if present)."""
+_SEABORN_BOX = '''def render(collection):
+    """Boxplot with seaborn."""
+    import matplotlib.pyplot as plt
     import seaborn as sns
 
-    df = context.to_dataframe(collection, max_rows=10000)
-    fig, ax = context.plt.subplots()
+    df = collection.items.open_one()
+    fig, ax = plt.subplots()
     sns.boxplot(data=df, x="group", y="value", ax=ax)
-    return context.save_figure(fig, "figure.svg")
+    return fig
 '''
 
-_GGPLOT2_POINT = """render <- function(collection, context) {
-  # ggplot2 scatter (FR-013, FR-015). Requires R + ggplot2 in the project env.
-  df <- context$to_dataframe(collection, max_rows = 10000)
-  p <- ggplot2::ggplot(df, ggplot2::aes(x = x, y = y)) +
+_GGPLOT2_POINT = """render <- function(collection) {
+  # ggplot2 scatter. Requires R + ggplot2 in the project environment.
+  df <- collection$items$open_one()
+  ggplot2::ggplot(df, ggplot2::aes(x = x, y = y)) +
     ggplot2::geom_point()
-  context$save_plot(p, "figure.pdf")
 }
 """
 
-_GGPLOT2_BAR = """render <- function(collection, context) {
+_GGPLOT2_BAR = """render <- function(collection) {
   # ggplot2 bar chart of a categorical count.
-  df <- context$to_dataframe(collection, max_rows = 10000)
-  p <- ggplot2::ggplot(df, ggplot2::aes(x = category)) +
+  df <- collection$items$open_one()
+  ggplot2::ggplot(df, ggplot2::aes(x = category)) +
     ggplot2::geom_bar()
-  context$save_plot(p, "figure.svg")
 }
 """
 
@@ -65,7 +67,7 @@ _EXAMPLES: tuple[PlotExample, ...] = (
         language="python",
         library="matplotlib",
         title="Scatter plot",
-        description="Two-column scatter using context.plt + context.save_figure → SVG.",
+        description="Two-column scatter using collection.items.open_one() and matplotlib.",
         source=_MATPLOTLIB_SCATTER,
         output_formats=["svg"],
     ),
@@ -74,7 +76,7 @@ _EXAMPLES: tuple[PlotExample, ...] = (
         language="python",
         library="matplotlib",
         title="Histogram",
-        description="Single-column histogram saved as PNG.",
+        description="Single-column histogram using collection.items.open_one() and matplotlib.",
         source=_MATPLOTLIB_HIST,
         output_formats=["png"],
     ),
@@ -83,7 +85,7 @@ _EXAMPLES: tuple[PlotExample, ...] = (
         language="python",
         library="seaborn",
         title="Boxplot",
-        description="Grouped boxplot via seaborn over a matplotlib Figure → SVG.",
+        description="Grouped boxplot via seaborn over a matplotlib Figure.",
         source=_SEABORN_BOX,
         output_formats=["svg"],
     ),
@@ -92,7 +94,7 @@ _EXAMPLES: tuple[PlotExample, ...] = (
         language="r",
         library="ggplot2",
         title="ggplot2 scatter",
-        description="Scatter via ggplot2 + context$save_plot → PDF.",
+        description="Scatter via collection$items$open_one() and ggplot2.",
         source=_GGPLOT2_POINT,
         output_formats=["pdf"],
     ),
@@ -101,7 +103,7 @@ _EXAMPLES: tuple[PlotExample, ...] = (
         language="r",
         library="ggplot2",
         title="ggplot2 bar chart",
-        description="Categorical bar chart via ggplot2 → SVG.",
+        description="Categorical bar chart via collection$items$open_one() and ggplot2.",
         source=_GGPLOT2_BAR,
         output_formats=["svg"],
     ),

--- a/src/scistudio/ai/agent/mcp/tools_plot/models.py
+++ b/src/scistudio/ai/agent/mcp/tools_plot/models.py
@@ -26,9 +26,10 @@ PlotStatus = Literal["succeeded", "failed", "cancelled", "timed_out"]
 # raise the caps beyond the safe envelope.
 DEFAULT_TIMEOUT_SECONDS: float = 30.0
 ABSOLUTE_MAX_TIMEOUT_SECONDS: float = 300.0
-DEFAULT_MAX_ROWS: int = 10000
 DEFAULT_MAX_OUTPUT_BYTES: int = 10 * 1024 * 1024  # 10 MiB
 ABSOLUTE_MAX_OUTPUT_BYTES: int = 64 * 1024 * 1024  # 64 MiB
+DEFAULT_MAX_INPUT_BYTES: int = 64 * 1024 * 1024  # 64 MiB
+ABSOLUTE_MAX_INPUT_BYTES: int = 512 * 1024 * 1024  # 512 MiB
 DEFAULT_MAX_FILES: int = 8
 ABSOLUTE_MAX_FILES: int = 32
 LOG_TRUNCATE_BYTES: int = 16 * 1024  # 16 KiB per stream (FR-029)
@@ -140,7 +141,7 @@ class PlotManifestLimits(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    max_rows: int = Field(default=DEFAULT_MAX_ROWS, gt=0)
+    max_input_bytes: int = Field(default=DEFAULT_MAX_INPUT_BYTES, gt=0)
     max_output_bytes: int = Field(default=DEFAULT_MAX_OUTPUT_BYTES, gt=0)
     max_files: int = Field(default=DEFAULT_MAX_FILES, gt=0)
 
@@ -332,11 +333,12 @@ class PlotRunResult(BaseModel):
 
 __all__ = [
     "ABSOLUTE_MAX_FILES",
+    "ABSOLUTE_MAX_INPUT_BYTES",
     "ABSOLUTE_MAX_OUTPUT_BYTES",
     "ABSOLUTE_MAX_TIMEOUT_SECONDS",
     "DEFAULT_MAX_FILES",
+    "DEFAULT_MAX_INPUT_BYTES",
     "DEFAULT_MAX_OUTPUT_BYTES",
-    "DEFAULT_MAX_ROWS",
     "DEFAULT_TIMEOUT_SECONDS",
     "LOG_TRUNCATE_BYTES",
     "ListPlotExamplesResult",

--- a/src/scistudio/ai/agent/mcp/tools_plot/runtime.py
+++ b/src/scistudio/ai/agent/mcp/tools_plot/runtime.py
@@ -28,6 +28,7 @@ from scistudio.ai.agent.mcp._context import _resolve_project_root, get_context
 from scistudio.ai.agent.mcp.tools_plot._harness import PYTHON_HARNESS, R_HARNESS
 from scistudio.ai.agent.mcp.tools_plot.models import (
     ABSOLUTE_MAX_FILES,
+    ABSOLUTE_MAX_INPUT_BYTES,
     ABSOLUTE_MAX_OUTPUT_BYTES,
     ABSOLUTE_MAX_TIMEOUT_SECONDS,
     LOG_TRUNCATE_BYTES,
@@ -45,6 +46,8 @@ _PYTHON_HARNESS_NAME = "_plot_harness.py"
 _R_HARNESS_NAME = "_plot_harness.R"
 _INPUTS_NAME = "_plot_inputs.json"
 _PREVIEW_ROOT = ".scistudio/previews"
+_CORE_OPEN_TYPES = ("Array", "DataFrame", "Series", "Text", "Artifact", "CompositeData")
+_CORE_OPEN_TYPE_SET = frozenset(_CORE_OPEN_TYPES)
 
 
 # ---------------------------------------------------------------------------
@@ -130,13 +133,14 @@ def _flatten_to_refs(value: Any) -> tuple[list[dict[str, Any]], list[str]]:
     refs: list[dict[str, Any]] = []
     collection_ids: list[str] = []
 
-    def _one(item: Any) -> None:
+    def _one(item: Any, *, item_type: str | None = None) -> None:
         if isinstance(item, dict) and "path" in item:
             refs.append(
                 {
                     "backend": item.get("backend", "filesystem"),
                     "path": str(item.get("path")),
                     "format": item.get("format"),
+                    "item_type": item.get("item_type") or item.get("type") or item_type,
                     "metadata": item.get("metadata"),
                 }
             )
@@ -155,8 +159,9 @@ def _flatten_to_refs(value: Any) -> tuple[list[dict[str, Any]], list[str]]:
         # a single ref. FR-016: the plot script must receive the actual
         # selected block-output collection, not an empty one.
         if value.get("_collection") and isinstance(value.get("items"), list):
+            item_type = str(value.get("item_type")) if value.get("item_type") else None
             for it in value["items"]:
-                _one(it)
+                _one(it, item_type=item_type)
         elif isinstance(value.get("_collection_items"), list):
             for it in value["_collection_items"]:
                 _one(it)
@@ -235,11 +240,94 @@ def _register_preview_artifact(
 # ---------------------------------------------------------------------------
 
 
-def _clamp_limits(manifest: PlotManifest) -> tuple[float, int, int]:
+def _clamp_limits(manifest: PlotManifest) -> tuple[float, int, int, int]:
     timeout = min(float(manifest.runtime.timeout_seconds), ABSOLUTE_MAX_TIMEOUT_SECONDS)
+    max_input_bytes = min(int(manifest.limits.max_input_bytes), ABSOLUTE_MAX_INPUT_BYTES)
     max_bytes = min(int(manifest.limits.max_output_bytes), ABSOLUTE_MAX_OUTPUT_BYTES)
     max_files = min(int(manifest.limits.max_files), ABSOLUTE_MAX_FILES)
-    return timeout, max_bytes, max_files
+    return timeout, max_bytes, max_files, max_input_bytes
+
+
+def _input_envelope(refs: list[dict[str, Any]], type_registry: Any | None = None) -> dict[str, Any]:
+    """Build the context-free collection envelope consumed by the harness."""
+    items = [_normalise_input_item(ref, type_registry=type_registry) for ref in refs]
+    types: list[str] = []
+    for item in items:
+        typ = str(item.get("type") or "DataObject")
+        if typ != "DataObject" and typ not in types:
+            types.append(typ)
+    return {"schema_version": 1, "collection": {"types": types, "items": items}}
+
+
+def _normalise_input_item(ref: dict[str, Any], *, type_registry: Any | None = None) -> dict[str, Any]:
+    """Fold package subclasses to supported core base types for user code."""
+    metadata = ref.get("metadata") if isinstance(ref.get("metadata"), dict) else {}
+    normalised_metadata = dict(metadata) if isinstance(metadata, dict) else {}
+    slots = normalised_metadata.get("slots")
+    if isinstance(slots, dict):
+        normalised_metadata["slots"] = {
+            str(name): _normalise_input_item(slot, type_registry=type_registry)
+            for name, slot in slots.items()
+            if isinstance(slot, dict)
+        }
+    return {
+        "type": _normalise_core_type(ref, type_registry=type_registry),
+        "_backend": ref.get("backend"),
+        "_path": ref.get("path"),
+        "_format": ref.get("format"),
+        "metadata": normalised_metadata,
+    }
+
+
+def _normalise_core_type(ref: dict[str, Any], *, type_registry: Any | None = None) -> str:
+    raw_chain: Any = None
+    metadata = ref.get("metadata")
+    if isinstance(metadata, dict):
+        raw_chain = metadata.get("type_chain")
+    if not raw_chain:
+        raw_chain = ref.get("type_chain")
+    if not raw_chain:
+        raw_chain = ref.get("item_type")
+    if isinstance(raw_chain, str):
+        chain = [raw_chain]
+    elif isinstance(raw_chain, (list, tuple)):
+        chain = [str(name) for name in raw_chain]
+    else:
+        chain = []
+    for name in reversed(chain):
+        if name in _CORE_OPEN_TYPE_SET:
+            return name
+        base = _registered_core_base(type_registry, name)
+        if base is not None:
+            return base
+    if str(ref.get("format") or "").lower() in {"csv", "tsv", "parquet", "pq"}:
+        return "DataFrame"
+    return "DataObject"
+
+
+def _registered_core_base(type_registry: Any | None, type_name: str) -> str | None:
+    if type_registry is None or type_name in _CORE_OPEN_TYPE_SET:
+        return type_name if type_name in _CORE_OPEN_TYPE_SET else None
+    try:
+        types = type_registry.all_types()
+    except Exception:
+        return None
+    if not isinstance(types, dict):
+        return None
+    current = type_name
+    seen: set[str] = set()
+    while current and current not in seen:
+        if current in _CORE_OPEN_TYPE_SET:
+            return current
+        seen.add(current)
+        spec = types.get(current)
+        if spec is None:
+            return None
+        if isinstance(spec, dict):
+            current = str(spec.get("base_type") or "")
+        else:
+            current = str(getattr(spec, "base_type", "") or "")
+    return None
 
 
 def _interpreter_for(loaded: LoadedPlot) -> list[str] | None:
@@ -299,7 +387,7 @@ def run_plot_job(plot_id: str, run_id: str | None = None, timeout_seconds: float
     root = _resolve_project_root(ctx)
     loaded = load_plot(plot_id=plot_id)
     manifest = loaded.manifest
-    timeout, max_bytes, max_files = _clamp_limits(manifest)
+    timeout, max_bytes, max_files, max_input_bytes = _clamp_limits(manifest)
     if timeout_seconds is not None:
         timeout = min(float(timeout_seconds), ABSOLUTE_MAX_TIMEOUT_SECONDS)
 
@@ -344,7 +432,10 @@ def run_plot_job(plot_id: str, run_id: str | None = None, timeout_seconds: float
         (work_dir / _R_HARNESS_NAME).write_text(R_HARNESS, encoding="utf-8")
     user_script_name = Path(manifest.script.path).name
     shutil.copy2(loaded.script_path, work_dir / user_script_name)
-    (work_dir / _INPUTS_NAME).write_text(json.dumps(resolved.refs), encoding="utf-8")
+    (work_dir / _INPUTS_NAME).write_text(
+        json.dumps(_input_envelope(resolved.refs, type_registry=getattr(ctx, "type_registry", None))),
+        encoding="utf-8",
+    )
 
     allowed_csv = ",".join(manifest.outputs.allowed_formats)
     argv = [
@@ -353,8 +444,9 @@ def run_plot_job(plot_id: str, run_id: str | None = None, timeout_seconds: float
         manifest.script.entrypoint,
         _INPUTS_NAME,
         ".",
-        str(manifest.limits.max_rows),
+        manifest.outputs.preferred_format,
         allowed_csv,
+        str(max_input_bytes),
     ]
 
     status: PlotStatus = "failed"

--- a/src/scistudio/ai/agent/mcp/tools_plot/scaffold.py
+++ b/src/scistudio/ai/agent/mcp/tools_plot/scaffold.py
@@ -36,53 +36,69 @@ What ``collection`` means:
   is bound to. If the block output is one table, the collection contains one
   table-like item. If the block output is a collection of five arrays, it
   contains five array items. Treat it as input data, not as workflow state.
-
-What ``context`` means:
-  ``context`` is the small plot-runtime helper object SciStudio gives this
-  script. It loads bounded input data, exposes matplotlib as ``context.plt``,
-  and saves the final artifact. It is not the workflow engine context and it
-  should not mutate blocks, nodes, files, or lineage records.
 """
 
 from __future__ import annotations
 
 
-def render(collection, context):
-    """Draw a figure from ``collection`` and return the saved artifact path.
+def render(collection):
+    """Draw a figure from ``collection`` and return a matplotlib Figure.
 
-    Available context helpers:
-      * context.to_dataframe(collection, max_rows=...) -> pandas.DataFrame
-      * context.items(collection, max_items=...)        -> bounded iterator
-      * context.plt                                      -> matplotlib.pyplot
-      * context.save_figure(fig, "figure.svg")           -> save PNG/JPEG/SVG/PDF
+    Available collection helpers:
+      * collection.types                  -> tuple[str, ...]
+      * collection.items                  -> sequence of item wrappers
+      * len(collection.items)             -> number of items
+      * collection.items.open()           -> list of native values
+      * collection.items.open(max_items=n)-> list of at most n native values
+      * collection.items.open_one()       -> first native value
+      * collection.items[index].type      -> normalized core base type
+      * collection.items[index].metadata  -> read-only non-storage metadata
+      * collection.items[index].open()    -> one native value
 
     Minimal examples you can paste over the default plot:
 
-      # Example A: collection contains up to 5 NumPy .npy arrays; draw each
-      # flattened value distribution.
+      # Example A: collection contains up to 5 arrays; draw each flattened
+      # value distribution.
       # import numpy as np
-      # fig, ax = context.plt.subplots()
-      # for index, item in enumerate(context.items(collection, max_items=5)):
-      #     path = item.get("path")
-      #     if not path:
-      #         continue
-      #     array = np.load(path)
+      # import matplotlib.pyplot as plt
+      # fig, ax = plt.subplots()
+      # for index, array in enumerate(collection.items.open(max_items=5)):
       #     ax.hist(np.asarray(array).ravel(), bins=64, alpha=0.35, label="array " + str(index + 1))
       # ax.legend()
-      # return context.save_figure(fig, "figure.svg")
+      # return fig
 
       # Example B: collection contains one dataframe; draw a box plot from the
       # 2nd and 3rd dataframe columns.
-      # df = context.to_dataframe(collection, max_rows=10000)
-      # fig, ax = context.plt.subplots()
+      # import matplotlib.pyplot as plt
+      # df = collection.items.open_one()
+      # fig, ax = plt.subplots()
       # df.iloc[:, [1, 2]].plot(kind="box", ax=ax)
-      # return context.save_figure(fig, "figure.svg")
+      # return fig
     """
-    df = context.to_dataframe(collection, max_rows={max_rows})
-    fig, ax = context.plt.subplots()
-    # EDIT HERE: replace with your plot. Example: ax.scatter(df["x"], df["y"], s=6)
-    ax.plot(range(len(df)))
-    return context.save_figure(fig, "figure.{ext}")
+    import numpy as np
+    import matplotlib.pyplot as plt
+
+    data = collection.items.open_one()
+    fig, ax = plt.subplots()
+
+    if hasattr(data, "select_dtypes"):
+        numeric = data.select_dtypes(include="number")
+        if len(numeric.columns) >= 2:
+            ax.scatter(numeric.iloc[:, 0], numeric.iloc[:, 1], s=6)
+            ax.set_xlabel(str(numeric.columns[0]))
+            ax.set_ylabel(str(numeric.columns[1]))
+        elif len(numeric.columns) == 1:
+            ax.plot(numeric.iloc[:, 0].to_numpy())
+            ax.set_ylabel(str(numeric.columns[0]))
+        else:
+            ax.text(0.5, 0.5, "No numeric columns", ha="center", va="center")
+    else:
+        array = np.asarray(data)
+        if array.ndim >= 2:
+            ax.imshow(array.squeeze())
+        else:
+            ax.plot(array.ravel())
+    return fig
 '''
 
 _R_TEMPLATE = """# Render script created by SciStudio.
@@ -94,52 +110,57 @@ _R_TEMPLATE = """# Render script created by SciStudio.
 #   `collection` is the read-only data passed from the workflow output this plot
 #   is bound to. If the block output is one table, the collection contains one
 #   table-like item. If the block output is a collection of five arrays, it
-#   contains five array items. In R it is a list of item references; each item
-#   usually has fields such as `path`, `format`, and metadata.
+#   contains five array items. Treat it as input data, not as workflow state.
 #
-# What `context` means:
-#   `context` is the small plot-runtime helper object SciStudio gives this
-#   script. It loads bounded input data and saves the final artifact. It is not
-#   the workflow engine context and it should not mutate blocks, nodes, files,
-#   or lineage records.
-#
-# Available context helpers:
-#   * context$to_dataframe(collection, max_rows = ...) -> data.frame
-#   * context$save_plot(plot_or_grob, "figure.pdf")    -> save PNG/JPEG/SVG/PDF
+# Available collection helpers:
+#   * collection$types                      -> character vector
+#   * collection$items                      -> sequence-like item wrapper
+#   * length(collection$items)              -> number of items
+#   * collection$items$open()               -> list of native values
+#   * collection$items$open(max_items = n)  -> list of at most n native values
+#   * collection$items$open_one()           -> first native value
+#   * collection$items[[index]]$type        -> normalized core base type
+#   * collection$items[[index]]$metadata    -> non-storage metadata
+#   * collection$items[[index]]$open()      -> one native value
 #
 # Minimal examples you can paste over the default plot:
 #
 #   # Example A: collection contains one dataframe; draw a box plot from the
 #   # 2nd and 3rd dataframe columns.
-#   # df <- context$to_dataframe(collection, max_rows = 10000)
+#   # df <- collection$items$open_one()
 #   # value_cols <- names(df)[2:3]
 #   # long <- stack(df[value_cols])
 #   # p <- ggplot2::ggplot(long, ggplot2::aes(x = ind, y = values)) +
 #   #   ggplot2::geom_boxplot()
-#   # context$save_plot(p, "figure.pdf")
+#   # p
 #
-#   # Example B: collection contains several CSV tables; draw each first-column
-#   # distribution.
-#   # frames <- list()
-#   # for (item in collection) {{
-#   #   if (!is.null(item$path) && tools::file_ext(item$path) == "csv") {{
-#   #     frames[[length(frames) + 1]] <- utils::read.csv(item$path)
-#   #   }}
-#   # }}
+#   # Example B: collection contains several tables; draw each first-column
+#   # distribution with ggplot2.
+#   # frames <- collection$items$open(max_items = 5)
 #   # values <- data.frame()
-#   # for (index in seq_along(frames)) {{
+#   # for (index in seq_along(frames)) {
 #   #   values <- rbind(values, data.frame(value = frames[[index]][[1]], source = paste("table", index)))
-#   # }}
+#   # }
 #   # p <- ggplot2::ggplot(values, ggplot2::aes(x = value, fill = source)) +
 #   #   ggplot2::geom_histogram(bins = 40, alpha = 0.35, position = "identity")
-#   # context$save_plot(p, "figure.pdf")
+#   # p
 
-render <- function(collection, context) {{
-  df <- context$to_dataframe(collection, max_rows = {max_rows})
-  p <- ggplot2::ggplot(df, ggplot2::aes(x = seq_along(df[[1]]), y = df[[1]])) +
-    ggplot2::geom_line()
-  context$save_plot(p, "figure.{ext}")
-}}
+render <- function(collection) {
+  data <- collection$items$open_one()
+  if (is.data.frame(data)) {
+    numeric_cols <- names(data)[vapply(data, is.numeric, logical(1))]
+    if (length(numeric_cols) >= 2) {
+      plot(data[[numeric_cols[[1]]]], data[[numeric_cols[[2]]]], xlab = numeric_cols[[1]], ylab = numeric_cols[[2]])
+    } else if (length(numeric_cols) == 1) {
+      plot(data[[numeric_cols[[1]]]], type = "l", ylab = numeric_cols[[1]])
+    } else {
+      plot.new()
+      text(0.5, 0.5, "No numeric columns")
+    }
+  } else {
+    plot(as.vector(data), type = "l")
+  }
+}
 """
 
 _SCRIPT_FILENAME: dict[PlotLanguage, str] = {"python": "render.py", "r": "render.R"}
@@ -201,13 +222,12 @@ def render_manifest_yaml(manifest: PlotManifest) -> str:
     return yaml.safe_dump(data, sort_keys=False, default_flow_style=False)
 
 
-def render_script_template(language: PlotLanguage, max_rows: int) -> str:
+def render_script_template(language: PlotLanguage) -> str:
     """Return the language-specific render-script template body (FR-012/FR-013)."""
-    ext = _default_format(language)
     if language == "python":
-        return _PYTHON_TEMPLATE.format(max_rows=max_rows, ext=ext)
+        return _PYTHON_TEMPLATE
     if language == "r":
-        return _R_TEMPLATE.format(max_rows=max_rows, ext="pdf")
+        return _R_TEMPLATE
     raise PlotScaffoldError(f"unsupported language: {language!r}")  # pragma: no cover
 
 
@@ -235,7 +255,7 @@ def scaffold_plot_files(
 
     plot_dir.mkdir(parents=True, exist_ok=True)
     manifest_text = render_manifest_yaml(manifest)
-    script_text = render_script_template(language, manifest.limits.max_rows)
+    script_text = render_script_template(language)
     manifest_path.write_text(manifest_text, encoding="utf-8")
     script_path.write_text(script_text, encoding="utf-8")
     bytes_written = len(manifest_text.encode("utf-8")) + len(script_text.encode("utf-8"))

--- a/src/scistudio/ai/agent/mcp/tools_plot/validation.py
+++ b/src/scistudio/ai/agent/mcp/tools_plot/validation.py
@@ -8,6 +8,8 @@ availability diagnostics (R is reported, never required — FR-021, FR-015).
 
 from __future__ import annotations
 
+import ast
+import re
 import shutil
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -183,6 +185,8 @@ def validate_plot(plot_id: str | None = None, path: str | None = None) -> Valida
             errors.append("script.path escapes the project root.")
         if not script_path.exists():
             errors.append(f"render script not found: {manifest.script.path}")
+        else:
+            errors.extend(_validate_render_signature(script_path, manifest))
 
     # Target existence (FR-021): the bound workflow path + node + output port
     # must still resolve to a discoverable target.
@@ -256,6 +260,52 @@ def _short_pydantic(exc: ValidationError) -> str:
         loc = ".".join(str(p) for p in err.get("loc", ()))
         parts.append(f"{loc}: {err.get('msg', '')}")
     return "; ".join(parts)
+
+
+def _validate_render_signature(script_path: Path, manifest: PlotManifest) -> list[str]:
+    entrypoint = manifest.script.entrypoint
+    if manifest.script.language == "python":
+        try:
+            tree = ast.parse(script_path.read_text(encoding="utf-8"), filename=str(script_path))
+        except SyntaxError as exc:
+            return [f"render script syntax error: {exc.msg} at line {exc.lineno}."]
+        render_node = next(
+            (node for node in tree.body if isinstance(node, ast.FunctionDef) and node.name == entrypoint),
+            None,
+        )
+        if render_node is None:
+            return [f"render script must define def {entrypoint}(collection)."]
+        args = render_node.args
+        positional = [*args.posonlyargs, *args.args]
+        ok = (
+            len(positional) == 1
+            and positional[0].arg == "collection"
+            and not args.defaults
+            and not args.vararg
+            and not args.kwonlyargs
+            and not args.kw_defaults
+            and not args.kwarg
+        )
+        if ok:
+            return []
+        return [
+            "Python render entrypoint must be exactly def render(collection). "
+            "render(collection, context) is not supported."
+        ]
+    if manifest.script.language == "r":
+        source = script_path.read_text(encoding="utf-8")
+        pattern = rf"(?s)\b{re.escape(entrypoint)}\s*(?:<-|=)\s*function\s*\((?P<formals>[^)]*)\)"
+        match = re.search(pattern, source)
+        if match is None:
+            return [f"R render script must define {entrypoint} <- function(collection)."]
+        formals = [part.strip() for part in match.group("formals").split(",") if part.strip()]
+        if formals == ["collection"]:
+            return []
+        return [
+            "R render entrypoint must be exactly render <- function(collection). "
+            "render <- function(collection, context) is not supported."
+        ]
+    return []
 
 
 __all__ = [

--- a/tests/ai/test_mcp_tools_plot.py
+++ b/tests/ai/test_mcp_tools_plot.py
@@ -629,6 +629,55 @@ def test_open_enforces_input_memory_guard(project: Path, csv_output: Path) -> No
     assert any("memory cap" in e for e in res.errors)
 
 
+def test_collection_open_enforces_cumulative_input_memory_guard(project: Path, tmp_path: Path) -> None:
+    first = tmp_path / "measurements_a.csv"
+    second = tmp_path / "measurements_b.csv"
+    first.write_text("x,y\n1,2\n3,4\n", encoding="utf-8")
+    second.write_text("x,y\n5,6\n7,8\n", encoding="utf-8")
+    metadata = {"type_chain": ["DataFrame"], "shape": [5, 5], "dtype": "float64"}
+    runtime = _make_runtime(project)
+    runtime.workflow_runs["run_1"] = _StubRun(
+        {
+            "node_a": {
+                "measurements": {
+                    "_collection": True,
+                    "item_type": "DataFrame",
+                    "items": [
+                        {
+                            "backend": "filesystem",
+                            "path": str(first),
+                            "format": "csv",
+                            "metadata": dict(metadata),
+                        },
+                        {
+                            "backend": "filesystem",
+                            "path": str(second),
+                            "format": "csv",
+                            "metadata": dict(metadata),
+                        },
+                    ],
+                }
+            }
+        }
+    )
+    _set_ctx(runtime)
+    tid = _target_id(project)
+    _run(scaffold_plot(plot_id="too_big_collection", target_id=tid, language="python"))
+    manifest = project / "plots" / "too_big_collection" / "plot.yaml"
+    manifest.write_text(
+        manifest.read_text(encoding="utf-8").replace("max_input_bytes: 67108864", "max_input_bytes: 300"),
+        encoding="utf-8",
+    )
+    _write_render(
+        project,
+        "too_big_collection",
+        ("def render(collection):\n    collection.items.open()\n    return None\n"),
+    )
+    res = _run(run_plot_job(plot_id="too_big_collection"))
+    assert res.status == "failed"
+    assert any("memory cap" in e for e in res.errors)
+
+
 def test_run_python_sanitized_failure(project: Path, csv_output: Path) -> None:
     _set_ctx(_make_runtime(project, with_output_csv=csv_output))
     tid = _target_id(project)
@@ -821,3 +870,85 @@ def test_run_r_ggplot2(project: Path, csv_output: Path) -> None:
     assert res.status in {"succeeded", "failed"}
     if res.status == "succeeded":
         assert any(p.endswith(".svg") for p in res.artifact_paths)
+
+
+@pytest.mark.requires_r
+def test_run_r_collection_open_enforces_cumulative_input_memory_guard(project: Path, tmp_path: Path) -> None:
+    if shutil.which("Rscript") is None:
+        pytest.skip("Rscript not on PATH")
+    first = tmp_path / "measurements_a.csv"
+    second = tmp_path / "measurements_b.csv"
+    first.write_text("x,y\n1,2\n3,4\n", encoding="utf-8")
+    second.write_text("x,y\n5,6\n7,8\n", encoding="utf-8")
+    metadata = {"type_chain": ["DataFrame"], "shape": [5, 5], "dtype": "float64"}
+    runtime = _make_runtime(project)
+    runtime.workflow_runs["run_1"] = _StubRun(
+        {
+            "node_a": {
+                "measurements": {
+                    "_collection": True,
+                    "item_type": "DataFrame",
+                    "items": [
+                        {
+                            "backend": "filesystem",
+                            "path": str(first),
+                            "format": "csv",
+                            "metadata": dict(metadata),
+                        },
+                        {
+                            "backend": "filesystem",
+                            "path": str(second),
+                            "format": "csv",
+                            "metadata": dict(metadata),
+                        },
+                    ],
+                }
+            }
+        }
+    )
+    _set_ctx(runtime)
+    tid = _target_id(project)
+    _run(scaffold_plot(plot_id="r_too_big_collection", target_id=tid, language="r"))
+    manifest = project / "plots" / "r_too_big_collection" / "plot.yaml"
+    manifest.write_text(
+        manifest.read_text(encoding="utf-8").replace("max_input_bytes: 67108864", "max_input_bytes: 300"),
+        encoding="utf-8",
+    )
+    (project / "plots" / "r_too_big_collection" / "render.R").write_text(
+        "render <- function(collection) {\n  collection$items$open()\n  NULL\n}\n",
+        encoding="utf-8",
+    )
+    res = _run(run_plot_job(plot_id="r_too_big_collection"))
+    assert res.status == "failed"
+    assert any("memory cap" in e for e in res.errors)
+
+
+@pytest.mark.requires_r
+def test_run_r_returned_path_does_not_count_blank_base_device(project: Path, csv_output: Path) -> None:
+    if shutil.which("Rscript") is None:
+        pytest.skip("Rscript not on PATH")
+    _set_ctx(_make_runtime(project, with_output_csv=csv_output))
+    tid = _target_id(project)
+    _run(scaffold_plot(plot_id="r_path_return", target_id=tid, language="r"))
+    manifest = project / "plots" / "r_path_return" / "plot.yaml"
+    manifest.write_text(
+        manifest.read_text(encoding="utf-8")
+        .replace("preferred_format: svg", "preferred_format: pdf")
+        .replace("max_files: 8", "max_files: 1"),
+        encoding="utf-8",
+    )
+    (project / "plots" / "r_path_return" / "render.R").write_text(
+        (
+            "render <- function(collection) {\n"
+            "  grDevices::pdf('custom.pdf')\n"
+            "  plot(c(1, 2, 3), c(1, 4, 9))\n"
+            "  grDevices::dev.off()\n"
+            "  'custom.pdf'\n"
+            "}\n"
+        ),
+        encoding="utf-8",
+    )
+    res = _run(run_plot_job(plot_id="r_path_return"))
+    assert res.status == "succeeded", res.errors
+    assert len(res.artifact_paths) == 1
+    assert Path(res.artifact_paths[0]).name == "current.pdf"

--- a/tests/ai/test_mcp_tools_plot.py
+++ b/tests/ai/test_mcp_tools_plot.py
@@ -32,6 +32,7 @@ from scistudio.ai.agent.mcp.tools_plot import (
 
 pytest.importorskip("pandas")
 pytest.importorskip("matplotlib")
+np = pytest.importorskip("numpy")
 
 _T = TypeVar("_T")
 
@@ -80,6 +81,19 @@ class _DynamicBlockRegistry(_StubBlockRegistry):
         if type_name != "demo.dynamic":
             raise KeyError(type_name)
         return _DynamicBlock(config or {})
+
+
+@dataclass
+class _StubTypeSpec:
+    base_type: str
+
+
+class _StubTypeRegistry:
+    def __init__(self, specs: dict[str, str]) -> None:
+        self._specs = {name: _StubTypeSpec(base_type=base_type) for name, base_type in specs.items()}
+
+    def all_types(self) -> dict[str, _StubTypeSpec]:
+        return dict(self._specs)
 
 
 class _StubScheduler:
@@ -298,6 +312,9 @@ def test_scaffold_creates_python_plot(project: Path) -> None:
     assert (project / "plots" / "cell_scatter" / "plot.yaml").is_file()
     assert (project / "plots" / "cell_scatter" / "render.py").is_file()
     body = (project / "plots" / "cell_scatter" / "render.py").read_text(encoding="utf-8")
+    assert "def render(collection):" in body
+    assert "context" not in body
+    assert "collection.items.open_one()" in body
     assert "ADR-048" not in body
 
 
@@ -307,9 +324,9 @@ def test_scaffold_creates_r_plot(project: Path) -> None:
     _run(scaffold_plot(plot_id="r_plot", target_id=tid, language="r"))
     assert (project / "plots" / "r_plot" / "render.R").is_file()
     body = (project / "plots" / "r_plot" / "render.R").read_text(encoding="utf-8")
-    assert "render <- function(collection, context)" in body
+    assert "render <- function(collection)" in body
     assert "What `collection` means" in body
-    assert "What `context` means" in body
+    assert "context" not in body
     assert "Minimal examples" in body
     assert "ADR-048" not in body
 
@@ -359,6 +376,18 @@ def test_list_examples_filter_by_language(project: Path) -> None:
     assert all(e.language == "r" for e in res.examples)
 
 
+def test_list_examples_are_context_free(project: Path) -> None:
+    _set_ctx(_make_runtime(project))
+    res = _run(list_plot_examples())
+    assert res.examples
+    for example in res.examples:
+        assert "context" not in example.source
+        if example.language == "python":
+            assert "def render(collection):" in example.source
+        if example.language == "r":
+            assert "render <- function(collection)" in example.source
+
+
 # ---------------------------------------------------------------------------
 # read_plot_source (FR-020).
 # ---------------------------------------------------------------------------
@@ -374,7 +403,8 @@ def test_read_requires_exactly_one_selector(project: Path) -> None:
         _run(read_plot_source(plot_id="readme", path="plots/readme/plot.yaml"))
     res = _run(read_plot_source(plot_id="readme"))
     assert res.plot_id == "readme"
-    assert "def render(collection, context)" in res.script_source
+    assert "def render(collection):" in res.script_source
+    assert "context" not in res.script_source
 
 
 def test_read_rejects_manifest_script_path_traversal(project: Path, tmp_path: Path) -> None:
@@ -383,7 +413,7 @@ def test_read_rejects_manifest_script_path_traversal(project: Path, tmp_path: Pa
     tid = _target_id(project)
     _run(scaffold_plot(plot_id="escaped_read", target_id=tid, language="python"))
     outside = tmp_path / "outside_render.py"
-    outside.write_text("def render(collection, context):\n    return None\n", encoding="utf-8")
+    outside.write_text("def render(collection):\n    return None\n", encoding="utf-8")
     manifest = project / "plots" / "escaped_read" / "plot.yaml"
     manifest.write_text(
         manifest.read_text(encoding="utf-8").replace("path: render.py", "path: ../../../outside_render.py"),
@@ -405,6 +435,32 @@ def test_validate_success(project: Path) -> None:
     res = _run(validate_plot(plot_id="good"))
     assert res.valid, res.errors
     assert res.manifest is not None
+
+
+def test_validate_rejects_python_context_signature(project: Path) -> None:
+    _set_ctx(_make_runtime(project))
+    tid = _target_id(project)
+    _run(scaffold_plot(plot_id="oldpy", target_id=tid, language="python"))
+    (project / "plots" / "oldpy" / "render.py").write_text(
+        "def render(collection, context):\n    return None\n",
+        encoding="utf-8",
+    )
+    res = _run(validate_plot(plot_id="oldpy"))
+    assert not res.valid
+    assert any("def render(collection)" in e and "context" in e for e in res.errors)
+
+
+def test_validate_rejects_r_context_signature(project: Path) -> None:
+    _set_ctx(_make_runtime(project))
+    tid = _target_id(project)
+    _run(scaffold_plot(plot_id="oldr", target_id=tid, language="r"))
+    (project / "plots" / "oldr" / "render.R").write_text(
+        "render <- function(collection, context) {\n  NULL\n}\n",
+        encoding="utf-8",
+    )
+    res = _run(validate_plot(plot_id="oldr"))
+    assert not res.valid
+    assert any("render <- function(collection)" in e and "context" in e for e in res.errors)
 
 
 def test_validate_broken_target(project: Path) -> None:
@@ -465,11 +521,20 @@ def test_run_python_svg_success(project: Path, csv_output: Path) -> None:
         project,
         "scatter",
         (
-            "def render(collection, context):\n"
-            "    df = context.to_dataframe(collection, max_rows=1000)\n"
-            "    fig, ax = context.plt.subplots()\n"
+            "def render(collection):\n"
+            "    import matplotlib.pyplot as plt\n"
+            "    assert collection.types == ('DataFrame',)\n"
+            "    assert len(collection.items) == 1\n"
+            "    assert collection.items[0].type == 'DataFrame'\n"
+            "    assert 'path' not in collection.items[0].metadata\n"
+            "    assert 'format' not in collection.items[0].metadata\n"
+            "    assert 'type_chain' not in collection.items[0].metadata\n"
+            "    assert collection.items[0:1][0].type == 'DataFrame'\n"
+            "    df = collection.items.open_one()\n"
+            "    assert len(collection.items.open(max_items=1)) == 1\n"
+            "    fig, ax = plt.subplots()\n"
             "    ax.scatter(df['x'], df['y'], s=4)\n"
-            "    return context.save_figure(fig, 'figure.svg')\n"
+            "    return fig\n"
         ),
     )
     res = _run(run_plot_job(plot_id="scatter"))
@@ -491,6 +556,79 @@ def test_run_python_svg_success(project: Path, csv_output: Path) -> None:
     assert res.metadata_path and Path(res.metadata_path).is_file()
 
 
+def test_run_normalizes_package_array_subclass_to_array(project: Path, tmp_path: Path) -> None:
+    array_path = tmp_path / "image.npy"
+    np.save(array_path, np.arange(9, dtype="float32").reshape(3, 3))
+    runtime = _make_runtime(project)
+    runtime.type_registry = _StubTypeRegistry({"Image": "Array"})
+    runtime.workflow_runs["run_1"] = _StubRun(
+        {
+            "node_a": {
+                "measurements": {
+                    "backend": "filesystem",
+                    "path": str(array_path),
+                    "format": "npy",
+                    "item_type": "Image",
+                    "metadata": {
+                        "shape": [3, 3],
+                        "dtype": "float32",
+                        "path": "should-not-leak",
+                        "format": "npy",
+                    },
+                }
+            }
+        }
+    )
+    _set_ctx(runtime)
+    tid = _target_id(project)
+    _run(scaffold_plot(plot_id="image_plot", target_id=tid, language="python"))
+    _write_render(
+        project,
+        "image_plot",
+        (
+            "def render(collection):\n"
+            "    import matplotlib.pyplot as plt\n"
+            "    assert collection.types == ('Array',)\n"
+            "    item = collection.items[0]\n"
+            "    assert item.type == 'Array'\n"
+            "    assert 'type_chain' not in item.metadata\n"
+            "    assert 'path' not in item.metadata\n"
+            "    array = item.open()\n"
+            "    assert array.shape == (3, 3)\n"
+            "    fig, ax = plt.subplots()\n"
+            "    ax.imshow(array)\n"
+            "    return fig\n"
+        ),
+    )
+    res = _run(run_plot_job(plot_id="image_plot"))
+    assert res.status == "succeeded", res.errors
+
+
+def test_open_enforces_input_memory_guard(project: Path, csv_output: Path) -> None:
+    runtime = _make_runtime(project, with_output_csv=csv_output)
+    runtime.workflow_runs["run_1"].scheduler._block_outputs["node_a"]["measurements"]["metadata"] = {
+        "type_chain": ["DataFrame"],
+        "shape": [10000, 10000],
+        "dtype": "float64",
+    }
+    _set_ctx(runtime)
+    tid = _target_id(project)
+    _run(scaffold_plot(plot_id="too_big", target_id=tid, language="python"))
+    manifest = project / "plots" / "too_big" / "plot.yaml"
+    manifest.write_text(
+        manifest.read_text(encoding="utf-8").replace("max_input_bytes: 67108864", "max_input_bytes: 64"),
+        encoding="utf-8",
+    )
+    _write_render(
+        project,
+        "too_big",
+        ("def render(collection):\n    collection.items.open_one()\n    return None\n"),
+    )
+    res = _run(run_plot_job(plot_id="too_big"))
+    assert res.status == "failed"
+    assert any("memory cap" in e for e in res.errors)
+
+
 def test_run_python_sanitized_failure(project: Path, csv_output: Path) -> None:
     _set_ctx(_make_runtime(project, with_output_csv=csv_output))
     tid = _target_id(project)
@@ -498,7 +636,7 @@ def test_run_python_sanitized_failure(project: Path, csv_output: Path) -> None:
     _write_render(
         project,
         "boom",
-        ("def render(collection, context):\n    raise RuntimeError('kaboom')\n"),
+        ("def render(collection):\n    raise RuntimeError('kaboom')\n"),
     )
     res = _run(run_plot_job(plot_id="boom"))
     assert res.status == "failed"
@@ -516,10 +654,11 @@ def test_run_rejects_manifest_script_path_traversal(project: Path, csv_output: P
     outside = tmp_path / "outside_render.py"
     outside.write_text(
         (
-            "def render(collection, context):\n"
-            "    fig, ax = context.plt.subplots()\n"
+            "def render(collection):\n"
+            "    import matplotlib.pyplot as plt\n"
+            "    fig, ax = plt.subplots()\n"
             "    ax.plot([1, 2, 3])\n"
-            "    return context.save_figure(fig, 'figure.svg')\n"
+            "    return fig\n"
         ),
         encoding="utf-8",
     )
@@ -541,10 +680,11 @@ def test_run_overwrites_current(project: Path, csv_output: Path) -> None:
         project,
         "rerun",
         (
-            "def render(collection, context):\n"
-            "    fig, ax = context.plt.subplots()\n"
+            "def render(collection):\n"
+            "    import matplotlib.pyplot as plt\n"
+            "    fig, ax = plt.subplots()\n"
             "    ax.plot([1, 2, 3])\n"
-            "    return context.save_figure(fig, 'figure.svg')\n"
+            "    return fig\n"
         ),
     )
     first = _run(run_plot_job(plot_id="rerun"))
@@ -556,10 +696,11 @@ def test_run_overwrites_current(project: Path, csv_output: Path) -> None:
         project,
         "rerun",
         (
-            "def render(collection, context):\n"
-            "    fig, ax = context.plt.subplots()\n"
+            "def render(collection):\n"
+            "    import matplotlib.pyplot as plt\n"
+            "    fig, ax = plt.subplots()\n"
             "    ax.bar([0, 1, 2], [3, 2, 1])\n"
-            "    return context.save_figure(fig, 'figure.svg')\n"
+            "    return fig\n"
         ),
     )
     second = _run(run_plot_job(plot_id="rerun"))
@@ -579,15 +720,16 @@ def test_run_failed_rerun_records_failure_state(project: Path, csv_output: Path)
         project,
         "flip",
         (
-            "def render(collection, context):\n"
-            "    fig, ax = context.plt.subplots()\n"
+            "def render(collection):\n"
+            "    import matplotlib.pyplot as plt\n"
+            "    fig, ax = plt.subplots()\n"
             "    ax.plot([1, 2, 3])\n"
-            "    return context.save_figure(fig, 'figure.svg')\n"
+            "    return fig\n"
         ),
     )
     ok = _run(run_plot_job(plot_id="flip"))
     assert ok.status == "succeeded"
-    _write_render(project, "flip", "def render(collection, context):\n    raise ValueError('nope')\n")
+    _write_render(project, "flip", "def render(collection):\n    raise ValueError('nope')\n")
     bad = _run(run_plot_job(plot_id="flip"))
     assert bad.status == "failed"
     assert bad.metadata_path is not None
@@ -609,12 +751,16 @@ def test_run_enforces_file_count_cap(project: Path, csv_output: Path) -> None:
         project,
         "manyfiles",
         (
-            "def render(collection, context):\n"
+            "def render(collection):\n"
+            "    import matplotlib.pyplot as plt\n"
+            "    paths = []\n"
             "    for i in range(3):\n"
-            "        fig, ax = context.plt.subplots()\n"
+            "        fig, ax = plt.subplots()\n"
             "        ax.plot([1, 2, 3])\n"
-            "        context.save_figure(fig, f'figure_{i}.svg')\n"
-            "    return None\n"
+            "        path = f'figure_{i}.svg'\n"
+            "        fig.savefig(path)\n"
+            "        paths.append(path)\n"
+            "    return paths\n"
         ),
     )
     res = _run(run_plot_job(plot_id="manyfiles"))
@@ -630,7 +776,7 @@ def test_run_timeout(project: Path, csv_output: Path) -> None:
     _write_render(
         project,
         "slow",
-        ("import time\n\ndef render(collection, context):\n    time.sleep(5)\n    return None\n"),
+        ("import time\n\ndef render(collection):\n    time.sleep(5)\n    return None\n"),
     )
     res = _run(run_plot_job(plot_id="slow", timeout_seconds=1.0))
     assert res.status == "timed_out"
@@ -654,7 +800,7 @@ def test_r_manifest_validates_without_runner(project: Path) -> None:
 
 @pytest.mark.requires_r
 def test_run_r_ggplot2(project: Path, csv_output: Path) -> None:
-    """SC-007: real R + ggplot2 run produces a PDF artifact (skipped without Rscript)."""
+    """SC-007: real R + ggplot2 run produces an artifact (skipped without Rscript)."""
     if shutil.which("Rscript") is None:
         pytest.skip("Rscript not on PATH")
     _set_ctx(_make_runtime(project, with_output_csv=csv_output))
@@ -662,10 +808,9 @@ def test_run_r_ggplot2(project: Path, csv_output: Path) -> None:
     _run(scaffold_plot(plot_id="rrun", target_id=tid, language="r"))
     (project / "plots" / "rrun" / "render.R").write_text(
         (
-            "render <- function(collection, context) {\n"
-            "  df <- context$to_dataframe(collection, max_rows = 100)\n"
-            "  p <- ggplot2::ggplot(df, ggplot2::aes(x = x, y = y)) + ggplot2::geom_point()\n"
-            "  context$save_plot(p, 'figure.pdf')\n"
+            "render <- function(collection) {\n"
+            "  df <- collection$items$open_one()\n"
+            "  ggplot2::ggplot(df, ggplot2::aes(x = x, y = y)) + ggplot2::geom_point()\n"
             "}\n"
         ),
         encoding="utf-8",
@@ -675,4 +820,4 @@ def test_run_r_ggplot2(project: Path, csv_output: Path) -> None:
     # clear error (not a crash).
     assert res.status in {"succeeded", "failed"}
     if res.status == "succeeded":
-        assert any(p.endswith(".pdf") for p in res.artifact_paths)
+        assert any(p.endswith(".svg") for p in res.artifact_paths)

--- a/tests/api/test_plot_preview_wiring.py
+++ b/tests/api/test_plot_preview_wiring.py
@@ -129,11 +129,12 @@ def _write_workflow_and_plot(client: TestClient, project: Path) -> None:
     )
     (plot_dir / "render.py").write_text(
         (
-            "def render(collection, context):\n"
-            "    df = context.to_dataframe(collection, max_rows=1000)\n"
-            "    fig, ax = context.plt.subplots()\n"
+            "def render(collection):\n"
+            "    import matplotlib.pyplot as plt\n"
+            "    df = collection.items.open_one()\n"
+            "    fig, ax = plt.subplots()\n"
             "    ax.scatter(df['x'], df['y'], s=4)\n"
-            "    return context.save_figure(fig, 'figure.svg')\n"
+            "    return fig\n"
         ),
         encoding="utf-8",
     )
@@ -229,7 +230,7 @@ def test_plot_list_route_filters_manifests_to_selected_block(
         "  entrypoint: render\n",
         encoding="utf-8",
     )
-    (plot_dir / "render.py").write_text("def render(collection, context):\n    return None\n", encoding="utf-8")
+    (plot_dir / "render.py").write_text("def render(collection):\n    return None\n", encoding="utf-8")
 
     resp = client.get("/api/plots", params={"workflow_id": "main", "node_id": "node_a"})
 
@@ -279,7 +280,9 @@ def test_plot_create_route_scaffolds_manifest_and_render_script(
     assert "id: quick_plot" in manifest_text
     assert "title: Quick Plot" in manifest_text
     assert "node_id:" in manifest_text
-    assert "def render(collection, context):" in script.read_text(encoding="utf-8")
+    script_text = script.read_text(encoding="utf-8")
+    assert "def render(collection):" in script_text
+    assert "context" not in script_text
 
 
 def test_plot_preview_resource_save_writes_export_to_user_selected_path(
@@ -422,7 +425,7 @@ def test_failed_plot_run_returns_status_without_data_ref(
     _write_workflow_and_plot(client, opened_project)
     # Overwrite the render with one that raises.
     (opened_project / "plots" / "p1" / "render.py").write_text(
-        "def render(collection, context):\n    raise ValueError('boom')\n",
+        "def render(collection):\n    raise ValueError('boom')\n",
         encoding="utf-8",
     )
     run = client.post("/api/plots/run", json={"plot_id": "p1"})

--- a/tests/api/test_preview_plot_jobs.py
+++ b/tests/api/test_preview_plot_jobs.py
@@ -14,9 +14,10 @@ from __future__ import annotations
 
 import asyncio
 import json
+from collections.abc import Coroutine, Generator
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import Any, TypeVar
 
 import pytest
 
@@ -27,6 +28,8 @@ from scistudio.ai.agent.mcp.tools_plot.targets import discover_targets
 
 pytest.importorskip("pandas")
 pytest.importorskip("matplotlib")
+
+_T = TypeVar("_T")
 
 
 # ---------------------------------------------------------------------------
@@ -67,6 +70,7 @@ class _StubRun:
 class _StubRuntime:
     _project_dir: Path
     block_registry: Any = None
+    type_registry: Any = None
     workflow_runs: dict[str, Any] = field(default_factory=dict)
     active_workflow_id: str | None = None
 
@@ -79,18 +83,18 @@ class _Measurements:  # pragma: no cover
     pass
 
 
-def _run(coro):
+def _run(coro: Coroutine[Any, Any, _T]) -> _T:
     return asyncio.run(coro)
 
 
 @pytest.fixture(autouse=True)
-def _teardown_ctx():
+def _teardown_ctx() -> Generator[None, None, None]:
     yield
     _context.set_context(None)
 
 
 @pytest.fixture
-def setup(tmp_path: Path):
+def setup(tmp_path: Path) -> tuple[Path, _StubRuntime, Path]:
     project = tmp_path / "proj"
     (project / "workflows").mkdir(parents=True)
     wf = project / "workflows" / "main.yaml"
@@ -125,11 +129,12 @@ def setup(tmp_path: Path):
     _run(scaffold_plot(plot_id="p1", target_id=tid, language="python"))
     (project / "plots" / "p1" / "render.py").write_text(
         (
-            "def render(collection, context):\n"
-            "    df = context.to_dataframe(collection, max_rows=1000)\n"
-            "    fig, ax = context.plt.subplots()\n"
+            "def render(collection):\n"
+            "    import matplotlib.pyplot as plt\n"
+            "    df = collection.items.open_one()\n"
+            "    fig, ax = plt.subplots()\n"
             "    ax.scatter(df['x'], df['y'], s=4)\n"
-            "    return context.save_figure(fig, 'figure.svg')\n"
+            "    return fig\n"
         ),
         encoding="utf-8",
     )
@@ -141,7 +146,7 @@ def setup(tmp_path: Path):
 # ---------------------------------------------------------------------------
 
 
-def test_writes_current_svg_and_json_at_fr026_layout(setup) -> None:
+def test_writes_current_svg_and_json_at_fr026_layout(setup: tuple[Path, _StubRuntime, Path]) -> None:
     project, _runtime, _wf = setup
     res = _run(run_plot_job(plot_id="p1"))
     assert res.status == "succeeded", res.errors
@@ -165,28 +170,31 @@ def test_writes_current_svg_and_json_at_fr026_layout(setup) -> None:
     assert record["cache_key"] == res.cache_key
 
 
-def test_rerun_overwrites_current(setup) -> None:
+def test_rerun_overwrites_current(setup: tuple[Path, _StubRuntime, Path]) -> None:
     _project, _runtime, _wf = setup
     first = _run(run_plot_job(plot_id="p1"))
     svg = Path(first.artifact_paths[0])
+    assert first.metadata_path is not None
     first_created = json.loads(Path(first.metadata_path).read_text(encoding="utf-8"))["created"]
     second = _run(run_plot_job(plot_id="p1"))
     assert Path(second.artifact_paths[0]) == svg
+    assert second.metadata_path is not None
     second_created = json.loads(Path(second.metadata_path).read_text(encoding="utf-8"))["created"]
     assert second_created >= first_created
 
 
-def test_failed_rerun_records_failure(setup) -> None:
+def test_failed_rerun_records_failure(setup: tuple[Path, _StubRuntime, Path]) -> None:
     project, _runtime, _wf = setup
     ok = _run(run_plot_job(plot_id="p1"))
     assert ok.status == "succeeded"
     previous_svg = Path(ok.artifact_paths[0])
     assert previous_svg.is_file()
     (project / "plots" / "p1" / "render.py").write_text(
-        "def render(collection, context):\n    raise ValueError('boom')\n", encoding="utf-8"
+        "def render(collection):\n    raise ValueError('boom')\n", encoding="utf-8"
     )
     bad = _run(run_plot_job(plot_id="p1"))
     assert bad.status == "failed"
+    assert bad.metadata_path is not None
     record = json.loads(Path(bad.metadata_path).read_text(encoding="utf-8"))
     assert record["status"] == "failed"
     assert record["error"]
@@ -198,7 +206,9 @@ def test_failed_rerun_records_failure(setup) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_plot_run_does_not_mutate_workflow_or_scheduler_or_lineage(setup) -> None:
+def test_plot_run_does_not_mutate_workflow_or_scheduler_or_lineage(
+    setup: tuple[Path, _StubRuntime, Path],
+) -> None:
     project, runtime, wf = setup
     wf_before = wf.read_text(encoding="utf-8")
     # Snapshot scheduler outputs (the only live run state).
@@ -227,7 +237,7 @@ def test_plot_run_does_not_mutate_workflow_or_scheduler_or_lineage(setup) -> Non
 # ---------------------------------------------------------------------------
 
 
-def test_artifact_consumable_by_plot_previewer(setup) -> None:
+def test_artifact_consumable_by_plot_previewer(setup: tuple[Path, _StubRuntime, Path]) -> None:
     _project, _runtime, _wf = setup
     res = _run(run_plot_job(plot_id="p1"))
     assert res.status == "succeeded", res.errors


### PR DESCRIPTION
## Summary

- Replace the plot render contract with `render(collection)` / `render <- function(collection)` and remove the user-facing context helper API.
- Add Python and R collection wrappers with `collection.items.open()`, `open_one()`, item helpers, native type conversion, core-base type normalization, and input memory guards.
- Update scaffolds, examples, plot docs, skill guidance, API wiring tests, and the persisted UX spec for the new pre-alpha breaking contract.

Closes #1684

## Verification

- `python -m scistudio.qa.governance.gate_record check --record .workflow/records/1684-plot-render-collection-api.json --mode pre-pr`
- `pytest --no-cov tests/ai/test_mcp_tools_plot.py tests/api/test_preview_plot_jobs.py tests/api/test_plot_preview_wiring.py -q`
- `ruff format --check .`
- `python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json`

Note: local R execution tests skip when `Rscript` is unavailable; Python and API plot paths ran successfully.
