### PR TITLE
docs(#1687): add canvas node readability ADR

### DIFF
--- a/.workflow/records/1687-canvas-node-readability-adr.json
+++ b/.workflow/records/1687-canvas-node-readability-adr.json
@@ -1,0 +1,1097 @@
+{
+  "branch": "docs/canvas-node-readability-adr",
+  "check_events": [
+    {
+      "at": "2026-06-18T18:57:18.037976Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T19:00:22.694317Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T19:08:19.082535Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T19:26:03.675855Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T19:27:49.362734Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T19:28:30.104808Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T19:29:04.581637Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T19:29:54.004026Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:68d62afd56d46a651d79c2a134dedd5e3db72f3afa91db16390fe2de08f8bbab",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T19:31:49.760233Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:68d62afd56d46a651d79c2a134dedd5e3db72f3afa91db16390fe2de08f8bbab",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    }
+  ],
+  "check_na": [],
+  "commit": null,
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "docs/adr/ADR-050.md"
+    ]
+  },
+  "directive_events": [
+    {
+      "at": "2026-06-18T19:04:47.123938Z",
+      "owner_directive": "Write implementation spec for ADR-050; include all affected surfaces and explicitly leave no compatibility or legacy node mode.",
+      "reason": "Owner requested implementation spec after ADR draft"
+    },
+    {
+      "at": "2026-06-18T19:25:39.100213Z",
+      "owner_directive": "Include docs/** in ADR-050 governance/documentation impact, remove previewer surfaces from canvas-node scope, and use the current worktree gate CLI via PYTHONPATH=src.",
+      "reason": "Owner correction: docs governance scope, previewer exclusion noise, and gate CLI import path"
+    }
+  ],
+  "docs_events": [
+    {
+      "at": "2026-06-18T18:56:41.995887Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/adr/ADR-050.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-18T18:56:49.621778Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/adr/ADR-050.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-18T19:00:19.401451Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/adr/ADR-050.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-18T19:04:47.124074Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/specs/adr-050-canvas-node-readability.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-18T19:08:15.558880Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/adr/ADR-050.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-18T19:08:15.559047Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/specs/adr-050-canvas-node-readability.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-18T19:25:39.100382Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/adr/ADR-050.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-18T19:25:39.100400Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/specs/adr-050-canvas-node-readability.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-18T19:26:00.339708Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/adr/ADR-050.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-18T19:26:00.339879Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/specs/adr-050-canvas-node-readability.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-18T19:27:45.562879Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/adr/ADR-050.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-18T19:27:45.563048Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/specs/adr-050-canvas-node-readability.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-18T19:28:26.433876Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/adr/ADR-050.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-18T19:28:26.434038Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/specs/adr-050-canvas-node-readability.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-18T19:29:01.068315Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/adr/ADR-050.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-18T19:29:01.068494Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/specs/adr-050-canvas-node-readability.md",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": false,
+  "guard_events": [
+    {
+      "at": "2026-06-18T18:57:18.060447Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T18:57:18.071297Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T18:57:18.082447Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T18:57:18.093505Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T18:57:18.104168Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T18:57:18.114650Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T18:57:18.125270Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T18:57:18.135973Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T18:57:18.146625Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T18:57:18.157622Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:00:22.715274Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:00:22.724749Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:00:22.734142Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:00:22.743140Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:00:22.752307Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:00:22.761489Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:00:22.770465Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:00:22.779792Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:00:22.788610Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:00:22.797864Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:08:19.106145Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:08:19.116782Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:08:19.127147Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:08:19.137498Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:08:19.148118Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:08:19.158340Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:08:19.168988Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:08:19.179058Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:08:19.189038Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:08:19.199432Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:26:03.696734Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:26:03.705720Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:26:03.714763Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:26:03.723497Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:26:03.732418Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:26:03.741909Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:26:03.751018Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:26:03.760182Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:26:03.768957Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:26:03.778120Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:27:32.497094Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:27:32.507441Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:27:32.518070Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:27:32.528453Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:27:32.538487Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:27:32.549246Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:27:32.560040Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:27:32.570674Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:27:32.580999Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:27:32.591404Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:27:49.386964Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:27:49.398227Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:27:49.410075Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:27:49.421066Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:27:49.434587Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:27:49.445479Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:27:49.456326Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:27:49.466817Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:27:49.477676Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:27:49.488808Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:28:30.125479Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:28:30.135197Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:28:30.144136Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:28:30.153125Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:28:30.161861Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:28:30.171135Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:28:30.179927Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:28:30.189109Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:28:30.198111Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:28:30.207098Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:29:04.605844Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:29:04.617326Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:29:04.628210Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:29:04.639191Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:29:04.649986Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:29:04.660831Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:29:04.671070Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:29:04.681636Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:29:04.692637Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:29:04.703124Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:31:49.802002Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:31:49.812377Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:31:49.823272Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:31:49.834069Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:31:49.844745Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:31:49.855628Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:31:49.866233Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:31:49.877970Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:31:49.888484Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:31:49.904891Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1687,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": {
+    "base": "origin/main",
+    "base_sha": "b6083cea",
+    "changed_files": [
+      ".workflow/records/1687-canvas-node-readability-adr.json",
+      "docs/adr/ADR-050.md",
+      "docs/specs/adr-050-canvas-node-readability.md"
+    ],
+    "diff_fingerprint": "sha256:0675c31bff951cf146143ae2123e31b0af63a82c6d322ce0575b1a1e9c6f8a20",
+    "head": "HEAD",
+    "head_sha": "f314de98",
+    "surfaces": {
+      "docs": 2,
+      "frontend": 0,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 0,
+      "packaging": 0,
+      "protected_core": 0,
+      "sentrux": 2,
+      "test": 0,
+      "workflow_ci": 0
+    }
+  },
+  "owner_directive": "Write ADR for workflow canvas square node design standard, focus mode, and auto-layout/tidy controls.",
+  "persona": "adr_author",
+  "pull_request": null,
+  "reconcile_events": [
+    {
+      "at": "2026-06-18T18:57:18.157677Z",
+      "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "mode": "local",
+      "result": "pass",
+      "tier": 3,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-18T19:00:22.797910Z",
+      "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "mode": "local",
+      "result": "pass",
+      "tier": 3,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-18T19:08:19.199487Z",
+      "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "mode": "local",
+      "result": "pass",
+      "tier": 3,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-18T19:26:03.778183Z",
+      "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "mode": "local",
+      "result": "pass",
+      "tier": 3,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-18T19:27:32.591460Z",
+      "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "mode": "local",
+      "result": "pass",
+      "tier": 3,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-18T19:27:49.488866Z",
+      "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "mode": "local",
+      "result": "fail",
+      "tier": 3,
+      "unsatisfied": [
+        "checks.full_audit"
+      ]
+    },
+    {
+      "at": "2026-06-18T19:28:30.207139Z",
+      "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "mode": "local",
+      "result": "fail",
+      "tier": 3,
+      "unsatisfied": [
+        "checks.full_audit"
+      ]
+    },
+    {
+      "at": "2026-06-18T19:29:04.703181Z",
+      "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "mode": "local",
+      "result": "pass",
+      "tier": 3,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-18T19:31:49.904936Z",
+      "diff_fingerprint": "sha256:0675c31bff951cf146143ae2123e31b0af63a82c6d322ce0575b1a1e9c6f8a20",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 3,
+      "unsatisfied": []
+    }
+  ],
+  "record_id": "1687-canvas-node-readability-adr",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [
+      "full_audit",
+      "semantic_dup"
+    ],
+    "docs": [],
+    "guards": [
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": []
+  },
+  "runtime": "codex",
+  "schema_version": 2,
+  "scope_events": [
+    {
+      "action": "add-include",
+      "at": "2026-06-18T18:56:41.995718Z",
+      "pattern": "docs/adr/ADR-050.md",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-18T19:04:47.124067Z",
+      "pattern": "docs/specs/adr-050-canvas-node-readability.md",
+      "reason": "Owner requested implementation spec after ADR draft"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-18T19:25:39.100373Z",
+      "pattern": "docs/adr/ADR-050.md",
+      "reason": "Owner correction: docs governance scope, previewer exclusion noise, and gate CLI import path"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-18T19:25:39.100377Z",
+      "pattern": "docs/specs/adr-050-canvas-node-readability.md",
+      "reason": "Owner correction: docs governance scope, previewer exclusion noise, and gate CLI import path"
+    }
+  ],
+  "session_id": "6ea66b40-9ffe-4841-a749-e3577c601415",
+  "strictness_tier": 3,
+  "task_kind": "docs",
+  "test_events": [
+    {
+      "at": "2026-06-18T18:56:41.995898Z",
+      "class": "implementation",
+      "kind": "na",
+      "path": null,
+      "rationale": "docs-only ADR; implementation tests are required in the follow-up implementation PR",
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-18T18:56:49.621945Z",
+      "class": "implementation",
+      "kind": "na",
+      "path": null,
+      "rationale": "docs-only ADR; implementation tests are required in the follow-up implementation PR",
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-18T19:00:19.401582Z",
+      "class": "implementation",
+      "kind": "na",
+      "path": null,
+      "rationale": "docs-only ADR; implementation tests are required in the follow-up implementation PR",
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-18T19:08:15.559054Z",
+      "class": "implementation",
+      "kind": "na",
+      "path": null,
+      "rationale": "docs-only ADR/spec; implementation tests are required in the follow-up implementation PR",
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-18T19:25:39.100410Z",
+      "class": "implementation",
+      "kind": "na",
+      "path": null,
+      "rationale": "docs/spec-only revision; implementation tests are specified for the follow-up ADR-050 implementation PR",
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-18T19:26:00.339893Z",
+      "class": "implementation",
+      "kind": "na",
+      "path": null,
+      "rationale": "docs/spec-only revision; implementation tests are specified for the follow-up ADR-050 implementation PR",
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-18T19:27:45.563058Z",
+      "class": "implementation",
+      "kind": "na",
+      "path": null,
+      "rationale": "docs/spec-only revision; implementation tests are specified for the follow-up ADR-050 implementation PR",
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-18T19:28:26.434048Z",
+      "class": "implementation",
+      "kind": "na",
+      "path": null,
+      "rationale": "docs/spec-only revision; implementation tests are specified for the follow-up ADR-050 implementation PR",
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-18T19:29:01.068502Z",
+      "class": "implementation",
+      "kind": "na",
+      "path": null,
+      "rationale": "docs/spec-only revision; implementation tests are specified for the follow-up ADR-050 implementation PR",
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/.workflow/records/1687-canvas-node-readability-adr.json
+++ b/.workflow/records/1687-canvas-node-readability-adr.json
@@ -135,10 +135,46 @@
       "status": "pass",
       "summary": "clean",
       "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T19:32:37.852134Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:68d62afd56d46a651d79c2a134dedd5e3db72f3afa91db16390fe2de08f8bbab",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T19:34:31.650156Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:68d62afd56d46a651d79c2a134dedd5e3db72f3afa91db16390fe2de08f8bbab",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
     }
   ],
   "check_na": [],
-  "commit": null,
+  "commit": {
+    "sha": "ef48c49ea7e0a5a731edd467d896decb5a5545ea",
+    "shas": [
+      "ef48c49ea7e0a5a731edd467d896decb5a5545ea"
+    ],
+    "trailers": []
+  },
   "declared_scope": {
     "exclude": [],
     "include": [
@@ -850,6 +886,170 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:34:31.695319Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:34:31.705764Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:34:31.716800Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:34:31.727589Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:34:31.738227Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:34:31.748690Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:34:31.758782Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:34:31.770513Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:34:31.781068Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:34:31.797043Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:34:41.772595Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:34:41.783366Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:34:41.793971Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:34:41.804623Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:34:41.815310Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:34:41.825999Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:34:41.836513Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:34:41.847288Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:34:41.858051Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T19:34:41.874199Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -862,16 +1062,16 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "origin/main",
+    "base": "b6083ceabb7b390a30d5d111c49491d9c8bd60cb",
     "base_sha": "b6083cea",
     "changed_files": [
       ".workflow/records/1687-canvas-node-readability-adr.json",
       "docs/adr/ADR-050.md",
       "docs/specs/adr-050-canvas-node-readability.md"
     ],
-    "diff_fingerprint": "sha256:0675c31bff951cf146143ae2123e31b0af63a82c6d322ce0575b1a1e9c6f8a20",
+    "diff_fingerprint": "sha256:867406a340f5864298bd9a16471643a2a089a4bdde844286769716a2399945d6",
     "head": "HEAD",
-    "head_sha": "f314de98",
+    "head_sha": "ef48c49e",
     "surfaces": {
       "docs": 2,
       "frontend": 0,
@@ -887,7 +1087,12 @@
   },
   "owner_directive": "Write ADR for workflow canvas square node design standard, focus mode, and auto-layout/tidy controls.",
   "persona": "adr_author",
-  "pull_request": null,
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [],
+    "number": 1688,
+    "url": null
+  },
   "reconcile_events": [
     {
       "at": "2026-06-18T18:57:18.157677Z",
@@ -964,16 +1169,29 @@
       "result": "pass",
       "tier": 3,
       "unsatisfied": []
+    },
+    {
+      "at": "2026-06-18T19:34:31.797098Z",
+      "diff_fingerprint": "sha256:867406a340f5864298bd9a16471643a2a089a4bdde844286769716a2399945d6",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 3,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-18T19:34:41.874231Z",
+      "diff_fingerprint": "sha256:867406a340f5864298bd9a16471643a2a089a4bdde844286769716a2399945d6",
+      "mode": "ci",
+      "result": "pass",
+      "tier": 3,
+      "unsatisfied": []
     }
   ],
   "record_id": "1687-canvas-node-readability-adr",
   "requested_admin_labels": [],
   "required_obligations": {
     "admin_labels": [],
-    "checks": [
-      "full_audit",
-      "semantic_dup"
-    ],
+    "checks": [],
     "docs": [],
     "guards": [
       "core_change_guard",

--- a/docs/adr/ADR-050.md
+++ b/docs/adr/ADR-050.md
@@ -1,0 +1,594 @@
+---
+adr: 50
+title: "Workflow Canvas Node Design And Readability Controls"
+status: Proposed
+date_created: 2026-06-18
+date_accepted: null
+date_superseded: null
+
+supersedes: []
+superseded_by: null
+related: [11, 14, 23, 28, 29, 44, 45]
+closes_issues: [1687]
+tracking_issue: 1687
+
+is_code_implementation: true
+governs:
+  modules:
+    - scistudio.api.routes.blocks
+    - scistudio.api.schemas
+    - scistudio.blocks.registry
+  contracts:
+    - scistudio.workflow.definition.NodeDef
+    - scistudio.workflow.schema.NodeModel
+    - scistudio.api.schemas.WorkflowNode
+    - scistudio.blocks.registry.BlockSpec
+    - scistudio.api.schemas.BlockSummary
+    - scistudio.api.schemas.BlockSchemaResponse
+    - scistudio.api.routes.blocks.list_blocks
+    - scistudio.api.routes.blocks.get_block_schema
+  entry_points:
+    - scistudio.blocks
+    - scistudio.types
+  files:
+    - docs/**
+    - src/scistudio/blocks/base/block.py
+    - src/scistudio/blocks/registry/**
+    - src/scistudio/api/schemas.py
+    - src/scistudio/api/routes/blocks.py
+    - packages/scistudio-blocks-*/pyproject.toml
+    - packages/scistudio-blocks-*/src/scistudio_blocks_*/__init__.py
+    - packages/scistudio-blocks-imaging/src/scistudio_blocks_imaging/interactive/**/*.py
+    - packages/scistudio-blocks-imaging/src/scistudio_blocks_imaging/io/**/*.py
+    - packages/scistudio-blocks-imaging/src/scistudio_blocks_imaging/math/**/*.py
+    - packages/scistudio-blocks-imaging/src/scistudio_blocks_imaging/measurement/**/*.py
+    - packages/scistudio-blocks-imaging/src/scistudio_blocks_imaging/morphology/**/*.py
+    - packages/scistudio-blocks-imaging/src/scistudio_blocks_imaging/preprocess/**/*.py
+    - packages/scistudio-blocks-imaging/src/scistudio_blocks_imaging/projection/**/*.py
+    - packages/scistudio-blocks-imaging/src/scistudio_blocks_imaging/registration/**/*.py
+    - packages/scistudio-blocks-imaging/src/scistudio_blocks_imaging/segmentation/**/*.py
+    - packages/scistudio-blocks-imaging/src/scistudio_blocks_imaging/tracking/**/*.py
+    - packages/scistudio-blocks-imaging/src/scistudio_blocks_imaging/visualization/**/*.py
+    - packages/scistudio-blocks-lcms/src/scistudio_blocks_lcms/analysis/**/*.py
+    - packages/scistudio-blocks-lcms/src/scistudio_blocks_lcms/external/**/*.py
+    - packages/scistudio-blocks-lcms/src/scistudio_blocks_lcms/io/**/*.py
+    - packages/scistudio-blocks-lcms/src/scistudio_blocks_lcms/isotope_tracing/**/*.py
+    - packages/scistudio-blocks-spectroscopy/src/scistudio_blocks_spectroscopy/blocks/**/*.py
+    - packages/scistudio-blocks-srs/src/scistudio_blocks_srs/component_analysis/**/*.py
+    - packages/scistudio-blocks-srs/src/scistudio_blocks_srs/preprocess/**/*.py
+    - packages/scistudio-blocks-srs/src/scistudio_blocks_srs/spectral_extraction/**/*.py
+    - frontend/package.json
+    - frontend/package-lock.json
+    - frontend/src/types/api.ts
+    - frontend/src/App.tsx
+    - frontend/src/App.parts/ProjectWorkspace.tsx
+    - frontend/src/App.parts/useBottomPanelControls.ts
+    - frontend/src/utils/computeEffectivePorts.ts
+    - frontend/src/api/capabilities.ts
+    - frontend/src/components/Toolbar.tsx
+    - frontend/src/components/Toolbar.parts/WorkflowGroups.tsx
+    - frontend/src/components/WorkflowCanvas.tsx
+    - frontend/src/components/WorkflowCanvas.parts/**
+    - frontend/src/components/nodes/BlockNode.tsx
+    - frontend/src/components/nodes/BlockNode.parts/**
+    - frontend/src/components/BottomPanel.tsx
+    - frontend/src/components/BottomPanel.parts/**
+    - frontend/src/components/PortEditorTable.tsx
+    - frontend/src/components/PortEditor/CapabilityDropdown.tsx
+    - frontend/src/components/WorkflowEditor/LossySaveWarning.tsx
+    - frontend/src/components/TypeLegend.tsx
+    - frontend/src/config/typeColorMap.ts
+    - frontend/src/store/types.ts
+    - frontend/src/store/uiSlice.ts
+    - frontend/src/store/workflowSlice.ts
+    - frontend/src/types/ui.ts
+    - frontend/src/store/workflowSlice.parts/**
+  excludes:
+    - docs/user/reference/**
+    - docs/user/llms.txt
+tests:
+  - tests/api/test_blocks.py
+  - tests/blocks/test_registry.py
+  - tests/blocks/test_dynamic_ports.py
+  - tests/blocks/test_registry_package_layout.py
+  - tests/packaging/test_adr043_package_capabilities.py
+  - frontend/src/utils/__tests__/computeEffectivePorts.test.ts
+  - frontend/src/__tests__/CapabilityDropdown.test.tsx
+  - frontend/src/components/nodes/__tests__/BlockNode/compactNode.test.tsx
+  - frontend/src/components/WorkflowCanvas.parts/__tests__/autoLayout.test.ts
+  - frontend/src/components/WorkflowCanvas.parts/__tests__/focusMode.test.ts
+  - frontend/src/components/BottomPanel.parts/ConfigPanel.test.tsx
+agent_editable: false
+assisted_by:
+  - "Codex:gpt-5"
+
+phase: planning
+tags:
+  - frontend
+  - workflow-canvas
+  - node-design
+  - focus-mode
+  - auto-layout
+owner: "@jiazhenz026"
+co_authors:
+  - "@codex"
+language_source: en
+translations: []
+---
+
+# ADR-050: Workflow Canvas Node Design And Readability Controls
+
+## 1. Decision Summary
+
+SciStudio will replace the current canvas block-node card model with a fixed
+square topology glyph model and add two readability controls to the workflow
+canvas: focus mode and a tidy layout action.
+
+The design body of this ADR has two parts:
+
+1. **Node new design** — canvas nodes are square, fixed-size glyphs whose body
+   shows block identity only. Ports remain on the left and right edges, `+/-`
+   controls remain for variadic port topology, and runtime state, warnings,
+   and errors are one unified status surface. Computational configuration moves
+   to the BottomPanel Config tab.
+2. **Focus mode and tidy layout** — the canvas gains a focus mode for reducing
+   graph noise without changing the workflow, and a tidy button that computes
+   deterministic node positions and persists them as existing layout metadata.
+
+This ADR supersedes ADR-023's node-rendering decision that placed top
+configuration fields inline inside block nodes. ADR-023 remains governing for
+the broader editor layout, bottom panel, preview panel, and selective execution
+contracts. ADR-029 remains governing for variadic ports; this ADR preserves its
+canvas `+/-` topology affordances.
+
+### 1.1 Problems Addressed
+
+| Problem | Risk | ADR response | Detailed section |
+|---|---|---|---|
+| Complex workflows make the main canvas visually dense and hard to scan | Users lose graph structure in card content, inline config, status footers, and crossing edges | Replace block cards with fixed square topology glyphs | Section 2 |
+| Inline config inside nodes competes with graph topology | The canvas becomes a form editor instead of a workflow topology editor | Move computational config to BottomPanel and keep only topology controls on canvas | Section 2 |
+| Error and warning details expand node bodies | Runtime problems change geometry and worsen graph readability | Use one status surface for runtime state, warnings, and errors; route details to Logs or BottomPanel | Section 2 |
+| Existing subworkflow support cannot solve all readability cases | Users need temporary graph reduction without changing workflow structure | Add focus mode as a view-only canvas state | Section 3 |
+| Manual dragging is not enough for large DAGs | Users spend time arranging nodes instead of authoring workflows | Add a tidy button backed by deterministic graph layout | Section 3 |
+
+## 2. Node New Design
+
+### 2.1 Canvas Node Standard
+
+A block node on the main canvas is a square fixed-size topology glyph.
+
+Normative requirements:
+
+- The default node body size is `104 x 104` CSS pixels.
+- A compact density MAY use `96 x 96`; an accessibility density MAY use
+  `112 x 112`. A single canvas MUST use one density consistently.
+- Width and height MUST be equal. Block nodes MUST NOT become long horizontal
+  cards.
+- Node body border radius MUST stay small, at `8px` or less.
+- The node body MUST NOT grow because of config fields, port count, runtime
+  messages, error text, warning text, or action buttons.
+- The node body shows block identity only:
+  - block-kind mark or icon;
+  - block display label;
+  - unified status surface.
+- The block display label is capped at two visual lines. Overflow is truncated
+  and exposed through tooltip or BottomPanel detail.
+- The node body MUST NOT show computational config fields.
+- The node body MUST NOT add a data type or role subtitle. Data type semantics
+  remain on ports, edges, hover detail, and the TypeLegend.
+
+Current implementation shows `data.label` in the node header and uses port
+color plus TypeLegend for data types. The new design keeps that information
+model and removes inline config from the node body.
+
+`Block-kind mark` means the existing block category carried by
+`base_category` / `data.category`, not a data type and not a role subtitle.
+The current category values are `io`, `process`, `code`, `app`, `ai`, and
+`subworkflow`, with `custom` as the frontend fallback when no known base
+category is available.
+
+### 2.2 Complete Node Instance
+
+This is the concrete node shape the implementation should target. It is an
+example selected `Cellpose Segment` node with one input, two outputs, a
+variadic output rail, a warning status, and hover actions visible.
+
+```text
+                       floating action toolbar
+                         [run] [restart] [delete]
+                                  |
+                                  v
+
+  input rail                 selected square node                 output rail
+
+  image port (Image)       +--------------------+       mask port (Mask)
+        o------------------| P              [!] |------------------o
+                           |                    |       labels port (Label)
+  add input port           |      Cellpose      |------------------o
+      [+]                  |       Segment      |
+                           |                    |       add output port
+                           +--------------------+           [+]
+                                                          remove on hover
+                                                              [-]
+```
+
+The same instance rendered as a pure body standard:
+
+```text
++--------------------+
+| kind         status|
+|                    |
+|      block label   |
+|      max 2 lines   |
+|                    |
++--------------------+
+```
+
+Interpretation:
+
+- `P` is the block-kind mark for a `process` block. It may be an icon in
+  implementation, but it is not a text-heavy role label.
+- `[!]` is the unified status surface. It represents the highest-priority
+  runtime/problem signal for the node and can open details.
+- Port data types are represented by port color, ring, hover title, edge color,
+  and TypeLegend. Type text is not duplicated inside the node body.
+- `+` and `-` live on the port rails because they edit port topology.
+- Action buttons float outside the square on hover or selected state. They do
+  not consume square body space and do not change the node's measured geometry.
+
+### 2.3 Canvas And BottomPanel Boundary
+
+Canvas nodes expose topology, identity, and status.
+
+The canvas may support these node-level interactions:
+
+- select node;
+- drag node;
+- create or remove edges through port handles;
+- add or remove variadic ports;
+- run, restart, delete, or open a node action menu;
+- open status details through the unified status surface;
+- open or focus the BottomPanel Config tab for node configuration.
+
+The canvas MUST NOT host computational configuration widgets inside block
+nodes. This includes text fields, file pickers, path inputs, enum selectors,
+capability selectors, numeric controls, boolean toggles, and advanced
+parameter editors.
+
+The BottomPanel Config tab is the authoritative human-editing surface for
+computational config. It owns:
+
+- schema-driven config fields;
+- capability selectors;
+- file and directory pickers;
+- CodeBlock config;
+- full variadic port renaming and type selection;
+- validation messages and warning detail.
+
+Topology edits are allowed on canvas. Computational config edits are not.
+Changing the number of ports is a topology edit, so ADR-029 `+/-` controls
+remain on canvas.
+
+### 2.4 Ports And Variadic `+/-` Controls
+
+Ports stay on the left and right rails:
+
+- input ports on the left;
+- output ports on the right;
+- port handles colored by accepted data type;
+- subtype or plugin-specific distinctions through existing ring color rules;
+- empty accepted type lists shown as `Any` through the existing dashed/neutral
+  convention.
+
+Port labels are hidden by default. They MAY appear when:
+
+- the node is selected;
+- the user hovers a port;
+- zoom level is high enough for readable labels;
+- accessibility mode requests persistent labels.
+
+Port labels and hover text MUST remain outside the node body. They may overlap
+neither the block label nor the status surface.
+
+For variadic ports:
+
+- `+` appears at the end of the relevant rail when the block can add a port;
+- `-` appears per removable port on hover, selected state, or explicit port
+  edit mode;
+- disabled `+/-` state follows ADR-029 min/max limits;
+- removing a connected port must preserve the current confirmation or
+  validation behavior for affected edges.
+
+If a node has more ports than fit comfortably beside the square, the rails may
+extend outside the square or switch to a compact rail presentation. The square
+body remains fixed-size. Dense port editing belongs in the BottomPanel port
+editor.
+
+### 2.5 Unified Status Surface
+
+Runtime state, error state, warnings, and problem indicators share one status
+surface on the node. They MUST NOT render as a footer, inline message, warning
+chip, or geometry-changing row inside the node body.
+
+The status surface has two layers:
+
+1. **Runtime state** — idle, ready, running, paused, done, error, cancelled,
+   or skipped.
+2. **Problem severity** — none, warning, or error.
+
+The implementation may render this as a corner dot, ring, badge, or compact
+glyph, but it must obey these rules:
+
+- error has highest priority and opens Logs or the relevant error detail;
+- warning overlays or replaces non-error runtime states and opens the
+  relevant BottomPanel detail;
+- running and paused remain visible without adding text rows;
+- verbose error messages, tracebacks, lossy-save details, and warning lists
+  live in Logs, BottomPanel, or tooltip detail;
+- status rendering never changes node width or height.
+
+Example status priority:
+
+| Runtime state | Problem severity | Node status surface |
+|---|---|---|
+| `running` | none | running indicator |
+| `done` | warning | warning indicator with done available in details |
+| `error` | error | error indicator |
+| `paused` | none | paused indicator |
+| `idle` | none | idle indicator |
+
+Existing `StatusBadge`, inline `ErrorMessage`, and lossy-save warning chips
+should converge into this single status surface during implementation.
+
+### 2.6 Relationship To Existing ADRs
+
+- ADR-011 remains authoritative: workflow YAML is the source of graph truth;
+  frontend layout remains optional metadata.
+- ADR-014 remains authoritative: the canvas remains ReactFlow-based.
+- ADR-023 remains authoritative for the broader editor layout, but its inline
+  node-config decision is replaced by this ADR.
+- ADR-028 remains authoritative for dynamic accepted types driven by config.
+  The visual result is still expressed through port colors and edge styling.
+- ADR-029 remains authoritative for variadic port storage and validation.
+  This ADR preserves canvas `+/-` as topology editing and moves full port
+  editing to BottomPanel.
+- Package-provided block metadata remains authoritative for frontend block
+  schema consumption. `base_category`, `subcategory`, ports, `dynamic_ports`,
+  variadic constraints, `format_capabilities`, and `config_schema` metadata
+  continue to flow through `BlockSpec`, `BlockSummary`, and
+  `BlockSchemaResponse`; this ADR changes where the frontend renders config,
+  not the package-facing block contract.
+- ADR-044 remains complementary: subworkflow blocks are a structural collapse
+  mechanism. Focus mode is a temporary view mode and does not replace
+  subworkflows.
+- ADR-045 remains authoritative for shared file/workflow state; focus mode is
+  frontend view state and tidy layout writes through normal workflow layout
+  update paths.
+
+## 3. Focus Mode And Tidy Layout
+
+### 3.1 Focus Mode
+
+Focus mode is a view-only canvas mode that reduces visible graph noise without
+changing the workflow definition.
+
+Requirements:
+
+- Focus mode MUST NOT add, remove, reorder, or rewrite workflow nodes or edges.
+- Focus mode MUST NOT change runtime scheduling, validation, lineage, or saved
+  workflow semantics.
+- Focus mode state is frontend UI state. It is not persisted into workflow
+  YAML unless a later ADR explicitly defines persisted view presets.
+- Exiting focus mode restores normal canvas visibility without data loss.
+
+The first supported focus target is the current selection:
+
+- if one node is selected, focus centers on that node;
+- if multiple nodes are selected, focus centers on the induced selected
+  subgraph;
+- if no node is selected, focus mode is unavailable or opens a selection
+  prompt.
+
+The focused graph includes:
+
+- selected nodes;
+- directly connected edges;
+- immediate upstream and downstream neighbor nodes by default.
+
+The UI MAY provide expand controls to add more upstream or downstream depth,
+and MAY provide a connected-component focus mode after the initial
+implementation. Those controls remain view state.
+
+Nodes and edges outside the focus set may be hidden or strongly dimmed. If
+hidden, the canvas must provide an obvious exit affordance and a count of
+hidden nodes/edges. If dimmed, unrelated nodes must not visually compete with
+the focused subgraph.
+
+Focus mode is different from `SubWorkflowBlock`:
+
+| Capability | Focus mode | SubWorkflowBlock |
+|---|---|---|
+| Changes workflow structure | No | Yes, authoring-time container |
+| Persists in workflow YAML | No | Yes |
+| Used for temporary inspection | Yes | Optional |
+| Used as reusable pipeline boundary | No | Yes |
+| Affects run-time flattening | No | Yes, per ADR-044 |
+
+### 3.2 Tidy Layout Button
+
+The canvas will expose a tidy layout action. The control belongs near existing
+ReactFlow canvas controls, not inside a node.
+
+Requirements:
+
+- Tidy computes deterministic node positions from graph topology.
+- Tidy writes positions through the existing `node.layout` metadata path.
+- Tidy MUST NOT change node ids, block types, config, ports, edges, execution
+  state, lineage, or runtime data.
+- Tidy MUST be explicit user action. It is not automatic on every graph edit.
+- Tidy SHOULD preserve manual layout when the user does not invoke it.
+- Dragging a node after tidy remains the normal manual override.
+- The algorithm should lay out workflows left-to-right by data flow.
+- The implementation SHOULD use a proven graph layout library instead of a
+  hand-rolled layout algorithm. `elkjs` layered layout is the preferred first
+  candidate because it supports directed graphs, port-aware spacing, and future
+  compound/group layout better than simple grid packing.
+
+When focus mode is active, tidy defaults to the current focus set. The UI
+should also offer a whole-workflow tidy action so users can choose whether to
+rearrange only the focused subgraph or the entire graph.
+
+The tidy output must use stable spacing constants derived from node density:
+
+- square node size;
+- minimum horizontal gap between layers;
+- minimum vertical gap between sibling nodes;
+- extra edge clearance around high-degree nodes;
+- optional group/subworkflow spacing.
+
+These constants are implementation details, but they must be deterministic and
+covered by tests so repeated tidy operations on the same graph produce the same
+layout.
+
+### 3.3 Layout Persistence And Source Of Truth
+
+SciStudio already stores optional node layout metadata on workflow nodes. This
+ADR reuses that contract.
+
+The workflow definition remains source of truth for nodes, edges, config, and
+layout metadata. ReactFlow state is a view and interaction layer.
+
+Tidy layout is therefore a frontend-authored layout write, not a runtime graph
+rewrite:
+
+1. Read the current workflow graph.
+2. Compute new `{x, y}` positions for the selected layout scope.
+3. Dispatch normal node layout updates.
+4. Persist through the existing workflow save/version flow.
+
+If a workflow has no layout metadata, the frontend may still apply its existing
+default layout for first render. Tidy is the explicit user command that turns a
+messy or absent layout into persisted positions.
+
+## 4. Scope
+
+In scope:
+
+- block node visual standard on the main workflow canvas;
+- removal of node-body computational config;
+- retention of canvas port handles and variadic `+/-` controls;
+- unified status surface for runtime state, errors, and warnings;
+- focus mode as a frontend view state;
+- tidy layout action and layout persistence through existing node metadata;
+- preservation and verification of existing package-to-registry-to-API block
+  schema contracts that feed canvas nodes, ports, capability selectors, and
+  BottomPanel Config;
+- updates to affected current docs under `docs/**`, plus frontend tests needed
+  to implement this decision.
+
+Out of scope:
+
+- changing workflow YAML node/edge schema beyond existing layout metadata;
+- changing runtime scheduling or execution semantics;
+- changing package block classes, package entry points, package assets, or
+  package runtime behavior to support the square node UI;
+- adding package-specific old-node, legacy-renderer, compact-card, or
+  square-node hint fields;
+- replacing ReactFlow;
+- replacing `SubWorkflowBlock`;
+- designing a persisted focus preset or named canvas view system;
+- implementing a full undo/redo stack for layout changes;
+- changing BottomPanel's broader tab architecture.
+
+## 5. Verification And Tooling Impact
+
+Implementation should add or update tests for:
+
+- block node renders as fixed square geometry;
+- node body omits inline config fields and config widgets;
+- long labels truncate without changing node geometry;
+- status, warning, and error render through one status surface;
+- error status opens Logs or configured error detail;
+- warning status opens BottomPanel detail or equivalent problem detail;
+- `+/-` controls remain available for variadic ports and obey min/max limits;
+- port type colors and hover titles remain correct;
+- package-provided block schemas from imaging, spectroscopy, LCMS, and SRS
+  render through the square node model without package source edits;
+- backend/API contract tests continue to prove `BlockSpec`, `BlockSummary`,
+  and `BlockSchemaResponse` expose category, port, dynamic-port, variadic,
+  config-schema, and capability metadata;
+- focus mode computes the expected focus set from selection and exits cleanly;
+- focus mode does not mutate workflow nodes, edges, or config;
+- tidy layout produces deterministic positions for representative DAGs;
+- tidy writes only node layout metadata;
+- tidy in focus mode can affect the focused scope without corrupting hidden
+  graph state.
+
+Expected check surface:
+
+- frontend unit/component tests for node rendering and status behavior;
+- frontend pure-function tests for focus set computation and auto-layout
+  normalization;
+- backend/API/package contract tests for block schema metadata consumed by the
+  canvas and BottomPanel;
+- existing workflow serializer tests should remain unchanged because no schema
+  change is required;
+- architecture documentation should be updated when implementation lands so
+  `docs/architecture/ARCHITECTURE.md` no longer describes block nodes as
+  inline-config cards with status footers.
+
+This ADR itself is documentation-only. Implementation tests are required in the
+follow-up implementation PR.
+
+## 6. Consequences And Risks
+
+Consequences:
+
+- The canvas becomes a topology-first surface rather than a form-first surface.
+- Users must use BottomPanel Config for all computational configuration.
+- Large workflows should be easier to scan because node geometry is stable.
+- Runtime problems remain visible but no longer make nodes expand.
+- Layout becomes more deterministic once users invoke tidy.
+
+Risks:
+
+- Removing inline config may increase one-click configuration friction for
+  very small workflows. Mitigation: selecting a node should make BottomPanel
+  Config fast to access, and focus mode reduces canvas noise while editing.
+- Square nodes reduce text capacity. Mitigation: strict two-line labels,
+  tooltips, and BottomPanel details.
+- Dense port nodes may have rails that visually extend beyond the square.
+  Mitigation: keep body fixed, use compact rails, and rely on BottomPanel for
+  full port editing.
+- Auto-layout may surprise users by moving carefully arranged nodes.
+  Mitigation: tidy is explicit, deterministic, and scope-aware in focus mode.
+- Adding a graph layout library introduces dependency and bundle-size cost.
+  Mitigation: prefer a mature library with deterministic output and isolate it
+  behind a small auto-layout adapter.
+
+## 7. Alternatives Considered
+
+### 7.1 Keep Compact Horizontal Cards
+
+Rejected. Horizontal cards preserve more label and status text, but they keep
+the canvas visually card-shaped rather than topology-shaped. The owner
+explicitly prefers square nodes.
+
+### 7.2 Keep Inline Top Config
+
+Rejected. ADR-023 chose inline top config to make important parameters
+scannable, but in complex workflows it turns the canvas into many tiny forms.
+This ADR moves all computational config to BottomPanel and keeps only topology
+controls on canvas.
+
+### 7.3 Use Subworkflows Only
+
+Rejected as incomplete. ADR-044 subworkflows remain useful for durable
+authoring boundaries, but they require structural modeling. Focus mode is a
+temporary view-only tool for inspecting complex graphs without changing the
+workflow.
+
+### 7.4 Auto-Layout On Every Graph Edit
+
+Rejected. Automatic re-layout on every change can fight user intent and make
+the canvas feel unstable. Tidy is an explicit command.

--- a/docs/specs/adr-050-canvas-node-readability.md
+++ b/docs/specs/adr-050-canvas-node-readability.md
@@ -1,0 +1,661 @@
+---
+spec_id: adr-050-canvas-node-readability
+title: "ADR-050 Canvas Node Readability Implementation Specification"
+status: Planned
+feature_branch: docs/canvas-node-readability-adr
+created: 2026-06-18
+input: "Owner request: write the implementation spec for ADR-050, list all affected surfaces, and make clear that the implementation leaves no compatibility or legacy node mode."
+owners:
+  - "@jiazhenz026"
+related_adrs:
+  - 50
+related_specs: []
+scope:
+  in:
+    - Replace the current block-node card implementation with ADR-050 fixed square topology glyphs.
+    - Remove node-body computational config and route all computational config editing through BottomPanel Config.
+    - Preserve canvas port handles and variadic +/- topology controls.
+    - Replace separate status footer, inline error text, and warning chips with one fixed-geometry node status surface.
+    - Preserve existing package-to-registry-to-API block schema contracts that feed canvas nodes and BottomPanel config.
+    - Verify package-provided blocks from every monorepo block package render through the new node model without package source changes.
+    - Add focus mode as frontend-only canvas view state.
+    - Add an explicit tidy layout command backed by deterministic graph layout and existing node.layout persistence.
+    - Update toolbar/canvas wiring, store actions, frontend/backend contract tests, and architecture documentation affected by the new canvas model.
+    - Remove old inline-config/card code paths rather than preserving them as compatibility or legacy modes.
+  out:
+    - Changing workflow YAML schema beyond existing node.layout metadata.
+    - Changing backend scheduler, validation, lineage, runtime execution, or data object contracts.
+    - Changing package block classes, package entry points, package assets, or package runtime behavior for node rendering.
+    - Adding package-specific UI fields, old-node compatibility flags, or square-node hints to block packages.
+    - Replacing ReactFlow.
+    - Replacing SubWorkflowBlock or changing ADR-044 flattening behavior.
+    - Adding persisted focus presets or named canvas views.
+    - Adding a new Problems bottom-panel tab in the first implementation.
+    - Maintaining a feature flag, user preference, or fallback that restores the old long-card node UI.
+governs:
+  modules:
+    - scistudio.api.routes.blocks
+    - scistudio.api.schemas
+    - scistudio.blocks.registry
+  contracts:
+    - scistudio.workflow.definition.NodeDef
+    - scistudio.workflow.schema.NodeModel
+    - scistudio.api.schemas.WorkflowNode
+    - scistudio.blocks.registry.BlockSpec
+    - scistudio.api.schemas.BlockSummary
+    - scistudio.api.schemas.BlockSchemaResponse
+    - scistudio.api.routes.blocks.list_blocks
+    - scistudio.api.routes.blocks.get_block_schema
+  entry_points:
+    - scistudio.blocks
+    - scistudio.types
+  files:
+    - docs/**
+    - src/scistudio/blocks/base/block.py
+    - src/scistudio/blocks/registry/__init__.py
+    - src/scistudio/blocks/registry/_spec.py
+    - src/scistudio/blocks/registry/_scan.py
+    - src/scistudio/api/schemas.py
+    - src/scistudio/api/routes/blocks.py
+    - packages/scistudio-blocks-*/pyproject.toml
+    - packages/scistudio-blocks-*/src/scistudio_blocks_*/__init__.py
+    - packages/scistudio-blocks-imaging/src/scistudio_blocks_imaging/interactive/**/*.py
+    - packages/scistudio-blocks-imaging/src/scistudio_blocks_imaging/io/**/*.py
+    - packages/scistudio-blocks-imaging/src/scistudio_blocks_imaging/math/**/*.py
+    - packages/scistudio-blocks-imaging/src/scistudio_blocks_imaging/measurement/**/*.py
+    - packages/scistudio-blocks-imaging/src/scistudio_blocks_imaging/morphology/**/*.py
+    - packages/scistudio-blocks-imaging/src/scistudio_blocks_imaging/preprocess/**/*.py
+    - packages/scistudio-blocks-imaging/src/scistudio_blocks_imaging/projection/**/*.py
+    - packages/scistudio-blocks-imaging/src/scistudio_blocks_imaging/registration/**/*.py
+    - packages/scistudio-blocks-imaging/src/scistudio_blocks_imaging/segmentation/**/*.py
+    - packages/scistudio-blocks-imaging/src/scistudio_blocks_imaging/tracking/**/*.py
+    - packages/scistudio-blocks-imaging/src/scistudio_blocks_imaging/visualization/**/*.py
+    - packages/scistudio-blocks-lcms/src/scistudio_blocks_lcms/analysis/**/*.py
+    - packages/scistudio-blocks-lcms/src/scistudio_blocks_lcms/external/**/*.py
+    - packages/scistudio-blocks-lcms/src/scistudio_blocks_lcms/io/**/*.py
+    - packages/scistudio-blocks-lcms/src/scistudio_blocks_lcms/isotope_tracing/**/*.py
+    - packages/scistudio-blocks-spectroscopy/src/scistudio_blocks_spectroscopy/blocks/**/*.py
+    - packages/scistudio-blocks-srs/src/scistudio_blocks_srs/component_analysis/**/*.py
+    - packages/scistudio-blocks-srs/src/scistudio_blocks_srs/preprocess/**/*.py
+    - packages/scistudio-blocks-srs/src/scistudio_blocks_srs/spectral_extraction/**/*.py
+    - frontend/package.json
+    - frontend/package-lock.json
+    - frontend/src/types/api.ts
+    - frontend/src/App.tsx
+    - frontend/src/App.parts/ProjectWorkspace.tsx
+    - frontend/src/App.parts/useBottomPanelControls.ts
+    - frontend/src/api/capabilities.ts
+    - frontend/src/utils/computeEffectivePorts.ts
+    - frontend/src/components/Toolbar.tsx
+    - frontend/src/components/Toolbar.parts/WorkflowGroups.tsx
+    - frontend/src/components/WorkflowCanvas.tsx
+    - frontend/src/components/WorkflowCanvas.parts/WorkflowMiniMap.tsx
+    - frontend/src/components/WorkflowCanvas.parts/flowNodeBuilder.ts
+    - frontend/src/components/WorkflowCanvas.parts/useCanvasHandlers.ts
+    - frontend/src/components/WorkflowCanvas.parts/useFlowCallbacks.ts
+    - frontend/src/components/WorkflowCanvas.parts/useFlowNodes.ts
+    - frontend/src/components/nodes/BlockNode.tsx
+    - frontend/src/components/nodes/BlockNode.parts/AddPortDialog.tsx
+    - frontend/src/components/nodes/BlockNode.parts/ErrorMessage.tsx
+    - frontend/src/components/nodes/BlockNode.parts/InlineCapabilitySelector.tsx
+    - frontend/src/components/nodes/BlockNode.parts/InlineConfigField.tsx
+    - frontend/src/components/nodes/BlockNode.parts/InlineTextInputField.tsx
+    - frontend/src/components/nodes/BlockNode.parts/PausedToast.tsx
+    - frontend/src/components/nodes/BlockNode.parts/PortHandles.tsx
+    - frontend/src/components/nodes/BlockNode.parts/StatusBadge.tsx
+    - frontend/src/components/nodes/BlockNode.parts/badgeStyles.ts
+    - frontend/src/components/nodes/BlockNode.parts/inlineConfigHelpers.ts
+    - frontend/src/components/BottomPanel.tsx
+    - frontend/src/components/BottomPanel.parts/ConfigPanel.tsx
+    - frontend/src/components/BottomPanel.parts/FormatCapabilityConfig.tsx
+    - frontend/src/components/BottomPanel.parts/TabBar.tsx
+    - frontend/src/components/PortEditorTable.tsx
+    - frontend/src/components/TypeLegend.tsx
+    - frontend/src/components/WorkflowEditor/LossySaveWarning.tsx
+    - frontend/src/components/PortEditor/CapabilityDropdown.tsx
+    - frontend/src/config/typeColorMap.ts
+    - frontend/src/store/types.ts
+    - frontend/src/store/uiSlice.ts
+    - frontend/src/store/workflowSlice.ts
+    - frontend/src/store/workflowSlice.parts/workflowEditActions.ts
+    - frontend/src/types/ui.ts
+  excludes:
+    - docs/user/reference/**
+    - docs/user/llms.txt
+tests:
+  - tests/api/test_blocks.py
+  - tests/blocks/test_registry.py
+  - tests/blocks/test_dynamic_ports.py
+  - tests/blocks/test_registry_package_layout.py
+  - tests/packaging/test_adr043_package_capabilities.py
+  - frontend/src/utils/__tests__/computeEffectivePorts.test.ts
+  - frontend/src/__tests__/CapabilityDropdown.test.tsx
+  - frontend/src/components/nodes/__tests__/BlockNode/compactNode.test.tsx
+  - frontend/src/components/nodes/__tests__/BlockNode/statusSurface.test.tsx
+  - frontend/src/components/nodes/__tests__/BlockNode/ports.test.tsx
+  - frontend/src/components/WorkflowCanvas.parts/__tests__/autoLayout.test.ts
+  - frontend/src/components/WorkflowCanvas.parts/__tests__/focusMode.test.ts
+  - frontend/src/components/BottomPanel.parts/ConfigPanel.test.tsx
+  - frontend/src/components/PortEditorTable.test.tsx
+  - frontend/src/store/__tests__/workflowSlice.layoutBatch.test.ts
+acceptance_source: adr
+language_source: en
+---
+
+# ADR-050 Canvas Node Readability Implementation Specification
+
+## 1. Change Summary
+
+This spec turns ADR-050 into an executable implementation plan. The workflow
+canvas must move from the current long card node shape to a fixed square node
+shape that shows block identity, port topology, and a single status surface.
+Computational config must leave the node body and live in BottomPanel Config.
+
+The implementation also adds two canvas readability controls:
+
+- **Focus mode** narrows or dims the graph around the selected node or selected
+  subgraph without changing workflow YAML.
+- **Tidy layout** computes deterministic node positions and writes only the
+  existing `node.layout` metadata.
+
+This is a replacement, not an additive compatibility layer. The old node card,
+inline config strip, status footer, inline error message, and warning chip
+inside the node body must be removed from the active implementation. Existing
+workflow YAML remains valid because the persistent schema is unchanged.
+
+## 2. User Scenarios & Testing
+
+### User Story 1 - Read A Complex Canvas Quickly (Priority: P1)
+
+As a workflow author, I can scan a complex workflow as topology instead of as a
+collection of mini forms.
+
+Why this priority: the owner problem is canvas spaghetti caused by large,
+content-heavy nodes and tangled graph structure.
+
+Independent Test: render representative block nodes and assert fixed square
+geometry, no inline config fields, stable port rails, and no geometry change
+when status or warning data is present.
+
+Acceptance Scenarios:
+
+- Given a block with several config fields, when it renders on the canvas, then
+  the node body contains the block label, block-kind mark, ports, actions, and
+  status only.
+- Given a long block name, when it renders, then the node remains square and
+  the label is truncated to two visual lines.
+- Given an error message, lossy-save warning, or paused state, when it renders,
+  then the node status surface changes but the node body does not grow.
+
+### User Story 2 - Configure Blocks In One Place (Priority: P1)
+
+As a workflow author, I can select a node and edit all computational config in
+BottomPanel Config without also seeing config duplicated in the node body.
+
+Why this priority: ADR-050 separates topology from computational configuration.
+
+Independent Test: select LoadData, SaveData, CodeBlock, and a generic process
+block; assert ConfigPanel renders the editable controls and BlockNode renders
+none of those controls.
+
+Acceptance Scenarios:
+
+- Given a LoadData node with `core_type` and `capability_id`, when the node is
+  selected, then BottomPanel Config shows the core type and format capability
+  controls and the canvas node body does not show either control.
+- Given a CodeBlock node, when it is selected, then CodeBlock config remains in
+  BottomPanel and the canvas node remains the square topology glyph.
+- Given a SaveData warning, when the warning status is clicked, then the
+  selected node opens the relevant BottomPanel detail instead of expanding the
+  canvas node.
+
+### User Story 3 - Edit Port Topology On Canvas (Priority: P1)
+
+As a workflow author, I can still quickly add or remove variadic ports from the
+canvas, because port count is topology rather than computational config.
+
+Why this priority: the owner explicitly requested that `+/-` remain on the
+canvas.
+
+Independent Test: render variadic blocks with min/max limits and assert `+/-`
+controls appear on rails, mutate port config correctly, and do not reintroduce
+node-body config rows.
+
+Acceptance Scenarios:
+
+- Given a variadic input block below its max input count, when the user clicks
+  the input rail `+`, then the add-port dialog opens and the confirmed port is
+  persisted through existing `input_ports` config.
+- Given a removable connected port, when the user clicks `-`, then existing
+  disconnect confirmation behavior still protects affected edges.
+- Given a block at its min or max port count, when it renders, then disabled
+  add/remove behavior matches ADR-029.
+
+### User Story 4 - Focus A Subgraph Without Changing The Workflow (Priority: P2)
+
+As a workflow author, I can focus the selected node or selected subgraph so
+unrelated graph regions stop competing for attention.
+
+Why this priority: subworkflows already exist but do not solve temporary graph
+inspection.
+
+Independent Test: run pure focus-set tests against graph fixtures and assert
+selection, one-hop neighbors, edge inclusion, exit behavior, and no workflow
+mutation.
+
+Acceptance Scenarios:
+
+- Given one selected node, when focus mode is enabled, then that node, its
+  directly connected edges, and immediate neighbors are visible or emphasized.
+- Given multiple selected nodes, when focus mode is enabled, then the induced
+  selected subgraph and immediate boundary neighbors are visible or emphasized.
+- Given focus mode is active, when the user exits it, then all nodes and edges
+  return to normal visibility and the workflow dirty flag is unchanged.
+
+### User Story 5 - Tidy A Messy Graph Deterministically (Priority: P2)
+
+As a workflow author, I can click a tidy action to arrange the graph by data
+flow without manually dragging every node.
+
+Why this priority: large workflows need an explicit mechanical cleanup tool.
+
+Independent Test: run auto-layout tests on representative DAGs and assert
+deterministic left-to-right positions, layout-only mutations, and stable output
+across repeated runs.
+
+Acceptance Scenarios:
+
+- Given a workflow without useful layout, when the user clicks Tidy, then nodes
+  receive deterministic `layout` positions ordered by data flow.
+- Given a workflow with config and edges, when Tidy runs, then only node layout
+  metadata changes.
+- Given focus mode is active, when Tidy is invoked for the focus scope, then
+  only focused nodes move unless the user chooses whole-workflow tidy.
+
+### Edge Cases
+
+- A node has more ports than fit beside the square body: rail layout may extend
+  beyond the square, but the square body remains fixed-size.
+- A block has no schema yet: render the square node with known label/status and
+  available summary ports, without inline config fallback.
+- A block has zero ports: render the square body without empty rails; selection
+  and status still work.
+- A plugin data type is unknown to the static type-color map: keep the existing
+  deterministic hash color behavior.
+- A cyclic or invalid workflow graph reaches tidy: auto-layout must not change
+  validation semantics; layout may still position connected components.
+- Focus mode with no selected node: the action is disabled or prompts the user
+  to select a node; it must not enter an ambiguous state.
+- BottomPanel is collapsed when a node is selected: selection expands Config as
+  current behavior already does.
+
+## 3. Requirements
+
+### Functional Requirements
+
+- FR-001: BlockNode MUST render block nodes as fixed square node bodies with
+  equal width and height.
+- FR-002: The default node body size MUST be `104 x 104` CSS pixels unless the
+  implementation centralizes density constants that still obey ADR-050.
+- FR-003: BlockNode MUST NOT render computational config controls in the node
+  body.
+- FR-004: BlockNode MUST NOT render a status footer, inline error text row, or
+  warning chip inside the node body.
+- FR-005: BlockNode MUST render a block label capped to two visual lines with
+  overflow handled without geometry changes.
+- FR-006: BlockNode MUST render the existing block-kind category as a compact
+  mark or icon, sourced from `data.category`.
+- FR-007: BlockNode MUST keep data type semantics on ports, edges, hover text,
+  and TypeLegend, not inside the node body.
+- FR-008: PortHandles MUST keep input ports on the left rail and output ports
+  on the right rail.
+- FR-009: Variadic `+/-` controls MUST remain available on canvas rails and
+  obey ADR-029 min/max constraints.
+- FR-010: Full variadic port editing, including naming and type selection, MUST
+  remain in BottomPanel Config / PortEditorTable.
+- FR-011: Runtime state, errors, warnings, and problem severity MUST be
+  represented through one fixed-geometry node status surface.
+- FR-012: Error status activation MUST select the node, open BottomPanel Logs,
+  and expose the full error detail through existing log rows.
+- FR-013: Warning status activation MUST select the node and open BottomPanel
+  Config or an equivalent in-scope detail area; the first implementation MUST
+  NOT add a new Problems tab.
+- FR-014: Lossy-save warning details MUST be available outside the node body,
+  preferably in the selected node's ConfigPanel.
+- FR-015: Existing inline config components MUST be deleted or removed from the
+  active import graph; they must not remain as a legacy path.
+- FR-016: Existing tests that assert inline node config MUST be deleted or
+  rewritten to assert BottomPanel config behavior.
+- FR-017: WorkflowCanvas MUST expose a focus mode control and visible exit
+  affordance when focus mode is active.
+- FR-018: Focus mode MUST be frontend view state and MUST NOT mutate workflow
+  nodes, edges, config, layout, or runtime state.
+- FR-019: Focus mode MUST compute a deterministic focus set from selection and
+  graph adjacency.
+- FR-020: WorkflowCanvas MUST expose a tidy layout action.
+- FR-021: Tidy layout MUST use a deterministic graph layout adapter and SHOULD
+  use `elkjs` layered layout unless implementation research finds a blocker.
+- FR-022: Tidy layout MUST write only existing `node.layout` metadata.
+- FR-023: Tidy layout MUST be explicit user action; it MUST NOT run
+  automatically on every graph edit.
+- FR-024: The workflow store MUST provide a batch layout update action or an
+  equivalent non-jitter implementation so tidy can update many nodes together.
+- FR-025: Architecture docs MUST be updated in the implementation PR so
+  `ARCHITECTURE.md` no longer describes inline-config card nodes.
+- FR-026: The implementation MUST NOT provide a feature flag, preference,
+  fallback component, or code path that restores the old long-card node UI.
+- FR-027: The implementation MUST preserve the package-to-registry-to-API
+  contract that carries block metadata into the frontend:
+  `Block` class metadata, `BlockSpec`, `BlockSummary`, and
+  `BlockSchemaResponse`.
+- FR-028: Package-provided `base_category` / `subcategory` metadata MUST
+  remain the source for block-kind marks, palette grouping, and API summaries;
+  the square node design MUST NOT require new package UI metadata.
+- FR-029: Package and API `config_schema` metadata, including `ui_priority`
+  and `ui_widget`, MUST remain active for BottomPanel Config field ordering
+  and widget selection. Removing node-body config MUST NOT remove those
+  schema fields or reinterpret them as legacy node UI.
+- FR-030: Package-provided ports, `dynamic_ports`, variadic flags, min/max
+  port limits, allowed variadic types, and `format_capabilities` MUST remain
+  active contracts for canvas ports, `+/-` topology controls, effective port
+  computation, and BottomPanel capability selection.
+- FR-031: The implementation MUST NOT require edits to package block classes,
+  package entry points, package assets, or package runtime behavior for the
+  square node UI.
+- FR-032: The implementation MUST NOT add package-specific old-node,
+  legacy-renderer, compact-card, or square-node hint fields.
+- FR-033: Verification MUST include representative package-provided blocks
+  from imaging, spectroscopy, LCMS, and SRS packages to prove the new node
+  model works with current package contracts.
+
+### Key Entities
+
+| Entity | Description | Attributes | Relationships |
+|---|---|---|---|
+| `SquareBlockNode` | The replacement canvas rendering model for block nodes | fixed size, label, block-kind mark, ports, status surface, hover actions | Replaces current BlockNode card rendering |
+| `NodeStatusSurface` | Single visual surface for runtime state and problem severity | runtime state, warning flag, error flag, click target | Opens Logs for errors and Config detail for warnings |
+| `FocusModeState` | Frontend-only view state for focused graph rendering | enabled, selected ids, visible ids, hidden/dimmed ids, depth | Derived from workflow nodes and edges; not persisted |
+| `TidyLayoutAction` | Explicit layout computation command | scope, algorithm, spacing constants, generated positions | Writes `WorkflowNode.layout` only |
+| `LayoutBatchUpdate` | Store-level mutation for applying many node positions | node id to position map | Marks workflow dirty and preserves history semantics chosen by implementation |
+| `PackageProvidedBlockSchema` | Existing block metadata produced by core and package block classes through registry/API | base category, subcategory, ports, dynamic ports, variadic flags, config schema, format capabilities | Consumed by canvas node rendering, BottomPanel Config, port editor, TypeLegend, and capability selectors |
+
+### No Compatibility Or Legacy Mode
+
+The implementation MUST be a clean replacement.
+
+Required removals:
+
+- Remove inline config rendering from BlockNode.
+- Remove active imports and usage of `InlineConfigField`,
+  `InlineTextInputField`, `InlineCapabilitySelector`, and
+  `inlineConfigHelpers`.
+- Remove or replace `StatusBadge` and `ErrorMessage` so the active node path
+  uses `NodeStatusSurface`.
+- Remove node-body use of `LossySaveWarning`; warning detail must move to
+  BottomPanel or a non-geometry-changing detail surface.
+- Remove tests whose only purpose is preserving inline node config behavior,
+  or rewrite them to assert the new BottomPanel-owned config contract.
+
+Prohibited compatibility mechanisms:
+
+- No `legacyBlockNode`, `CardBlockNode`, `compact=false`, or old/new node mode
+  switch.
+- No user preference or localStorage flag to restore inline config nodes.
+- No temporary feature flag that ships the old card in production.
+- No duplicate config editing on canvas and BottomPanel.
+- No status footer kept for "old workflows".
+
+Workflow file compatibility is different: existing workflow YAML remains valid
+because this implementation does not change node, edge, config, or layout
+schema. There is no workflow migration and no legacy workflow renderer.
+
+Package/API schema compatibility is also different from legacy node UI. The
+fields that packages and the backend currently expose through `BlockSpec`,
+`BlockSummary`, and `BlockSchemaResponse` remain active contracts. Do not
+delete `base_category`, `subcategory`, port declarations, `dynamic_ports`,
+variadic flags, min/max port limits, allowed variadic type lists,
+`format_capabilities`, or `config_schema` metadata such as `ui_priority` and
+`ui_widget` as part of removing inline node config. Those fields still drive
+BottomPanel Config, file/directory pickers, capability selection, effective
+ports, port rails, and palette grouping. If implementation discovers a truly
+obsolete frontend-only field used only by the old node card, delete that
+frontend path; do not delete package-facing block schema contracts without a
+new ADR/spec amendment.
+
+## 4. Implementation Plan
+
+### 4.1 Technical Approach
+
+Implement the change in six layers.
+
+1. **Node geometry and status layer**
+   Replace BlockNode's card layout with a square shell. Move actions into a
+   floating toolbar and status into a `NodeStatusSurface`. Keep port handles
+   attached to left/right rails.
+
+2. **Config ownership layer**
+   Delete node-body config rendering. Ensure BottomPanel Config exposes every
+   config field, capability selector, CodeBlock editor, port editor, and
+   warning detail needed after node simplification.
+
+3. **Package/API contract layer**
+   Treat package-provided block metadata as an existing contract surface.
+   Verify that the registry and block API continue to expose the metadata the
+   frontend needs, but do not add package-specific UI hints or edit package
+   runtime logic for the square node model.
+
+4. **Focus mode layer**
+   Add a pure `focusMode.ts` helper that computes visible/emphasized nodes and
+   edges from selected ids and workflow edges. Wire view state in
+   WorkflowCanvas or UI slice without persisting it to workflow YAML.
+
+5. **Tidy layout layer**
+   Add an `autoLayout.ts` adapter around a deterministic graph layout engine.
+   The adapter accepts workflow nodes, edges, node dimensions, and scope; it
+   returns `{nodeId: {x, y}}`. WorkflowCanvas applies the result through a
+   batch layout update.
+
+6. **Documentation and test layer**
+   Search current documentation for old inline-card node descriptions, update
+   affected current docs, and replace old node tests with geometry, status,
+   focus, tidy, package-backed contract, and BottomPanel ownership tests.
+
+### 4.2 Affected Files
+
+| File or glob | Action | Rationale |
+|---|---|---|
+| `docs/**` | verify/modify affected current docs | Governance/documentation impact surface; search all docs for old node-card, inline-config, status-footer, and canvas-control descriptions. Generated references remain excluded. |
+| `docs/adr/ADR-050.md` | modify if needed | Governing ADR for design decisions and constraints. |
+| `docs/specs/adr-050-canvas-node-readability.md` | create | This implementation specification. |
+| `docs/architecture/ARCHITECTURE.md` | modify | Replace §9.5 old card/inline-config/status-footer description. |
+| `src/scistudio/blocks/base/block.py` | verify only | Package block class metadata is an active producer contract; no ADR-050 code change expected. |
+| `src/scistudio/blocks/registry/__init__.py` | verify only | `BlockSpec` carries metadata consumed by API and frontend nodes. |
+| `src/scistudio/blocks/registry/_spec.py` | verify only | Registry scan maps block class metadata into `BlockSpec`; no square-node-specific fields should be added. |
+| `src/scistudio/blocks/registry/_scan.py` | verify only | Package entry point and monorepo scan behavior feed available package blocks. |
+| `src/scistudio/api/schemas.py` | verify/modify only if contract tests expose a gap | `BlockSummary` and `BlockSchemaResponse` carry the metadata consumed by BlockNode, BottomPanel, and port editors. |
+| `src/scistudio/api/routes/blocks.py` | verify/modify only if contract tests expose a gap | `/api/blocks` and `/api/blocks/{type}/schema` are the package-to-frontend schema bridge. |
+| `packages/scistudio-blocks-*/pyproject.toml` | verify only | Existing `scistudio.blocks` and `scistudio.types` entry points define package discovery; no edit expected. |
+| `packages/scistudio-blocks-*/src/scistudio_blocks_*/__init__.py` | verify only | `get_block_package()` metadata feeds registry scan; no edit expected. |
+| `packages/scistudio-blocks-*/src/scistudio_blocks_*/<block-source-dirs>/**/*.py` | verify only | Representative block metadata, ports, config schemas, and capabilities must render through new node UI without package code changes. |
+| `frontend/package.json` | modify | Add graph layout dependency, expected `elkjs`, if implementation confirms choice. |
+| `frontend/package-lock.json` | modify | Lock dependency changes. |
+| `frontend/src/types/api.ts` | verify/modify only if API contract tests expose a gap | Frontend `BlockSummary` and `BlockSchemaResponse` mirror backend block schema. |
+| `frontend/src/types/ui.ts` | modify | Add status-surface fields if BlockNodeData needs explicit warning/problem metadata; keep BottomTab unchanged unless owner approves Problems tab. |
+| `frontend/src/store/types.ts` | modify | Add focus mode state and batch layout action signatures if implemented in store. |
+| `frontend/src/store/uiSlice.ts` | modify | Store focus mode UI state if not kept local to WorkflowCanvas. |
+| `frontend/src/store/workflowSlice.ts` | modify | Wire batch layout update action if added. |
+| `frontend/src/store/workflowSlice.parts/workflowEditActions.ts` | modify | Implement batch layout updates for tidy. |
+| `frontend/src/App.tsx` | modify | Wire new toolbar/canvas props and bottom-panel handlers. |
+| `frontend/src/App.parts/ProjectWorkspace.tsx` | modify | Pass focus/tidy callbacks and layout update callbacks to canvas and toolbar. |
+| `frontend/src/App.parts/useBottomPanelControls.ts` | modify | Add warning-status click handler opening Config detail if needed. |
+| `frontend/src/api/capabilities.ts` | verify/modify only if contract tests expose a gap | Capability lookup remains backed by API/package `format_capabilities`. |
+| `frontend/src/utils/computeEffectivePorts.ts` | verify/modify only if contract tests expose a gap | Dynamic accepted types remain driven by `BlockSchemaResponse.dynamic_ports`. |
+| `frontend/src/components/Toolbar.tsx` | modify | Pass Tidy and Focus controls into workflow toolbar or delegate to canvas controls. |
+| `frontend/src/components/Toolbar.parts/WorkflowGroups.tsx` | modify | Add Focus and Tidy buttons if toolbar placement is chosen. |
+| `frontend/src/components/WorkflowCanvas.tsx` | modify | Apply focus filtering/dimming, expose tidy control, call auto-layout adapter. |
+| `frontend/src/components/WorkflowCanvas.parts/CanvasReadabilityControls.tsx` | create | Optional focused controls component for Focus/Tidy if not placed in main toolbar. |
+| `frontend/src/components/WorkflowCanvas.parts/focusMode.ts` | create | Pure focus-set computation. |
+| `frontend/src/components/WorkflowCanvas.parts/autoLayout.ts` | create | Pure layout adapter around graph layout library. |
+| `frontend/src/components/WorkflowCanvas.parts/layoutConstants.ts` | create | Shared square-node dimensions and layout spacing constants. |
+| `frontend/src/components/WorkflowCanvas.parts/flowNodeBuilder.ts` | modify | Change initial node dimensions from card values to square geometry. |
+| `frontend/src/components/WorkflowCanvas.parts/useFlowNodes.ts` | modify | Pass warning/status metadata and selected/focus state needed by BlockNode. |
+| `frontend/src/components/WorkflowCanvas.parts/useCanvasHandlers.ts` | modify | Keep drag behavior compatible with focus/tidy state and batch layout writes. |
+| `frontend/src/components/WorkflowCanvas.parts/WorkflowMiniMap.tsx` | modify | Ensure minimap remains useful with square nodes and focus mode. |
+| `frontend/src/components/nodes/BlockNode.tsx` | rewrite | Replace card UI with square topology glyph. |
+| `frontend/src/components/nodes/BlockNode.parts/NodeStatusSurface.tsx` | create | Unified runtime/problem status surface. |
+| `frontend/src/components/nodes/BlockNode.parts/NodeActionToolbar.tsx` | create | Floating run/restart/delete/action controls. |
+| `frontend/src/components/nodes/BlockNode.parts/nodeGeometry.ts` | create | Shared constants/helpers for node body and port rail positions. |
+| `frontend/src/components/nodes/BlockNode.parts/PortHandles.tsx` | modify | Align rails to square geometry while preserving add/remove behavior. |
+| `frontend/src/components/nodes/BlockNode.parts/AddPortDialog.tsx` | modify as needed | Ensure dialog still opens from rail controls with square nodes. |
+| `frontend/src/components/nodes/BlockNode.parts/PausedToast.tsx` | delete or move | Paused detail cannot render in node body. |
+| `frontend/src/components/nodes/BlockNode.parts/StatusBadge.tsx` | delete or replace | Superseded by `NodeStatusSurface`. |
+| `frontend/src/components/nodes/BlockNode.parts/ErrorMessage.tsx` | delete | Inline error text is prohibited by ADR-050. |
+| `frontend/src/components/nodes/BlockNode.parts/InlineConfigField.tsx` | delete | Old inline node config path. |
+| `frontend/src/components/nodes/BlockNode.parts/InlineTextInputField.tsx` | delete | Old inline node config path. |
+| `frontend/src/components/nodes/BlockNode.parts/InlineCapabilitySelector.tsx` | delete | Capability config belongs in BottomPanel. |
+| `frontend/src/components/nodes/BlockNode.parts/inlineConfigHelpers.ts` | delete | Old inline config priority helper. |
+| `frontend/src/components/nodes/BlockNode.parts/badgeStyles.ts` | modify or delete | Category icon/status style tables should be split or replaced. |
+| `frontend/src/components/WorkflowEditor/LossySaveWarning.tsx` | modify | Keep warning computation but move node-body chip use into BottomPanel detail. |
+| `frontend/src/components/BottomPanel.tsx` | modify | Pass selected-node warning/problem detail to ConfigPanel if needed. |
+| `frontend/src/components/BottomPanel.parts/ConfigPanel.tsx` | modify | Render lossy-save and validation/problem detail for selected node. |
+| `frontend/src/components/BottomPanel.parts/FormatCapabilityConfig.tsx` | verify/modify | Ensure capability config remains complete after inline selector deletion. |
+| `frontend/src/components/BottomPanel.parts/TabBar.tsx` | verify/modify | Do not add Problems tab in first implementation; logs/config remain destinations. |
+| `frontend/src/components/PortEditor/CapabilityDropdown.tsx` | verify/modify | Capability dropdown remains the BottomPanel/PortEditor path for package/API capabilities. |
+| `frontend/src/components/PortEditorTable.tsx` | verify/modify | Ensure full variadic port edit behavior remains after canvas rails simplify. |
+| `frontend/src/components/TypeLegend.tsx` | verify/modify | Continue serving type semantics; no type subtitle in node body. |
+| `frontend/src/config/typeColorMap.ts` | verify/modify | Existing port color behavior must remain stable. |
+| `tests/api/test_blocks.py` | verify/modify | Contract coverage for block list/schema payloads consumed by the canvas. |
+| `tests/blocks/test_registry.py` | verify/modify | Registry `BlockSpec` metadata coverage. |
+| `tests/blocks/test_dynamic_ports.py` | verify/modify | Dynamic port schema serialization coverage. |
+| `tests/blocks/test_registry_package_layout.py` | verify/modify | Package/registry layout and capability contract coverage. |
+| `tests/packaging/test_adr043_package_capabilities.py` | verify/modify | Package capability contract coverage. |
+| `frontend/src/utils/__tests__/computeEffectivePorts.test.ts` | verify/modify | Frontend dynamic-port computation coverage. |
+| `frontend/src/__tests__/CapabilityDropdown.test.tsx` | verify/modify | Capability selector coverage after inline selector deletion. |
+| `frontend/src/components/nodes/__tests__/BlockNode/**` | modify/delete/create | Replace inline config expectations with square geometry/status/ports tests. |
+| `frontend/src/components/WorkflowCanvas.parts/__tests__/**` | create | Focus and tidy pure-function coverage. |
+| `frontend/src/components/BottomPanel.parts/ConfigPanel.test.tsx` | modify | Prove BottomPanel owns config and warning detail. |
+| `frontend/src/store/__tests__/workflowSlice.layoutBatch.test.ts` | create | Prove batch layout writes only layout metadata. |
+
+### 4.3 Implementation Sequence
+
+1. Add layout constants and BlockNode square shell.
+2. Replace header/footer/action layout with square body, floating action
+   toolbar, and port rails.
+3. Add `NodeStatusSurface`; route error click to Logs and warning click to
+   Config detail.
+4. Move lossy-save warning detail into BottomPanel Config.
+5. Confirm package/registry/API contract payloads still expose block-kind,
+   port, dynamic-port, variadic, config-schema, and capability metadata.
+6. Delete inline config components and rewrite affected tests.
+7. Add focus-mode pure helper and unit tests.
+8. Wire focus mode into WorkflowCanvas rendering and controls.
+9. Add auto-layout adapter and unit tests.
+10. Add workflow store batch layout update and tests.
+11. Wire Tidy action into canvas/toolbar and persist positions through
+    existing layout save path.
+12. Update architecture documentation.
+13. Run frontend tests, backend contract/package checks, frontend
+    typecheck/build, full audit, and gate check.
+
+### 4.4 Verification Plan
+
+Required local checks for implementation PR:
+
+- `npm --prefix frontend test -- BlockNode`
+- `npm --prefix frontend test -- WorkflowCanvas`
+- `npm --prefix frontend test -- ConfigPanel`
+- `npm --prefix frontend test -- workflowSlice`
+- `npm --prefix frontend test -- computeEffectivePorts`
+- `npm --prefix frontend test -- CapabilityDropdown`
+- `npm --prefix frontend run typecheck`
+- `npm --prefix frontend run build`
+- `PYTHONPATH=src pytest tests/api/test_blocks.py tests/blocks/test_registry.py tests/blocks/test_dynamic_ports.py tests/blocks/test_registry_package_layout.py tests/packaging/test_adr043_package_capabilities.py`
+- `PYTHONPATH=src python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .workflow/local/full-audit.json`
+- `PYTHONPATH=src python -m scistudio.qa.governance.gate_record check --base origin/main --head HEAD`
+
+Manual verification before merge:
+
+- Open a workflow with several block categories and verify all nodes are square.
+- Select LoadData, SaveData, CodeBlock, and process blocks; verify config is
+  available only in BottomPanel.
+- Select representative package-provided blocks from imaging, spectroscopy,
+  LCMS, and SRS; verify block-kind mark, ports, capability controls, and
+  config fields render without package source edits.
+- Trigger or mock error/warning/paused/running states; verify node geometry is
+  unchanged.
+- Add and remove variadic ports from canvas rails and from BottomPanel.
+- Enable and exit focus mode.
+- Run Tidy on whole graph and focus scope; save and reload to verify layout
+  persistence.
+
+### 4.5 Risks And Rollback
+
+Risks:
+
+- Removing inline config can feel slower for simple workflows.
+  Mitigation: selecting a node already opens Config; keep that path fast.
+- Square nodes may make port-heavy blocks visually dense.
+  Mitigation: rails may extend outside the square and full editing remains in
+  BottomPanel.
+- Layout dependency output may be unstable across versions.
+  Mitigation: lock dependency and test representative fixtures.
+- Batch layout update may interact badly with undo/redo.
+  Mitigation: define one history entry per tidy action and add store tests.
+- "No legacy" may be misread as permission to remove active package/API
+  metadata. Mitigation: this spec distinguishes old frontend node UI paths
+  from active block schema contracts and requires package-backed verification.
+
+Rollback:
+
+- Reverting the implementation PR restores the previous node UI because no
+  workflow schema migration is performed.
+- Do not keep a runtime toggle for rollback. Rollback is by git revert, not by
+  shipping a legacy UI path.
+
+## 5. Success Criteria
+
+### Measurable Outcomes
+
+- SC-001: BlockNode tests prove node body dimensions remain equal and stable
+  across idle, running, warning, error, and paused states.
+- SC-002: No production import path references `InlineConfigField`,
+  `InlineTextInputField`, `InlineCapabilitySelector`, or `inlineConfigHelpers`.
+- SC-003: ConfigPanel tests prove core type, capability, file path, CodeBlock,
+  and variadic port editing remain accessible after inline config removal.
+- SC-004: Variadic port tests prove `+/-` canvas controls still mutate
+  `input_ports` / `output_ports` and enforce min/max limits.
+- SC-005: Focus-mode tests prove the selected focus set and exit behavior
+  without mutating workflow state.
+- SC-006: Auto-layout tests prove deterministic output for the same graph input.
+- SC-007: Store tests prove tidy changes only `layout` fields and creates the
+  intended dirty/history behavior.
+- SC-008: Architecture docs no longer describe block nodes as inline-config
+  cards with status footers.
+- SC-009: `npm --prefix frontend run typecheck` and `npm --prefix frontend run
+  build` pass.
+- SC-010: Backend contract tests prove `BlockSpec`, `BlockSummary`, and
+  `BlockSchemaResponse` still expose category, port, dynamic-port, variadic,
+  config-schema, and capability metadata required by the frontend.
+- SC-011: Representative package-provided imaging, spectroscopy, LCMS, and SRS
+  blocks render through the square node model and BottomPanel config without
+  edits to package source files.
+- SC-012: No package-facing API or block schema field is removed solely because
+  the old node body no longer renders inline config.
+- SC-013: `gate_record check` passes for the implementation PR.
+
+## 6. Assumptions
+
+- The implementation is ADR-050-governed and may remove ADR-023 inline node
+  config behavior without a compatibility period. Source: owner.
+- Existing workflow YAML must continue to load because node, edge, config, and
+  layout schema are unchanged. Source: existing-system.
+- `elkjs` is the preferred layout dependency but may be replaced by an
+  equivalent deterministic graph-layout library if implementation research
+  finds a blocker. Source: ADR-050.
+- The first implementation routes warnings to Config and errors to Logs; it
+  does not add a Problems tab. Source: inferred from current BottomPanel.
+- Focus mode is local UI state, not persisted workflow state. Source: ADR-050.
+- Package block metadata and API schema fields remain active contracts for the
+  BottomPanel, ports, capability selectors, palette grouping, and TypeLegend;
+  ADR-050 removes only old frontend node-body rendering paths. Source:
+  existing-system.


### PR DESCRIPTION
Gate record: .workflow/records/1687-canvas-node-readability-adr.json

Closes #1687

## Summary

- Add ADR-050 for square workflow canvas nodes, BottomPanel-owned config, unified node status, focus mode, and tidy layout.
- Add the ADR-050 implementation spec with affected frontend, backend/API, package-contract, docs, and verification surfaces.
- Clarify that old frontend inline node config paths are deletion scope, while package/API block schema metadata remains active contract.

## Validation

- `PYTHONPATH=src python -m scistudio.qa.audit.frontmatter_lint --repo-root . --format text docs/adr/ADR-050.md docs/specs/adr-050-canvas-node-readability.md`
- `PYTHONPATH=src python -m scistudio.qa.governance.gate_record check --record .workflow/records/1687-canvas-node-readability-adr.json --base origin/main --head HEAD --mode local --docs-updated docs/adr/ADR-050.md --docs-updated docs/specs/adr-050-canvas-node-readability.md --test-na "implementation:docs/spec-only revision; implementation tests are specified for the follow-up ADR-050 implementation PR"`
