### PR TITLE
hotfix(#1701): stabilize desktop toolbar and terminal UX

### DIFF
--- a/.workflow/records/1701-hotfix-desktop-toolbar-project-label-layout.json
+++ b/.workflow/records/1701-hotfix-desktop-toolbar-project-label-layout.json
@@ -350,13 +350,139 @@
       "tool_versions": {
         "mypy": "2.1.0"
       }
+    },
+    {
+      "at": "2026-06-19T05:14:49.978369Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e4ee0b3aa6f37143a6756338223365b450ca858c8757883e03357230acfcc606",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-19T05:14:53.074414Z",
+      "command": "(cd frontend && npm run lint)",
+      "covered_surface": "frontend",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e4ee0b3aa6f37143a6756338223365b450ca858c8757883e03357230acfcc606",
+      "name": "frontend",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/frontend.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-19T05:14:56.729358Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e4ee0b3aa6f37143a6756338223365b450ca858c8757883e03357230acfcc606",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-19T05:14:56.833270Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e4ee0b3aa6f37143a6756338223365b450ca858c8757883e03357230acfcc606",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-19T05:14:56.849754Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e4ee0b3aa6f37143a6756338223365b450ca858c8757883e03357230acfcc606",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-19T05:16:35.941510Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e4ee0b3aa6f37143a6756338223365b450ca858c8757883e03357230acfcc606",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-19T05:18:35.049882Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e4ee0b3aa6f37143a6756338223365b450ca858c8757883e03357230acfcc606",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-19T05:18:35.606014Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e4ee0b3aa6f37143a6756338223365b450ca858c8757883e03357230acfcc606",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
     }
   ],
   "check_na": [],
   "commit": {
-    "sha": "6cb358d10bdd678eddb235d4be658287e6afc5c5",
+    "sha": "7268195ed6594e313ad308bb747a6c8a8407c3c3",
     "shas": [
-      "6cb358d10bdd678eddb235d4be658287e6afc5c5"
+      "7268195ed6594e313ad308bb747a6c8a8407c3c3"
     ],
     "trailers": []
   },
@@ -703,6 +829,88 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-06-19T05:18:35.659909Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T05:18:35.671437Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T05:18:35.682828Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T05:18:35.694259Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T05:18:35.704914Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T05:18:35.715933Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T05:18:35.726983Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T05:18:35.739680Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T05:18:35.750657Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T05:18:35.767422Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -739,12 +947,13 @@
       "frontend/src/store/types.ts",
       "frontend/src/types/ui.ts",
       "src/scistudio/api/routes/ai.py",
+      "tests/ai/test_windows_executable_resolution.py",
       "tests/api/test_provider_discovery.py",
       "tests/packaging/test_desktop_mvp_resources.py"
     ],
-    "diff_fingerprint": "sha256:9428751beae6bae3027488510130569decff3b6a9ead417a14ecca04c8ff32f9",
+    "diff_fingerprint": "sha256:2878cd98b194b7c383bafc5090fb05d540a06ccba94347df40e08d29dd95cf85",
     "head": "HEAD",
-    "head_sha": "6cb358d1",
+    "head_sha": "7268195e",
     "surfaces": {
       "docs": 0,
       "frontend": 17,
@@ -753,8 +962,8 @@
       "implementation": 18,
       "packaging": 0,
       "protected_core": 0,
-      "sentrux": 20,
-      "test": 7,
+      "sentrux": 21,
+      "test": 8,
       "workflow_ci": 0
     }
   },
@@ -801,6 +1010,14 @@
       "at": "2026-06-19T05:14:37.044710Z",
       "diff_fingerprint": "sha256:9428751beae6bae3027488510130569decff3b6a9ead417a14ecca04c8ff32f9",
       "mode": "local",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-19T05:18:35.767485Z",
+      "diff_fingerprint": "sha256:2878cd98b194b7c383bafc5090fb05d540a06ccba94347df40e08d29dd95cf85",
+      "mode": "pre-pr",
       "result": "pass",
       "tier": 2,
       "unsatisfied": []

--- a/.workflow/records/1701-hotfix-desktop-toolbar-project-label-layout.json
+++ b/.workflow/records/1701-hotfix-desktop-toolbar-project-label-layout.json
@@ -476,13 +476,265 @@
       "tool_versions": {
         "mypy": "2.1.0"
       }
+    },
+    {
+      "at": "2026-06-19T05:19:33.589190Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e4ee0b3aa6f37143a6756338223365b450ca858c8757883e03357230acfcc606",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-19T05:19:36.623396Z",
+      "command": "(cd frontend && npm run lint)",
+      "covered_surface": "frontend",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e4ee0b3aa6f37143a6756338223365b450ca858c8757883e03357230acfcc606",
+      "name": "frontend",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/frontend.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-19T05:19:40.200463Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e4ee0b3aa6f37143a6756338223365b450ca858c8757883e03357230acfcc606",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-19T05:19:40.311045Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e4ee0b3aa6f37143a6756338223365b450ca858c8757883e03357230acfcc606",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-19T05:19:40.327652Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e4ee0b3aa6f37143a6756338223365b450ca858c8757883e03357230acfcc606",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-19T05:21:24.580020Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:e4ee0b3aa6f37143a6756338223365b450ca858c8757883e03357230acfcc606",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-19T05:23:19.586256Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e4ee0b3aa6f37143a6756338223365b450ca858c8757883e03357230acfcc606",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-19T05:23:20.128111Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e4ee0b3aa6f37143a6756338223365b450ca858c8757883e03357230acfcc606",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    },
+    {
+      "at": "2026-06-19T05:24:19.337943Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e4ee0b3aa6f37143a6756338223365b450ca858c8757883e03357230acfcc606",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-19T05:24:22.270924Z",
+      "command": "(cd frontend && npm run lint)",
+      "covered_surface": "frontend",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e4ee0b3aa6f37143a6756338223365b450ca858c8757883e03357230acfcc606",
+      "name": "frontend",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/frontend.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-19T05:24:25.937683Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e4ee0b3aa6f37143a6756338223365b450ca858c8757883e03357230acfcc606",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-19T05:24:26.048610Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e4ee0b3aa6f37143a6756338223365b450ca858c8757883e03357230acfcc606",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-19T05:24:26.063210Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e4ee0b3aa6f37143a6756338223365b450ca858c8757883e03357230acfcc606",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-19T05:26:03.785861Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e4ee0b3aa6f37143a6756338223365b450ca858c8757883e03357230acfcc606",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-19T05:27:51.727728Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e4ee0b3aa6f37143a6756338223365b450ca858c8757883e03357230acfcc606",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-19T05:27:52.259261Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e4ee0b3aa6f37143a6756338223365b450ca858c8757883e03357230acfcc606",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
     }
   ],
   "check_na": [],
   "commit": {
-    "sha": "7268195ed6594e313ad308bb747a6c8a8407c3c3",
+    "sha": "a04a413a2c0cfa1ed1c75c4a6e692daf10a00189",
     "shas": [
-      "7268195ed6594e313ad308bb747a6c8a8407c3c3"
+      "a04a413a2c0cfa1ed1c75c4a6e692daf10a00189"
     ],
     "trailers": []
   },
@@ -911,6 +1163,252 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-06-19T05:23:20.185453Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T05:23:20.195421Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T05:23:20.205978Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T05:23:20.216626Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T05:23:20.226467Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T05:23:20.236749Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T05:23:20.246420Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T05:23:20.256239Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T05:23:20.265939Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T05:23:20.282246Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T05:27:52.308524Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T05:27:52.319730Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T05:27:52.331217Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T05:27:52.343332Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T05:27:52.354901Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T05:27:52.367394Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T05:27:52.379512Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T05:27:52.391020Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T05:27:52.402197Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T05:27:52.419618Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T05:28:09.489678Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T05:28:09.498848Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T05:28:09.507668Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T05:28:09.516637Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T05:28:09.525232Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T05:28:09.533865Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T05:28:09.542559Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T05:28:09.551510Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T05:28:09.560380Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T05:28:09.575357Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -923,7 +1421,7 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "origin/main",
+    "base": "0f7a2e169270ae4b180ed685dc0dcc9d9dc9e983",
     "base_sha": "0f7a2e16",
     "changed_files": [
       ".workflow/records/1701-hotfix-desktop-toolbar-project-label-layout.json",
@@ -951,9 +1449,9 @@
       "tests/api/test_provider_discovery.py",
       "tests/packaging/test_desktop_mvp_resources.py"
     ],
-    "diff_fingerprint": "sha256:2878cd98b194b7c383bafc5090fb05d540a06ccba94347df40e08d29dd95cf85",
+    "diff_fingerprint": "sha256:0e66fe5b4206f1d6ae2ae96168a5eac164969b9b5fe62d5544ee4c4538f01fa2",
     "head": "HEAD",
-    "head_sha": "7268195e",
+    "head_sha": "a04a413a",
     "surfaces": {
       "docs": 0,
       "frontend": 17,
@@ -974,8 +1472,8 @@
     "closes": [
       1701
     ],
-    "number": null,
-    "url": null
+    "number": 1702,
+    "url": "https://github.com/zjzcpj/SciStudio/pull/1702"
   },
   "reconcile_events": [
     {
@@ -1021,22 +1519,39 @@
       "result": "pass",
       "tier": 2,
       "unsatisfied": []
+    },
+    {
+      "at": "2026-06-19T05:23:20.282316Z",
+      "diff_fingerprint": "sha256:0e66fe5b4206f1d6ae2ae96168a5eac164969b9b5fe62d5544ee4c4538f01fa2",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.python_tests"
+      ]
+    },
+    {
+      "at": "2026-06-19T05:27:52.419706Z",
+      "diff_fingerprint": "sha256:0e66fe5b4206f1d6ae2ae96168a5eac164969b9b5fe62d5544ee4c4538f01fa2",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-19T05:28:09.575407Z",
+      "diff_fingerprint": "sha256:0e66fe5b4206f1d6ae2ae96168a5eac164969b9b5fe62d5544ee4c4538f01fa2",
+      "mode": "ci",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
     }
   ],
   "record_id": "1701-hotfix-desktop-toolbar-project-label-layout",
   "requested_admin_labels": [],
   "required_obligations": {
     "admin_labels": [],
-    "checks": [
-      "format_check",
-      "frontend",
-      "full_audit",
-      "import_contracts",
-      "lint_format",
-      "python_tests",
-      "semantic_dup",
-      "type_check"
-    ],
+    "checks": [],
     "docs": [
       "docs_required_or_na"
     ],

--- a/.workflow/records/1701-hotfix-desktop-toolbar-project-label-layout.json
+++ b/.workflow/records/1701-hotfix-desktop-toolbar-project-label-layout.json
@@ -732,9 +732,9 @@
   ],
   "check_na": [],
   "commit": {
-    "sha": "a04a413a2c0cfa1ed1c75c4a6e692daf10a00189",
+    "sha": "73bd5415",
     "shas": [
-      "a04a413a2c0cfa1ed1c75c4a6e692daf10a00189"
+      "73bd5415"
     ],
     "trailers": []
   },
@@ -1409,6 +1409,88 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-06-19T05:32:25.504197Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T05:32:25.513015Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T05:32:25.521645Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T05:32:25.530500Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T05:32:25.538920Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T05:32:25.547868Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T05:32:25.556744Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T05:32:25.565506Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T05:32:25.574425Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T05:32:25.589461Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -1449,9 +1531,9 @@
       "tests/api/test_provider_discovery.py",
       "tests/packaging/test_desktop_mvp_resources.py"
     ],
-    "diff_fingerprint": "sha256:0e66fe5b4206f1d6ae2ae96168a5eac164969b9b5fe62d5544ee4c4538f01fa2",
+    "diff_fingerprint": "sha256:880e07b4f076eb6b41767df31493869bf1d89a3375d11442bcb58f56faf6c4a8",
     "head": "HEAD",
-    "head_sha": "a04a413a",
+    "head_sha": "73bd5415",
     "surfaces": {
       "docs": 0,
       "frontend": 17,
@@ -1541,6 +1623,14 @@
     {
       "at": "2026-06-19T05:28:09.575407Z",
       "diff_fingerprint": "sha256:0e66fe5b4206f1d6ae2ae96168a5eac164969b9b5fe62d5544ee4c4538f01fa2",
+      "mode": "ci",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-19T05:32:25.589508Z",
+      "diff_fingerprint": "sha256:880e07b4f076eb6b41767df31493869bf1d89a3375d11442bcb58f56faf6c4a8",
       "mode": "ci",
       "result": "pass",
       "tier": 2,

--- a/.workflow/records/1701-hotfix-desktop-toolbar-project-label-layout.json
+++ b/.workflow/records/1701-hotfix-desktop-toolbar-project-label-layout.json
@@ -1,0 +1,1193 @@
+{
+  "branch": "hotfix/desktop-toolbar-project-label-layout",
+  "check_events": [
+    {
+      "at": "2026-06-19T05:04:57.149418Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-19T05:05:01.636583Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-19T05:05:01.693279Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-19T05:05:25.139759Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-19T05:05:28.575722Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-19T05:05:28.601411Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-19T05:06:17.299774Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:c7de74864bd9564cc852b68b1cfeadfe9d8c439335ac3befa263fce71aaa727b",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-19T05:06:20.561264Z",
+      "command": "(cd frontend && npm run lint)",
+      "covered_surface": "frontend",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:c7de74864bd9564cc852b68b1cfeadfe9d8c439335ac3befa263fce71aaa727b",
+      "name": "frontend",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/frontend.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-19T05:06:23.879622Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:c7de74864bd9564cc852b68b1cfeadfe9d8c439335ac3befa263fce71aaa727b",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-19T05:06:24.365382Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:c7de74864bd9564cc852b68b1cfeadfe9d8c439335ac3befa263fce71aaa727b",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-19T05:06:24.380321Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:c7de74864bd9564cc852b68b1cfeadfe9d8c439335ac3befa263fce71aaa727b",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-19T05:08:21.936361Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:c7de74864bd9564cc852b68b1cfeadfe9d8c439335ac3befa263fce71aaa727b",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-19T05:10:11.356365Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:c7de74864bd9564cc852b68b1cfeadfe9d8c439335ac3befa263fce71aaa727b",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-19T05:10:18.724619Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:c7de74864bd9564cc852b68b1cfeadfe9d8c439335ac3befa263fce71aaa727b",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    },
+    {
+      "at": "2026-06-19T05:11:03.929436Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:c7de74864bd9564cc852b68b1cfeadfe9d8c439335ac3befa263fce71aaa727b",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-19T05:11:06.890476Z",
+      "command": "(cd frontend && npm run lint)",
+      "covered_surface": "frontend",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:c7de74864bd9564cc852b68b1cfeadfe9d8c439335ac3befa263fce71aaa727b",
+      "name": "frontend",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/frontend.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-19T05:11:10.448528Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:c7de74864bd9564cc852b68b1cfeadfe9d8c439335ac3befa263fce71aaa727b",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-19T05:11:10.551864Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:c7de74864bd9564cc852b68b1cfeadfe9d8c439335ac3befa263fce71aaa727b",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-19T05:11:10.573758Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:c7de74864bd9564cc852b68b1cfeadfe9d8c439335ac3befa263fce71aaa727b",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-19T05:12:46.928457Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:c7de74864bd9564cc852b68b1cfeadfe9d8c439335ac3befa263fce71aaa727b",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-19T05:14:36.405253Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:c7de74864bd9564cc852b68b1cfeadfe9d8c439335ac3befa263fce71aaa727b",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-19T05:14:36.914518Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:c7de74864bd9564cc852b68b1cfeadfe9d8c439335ac3befa263fce71aaa727b",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    }
+  ],
+  "check_na": [],
+  "commit": {
+    "sha": "6cb358d10bdd678eddb235d4be658287e6afc5c5",
+    "shas": [
+      "6cb358d10bdd678eddb235d4be658287e6afc5c5"
+    ],
+    "trailers": []
+  },
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "desktop/main.js",
+      "desktop/scripts/start-dev.js",
+      "frontend/src/components/AIChat/**",
+      "frontend/src/components/BottomPanel*",
+      "frontend/src/components/BottomPanel.parts/**",
+      "frontend/src/components/Toolbar*",
+      "frontend/src/components/Toolbar.parts/**",
+      "frontend/src/store/**",
+      "frontend/src/types/ui.ts",
+      "src/scistudio/api/routes/ai.py",
+      "tests/api/test_provider_discovery.py",
+      "tests/packaging/test_desktop_mvp_resources.py"
+    ]
+  },
+  "directive_events": [
+    {
+      "at": "2026-06-19T05:03:51.401860Z",
+      "owner_directive": "Finalize owner-approved hotfix batch after reverting the too-early toolbar label hiding experiment.",
+      "reason": "plan"
+    }
+  ],
+  "docs_events": [
+    {
+      "at": "2026-06-19T05:03:51.402084Z",
+      "class": "product-docs",
+      "kind": "na",
+      "path": null,
+      "rationale": "owner-guided desktop UX/runtime hotfix; no public contract or user workflow documentation change required beyond tests",
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-19T05:04:28.744432Z",
+      "class": "product-docs",
+      "kind": "na",
+      "path": null,
+      "rationale": "owner-guided desktop UX/runtime hotfix; no public contract or user workflow documentation change required beyond tests",
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-19T05:05:24.974809Z",
+      "class": "product-docs",
+      "kind": "na",
+      "path": null,
+      "rationale": "owner-guided desktop UX/runtime hotfix; no public contract or user workflow documentation change required beyond tests",
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-19T05:11:03.742474Z",
+      "class": "product-docs",
+      "kind": "na",
+      "path": null,
+      "rationale": "owner-guided desktop UX/runtime hotfix; no public contract or user workflow documentation change required beyond tests",
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": false,
+  "guard_events": [
+    {
+      "at": "2026-06-19T05:05:01.717701Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T05:05:01.729633Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T05:05:01.740717Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T05:05:01.750889Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T05:05:01.761041Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T05:05:01.772090Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T05:05:01.782460Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T05:05:01.792908Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T05:05:01.803198Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T05:05:01.813472Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T05:05:28.622911Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T05:05:28.633450Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T05:05:28.644530Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T05:05:28.654949Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T05:05:28.665141Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T05:05:28.674971Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T05:05:28.685387Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T05:05:28.695629Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T05:05:28.705428Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T05:05:28.715674Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T05:10:18.765464Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T05:10:18.774896Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T05:10:18.785275Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T05:10:18.794633Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T05:10:18.803979Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T05:10:18.813096Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T05:10:18.822223Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T05:10:18.831487Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T05:10:18.840942Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T05:10:18.854567Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T05:14:36.958467Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T05:14:36.968422Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T05:14:36.977599Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T05:14:36.987246Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T05:14:36.996267Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T05:14:37.005279Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T05:14:37.014291Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T05:14:37.023479Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T05:14:37.032155Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-19T05:14:37.044648Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1701,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": {
+    "base": "origin/main",
+    "base_sha": "0f7a2e16",
+    "changed_files": [
+      ".workflow/records/1701-hotfix-desktop-toolbar-project-label-layout.json",
+      "desktop/main.js",
+      "desktop/scripts/start-dev.js",
+      "frontend/src/components/AIChat/SetupScreen.tsx",
+      "frontend/src/components/AIChat/TerminalTabs.parts/TabStrip.tsx",
+      "frontend/src/components/AIChat/TerminalTabs.tsx",
+      "frontend/src/components/AIChat/__tests__/SetupScreen.test.tsx",
+      "frontend/src/components/AIChat/__tests__/TerminalTabs.test.tsx",
+      "frontend/src/components/BottomPanel.parts/ConfigPanel.test.tsx",
+      "frontend/src/components/BottomPanel.parts/ConfigPanel.tsx",
+      "frontend/src/components/BottomPanel.parts/TabBar.tsx",
+      "frontend/src/components/BottomPanel.test.tsx",
+      "frontend/src/components/BottomPanel.tsx",
+      "frontend/src/components/Toolbar.parts/ProjectHeader.tsx",
+      "frontend/src/components/Toolbar.parts/WorkflowGroups.tsx",
+      "frontend/src/components/Toolbar.test.tsx",
+      "frontend/src/store/index.ts",
+      "frontend/src/store/terminalTabsSlice.ts",
+      "frontend/src/store/types.ts",
+      "frontend/src/types/ui.ts",
+      "src/scistudio/api/routes/ai.py",
+      "tests/api/test_provider_discovery.py",
+      "tests/packaging/test_desktop_mvp_resources.py"
+    ],
+    "diff_fingerprint": "sha256:9428751beae6bae3027488510130569decff3b6a9ead417a14ecca04c8ff32f9",
+    "head": "HEAD",
+    "head_sha": "6cb358d1",
+    "surfaces": {
+      "docs": 0,
+      "frontend": 17,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 18,
+      "packaging": 0,
+      "protected_core": 0,
+      "sentrux": 20,
+      "test": 7,
+      "workflow_ci": 0
+    }
+  },
+  "owner_directive": "Owner-guided desktop hotfix batch for toolbar UX, AI provider auth detection, terminal tab semantics, PTY proxying, and AI chat setup button visibility.",
+  "persona": "implementer",
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [
+      1701
+    ],
+    "number": null,
+    "url": null
+  },
+  "reconcile_events": [
+    {
+      "at": "2026-06-19T05:05:01.813532Z",
+      "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "mode": "local",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.format_check"
+      ]
+    },
+    {
+      "at": "2026-06-19T05:05:28.715755Z",
+      "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "mode": "local",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-19T05:10:18.854627Z",
+      "diff_fingerprint": "sha256:9428751beae6bae3027488510130569decff3b6a9ead417a14ecca04c8ff32f9",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.python_tests"
+      ]
+    },
+    {
+      "at": "2026-06-19T05:14:37.044710Z",
+      "diff_fingerprint": "sha256:9428751beae6bae3027488510130569decff3b6a9ead417a14ecca04c8ff32f9",
+      "mode": "local",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    }
+  ],
+  "record_id": "1701-hotfix-desktop-toolbar-project-label-layout",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [
+      "format_check",
+      "frontend",
+      "full_audit",
+      "import_contracts",
+      "lint_format",
+      "python_tests",
+      "semantic_dup",
+      "type_check"
+    ],
+    "docs": [
+      "docs_required_or_na"
+    ],
+    "guards": [
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": [
+      "changed_test_required"
+    ]
+  },
+  "runtime": "codex",
+  "schema_version": 2,
+  "scope_events": [
+    {
+      "action": "add-include",
+      "at": "2026-06-19T05:10:33.718340Z",
+      "pattern": "tests/ai/test_windows_executable_resolution.py",
+      "reason": "pre-PR full pytest found existing Windows binary-status contract test needed update for the new binary return value"
+    }
+  ],
+  "session_id": "833baf55-80da-4378-80eb-f5540c094489",
+  "strictness_tier": 2,
+  "task_kind": "hotfix",
+  "test_events": [
+    {
+      "at": "2026-06-19T05:03:51.402097Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/components/Toolbar.test.tsx",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-19T05:03:51.402102Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/components/BottomPanel.test.tsx",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-19T05:03:51.402104Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/components/BottomPanel.parts/ConfigPanel.test.tsx",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-19T05:03:51.402105Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/components/AIChat/__tests__/SetupScreen.test.tsx",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-19T05:03:51.402106Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/components/AIChat/__tests__/TerminalTabs.test.tsx",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-19T05:03:51.402107Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/components/AIChat/__tests__/TerminalTab.test.tsx",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-19T05:03:51.402108Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/components/AIChat/__tests__/usePtyWebSocket.test.ts",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-19T05:03:51.402109Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/api/test_provider_discovery.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-19T05:03:51.402110Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/api/test_ai_pty.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-19T05:03:51.402111Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/packaging/test_desktop_mvp_resources.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-19T05:04:28.744564Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/components/Toolbar.test.tsx",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-19T05:04:28.744571Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/components/BottomPanel.test.tsx",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-19T05:04:28.744573Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/components/BottomPanel.parts/ConfigPanel.test.tsx",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-19T05:04:28.744574Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/components/AIChat/__tests__/SetupScreen.test.tsx",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-19T05:04:28.744575Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/components/AIChat/__tests__/TerminalTabs.test.tsx",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-19T05:04:28.744576Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/components/AIChat/__tests__/TerminalTab.test.tsx",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-19T05:04:28.744577Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/components/AIChat/__tests__/usePtyWebSocket.test.ts",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-19T05:04:28.744578Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/api/test_provider_discovery.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-19T05:04:28.744579Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/api/test_ai_pty.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-19T05:04:28.744580Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/packaging/test_desktop_mvp_resources.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-19T05:05:24.974986Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/components/Toolbar.test.tsx",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-19T05:05:24.974992Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/components/BottomPanel.test.tsx",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-19T05:05:24.974994Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/components/BottomPanel.parts/ConfigPanel.test.tsx",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-19T05:05:24.974995Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/components/AIChat/__tests__/SetupScreen.test.tsx",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-19T05:05:24.974996Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/components/AIChat/__tests__/TerminalTabs.test.tsx",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-19T05:05:24.974997Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/components/AIChat/__tests__/TerminalTab.test.tsx",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-19T05:05:24.974998Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/components/AIChat/__tests__/usePtyWebSocket.test.ts",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-19T05:05:24.974999Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/api/test_provider_discovery.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-19T05:05:24.975000Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/api/test_ai_pty.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-19T05:05:24.975001Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/packaging/test_desktop_mvp_resources.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-19T05:10:33.718469Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/ai/test_windows_executable_resolution.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-19T05:11:03.742613Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/components/Toolbar.test.tsx",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-19T05:11:03.742618Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/components/BottomPanel.test.tsx",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-19T05:11:03.742620Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/components/BottomPanel.parts/ConfigPanel.test.tsx",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-19T05:11:03.742621Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/components/AIChat/__tests__/SetupScreen.test.tsx",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-19T05:11:03.742623Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/components/AIChat/__tests__/TerminalTabs.test.tsx",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-19T05:11:03.742624Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/components/AIChat/__tests__/TerminalTab.test.tsx",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-19T05:11:03.742625Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/components/AIChat/__tests__/usePtyWebSocket.test.ts",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-19T05:11:03.742626Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/api/test_provider_discovery.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-19T05:11:03.742627Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/api/test_ai_pty.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-19T05:11:03.742628Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/packaging/test_desktop_mvp_resources.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-19T05:11:03.742629Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/ai/test_windows_executable_resolution.py",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -1,5 +1,5 @@
 const { app, BrowserWindow, dialog, session } = require("electron");
-const { spawn } = require("child_process");
+const { spawn, spawnSync } = require("child_process");
 const fs = require("fs");
 const http = require("http");
 const https = require("https");
@@ -15,6 +15,7 @@ const DEFAULT_DEV_FRONTEND_URL = "http://127.0.0.1:5173";
 let mainWindow = null;
 let runtimeProcess = null;
 let isQuitting = false;
+let cachedMacLoginShellEnv = null;
 
 function installPipeGuard(stream) {
   if (!stream || typeof stream.on !== "function") {
@@ -138,23 +139,89 @@ function commonUserCliDirs(userHome) {
   return dirs;
 }
 
+function parseNullSeparatedEnv(payload) {
+  const env = {};
+  for (const record of payload.split("\0")) {
+    if (!record) {
+      continue;
+    }
+    const equalsAt = record.indexOf("=");
+    if (equalsAt <= 0) {
+      continue;
+    }
+    const key = record.slice(0, equalsAt);
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) {
+      continue;
+    }
+    env[key] = record.slice(equalsAt + 1);
+  }
+  return env;
+}
+
+function macLoginShellEnv() {
+  if (process.platform !== "darwin") {
+    return {};
+  }
+  if (cachedMacLoginShellEnv !== null) {
+    return cachedMacLoginShellEnv;
+  }
+
+  cachedMacLoginShellEnv = {};
+  const userInfo = (() => {
+    try {
+      return os.userInfo();
+    } catch {
+      return {};
+    }
+  })();
+  const shell = process.env.SHELL || userInfo.shell || "/bin/zsh";
+  const marker = "__SCISTUDIO_ENV_START__\0";
+  const script = "printf '__SCISTUDIO_ENV_START__\\0'; /usr/bin/env -0";
+
+  try {
+    const result = spawnSync(shell, ["-l", "-c", script], {
+      cwd: os.homedir(),
+      env: process.env,
+      encoding: "utf8",
+      timeout: 3000,
+      windowsHide: true
+    });
+    if (result.error || result.status !== 0 || !result.stdout) {
+      return cachedMacLoginShellEnv;
+    }
+    const markerAt = result.stdout.indexOf(marker);
+    const payload =
+      markerAt >= 0 ? result.stdout.slice(markerAt + marker.length) : result.stdout;
+    cachedMacLoginShellEnv = parseNullSeparatedEnv(payload);
+  } catch (error) {
+    safeError(`[scistudio] Failed to read macOS login shell environment: ${error.message}`);
+  }
+  return cachedMacLoginShellEnv;
+}
+
 function runtimeEnv() {
   const resources = resourcesDir();
   const stagedSrc = path.join(resources, "backend", "src");
   const checkoutSrc = path.join(repoRoot(), "src");
   const pythonPathEntries = [stagedSrc, checkoutSrc].filter(Boolean);
-  const existingPythonPath = process.env.PYTHONPATH;
-  const userHome = process.env.USERPROFILE || process.env.HOME || "";
+  const loginShellEnv = macLoginShellEnv();
+  const baseEnv = {
+    ...loginShellEnv,
+    ...process.env
+  };
+  const existingPythonPath = baseEnv.PYTHONPATH;
+  const userHome = baseEnv.USERPROFILE || baseEnv.HOME || os.homedir() || "";
   const pathEntries = [];
 
   if (existingPythonPath) {
     pythonPathEntries.push(existingPythonPath);
   }
   pathEntries.push(...commonUserCliDirs(userHome));
+  pathEntries.push(loginShellEnv.PATH || "");
   pathEntries.push(process.env.PATH || "");
 
   const env = {
-    ...process.env,
+    ...baseEnv,
     PATH: pathEntries.filter(Boolean).join(path.delimiter),
     PYTHONPATH: pythonPathEntries.join(path.delimiter),
     SCISTUDIO_BUNDLED: "1",

--- a/desktop/scripts/start-dev.js
+++ b/desktop/scripts/start-dev.js
@@ -6,6 +6,7 @@ delete process.env.ELECTRON_RUN_AS_NODE;
 const repoRoot = path.resolve(__dirname, "..", "..");
 const frontendUrl = process.env.SCISTUDIO_DESKTOP_FRONTEND_URL || "http://127.0.0.1:5173";
 const runtimePort = process.env.SCISTUDIO_DESKTOP_RUNTIME_PORT || "8000";
+const apiProxyTarget = process.env.SCISTUDIO_API_PROXY || `http://127.0.0.1:${runtimePort}`;
 const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
 
 function spawnChild(command, args, options = {}) {
@@ -32,7 +33,12 @@ const vite = spawnChild(npmCommand, [
   "127.0.0.1",
   "--port",
   "5173",
-]);
+], {
+  env: {
+    ...process.env,
+    SCISTUDIO_API_PROXY: apiProxyTarget,
+  },
+});
 
 const electron = spawnChild(
   npmCommand,

--- a/frontend/src/components/AIChat/SetupScreen.tsx
+++ b/frontend/src/components/AIChat/SetupScreen.tsx
@@ -122,7 +122,10 @@ export function SetupScreen({ tabId, onLaunch, onCancel }: SetupScreenProps) {
       className="flex h-full min-h-0 flex-col overflow-hidden px-4 py-3"
       data-testid={`setup-screen-${tabId}`}
     >
-      <div className="min-h-0 flex-1 space-y-4 overflow-y-auto pr-1" data-testid="setup-scroll-body">
+      <div
+        className="min-h-0 flex-1 space-y-4 overflow-y-auto pr-1"
+        data-testid="setup-scroll-body"
+      >
         <h3 className="text-base font-semibold text-ink">New chat — Setup</h3>
 
         {statusError ? (

--- a/frontend/src/components/AIChat/SetupScreen.tsx
+++ b/frontend/src/components/AIChat/SetupScreen.tsx
@@ -119,47 +119,52 @@ export function SetupScreen({ tabId, onLaunch, onCancel }: SetupScreenProps) {
 
   return (
     <div
-      className="flex h-full flex-col gap-4 overflow-y-auto px-4 py-3"
+      className="flex h-full min-h-0 flex-col overflow-hidden px-4 py-3"
       data-testid={`setup-screen-${tabId}`}
     >
-      <h3 className="text-base font-semibold text-ink">New chat — Setup</h3>
+      <div className="min-h-0 flex-1 space-y-4 overflow-y-auto pr-1" data-testid="setup-scroll-body">
+        <h3 className="text-base font-semibold text-ink">New chat — Setup</h3>
 
-      {statusError ? (
+        {statusError ? (
+          <div
+            className="rounded-2xl border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800"
+            data-testid="setup-status-error"
+          >
+            Could not check provider status ({statusError}). Launch will be disabled until
+            /api/ai/status is reachable.
+          </div>
+        ) : null}
+
+        <ProviderPicker
+          tabId={tabId}
+          claudeStatus={providersByName["claude-code"]}
+          codexStatus={providersByName["codex"]}
+          statusLoading={statusLoading}
+          provider={provider}
+          onChange={setProvider}
+        />
+
+        <PermissionModePicker
+          tabId={tabId}
+          permissionMode={permissionMode}
+          onChange={setPermissionMode}
+        />
+
         <div
-          className="rounded-2xl border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800"
-          data-testid="setup-status-error"
+          className="rounded-2xl border border-stone-200 bg-stone-50 px-3 py-2 text-xs text-stone-600"
+          data-testid="setup-working-dir"
         >
-          Could not check provider status ({statusError}). Launch will be disabled until
-          /api/ai/status is reachable.
+          Working dir:{" "}
+          <span className="font-mono">
+            {projectPath ?? <em className="text-stone-400">(no project open)</em>}
+          </span>
         </div>
-      ) : null}
-
-      <ProviderPicker
-        tabId={tabId}
-        claudeStatus={providersByName["claude-code"]}
-        codexStatus={providersByName["codex"]}
-        statusLoading={statusLoading}
-        provider={provider}
-        onChange={setProvider}
-      />
-
-      <PermissionModePicker
-        tabId={tabId}
-        permissionMode={permissionMode}
-        onChange={setPermissionMode}
-      />
-
-      <div
-        className="rounded-2xl border border-stone-200 bg-stone-50 px-3 py-2 text-xs text-stone-600"
-        data-testid="setup-working-dir"
-      >
-        Working dir:{" "}
-        <span className="font-mono">
-          {projectPath ?? <em className="text-stone-400">(no project open)</em>}
-        </span>
       </div>
 
-      <div className="mt-auto flex items-center justify-end gap-2 pt-2">
+      <div
+        className="flex shrink-0 items-center justify-end gap-2 border-t border-stone-200 pt-3"
+        data-testid="setup-actions"
+      >
         <button
           type="button"
           className="rounded-full border border-stone-300 px-4 py-2 text-sm text-stone-600 hover:bg-stone-50"

--- a/frontend/src/components/AIChat/TerminalTabs.parts/TabStrip.tsx
+++ b/frontend/src/components/AIChat/TerminalTabs.parts/TabStrip.tsx
@@ -23,11 +23,19 @@ export interface TabStripProps {
   onRenameCancel: () => void;
   onRequestClose: (id: string) => void;
   onAdd: () => void;
+  primaryAddLabel?: string;
+  showUserTerminalButton?: boolean;
   onAddUserTerminal: () => void;
 }
 
 export function TabStrip(props: TabStripProps) {
-  const { tabs, activeTabId, onAdd } = props;
+  const {
+    tabs,
+    activeTabId,
+    onAdd,
+    primaryAddLabel = "New chat tab",
+    showUserTerminalButton = true,
+  } = props;
   return (
     <div
       className="flex shrink-0 items-center gap-1 border-b border-stone-200 bg-stone-50/60 px-2 py-1"
@@ -54,21 +62,23 @@ export function TabStrip(props: TabStripProps) {
         type="button"
         className="ml-1 rounded p-1 text-stone-500 hover:bg-stone-200 hover:text-stone-700"
         onClick={onAdd}
-        aria-label="New chat tab"
+        aria-label={primaryAddLabel}
         data-testid="terminal-tabs-add"
       >
         <Plus size={16} aria-hidden="true" />
       </button>
-      <button
-        type="button"
-        className="ml-1 inline-flex items-center gap-1 rounded px-2 py-1 text-xs text-stone-600 hover:bg-stone-200 hover:text-stone-800"
-        onClick={props.onAddUserTerminal}
-        aria-label="New Python terminal"
-        data-testid="terminal-tabs-add-user-terminal"
-      >
-        <TerminalIcon size={14} aria-hidden="true" />
-        <span>Terminal</span>
-      </button>
+      {showUserTerminalButton ? (
+        <button
+          type="button"
+          className="ml-1 inline-flex items-center gap-1 rounded px-2 py-1 text-xs text-stone-600 hover:bg-stone-200 hover:text-stone-800"
+          onClick={props.onAddUserTerminal}
+          aria-label="New Python terminal"
+          data-testid="terminal-tabs-add-user-terminal"
+        >
+          <TerminalIcon size={14} aria-hidden="true" />
+          <span>Terminal</span>
+        </button>
+      ) : null}
     </div>
   );
 }

--- a/frontend/src/components/AIChat/TerminalTabs.tsx
+++ b/frontend/src/components/AIChat/TerminalTabs.tsx
@@ -17,7 +17,7 @@
  *     PTY; the WS handshake reuses it by tab_id).
  *   - See `handleBlockPtyOpened` / `handleBlockPtyClosed` stubs below.
  */
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { sendWebSocketMessage } from "../../hooks/useWebSocket";
 import { useAppStore } from "../../store";
@@ -31,22 +31,25 @@ import { TabStrip } from "./TerminalTabs.parts/TabStrip";
 export { handleBlockPtyClosed, handleBlockPtyOpened } from "./blockPtyHandlers";
 
 interface ShortcutHandlers {
-  addTerminalTab: () => string;
+  addPrimaryTab: () => string;
   setActiveTerminalTab: (id: string) => void;
   requestCloseTab: (id: string) => void;
   activeTabId: string | null;
   tabs: TerminalTabModel[];
+  active: boolean;
 }
 
 function useTabKeyboardShortcuts({
-  addTerminalTab,
+  addPrimaryTab,
   setActiveTerminalTab,
   requestCloseTab,
   activeTabId,
   tabs,
+  active,
 }: ShortcutHandlers) {
   // Keyboard shortcuts (window-level, capture phase so Ctrl+W beats Chrome).
   useEffect(() => {
+    if (!active) return;
     const handler = (ev: KeyboardEvent) => {
       const ctrl = ev.ctrlKey || ev.metaKey;
       if (!ctrl) return;
@@ -54,7 +57,7 @@ function useTabKeyboardShortcuts({
       if (key === "t" && !ev.shiftKey) {
         ev.preventDefault();
         ev.stopPropagation();
-        addTerminalTab();
+        addPrimaryTab();
         return;
       }
       if (key === "w" && !ev.shiftKey) {
@@ -75,7 +78,7 @@ function useTabKeyboardShortcuts({
     };
     window.addEventListener("keydown", handler, true);
     return () => window.removeEventListener("keydown", handler, true);
-  }, [activeTabId, addTerminalTab, requestCloseTab, setActiveTerminalTab, tabs]);
+  }, [active, activeTabId, addPrimaryTab, requestCloseTab, setActiveTerminalTab, tabs]);
 }
 
 interface CloseConfirmProps {
@@ -102,7 +105,20 @@ function PendingCloseDialog({ pendingClose, tabs, onConfirm, onCancel }: CloseCo
   );
 }
 
-export function TerminalTabs() {
+export type TerminalSurface = "mixed" | "chat" | "terminal";
+
+export interface TerminalTabsProps {
+  surface?: TerminalSurface;
+  active?: boolean;
+}
+
+function tabBelongsToSurface(tab: TerminalTabModel, surface: TerminalSurface): boolean {
+  if (surface === "mixed") return true;
+  const isUserTerminal = tab.provider === "user-terminal";
+  return surface === "terminal" ? isUserTerminal : !isUserTerminal;
+}
+
+export function TerminalTabs({ surface = "mixed", active = true }: TerminalTabsProps = {}) {
   const tabs = useAppStore((s) => s.terminalTabs);
   const activeTabId = useAppStore((s) => s.activeTerminalTabId);
   const addTerminalTab = useAppStore((s) => s.addTerminalTab);
@@ -114,16 +130,40 @@ export function TerminalTabs() {
   const [renamingId, setRenamingId] = useState<string | null>(null);
   const [renameDraft, setRenameDraft] = useState("");
   const [pendingClose, setPendingClose] = useState<string | null>(null);
+  const initializedSurfaceRef = useRef(false);
+  const visibleTabs = useMemo(
+    () => tabs.filter((tab) => tabBelongsToSurface(tab, surface)),
+    [surface, tabs],
+  );
+  const visibleActiveTabId = useMemo(
+    () =>
+      visibleTabs.some((tab) => tab.id === activeTabId)
+        ? activeTabId
+        : (visibleTabs[0]?.id ?? null),
+    [activeTabId, visibleTabs],
+  );
+  const addPrimaryTab = useCallback(
+    () => (surface === "terminal" ? addUserTerminalTab() : addTerminalTab()),
+    [addTerminalTab, addUserTerminalTab, surface],
+  );
+  const primaryAddLabel = surface === "terminal" ? "New terminal tab" : "New chat tab";
 
-  // Auto-create a tab on first mount when none exist. Effect-driven so it
-  // never runs in the reducer (which would break SSR / Vitest).
+  // Auto-create the first tab only when the surface is first activated. The
+  // terminal surface creates a user shell; the chat surface creates a provider
+  // setup tab. Hidden surfaces remain mounted without spawning new processes.
+  // Once initialized, closing the final tab leaves the surface empty until the
+  // user explicitly opens another tab.
   useEffect(() => {
-    if (tabs.length === 0) {
-      addTerminalTab();
+    if (!active) return;
+    if (visibleTabs.length > 0) {
+      initializedSurfaceRef.current = true;
+      return;
     }
-    // intentional one-shot
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+    if (!initializedSurfaceRef.current) {
+      initializedSurfaceRef.current = true;
+      addPrimaryTab();
+    }
+  }, [active, addPrimaryTab, visibleTabs.length]);
 
   const requestCloseTab = useCallback(
     (id: string) => {
@@ -138,11 +178,12 @@ export function TerminalTabs() {
   );
 
   useTabKeyboardShortcuts({
-    addTerminalTab,
+    addPrimaryTab,
     setActiveTerminalTab,
     requestCloseTab,
-    activeTabId,
-    tabs,
+    activeTabId: visibleActiveTabId,
+    tabs: visibleTabs,
+    active,
   });
 
   const commitRename = useCallback(() => {
@@ -183,8 +224,8 @@ export function TerminalTabs() {
   return (
     <div className="flex h-full flex-col" data-testid="terminal-tabs">
       <TabStrip
-        tabs={tabs}
-        activeTabId={activeTabId}
+        tabs={visibleTabs}
+        activeTabId={visibleActiveTabId}
         renamingId={renamingId}
         renameDraft={renameDraft}
         onSelect={setActiveTerminalTab}
@@ -193,29 +234,29 @@ export function TerminalTabs() {
         onRenameCommit={commitRename}
         onRenameCancel={cancelRename}
         onRequestClose={requestCloseTab}
-        onAdd={() => {
-          addTerminalTab();
-        }}
+        onAdd={addPrimaryTab}
+        primaryAddLabel={primaryAddLabel}
+        showUserTerminalButton={surface === "mixed"}
         onAddUserTerminal={() => {
           addUserTerminalTab();
         }}
       />
 
       <div className="min-h-0 flex-1">
-        {/* Render every tab and hide non-active ones via CSS. Conditional
-            rendering would unmount the inactive TerminalTab whenever the
-            user switches tabs, which tears down the WS and kills the PTY
-            subprocess — every tab switch would lose the conversation. */}
-        {tabs.map((tab) => (
+        {/* Render every tab in this surface and hide non-active ones via CSS.
+            Conditional rendering would unmount the inactive TerminalTab
+            whenever the user switches tabs, which tears down the WS and kills
+            the PTY subprocess — every tab switch would lose the conversation. */}
+        {visibleTabs.map((tab) => (
           <div
             key={tab.id}
-            className={`h-full ${tab.id === activeTabId ? "" : "hidden"}`}
+            className={`h-full ${tab.id === visibleActiveTabId ? "" : "hidden"}`}
             data-testid={`terminal-tab-host-${tab.id}`}
           >
             <TerminalTab tabId={tab.id} />
           </div>
         ))}
-        {tabs.length === 0 || !activeTabId ? (
+        {visibleTabs.length === 0 || !visibleActiveTabId ? (
           <div className="flex h-full items-center justify-center text-sm text-stone-400">
             No active tab. Press <kbd className="mx-1 rounded bg-stone-200 px-1">Ctrl</kbd>+
             <kbd className="mx-1 rounded bg-stone-200 px-1">T</kbd> to open one.

--- a/frontend/src/components/AIChat/__tests__/SetupScreen.test.tsx
+++ b/frontend/src/components/AIChat/__tests__/SetupScreen.test.tsx
@@ -63,6 +63,29 @@ describe("SetupScreen", () => {
     expect(screen.getByTestId("setup-permission-dangerous")).toBeInTheDocument();
   });
 
+  it("keeps Cancel and Launch outside the scrollable setup body", async () => {
+    mockStatusOnce({
+      providers: [
+        { name: "claude-code", available: true, version: "2.1.0", logged_in: true },
+        { name: "codex", available: true, version: "0.118.0", logged_in: true },
+      ],
+    });
+    render(<SetupScreen tabId="t1" onLaunch={vi.fn()} onCancel={vi.fn()} />);
+
+    const launch = await screen.findByTestId("setup-launch");
+    const root = screen.getByTestId("setup-screen-t1");
+    const scrollBody = screen.getByTestId("setup-scroll-body");
+    const actions = screen.getByTestId("setup-actions");
+
+    expect(root.className).toContain("overflow-hidden");
+    expect(scrollBody.className).toContain("overflow-y-auto");
+    expect(actions.className).toContain("shrink-0");
+    expect(actions.className).not.toContain("bg-white");
+    expect(scrollBody.contains(actions)).toBe(false);
+    expect(actions.contains(screen.getByTestId("setup-cancel"))).toBe(true);
+    expect(actions.contains(launch)).toBe(true);
+  });
+
   it("disables the Launch button until provider AND permission are chosen", async () => {
     mockStatusOnce({
       providers: [

--- a/frontend/src/components/AIChat/__tests__/TerminalTabs.test.tsx
+++ b/frontend/src/components/AIChat/__tests__/TerminalTabs.test.tsx
@@ -59,6 +59,17 @@ describe("TerminalTabs", () => {
     expect(useAppStore.getState().activeTerminalTabId).toBe(tab.id);
   });
 
+  it("auto-creates a user terminal when the terminal surface is active", async () => {
+    render(<TerminalTabs surface="terminal" />);
+    await waitFor(() => expect(useAppStore.getState().terminalTabs.length).toBe(1));
+    const tab = useAppStore.getState().terminalTabs[0];
+    expect(tab.title).toBe("Terminal 1");
+    expect(tab.provider).toBe("user-terminal");
+    expect(tab.permissionMode).toBe("safe");
+    expect(tab.state).toBe("running");
+    expect(screen.queryByTestId("terminal-tabs-add-user-terminal")).toBeNull();
+  });
+
   it("adds a new tab when the + button is clicked", async () => {
     render(<TerminalTabs />);
     await waitFor(() => expect(useAppStore.getState().terminalTabs.length).toBe(1));
@@ -164,6 +175,23 @@ describe("TerminalTabs", () => {
     const rehydrated = rehydrateTerminalTabs(persisted);
     expect(rehydrated[0].state).toBe("closed");
     expect(rehydrated[0].exitCode).toBe(-1);
+  });
+
+  it("rehydrate drops stale user-terminal invalid-provider tabs", async () => {
+    const { rehydrateTerminalTabs } = await import("../../../store/terminalTabsSlice");
+    const rehydrated = rehydrateTerminalTabs([
+      {
+        id: "bad-terminal",
+        title: "Terminal 1",
+        provider: "user-terminal",
+        permissionMode: "safe",
+        state: "closed",
+        exitCode: -2,
+        errorMessage: "Invalid provider 'user-terminal'; expected one of ('claude-code', 'codex').",
+      },
+    ]);
+
+    expect(rehydrated).toEqual([]);
   });
 
   // ADR-035 §3.10 — engine-initiated AI Block tabs.

--- a/frontend/src/components/BottomPanel.parts/ConfigPanel.test.tsx
+++ b/frontend/src/components/BottomPanel.parts/ConfigPanel.test.tsx
@@ -62,6 +62,13 @@ describe("ConfigPanel", () => {
     apiMocks.openNativeDialog.mockReset();
   });
 
+  it("uses user-friendly empty state copy", () => {
+    render(<ConfigPanel onUpdateConfig={() => {}} selectedNode={null} />);
+
+    expect(screen.getByText("Select a node to edit its settings.")).toBeInTheDocument();
+    expect(screen.queryByText(/JSON|schema/i)).toBeNull();
+  });
+
   it("uses the native dialog first from the config Browse button", async () => {
     const onUpdateConfig = vi.fn();
     apiMocks.openNativeDialog.mockResolvedValueOnce({

--- a/frontend/src/components/BottomPanel.parts/ConfigPanel.tsx
+++ b/frontend/src/components/BottomPanel.parts/ConfigPanel.tsx
@@ -299,11 +299,7 @@ export function ConfigPanel({
   const ordered = orderedConfigEntries(schema, selectedNode);
 
   if (!selectedNode || !schema) {
-    return (
-      <div className="text-sm text-stone-500">
-        Select a node to edit its settings.
-      </div>
-    );
+    return <div className="text-sm text-stone-500">Select a node to edit its settings.</div>;
   }
 
   if (isCodeBlockConfigTarget(selectedNode, schema)) {

--- a/frontend/src/components/BottomPanel.parts/ConfigPanel.tsx
+++ b/frontend/src/components/BottomPanel.parts/ConfigPanel.tsx
@@ -301,7 +301,7 @@ export function ConfigPanel({
   if (!selectedNode || !schema) {
     return (
       <div className="text-sm text-stone-500">
-        Select a node to edit its JSON-schema-driven configuration.
+        Select a node to edit its settings.
       </div>
     );
   }

--- a/frontend/src/components/BottomPanel.parts/TabBar.tsx
+++ b/frontend/src/components/BottomPanel.parts/TabBar.tsx
@@ -1,4 +1,4 @@
-import { GitBranch, Pin, PinOff } from "lucide-react";
+import { GitBranch, Pin, PinOff, Terminal } from "lucide-react";
 import { type ReactNode } from "react";
 
 import type { BottomTab } from "../../types/ui";
@@ -9,6 +9,12 @@ import type { BottomTab } from "../../types/ui";
 // renders inconsistently across OS font sets.
 const TAB_LABELS: Record<BottomTab, ReactNode> = {
   ai: "💬 AI Chat",
+  terminal: (
+    <span className="inline-flex items-center gap-1.5">
+      <Terminal className="h-4 w-4" aria-hidden="true" />
+      Terminal
+    </span>
+  ),
   config: "📋 Config",
   logs: "📜 Logs",
   // ADR-038 §3.8 — Lineage tab promoted to a first-class entry; replaces
@@ -31,7 +37,8 @@ const TAB_LABELS: Record<BottomTab, ReactNode> = {
 // rendered on the BlockNode itself by WorkflowCanvas.
 // ADR-038 §3.8 — Jobs tab removed (subsumed by Lineage).
 // ADR-039 §3.5 (#972) — Git tab added.
-export const ALL_TABS: BottomTab[] = ["ai", "config", "logs", "lineage", "git"];
+// Hotfix: Terminal is promoted to a top-level tab alongside AI Chat.
+export const ALL_TABS: BottomTab[] = ["ai", "terminal", "config", "logs", "lineage", "git"];
 
 function formatBadge(n: number): string {
   return n > 99 ? "99+" : String(n);

--- a/frontend/src/components/BottomPanel.test.tsx
+++ b/frontend/src/components/BottomPanel.test.tsx
@@ -161,6 +161,22 @@ describe("BottomPanel", () => {
     expect(screen.queryByTestId("unread-badge-logs")).toBeNull();
   });
 
+  it("exposes Terminal as a top-level bottom-panel tab", () => {
+    const onTabChange = vi.fn();
+    render(
+      <BottomPanel
+        activeTab="config"
+        logEntries={[]}
+        onTabChange={onTabChange}
+        onUpdateConfig={() => {}}
+        selectedNode={null}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Terminal" }));
+    expect(onTabChange).toHaveBeenCalledWith("terminal");
+  });
+
   it("caps the unread badge at 99+", () => {
     render(
       <BottomPanel

--- a/frontend/src/components/BottomPanel.tsx
+++ b/frontend/src/components/BottomPanel.tsx
@@ -68,16 +68,23 @@ export function BottomPanel({
 
       <div className="min-h-0 flex-1 overflow-y-auto px-2 py-2 scrollbar-thin">
         {/* TerminalTabs must stay MOUNTED across bottom-panel tab switches
-            so the PTY subprocess survives (unmount fires the WS cleanup
-            hook which kills the child process tree). Hide via CSS when
-            another tab is active.
+            so PTY subprocesses survive (unmount fires the WS cleanup hook
+            which kills the child process tree). Hide via CSS when another
+            tab is active.
+
+            AI Chat owns provider/AI-block chat tabs; Terminal owns
+            user-terminal tabs. Each surface renders only its own tabs so a
+            running PTY is mounted exactly once.
 
             Hotfix #977: the inner white-card frame was removed so the
             active-tab body fills the available space without a nested
             scroll context. The lineage tab (ADR-038 §3.8) and git tab
             (ADR-039 §3.5, #972) both render inside this flat container. */}
         <div className={`h-full ${activeTab === "ai" ? "" : "hidden"}`}>
-          <TerminalTabs />
+          <TerminalTabs active={activeTab === "ai"} surface="chat" />
+        </div>
+        <div className={`h-full ${activeTab === "terminal" ? "" : "hidden"}`}>
+          <TerminalTabs active={activeTab === "terminal"} surface="terminal" />
         </div>
         {activeTab === "config" ? (
           <ConfigPanel
@@ -99,7 +106,7 @@ export function BottomPanel({
           // conflict-state close guard must survive bottom-tab
           // switches; Codex P1 on PR #974).
           <GitTab />
-        ) : activeTab !== "ai" ? (
+        ) : activeTab !== "ai" && activeTab !== "terminal" ? (
           <PlaceholderTab />
         ) : null}
       </div>

--- a/frontend/src/components/Toolbar.parts/ProjectHeader.tsx
+++ b/frontend/src/components/Toolbar.parts/ProjectHeader.tsx
@@ -13,13 +13,16 @@ export interface ProjectHeaderProps {
 export function ProjectHeader({ currentProject, workflowName, workflowDirty }: ProjectHeaderProps) {
   return (
     <div
-      className="flex min-w-fit shrink-0 items-center gap-3"
+      className="flex min-w-0 shrink-0 items-center gap-2 xl:gap-3"
       data-testid="toolbar-project-header"
     >
       <div className="shrink-0 rounded-[1.4rem] bg-ink px-3 py-2 text-stone-50 xl:px-4 xl:py-2.5">
         <p className="font-display text-lg leading-tight">SciStudio</p>
       </div>
-      <div className="hidden min-w-0 shrink xl:block xl:w-[160px] 2xl:w-[200px]">
+      <div
+        className="hidden min-w-0 shrink xl:block xl:max-w-[160px] 2xl:max-w-[200px]"
+        data-testid="toolbar-project-meta"
+      >
         <p
           className="truncate font-display text-base leading-tight text-ink"
           title={currentProject?.name ?? undefined}

--- a/frontend/src/components/Toolbar.parts/WorkflowGroups.tsx
+++ b/frontend/src/components/Toolbar.parts/WorkflowGroups.tsx
@@ -1,6 +1,6 @@
 /**
- * Workflow-only toolbar groups (Run/Pause/Stop/Reset + Delete/Reload/Note/
- * Group/View-source). Hidden when a file tab is active. Extracted in #1413.
+ * Workflow-only toolbar groups (Run/Pause/Stop/Reload + Note/Group/
+ * View-source). Hidden when a file tab is active. Extracted in #1413.
  */
 import {
   BoxSelect,
@@ -8,10 +8,8 @@ import {
   Loader2,
   Play,
   RefreshCw,
-  RotateCcw,
   Square,
   StickyNote,
-  Trash2,
 } from "lucide-react";
 
 import { Separator } from "@/components/ui/separator";
@@ -36,7 +34,7 @@ export interface WorkflowGroupsProps {
 }
 
 function ExecutionControls(props: WorkflowGroupsProps) {
-  const { currentProject, workflowId, isRunning, onRun, onStop, onReset } = props;
+  const { currentProject, workflowId, isRunning, onRun, onStop, onReloadBlocks } = props;
   return (
     <div className="flex shrink-0 items-center gap-1">
       <ToolbarButton
@@ -55,7 +53,7 @@ function ExecutionControls(props: WorkflowGroupsProps) {
         disabled={!workflowId}
         onClick={onStop}
       />
-      <ToolbarButton icon={RotateCcw} label="Reset" disabled={!workflowId} onClick={onReset} />
+      <ToolbarButton icon={RefreshCw} label="Reload" onClick={onReloadBlocks} />
     </div>
   );
 }
@@ -64,17 +62,12 @@ function EditOperations(props: WorkflowGroupsProps) {
   const {
     currentProject,
     workflowId,
-    selectedNodeId,
-    onDelete,
-    onReloadBlocks,
     onAddAnnotation,
     onAddGroup,
     onViewSource,
   } = props;
   return (
     <div className="flex shrink-0 items-center gap-1">
-      <ToolbarButton icon={Trash2} label="Delete" disabled={!selectedNodeId} onClick={onDelete} />
-      <ToolbarButton icon={RefreshCw} label="Reload" onClick={onReloadBlocks} />
       <ToolbarButton
         icon={StickyNote}
         label="Note"

--- a/frontend/src/components/Toolbar.parts/WorkflowGroups.tsx
+++ b/frontend/src/components/Toolbar.parts/WorkflowGroups.tsx
@@ -2,15 +2,7 @@
  * Workflow-only toolbar groups (Run/Pause/Stop/Reload + Note/Group/
  * View-source). Hidden when a file tab is active. Extracted in #1413.
  */
-import {
-  BoxSelect,
-  Eye,
-  Loader2,
-  Play,
-  RefreshCw,
-  Square,
-  StickyNote,
-} from "lucide-react";
+import { BoxSelect, Eye, Loader2, Play, RefreshCw, Square, StickyNote } from "lucide-react";
 
 import { Separator } from "@/components/ui/separator";
 
@@ -59,13 +51,7 @@ function ExecutionControls(props: WorkflowGroupsProps) {
 }
 
 function EditOperations(props: WorkflowGroupsProps) {
-  const {
-    currentProject,
-    workflowId,
-    onAddAnnotation,
-    onAddGroup,
-    onViewSource,
-  } = props;
+  const { currentProject, workflowId, onAddAnnotation, onAddGroup, onViewSource } = props;
   return (
     <div className="flex shrink-0 items-center gap-1">
       <ToolbarButton

--- a/frontend/src/components/Toolbar.test.tsx
+++ b/frontend/src/components/Toolbar.test.tsx
@@ -3,8 +3,8 @@
  *
  * Verifies that:
  *   - When ``activeTabKind === "workflow"`` (default), the existing button
- *     set is rendered: Run / Stop / Reset / Reload / Delete /
- *     Note / Group are all present.
+ *     set is rendered: Run / Stop / Reload / Note / Group are all present,
+ *     while Reset / Delete are omitted.
  *   - When ``activeTabKind === "file"``, those workflow-only buttons are
  *     hidden; only New / Import / Save remain.
  */
@@ -60,7 +60,7 @@ function makeProps(overrides: Partial<React.ComponentProps<typeof Toolbar>> = {}
 }
 
 describe("Toolbar — ADR-036 §3.7 kind-swap", () => {
-  it("workflow tab: Run / Stop / Reset / Reload / Delete / Note / Group are visible", () => {
+  it("workflow tab: Run / Stop / Reload / Note / Group are visible without Reset or Delete", () => {
     render(<Toolbar {...makeProps({ activeTabKind: "workflow" })} />);
     // Group 2 (always present)
     expect(screen.getByRole("button", { name: /^new$/i })).toBeTruthy();
@@ -70,11 +70,29 @@ describe("Toolbar — ADR-036 §3.7 kind-swap", () => {
     expect(screen.getByRole("button", { name: /^run$/i })).toBeTruthy();
     expect(screen.queryByRole("button", { name: /^pause$/i })).toBeNull();
     expect(screen.getByRole("button", { name: /^stop$/i })).toBeTruthy();
-    expect(screen.getByRole("button", { name: /^reset$/i })).toBeTruthy();
-    expect(screen.getByRole("button", { name: /^delete$/i })).toBeTruthy();
     expect(screen.getByRole("button", { name: /^reload$/i })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /^reset$/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /^delete$/i })).toBeNull();
     expect(screen.getByRole("button", { name: /^note$/i })).toBeTruthy();
     expect(screen.getByRole("button", { name: /^group$/i })).toBeTruthy();
+  });
+
+  it("workflow tab: Reload sits in the old Reset slot and calls reload blocks", () => {
+    const onReloadBlocks = vi.fn();
+    const onReset = vi.fn();
+    render(<Toolbar {...makeProps({ activeTabKind: "workflow", onReloadBlocks, onReset })} />);
+
+    const buttonLabels = screen
+      .getAllByRole("button")
+      .map((button) => button.getAttribute("aria-label"))
+      .filter(Boolean);
+
+    expect(buttonLabels.indexOf("Reload")).toBeGreaterThan(buttonLabels.indexOf("Stop"));
+    expect(buttonLabels.indexOf("Reload")).toBeLessThan(buttonLabels.indexOf("Note"));
+
+    fireEvent.click(screen.getByRole("button", { name: /^reload$/i }));
+    expect(onReloadBlocks).toHaveBeenCalledTimes(1);
+    expect(onReset).not.toHaveBeenCalled();
   });
 
   it("workflow tab: defaults to workflow when activeTabKind is omitted", () => {
@@ -192,10 +210,15 @@ describe("Toolbar — ADR-036 §3.4 View source button (I36c)", () => {
 });
 
 describe("Toolbar responsive layout", () => {
-  it("keeps the SciStudio brand from shrinking under the Projects control", () => {
+  it("bounds the project label without reserving fixed toolbar space", () => {
     render(<Toolbar {...makeProps()} />);
     const header = screen.getByTestId("toolbar-project-header");
+    const meta = screen.getByTestId("toolbar-project-meta");
     expect(header.className).toContain("shrink-0");
-    expect(header.className).toContain("min-w-fit");
+    expect(header.className).not.toContain("min-w-fit");
+    expect(meta.className).toContain("xl:max-w-[160px]");
+    expect(meta.className).toContain("2xl:max-w-[200px]");
+    expect(meta.className).not.toContain("xl:w-[160px]");
+    expect(meta.className).not.toContain("2xl:w-[200px]");
   });
 });

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -89,14 +89,14 @@ export const useAppStore = create<AppStore>()(
         if (!state) return;
         // ADR-038 §3.8 + ADR-039 §3.5 — `activeBottomTab` valid values
         // after integration are exactly the BottomTab union members
-        // ("ai", "config", "logs", "lineage", "git"). The historical
+        // ("ai", "terminal", "config", "logs", "lineage", "git"). The historical
         // "jobs" placeholder was removed by ADR-038 §3.8 (run history
         // now lives in Lineage). Older persisted snapshots may still
         // carry "jobs", "problems", or other retired values; coerce
         // anything not in the current union back to "lineage" — the
         // semantic replacement for the run-history surface Jobs used
         // to occupy. This also covers any future tab removals.
-        const validTabs = new Set<string>(["ai", "config", "logs", "lineage", "git"]);
+        const validTabs = new Set<string>(["ai", "terminal", "config", "logs", "lineage", "git"]);
         if (typeof state.activeBottomTab !== "string" || !validTabs.has(state.activeBottomTab)) {
           state.activeBottomTab = "lineage";
         }

--- a/frontend/src/store/terminalTabsSlice.ts
+++ b/frontend/src/store/terminalTabsSlice.ts
@@ -212,18 +212,27 @@ export const createTerminalTabsSlice: StateCreator<AppStore, [], [], TerminalTab
  * `onRehydrateStorage`.
  */
 export function rehydrateTerminalTabs(tabs: TerminalTab[]): TerminalTab[] {
-  return tabs.map((t) => {
-    if (t.state !== "running") return t;
-    // PTY didn't survive page unload. AI-Block tabs additionally get their
-    // blockStatus downgraded to "cancelled" — the workflow run is gone too.
-    return {
-      ...t,
-      state: "closed" as const,
-      exitCode: -1,
-      errorMessage: undefined,
-      ...(t.source === "ai-block" ? { blockStatus: "cancelled" as const } : {}),
-    };
-  });
+  return tabs
+    .filter(
+      (t) =>
+        !(
+          t.provider === "user-terminal" &&
+          t.state === "closed" &&
+          t.errorMessage?.includes("Invalid provider 'user-terminal'")
+        ),
+    )
+    .map((t) => {
+      if (t.state !== "running") return t;
+      // PTY didn't survive page unload. AI-Block tabs additionally get their
+      // blockStatus downgraded to "cancelled" — the workflow run is gone too.
+      return {
+        ...t,
+        state: "closed" as const,
+        exitCode: -1,
+        errorMessage: undefined,
+        ...(t.source === "ai-block" ? { blockStatus: "cancelled" as const } : {}),
+      };
+    });
 }
 
 // Re-export for convenience.

--- a/frontend/src/store/types.ts
+++ b/frontend/src/store/types.ts
@@ -146,8 +146,8 @@ export interface UISlice {
   /**
    * When true, the bottom panel does not auto-collapse on canvas-pane
    * clicks. Toggled via the pin button in the BottomPanel tab strip.
-   * Useful when the user is actively chatting in the AI Chat tab and
-   * doesn't want a stray canvas click to fold the panel closed.
+   * Useful when the user is actively chatting in the AI Chat tab, working in
+   * Terminal, and doesn't want a stray canvas click to fold the panel closed.
    */
   bottomPanelPinned: boolean;
   panelSizes: { palette: number; preview: number; bottom: number };

--- a/frontend/src/types/ui.ts
+++ b/frontend/src/types/ui.ts
@@ -11,8 +11,11 @@ import type { BlockPortResponse, BlockSchemaResponse, BlockSummary } from "./api
  * ADR-039 was developed in parallel and still referenced `"jobs"` on its
  * track; the integration takes the ADR-038 removal and adds the ADR-039
  * `"git"` tab on top.
+ *
+ * Hotfix: terminal sessions are a first-class surface instead of being nested
+ * under the AI Chat tab.
  */
-export type BottomTab = "ai" | "config" | "logs" | "lineage" | "git";
+export type BottomTab = "ai" | "terminal" | "config" | "logs" | "lineage" | "git";
 
 export interface BlockNodeData extends Record<string, unknown> {
   label: string;

--- a/src/scistudio/api/routes/ai.py
+++ b/src/scistudio/api/routes/ai.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 import logging
 import shutil
 import subprocess
-import sys
 from pathlib import Path
 from typing import Annotated, Any
 
@@ -95,8 +94,8 @@ async def provider_status() -> dict[str, Any]:
 
 def _probe_claude() -> dict[str, Any]:
     """Probe ``claude`` binary + credentials."""
-    available, version = _binary_status("claude")
-    logged_in = _claude_logged_in()
+    binary, available, version = _binary_status("claude")
+    logged_in = _claude_logged_in(binary)
     return {
         "name": "claude-code",
         "available": available,
@@ -109,22 +108,22 @@ def _probe_codex() -> dict[str, Any]:
     """Probe ``codex`` binary + credentials.
 
     Codex stores its auth in ``~/.codex/auth.json`` after
-    ``codex login``; presence of that file is treated as "looks logged
-    in" for the frontend gate.  Codex may evolve its auth storage
-    format; if so this probe gets bumped.
+    ``codex login`` when file-based storage is selected. Current Codex
+    builds may also store credentials in the OS keychain/keyring, so we
+    ask the provider-owned ``codex login status`` command before falling
+    back to file presence.
     """
-    available, version = _binary_status("codex")
-    auth_file = Path.home() / ".codex" / "auth.json"
+    binary, available, version = _binary_status("codex")
     return {
         "name": "codex",
         "available": available,
         "version": version,
-        "logged_in": auth_file.is_file(),
+        "logged_in": _codex_logged_in(binary),
     }
 
 
-def _binary_status(name: str) -> tuple[bool, str | None]:
-    """Return ``(available, version_string_or_None)`` for ``name``.
+def _binary_status(name: str) -> tuple[str | None, bool, str | None]:
+    """Return ``(binary, available, version_string_or_None)`` for ``name``.
 
     Available iff ``shutil.which`` finds the binary AND ``<name> --version``
     completes within 2 s with non-empty stdout.  Version is the trimmed
@@ -132,7 +131,7 @@ def _binary_status(name: str) -> tuple[bool, str | None]:
     """
     binary = resolve_windows_executable(name, which=shutil.which)
     if not binary:
-        return False, None
+        return None, False, None
     try:
         result = subprocess.run(
             [binary, "--version"],
@@ -142,40 +141,51 @@ def _binary_status(name: str) -> tuple[bool, str | None]:
             check=False,
         )
     except (subprocess.TimeoutExpired, OSError):
-        return False, None
+        return binary, False, None
     version = (result.stdout or result.stderr or "").strip()
     if not version:
-        return False, None
-    return True, version
+        return binary, False, None
+    return binary, True, version
 
 
-def _claude_logged_in() -> bool:
+def _claude_logged_in(binary: str | None) -> bool:
     """Heuristic: does claude appear to have stored credentials?
 
     Order of probes:
 
     1. ``~/.claude/.credentials.json`` exists — covers Linux / Windows
        and the macOS file-fallback path.
-    2. On macOS, ``security find-generic-password`` against either of
-       the two known service names (``Claude Code-credentials`` is the
-       current name; ``claude-code`` was used briefly).  Bounded by a
-       2 s timeout so a slow Keychain doesn't hang the endpoint.
+    2. ``claude auth status --json`` exits 0 — asks the provider CLI to
+       inspect its own auth state instead of probing macOS Keychain
+       directly from SciStudio.
     """
     if (Path.home() / ".claude" / ".credentials.json").is_file():
         return True
-    if sys.platform != "darwin":
+    if not binary:
         return False
-    for service in ("Claude Code-credentials", "claude-code"):
-        try:
-            result = subprocess.run(
-                ["security", "find-generic-password", "-s", service],
-                capture_output=True,
-                text=True,
-                timeout=2,
-                check=False,
-            )
-        except (subprocess.TimeoutExpired, OSError):
-            continue
-        if result.returncode == 0:
-            return True
-    return False
+    return _auth_status_command_logged_in([binary, "auth", "status", "--json"])
+
+
+def _codex_logged_in(binary: str | None) -> bool:
+    """Heuristic: does codex appear to have stored credentials?"""
+    auth_file = Path.home() / ".codex" / "auth.json"
+    if auth_file.is_file():
+        return True
+    if not binary:
+        return False
+    return _auth_status_command_logged_in([binary, "login", "status"])
+
+
+def _auth_status_command_logged_in(argv: list[str]) -> bool:
+    """Run a provider-owned auth-status command with a short timeout."""
+    try:
+        result = subprocess.run(
+            argv,
+            capture_output=True,
+            text=True,
+            timeout=2,
+            check=False,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return False
+    return result.returncode == 0

--- a/tests/ai/test_windows_executable_resolution.py
+++ b/tests/ai/test_windows_executable_resolution.py
@@ -46,7 +46,11 @@ def test_binary_status_uses_cmd_when_windows_which_finds_bare_wrapper(monkeypatc
     monkeypatch.setattr(terminal.shutil, "which", _npm_shim_which)
     monkeypatch.setattr(ai_route.subprocess, "run", fake_run)
 
-    assert ai_route._binary_status("codex") == (True, "codex 0.1.0")
+    assert ai_route._binary_status("codex") == (
+        "C:/Users/dev/AppData/Roaming/npm/codex.cmd",
+        True,
+        "codex 0.1.0",
+    )
     assert calls == [["C:/Users/dev/AppData/Roaming/npm/codex.cmd", "--version"]]
 
 

--- a/tests/api/test_provider_discovery.py
+++ b/tests/api/test_provider_discovery.py
@@ -111,29 +111,66 @@ def test_status_codex_logged_in_via_auth_file(
     assert codex["logged_in"] is True
 
 
-def test_status_logged_in_via_macos_keychain(
+def test_status_claude_logged_in_via_provider_auth_status(
     client: TestClient,
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    """On macOS, a Keychain hit must mark claude as logged in."""
+    """Claude login status should be delegated to the provider CLI."""
     fake_home = tmp_path / "discovery_home"
     fake_home.mkdir()
-    # Pretend we're on macOS and credentials.json is absent.
-    monkeypatch.setattr(ai_routes.sys, "platform", "darwin")
     monkeypatch.setattr(ai_routes.Path, "home", classmethod(lambda _cls: fake_home))
-    monkeypatch.setattr(ai_routes.shutil, "which", lambda _name: None)
+    monkeypatch.setattr(ai_routes.shutil, "which", lambda name: f"/fake/bin/{name}")
 
-    def fake_security(argv: list[str], **_: object) -> subprocess.CompletedProcess[str]:
-        # `security find-generic-password -s Claude Code-credentials` returns 0
-        # when the entry exists.
-        if "security" in argv[0]:
-            return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+    seen: list[list[str]] = []
+
+    def fake_run(argv: list[str], **_: object) -> subprocess.CompletedProcess[str]:
+        seen.append(argv)
+        if argv == ["/fake/bin/claude", "--version"]:
+            return subprocess.CompletedProcess(argv, 0, stdout="2.1.141\n", stderr="")
+        if argv == ["/fake/bin/claude", "auth", "status", "--json"]:
+            return subprocess.CompletedProcess(argv, 0, stdout='{"loggedIn": true}\n', stderr="")
+        if argv == ["/fake/bin/codex", "--version"]:
+            return subprocess.CompletedProcess(argv, 0, stdout="0.118.0\n", stderr="")
+        if argv == ["/fake/bin/codex", "login", "status"]:
+            return subprocess.CompletedProcess(argv, 1, stdout="", stderr="not logged in")
         return subprocess.CompletedProcess(argv, 1, stdout="", stderr="")
 
-    monkeypatch.setattr(ai_routes.subprocess, "run", fake_security)
+    monkeypatch.setattr(ai_routes.subprocess, "run", fake_run)
 
     res = client.get("/api/ai/status")
     body = res.json()
     claude = next(p for p in body["providers"] if p["name"] == "claude-code")
     assert claude["logged_in"] is True
+    assert ["/fake/bin/claude", "auth", "status", "--json"] in seen
+    assert all("security" not in argv[0] for argv in seen)
+
+
+def test_status_codex_logged_in_via_provider_login_status(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Codex keychain/keyring auth should be delegated to the provider CLI."""
+    fake_home = tmp_path / "discovery_home"
+    fake_home.mkdir()
+    monkeypatch.setattr(ai_routes.Path, "home", classmethod(lambda _cls: fake_home))
+    monkeypatch.setattr(ai_routes.shutil, "which", lambda name: f"/fake/bin/{name}")
+
+    def fake_run(argv: list[str], **_: object) -> subprocess.CompletedProcess[str]:
+        if argv == ["/fake/bin/claude", "--version"]:
+            return subprocess.CompletedProcess(argv, 0, stdout="2.1.141\n", stderr="")
+        if argv == ["/fake/bin/claude", "auth", "status", "--json"]:
+            return subprocess.CompletedProcess(argv, 1, stdout="", stderr="not logged in")
+        if argv == ["/fake/bin/codex", "--version"]:
+            return subprocess.CompletedProcess(argv, 0, stdout="0.118.0\n", stderr="")
+        if argv == ["/fake/bin/codex", "login", "status"]:
+            return subprocess.CompletedProcess(argv, 0, stdout="Logged in\n", stderr="")
+        return subprocess.CompletedProcess(argv, 1, stdout="", stderr="")
+
+    monkeypatch.setattr(ai_routes.subprocess, "run", fake_run)
+
+    res = client.get("/api/ai/status")
+    body = res.json()
+    codex = next(p for p in body["providers"] if p["name"] == "codex")
+    assert codex["logged_in"] is True

--- a/tests/packaging/test_desktop_mvp_resources.py
+++ b/tests/packaging/test_desktop_mvp_resources.py
@@ -80,6 +80,29 @@ def test_desktop_runtime_env_adds_common_user_cli_paths() -> None:
     assert '"/usr/local/bin"' in main_js
 
 
+def test_desktop_runtime_env_imports_macos_login_shell_environment() -> None:
+    """macOS packaged apps must pass login-shell auth env to provider CLIs."""
+    main_js = (DESKTOP_DIR / "main.js").read_text(encoding="utf-8")
+
+    assert "spawnSync" in main_js
+    assert "function macLoginShellEnv()" in main_js
+    assert 'process.platform !== "darwin"' in main_js
+    assert "/usr/bin/env -0" in main_js
+    assert "__SCISTUDIO_ENV_START__" in main_js
+    assert "...loginShellEnv" in main_js
+    assert 'pathEntries.push(loginShellEnv.PATH || "")' in main_js
+
+
+def test_desktop_dev_runner_points_vite_proxy_at_runtime_port() -> None:
+    """Desktop dev must not proxy PTY WebSockets to an unrelated backend."""
+    start_dev_js = (DESKTOP_DIR / "scripts" / "start-dev.js").read_text(encoding="utf-8")
+
+    assert "const apiProxyTarget" in start_dev_js
+    assert "SCISTUDIO_API_PROXY" in start_dev_js
+    assert "`http://127.0.0.1:${runtimePort}`" in start_dev_js
+    assert "SCISTUDIO_API_PROXY: apiProxyTarget" in start_dev_js
+
+
 def test_desktop_has_portable_python_runtime_builder() -> None:
     """The desktop MVP must have a reproducible self-contained Python builder."""
     script = DESKTOP_DIR / "scripts" / "build-python-runtime.ps1"


### PR DESCRIPTION
Gate record: .workflow/records/1701-hotfix-desktop-toolbar-project-label-layout.json

Closes #1701

## Summary
- polish desktop toolbar UX by bounding the project label, removing unused Reset/Delete controls, and moving Reload into the former Reset slot
- promote Terminal to a top-level bottom-panel tab while keeping AI Chat terminal sessions mounted safely
- fix desktop provider auth discovery by passing macOS login-shell env to runtime and delegating provider login checks to provider CLIs
- point desktop dev Vite proxy at the active runtime port so user-terminal PTY websockets reach the right backend
- make Config empty-state copy user-friendly and keep AI Chat setup Cancel/Launch visible outside the scroll body

## Validation
- `npm --prefix frontend test -- Toolbar.test.tsx BottomPanel.test.tsx BottomPanel.parts/ConfigPanel.test.tsx AIChat/__tests__/SetupScreen.test.tsx AIChat/__tests__/TerminalTabs.test.tsx AIChat/__tests__/TerminalTab.test.tsx AIChat/__tests__/usePtyWebSocket.test.ts`
- `npm --prefix frontend run typecheck`
- `PYTHONPATH=src python -m pytest --no-cov tests/api/test_provider_discovery.py tests/api/test_ai_pty.py::test_pty_ws_accepts_user_terminal_provider tests/api/test_ai_pty.py::test_pty_ws_invalid_provider tests/packaging/test_desktop_mvp_resources.py -q`
- `node --check desktop/main.js`
- `node --check desktop/scripts/start-dev.js`
- `git diff --check`
- `PYTHONPATH=src python -m scistudio.qa.governance.gate_record check --base origin/main --head HEAD --mode local ...`
