### PR TITLE
Hotfix: stabilize package install, desktop CLI, variadic ports, and PTY

### DIFF
--- a/.workflow/records/1694-1697-hotfix-batch.json
+++ b/.workflow/records/1694-1697-hotfix-batch.json
@@ -350,13 +350,325 @@
       "tool_versions": {
         "mypy": "2.1.0"
       }
+    },
+    {
+      "at": "2026-06-18T22:39:48.871257Z",
+      "command": "pytest tests/architecture/ -v --no-cov",
+      "covered_surface": "architecture",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cc10b47a1af21e7c9d50d203a91d080c30141e530f6e1a2decc034fee747da1f",
+      "name": "architecture_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/architecture_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T22:39:49.521550Z",
+      "command": "python scripts/deferral_scan.py --check docs/audit/baselines/deferral-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cc10b47a1af21e7c9d50d203a91d080c30141e530f6e1a2decc034fee747da1f",
+      "name": "deferral_discipline",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/deferral_discipline.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T22:39:49.568897Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cc10b47a1af21e7c9d50d203a91d080c30141e530f6e1a2decc034fee747da1f",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-18T22:39:52.828916Z",
+      "command": "(cd frontend && npm run lint)",
+      "covered_surface": "frontend",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cc10b47a1af21e7c9d50d203a91d080c30141e530f6e1a2decc034fee747da1f",
+      "name": "frontend",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/frontend.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T22:39:56.483957Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cc10b47a1af21e7c9d50d203a91d080c30141e530f6e1a2decc034fee747da1f",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T22:39:56.592689Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cc10b47a1af21e7c9d50d203a91d080c30141e530f6e1a2decc034fee747da1f",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T22:39:56.614486Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cc10b47a1af21e7c9d50d203a91d080c30141e530f6e1a2decc034fee747da1f",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-18T22:41:45.597649Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cc10b47a1af21e7c9d50d203a91d080c30141e530f6e1a2decc034fee747da1f",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T22:43:47.698964Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cc10b47a1af21e7c9d50d203a91d080c30141e530f6e1a2decc034fee747da1f",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T22:43:48.533170Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cc10b47a1af21e7c9d50d203a91d080c30141e530f6e1a2decc034fee747da1f",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    },
+    {
+      "at": "2026-06-18T22:44:43.133355Z",
+      "command": "pytest tests/architecture/ -v --no-cov",
+      "covered_surface": "architecture",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cc10b47a1af21e7c9d50d203a91d080c30141e530f6e1a2decc034fee747da1f",
+      "name": "architecture_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/architecture_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T22:44:43.780590Z",
+      "command": "python scripts/deferral_scan.py --check docs/audit/baselines/deferral-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cc10b47a1af21e7c9d50d203a91d080c30141e530f6e1a2decc034fee747da1f",
+      "name": "deferral_discipline",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/deferral_discipline.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T22:44:43.822448Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cc10b47a1af21e7c9d50d203a91d080c30141e530f6e1a2decc034fee747da1f",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-18T22:44:47.148458Z",
+      "command": "(cd frontend && npm run lint)",
+      "covered_surface": "frontend",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cc10b47a1af21e7c9d50d203a91d080c30141e530f6e1a2decc034fee747da1f",
+      "name": "frontend",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/frontend.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T22:44:50.765603Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cc10b47a1af21e7c9d50d203a91d080c30141e530f6e1a2decc034fee747da1f",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T22:44:50.884985Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cc10b47a1af21e7c9d50d203a91d080c30141e530f6e1a2decc034fee747da1f",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T22:44:50.904526Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cc10b47a1af21e7c9d50d203a91d080c30141e530f6e1a2decc034fee747da1f",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-18T22:46:30.309867Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cc10b47a1af21e7c9d50d203a91d080c30141e530f6e1a2decc034fee747da1f",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T22:48:25.921319Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cc10b47a1af21e7c9d50d203a91d080c30141e530f6e1a2decc034fee747da1f",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T22:48:26.462191Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cc10b47a1af21e7c9d50d203a91d080c30141e530f6e1a2decc034fee747da1f",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
     }
   ],
   "check_na": [],
   "commit": {
-    "sha": "b8cdfd6ebe0c580752c0daf6497a45ee01c84bd5",
+    "sha": "c8da7d93bab0b7bd1574e8f7c3069fd587baaf91",
     "shas": [
-      "b8cdfd6ebe0c580752c0daf6497a45ee01c84bd5"
+      "c8da7d93bab0b7bd1574e8f7c3069fd587baaf91"
     ],
     "trailers": []
   },
@@ -698,6 +1010,214 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-06-18T22:43:48.567322Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/registry/_scan.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/registry/_scan.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "error",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "fail"
+    },
+    {
+      "at": "2026-06-18T22:43:48.575964Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T22:43:48.584876Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T22:43:48.593872Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T22:43:48.602590Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T22:43:48.611531Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T22:43:48.620383Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T22:43:48.629026Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T22:43:48.638252Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T22:43:48.652101Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T22:48:26.503151Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/registry/_scan.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/registry/_scan.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T22:48:26.512660Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T22:48:26.522388Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T22:48:26.531851Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T22:48:26.540947Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T22:48:26.550330Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T22:48:26.559627Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T22:48:26.569374Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T22:48:26.578706Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T22:48:26.592905Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -743,23 +1263,24 @@
       "src/scistudio/api/routes/ai_pty/__init__.py",
       "src/scistudio/api/routes/ai_pty/websocket.py",
       "src/scistudio/api/routes/packages.py",
+      "src/scistudio/blocks/registry/_scan.py",
       "tests/api/routes/ai_pty/test_public_surface.py",
       "tests/api/test_ai_pty.py",
       "tests/api/test_packages.py",
       "tests/packaging/test_desktop_mvp_resources.py"
     ],
-    "diff_fingerprint": "sha256:c4115789099c91c517b7d01d5621a1f8095c775d04f55f6b762b64deb8186ecf",
+    "diff_fingerprint": "sha256:067c6237b0f5f635fa6086aed0b1c9fdc53ea3e5bb7cddcc20115f7317e6891a",
     "head": "HEAD",
-    "head_sha": "b8cdfd6e",
+    "head_sha": "c8da7d93",
     "surfaces": {
       "docs": 0,
       "frontend": 7,
       "governance": 0,
       "governed_docs": 0,
-      "implementation": 10,
+      "implementation": 11,
       "packaging": 0,
-      "protected_core": 0,
-      "sentrux": 14,
+      "protected_core": 1,
+      "sentrux": 15,
       "test": 7,
       "workflow_ci": 0
     }
@@ -816,13 +1337,42 @@
       "unsatisfied": [
         "checks.python_tests"
       ]
+    },
+    {
+      "at": "2026-06-18T22:43:48.652152Z",
+      "diff_fingerprint": "sha256:067c6237b0f5f635fa6086aed0b1c9fdc53ea3e5bb7cddcc20115f7317e6891a",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "guard.core_change_guard"
+      ]
+    },
+    {
+      "at": "2026-06-18T22:48:26.592952Z",
+      "diff_fingerprint": "sha256:067c6237b0f5f635fa6086aed0b1c9fdc53ea3e5bb7cddcc20115f7317e6891a",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
     }
   ],
   "record_id": "1694-1697-hotfix-batch",
-  "requested_admin_labels": [],
+  "requested_admin_labels": [
+    {
+      "actor_permission": null,
+      "applied_at": null,
+      "applied_by": null,
+      "name": "admin-approved:core-change"
+    }
+  ],
   "required_obligations": {
-    "admin_labels": [],
+    "admin_labels": [
+      "admin-approved:core-change"
+    ],
     "checks": [
+      "architecture_tests",
+      "deferral_discipline",
       "format_check",
       "frontend",
       "full_audit",
@@ -862,7 +1412,7 @@
     }
   ],
   "session_id": "1846ad53-9708-483c-9d88-9fd316faef54",
-  "strictness_tier": 2,
+  "strictness_tier": 1,
   "task_kind": "hotfix",
   "test_events": [
     {

--- a/.workflow/records/1694-1697-hotfix-batch.json
+++ b/.workflow/records/1694-1697-hotfix-batch.json
@@ -1,0 +1,965 @@
+{
+  "branch": "hotfix/1694-package-install-register-blocks",
+  "check_events": [
+    {
+      "at": "2026-06-18T22:13:01.575604Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-18T22:13:05.894719Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T22:13:05.941632Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-18T22:13:30.142136Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-18T22:13:33.901244Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T22:13:33.924909Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-18T22:14:31.001591Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:bbbcf2b4cced739bb5f18ee397ded65b3e97e7acc88a20f779c019af8c5cc8f2",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-18T22:14:34.533447Z",
+      "command": "(cd frontend && npm run lint)",
+      "covered_surface": "frontend",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:bbbcf2b4cced739bb5f18ee397ded65b3e97e7acc88a20f779c019af8c5cc8f2",
+      "name": "frontend",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/frontend.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T22:14:38.190314Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:bbbcf2b4cced739bb5f18ee397ded65b3e97e7acc88a20f779c019af8c5cc8f2",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T22:14:38.713802Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:bbbcf2b4cced739bb5f18ee397ded65b3e97e7acc88a20f779c019af8c5cc8f2",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T22:14:38.732398Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:bbbcf2b4cced739bb5f18ee397ded65b3e97e7acc88a20f779c019af8c5cc8f2",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-18T22:17:00.077894Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:bbbcf2b4cced739bb5f18ee397ded65b3e97e7acc88a20f779c019af8c5cc8f2",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T22:18:59.406205Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:bbbcf2b4cced739bb5f18ee397ded65b3e97e7acc88a20f779c019af8c5cc8f2",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T22:19:06.446650Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:bbbcf2b4cced739bb5f18ee397ded65b3e97e7acc88a20f779c019af8c5cc8f2",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    },
+    {
+      "at": "2026-06-18T22:30:50.750173Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:bbbcf2b4cced739bb5f18ee397ded65b3e97e7acc88a20f779c019af8c5cc8f2",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-18T22:30:53.747627Z",
+      "command": "(cd frontend && npm run lint)",
+      "covered_surface": "frontend",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:bbbcf2b4cced739bb5f18ee397ded65b3e97e7acc88a20f779c019af8c5cc8f2",
+      "name": "frontend",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/frontend.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T22:30:57.277705Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:bbbcf2b4cced739bb5f18ee397ded65b3e97e7acc88a20f779c019af8c5cc8f2",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T22:30:57.417232Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:bbbcf2b4cced739bb5f18ee397ded65b3e97e7acc88a20f779c019af8c5cc8f2",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T22:30:57.441513Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:bbbcf2b4cced739bb5f18ee397ded65b3e97e7acc88a20f779c019af8c5cc8f2",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-18T22:32:49.737865Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:bbbcf2b4cced739bb5f18ee397ded65b3e97e7acc88a20f779c019af8c5cc8f2",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T22:34:53.286985Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:bbbcf2b4cced739bb5f18ee397ded65b3e97e7acc88a20f779c019af8c5cc8f2",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T22:34:54.046855Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:bbbcf2b4cced739bb5f18ee397ded65b3e97e7acc88a20f779c019af8c5cc8f2",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    }
+  ],
+  "check_na": [],
+  "commit": {
+    "sha": "b8cdfd6ebe0c580752c0daf6497a45ee01c84bd5",
+    "shas": [
+      "b8cdfd6ebe0c580752c0daf6497a45ee01c84bd5"
+    ],
+    "trailers": []
+  },
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "desktop/main.js",
+      "frontend/src/App.parts/useWorkflowSync.ts",
+      "frontend/src/components/AIChat/TerminalView.tsx",
+      "frontend/src/components/AIChat/__tests__/TerminalView.test.tsx",
+      "frontend/src/components/AIChat/__tests__/usePtyWebSocket.test.ts",
+      "frontend/src/components/AIChat/hooks/usePtyWebSocket.ts",
+      "frontend/src/store/workflowSlice.parts/workflowEditActions.ts",
+      "frontend/src/store/__tests__/workflowSlice.variadicPorts.test.ts",
+      "src/scistudio/api/routes/ai_pty/__init__.py",
+      "src/scistudio/api/routes/ai_pty/websocket.py",
+      "src/scistudio/api/routes/packages.py",
+      "tests/api/routes/ai_pty/test_public_surface.py",
+      "tests/api/test_ai_pty.py",
+      "tests/api/test_packages.py",
+      "tests/packaging/test_desktop_mvp_resources.py"
+    ]
+  },
+  "directive_events": [
+    {
+      "at": "2026-06-18T22:11:51.751356Z",
+      "owner_directive": "Final hotfix batch scope: package install registered-block count, desktop runtime PATH for local CLIs, variadic block initial port seeding, and PTY terminal rendering stability",
+      "reason": "plan"
+    }
+  ],
+  "docs_events": [
+    {
+      "at": "2026-06-18T22:11:51.751497Z",
+      "class": "architecture",
+      "kind": "na",
+      "path": null,
+      "rationale": "Localized hotfixes preserve existing architecture; no ADR or spec change required",
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-18T22:11:51.751513Z",
+      "class": "user-docs",
+      "kind": "na",
+      "path": null,
+      "rationale": "No user-facing workflow semantics changed beyond fixing broken behavior",
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-18T22:11:51.751516Z",
+      "class": "changelog",
+      "kind": "na",
+      "path": null,
+      "rationale": "Hotfix branch will be documented by PR body and linked issues",
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": false,
+  "guard_events": [
+    {
+      "at": "2026-06-18T22:13:05.964742Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T22:13:05.975275Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T22:13:05.986058Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T22:13:05.997033Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T22:13:06.007944Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T22:13:06.018518Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T22:13:06.028804Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T22:13:06.039693Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T22:13:06.050190Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T22:13:06.060609Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T22:13:33.949883Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T22:13:33.961125Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T22:13:33.972330Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T22:13:33.983291Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T22:13:33.994681Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T22:13:34.005848Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T22:13:34.017005Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T22:13:34.027730Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T22:13:34.038519Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T22:13:34.049468Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T22:19:06.478986Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T22:19:06.487459Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T22:19:06.496098Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T22:19:06.504777Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T22:19:06.513321Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T22:19:06.522033Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T22:19:06.530451Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T22:19:06.539062Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T22:19:06.547594Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T22:19:06.559624Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T22:34:54.080883Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T22:34:54.091387Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T22:34:54.101415Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T22:34:54.112258Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T22:34:54.122528Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T22:34:54.132412Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T22:34:54.141804Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T22:34:54.152315Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T22:34:54.162893Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T22:34:54.177614Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1694,
+      "url": null
+    },
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1695,
+      "url": null
+    },
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1696,
+      "url": null
+    },
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1697,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": {
+    "base": "origin/main",
+    "base_sha": "ae552015",
+    "changed_files": [
+      ".workflow/records/1694-1697-hotfix-batch.json",
+      "desktop/main.js",
+      "frontend/src/App.parts/useWorkflowSync.ts",
+      "frontend/src/components/AIChat/TerminalView.tsx",
+      "frontend/src/components/AIChat/__tests__/TerminalView.test.tsx",
+      "frontend/src/components/AIChat/__tests__/usePtyWebSocket.test.ts",
+      "frontend/src/components/AIChat/hooks/usePtyWebSocket.ts",
+      "frontend/src/store/__tests__/workflowSlice.variadicPorts.test.ts",
+      "frontend/src/store/workflowSlice.parts/workflowEditActions.ts",
+      "src/scistudio/api/routes/ai_pty/__init__.py",
+      "src/scistudio/api/routes/ai_pty/websocket.py",
+      "src/scistudio/api/routes/packages.py",
+      "tests/api/routes/ai_pty/test_public_surface.py",
+      "tests/api/test_ai_pty.py",
+      "tests/api/test_packages.py",
+      "tests/packaging/test_desktop_mvp_resources.py"
+    ],
+    "diff_fingerprint": "sha256:c4115789099c91c517b7d01d5621a1f8095c775d04f55f6b762b64deb8186ecf",
+    "head": "HEAD",
+    "head_sha": "b8cdfd6e",
+    "surfaces": {
+      "docs": 0,
+      "frontend": 7,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 10,
+      "packaging": 0,
+      "protected_core": 0,
+      "sentrux": 14,
+      "test": 7,
+      "workflow_ci": 0
+    }
+  },
+  "owner_directive": "Owner-confirmed hotfix batch for package install block registration, desktop CLI PATH detection, variadic block initialization, and PTY terminal rendering",
+  "persona": "implementer",
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [
+      1694,
+      1695,
+      1696,
+      1697
+    ],
+    "number": null,
+    "url": null
+  },
+  "reconcile_events": [
+    {
+      "at": "2026-06-18T22:13:06.060645Z",
+      "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.format_check"
+      ]
+    },
+    {
+      "at": "2026-06-18T22:13:34.049523Z",
+      "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-18T22:19:06.559669Z",
+      "diff_fingerprint": "sha256:73fdb1b405c1630230dd1a03bc484ab1e3d5172857a0b2d3be048ca3bb6ccbe3",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.python_tests",
+        "checks.semantic_dup"
+      ]
+    },
+    {
+      "at": "2026-06-18T22:34:54.177665Z",
+      "diff_fingerprint": "sha256:c4115789099c91c517b7d01d5621a1f8095c775d04f55f6b762b64deb8186ecf",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.python_tests"
+      ]
+    }
+  ],
+  "record_id": "1694-1697-hotfix-batch",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [
+      "format_check",
+      "frontend",
+      "full_audit",
+      "import_contracts",
+      "lint_format",
+      "python_tests",
+      "semantic_dup",
+      "type_check"
+    ],
+    "docs": [
+      "docs_required_or_na"
+    ],
+    "guards": [
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": [
+      "changed_test_required"
+    ]
+  },
+  "runtime": "codex",
+  "schema_version": 2,
+  "scope_events": [
+    {
+      "action": "add-include",
+      "at": "2026-06-18T22:37:08.913635Z",
+      "pattern": "src/scistudio/blocks/registry/_scan.py",
+      "reason": "Include package source scanner class-identity fix discovered by full-suite package image regression"
+    }
+  ],
+  "session_id": "1846ad53-9708-483c-9d88-9fd316faef54",
+  "strictness_tier": 2,
+  "task_kind": "hotfix",
+  "test_events": [
+    {
+      "at": "2026-06-18T22:11:51.751519Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/api/test_packages.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-18T22:11:51.751521Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/desktop/test_package_installer.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-18T22:11:51.751523Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/packaging/test_desktop_mvp_resources.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-18T22:11:51.751524Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/api/test_ai_pty.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-18T22:11:51.751525Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/api/routes/ai_pty/test_public_surface.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-18T22:11:51.751526Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/store/__tests__/workflowSlice.variadicPorts.test.ts",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-18T22:11:51.751527Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/App.parts/useWorkflowSync.test.tsx",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-18T22:11:51.751528Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/components/AIChat/__tests__/usePtyWebSocket.test.ts",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-18T22:11:51.751530Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/components/AIChat/__tests__/TerminalView.test.tsx",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-18T22:37:08.913773Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/blocks/io/test_load_data.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-18T22:37:08.913788Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/blocks/test_desktop_package_discovery.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-18T22:37:08.913790Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/desktop/test_package_installer.py",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/.workflow/records/1694-1697-hotfix-batch.json
+++ b/.workflow/records/1694-1697-hotfix-batch.json
@@ -662,13 +662,169 @@
       "tool_versions": {
         "mypy": "2.1.0"
       }
+    },
+    {
+      "at": "2026-06-18T22:49:15.216426Z",
+      "command": "pytest tests/architecture/ -v --no-cov",
+      "covered_surface": "architecture",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cc10b47a1af21e7c9d50d203a91d080c30141e530f6e1a2decc034fee747da1f",
+      "name": "architecture_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/architecture_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T22:49:16.176336Z",
+      "command": "python scripts/deferral_scan.py --check docs/audit/baselines/deferral-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cc10b47a1af21e7c9d50d203a91d080c30141e530f6e1a2decc034fee747da1f",
+      "name": "deferral_discipline",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/deferral_discipline.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T22:49:16.225408Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cc10b47a1af21e7c9d50d203a91d080c30141e530f6e1a2decc034fee747da1f",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-18T22:49:19.627357Z",
+      "command": "(cd frontend && npm run lint)",
+      "covered_surface": "frontend",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cc10b47a1af21e7c9d50d203a91d080c30141e530f6e1a2decc034fee747da1f",
+      "name": "frontend",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/frontend.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T22:49:23.246752Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cc10b47a1af21e7c9d50d203a91d080c30141e530f6e1a2decc034fee747da1f",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T22:49:23.352302Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cc10b47a1af21e7c9d50d203a91d080c30141e530f6e1a2decc034fee747da1f",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T22:49:23.367940Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cc10b47a1af21e7c9d50d203a91d080c30141e530f6e1a2decc034fee747da1f",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-18T22:51:18.404999Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cc10b47a1af21e7c9d50d203a91d080c30141e530f6e1a2decc034fee747da1f",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T22:53:25.821664Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cc10b47a1af21e7c9d50d203a91d080c30141e530f6e1a2decc034fee747da1f",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T22:53:26.407110Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cc10b47a1af21e7c9d50d203a91d080c30141e530f6e1a2decc034fee747da1f",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
     }
   ],
   "check_na": [],
   "commit": {
-    "sha": "c8da7d93bab0b7bd1574e8f7c3069fd587baaf91",
+    "sha": "8c71a69d6f3d7a19ad5bd2b232287c367fb38273",
     "shas": [
-      "c8da7d93bab0b7bd1574e8f7c3069fd587baaf91"
+      "8c71a69d6f3d7a19ad5bd2b232287c367fb38273"
     ],
     "trailers": []
   },
@@ -1218,6 +1374,214 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-06-18T22:53:26.452397Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/registry/_scan.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/registry/_scan.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T22:53:26.464126Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T22:53:26.475657Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T22:53:26.487468Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T22:53:26.498857Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T22:53:26.510213Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T22:53:26.520987Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T22:53:26.531795Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T22:53:26.543203Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T22:53:26.560279Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T22:53:43.927866Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/registry/_scan.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/registry/_scan.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "error",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "fail"
+    },
+    {
+      "at": "2026-06-18T22:53:43.938249Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T22:53:43.948316Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T22:53:43.958470Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T22:53:43.968533Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T22:53:43.978750Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T22:53:43.988967Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T22:53:43.999410Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T22:53:44.009457Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T22:53:44.026156Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -1248,7 +1612,7 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "origin/main",
+    "base": "ae552015125ac67b3c23a1d51327e470df95a1e6",
     "base_sha": "ae552015",
     "changed_files": [
       ".workflow/records/1694-1697-hotfix-batch.json",
@@ -1269,9 +1633,9 @@
       "tests/api/test_packages.py",
       "tests/packaging/test_desktop_mvp_resources.py"
     ],
-    "diff_fingerprint": "sha256:067c6237b0f5f635fa6086aed0b1c9fdc53ea3e5bb7cddcc20115f7317e6891a",
+    "diff_fingerprint": "sha256:c2b73ce5abfed9a26c5b2df09d7d21d55a781c9213311d1c893668dbc8a988fd",
     "head": "HEAD",
-    "head_sha": "c8da7d93",
+    "head_sha": "8c71a69d",
     "surfaces": {
       "docs": 0,
       "frontend": 7,
@@ -1295,8 +1659,8 @@
       1696,
       1697
     ],
-    "number": null,
-    "url": null
+    "number": 1700,
+    "url": "https://github.com/zjzcpj/SciStudio/pull/1700"
   },
   "reconcile_events": [
     {
@@ -1355,6 +1719,24 @@
       "result": "pass",
       "tier": 1,
       "unsatisfied": []
+    },
+    {
+      "at": "2026-06-18T22:53:26.560350Z",
+      "diff_fingerprint": "sha256:c2b73ce5abfed9a26c5b2df09d7d21d55a781c9213311d1c893668dbc8a988fd",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-18T22:53:44.026202Z",
+      "diff_fingerprint": "sha256:c2b73ce5abfed9a26c5b2df09d7d21d55a781c9213311d1c893668dbc8a988fd",
+      "mode": "ci",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "guard.core_change_guard"
+      ]
     }
   ],
   "record_id": "1694-1697-hotfix-batch",
@@ -1370,18 +1752,7 @@
     "admin_labels": [
       "admin-approved:core-change"
     ],
-    "checks": [
-      "architecture_tests",
-      "deferral_discipline",
-      "format_check",
-      "frontend",
-      "full_audit",
-      "import_contracts",
-      "lint_format",
-      "python_tests",
-      "semantic_dup",
-      "type_check"
-    ],
+    "checks": [],
     "docs": [
       "docs_required_or_na"
     ],

--- a/.workflow/records/1694-1697-hotfix-batch.json
+++ b/.workflow/records/1694-1697-hotfix-batch.json
@@ -818,6 +818,630 @@
       "tool_versions": {
         "mypy": "2.1.0"
       }
+    },
+    {
+      "at": "2026-06-18T23:27:28.391794Z",
+      "command": "pytest tests/architecture/ -v --no-cov",
+      "covered_surface": "architecture",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cc10b47a1af21e7c9d50d203a91d080c30141e530f6e1a2decc034fee747da1f",
+      "name": "architecture_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/architecture_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T23:27:29.112081Z",
+      "command": "python scripts/deferral_scan.py --check docs/audit/baselines/deferral-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:cc10b47a1af21e7c9d50d203a91d080c30141e530f6e1a2decc034fee747da1f",
+      "name": "deferral_discipline",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/deferral_discipline.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T23:27:29.174208Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cc10b47a1af21e7c9d50d203a91d080c30141e530f6e1a2decc034fee747da1f",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-18T23:27:32.734729Z",
+      "command": "(cd frontend && npm run lint)",
+      "covered_surface": "frontend",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cc10b47a1af21e7c9d50d203a91d080c30141e530f6e1a2decc034fee747da1f",
+      "name": "frontend",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/frontend.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T23:27:36.569625Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cc10b47a1af21e7c9d50d203a91d080c30141e530f6e1a2decc034fee747da1f",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T23:27:36.707087Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cc10b47a1af21e7c9d50d203a91d080c30141e530f6e1a2decc034fee747da1f",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T23:27:36.730215Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cc10b47a1af21e7c9d50d203a91d080c30141e530f6e1a2decc034fee747da1f",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-18T23:29:29.673921Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cc10b47a1af21e7c9d50d203a91d080c30141e530f6e1a2decc034fee747da1f",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T23:31:26.877238Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cc10b47a1af21e7c9d50d203a91d080c30141e530f6e1a2decc034fee747da1f",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T23:31:27.939753Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cc10b47a1af21e7c9d50d203a91d080c30141e530f6e1a2decc034fee747da1f",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    },
+    {
+      "at": "2026-06-18T23:34:36.965820Z",
+      "command": "pytest tests/architecture/ -v --no-cov",
+      "covered_surface": "architecture",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cc10b47a1af21e7c9d50d203a91d080c30141e530f6e1a2decc034fee747da1f",
+      "name": "architecture_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/architecture_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T23:34:38.420958Z",
+      "command": "python scripts/deferral_scan.py --check docs/audit/baselines/deferral-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cc10b47a1af21e7c9d50d203a91d080c30141e530f6e1a2decc034fee747da1f",
+      "name": "deferral_discipline",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/deferral_discipline.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T23:34:38.492588Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cc10b47a1af21e7c9d50d203a91d080c30141e530f6e1a2decc034fee747da1f",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-18T23:34:47.272871Z",
+      "command": "(cd frontend && npm run lint)",
+      "covered_surface": "frontend",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cc10b47a1af21e7c9d50d203a91d080c30141e530f6e1a2decc034fee747da1f",
+      "name": "frontend",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/frontend.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T23:34:59.671194Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cc10b47a1af21e7c9d50d203a91d080c30141e530f6e1a2decc034fee747da1f",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T23:35:00.253898Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cc10b47a1af21e7c9d50d203a91d080c30141e530f6e1a2decc034fee747da1f",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T23:35:00.359419Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cc10b47a1af21e7c9d50d203a91d080c30141e530f6e1a2decc034fee747da1f",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-18T23:37:58.008529Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cc10b47a1af21e7c9d50d203a91d080c30141e530f6e1a2decc034fee747da1f",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T23:40:56.751088Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cc10b47a1af21e7c9d50d203a91d080c30141e530f6e1a2decc034fee747da1f",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-18T23:40:57.788506Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cc10b47a1af21e7c9d50d203a91d080c30141e530f6e1a2decc034fee747da1f",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    },
+    {
+      "at": "2026-06-19T03:21:49.763834Z",
+      "command": "pytest tests/architecture/ -v --no-cov",
+      "covered_surface": "architecture",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cc10b47a1af21e7c9d50d203a91d080c30141e530f6e1a2decc034fee747da1f",
+      "name": "architecture_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/architecture_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-19T03:21:50.652678Z",
+      "command": "python scripts/deferral_scan.py --check docs/audit/baselines/deferral-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cc10b47a1af21e7c9d50d203a91d080c30141e530f6e1a2decc034fee747da1f",
+      "name": "deferral_discipline",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/deferral_discipline.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-19T03:21:50.707774Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cc10b47a1af21e7c9d50d203a91d080c30141e530f6e1a2decc034fee747da1f",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-19T03:21:55.748920Z",
+      "command": "(cd frontend && npm run lint)",
+      "covered_surface": "frontend",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cc10b47a1af21e7c9d50d203a91d080c30141e530f6e1a2decc034fee747da1f",
+      "name": "frontend",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/frontend.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-19T03:25:34.592806Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cc10b47a1af21e7c9d50d203a91d080c30141e530f6e1a2decc034fee747da1f",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-19T03:25:34.716342Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cc10b47a1af21e7c9d50d203a91d080c30141e530f6e1a2decc034fee747da1f",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-19T03:25:34.741898Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cc10b47a1af21e7c9d50d203a91d080c30141e530f6e1a2decc034fee747da1f",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-19T03:27:54.244738Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cc10b47a1af21e7c9d50d203a91d080c30141e530f6e1a2decc034fee747da1f",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-19T03:30:35.485840Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:cc10b47a1af21e7c9d50d203a91d080c30141e530f6e1a2decc034fee747da1f",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-19T03:30:36.464651Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cc10b47a1af21e7c9d50d203a91d080c30141e530f6e1a2decc034fee747da1f",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    },
+    {
+      "at": "2026-06-19T03:37:42.046638Z",
+      "command": "pytest tests/architecture/ -v --no-cov",
+      "covered_surface": "architecture",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cc10b47a1af21e7c9d50d203a91d080c30141e530f6e1a2decc034fee747da1f",
+      "name": "architecture_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/architecture_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-19T03:37:42.703453Z",
+      "command": "python scripts/deferral_scan.py --check docs/audit/baselines/deferral-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cc10b47a1af21e7c9d50d203a91d080c30141e530f6e1a2decc034fee747da1f",
+      "name": "deferral_discipline",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/deferral_discipline.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-19T03:37:42.750091Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cc10b47a1af21e7c9d50d203a91d080c30141e530f6e1a2decc034fee747da1f",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-19T03:37:45.598673Z",
+      "command": "(cd frontend && npm run lint)",
+      "covered_surface": "frontend",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cc10b47a1af21e7c9d50d203a91d080c30141e530f6e1a2decc034fee747da1f",
+      "name": "frontend",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/frontend.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-19T03:37:49.623764Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cc10b47a1af21e7c9d50d203a91d080c30141e530f6e1a2decc034fee747da1f",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-19T03:37:49.741219Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cc10b47a1af21e7c9d50d203a91d080c30141e530f6e1a2decc034fee747da1f",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-19T03:37:49.765412Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cc10b47a1af21e7c9d50d203a91d080c30141e530f6e1a2decc034fee747da1f",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-19T03:39:31.499788Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cc10b47a1af21e7c9d50d203a91d080c30141e530f6e1a2decc034fee747da1f",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-19T03:41:19.912491Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cc10b47a1af21e7c9d50d203a91d080c30141e530f6e1a2decc034fee747da1f",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-19T03:41:20.877838Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cc10b47a1af21e7c9d50d203a91d080c30141e530f6e1a2decc034fee747da1f",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
     }
   ],
   "check_na": [],
@@ -853,6 +1477,21 @@
       "at": "2026-06-18T22:11:51.751356Z",
       "owner_directive": "Final hotfix batch scope: package install registered-block count, desktop runtime PATH for local CLIs, variadic block initial port seeding, and PTY terminal rendering stability",
       "reason": "plan"
+    },
+    {
+      "at": "2026-06-18T23:12:26.079647Z",
+      "owner_directive": "DMG still reports Installed scistudio-blocks-imaging 0.1.0. Registered 0 blocks; do not prebundle every package dependency, make package install scalable.",
+      "reason": "Owner rejected bundling package dependencies into the DMG; package install must resolve dependencies on demand into a user-scoped plugin runtime instead."
+    },
+    {
+      "at": "2026-06-18T23:21:05.918257Z",
+      "owner_directive": "Allow network dependency installation for selected desktop packages, using bundled Python instead of user Python.",
+      "reason": "Activate desktop package import roots before entry-point scanning so previously installed package runtimes are visible after app restart."
+    },
+    {
+      "at": "2026-06-18T23:48:40.649048Z",
+      "owner_directive": "Add a desktop GUI terminal entry so users can install custom-block dependencies themselves.",
+      "reason": "Owner approved a desktop user terminal entry for manual dependency installation using the bundled Python and user plugin runtime."
     }
   ],
   "docs_events": [
@@ -878,6 +1517,30 @@
       "kind": "na",
       "path": null,
       "rationale": "Hotfix branch will be documented by PR body and linked issues",
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-18T23:12:26.079860Z",
+      "class": null,
+      "kind": "path",
+      "path": "desktop/README.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-18T23:22:57.423792Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/planning/adr-037-desktop-mvp-spec.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-18T23:48:40.649210Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/planning/adr-037-desktop-mvp-spec.md",
+      "rationale": null,
       "verified_in_diff": null
     }
   ],
@@ -1582,6 +2245,422 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-06-18T23:31:27.984563Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/registry/_scan.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/registry/_scan.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T23:31:27.994381Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T23:31:28.004285Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T23:31:28.014341Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T23:31:28.024458Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T23:31:28.033903Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T23:31:28.044240Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T23:31:28.054670Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T23:31:28.063999Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T23:31:28.080560Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T23:40:57.834267Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/registry/_scan.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/registry/_scan.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T23:40:57.845205Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T23:40:57.856153Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T23:40:57.867053Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T23:40:57.877708Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T23:40:57.888455Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T23:40:57.899329Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T23:40:57.911107Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T23:40:57.921703Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-18T23:40:57.939969Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T03:30:36.513199Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/registry/_scan.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/registry/_scan.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T03:30:36.522967Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T03:30:36.532634Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T03:30:36.543278Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T03:30:36.552924Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T03:30:36.562221Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T03:30:36.571399Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T03:30:36.580417Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T03:30:36.589253Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T03:30:36.605420Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T03:41:20.922357Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/registry/_scan.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/registry/_scan.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T03:41:20.932163Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T03:41:20.941791Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T03:41:20.951753Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T03:41:20.962226Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T03:41:20.971916Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T03:41:20.981172Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T03:41:20.990925Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T03:41:21.000435Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T03:41:21.016817Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -1633,9 +2712,9 @@
       "tests/api/test_packages.py",
       "tests/packaging/test_desktop_mvp_resources.py"
     ],
-    "diff_fingerprint": "sha256:c2b73ce5abfed9a26c5b2df09d7d21d55a781c9213311d1c893668dbc8a988fd",
+    "diff_fingerprint": "sha256:090d6754261e9a69403b98be22465c6b20fa0b17534cef7a778ed8f5d46a48f5",
     "head": "HEAD",
-    "head_sha": "8c71a69d",
+    "head_sha": "c4feb8c6",
     "surfaces": {
       "docs": 0,
       "frontend": 7,
@@ -1737,6 +2816,42 @@
       "unsatisfied": [
         "guard.core_change_guard"
       ]
+    },
+    {
+      "at": "2026-06-18T23:31:28.080606Z",
+      "diff_fingerprint": "sha256:090d6754261e9a69403b98be22465c6b20fa0b17534cef7a778ed8f5d46a48f5",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.deferral_discipline"
+      ]
+    },
+    {
+      "at": "2026-06-18T23:40:57.940039Z",
+      "diff_fingerprint": "sha256:090d6754261e9a69403b98be22465c6b20fa0b17534cef7a778ed8f5d46a48f5",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-19T03:30:36.605473Z",
+      "diff_fingerprint": "sha256:090d6754261e9a69403b98be22465c6b20fa0b17534cef7a778ed8f5d46a48f5",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.semantic_dup"
+      ]
+    },
+    {
+      "at": "2026-06-19T03:41:21.016903Z",
+      "diff_fingerprint": "sha256:090d6754261e9a69403b98be22465c6b20fa0b17534cef7a778ed8f5d46a48f5",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
     }
   ],
   "record_id": "1694-1697-hotfix-batch",
@@ -1752,7 +2867,18 @@
     "admin_labels": [
       "admin-approved:core-change"
     ],
-    "checks": [],
+    "checks": [
+      "architecture_tests",
+      "deferral_discipline",
+      "format_check",
+      "frontend",
+      "full_audit",
+      "import_contracts",
+      "lint_format",
+      "python_tests",
+      "semantic_dup",
+      "type_check"
+    ],
     "docs": [
       "docs_required_or_na"
     ],
@@ -1780,6 +2906,180 @@
       "at": "2026-06-18T22:37:08.913635Z",
       "pattern": "src/scistudio/blocks/registry/_scan.py",
       "reason": "Include package source scanner class-identity fix discovered by full-suite package image regression"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-18T23:12:26.079802Z",
+      "pattern": "src/scistudio/desktop/paths.py",
+      "reason": "Owner rejected bundling package dependencies into the DMG; package install must resolve dependencies on demand into a user-scoped plugin runtime instead."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-18T23:12:26.079807Z",
+      "pattern": "src/scistudio/desktop/package_installer.py",
+      "reason": "Owner rejected bundling package dependencies into the DMG; package install must resolve dependencies on demand into a user-scoped plugin runtime instead."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-18T23:12:26.079808Z",
+      "pattern": "src/scistudio/blocks/registry/_scan.py",
+      "reason": "Owner rejected bundling package dependencies into the DMG; package install must resolve dependencies on demand into a user-scoped plugin runtime instead."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-18T23:12:26.079812Z",
+      "pattern": "src/scistudio/api/routes/packages.py",
+      "reason": "Owner rejected bundling package dependencies into the DMG; package install must resolve dependencies on demand into a user-scoped plugin runtime instead."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-18T23:12:26.079813Z",
+      "pattern": "tests/desktop/test_package_installer.py",
+      "reason": "Owner rejected bundling package dependencies into the DMG; package install must resolve dependencies on demand into a user-scoped plugin runtime instead."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-18T23:12:26.079814Z",
+      "pattern": "tests/blocks/test_desktop_package_discovery.py",
+      "reason": "Owner rejected bundling package dependencies into the DMG; package install must resolve dependencies on demand into a user-scoped plugin runtime instead."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-18T23:12:26.079815Z",
+      "pattern": "tests/api/test_packages.py",
+      "reason": "Owner rejected bundling package dependencies into the DMG; package install must resolve dependencies on demand into a user-scoped plugin runtime instead."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-18T23:12:26.079816Z",
+      "pattern": "desktop/README.md",
+      "reason": "Owner rejected bundling package dependencies into the DMG; package install must resolve dependencies on demand into a user-scoped plugin runtime instead."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-18T23:12:26.079817Z",
+      "pattern": "desktop/scripts/stage-resources.sh",
+      "reason": "Owner rejected bundling package dependencies into the DMG; package install must resolve dependencies on demand into a user-scoped plugin runtime instead."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-18T23:12:26.079818Z",
+      "pattern": "desktop/scripts/stage-resources.ps1",
+      "reason": "Owner rejected bundling package dependencies into the DMG; package install must resolve dependencies on demand into a user-scoped plugin runtime instead."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-18T23:12:26.079855Z",
+      "pattern": "desktop/resources/packages/README.md",
+      "reason": "Owner rejected bundling package dependencies into the DMG; package install must resolve dependencies on demand into a user-scoped plugin runtime instead."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-18T23:21:05.918426Z",
+      "pattern": "src/scistudio/blocks/registry/__init__.py",
+      "reason": "Activate desktop package import roots before entry-point scanning so previously installed package runtimes are visible after app restart."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-18T23:22:57.423656Z",
+      "pattern": "docs/planning/adr-037-desktop-mvp-spec.md",
+      "reason": "Document owner-approved online dependency resolution for selected desktop package installs."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-18T23:48:40.649186Z",
+      "pattern": "src/scistudio/ai/agent/terminal.py",
+      "reason": "Owner approved a desktop user terminal entry for manual dependency installation using the bundled Python and user plugin runtime."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-18T23:48:40.649190Z",
+      "pattern": "src/scistudio/api/routes/ai_pty/__init__.py",
+      "reason": "Owner approved a desktop user terminal entry for manual dependency installation using the bundled Python and user plugin runtime."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-18T23:48:40.649192Z",
+      "pattern": "src/scistudio/desktop/paths.py",
+      "reason": "Owner approved a desktop user terminal entry for manual dependency installation using the bundled Python and user plugin runtime."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-18T23:48:40.649193Z",
+      "pattern": "frontend/src/store/types.ts",
+      "reason": "Owner approved a desktop user terminal entry for manual dependency installation using the bundled Python and user plugin runtime."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-18T23:48:40.649194Z",
+      "pattern": "frontend/src/store/terminalTabsSlice.ts",
+      "reason": "Owner approved a desktop user terminal entry for manual dependency installation using the bundled Python and user plugin runtime."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-18T23:48:40.649195Z",
+      "pattern": "frontend/src/components/AIChat/TerminalTabs.tsx",
+      "reason": "Owner approved a desktop user terminal entry for manual dependency installation using the bundled Python and user plugin runtime."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-18T23:48:40.649196Z",
+      "pattern": "frontend/src/components/AIChat/TerminalTabs.parts/TabStrip.tsx",
+      "reason": "Owner approved a desktop user terminal entry for manual dependency installation using the bundled Python and user plugin runtime."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-18T23:48:40.649197Z",
+      "pattern": "frontend/src/components/AIChat/TerminalTab.tsx",
+      "reason": "Owner approved a desktop user terminal entry for manual dependency installation using the bundled Python and user plugin runtime."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-18T23:48:40.649198Z",
+      "pattern": "frontend/src/components/AIChat/TerminalView.tsx",
+      "reason": "Owner approved a desktop user terminal entry for manual dependency installation using the bundled Python and user plugin runtime."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-18T23:48:40.649199Z",
+      "pattern": "frontend/src/components/AIChat/hooks/usePtyWebSocket.ts",
+      "reason": "Owner approved a desktop user terminal entry for manual dependency installation using the bundled Python and user plugin runtime."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-18T23:48:40.649200Z",
+      "pattern": "tests/ai/test_windows_executable_resolution.py",
+      "reason": "Owner approved a desktop user terminal entry for manual dependency installation using the bundled Python and user plugin runtime."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-18T23:48:40.649201Z",
+      "pattern": "tests/api/test_ai_pty.py",
+      "reason": "Owner approved a desktop user terminal entry for manual dependency installation using the bundled Python and user plugin runtime."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-18T23:48:40.649205Z",
+      "pattern": "frontend/src/components/AIChat/__tests__/TerminalTabs.test.tsx",
+      "reason": "Owner approved a desktop user terminal entry for manual dependency installation using the bundled Python and user plugin runtime."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-18T23:48:40.649206Z",
+      "pattern": "frontend/src/components/AIChat/__tests__/usePtyWebSocket.test.ts",
+      "reason": "Owner approved a desktop user terminal entry for manual dependency installation using the bundled Python and user plugin runtime."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-18T23:49:44.747930Z",
+      "pattern": "src/scistudio/blocks/registry/_scan.py",
+      "reason": "User terminal dependency path must also be visible to custom block discovery and worker imports without broad source path leakage."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-18T23:49:44.748105Z",
+      "pattern": "tests/blocks/test_desktop_package_discovery.py",
+      "reason": "User terminal dependency path must also be visible to custom block discovery and worker imports without broad source path leakage."
     }
   ],
   "session_id": "1846ad53-9708-483c-9d88-9fd316faef54",
@@ -1879,6 +3179,70 @@
       "class": null,
       "kind": "path",
       "path": "tests/desktop/test_package_installer.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-18T23:12:26.080063Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/desktop/test_package_installer.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-18T23:12:26.080066Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/blocks/test_desktop_package_discovery.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-18T23:12:26.080067Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/api/test_packages.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-18T23:48:40.649216Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/ai/test_windows_executable_resolution.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-18T23:48:40.649218Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/api/test_ai_pty.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-18T23:48:40.649219Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/components/AIChat/__tests__/TerminalTabs.test.tsx",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-18T23:48:40.649220Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/components/AIChat/__tests__/usePtyWebSocket.test.ts",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-18T23:49:44.748120Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/blocks/test_desktop_package_discovery.py",
       "rationale": null,
       "verified_in_diff": null
     }

--- a/.workflow/records/1694-1697-hotfix-batch.json
+++ b/.workflow/records/1694-1697-hotfix-batch.json
@@ -1442,13 +1442,169 @@
       "tool_versions": {
         "mypy": "2.1.0"
       }
+    },
+    {
+      "at": "2026-06-19T03:44:47.906716Z",
+      "command": "pytest tests/architecture/ -v --no-cov",
+      "covered_surface": "architecture",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cc593ef95b2d7afaac3783a3c1ca818a7933b8df82e865448d0df672cd66b327",
+      "name": "architecture_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/architecture_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-19T03:44:48.562927Z",
+      "command": "python scripts/deferral_scan.py --check docs/audit/baselines/deferral-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cc593ef95b2d7afaac3783a3c1ca818a7933b8df82e865448d0df672cd66b327",
+      "name": "deferral_discipline",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/deferral_discipline.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-19T03:44:48.608147Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cc593ef95b2d7afaac3783a3c1ca818a7933b8df82e865448d0df672cd66b327",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-19T03:44:51.566044Z",
+      "command": "(cd frontend && npm run lint)",
+      "covered_surface": "frontend",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cc593ef95b2d7afaac3783a3c1ca818a7933b8df82e865448d0df672cd66b327",
+      "name": "frontend",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/frontend.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-19T03:44:55.725360Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cc593ef95b2d7afaac3783a3c1ca818a7933b8df82e865448d0df672cd66b327",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-19T03:44:55.839071Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cc593ef95b2d7afaac3783a3c1ca818a7933b8df82e865448d0df672cd66b327",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-19T03:44:55.856624Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cc593ef95b2d7afaac3783a3c1ca818a7933b8df82e865448d0df672cd66b327",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-19T03:46:31.276464Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cc593ef95b2d7afaac3783a3c1ca818a7933b8df82e865448d0df672cd66b327",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-19T03:48:24.456914Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cc593ef95b2d7afaac3783a3c1ca818a7933b8df82e865448d0df672cd66b327",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-19T03:48:25.040639Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cc593ef95b2d7afaac3783a3c1ca818a7933b8df82e865448d0df672cd66b327",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
     }
   ],
   "check_na": [],
   "commit": {
-    "sha": "8c71a69d6f3d7a19ad5bd2b232287c367fb38273",
+    "sha": "c92fa184a95f5c9edd07cf27e59a174673bb744e",
     "shas": [
-      "8c71a69d6f3d7a19ad5bd2b232287c367fb38273"
+      "c92fa184a95f5c9edd07cf27e59a174673bb744e"
     ],
     "trailers": []
   },
@@ -2661,6 +2817,381 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-06-19T03:42:16.069731Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/registry/__init__.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/registry/__init__.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "error",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/registry/_scan.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/registry/_scan.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "error",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "fail"
+    },
+    {
+      "at": "2026-06-19T03:42:16.078231Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T03:42:16.086807Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T03:42:16.095278Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T03:42:16.103749Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T03:42:16.112193Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T03:42:16.120723Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T03:42:16.129122Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T03:42:16.140530Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T03:42:16.160412Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T03:42:50.579583Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/registry/__init__.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/registry/__init__.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "error",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/registry/_scan.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/registry/_scan.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "error",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "fail"
+    },
+    {
+      "at": "2026-06-19T03:42:50.588055Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T03:42:50.596172Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T03:42:50.604311Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T03:42:50.612652Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T03:42:50.620986Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T03:42:50.629365Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T03:42:50.637734Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T03:42:50.645850Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T03:42:50.666074Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T03:48:25.090609Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/registry/__init__.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/registry/__init__.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/registry/_scan.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/registry/_scan.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T03:48:25.100538Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T03:48:25.111469Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T03:48:25.122470Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T03:48:25.132758Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T03:48:25.143238Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T03:48:25.153981Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T03:48:25.164616Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T03:48:25.175198Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T03:48:25.198170Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -2695,36 +3226,53 @@
     "base_sha": "ae552015",
     "changed_files": [
       ".workflow/records/1694-1697-hotfix-batch.json",
+      "desktop/README.md",
       "desktop/main.js",
+      "desktop/resources/packages/README.md",
+      "desktop/scripts/stage-resources.ps1",
+      "desktop/scripts/stage-resources.sh",
+      "docs/planning/adr-037-desktop-mvp-spec.md",
       "frontend/src/App.parts/useWorkflowSync.ts",
+      "frontend/src/components/AIChat/TerminalTabs.parts/TabStrip.tsx",
+      "frontend/src/components/AIChat/TerminalTabs.tsx",
       "frontend/src/components/AIChat/TerminalView.tsx",
+      "frontend/src/components/AIChat/__tests__/TerminalTabs.test.tsx",
       "frontend/src/components/AIChat/__tests__/TerminalView.test.tsx",
       "frontend/src/components/AIChat/__tests__/usePtyWebSocket.test.ts",
       "frontend/src/components/AIChat/hooks/usePtyWebSocket.ts",
       "frontend/src/store/__tests__/workflowSlice.variadicPorts.test.ts",
+      "frontend/src/store/terminalTabsSlice.ts",
+      "frontend/src/store/types.ts",
       "frontend/src/store/workflowSlice.parts/workflowEditActions.ts",
+      "src/scistudio/ai/agent/terminal.py",
       "src/scistudio/api/routes/ai_pty/__init__.py",
       "src/scistudio/api/routes/ai_pty/websocket.py",
       "src/scistudio/api/routes/packages.py",
+      "src/scistudio/blocks/registry/__init__.py",
       "src/scistudio/blocks/registry/_scan.py",
+      "src/scistudio/desktop/package_installer.py",
+      "src/scistudio/desktop/paths.py",
+      "tests/ai/test_windows_executable_resolution.py",
       "tests/api/routes/ai_pty/test_public_surface.py",
       "tests/api/test_ai_pty.py",
       "tests/api/test_packages.py",
+      "tests/blocks/test_desktop_package_discovery.py",
+      "tests/desktop/test_package_installer.py",
       "tests/packaging/test_desktop_mvp_resources.py"
     ],
-    "diff_fingerprint": "sha256:090d6754261e9a69403b98be22465c6b20fa0b17534cef7a778ed8f5d46a48f5",
+    "diff_fingerprint": "sha256:c0db28833751b1844338db83b8e7d9e35a785ed2fe211ada606e215987d0a2c5",
     "head": "HEAD",
-    "head_sha": "c4feb8c6",
+    "head_sha": "c92fa184",
     "surfaces": {
-      "docs": 0,
-      "frontend": 7,
+      "docs": 1,
+      "frontend": 12,
       "governance": 0,
       "governed_docs": 0,
-      "implementation": 11,
+      "implementation": 20,
       "packaging": 0,
-      "protected_core": 1,
-      "sentrux": 15,
-      "test": 7,
+      "protected_core": 2,
+      "sentrux": 27,
+      "test": 11,
       "workflow_ci": 0
     }
   },
@@ -2848,6 +3396,34 @@
     {
       "at": "2026-06-19T03:41:21.016903Z",
       "diff_fingerprint": "sha256:090d6754261e9a69403b98be22465c6b20fa0b17534cef7a778ed8f5d46a48f5",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-19T03:42:16.160455Z",
+      "diff_fingerprint": "sha256:c0db28833751b1844338db83b8e7d9e35a785ed2fe211ada606e215987d0a2c5",
+      "mode": "ci",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "guard.core_change_guard"
+      ]
+    },
+    {
+      "at": "2026-06-19T03:42:50.666116Z",
+      "diff_fingerprint": "sha256:c0db28833751b1844338db83b8e7d9e35a785ed2fe211ada606e215987d0a2c5",
+      "mode": "ci",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "guard.core_change_guard"
+      ]
+    },
+    {
+      "at": "2026-06-19T03:48:25.198234Z",
+      "diff_fingerprint": "sha256:c0db28833751b1844338db83b8e7d9e35a785ed2fe211ada606e215987d0a2c5",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 1,

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -76,6 +76,24 @@ package into the user-scoped plugin directory:
 ```
 
 After installation the backend refreshes the block registry, so package blocks
-appear in the palette without a remote package index. This path is strictly
-local: it does not download dependencies or query PyPI. The install endpoint is
-enabled only when the backend is running in bundled desktop mode.
+appear in the palette without a remote package browser. The installer uses the
+bundled Python interpreter to install the selected package's Python runtime
+dependencies into that package's user-scoped plugin directory. It does not rely
+on a user-installed Python and does not mutate the application bundle. The
+install endpoint is enabled only when the backend is running in bundled desktop
+mode.
+
+## User Python Terminal
+
+The AI chat panel also exposes a desktop terminal tab for manual dependency
+installation. It opens in the current project and puts SciStudio's user Python
+wrappers first on `PATH`, so `python` and `pip` use the bundled Python while
+manual installs land in the user-scoped dependency runtime:
+
+```text
+<user data dir>/SciStudio/plugins/python/site-packages/
+```
+
+That runtime is added to `PYTHONPATH` for trusted custom-block discovery and
+worker subprocesses. It does not mutate the application bundle or require a
+system Python install.

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -112,6 +112,32 @@ function pythonCandidates() {
   return candidates;
 }
 
+function commonUserCliDirs(userHome) {
+  const dirs = [];
+  if (userHome) {
+    dirs.push(
+      path.join(userHome, ".local", "bin"),
+      path.join(userHome, "bin"),
+      path.join(userHome, ".npm-global", "bin"),
+      path.join(userHome, ".volta", "bin"),
+      path.join(userHome, ".bun", "bin"),
+      path.join(userHome, "AppData", "Roaming", "npm")
+    );
+  }
+
+  if (process.platform !== "win32") {
+    dirs.push(
+      "/opt/homebrew/bin",
+      "/opt/homebrew/sbin",
+      "/usr/local/bin",
+      "/usr/local/sbin",
+      "/opt/local/bin",
+      "/opt/local/sbin"
+    );
+  }
+  return dirs;
+}
+
 function runtimeEnv() {
   const resources = resourcesDir();
   const stagedSrc = path.join(resources, "backend", "src");
@@ -124,12 +150,7 @@ function runtimeEnv() {
   if (existingPythonPath) {
     pythonPathEntries.push(existingPythonPath);
   }
-  if (userHome) {
-    pathEntries.push(
-      path.join(userHome, ".local", "bin"),
-      path.join(userHome, "AppData", "Roaming", "npm")
-    );
-  }
+  pathEntries.push(...commonUserCliDirs(userHome));
   pathEntries.push(process.env.PATH || "");
 
   const env = {

--- a/desktop/resources/packages/README.md
+++ b/desktop/resources/packages/README.md
@@ -9,6 +9,6 @@ packages/
 
 The GUI local package installer writes user-installed packages to the
 user-scoped plugin directory instead of this bundled resources directory.
-Both locations are scanned by the same package discovery path. Neither path
-downloads dependencies; packages must be compatible with the bundled Python
-environment.
+Both locations are scanned by the same package discovery path. User-installed
+packages may resolve Python runtime dependencies with the bundled interpreter,
+but dependency files stay in the user-scoped plugin directory.

--- a/desktop/scripts/stage-resources.ps1
+++ b/desktop/scripts/stage-resources.ps1
@@ -67,9 +67,9 @@ packages/
 
 The GUI local package installer writes user-installed packages to the
 user-scoped plugin directory instead of this bundled resources directory.
-Both locations are scanned by the same package discovery path. Neither path
-downloads dependencies; packages must be compatible with the bundled Python
-environment.
+Both locations are scanned by the same package discovery path. User-installed
+packages may resolve Python runtime dependencies with the bundled interpreter,
+but dependency files stay in the user-scoped plugin directory.
 "@ | Set-Content -Encoding ASCII (Join-Path $ResourcesRoot "packages\README.md")
 
 Write-Host "Staged desktop resources under $ResourcesRoot"

--- a/desktop/scripts/stage-resources.sh
+++ b/desktop/scripts/stage-resources.sh
@@ -49,9 +49,9 @@ packages/
 
 The GUI local package installer writes user-installed packages to the
 user-scoped plugin directory instead of this bundled resources directory.
-Both locations are scanned by the same package discovery path. Neither path
-downloads dependencies; packages must be compatible with the bundled Python
-environment.
+Both locations are scanned by the same package discovery path. User-installed
+packages may resolve Python runtime dependencies with the bundled interpreter,
+but dependency files stay in the user-scoped plugin directory.
 EOF
 
 echo "Staged desktop resources under $RESOURCES_ROOT"

--- a/docs/planning/adr-037-desktop-mvp-spec.md
+++ b/docs/planning/adr-037-desktop-mvp-spec.md
@@ -85,11 +85,19 @@ or in an installed app layout:
     src/scistudio_blocks_imaging/...
 ```
 
-When the backend starts in bundled mode, it adds every `packages/*/src` folder
-to `sys.path` and asks `BlockRegistry.scan(include_monorepo=True)` to discover
-`scistudio_blocks_*` packages via the existing package protocol. This supports
-source packages that are already self-contained and whose Python dependencies
-are present in the bundled Python environment. It does not install dependencies.
+When the backend starts in bundled mode, it activates desktop package import
+roots for registry and worker subprocesses, then asks
+`BlockRegistry.scan(include_monorepo=True)` to discover `scistudio_blocks_*`
+packages via the existing package protocol. For user selected local packages,
+the installer may use the bundled Python interpreter to resolve that package's
+Python dependencies from the configured package index into a user-scoped plugin
+runtime. It must not rely on a user-installed system Python and must not install
+dependencies into the application bundle.
+
+As an advanced desktop user writing local custom blocks, I can open a SciStudio
+desktop terminal from the GUI. The terminal starts in the current project and
+routes `python`/`pip` commands through the bundled Python while installing
+manual dependencies into a shared user-scoped dependency runtime.
 
 ## 5. In Scope
 
@@ -125,7 +133,7 @@ are present in the bundled Python environment. It does not install dependencies.
 - Add `src/scistudio/desktop/paths.py`:
   - `config_dir()`, `cache_dir()`, `logs_dir()`, `plugins_dir()`,
     `shared_model_cache()`, `desktop_resources_dir()`, `bundled_resource()`,
-    and `bundled_packages_dir()`;
+    `bundled_packages_dir()`, and the user Python dependency runtime helpers;
   - use `platformdirs` when available;
   - keep a conservative stdlib fallback so tests can run before dependency
     installation;
@@ -141,10 +149,22 @@ are present in the bundled Python environment. It does not install dependencies.
 - For each `packages/*/src`, temporarily prepend to `sys.path`, import
   `scistudio_blocks_*`, and use existing `get_block_package()` or
   `get_blocks()` protocol.
-- This is source-package hard install only. No `pip install`, no `uv`, no PyPI
-  query, no dependency resolver.
+- This is source-package hard install plus per-package dependency resolution
+  using the bundled Python interpreter. Dependency installs are scoped to the
+  selected package's user plugin directory; they must not mutate the bundled
+  application runtime or the user's system Python.
 
-### 5.5 Staging Scripts
+### 5.5 Desktop User Terminal
+
+- Add a desktop terminal provider on the existing PTY WebSocket route.
+- The terminal starts a user shell in the current project directory.
+- `PATH`, `PYTHONPATH`, and pip-related environment are set so `python` and
+  `pip` use the bundled Python and shared user-scoped dependency runtime.
+- The shared user dependency import root is visible to trusted project drop-in
+  block scans and worker subprocesses without globally leaking package source
+  roots into the server process.
+
+### 5.6 Staging Scripts
 
 - Add cross-platform staging scripts:
   - build frontend to `frontend/dist`;
@@ -159,7 +179,7 @@ The following are ADR-037-compliant deferrals and must remain visible:
 
 - PyPI plugin search/browser.
 - Per-plugin venvs and bundled `uv` installation.
-- Heavy dependency download from GitHub Releases.
+- Heavy dependency prebundling in the DMG or download from GitHub Releases.
 - Plugin permission confirmation UI.
 - Plugin hot-upgrade quiescence and deletion.
 - First-run claude/codex/git-bash installer UI.

--- a/frontend/src/App.parts/useWorkflowSync.ts
+++ b/frontend/src/App.parts/useWorkflowSync.ts
@@ -72,12 +72,12 @@ export function useWorkflowSync(deps: WorkflowSyncDeps): WorkflowSync {
 
   const refreshBlocks = useCallback(async () => {
     const payload = await api.listBlocks();
-    startTransition(() => setBlocks(payload.blocks));
     const schemas = await Promise.all(
       payload.blocks.map((block) => api.getBlockSchema(block.type_name)),
     );
     startTransition(() => {
       schemas.forEach((schema) => setBlockSchema(schema));
+      setBlocks(payload.blocks);
     });
   }, [setBlocks, setBlockSchema]);
 

--- a/frontend/src/components/AIChat/TerminalTabs.parts/TabStrip.tsx
+++ b/frontend/src/components/AIChat/TerminalTabs.parts/TabStrip.tsx
@@ -5,6 +5,8 @@
  * lines. State (renaming draft, active id, etc.) lives in the parent and
  * flows in via props.
  */
+import { Plus, Terminal as TerminalIcon } from "lucide-react";
+
 import type { TerminalTab as TerminalTabModel } from "../../../store/types";
 import { AiBlockStatusBadge } from "../TerminalTab";
 import { TabStripItem } from "./TabStripItem";
@@ -21,6 +23,7 @@ export interface TabStripProps {
   onRenameCancel: () => void;
   onRequestClose: (id: string) => void;
   onAdd: () => void;
+  onAddUserTerminal: () => void;
 }
 
 export function TabStrip(props: TabStripProps) {
@@ -54,7 +57,17 @@ export function TabStrip(props: TabStripProps) {
         aria-label="New chat tab"
         data-testid="terminal-tabs-add"
       >
-        +
+        <Plus size={16} aria-hidden="true" />
+      </button>
+      <button
+        type="button"
+        className="ml-1 inline-flex items-center gap-1 rounded px-2 py-1 text-xs text-stone-600 hover:bg-stone-200 hover:text-stone-800"
+        onClick={props.onAddUserTerminal}
+        aria-label="New Python terminal"
+        data-testid="terminal-tabs-add-user-terminal"
+      >
+        <TerminalIcon size={14} aria-hidden="true" />
+        <span>Terminal</span>
       </button>
     </div>
   );

--- a/frontend/src/components/AIChat/TerminalTabs.tsx
+++ b/frontend/src/components/AIChat/TerminalTabs.tsx
@@ -106,6 +106,7 @@ export function TerminalTabs() {
   const tabs = useAppStore((s) => s.terminalTabs);
   const activeTabId = useAppStore((s) => s.activeTerminalTabId);
   const addTerminalTab = useAppStore((s) => s.addTerminalTab);
+  const addUserTerminalTab = useAppStore((s) => s.addUserTerminalTab);
   const closeTerminalTab = useAppStore((s) => s.closeTerminalTab);
   const renameTerminalTab = useAppStore((s) => s.renameTerminalTab);
   const setActiveTerminalTab = useAppStore((s) => s.setActiveTerminalTab);
@@ -194,6 +195,9 @@ export function TerminalTabs() {
         onRequestClose={requestCloseTab}
         onAdd={() => {
           addTerminalTab();
+        }}
+        onAddUserTerminal={() => {
+          addUserTerminalTab();
         }}
       />
 

--- a/frontend/src/components/AIChat/TerminalView.tsx
+++ b/frontend/src/components/AIChat/TerminalView.tsx
@@ -14,12 +14,13 @@ import "@xterm/xterm/css/xterm.css";
 
 import { useEffect, useRef, useState } from "react";
 
+import type { TerminalProvider } from "../../store/types";
 import { usePtyWebSocket } from "./hooks/usePtyWebSocket";
 
 export interface TerminalViewProps {
   tabId: string;
   projectDir: string;
-  provider: "claude-code" | "codex";
+  provider: TerminalProvider;
   dangerous: boolean;
   onExit: (code: number) => void;
   onError: (message: string) => void;

--- a/frontend/src/components/AIChat/TerminalView.tsx
+++ b/frontend/src/components/AIChat/TerminalView.tsx
@@ -12,7 +12,7 @@
  */
 import "@xterm/xterm/css/xterm.css";
 
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { usePtyWebSocket } from "./hooks/usePtyWebSocket";
 
@@ -38,6 +38,9 @@ export function TerminalView({
   // closure can reach them without re-rendering.
   const termRef = useRef<unknown>(null);
   const fitRef = useRef<{ fit: () => void } | null>(null);
+  const [initialSize, setInitialSize] = useState<{ cols: number; rows: number } | null>(null);
+  const ptyOpenRef = useRef(false);
+  const lastSentResizeRef = useRef<{ cols: number; rows: number } | null>(null);
   // Buffer stdout that arrives before xterm finishes its async dynamic-import
   // bootstrap. Without this, the PTY's startup banner (claude-code prints
   // several KB immediately on spawn) gets silently dropped, leaving the TUI
@@ -54,6 +57,9 @@ export function TerminalView({
 
   useEffect(() => {
     sawExitRef.current = false;
+    ptyOpenRef.current = false;
+    lastSentResizeRef.current = null;
+    setInitialSize(null);
   }, [tabId, projectDir, provider, dangerous]);
 
   const { send } = usePtyWebSocket({
@@ -61,6 +67,9 @@ export function TerminalView({
     projectDir,
     provider,
     dangerous,
+    enabled: initialSize !== null,
+    initialCols: initialSize?.cols ?? null,
+    initialRows: initialSize?.rows ?? null,
     onMessage: (frame) => {
       if (frame.type === "stdout") {
         const t = termRef.current as { write?: (data: string) => void } | null;
@@ -76,7 +85,11 @@ export function TerminalView({
         onErrorRef.current(frame.message);
       }
     },
+    onOpen: () => {
+      ptyOpenRef.current = true;
+    },
     onClose: (ev) => {
+      ptyOpenRef.current = false;
       if (sawExitRef.current) {
         return;
       }
@@ -102,6 +115,22 @@ export function TerminalView({
     } | null = null;
     let onDataDisposable: { dispose: () => void } | null = null;
     let resizeObserver: ResizeObserver | null = null;
+
+    const rememberInitialSize = () => {
+      if (!term || term.cols <= 0 || term.rows <= 0) return;
+      const next = { cols: term.cols, rows: term.rows };
+      lastSentResizeRef.current = next;
+      setInitialSize(next);
+    };
+
+    const sendResizeIfChanged = () => {
+      if (!ptyOpenRef.current || !term || term.cols <= 0 || term.rows <= 0) return;
+      const previous = lastSentResizeRef.current;
+      if (previous?.cols === term.cols && previous.rows === term.rows) return;
+      const next = { cols: term.cols, rows: term.rows };
+      lastSentResizeRef.current = next;
+      send({ type: "resize", cols: next.cols, rows: next.rows });
+    };
 
     void (async () => {
       // Dynamic import so SSR / Vitest can mock the module without polluting
@@ -138,7 +167,10 @@ export function TerminalView({
         fontFamily: "Consolas, Menlo, monospace",
         fontSize: 14,
         cursorBlink: true,
-        convertEol: true,
+        // PTY-backed TUIs own their cursor movement and redraw protocol.
+        // Converting LF to CRLF is useful for plain logs, but it corrupts
+        // full-screen redraws such as Claude Code's startup/status repaint.
+        convertEol: false,
       }) as typeof term;
 
       const fit = new FitAddon();
@@ -167,19 +199,17 @@ export function TerminalView({
         // fit can throw if the container has zero dims; ignore — the resize
         // observer will fire once layout settles.
       }
+      rememberInitialSize();
 
-      // Flush stdout that arrived during the async xterm bootstrap, then
-      // notify the PTY of the post-fit viewport so subsequent output is
-      // laid out against the real cols/rows rather than the 120x30 default.
+      // Flush stdout that arrived during the async xterm bootstrap.
+      // Normally there is none now: the PTY WebSocket waits for initialSize
+      // so the backend can spawn the process at the fitted viewport.
       const pending = pendingWritesRef.current;
       if (pending.length > 0) {
         for (const chunk of pending) {
           term!.write(chunk);
         }
         pendingWritesRef.current = [];
-      }
-      if (term!.cols > 0 && term!.rows > 0) {
-        send({ type: "resize", cols: term!.cols, rows: term!.rows });
       }
 
       onDataDisposable = term!.onData((data: string) => {
@@ -193,8 +223,10 @@ export function TerminalView({
         resizeObserver = new ResizeObserver(() => {
           try {
             fit.fit();
-            if (term && term.cols > 0 && term.rows > 0) {
-              send({ type: "resize", cols: term.cols, rows: term.rows });
+            if (!lastSentResizeRef.current) {
+              rememberInitialSize();
+            } else {
+              sendResizeIfChanged();
             }
           } catch {
             // Ignore transient layout glitches.

--- a/frontend/src/components/AIChat/__tests__/TerminalTabs.test.tsx
+++ b/frontend/src/components/AIChat/__tests__/TerminalTabs.test.tsx
@@ -67,6 +67,18 @@ describe("TerminalTabs", () => {
     expect(useAppStore.getState().terminalTabs[1].title).toBe("Chat 2");
   });
 
+  it("opens a user terminal tab from the terminal button", async () => {
+    render(<TerminalTabs />);
+    await waitFor(() => expect(useAppStore.getState().terminalTabs.length).toBe(1));
+    act(() => fireEvent.click(screen.getByTestId("terminal-tabs-add-user-terminal")));
+    const tab = useAppStore.getState().terminalTabs[1];
+    expect(tab.title).toBe("Terminal 1");
+    expect(tab.provider).toBe("user-terminal");
+    expect(tab.permissionMode).toBe("safe");
+    expect(tab.state).toBe("running");
+    expect(useAppStore.getState().activeTerminalTabId).toBe(tab.id);
+  });
+
   it("closes a setup-state tab without confirm dialog", async () => {
     render(<TerminalTabs />);
     await waitFor(() => expect(useAppStore.getState().terminalTabs.length).toBe(1));

--- a/frontend/src/components/AIChat/__tests__/TerminalView.test.tsx
+++ b/frontend/src/components/AIChat/__tests__/TerminalView.test.tsx
@@ -124,6 +124,7 @@ describe("TerminalView", () => {
     );
     await waitForTerm();
     expect(xtermState.lastInstance).toBeInstanceOf(FakeTerm);
+    expect(xtermState.lastInstance?.opts).toMatchObject({ convertEol: false });
     // fit + search + web-links + canvas (hotfix #1320: canvas renderer
     // replaces the default DOM renderer to fix alt-screen scroll ghosting).
     expect(xtermState.loadedAddons).toHaveLength(4);
@@ -146,6 +147,8 @@ describe("TerminalView", () => {
     expect(url).toContain("/api/ai/pty/abc");
     expect(url).toContain("dangerous=true");
     expect(url).toContain("provider=claude-code");
+    expect(url).toContain("cols=80");
+    expect(url).toContain("rows=24");
   });
 
   it("writes server stdout into the terminal", async () => {

--- a/frontend/src/components/AIChat/__tests__/usePtyWebSocket.test.ts
+++ b/frontend/src/components/AIChat/__tests__/usePtyWebSocket.test.ts
@@ -58,13 +58,22 @@ class FakeWebSocket {
 const originalWs = global.WebSocket;
 
 beforeEach(() => {
+  vi.useFakeTimers();
   FakeWebSocket.instances = [];
   (global as unknown as { WebSocket: typeof FakeWebSocket }).WebSocket = FakeWebSocket;
 });
 
 afterEach(() => {
+  vi.runOnlyPendingTimers();
+  vi.useRealTimers();
   (global as unknown as { WebSocket: typeof WebSocket }).WebSocket = originalWs;
 });
+
+function flushConnectTimer() {
+  act(() => {
+    vi.runOnlyPendingTimers();
+  });
+}
 
 describe("buildPtyUrl", () => {
   it("encodes project_dir, provider, dangerous, and tab_id", () => {
@@ -89,10 +98,14 @@ describe("buildPtyUrl", () => {
       projectDir: "/p",
       provider: "codex",
       dangerous: false,
+      cols: 101,
+      rows: 33,
       baseOrigin: "ws://h",
     });
     expect(url).toContain("dangerous=false");
     expect(url).toContain("provider=codex");
+    expect(url).toContain("cols=101");
+    expect(url).toContain("rows=33");
   });
 });
 
@@ -108,6 +121,7 @@ describe("usePtyWebSocket", () => {
         onMessage,
       }),
     );
+    flushConnectTimer();
     expect(FakeWebSocket.instances).toHaveLength(1);
     const ws = FakeWebSocket.instances[0];
     expect(ws.url).toContain("/api/ai/pty/t1");
@@ -127,6 +141,23 @@ describe("usePtyWebSocket", () => {
         onMessage,
       }),
     );
+    flushConnectTimer();
+    expect(FakeWebSocket.instances).toHaveLength(0);
+  });
+
+  it("does not open a socket while disabled", () => {
+    const onMessage = vi.fn();
+    renderHook(() =>
+      usePtyWebSocket({
+        tabId: "t1",
+        projectDir: "/p",
+        provider: "claude-code",
+        dangerous: false,
+        enabled: false,
+        onMessage,
+      }),
+    );
+    flushConnectTimer();
     expect(FakeWebSocket.instances).toHaveLength(0);
   });
 
@@ -141,6 +172,7 @@ describe("usePtyWebSocket", () => {
         onMessage,
       }),
     );
+    flushConnectTimer();
     const ws = FakeWebSocket.instances[0];
     act(() => ws.open());
     act(() => ws.message(JSON.stringify({ type: "stdout", data: "hello" })));
@@ -160,6 +192,7 @@ describe("usePtyWebSocket", () => {
         onMessage,
       }),
     );
+    flushConnectTimer();
     const ws = FakeWebSocket.instances[0];
     act(() => ws.open());
     act(() => ws.message("not json"));
@@ -181,6 +214,7 @@ describe("usePtyWebSocket", () => {
         onClose,
       }),
     );
+    flushConnectTimer();
     const ws = FakeWebSocket.instances[0];
     act(() => ws.open());
     act(() => ws.onerror?.());
@@ -200,6 +234,7 @@ describe("usePtyWebSocket", () => {
         onMessage,
       }),
     );
+    flushConnectTimer();
     const ws = FakeWebSocket.instances[0];
     // Before open, send is dropped silently.
     act(() => result.current.send({ type: "stdin", data: "x" }));
@@ -224,9 +259,28 @@ describe("usePtyWebSocket", () => {
         onMessage,
       }),
     );
+    flushConnectTimer();
     const ws = FakeWebSocket.instances[0];
     expect(ws.closed).toBe(false);
     unmount();
     expect(ws.closed).toBe(true);
+  });
+
+  it("cancels a pending socket open when unmounted before the next tick", () => {
+    const onMessage = vi.fn();
+    const { unmount } = renderHook(() =>
+      usePtyWebSocket({
+        tabId: "t1",
+        projectDir: "/p",
+        provider: "claude-code",
+        dangerous: false,
+        onMessage,
+      }),
+    );
+
+    unmount();
+    flushConnectTimer();
+
+    expect(FakeWebSocket.instances).toHaveLength(0);
   });
 });

--- a/frontend/src/components/AIChat/__tests__/usePtyWebSocket.test.ts
+++ b/frontend/src/components/AIChat/__tests__/usePtyWebSocket.test.ts
@@ -107,6 +107,17 @@ describe("buildPtyUrl", () => {
     expect(url).toContain("cols=101");
     expect(url).toContain("rows=33");
   });
+
+  it("allows the user-terminal provider", () => {
+    const url = buildPtyUrl({
+      tabId: "term",
+      projectDir: "/p",
+      provider: "user-terminal",
+      dangerous: false,
+      baseOrigin: "ws://h",
+    });
+    expect(url).toContain("provider=user-terminal");
+  });
 });
 
 describe("usePtyWebSocket", () => {

--- a/frontend/src/components/AIChat/hooks/usePtyWebSocket.ts
+++ b/frontend/src/components/AIChat/hooks/usePtyWebSocket.ts
@@ -141,7 +141,14 @@ export function usePtyWebSocket(params: UsePtyWebSocketParams): UsePtyWebSocketR
     // tears the user's tab into the closed state on every mount.
     let disposed = false;
     let ws: WebSocket | null = null;
-    const url = buildPtyUrl({ tabId, projectDir, provider, dangerous, cols: initialCols, rows: initialRows });
+    const url = buildPtyUrl({
+      tabId,
+      projectDir,
+      provider,
+      dangerous,
+      cols: initialCols,
+      rows: initialRows,
+    });
     const connectTimer = window.setTimeout(() => {
       if (disposed) return;
       ws = new WebSocket(url);

--- a/frontend/src/components/AIChat/hooks/usePtyWebSocket.ts
+++ b/frontend/src/components/AIChat/hooks/usePtyWebSocket.ts
@@ -4,7 +4,7 @@
  * Protocol (LOCKED — backend uses the same spec):
  *   URL: ws://host/api/ai/pty/{tab_id}
  *          ?project_dir=<urlencoded_abs_path>
- *          &provider=<claude-code|codex>
+ *          &provider=<claude-code|codex|user-terminal>
  *          &dangerous=<true|false>
  *
  *   Client -> Server (JSON, one frame per WS message):
@@ -33,7 +33,7 @@ export type PtyServerFrame =
 export interface UsePtyWebSocketParams {
   tabId: string;
   projectDir: string | null;
-  provider: "claude-code" | "codex";
+  provider: "claude-code" | "codex" | "user-terminal";
   dangerous: boolean;
   /** Delay launch until the terminal has enough layout state to spawn cleanly. */
   enabled?: boolean;

--- a/frontend/src/components/AIChat/hooks/usePtyWebSocket.ts
+++ b/frontend/src/components/AIChat/hooks/usePtyWebSocket.ts
@@ -35,6 +35,11 @@ export interface UsePtyWebSocketParams {
   projectDir: string | null;
   provider: "claude-code" | "codex";
   dangerous: boolean;
+  /** Delay launch until the terminal has enough layout state to spawn cleanly. */
+  enabled?: boolean;
+  /** Optional initial PTY dimensions, sent in the spawn handshake. */
+  initialCols?: number | null;
+  initialRows?: number | null;
   /** Called for each parsed server-side frame. */
   onMessage: (frame: PtyServerFrame) => void;
   /** Called once when the underlying socket opens. */
@@ -55,12 +60,16 @@ export function buildPtyUrl({
   projectDir,
   provider,
   dangerous,
+  cols,
+  rows,
   baseOrigin,
 }: {
   tabId: string;
   projectDir: string;
   provider: string;
   dangerous: boolean;
+  cols?: number | null;
+  rows?: number | null;
   baseOrigin?: string;
 }): string {
   // Derive ws:// or wss:// from window.location.protocol; in tests fall back
@@ -77,6 +86,12 @@ export function buildPtyUrl({
     provider,
     dangerous: dangerous ? "true" : "false",
   });
+  if (Number.isFinite(cols) && cols && cols > 0) {
+    params.set("cols", String(Math.trunc(cols)));
+  }
+  if (Number.isFinite(rows) && rows && rows > 0) {
+    params.set("rows", String(Math.trunc(rows)));
+  }
   return `${origin}/api/ai/pty/${encodeURIComponent(tabId)}?${params.toString()}`;
 }
 
@@ -90,7 +105,18 @@ export function buildPtyUrl({
  * not flipping params during a live session.
  */
 export function usePtyWebSocket(params: UsePtyWebSocketParams): UsePtyWebSocketResult {
-  const { tabId, projectDir, provider, dangerous, onMessage, onOpen, onClose } = params;
+  const {
+    tabId,
+    projectDir,
+    provider,
+    dangerous,
+    enabled = true,
+    initialCols,
+    initialRows,
+    onMessage,
+    onOpen,
+    onClose,
+  } = params;
 
   const wsRef = useRef<WebSocket | null>(null);
   const readyStateRef = useRef<number>(WebSocket.CLOSED);
@@ -103,67 +129,73 @@ export function usePtyWebSocket(params: UsePtyWebSocketParams): UsePtyWebSocketR
   onCloseRef.current = onClose;
 
   useEffect(() => {
-    if (!projectDir) {
+    if (!enabled || !projectDir) {
       // No working dir -> cannot launch a PTY. Caller is in setup or closed
       // state; do nothing.
       return undefined;
     }
-    const url = buildPtyUrl({ tabId, projectDir, provider, dangerous });
-    const ws = new WebSocket(url);
-    wsRef.current = ws;
-    readyStateRef.current = ws.readyState;
-
     // `disposed` guards against late-firing onerror/onclose after an
     // intentional cleanup (StrictMode double-mount in dev, or any caller-
     // triggered teardown). Without this guard, the browser's close-side
     // `onerror` propagates upward as a fake "WebSocket error" frame and
     // tears the user's tab into the closed state on every mount.
     let disposed = false;
+    let ws: WebSocket | null = null;
+    const url = buildPtyUrl({ tabId, projectDir, provider, dangerous, cols: initialCols, rows: initialRows });
+    const connectTimer = window.setTimeout(() => {
+      if (disposed) return;
+      ws = new WebSocket(url);
+      wsRef.current = ws;
+      readyStateRef.current = ws.readyState;
 
-    ws.onopen = () => {
-      if (disposed) return;
-      readyStateRef.current = ws.readyState;
-      onOpenRef.current?.();
-    };
-    ws.onmessage = (ev) => {
-      if (disposed) return;
-      // Server always sends JSON-encoded text frames. Anything else is a
-      // protocol violation and surfaced as an error frame so the UI shows it.
-      try {
-        const data = typeof ev.data === "string" ? ev.data : "";
-        if (!data) return;
-        const frame = JSON.parse(data) as PtyServerFrame;
-        onMessageRef.current(frame);
-      } catch (err) {
-        onMessageRef.current({
-          type: "error",
-          message: `Malformed server frame: ${(err as Error).message}`,
-        });
-      }
-    };
-    ws.onerror = () => {
-      if (disposed) return;
-      // Browser WebSocket errors are intentionally opaque and are normally
-      // followed by close. Let the close handler surface the actionable code
-      // instead of replacing the real PTY/server error with "WebSocket error".
-    };
-    ws.onclose = (ev) => {
-      if (disposed) return;
-      readyStateRef.current = ws.readyState;
-      onCloseRef.current?.(ev);
-    };
+      ws.onopen = () => {
+        if (disposed || !ws) return;
+        readyStateRef.current = ws.readyState;
+        onOpenRef.current?.();
+      };
+      ws.onmessage = (ev) => {
+        if (disposed) return;
+        // Server always sends JSON-encoded text frames. Anything else is a
+        // protocol violation and surfaced as an error frame so the UI shows it.
+        try {
+          const data = typeof ev.data === "string" ? ev.data : "";
+          if (!data) return;
+          const frame = JSON.parse(data) as PtyServerFrame;
+          onMessageRef.current(frame);
+        } catch (err) {
+          onMessageRef.current({
+            type: "error",
+            message: `Malformed server frame: ${(err as Error).message}`,
+          });
+        }
+      };
+      ws.onerror = () => {
+        if (disposed) return;
+        // Browser WebSocket errors are intentionally opaque and are normally
+        // followed by close. Let the close handler surface the actionable code
+        // instead of replacing the real PTY/server error with "WebSocket error".
+      };
+      ws.onclose = (ev) => {
+        if (disposed || !ws) return;
+        readyStateRef.current = ws.readyState;
+        onCloseRef.current?.(ev);
+      };
+    }, 0);
 
     return () => {
       disposed = true;
+      window.clearTimeout(connectTimer);
       readyStateRef.current = WebSocket.CLOSING;
-      try {
-        ws.close();
-      } catch {
-        // Already closed.
+      if (ws) {
+        try {
+          ws.close();
+        } catch {
+          // Already closed.
+        }
       }
       wsRef.current = null;
     };
-  }, [tabId, projectDir, provider, dangerous]);
+  }, [tabId, projectDir, provider, dangerous, enabled, initialCols, initialRows]);
 
   const send = useCallback((frame: PtyClientFrame) => {
     const ws = wsRef.current;

--- a/frontend/src/store/__tests__/workflowSlice.variadicPorts.test.ts
+++ b/frontend/src/store/__tests__/workflowSlice.variadicPorts.test.ts
@@ -1,0 +1,134 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { BlockSchemaResponse, BlockSummary } from "../../types/api";
+import { useAppStore } from "../index";
+
+vi.mock("../../lib/api/ai", () => ({
+  postActiveWorkflowContext: vi.fn().mockResolvedValue(undefined),
+}));
+
+function blockSummary(overrides: Partial<BlockSummary> = {}): BlockSummary {
+  return {
+    name: "Variadic Block",
+    type_name: "variadic_block",
+    base_category: "process",
+    subcategory: "routing",
+    description: "",
+    version: "0.1.0",
+    input_ports: [],
+    output_ports: [],
+    variadic_inputs: true,
+    variadic_outputs: true,
+    ...overrides,
+  };
+}
+
+function blockSchema(overrides: Partial<BlockSchemaResponse> = {}): BlockSchemaResponse {
+  const summary = blockSummary(overrides);
+  return {
+    ...summary,
+    config_schema: {},
+    type_hierarchy: [],
+    dynamic_ports: null,
+    allowed_input_types: [],
+    allowed_output_types: [],
+    min_input_ports: null,
+    max_input_ports: null,
+    min_output_ports: null,
+    max_output_ports: null,
+    ...overrides,
+  };
+}
+
+function resetWorkflowStore(): void {
+  useAppStore.setState({
+    currentProject: null,
+    workflowId: null,
+    workflowName: "Untitled",
+    workflowDescription: "",
+    workflowVersion: "1.0.0",
+    workflowMetadata: {},
+    workflowNodes: [],
+    workflowEdges: [],
+    workflowDirty: false,
+    workflowBaseVersion: null,
+    workflowPendingVersion: null,
+    workflowPendingSourceId: null,
+    workflowConflict: null,
+    workflowHistory: [],
+    workflowFuture: [],
+    blockSchemas: {},
+  });
+}
+
+describe("workflowSlice variadic port initialization", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetWorkflowStore();
+    vi.spyOn(Date, "now").mockReturnValue(1781818299312);
+  });
+
+  it("seeds minimum variadic ports before the first autosave can validate the node", () => {
+    const block = blockSummary({ type_name: "datarouter_block", name: "Data Router" });
+    useAppStore.setState({
+      blockSchemas: {
+        datarouter_block: blockSchema({
+          ...block,
+          min_input_ports: 1,
+          min_output_ports: 1,
+        }),
+      },
+    });
+
+    useAppStore.getState().addNode(block, { x: 160, y: 160 }, { direction: "process" });
+
+    const node = useAppStore.getState().workflowNodes[0];
+    expect(node.id).toBe("datarouter_block-1781818299312");
+    expect(node.config.params).toMatchObject({
+      direction: "process",
+      input_ports: [{ name: "input_1", types: ["DataObject"] }],
+      output_ports: [{ name: "output_1", types: ["DataObject"] }],
+    });
+  });
+
+  it("does not override variadic blocks whose static scaffold already satisfies the minimum", () => {
+    const block = blockSummary({ type_name: "code_block", name: "Code Block" });
+    useAppStore.setState({
+      blockSchemas: {
+        code_block: blockSchema({
+          ...block,
+          input_ports: [
+            {
+              name: "data",
+              direction: "input",
+              accepted_types: ["DataObject"],
+              required: false,
+              description: "",
+              constraint_description: "",
+              is_collection: false,
+            },
+          ],
+          output_ports: [
+            {
+              name: "result",
+              direction: "output",
+              accepted_types: ["DataObject"],
+              required: true,
+              description: "",
+              constraint_description: "",
+              is_collection: false,
+            },
+          ],
+          min_input_ports: 1,
+          min_output_ports: 1,
+        }),
+      },
+    });
+
+    useAppStore.getState().addNode(block, { x: 160, y: 160 });
+
+    const params = useAppStore.getState().workflowNodes[0].config.params as Record<string, unknown>;
+    expect(params.input_ports).toBeUndefined();
+    expect(params.output_ports).toBeUndefined();
+  });
+});

--- a/frontend/src/store/terminalTabsSlice.ts
+++ b/frontend/src/store/terminalTabsSlice.ts
@@ -32,6 +32,19 @@ function nextDefaultTitle(tabs: TerminalTab[]): string {
   return `Chat ${max + 1}`;
 }
 
+/** Compute the next default title ("Terminal N") given existing tabs. */
+function nextDefaultUserTerminalTitle(tabs: TerminalTab[]): string {
+  let max = 0;
+  for (const t of tabs) {
+    const m = /^Terminal (\d+)$/.exec(t.title);
+    if (m) {
+      const n = parseInt(m[1], 10);
+      if (!Number.isNaN(n) && n > max) max = n;
+    }
+  }
+  return `Terminal ${max + 1}`;
+}
+
 export const createTerminalTabsSlice: StateCreator<AppStore, [], [], TerminalTabsSlice> = (
   set,
 ) => ({
@@ -48,6 +61,26 @@ export const createTerminalTabsSlice: StateCreator<AppStore, [], [], TerminalTab
         provider: null,
         permissionMode: null,
         state: "setup",
+      };
+      return {
+        terminalTabs: [...state.terminalTabs, tab],
+        activeTerminalTabId: id,
+      };
+    });
+    return id;
+  },
+
+  addUserTerminalTab: () => {
+    const id = newTabId();
+    set((state) => {
+      const title = nextDefaultUserTerminalTitle(state.terminalTabs);
+      const tab: TerminalTab = {
+        id,
+        title,
+        provider: "user-terminal",
+        permissionMode: "safe",
+        state: "running",
+        source: "user",
       };
       return {
         terminalTabs: [...state.terminalTabs, tab],
@@ -114,7 +147,14 @@ export const createTerminalTabsSlice: StateCreator<AppStore, [], [], TerminalTab
   reopenTerminalTab: (id) =>
     set((state) => ({
       terminalTabs: state.terminalTabs.map((t) =>
-        t.id === id ? { ...t, state: "setup", exitCode: undefined, errorMessage: undefined } : t,
+        t.id === id
+          ? {
+              ...t,
+              state: t.provider === "user-terminal" ? "running" : "setup",
+              exitCode: undefined,
+              errorMessage: undefined,
+            }
+          : t,
       ),
     })),
 
@@ -190,4 +230,4 @@ export function rehydrateTerminalTabs(tabs: TerminalTab[]): TerminalTab[] {
 export type { TerminalTab, TerminalTabsSlice };
 
 // Re-export internal helper for tests.
-export { newTabId, nextDefaultTitle };
+export { newTabId, nextDefaultTitle, nextDefaultUserTerminalTitle };

--- a/frontend/src/store/types.ts
+++ b/frontend/src/store/types.ts
@@ -224,11 +224,12 @@ export interface PaletteSlice {
  * transitions and remain interactive.
  */
 export type AiBlockStatus = "running" | "paused" | "done" | "error" | "cancelled";
+export type TerminalProvider = "claude-code" | "codex" | "user-terminal";
 
 export interface TerminalTab {
   id: string;
   title: string;
-  provider: "claude-code" | "codex" | null;
+  provider: TerminalProvider | null;
   permissionMode: "safe" | "dangerous" | null;
   state: "setup" | "running" | "closed";
   exitCode?: number;
@@ -258,11 +259,13 @@ export interface TerminalTabsSlice {
   activeTerminalTabId: string | null;
   /** Create a new tab in `setup` state and make it active. Returns its id. */
   addTerminalTab: () => string;
+  /** Create a user shell tab backed by the desktop Python dependency env. */
+  addUserTerminalTab: () => string;
   closeTerminalTab: (id: string) => void;
   renameTerminalTab: (id: string, title: string) => void;
   launchTerminalTab: (
     id: string,
-    provider: "claude-code" | "codex",
+    provider: TerminalProvider,
     permissionMode: "safe" | "dangerous",
   ) => void;
   markTerminalTabExited: (id: string, code: number) => void;

--- a/frontend/src/store/workflowSlice.parts/workflowEditActions.ts
+++ b/frontend/src/store/workflowSlice.parts/workflowEditActions.ts
@@ -7,17 +7,95 @@
  */
 import type { StoreApi } from "zustand";
 
-import type { BlockSummary, WorkflowEdge } from "../../types/api";
+import type {
+  BlockPortResponse,
+  BlockSchemaResponse,
+  BlockSummary,
+  WorkflowEdge,
+} from "../../types/api";
 import type { AppStore, WorkflowSlice } from "../types";
 import { markDirty, mergeNodeConfig, pushHistory } from "./workflowHelpers";
 
 type Setter = StoreApi<AppStore>["setState"];
+type Direction = "input" | "output";
+type VariadicPortParam = { name: string; types: string[] };
+
+function portsFor(schema: Partial<BlockSchemaResponse>, direction: Direction): BlockPortResponse[] {
+  return direction === "input" ? (schema.input_ports ?? []) : (schema.output_ports ?? []);
+}
+
+function minPortsFor(schema: Partial<BlockSchemaResponse>, direction: Direction): number | null {
+  const value = direction === "input" ? schema.min_input_ports : schema.min_output_ports;
+  return typeof value === "number" && value > 0 ? value : null;
+}
+
+function isVariadic(schema: Partial<BlockSchemaResponse>, direction: Direction): boolean {
+  return direction === "input"
+    ? schema.variadic_inputs === true
+    : schema.variadic_outputs === true;
+}
+
+function defaultTypesFor(schema: Partial<BlockSchemaResponse>, direction: Direction): string[] {
+  const allowedTypes =
+    direction === "input" ? (schema.allowed_input_types ?? []) : (schema.allowed_output_types ?? []);
+  return allowedTypes.length > 0 ? [allowedTypes[0]] : ["DataObject"];
+}
+
+function minimumVariadicPorts(
+  schema: Partial<BlockSchemaResponse>,
+  direction: Direction,
+): VariadicPortParam[] {
+  if (!isVariadic(schema, direction)) return [];
+  const minPorts = minPortsFor(schema, direction);
+  if (minPorts == null) return [];
+
+  const staticPorts = portsFor(schema, direction);
+  if (staticPorts.length >= minPorts) return [];
+
+  const fallbackTypes = defaultTypesFor(schema, direction);
+  return Array.from({ length: minPorts }, (_, index) => {
+    const staticPort = staticPorts[index];
+    const acceptedTypes =
+      staticPort?.accepted_types && staticPort.accepted_types.length > 0
+        ? staticPort.accepted_types
+        : fallbackTypes;
+    return {
+      name: staticPort?.name || `${direction}_${index + 1}`,
+      types: [...acceptedTypes],
+    };
+  });
+}
+
+export function createInitialNodeParams(
+  block: BlockSummary,
+  schema: BlockSchemaResponse | undefined,
+  defaultParams?: Record<string, unknown>,
+): Record<string, unknown> {
+  const params: Record<string, unknown> = { ...(defaultParams ?? {}) };
+  const source = (schema ?? block) as Partial<BlockSchemaResponse>;
+
+  for (const direction of ["input", "output"] as const) {
+    const key = direction === "input" ? "input_ports" : "output_ports";
+    const current = params[key];
+    if (Array.isArray(current) && current.length > 0) continue;
+    const seededPorts = minimumVariadicPorts(source, direction);
+    if (seededPorts.length > 0) {
+      params[key] = seededPorts;
+    }
+  }
+
+  return params;
+}
 
 export function createAddNode(set: Setter): WorkflowSlice["addNode"] {
   return (block: BlockSummary, position, defaultParams) =>
     set((state) => {
       const nodeId = `${block.type_name}-${Date.now()}`;
-      const params: Record<string, unknown> = { ...(defaultParams ?? {}) };
+      const params = createInitialNodeParams(
+        block,
+        (state as AppStore).blockSchemas[block.type_name],
+        defaultParams,
+      );
 
       // Auto-fill output_dir for AppBlock-category blocks with the
       // project exchange directory so users see the default path.

--- a/frontend/src/store/workflowSlice.parts/workflowEditActions.ts
+++ b/frontend/src/store/workflowSlice.parts/workflowEditActions.ts
@@ -30,14 +30,14 @@ function minPortsFor(schema: Partial<BlockSchemaResponse>, direction: Direction)
 }
 
 function isVariadic(schema: Partial<BlockSchemaResponse>, direction: Direction): boolean {
-  return direction === "input"
-    ? schema.variadic_inputs === true
-    : schema.variadic_outputs === true;
+  return direction === "input" ? schema.variadic_inputs === true : schema.variadic_outputs === true;
 }
 
 function defaultTypesFor(schema: Partial<BlockSchemaResponse>, direction: Direction): string[] {
   const allowedTypes =
-    direction === "input" ? (schema.allowed_input_types ?? []) : (schema.allowed_output_types ?? []);
+    direction === "input"
+      ? (schema.allowed_input_types ?? [])
+      : (schema.allowed_output_types ?? []);
   return allowedTypes.length > 0 ? [allowedTypes[0]] : ["DataObject"];
 }
 

--- a/src/scistudio/ai/agent/terminal.py
+++ b/src/scistudio/ai/agent/terminal.py
@@ -71,7 +71,13 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 # Public re-exports for the route layer.
-__all__ = ["PtyProcess", "resolve_windows_executable", "spawn_claude", "spawn_codex"]
+__all__ = [
+    "PtyProcess",
+    "resolve_windows_executable",
+    "spawn_claude",
+    "spawn_codex",
+    "spawn_user_terminal",
+]
 
 _WINDOWS_EXECUTABLE_SUFFIXES = (".cmd", ".bat", ".exe")
 _PTY_BLOCKED_ENV_VARS = frozenset({"ELECTRON_RUN_AS_NODE"})
@@ -627,6 +633,54 @@ def spawn_codex(
         cleanup_paths=[],
         extra_env=extra_env,
     )
+
+
+def spawn_user_terminal(
+    *,
+    project_dir: Path,
+    dangerous: bool,
+    cols: int = 120,
+    rows: int = 30,
+    extra_env: dict[str, str] | None = None,
+    _spawn_argv: list[str] | None = None,
+) -> PtyProcess:
+    """Spawn a desktop user shell with SciStudio's user dependency env."""
+    del dangerous
+    from scistudio.desktop.paths import user_python_terminal_env
+
+    env = user_python_terminal_env(sys.executable)
+    if extra_env:
+        env.update(extra_env)
+
+    return PtyProcess(
+        list(_spawn_argv or _user_shell_argv()),
+        cwd=project_dir,
+        cols=cols,
+        rows=rows,
+        cleanup_paths=[],
+        extra_env=env,
+    )
+
+
+def _user_shell_argv() -> list[str]:
+    if sys.platform == "win32":
+        for name, args in (
+            ("pwsh", ["-NoLogo"]),
+            ("powershell", ["-NoLogo"]),
+            ("cmd", []),
+        ):
+            resolved = resolve_windows_executable(name)
+            if resolved:
+                return [resolved, *args]
+        return ["cmd"]
+
+    shell = os.environ.get("SHELL")
+    if shell and Path(shell).is_file():
+        return [shell]
+    for candidate in ("/bin/zsh", "/bin/bash", "/bin/sh"):
+        if Path(candidate).is_file():
+            return [candidate]
+    return ["sh"]
 
 
 def _codex_mcp_config_overrides(project_dir: Path) -> list[str]:

--- a/src/scistudio/api/routes/ai_pty/__init__.py
+++ b/src/scistudio/api/routes/ai_pty/__init__.py
@@ -2,7 +2,7 @@
 
 This package exposes a single endpoint:
 
-    ``ws://host/api/ai/pty/{tab_id}?project_dir=<urlencoded>&provider=<claude-code|codex>&dangerous=<true|false>[&cols=<n>&rows=<n>]``
+    ``ws://host/api/ai/pty/{tab_id}?project_dir=<urlencoded>&provider=<claude-code|codex|user-terminal>&dangerous=<true|false>[&cols=<n>&rows=<n>]``
 
 The route validates query parameters, spawns the appropriate PTY via
 :mod:`scistudio.ai.agent.terminal`, runs two concurrent pump tasks
@@ -70,7 +70,7 @@ from typing import Any
 
 from fastapi import APIRouter
 
-from scistudio.ai.agent.terminal import PtyProcess, spawn_claude, spawn_codex
+from scistudio.ai.agent.terminal import PtyProcess, spawn_claude, spawn_codex, spawn_user_terminal
 
 # ---------------------------------------------------------------------------
 # Public router
@@ -94,8 +94,12 @@ MAX_ACTIVE_PTYS = 16
 _active_ptys: dict[str, PtyProcess] = {}
 _active_lock = asyncio.Lock()
 
-_VALID_PROVIDERS = ("claude-code", "codex")
-_PROVIDER_SPAWNERS = {"claude-code": spawn_claude, "codex": spawn_codex}
+_VALID_PROVIDERS = ("claude-code", "codex", "user-terminal")
+_PROVIDER_SPAWNERS = {
+    "claude-code": spawn_claude,
+    "codex": spawn_codex,
+    "user-terminal": spawn_user_terminal,
+}
 
 # ADR-035 §3.10 — engine-initiated tab tracking.
 # Map tab_id → block_run_id so completion notifies can resolve back.

--- a/src/scistudio/api/routes/ai_pty/__init__.py
+++ b/src/scistudio/api/routes/ai_pty/__init__.py
@@ -2,7 +2,7 @@
 
 This package exposes a single endpoint:
 
-    ``ws://host/api/ai/pty/{tab_id}?project_dir=<urlencoded>&provider=<claude-code|codex>&dangerous=<true|false>``
+    ``ws://host/api/ai/pty/{tab_id}?project_dir=<urlencoded>&provider=<claude-code|codex>&dangerous=<true|false>[&cols=<n>&rows=<n>]``
 
 The route validates query parameters, spawns the appropriate PTY via
 :mod:`scistudio.ai.agent.terminal`, runs two concurrent pump tasks
@@ -95,6 +95,7 @@ _active_ptys: dict[str, PtyProcess] = {}
 _active_lock = asyncio.Lock()
 
 _VALID_PROVIDERS = ("claude-code", "codex")
+_PROVIDER_SPAWNERS = {"claude-code": spawn_claude, "codex": spawn_codex}
 
 # ADR-035 §3.10 — engine-initiated tab tracking.
 # Map tab_id → block_run_id so completion notifies can resolve back.
@@ -142,26 +143,14 @@ def _spawn(
     provider: str,
     project_dir: Path,
     dangerous: bool,
+    cols: int = 120,
+    rows: int = 30,
     extra_env: dict[str, str] | None = None,
 ) -> PtyProcess:
-    """Dispatch to the right factory for ``provider``.
-
-    Test hook: callers may monkeypatch this function (via
-    ``monkeypatch.setattr(ai_pty, "_spawn", fake)``) to inject a fake
-    PTY that runs an echo subprocess instead of the real claude / codex
-    binary (the WS integration tests rely on this seam).
-
-    ``extra_env`` lets engine-initiated callers thread per-AI-Block env
-    (e.g. ``SCISTUDIO_AI_BLOCK_RUN_DIR`` for ``finish_ai_block``, ADR-035
-    §3.5 path a) into the spawned PTY without polluting the engine's
-    global env.
-    """
-    if provider == "claude-code":
-        return spawn_claude(project_dir=project_dir, dangerous=dangerous, extra_env=extra_env)
-    if provider == "codex":
-        return spawn_codex(project_dir=project_dir, dangerous=dangerous, extra_env=extra_env)
-    # Defensive — guarded earlier in the route too.
-    raise ValueError(f"Unknown provider {provider!r}")
+    spawner = _PROVIDER_SPAWNERS.get(provider)
+    if spawner is None:
+        raise ValueError(f"Unknown provider {provider!r}")
+    return spawner(project_dir=project_dir, dangerous=dangerous, cols=cols, rows=rows, extra_env=extra_env)
 
 
 # ---------------------------------------------------------------------------

--- a/src/scistudio/api/routes/ai_pty/websocket.py
+++ b/src/scistudio/api/routes/ai_pty/websocket.py
@@ -16,6 +16,7 @@ working — pre-existing test contract.
 from __future__ import annotations
 
 import asyncio
+import codecs
 import contextlib
 import logging
 import threading
@@ -40,6 +41,8 @@ async def pty_endpoint(websocket: WebSocket, tab_id: str) -> None:
     provider = params.get("provider", "")
     project_dir_raw = params.get("project_dir", "")
     dangerous_raw = params.get("dangerous", "false").lower()
+    initial_cols = _parse_initial_size(params.get("cols"), default=120, min_value=1, max_value=1000)
+    initial_rows = _parse_initial_size(params.get("rows"), default=30, min_value=1, max_value=500)
 
     if provider not in _pkg._VALID_PROVIDERS:
         await _send_error(
@@ -104,7 +107,13 @@ async def pty_endpoint(websocket: WebSocket, tab_id: str) -> None:
 
         # ---- Spawn PTY -----------------------------------------------------
         try:
-            pty = _pkg._spawn(provider=provider, project_dir=project_dir, dangerous=dangerous)
+            pty = _pkg._spawn(
+                provider=provider,
+                project_dir=project_dir,
+                dangerous=dangerous,
+                cols=initial_cols,
+                rows=initial_rows,
+            )
         except FileNotFoundError as exc:
             # claude / codex binary missing on PATH — actionable error.
             await _send_error(websocket, f"Provider binary not found: {exc}")
@@ -125,26 +134,20 @@ async def pty_endpoint(websocket: WebSocket, tab_id: str) -> None:
 
     async def pump_pty_to_ws() -> None:
         """Forward PTY stdout to WS as ``{type:stdout,data:...}`` frames."""
+        decoder = codecs.getincrementaldecoder("utf-8")("replace")
         try:
             while not stop.is_set():
                 # Use an executor — :meth:`PtyProcess.read` blocks up to
                 # ~100 ms which would stall the event loop otherwise.
                 data = await loop.run_in_executor(None, pty.read, 0.1)
-                if data:
-                    if websocket.client_state != WebSocketState.CONNECTED:
-                        # Client closed already (StrictMode dev double-mount,
-                        # tab close, etc.) — abort cleanly instead of letting
-                        # send_json explode with "after websocket.close".
-                        break
-                    try:
-                        await websocket.send_json({"type": "stdout", "data": data.decode("utf-8", errors="replace")})
-                    except RuntimeError:
-                        # ASGI race: client_state can flip between the check
-                        # above and the send when uvicorn flushes a close
-                        # frame concurrently. Treat as a graceful end.
-                        break
+                # PTY reads are arbitrary byte chunks. Decode incrementally so
+                # multibyte UTF-8 glyphs used by TUIs can span reads without
+                # being replaced by U+FFFD.
+                if data and not await _send_stdout_frame(websocket, decoder.decode(data)):
+                    break
                 if not pty.is_alive():
                     break
+            await _send_stdout_frame(websocket, decoder.decode(b"", final=True))
         except WebSocketDisconnect:
             return
         except Exception:  # pragma: no cover - logged, swallowed to trigger cleanup
@@ -256,3 +259,31 @@ async def _send_error(websocket: WebSocket, message: str) -> None:
         await websocket.send_json({"type": "error", "message": message})
     except Exception:  # pragma: no cover
         logger.debug("Failed to send error frame", exc_info=True)
+
+
+async def _send_stdout_frame(websocket: WebSocket, text: str) -> bool:
+    """Best-effort send of a stdout frame, returning false after close races."""
+    if not text:
+        return True
+    if websocket.client_state != WebSocketState.CONNECTED:
+        # Client closed already (StrictMode dev double-mount, tab close, etc.)
+        # — abort cleanly instead of letting send_json explode.
+        return False
+    try:
+        await websocket.send_json({"type": "stdout", "data": text})
+    except RuntimeError:
+        # ASGI race: client_state can flip between the check above and the send
+        # when uvicorn flushes a close frame concurrently.
+        return False
+    return True
+
+
+def _parse_initial_size(value: str | None, *, default: int, min_value: int, max_value: int) -> int:
+    """Parse optional initial PTY dimensions from the frontend handshake."""
+    if value is None:
+        return default
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return max(min_value, min(parsed, max_value))

--- a/src/scistudio/api/routes/packages.py
+++ b/src/scistudio/api/routes/packages.py
@@ -48,7 +48,7 @@ async def install_local_package_route(
         )
 
     try:
-        result = install_local_package(body.path)
+        result = install_local_package(body.path, install_dependencies=True)
     except PackageInstallError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     except OSError as exc:

--- a/src/scistudio/api/routes/packages.py
+++ b/src/scistudio/api/routes/packages.py
@@ -14,6 +14,7 @@ from scistudio.desktop.package_installer import PackageInstallError, install_loc
 
 router = APIRouter(prefix="/api/packages", tags=["packages"])
 RuntimeDep = Annotated[ApiRuntime, Depends(get_runtime)]
+_PACKAGE_BLOCK_SOURCES = {"entry_point", "monorepo", "package_src"}
 
 
 class LocalPackageInstallRequest(BaseModel):
@@ -55,11 +56,14 @@ async def install_local_package_route(
 
     runtime.refresh_block_registry()
     module_names = set(result.modules)
-    blocks_count = sum(
-        1
-        for spec in runtime.block_registry.all_specs().values()
-        if getattr(spec, "source", "") == "package_src" and getattr(spec, "module_path", "") in module_names
-    )
+    blocks_count = 0
+    for spec in runtime.block_registry.all_specs().values():
+        source = getattr(spec, "source", "")
+        module_path = getattr(spec, "module_path", "")
+        if source in _PACKAGE_BLOCK_SOURCES and any(
+            module_path == module_name or module_path.startswith(f"{module_name}.") for module_name in module_names
+        ):
+            blocks_count += 1
     return LocalPackageInstallResponse(
         package_name=result.package_name,
         version=result.version,

--- a/src/scistudio/blocks/registry/__init__.py
+++ b/src/scistudio/blocks/registry/__init__.py
@@ -169,6 +169,12 @@ class BlockRegistry:
 
     def scan(self, *, include_monorepo: bool = False) -> None:
         """Discover block classes from entry-points and drop-in directories."""
+        from scistudio.blocks.registry._scan import (
+            _activate_desktop_package_import_roots,
+            _desktop_resource_package_dirs,
+        )
+
+        _activate_desktop_package_import_roots(_desktop_resource_package_dirs())
         self._scan_builtins()
         self._scan_tier1()
         self._scan_tier2()

--- a/src/scistudio/blocks/registry/_scan.py
+++ b/src/scistudio/blocks/registry/_scan.py
@@ -439,6 +439,9 @@ def _scan_source_package_module(registry: BlockRegistry, *, src_dir: Path, modul
         with _prepended_sys_path(src_dir):
             stale_modules = [name for name in sys.modules if name == module_name or name.startswith(f"{module_name}.")]
             for name in stale_modules:
+                # Keep DataObject type modules stable across block-package refreshes.
+                if name.endswith(".types"):
+                    continue
                 sys.modules.pop(name, None)
             importlib.invalidate_caches()
             module = importlib.import_module(module_name)

--- a/src/scistudio/blocks/registry/_scan.py
+++ b/src/scistudio/blocks/registry/_scan.py
@@ -159,7 +159,8 @@ def _scan_tier1(registry: BlockRegistry) -> None:
                 # Issue #1531: wrap exec_module in its own try/except so a
                 # failing or hostile drop-in cannot crash the palette refresh.
                 try:
-                    spec.loader.exec_module(module)
+                    with _prepended_sys_paths(_desktop_user_python_import_roots()):
+                        spec.loader.exec_module(module)
                 except Exception:
                     # #1531: skip-don't-crash on a failing/hostile drop-in.
                     # Keep the historical "Failed to import block from" wording
@@ -326,11 +327,19 @@ def _scan_tier2(registry: BlockRegistry) -> None:
 @contextlib.contextmanager
 def _prepended_sys_path(path: Path) -> Iterator[None]:
     """Prepend *path* to ``sys.path`` for one source-package import."""
-    path_str = str(path)
+    with _prepended_sys_paths([path]):
+        yield
+
+
+@contextlib.contextmanager
+def _prepended_sys_paths(paths: list[Path]) -> Iterator[None]:
+    """Prepend paths to ``sys.path`` for one source-package import."""
     original = list(sys.path)
-    if path_str in sys.path:
-        sys.path.remove(path_str)
-    sys.path.insert(0, path_str)
+    for path in reversed(paths):
+        path_str = str(path)
+        if path_str in sys.path:
+            sys.path.remove(path_str)
+        sys.path.insert(0, path_str)
     try:
         importlib.invalidate_caches()
         yield
@@ -382,6 +391,49 @@ def _desktop_resource_package_dirs() -> list[Path]:
     except Exception:
         logger.debug("Failed to resolve desktop package directories", exc_info=True)
         return []
+
+
+def _source_package_import_roots(src_dir: Path) -> list[Path]:
+    """Return scan-local import roots for a source package and its runtime deps."""
+    try:
+        from scistudio.desktop.paths import package_import_roots
+    except Exception:
+        return [src_dir]
+
+    package_root = src_dir.parent if src_dir.name == "src" else src_dir
+    roots = [src_dir]
+    roots.extend(path for path in package_import_roots(package_root) if path != src_dir)
+    return roots
+
+
+def _desktop_user_python_import_roots() -> list[Path]:
+    """Return shared user dependency roots for trusted drop-in imports."""
+    try:
+        from scistudio.desktop.paths import user_python_import_roots
+    except Exception:
+        return []
+    return user_python_import_roots()
+
+
+def _activate_desktop_package_import_roots(package_dirs: list[Path]) -> None:
+    """Expose user-installed package roots to registry and worker imports."""
+    try:
+        from scistudio.desktop.paths import activate_pythonpath_entries, package_import_roots
+    except Exception:
+        logger.debug("Failed to activate desktop package import roots", exc_info=True)
+        return
+
+    import_roots: list[Path] = []
+    for package_dir in package_dirs:
+        expanded = package_dir.expanduser()
+        import_roots.extend(package_import_roots(expanded))
+        if expanded.is_dir():
+            for child in sorted(expanded.iterdir()):
+                if child.is_dir():
+                    import_roots.extend(package_import_roots(child))
+        for src_dir in _iter_package_src_dirs(expanded):
+            import_roots.extend(_source_package_import_roots(src_dir))
+    activate_pythonpath_entries(import_roots)
 
 
 def _process_package_protocol_result(
@@ -436,7 +488,7 @@ def _process_package_protocol_result(
 def _scan_source_package_module(registry: BlockRegistry, *, src_dir: Path, module_name: str, source: str) -> None:
     """Import one ``scistudio_blocks_*`` package and register its block classes."""
     try:
-        with _prepended_sys_path(src_dir):
+        with _prepended_sys_paths(_source_package_import_roots(src_dir)):
             stale_modules = [name for name in sys.modules if name == module_name or name.startswith(f"{module_name}.")]
             for name in stale_modules:
                 # Keep DataObject type modules stable across block-package refreshes.
@@ -460,12 +512,12 @@ def _scan_source_package_module(registry: BlockRegistry, *, src_dir: Path, modul
 def _scan_package_src_dirs(registry: BlockRegistry) -> None:
     """Tier 3: scan hard-installed ``packages/*/src`` source packages.
 
-    This desktop package path does not install dependencies or query package
-    indexes. It imports already-present ``scistudio_blocks_*`` source packages
-    through the existing ADR-025 package protocol so ADR-043 capability
-    validation remains the registry's single source of truth.
+    This desktop package path imports already-present ``scistudio_blocks_*``
+    source packages through the existing ADR-025 package protocol so ADR-043
+    capability validation remains the registry's single source of truth.
     """
     package_dirs = [*registry._package_src_dirs, *_desktop_resource_package_dirs()]
+    _activate_desktop_package_import_roots(package_dirs)
     seen_src_dirs: set[Path] = set()
     for package_dir in package_dirs:
         for src_dir in _iter_package_src_dirs(package_dir):

--- a/src/scistudio/desktop/package_installer.py
+++ b/src/scistudio/desktop/package_installer.py
@@ -6,6 +6,8 @@ import json
 import os
 import re
 import shutil
+import subprocess
+import sys
 import tarfile
 import tempfile
 import tomllib
@@ -46,6 +48,8 @@ def install_local_package(
     source: str | Path,
     *,
     install_root: str | Path | None = None,
+    install_dependencies: bool = False,
+    python_executable: str | Path | None = None,
 ) -> LocalPackageInstallResult:
     """Install a local SciStudio block package into the user plugin area."""
 
@@ -60,17 +64,23 @@ def install_local_package(
     with tempfile.TemporaryDirectory(prefix=".scistudio-install-", dir=str(root)) as stage_name:
         stage_dir = Path(stage_name)
         prepared_dir = stage_dir / "prepared"
+        install_source: Path
+        dependencies: tuple[str, ...] = ()
 
         if resolved_source.is_dir():
             package_root = _find_source_root(resolved_source)
             if package_root is None:
                 raise PackageInstallError(f"No SciStudio block package found in {resolved_source}")
             metadata = _source_metadata(package_root)
+            dependencies = _source_dependencies(package_root)
             shutil.copytree(package_root, prepared_dir, ignore=shutil.ignore_patterns("__pycache__", "*.pyc"))
+            install_source = prepared_dir
         elif _is_wheel(resolved_source):
             metadata = _wheel_metadata(resolved_source)
+            dependencies = _wheel_dependencies(resolved_source)
             prepared_dir.mkdir()
             _extract_zip(resolved_source, prepared_dir)
+            install_source = resolved_source
         elif _is_supported_archive(resolved_source):
             extract_dir = stage_dir / "archive"
             extract_dir.mkdir()
@@ -82,7 +92,9 @@ def install_local_package(
             if package_root is None:
                 raise PackageInstallError(f"No SciStudio block package found in {resolved_source}")
             metadata = _source_metadata(package_root)
+            dependencies = _source_dependencies(package_root)
             shutil.copytree(package_root, prepared_dir, ignore=shutil.ignore_patterns("__pycache__", "*.pyc"))
+            install_source = prepared_dir
         else:
             suffixes = "".join(resolved_source.suffixes) or resolved_source.suffix
             raise PackageInstallError(f"Unsupported package file type: {suffixes or resolved_source.name}")
@@ -92,6 +104,14 @@ def install_local_package(
             raise PackageInstallError("Package does not contain a scistudio_blocks_* module with an __init__.py file.")
 
         target_dir = root / _install_dir_name(metadata)
+        if install_dependencies:
+            _install_runtime_package(
+                install_source,
+                dependencies=dependencies,
+                target_dir=prepared_dir / paths.PACKAGE_SITE_DIR_NAME,
+                python_executable=python_executable,
+            )
+
         manifest_path = prepared_dir / _MANIFEST_NAME
         manifest_path.write_text(
             json.dumps(
@@ -199,6 +219,33 @@ def _wheel_metadata(wheel_path: Path) -> _PackageMetadata:
     raise PackageInstallError(f"Wheel metadata is missing a package name: {wheel_path}")
 
 
+def _source_dependencies(package_root: Path) -> tuple[str, ...]:
+    pyproject = package_root / "pyproject.toml"
+    if not pyproject.is_file():
+        return ()
+    try:
+        parsed = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+    except tomllib.TOMLDecodeError as exc:
+        raise PackageInstallError(f"Invalid pyproject.toml in {package_root}: {exc}") from exc
+    project = parsed.get("project", {}) if isinstance(parsed, dict) else {}
+    dependencies = project.get("dependencies") if isinstance(project, dict) else None
+    if not isinstance(dependencies, list):
+        return ()
+    return tuple(dep for dep in dependencies if isinstance(dep, str) and dep.strip())
+
+
+def _wheel_dependencies(wheel_path: Path) -> tuple[str, ...]:
+    with zipfile.ZipFile(wheel_path) as archive:
+        metadata_names = [
+            name for name in archive.namelist() if name.endswith(".dist-info/METADATA") and not name.startswith("/")
+        ]
+        if not metadata_names:
+            return ()
+        raw = archive.read(metadata_names[0]).decode("utf-8", errors="replace")
+    message = Parser().parsestr(raw)
+    return tuple(dep for dep in message.get_all("Requires-Dist", []) if isinstance(dep, str) and dep.strip())
+
+
 def _find_source_root(root: Path) -> Path | None:
     if _looks_like_source_package(root):
         return root
@@ -228,6 +275,92 @@ def _discover_block_modules(package_root: Path) -> list[str]:
 def _candidate_import_roots(package_root: Path) -> tuple[Path, ...]:
     src_dir = package_root / "src"
     return (src_dir, package_root) if src_dir.is_dir() else (package_root,)
+
+
+def _install_runtime_package(
+    install_source: Path,
+    *,
+    dependencies: tuple[str, ...],
+    target_dir: Path,
+    python_executable: str | Path | None,
+) -> None:
+    target_dir.mkdir(parents=True, exist_ok=True)
+    python = str(Path(python_executable)) if python_executable is not None else sys.executable
+    _run_pip(
+        [
+            python,
+            "-m",
+            "pip",
+            "install",
+            "--disable-pip-version-check",
+            "--no-input",
+            "--no-warn-script-location",
+            "--target",
+            str(target_dir),
+            "--no-deps",
+            str(install_source),
+        ]
+    )
+    runtime_dependencies = tuple(dep for dep in dependencies if not _is_core_runtime_dependency(dep))
+    if runtime_dependencies:
+        _run_pip(
+            [
+                python,
+                "-m",
+                "pip",
+                "install",
+                "--disable-pip-version-check",
+                "--no-input",
+                "--no-warn-script-location",
+                "--target",
+                str(target_dir),
+                *runtime_dependencies,
+            ]
+        )
+    _remove_core_runtime_shadow(target_dir)
+
+
+def _run_pip(command: list[str]) -> None:
+    try:
+        completed = subprocess.run(command, capture_output=True, text=True, check=False)
+    except OSError as exc:
+        raise PackageInstallError(f"Failed to launch pip for package dependency installation: {exc}") from exc
+    if completed.returncode != 0:
+        output = "\n".join(part for part in (completed.stdout.strip(), completed.stderr.strip()) if part)
+        tail = "\n".join(output.splitlines()[-20:]) if output else "pip produced no output"
+        raise PackageInstallError(
+            "Failed to install package dependencies into the bundled Python plugin environment. "
+            f"pip exited with code {completed.returncode}:\n{tail}"
+        )
+
+
+def _is_core_runtime_dependency(requirement: str) -> bool:
+    return _requirement_name(requirement) == "scistudio"
+
+
+def _requirement_name(requirement: str) -> str:
+    try:
+        from packaging.requirements import Requirement
+    except Exception:
+        raw_name = re.split(r"[\s<>=!~;\[]", requirement.strip(), maxsplit=1)[0]
+    else:
+        try:
+            raw_name = Requirement(requirement).name
+        except Exception:
+            raw_name = re.split(r"[\s<>=!~;\[]", requirement.strip(), maxsplit=1)[0]
+    return re.sub(r"[-_.]+", "-", raw_name).lower()
+
+
+def _remove_core_runtime_shadow(target_dir: Path) -> None:
+    for candidate in (
+        target_dir / "scistudio",
+        *target_dir.glob("scistudio-*.dist-info"),
+        *target_dir.glob("scistudio-*.egg-info"),
+    ):
+        if candidate.is_dir():
+            shutil.rmtree(candidate)
+        elif candidate.exists():
+            candidate.unlink()
 
 
 def _extract_zip(source: Path, destination: Path) -> None:

--- a/src/scistudio/desktop/paths.py
+++ b/src/scistudio/desktop/paths.py
@@ -3,11 +3,15 @@
 from __future__ import annotations
 
 import os
+import shlex
 import sys
+from collections.abc import Iterable
 from pathlib import Path
 
 APP_NAME = "SciStudio"
 APP_AUTHOR = "SciStudio"
+PACKAGE_SITE_DIR_NAME = "site-packages"
+USER_PYTHON_DIR_NAME = "python"
 
 
 def _platformdirs_dir(kind: str) -> Path | None:
@@ -76,6 +80,178 @@ def installed_packages_dir() -> Path:
     return plugins_dir() / "packages"
 
 
+def user_python_dir() -> Path:
+    """Return the shared user dependency runtime directory."""
+    return plugins_dir() / USER_PYTHON_DIR_NAME
+
+
+def user_python_site_dir() -> Path:
+    """Return the shared user dependency import directory."""
+    return user_python_dir() / PACKAGE_SITE_DIR_NAME
+
+
+def user_python_bin_dir() -> Path:
+    """Return the directory containing SciStudio Python command wrappers."""
+    return user_python_dir() / ("Scripts" if sys.platform == "win32" else "bin")
+
+
+def user_python_import_roots() -> list[Path]:
+    """Return shared user dependency import roots that already exist."""
+    site_dir = user_python_site_dir()
+    return [site_dir] if site_dir.is_dir() else []
+
+
+def package_import_roots(package_root: str | Path) -> tuple[Path, ...]:
+    """Return import roots for one user-installed desktop package."""
+    root = Path(package_root).expanduser()
+    roots: list[Path] = []
+    src_dir = root / "src"
+    site_dir = root / PACKAGE_SITE_DIR_NAME
+    if src_dir.is_dir():
+        roots.append(src_dir)
+    if root.is_dir() and any(root.glob("scistudio_blocks_*/__init__.py")):
+        roots.append(root)
+    if site_dir.is_dir():
+        roots.append(site_dir)
+    return tuple(roots)
+
+
+def installed_package_import_roots() -> list[Path]:
+    """Return import roots for all user-installed desktop packages."""
+    roots: list[Path] = user_python_import_roots()
+    packages_root = installed_packages_dir()
+    if not packages_root.is_dir():
+        return roots
+    for child in sorted(packages_root.iterdir()):
+        if child.is_dir():
+            roots.extend(package_import_roots(child))
+    return roots
+
+
+def activate_pythonpath_entries(
+    entries: Iterable[str | Path],
+    *,
+    update_sys_path: bool = False,
+) -> tuple[Path, ...]:
+    """Add plugin import roots to inherited worker env.
+
+    ``update_sys_path`` is opt-in so registry scans can keep their historical
+    no-leak behavior and use scoped import contexts for in-process imports.
+    """
+    resolved: list[Path] = []
+    seen: set[str] = set()
+    for entry in entries:
+        path = Path(entry).expanduser()
+        if not path.is_dir():
+            continue
+        key = str(path.resolve())
+        if key in seen:
+            continue
+        seen.add(key)
+        resolved.append(Path(key))
+    if not resolved:
+        return ()
+
+    if update_sys_path:
+        existing_sys_path = list(sys.path)
+        for path in reversed(resolved):
+            path_str = str(path)
+            if path_str in sys.path:
+                sys.path.remove(path_str)
+            sys.path.insert(0, path_str)
+        sys.path[:] = list(dict.fromkeys(sys.path + existing_sys_path))
+
+    env_parts = [str(path) for path in resolved]
+    for part in os.environ.get("PYTHONPATH", "").split(os.pathsep):
+        if part and part not in env_parts:
+            env_parts.append(part)
+    os.environ["PYTHONPATH"] = os.pathsep.join(env_parts)
+    return tuple(resolved)
+
+
+def ensure_user_python_environment(python_executable: str | Path | None = None) -> dict[str, Path]:
+    """Create user dependency directories and command wrappers.
+
+    The wrappers make the desktop terminal feel like a normal shell while
+    routing ``python``/``pip`` through the bundled runtime and user data dir.
+    """
+    python_path = Path(python_executable or sys.executable).resolve()
+    site_dir = user_python_site_dir()
+    bin_dir = user_python_bin_dir()
+    site_dir.mkdir(parents=True, exist_ok=True)
+    bin_dir.mkdir(parents=True, exist_ok=True)
+
+    if sys.platform == "win32":
+        _write_command_wrapper(bin_dir / "python.cmd", python_path, site_dir, pip=False)
+        _write_command_wrapper(bin_dir / "python3.cmd", python_path, site_dir, pip=False)
+        _write_command_wrapper(bin_dir / "pip.cmd", python_path, site_dir, pip=True)
+        _write_command_wrapper(bin_dir / "pip3.cmd", python_path, site_dir, pip=True)
+    else:
+        _write_command_wrapper(bin_dir / "python", python_path, site_dir, pip=False)
+        _write_command_wrapper(bin_dir / "python3", python_path, site_dir, pip=False)
+        _write_command_wrapper(bin_dir / "pip", python_path, site_dir, pip=True)
+        _write_command_wrapper(bin_dir / "pip3", python_path, site_dir, pip=True)
+
+    return {"bin": bin_dir, "site": site_dir, "python": python_path}
+
+
+def user_python_terminal_env(python_executable: str | Path | None = None) -> dict[str, str]:
+    """Return environment overrides for a desktop user dependency terminal."""
+    paths = ensure_user_python_environment(python_executable)
+    python_bin = paths["python"].parent
+    activate_pythonpath_entries(
+        [paths["site"], *installed_package_import_roots()],
+        update_sys_path=False,
+    )
+
+    path_parts = [str(paths["bin"]), str(python_bin)]
+    for part in os.environ.get("PATH", "").split(os.pathsep):
+        if part and part not in path_parts:
+            path_parts.append(part)
+
+    return {
+        "PATH": os.pathsep.join(path_parts),
+        "PYTHONPATH": os.environ.get("PYTHONPATH", ""),
+        "PIP_TARGET": str(paths["site"]),
+        "PIP_REQUIRE_VIRTUALENV": "false",
+        "SCISTUDIO_USER_PYTHON_SITE": str(paths["site"]),
+        "SCISTUDIO_PYTHON": str(paths["python"]),
+    }
+
+
+def _write_command_wrapper(path: Path, python_path: Path, site_dir: Path, *, pip: bool) -> None:
+    if sys.platform == "win32":
+        command = '"%SCISTUDIO_PYTHON%" -m pip %*' if pip else '"%SCISTUDIO_PYTHON%" %*'
+        lines = [
+            "@echo off",
+            f'set "SCISTUDIO_PYTHON={python_path}"',
+            f'set "SCISTUDIO_USER_PYTHON_SITE={site_dir}"',
+            *(['set "PIP_TARGET=%SCISTUDIO_USER_PYTHON_SITE%"', 'set "PIP_REQUIRE_VIRTUALENV=false"'] if pip else []),
+            'set "PYTHONPATH=%SCISTUDIO_USER_PYTHON_SITE%;%PYTHONPATH%"',
+            command,
+            "exit /b %ERRORLEVEL%",
+        ]
+    else:
+        command = 'exec "${SCISTUDIO_PYTHON}" -m pip "$@"' if pip else 'exec "${SCISTUDIO_PYTHON}" "$@"'
+        lines = [
+            "#!/bin/sh",
+            f"SCISTUDIO_PYTHON={shlex.quote(str(python_path))}",
+            f"SCISTUDIO_USER_PYTHON_SITE={shlex.quote(str(site_dir))}",
+            "export SCISTUDIO_USER_PYTHON_SITE",
+            *(
+                ['export PIP_TARGET="${SCISTUDIO_USER_PYTHON_SITE}"', "export PIP_REQUIRE_VIRTUALENV=false"]
+                if pip
+                else []
+            ),
+            'export PYTHONPATH="${SCISTUDIO_USER_PYTHON_SITE}${PYTHONPATH:+:${PYTHONPATH}}"',
+            command,
+        ]
+    body = "\n".join([*lines, ""])
+    path.write_text(body, encoding="utf-8")
+    if sys.platform != "win32":
+        path.chmod(path.stat().st_mode | 0o755)
+
+
 def shared_model_cache() -> Path:
     if sys.platform == "win32":
         return Path(os.environ.get("PROGRAMDATA", r"C:\ProgramData")) / APP_NAME / "models"
@@ -115,6 +291,7 @@ def candidate_package_dirs() -> list[Path]:
     for item in env.split(os.pathsep):
         if item:
             dirs.append(Path(item).resolve())
+    dirs.append(user_python_dir())
     dirs.append(installed_packages_dir())
     dirs.append(bundled_packages_dir())
     root = repo_root()

--- a/tests/ai/test_windows_executable_resolution.py
+++ b/tests/ai/test_windows_executable_resolution.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from scistudio.ai.agent import terminal
 from scistudio.api.routes import ai as ai_route
+from scistudio.desktop import paths as desktop_paths
 
 
 def _npm_shim_which(name: str) -> str | None:
@@ -64,6 +65,18 @@ def test_spawn_codex_uses_cmd_when_windows_which_finds_bare_wrapper(
     monkeypatch.setattr(terminal.sys, "platform", "win32")
     monkeypatch.setattr(terminal.shutil, "which", _npm_shim_which)
     monkeypatch.setattr(terminal, "PtyProcess", FakePtyProcess)
+    monkeypatch.setattr(
+        terminal,
+        "_codex_mcp_config_overrides",
+        lambda project_dir: [
+            "-c",
+            f"mcp_servers.scistudio.command={json.dumps(sys.executable)}",
+            "-c",
+            'mcp_servers.scistudio.args=["-m", "scistudio", "mcp-bridge"]',
+            "-c",
+            f"mcp_servers.scistudio.env={{SCISTUDIO_PROJECT_DIR={json.dumps(str(project_dir))}}}",
+        ],
+    )
 
     terminal.spawn_codex(project_dir=tmp_path, dangerous=True)
 
@@ -152,3 +165,31 @@ def test_spawn_codex_injects_project_mcp_config_overrides(monkeypatch: Any, tmp_
     assert f"mcp_servers.scistudio.command={json.dumps(sys.executable)}" in argv
     assert 'mcp_servers.scistudio.args=["-m", "scistudio", "mcp-bridge"]' in argv
     assert f"SCISTUDIO_PROJECT_DIR={json.dumps(str(tmp_path))}" in argv[-1]
+
+
+def test_spawn_user_terminal_uses_user_dependency_env(monkeypatch: Any, tmp_path: Path) -> None:
+    spawned: dict[str, Any] = {}
+
+    class FakePtyProcess:
+        def __init__(self, argv: list[str], *args: Any, **kwargs: Any) -> None:
+            spawned["argv"] = argv
+            spawned["args"] = args
+            spawned["kwargs"] = kwargs
+
+    monkeypatch.setattr(terminal, "PtyProcess", FakePtyProcess)
+    monkeypatch.setattr(terminal, "_user_shell_argv", lambda: ["shell"])
+    monkeypatch.setattr(
+        desktop_paths,
+        "user_python_terminal_env",
+        lambda python_executable: {
+            "SCISTUDIO_PYTHON": str(python_executable),
+            "SCISTUDIO_USER_PYTHON_SITE": str(tmp_path / "deps"),
+        },
+    )
+
+    terminal.spawn_user_terminal(project_dir=tmp_path, dangerous=False, extra_env={"EXTRA": "1"})
+
+    assert spawned["argv"] == ["shell"]
+    assert spawned["kwargs"]["extra_env"]["SCISTUDIO_PYTHON"] == sys.executable
+    assert spawned["kwargs"]["extra_env"]["SCISTUDIO_USER_PYTHON_SITE"] == str(tmp_path / "deps")
+    assert spawned["kwargs"]["extra_env"]["EXTRA"] == "1"

--- a/tests/api/routes/ai_pty/test_public_surface.py
+++ b/tests/api/routes/ai_pty/test_public_surface.py
@@ -87,14 +87,14 @@ def test_spawn_signature_unchanged() -> None:
     """``_spawn`` test seam must keep the exact kwargs the fakes use.
 
     Tests call ``_spawn(provider=..., project_dir=..., dangerous=...,
-    extra_env=...)``; a signature drift would make the fake replacement
-    accept wrong arguments and mask real bugs.
+    cols=..., rows=..., extra_env=...)``; a signature drift would make
+    the fake replacement accept wrong arguments and mask real bugs.
     """
     from scistudio.api.routes.ai_pty import _spawn
 
     sig = inspect.signature(_spawn)
-    assert list(sig.parameters) == ["provider", "project_dir", "dangerous", "extra_env"]
-    for name in ("provider", "project_dir", "dangerous", "extra_env"):
+    assert list(sig.parameters) == ["provider", "project_dir", "dangerous", "cols", "rows", "extra_env"]
+    for name in ("provider", "project_dir", "dangerous", "cols", "rows", "extra_env"):
         assert sig.parameters[name].kind == inspect.Parameter.KEYWORD_ONLY
 
 

--- a/tests/api/test_ai_pty.py
+++ b/tests/api/test_ai_pty.py
@@ -53,9 +53,11 @@ def _fake_spawn(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Iterator[Non
         provider: str,
         project_dir: Path,
         dangerous: bool,
+        cols: int = 80,
+        rows: int = 24,
         extra_env: dict[str, str] | None = None,
     ) -> PtyProcess:
-        return PtyProcess(_echo_argv(), cwd=project_dir, cols=80, rows=24, extra_env=extra_env)
+        return PtyProcess(_echo_argv(), cwd=project_dir, cols=cols, rows=rows, extra_env=extra_env)
 
     monkeypatch.setattr(ai_pty, "_spawn", fake)
     _active_ptys.clear()
@@ -112,6 +114,60 @@ def test_pty_ws_lifecycle(client: TestClient, opened_project: Path) -> None:
     assert not _active_ptys, f"PTY not cleaned up: {list(_active_ptys)}"
 
 
+def test_pty_ws_preserves_utf8_split_across_reads(
+    client: TestClient,
+    opened_project: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """UTF-8 glyphs split across PTY reads must reach xterm intact."""
+
+    banner = "READY ────────────────────\n"
+    raw = banner.encode("utf-8")
+
+    class SplitUtf8Pty:
+        def __init__(self) -> None:
+            self._chunks = [raw[:7], raw[7:]]
+            self._alive = True
+
+        def read(self, _timeout: float) -> bytes:
+            if not self._chunks:
+                self._alive = False
+                return b""
+            chunk = self._chunks.pop(0)
+            if not self._chunks:
+                self._alive = False
+            return chunk
+
+        def is_alive(self) -> bool:
+            return self._alive
+
+        def write(self, _data: bytes) -> None:
+            return None
+
+        def resize(self, *, cols: int, rows: int) -> None:
+            return None
+
+        def kill_tree(self) -> None:
+            self._alive = False
+
+    monkeypatch.setattr(
+        ai_pty,
+        "_spawn",
+        lambda **_kwargs: SplitUtf8Pty(),
+    )
+
+    collected = ""
+    with client.websocket_connect(_ws_url("tab-utf8", opened_project)) as ws:
+        deadline = time.monotonic() + 5.0
+        while time.monotonic() < deadline and banner not in collected:
+            frame = ws.receive_json()
+            if frame["type"] == "stdout":
+                collected += frame.get("data", "")
+
+    assert banner in collected
+    assert "\ufffd" not in collected
+
+
 def test_pty_ws_resize_no_error(client: TestClient, opened_project: Path) -> None:
     """Sending a resize frame must not produce an error frame."""
     with client.websocket_connect(_ws_url("tab-resize", opened_project)) as ws:
@@ -128,6 +184,40 @@ def test_pty_ws_resize_no_error(client: TestClient, opened_project: Path) -> Non
             if frame["type"] == "stdout" and "x" in frame.get("data", ""):
                 saw_x = True
         assert saw_x
+
+
+def test_pty_ws_spawn_uses_initial_size_query(
+    client: TestClient,
+    opened_project: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The PTY should spawn at xterm's fitted size, before first TUI paint."""
+
+    captured: dict[str, int] = {}
+
+    def fake(
+        *,
+        provider: str,
+        project_dir: Path,
+        dangerous: bool,
+        cols: int = 120,
+        rows: int = 30,
+        extra_env: dict[str, str] | None = None,
+    ) -> PtyProcess:
+        captured["cols"] = cols
+        captured["rows"] = rows
+        return PtyProcess(_echo_argv(), cwd=project_dir, cols=cols, rows=rows, extra_env=extra_env)
+
+    monkeypatch.setattr(ai_pty, "_spawn", fake)
+
+    with client.websocket_connect(f"{_ws_url('tab-size', opened_project)}&cols=101&rows=33") as ws:
+        deadline = time.monotonic() + 5.0
+        while time.monotonic() < deadline:
+            frame = ws.receive_json()
+            if frame["type"] == "stdout" and "READY" in frame.get("data", ""):
+                break
+
+    assert captured == {"cols": 101, "rows": 33}
 
 
 def test_pty_ws_invalid_provider(client: TestClient, opened_project: Path) -> None:

--- a/tests/api/test_ai_pty.py
+++ b/tests/api/test_ai_pty.py
@@ -220,6 +220,38 @@ def test_pty_ws_spawn_uses_initial_size_query(
     assert captured == {"cols": 101, "rows": 33}
 
 
+def test_pty_ws_accepts_user_terminal_provider(
+    client: TestClient,
+    opened_project: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The desktop user terminal reuses the PTY WS with its own provider key."""
+    captured: dict[str, str] = {}
+
+    def fake(
+        *,
+        provider: str,
+        project_dir: Path,
+        dangerous: bool,
+        cols: int = 120,
+        rows: int = 30,
+        extra_env: dict[str, str] | None = None,
+    ) -> PtyProcess:
+        captured["provider"] = provider
+        return PtyProcess(_echo_argv(), cwd=project_dir, cols=cols, rows=rows, extra_env=extra_env)
+
+    monkeypatch.setattr(ai_pty, "_spawn", fake)
+
+    with client.websocket_connect(_ws_url("tab-user-terminal", opened_project, provider="user-terminal")) as ws:
+        deadline = time.monotonic() + 5.0
+        while time.monotonic() < deadline:
+            frame = ws.receive_json()
+            if frame["type"] == "stdout" and "READY" in frame.get("data", ""):
+                break
+
+    assert captured == {"provider": "user-terminal"}
+
+
 def test_pty_ws_invalid_provider(client: TestClient, opened_project: Path) -> None:
     """An unknown provider must yield an error frame and a close."""
     with client.websocket_connect(_ws_url("tab-bad", opened_project, provider="bogus")) as ws:

--- a/tests/api/test_packages.py
+++ b/tests/api/test_packages.py
@@ -16,8 +16,9 @@ from scistudio.desktop.package_installer import LocalPackageInstallResult
 class _Registry:
     def all_specs(self) -> dict[str, object]:
         return {
-            "probe": SimpleNamespace(source="package_src", module_path="scistudio_blocks_probe"),
-            "builtin": SimpleNamespace(source="builtin", module_path="scistudio.blocks.io"),
+            "probe": SimpleNamespace(source="entry_point", module_path="scistudio_blocks_probe.blocks"),
+            "near_prefix": SimpleNamespace(source="entry_point", module_path="scistudio_blocks_probe_extra.blocks"),
+            "builtin": SimpleNamespace(source="builtin", module_path="scistudio_blocks_probe.blocks"),
         }
 
 

--- a/tests/api/test_packages.py
+++ b/tests/api/test_packages.py
@@ -35,7 +35,10 @@ def test_install_local_package_route_refreshes_registry(monkeypatch: pytest.Monk
     monkeypatch.setenv("SCISTUDIO_BUNDLED", "1")
     install_path = tmp_path / "installed" / "scistudio-blocks-probe-0.1.0"
 
-    def fake_install(path: str) -> LocalPackageInstallResult:
+    install_kwargs: dict[str, object] = {}
+
+    def fake_install(path: str, **kwargs: object) -> LocalPackageInstallResult:
+        install_kwargs.update(kwargs)
         return LocalPackageInstallResult(
             package_name="scistudio-blocks-probe",
             version="0.1.0",
@@ -56,6 +59,7 @@ def test_install_local_package_route_refreshes_registry(monkeypatch: pytest.Monk
 
     assert response.status_code == 200
     assert runtime.refreshed is True
+    assert install_kwargs == {"install_dependencies": True}
     assert response.json() == {
         "package_name": "scistudio-blocks-probe",
         "version": "0.1.0",

--- a/tests/blocks/test_desktop_package_discovery.py
+++ b/tests/blocks/test_desktop_package_discovery.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import pytest
 
 from scistudio.blocks.registry import BlockRegistry
+from scistudio.desktop import paths as desktop_paths
 
 
 def _write_source_package(
@@ -148,6 +149,93 @@ def test_add_package_src_dir_accepts_flat_installed_package(tmp_path: Path) -> N
     assert spec.source == "package_src"
     assert spec.module_path == "scistudio_blocks_flatprobe"
     assert spec.package_name == "Flat Probe"
+
+
+def test_scan_imports_source_package_with_per_package_runtime_dependencies(tmp_path: Path) -> None:
+    packages_dir = tmp_path / "installed-packages"
+    package_root = packages_dir / "scistudio-blocks-runtimeprobe-0.1.0"
+    module_dir = package_root / "src" / "scistudio_blocks_runtimeprobe"
+    runtime_dir = package_root / "site-packages"
+    module_dir.mkdir(parents=True)
+    runtime_dir.mkdir(parents=True)
+    (runtime_dir / "runtime_dep.py").write_text("VALUE = 'runtime-ok'\n", encoding="utf-8")
+    (package_root / "pyproject.toml").write_text(
+        '[project]\nname = "scistudio-blocks-runtimeprobe"\nversion = "0.1.0"\n',
+        encoding="utf-8",
+    )
+    (module_dir / "__init__.py").write_text(
+        "from typing import Any\n"
+        "\n"
+        "import runtime_dep\n"
+        "from scistudio.blocks.base.config import BlockConfig\n"
+        "from scistudio.blocks.base.package_info import PackageInfo\n"
+        "from scistudio.blocks.base.block import Block\n"
+        "\n"
+        "class RuntimeProbeBlock(Block):\n"
+        '    name = "RuntimeProbeBlock"\n'
+        "    description = runtime_dep.VALUE\n"
+        "    input_ports = []\n"
+        "    output_ports = []\n"
+        '    config_schema = {"type": "object", "properties": {}}\n'
+        "\n"
+        "    def run(self, inputs: dict[str, Any], config: BlockConfig) -> dict[str, Any]:\n"
+        "        return {}\n"
+        "\n"
+        "def get_block_package():\n"
+        '    return PackageInfo(name="Runtime Probe", version="0.1.0"), [RuntimeProbeBlock]\n',
+        encoding="utf-8",
+    )
+
+    registry = BlockRegistry()
+    registry.add_package_src_dir(packages_dir)
+    registry.scan()
+
+    spec = registry.get_spec("RuntimeProbeBlock")
+    assert spec is not None
+    assert spec.description == "runtime-ok"
+    assert spec.source == "package_src"
+    assert str(module_dir.parent) not in sys.path
+    assert str(runtime_dir) not in sys.path
+
+
+def test_tier1_dropin_imports_shared_user_python_dependency(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(desktop_paths, "_platformdirs_dir", lambda kind: tmp_path / kind)
+    runtime_dir = desktop_paths.user_python_site_dir()
+    runtime_dir.mkdir(parents=True)
+    (runtime_dir / "user_dep.py").write_text("VALUE = 'user-dep-ok'\n", encoding="utf-8")
+
+    scan_dir = tmp_path / "blocks"
+    scan_dir.mkdir()
+    (scan_dir / "user_dep_block.py").write_text(
+        "from typing import Any\n"
+        "\n"
+        "import user_dep\n"
+        "from scistudio.blocks.base.config import BlockConfig\n"
+        "from scistudio.blocks.base.block import Block\n"
+        "\n"
+        "class UserDepProbeBlock(Block):\n"
+        '    name = "UserDepProbeBlock"\n'
+        "    description = user_dep.VALUE\n"
+        "    input_ports = []\n"
+        "    output_ports = []\n"
+        '    config_schema = {"type": "object", "properties": {}}\n'
+        "\n"
+        "    def run(self, inputs: dict[str, Any], config: BlockConfig) -> dict[str, Any]:\n"
+        "        return {}\n",
+        encoding="utf-8",
+    )
+
+    registry = BlockRegistry()
+    registry.add_scan_dir(scan_dir)
+    registry.scan()
+
+    spec = registry.get_spec("UserDepProbeBlock")
+    assert spec is not None
+    assert spec.description == "user-dep-ok"
+    assert str(runtime_dir) not in sys.path
 
 
 def test_scan_reloads_reinstalled_package_from_same_source_path(tmp_path: Path) -> None:

--- a/tests/desktop/test_package_installer.py
+++ b/tests/desktop/test_package_installer.py
@@ -3,13 +3,17 @@
 from __future__ import annotations
 
 import json
+import os
 import sys
 import zipfile
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
 from scistudio.blocks.registry import BlockRegistry
+from scistudio.desktop import package_installer
+from scistudio.desktop import paths as desktop_paths
 from scistudio.desktop.package_installer import PackageInstallError, install_local_package
 
 
@@ -43,12 +47,15 @@ def _write_source_package(
     block_name: str,
     package_name: str,
     version: str = "0.1.0",
+    dependencies: tuple[str, ...] = (),
 ) -> Path:
     package_root = root / dist_name
     module_dir = package_root / "src" / module_name
     module_dir.mkdir(parents=True)
+    deps = "".join(f'    "{dependency}",\n' for dependency in dependencies)
+    dependency_block = f"dependencies = [\n{deps}]\n" if dependencies else ""
     (package_root / "pyproject.toml").write_text(
-        f'[project]\nname = "{dist_name}"\nversion = "{version}"\n',
+        f'[project]\nname = "{dist_name}"\nversion = "{version}"\n{dependency_block}',
         encoding="utf-8",
     )
     (module_dir / "__init__.py").write_text(
@@ -116,6 +123,77 @@ def test_install_wheel_registers_flat_module_layout(tmp_path: Path) -> None:
     assert spec.source == "package_src"
     assert spec.module_path == "scistudio_blocks_wheelprobe"
     assert spec.package_name == "Wheel Probe"
+
+
+def test_install_source_directory_installs_runtime_dependencies_with_selected_python(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    source_root = _write_source_package(
+        tmp_path / "source",
+        dist_name="scistudio-blocks-depprobe",
+        module_name="scistudio_blocks_depprobe",
+        block_name="DependencyProbeBlock",
+        package_name="Dependency Probe",
+        dependencies=("scistudio>=0.2.1", "ome-types>=0.5,<0.6", "numpy>=1.24"),
+    )
+    calls: list[list[str]] = []
+
+    def fake_run(command: list[str], **_kwargs: object) -> SimpleNamespace:
+        calls.append(command)
+        target_dir = Path(command[command.index("--target") + 1])
+        target_dir.mkdir(parents=True, exist_ok=True)
+        (target_dir / "scistudio").mkdir(exist_ok=True)
+        (target_dir / "scistudio-999.dist-info").mkdir(exist_ok=True)
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(package_installer.subprocess, "run", fake_run)
+    bundled_python = tmp_path / "bundled-python"
+
+    result = install_local_package(
+        source_root,
+        install_root=tmp_path / "installed",
+        install_dependencies=True,
+        python_executable=bundled_python,
+    )
+
+    assert len(calls) == 2
+    assert calls[0][:4] == [str(bundled_python), "-m", "pip", "install"]
+    assert "--no-deps" in calls[0]
+    assert str(source_root.resolve()) not in calls[0]
+    dependency_command = calls[1]
+    assert dependency_command[:4] == [str(bundled_python), "-m", "pip", "install"]
+    assert "ome-types>=0.5,<0.6" in dependency_command
+    assert "numpy>=1.24" in dependency_command
+    assert all(not arg.startswith("scistudio>=") for arg in dependency_command)
+    runtime_dir = result.install_path / desktop_paths.PACKAGE_SITE_DIR_NAME
+    assert runtime_dir.is_dir()
+    assert not (runtime_dir / "scistudio").exists()
+    assert not (runtime_dir / "scistudio-999.dist-info").exists()
+
+
+def test_user_python_terminal_env_creates_user_wrappers(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(desktop_paths, "_platformdirs_dir", lambda kind: tmp_path / kind)
+    monkeypatch.setenv("PYTHONPATH", "/existing")
+
+    env = desktop_paths.user_python_terminal_env(tmp_path / "bundled-python")
+
+    site_dir = tmp_path / "data" / "plugins" / "python" / desktop_paths.PACKAGE_SITE_DIR_NAME
+    bin_dir = tmp_path / "data" / "plugins" / "python" / ("Scripts" if sys.platform == "win32" else "bin")
+    pip_wrapper = bin_dir / ("pip.cmd" if sys.platform == "win32" else "pip")
+
+    assert site_dir.is_dir()
+    assert pip_wrapper.is_file()
+    assert env["PIP_TARGET"] == str(site_dir)
+    assert env["SCISTUDIO_USER_PYTHON_SITE"] == str(site_dir)
+    assert str(bin_dir) == env["PATH"].split(os.pathsep)[0]
+    assert env["PYTHONPATH"].split(os.pathsep)[0] == str(site_dir.resolve())
+    wrapper_text = pip_wrapper.read_text(encoding="utf-8")
+    assert "-m pip" in wrapper_text
+    assert str(site_dir) in wrapper_text
 
 
 def test_install_archive_rejects_path_traversal(tmp_path: Path) -> None:

--- a/tests/packaging/test_desktop_mvp_resources.py
+++ b/tests/packaging/test_desktop_mvp_resources.py
@@ -69,6 +69,17 @@ def test_desktop_main_checks_windows_pty_python_dependency() -> None:
     assert "SCISTUDIO_DESKTOP_PYTHON" in main_js
 
 
+def test_desktop_runtime_env_adds_common_user_cli_paths() -> None:
+    """Dock/Finder-launched desktop sessions must still find user CLIs."""
+    main_js = (DESKTOP_DIR / "main.js").read_text(encoding="utf-8")
+
+    assert "commonUserCliDirs" in main_js
+    assert 'path.join(userHome, ".local", "bin")' in main_js
+    assert 'path.join(userHome, ".npm-global", "bin")' in main_js
+    assert '"/opt/homebrew/bin"' in main_js
+    assert '"/usr/local/bin"' in main_js
+
+
 def test_desktop_has_portable_python_runtime_builder() -> None:
     """The desktop MVP must have a reproducible self-contained Python builder."""
     script = DESKTOP_DIR / "scripts" / "build-python-runtime.ps1"


### PR DESCRIPTION
Closes #1694
Closes #1695
Closes #1696
Closes #1697

## Summary
- Fix desktop local package installs so selected source/wheel packages register blocks and resolve runtime dependencies with bundled Python into user-scoped plugin runtime directories.
- Add a desktop user Terminal entry that opens a PTY shell in the current project with `python`/`pip` routed through bundled Python and a shared user dependency runtime.
- Preserve package/core boundaries by filtering `scistudio` from plugin dependency installs and keeping package/user dependency roots scoped to registry scans and worker import env.
- Keep existing PTY rendering and variadic-port hotfixes in the same batch PR.

## Validation
- `PYTHONPATH=src pytest -q --no-cov tests/desktop/test_package_installer.py tests/blocks/test_desktop_package_discovery.py tests/api/test_ai_pty.py tests/ai/test_windows_executable_resolution.py`
- `npm --prefix frontend test -- TerminalTabs.test.tsx usePtyWebSocket.test.ts`
- `ruff check` / `ruff format --check` on touched Python files
- `npm --prefix frontend run typecheck`
- `npm --prefix frontend exec prettier -- --check ...` on touched frontend files
- `python scripts/deferral_scan.py --check docs/audit/baselines/deferral-baseline.json`
- `.workflow/local/venv/bin/python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json`
- `PYTHONPATH=src python -m scistudio.qa.governance.gate_record check --record .workflow/records/1694-1697-hotfix-batch.json --mode pre-pr`
- Desktop runtime validation through Electron/staged resources, including `user-terminal` PTY env showing bundled Python and user dependency `PIP_TARGET`.
