### PR TITLE
hotfix(#1705): restore packaged agent backend wiring

### DIFF
--- a/.workflow/records/hotfix-live-bugs-20260619-live-bugs-20260619.json
+++ b/.workflow/records/hotfix-live-bugs-20260619-live-bugs-20260619.json
@@ -164,9 +164,9 @@
   ],
   "check_na": [],
   "commit": {
-    "sha": "7acf1968",
+    "sha": "686318c9",
     "shas": [
-      "7acf1968"
+      "686318c9"
     ],
     "trailers": []
   },
@@ -529,6 +529,334 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:13:20.024346Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:13:20.034763Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:13:20.045062Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:13:20.055303Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:13:20.065984Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:13:20.076477Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:13:20.086407Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:13:20.096339Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:13:20.106739Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:13:20.120018Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:13:28.691065Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:13:28.701133Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:13:28.711186Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:13:28.721625Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:13:28.731650Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:13:28.741709Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:13:28.751324Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:13:28.761523Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:13:28.772003Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:13:28.784873Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:13:44.957649Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:13:44.968353Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:13:44.978750Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:13:44.989113Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:13:44.999097Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:13:45.009713Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:13:45.020215Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:13:45.030508Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:13:45.040739Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:13:45.053924Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:14:01.690677Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:14:01.701989Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:14:01.712489Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:14:01.722824Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:14:01.732996Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:14:01.742830Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:14:01.752769Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:14:01.763049Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:14:01.773421Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:14:01.786312Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -541,7 +869,7 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "origin/main",
+    "base": "8caa7b7321f18f3ae4139a8254c94fe467f075bb",
     "base_sha": "8caa7b73",
     "changed_files": [
       ".workflow/records/hotfix-live-bugs-20260619-live-bugs-20260619.json",
@@ -555,9 +883,9 @@
       "tests/api/test_mcp_transport_publish.py",
       "tests/cli/test_mcp_bridge.py"
     ],
-    "diff_fingerprint": "sha256:d047771e5eeec1c61eaa0d6dc9f071b3e5f084b6b452b61b74a8b6f769b652fa",
+    "diff_fingerprint": "sha256:6a16b8092a4d94e2e018b86f6d1251222c2dfd5ecfad897ff72716a3198c2257",
     "head": "HEAD",
-    "head_sha": "7acf1968",
+    "head_sha": "686318c9",
     "surfaces": {
       "docs": 0,
       "frontend": 0,
@@ -578,7 +906,7 @@
     "closes": [
       1705
     ],
-    "number": null,
+    "number": 1706,
     "url": null
   },
   "reconcile_events": [
@@ -617,6 +945,38 @@
     {
       "at": "2026-06-20T00:12:15.306838Z",
       "diff_fingerprint": "sha256:d047771e5eeec1c61eaa0d6dc9f071b3e5f084b6b452b61b74a8b6f769b652fa",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-20T00:13:20.120062Z",
+      "diff_fingerprint": "sha256:6a16b8092a4d94e2e018b86f6d1251222c2dfd5ecfad897ff72716a3198c2257",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-20T00:13:28.784919Z",
+      "diff_fingerprint": "sha256:6a16b8092a4d94e2e018b86f6d1251222c2dfd5ecfad897ff72716a3198c2257",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-20T00:13:45.053970Z",
+      "diff_fingerprint": "sha256:6a16b8092a4d94e2e018b86f6d1251222c2dfd5ecfad897ff72716a3198c2257",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-20T00:14:01.786377Z",
+      "diff_fingerprint": "sha256:6a16b8092a4d94e2e018b86f6d1251222c2dfd5ecfad897ff72716a3198c2257",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 2,

--- a/.workflow/records/hotfix-live-bugs-20260619-live-bugs-20260619.json
+++ b/.workflow/records/hotfix-live-bugs-20260619-live-bugs-20260619.json
@@ -1,0 +1,845 @@
+{
+  "branch": "hotfix/live-bugs-20260619",
+  "check_events": [
+    {
+      "at": "2026-06-20T00:06:52.309892Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:bee0017f30f552d2df2de1173f9ac14b9aee5192ca5e5c1de574bb119512b275",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-20T00:06:56.369700Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:d2016153ffe72f6d9588cf72b647d8f545261ca64eb63f312f104e3c66e7d074",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-20T00:06:56.414480Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e31351abfc33f0b3c0f28bc9f2f3d59ae3bc5d4925dc1159a7f931aa932441ed",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-20T00:07:25.165134Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:c2472cd5d8f3845e04a7c485171538ae462d4b20570227f1361e5b78a2bc054b",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-20T00:07:28.500378Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:4aed7f1a7258f9f4c4070996ae6324a65902f740329df34cbe73c7e5ea1a18ae",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-20T00:07:28.992300Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:09e863a3c73b7b65a6804c58482062cf58b77ec6cfb84f94a92ae427b75e1c5a",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-20T00:07:29.006044Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cca5b44f477c85d25e0bbe69432c737d3dd482829cfb6fcf6e198faade437740",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-20T00:09:42.536017Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:015de02bf585064ee46c278af12c60473b478e4c21381b7e6371f8aeceea333a",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-20T00:11:42.332889Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:df4f73b51a856aa776f30468ff24d9d640df849a9ead24bf377cf81dadba3e6e",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-20T00:11:50.115651Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:677698c1c3416c1399ad3619793e5118ba7dedbb9a3acdf0b197560a338cd53e",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    }
+  ],
+  "check_na": [],
+  "commit": {
+    "sha": "7acf1968",
+    "shas": [
+      "7acf1968"
+    ],
+    "trailers": []
+  },
+  "declared_scope": {
+    "exclude": [],
+    "include": []
+  },
+  "directive_events": [
+    {
+      "at": "2026-06-19T23:57:39.891986Z",
+      "owner_directive": "Fix packaged desktop SciStudio MCP server bugs: get_lineage returns 'no MetadataStore installed'; run_workflow reports only available when backend is running even though :8000 is alive, indicating MCP bridge failed to connect to live backend.",
+      "reason": "Owner reported packaged desktop MCP server live-backend integration bugs"
+    },
+    {
+      "at": "2026-06-19T23:59:33.775713Z",
+      "owner_directive": "Fix packaged desktop MCP bridge live-backend discovery so project-scoped bridge attaches to the running backend transport after the GUI opens a project.",
+      "reason": "Narrow MCP bridge hotfix scope after investigation"
+    },
+    {
+      "at": "2026-06-20T00:01:08.098898Z",
+      "owner_directive": "Fix internal agent hooks in packaged desktop where PreToolUse:Bash reports '/bin/sh: python: command not found'.",
+      "reason": "Owner reported packaged internal-agent hook interpreter bug"
+    },
+    {
+      "at": "2026-06-20T00:05:47.671167Z",
+      "owner_directive": "Submit hotfix PR for packaged desktop MCP live-backend discovery and generated hook Python interpreter failures.",
+      "reason": "plan"
+    }
+  ],
+  "docs_events": [
+    {
+      "at": "2026-06-19T23:59:33.775912Z",
+      "class": "architecture",
+      "kind": "na",
+      "path": null,
+      "rationale": "No contract change; aligns implementation with existing ARCHITECTURE MCP backend/standalone transport contract.",
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-20T00:01:08.099114Z",
+      "class": "architecture",
+      "kind": "na",
+      "path": null,
+      "rationale": "No contract change; hook commands should use the already selected SciStudio Python instead of relying on PATH python.",
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-20T00:05:47.671461Z",
+      "class": "architecture",
+      "kind": "na",
+      "path": null,
+      "rationale": "No contract change; implementation now matches existing MCP backend/standalone and hook provisioning contracts.",
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": false,
+  "guard_events": [
+    {
+      "at": "2026-06-20T00:06:56.435247Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:06:56.444518Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:06:56.453787Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:06:56.464057Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:06:56.473665Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:06:56.483023Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:06:56.492675Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:06:56.502465Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:06:56.512055Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:06:56.521534Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:07:18.084079Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:07:18.094567Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:07:18.105130Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:07:18.116083Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:07:18.126048Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:07:18.136121Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:07:18.146055Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:07:18.156435Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:07:18.166963Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:07:18.179536Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:11:50.164968Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:11:50.176022Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:11:50.186792Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:11:50.196961Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:11:50.207606Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:11:50.218584Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:11:50.229210Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:11:50.239852Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:11:50.249957Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:11:50.263388Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:12:15.209209Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:12:15.219975Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:12:15.230782Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:12:15.241131Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:12:15.251610Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:12:15.261899Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:12:15.272692Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:12:15.283303Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:12:15.293539Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:12:15.306774Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1705,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": {
+    "base": "origin/main",
+    "base_sha": "8caa7b73",
+    "changed_files": [
+      ".workflow/records/hotfix-live-bugs-20260619-live-bugs-20260619.json",
+      "src/scistudio/agent_provisioning/codex_config.py",
+      "src/scistudio/agent_provisioning/hooks.py",
+      "src/scistudio/api/app.py",
+      "src/scistudio/api/runtime/__init__.py",
+      "src/scistudio/api/runtime/_projects.py",
+      "tests/agent_provisioning/test_codex_config.py",
+      "tests/agent_provisioning/test_hooks.py",
+      "tests/api/test_mcp_transport_publish.py",
+      "tests/cli/test_mcp_bridge.py"
+    ],
+    "diff_fingerprint": "sha256:d047771e5eeec1c61eaa0d6dc9f071b3e5f084b6b452b61b74a8b6f769b652fa",
+    "head": "HEAD",
+    "head_sha": "7acf1968",
+    "surfaces": {
+      "docs": 0,
+      "frontend": 0,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 5,
+      "packaging": 0,
+      "protected_core": 0,
+      "sentrux": 9,
+      "test": 4,
+      "workflow_ci": 0
+    }
+  },
+  "owner_directive": "Owner opened a new live hotfix worktree to fix newly observed bugs, submit a PR, and compare the faster gate workflow.",
+  "persona": "implementer",
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [
+      1705
+    ],
+    "number": null,
+    "url": null
+  },
+  "reconcile_events": [
+    {
+      "at": "2026-06-20T00:06:56.521582Z",
+      "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-20T00:07:18.179586Z",
+      "diff_fingerprint": "sha256:9559371a9c6e59e698dfbeb4fe167b4f4660abaa06721ed3afdfaafd13d03022",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.format_check",
+        "checks.full_audit",
+        "checks.import_contracts",
+        "checks.lint_format",
+        "checks.python_tests",
+        "checks.semantic_dup",
+        "checks.type_check"
+      ]
+    },
+    {
+      "at": "2026-06-20T00:11:50.263443Z",
+      "diff_fingerprint": "sha256:9559371a9c6e59e698dfbeb4fe167b4f4660abaa06721ed3afdfaafd13d03022",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-20T00:12:15.306838Z",
+      "diff_fingerprint": "sha256:d047771e5eeec1c61eaa0d6dc9f071b3e5f084b6b452b61b74a8b6f769b652fa",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    }
+  ],
+  "record_id": "hotfix-live-bugs-20260619-live-bugs-20260619",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [
+      "format_check",
+      "full_audit",
+      "import_contracts",
+      "lint_format",
+      "python_tests",
+      "semantic_dup",
+      "type_check"
+    ],
+    "docs": [
+      "docs_required_or_na"
+    ],
+    "guards": [
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": [
+      "changed_test_required"
+    ]
+  },
+  "runtime": "codex",
+  "schema_version": 2,
+  "scope_events": [
+    {
+      "action": "add-include",
+      "at": "2026-06-19T23:59:33.775865Z",
+      "pattern": "src/scistudio/api/app.py",
+      "reason": "Narrow MCP bridge hotfix scope after investigation"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-19T23:59:33.775882Z",
+      "pattern": "src/scistudio/api/runtime/_projects.py",
+      "reason": "Narrow MCP bridge hotfix scope after investigation"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-19T23:59:33.775889Z",
+      "pattern": "src/scistudio/api/runtime/__init__.py",
+      "reason": "Narrow MCP bridge hotfix scope after investigation"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-19T23:59:33.775891Z",
+      "pattern": "src/scistudio/cli/mcp_bridge.py",
+      "reason": "Narrow MCP bridge hotfix scope after investigation"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-19T23:59:33.775892Z",
+      "pattern": "tests/cli/test_mcp_bridge.py",
+      "reason": "Narrow MCP bridge hotfix scope after investigation"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-20T00:01:08.099095Z",
+      "pattern": "src/scistudio/agent_provisioning",
+      "reason": "Owner reported packaged internal-agent hook interpreter bug"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-20T00:01:08.099099Z",
+      "pattern": "tests/agent_provisioning",
+      "reason": "Owner reported packaged internal-agent hook interpreter bug"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-20T00:01:08.099100Z",
+      "pattern": "tests/ai",
+      "reason": "Owner reported packaged internal-agent hook interpreter bug"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-20T00:04:21.127351Z",
+      "pattern": "tests/api/test_mcp_transport_publish.py",
+      "reason": "Record MCP transport regression test path"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-20T00:05:47.671308Z",
+      "pattern": "src/scistudio/api/app.py",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-20T00:05:47.671311Z",
+      "pattern": "src/scistudio/api/runtime/__init__.py",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-20T00:05:47.671312Z",
+      "pattern": "src/scistudio/api/runtime/_projects.py",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-20T00:05:47.671314Z",
+      "pattern": "src/scistudio/cli/mcp_bridge.py",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-20T00:05:47.671315Z",
+      "pattern": "src/scistudio/agent_provisioning/hooks.py",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-20T00:05:47.671316Z",
+      "pattern": "src/scistudio/agent_provisioning/codex_config.py",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-20T00:05:47.671317Z",
+      "pattern": "tests/cli/test_mcp_bridge.py",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-20T00:05:47.671318Z",
+      "pattern": "tests/api/test_mcp_transport_publish.py",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-20T00:05:47.671319Z",
+      "pattern": "tests/agent_provisioning/test_hooks.py",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-20T00:05:47.671320Z",
+      "pattern": "tests/agent_provisioning/test_codex_config.py",
+      "reason": "plan"
+    }
+  ],
+  "session_id": "888b4666-3491-403d-9dd1-c62457362d43",
+  "strictness_tier": 2,
+  "task_kind": "hotfix",
+  "test_events": [
+    {
+      "at": "2026-06-19T23:59:33.775921Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/cli/test_mcp_bridge.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-20T00:01:08.099120Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/agent_provisioning",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-20T00:01:08.099122Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/ai",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-20T00:04:21.127520Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/api/test_mcp_transport_publish.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-20T00:05:47.671467Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/cli/test_mcp_bridge.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-20T00:05:47.671469Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/api/test_mcp_transport_publish.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-20T00:05:47.671470Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/agent_provisioning/test_hooks.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-20T00:05:47.671471Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/agent_provisioning/test_codex_config.py",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/src/scistudio/agent_provisioning/codex_config.py
+++ b/src/scistudio/agent_provisioning/codex_config.py
@@ -30,6 +30,7 @@ over ``~/.codex/config.toml`` for sessions opened inside this project.
 
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 
 _TARGET_REL = ".codex/config.toml"
@@ -100,11 +101,22 @@ def _render_hook_command(script_name: str) -> str:
 
     On Windows the shell that executes this is whatever Codex spawns
     (PowerShell or bash via Git for Windows); `git rev-parse` works in
-    both. ``python`` is resolved from PATH; the user's project is
-    expected to have ADR-039 git auto-init so the toplevel is the
-    project root.
+    both. The Python executable is pinned to the interpreter running
+    SciStudio so hooks do not depend on a ``python`` shim being present
+    on PATH.
     """
-    return f'python "$(git rev-parse --show-toplevel)/.claude/hooks/{script_name}"'
+    return f'{_quote_shell_path(sys.executable)} "$(git rev-parse --show-toplevel)/.claude/hooks/{script_name}"'
+
+
+def _quote_shell_path(path: str | Path) -> str:
+    escaped = str(path).replace('"', '\\"')
+    return f'"{escaped}"'
+
+
+def _upgrade_legacy_hook_commands(raw: str) -> str:
+    legacy = 'python "$(git rev-parse --show-toplevel)/.claude/hooks/'
+    current = f'{_quote_shell_path(sys.executable)} "$(git rev-parse --show-toplevel)/.claude/hooks/'
+    return raw.replace(_toml_escape(legacy), _toml_escape(current)).replace(legacy, current)
 
 
 def _render_hooks_block() -> str:
@@ -159,6 +171,14 @@ def write_codex_config(
     """
     dest = project_dir / _TARGET_REL
     if dest.exists() and not force:
+        try:
+            raw = dest.read_text(encoding="utf-8")
+        except OSError:
+            return []
+        upgraded = _upgrade_legacy_hook_commands(raw)
+        if upgraded != raw:
+            dest.write_text(upgraded, encoding="utf-8")
+            return [_TARGET_REL]
         return []
 
     # Local import: avoid pulling scistudio.cli.install at module load time;

--- a/src/scistudio/agent_provisioning/hooks.py
+++ b/src/scistudio/agent_provisioning/hooks.py
@@ -30,6 +30,7 @@ import importlib.resources
 import json
 import os
 import stat
+import sys
 from pathlib import Path
 
 _HOOKS_DIR_REL = ".claude/hooks"
@@ -69,12 +70,12 @@ def _load_template(filename: str) -> str:
 def _build_settings_json(hooks_dir_rel: str) -> dict:
     """Build the canonical ``.claude/settings.json`` content per ADR §3.6.
 
-    Hook command lines explicitly invoke ``python`` so the executable
-    bit is not required on Windows. Paths are project-relative via
-    ``$CLAUDE_PROJECT_DIR`` so the settings.json survives moving the
-    project directory.
+    Hook command lines explicitly invoke the Python executable running
+    SciStudio so they do not depend on a ``python`` shim being present on
+    PATH. Hook script paths are project-relative via ``$CLAUDE_PROJECT_DIR``
+    so the settings.json survives moving the project directory.
     """
-    py = "python"  # interpreter resolved by PATH in the user's shell
+    py = _quote_shell_path(sys.executable)
     # Codex P1 reconcile (PR #1047): include MultiEdit in every Edit|Write
     # matcher so multi-edit operations are not a bypass path. Claude Code
     # treats MultiEdit as a distinct tool name.
@@ -111,6 +112,51 @@ def _build_settings_json(hooks_dir_rel: str) -> dict:
     }
 
 
+def _quote_shell_path(path: str | Path) -> str:
+    """Quote an executable path for hook command strings."""
+    escaped = str(path).replace('"', '\\"')
+    return f'"{escaped}"'
+
+
+def _legacy_python_hook_command(script: str, hooks_dir_rel: str) -> str:
+    return f'python "$CLAUDE_PROJECT_DIR/{hooks_dir_rel}/{script}"'
+
+
+def _upgrade_legacy_settings_commands(settings: dict, hooks_dir_rel: str) -> bool:
+    """Replace old PATH-dependent SciStudio hook commands in-place.
+
+    User-owned custom commands are preserved. Only the exact command strings
+    emitted by older SciStudio versions are upgraded.
+    """
+    hooks = settings.get("hooks")
+    if not isinstance(hooks, dict):
+        return False
+    scripts = {dest for _template, dest in _HOOK_FILES}
+    py = _quote_shell_path(sys.executable)
+    changed = False
+    for groups in hooks.values():
+        if not isinstance(groups, list):
+            continue
+        for entry in groups:
+            if not isinstance(entry, dict):
+                continue
+            handlers = entry.get("hooks")
+            if not isinstance(handlers, list):
+                continue
+            for handler in handlers:
+                if not isinstance(handler, dict):
+                    continue
+                command = handler.get("command")
+                if not isinstance(command, str):
+                    continue
+                for script in scripts:
+                    if command == _legacy_python_hook_command(script, hooks_dir_rel):
+                        handler["command"] = f'{py} "$CLAUDE_PROJECT_DIR/{hooks_dir_rel}/{script}"'
+                        changed = True
+                        break
+    return changed
+
+
 def write_hooks(
     project_dir: Path,
     *,
@@ -134,6 +180,14 @@ def write_hooks(
             encoding="utf-8",
         )
         written.append(_SETTINGS_REL)
+    else:
+        try:
+            existing = json.loads(settings_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            existing = None
+        if isinstance(existing, dict) and _upgrade_legacy_settings_commands(existing, _HOOKS_DIR_REL):
+            settings_path.write_text(json.dumps(existing, indent=2) + "\n", encoding="utf-8")
+            written.append(_SETTINGS_REL)
 
     for template_name, dest_name in _HOOK_FILES:
         dest = hooks_dir / dest_name

--- a/src/scistudio/api/app.py
+++ b/src/scistudio/api/app.py
@@ -170,7 +170,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         app.state.mcp_server = mcp_server
         # ADR-034: publish the live MCP port into the active project's
         # .scistudio/ so the per-project mcp-bridge can find it on (re)open.
-        runtime.set_mcp_port(mcp_server.port)
+        runtime.set_mcp_port(mcp_server.port, socket_path=mcp_server.socket_path)
     except Exception:
         import logging
 

--- a/src/scistudio/api/runtime/__init__.py
+++ b/src/scistudio/api/runtime/__init__.py
@@ -358,8 +358,10 @@ class ApiRuntime:
         )
         # ADR-034: the MCP server's TCP/socket port is published into the
         # active project's ``.scistudio/`` so the per-project ``mcp-bridge``
-        # subprocess can discover it.
+        # subprocess can discover it. POSIX transports publish a socket pointer;
+        # Windows publishes a loopback TCP port.
         self._mcp_port: int | None = None
+        self._mcp_socket_path: Path | None = None
         # ADR-040 Addendum 5 / #1488: the workflow id the GUI is currently
         # editing. Frontend POSTs to ``/api/ai/active-context`` on every
         # change; the value is persisted to

--- a/src/scistudio/api/runtime/_projects.py
+++ b/src/scistudio/api/runtime/_projects.py
@@ -364,32 +364,46 @@ def open_project(self: ApiRuntime, project_id_or_path: str) -> KnownProject:
     return candidate
 
 
-def set_mcp_port(self: ApiRuntime, port: int | None) -> None:
-    """Register the live MCP server port for publishing on project switch.
+def set_mcp_port(self: ApiRuntime, port: int | None, *, socket_path: Path | None = None) -> None:
+    """Register the live MCP transport for publishing on project switch.
 
     Called once from the FastAPI ``lifespan`` after ``MCPServer.start()``.
-    ``None`` clears the registration (used during shutdown).
+    ``None`` clears the registration when no ``socket_path`` is provided
+    (used during shutdown). On Windows, ``port`` points to the loopback MCP
+    transport. On POSIX, ``socket_path`` points to the bound Unix socket.
     """
     self._mcp_port = port
-    if port is not None and self.active_project is not None:
+    self._mcp_socket_path = socket_path
+    if self.active_project is not None:
         self._publish_mcp_port(Path(self.active_project.path))
 
 
 def _publish_mcp_port(self: ApiRuntime, project_dir: Path) -> None:
-    """Write the live MCP port into ``<project>/.scistudio/mcp.sock.port``.
+    """Publish the live MCP transport under ``<project>/.scistudio/``.
 
     Best-effort: failures are logged and swallowed (e.g. read-only
     project root) so they cannot break ``open_project``.
     """
-    if self._mcp_port is None:
-        return
     try:
         target_dir = project_dir / ".scistudio"
         target_dir.mkdir(parents=True, exist_ok=True)
-        (target_dir / "mcp.sock.port").write_text(str(self._mcp_port), encoding="utf-8")
+        port_file = target_dir / "mcp.sock.port"
+        path_file = target_dir / "mcp.sock.path"
+        if self._mcp_port is not None:
+            port_file.write_text(str(self._mcp_port), encoding="utf-8")
+            if path_file.exists():
+                path_file.unlink()
+        elif self._mcp_socket_path is not None:
+            path_file.write_text(str(self._mcp_socket_path), encoding="utf-8")
+            if port_file.exists():
+                port_file.unlink()
+        else:
+            for stale in (port_file, path_file):
+                if stale.exists():
+                    stale.unlink()
     except OSError:
         logger.warning(
-            "ApiRuntime: could not publish MCP port to %s/.scistudio/mcp.sock.port",
+            "ApiRuntime: could not publish MCP transport to %s/.scistudio/",
             project_dir,
             exc_info=True,
         )

--- a/tests/agent_provisioning/test_codex_config.py
+++ b/tests/agent_provisioning/test_codex_config.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sys
 import tomllib
 from pathlib import Path
 
@@ -85,6 +86,7 @@ def test_codex_config_emits_hooks(tmp_project_dir: Path) -> None:
                 # Every hook command must invoke a .claude/hooks/ script
                 # (cross-provider DRY — no Codex-specific script tree).
                 assert ".claude/hooks/" in cmd, f"hook command should target .claude/hooks/, got: {cmd!r}"
+                assert sys.executable in cmd, f"hook command should pin SciStudio Python, got: {cmd!r}"
         return names
 
     assert _script_names(pre) == expected_pre_scripts
@@ -101,6 +103,29 @@ def test_idempotent_preserves_user_managed_toml(tmp_project_dir: Path) -> None:
     written = write_codex_config(tmp_project_dir, force=False)
     assert written == []
     assert (codex_dir / "config.toml").read_text(encoding="utf-8") == user_body
+
+
+def test_existing_codex_config_upgrades_legacy_python_hook_command(tmp_project_dir: Path) -> None:
+    codex_dir = tmp_project_dir / ".codex"
+    codex_dir.mkdir(parents=True, exist_ok=True)
+    legacy_body = (
+        "[features]\n"
+        "hooks = true\n"
+        "[[hooks.PreToolUse]]\n"
+        'matcher = "^Bash$"\n'
+        "[[hooks.PreToolUse.hooks]]\n"
+        'type = "command"\n'
+        'command = "python \\"$(git rev-parse --show-toplevel)/.claude/hooks/deny_scistudio_cli.py\\""\n'
+    )
+    target = codex_dir / "config.toml"
+    target.write_text(legacy_body, encoding="utf-8")
+
+    written = write_codex_config(tmp_project_dir, force=False)
+
+    assert written == [".codex/config.toml"]
+    upgraded = target.read_text(encoding="utf-8")
+    assert sys.executable in upgraded
+    assert 'command = "python \\"$(git rev-parse' not in upgraded
 
 
 def test_force_overwrites(tmp_project_dir: Path) -> None:

--- a/tests/agent_provisioning/test_hooks.py
+++ b/tests/agent_provisioning/test_hooks.py
@@ -42,7 +42,7 @@ def test_write_hooks_creates_settings_json(tmp_project_dir: Path) -> None:
     # Every entry references a python interpreter and a hook script path.
     for entry in pre + post:
         cmd = entry["hooks"][0]["command"]
-        assert "python" in cmd
+        assert sys.executable in cmd
         assert "$CLAUDE_PROJECT_DIR" in cmd
         assert ".claude/hooks/" in cmd
 
@@ -73,6 +73,39 @@ def test_write_hooks_idempotent_preserves_user_edits(tmp_project_dir: Path) -> N
     assert ".claude/settings.json" not in written
     data = json.loads((tmp_project_dir / ".claude" / "settings.json").read_text(encoding="utf-8"))
     assert data.get("hooks", {}).get("_custom") == "user-added"
+
+
+def test_write_hooks_upgrades_legacy_python_commands(tmp_project_dir: Path) -> None:
+    """Old generated hooks used PATH ``python``; reopen should repair them."""
+    settings_path = tmp_project_dir / ".claude" / "settings.json"
+    settings_path.parent.mkdir(parents=True, exist_ok=True)
+    legacy = {
+        "hooks": {
+            "PreToolUse": [
+                {
+                    "matcher": "Bash",
+                    "hooks": [
+                        {
+                            "type": "command",
+                            "command": 'python "$CLAUDE_PROJECT_DIR/.claude/hooks/deny_scistudio_cli.py"',
+                        }
+                    ],
+                }
+            ],
+            "PostToolUse": [],
+            "_custom": "user-added",
+        }
+    }
+    settings_path.write_text(json.dumps(legacy), encoding="utf-8")
+
+    written = write_hooks(tmp_project_dir, force=False)
+
+    assert ".claude/settings.json" in written
+    data = json.loads(settings_path.read_text(encoding="utf-8"))
+    cmd = data["hooks"]["PreToolUse"][0]["hooks"][0]["command"]
+    assert cmd.startswith(f'"{sys.executable}" ')
+    assert 'python "$CLAUDE_PROJECT_DIR' not in cmd
+    assert data["hooks"]["_custom"] == "user-added"
 
 
 def test_write_hooks_force_overwrites_settings_json(tmp_project_dir: Path) -> None:

--- a/tests/api/test_mcp_transport_publish.py
+++ b/tests/api/test_mcp_transport_publish.py
@@ -1,0 +1,46 @@
+"""Regression tests for project-scoped MCP transport publication."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def _make_project(root: Path) -> Path:
+    project = root / "project"
+    project.mkdir()
+    (project / "project.yaml").write_text(
+        "project:\n  name: test\n  version: 0.1.0\n",
+        encoding="utf-8",
+    )
+    return project
+
+
+def test_open_project_publishes_posix_mcp_socket_pointer(tmp_path: Path) -> None:
+    """A backend socket bound before project-open is discoverable afterward."""
+    from scistudio.api.runtime import ApiRuntime
+
+    runtime = ApiRuntime()
+    backend_socket = tmp_path / "backend.sock"
+    runtime.set_mcp_port(None, socket_path=backend_socket)
+
+    project = _make_project(tmp_path)
+    runtime.open_project(str(project))
+
+    pointer = project / ".scistudio" / "mcp.sock.path"
+    assert pointer.read_text(encoding="utf-8") == str(backend_socket)
+    assert not (project / ".scistudio" / "mcp.sock.port").exists()
+
+
+def test_open_project_publishes_tcp_mcp_port(tmp_path: Path) -> None:
+    """TCP transport publication remains the preferred Windows path."""
+    from scistudio.api.runtime import ApiRuntime
+
+    runtime = ApiRuntime()
+    runtime.set_mcp_port(49152, socket_path=tmp_path / "backend.sock")
+
+    project = _make_project(tmp_path)
+    runtime.open_project(str(project))
+
+    port_file = project / ".scistudio" / "mcp.sock.port"
+    assert port_file.read_text(encoding="utf-8") == "49152"
+    assert not (project / ".scistudio" / "mcp.sock.path").exists()

--- a/tests/cli/test_mcp_bridge.py
+++ b/tests/cli/test_mcp_bridge.py
@@ -22,8 +22,10 @@ import asyncio
 import contextlib
 import io
 import json
+import os
 import socket as socket_mod
 import sys
+import tempfile
 import threading
 from pathlib import Path
 
@@ -237,6 +239,38 @@ def test_try_connect_attached_returns_none_without_socket(tmp_path: Path) -> Non
 
     project = _make_project(tmp_path)
     assert _try_connect_attached(project) is None
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX socket pointer only")
+def test_try_connect_attached_uses_project_socket_pointer(tmp_path: Path) -> None:
+    """POSIX project-scope bridge discovery follows ``mcp.sock.path``.
+
+    Packaged desktop starts the backend before a project is open, so the
+    backend MCP server may be bound to a process-level socket rather than
+    ``<project>/.scistudio/mcp.sock``. The runtime publishes that actual
+    socket path through ``mcp.sock.path`` when the GUI opens a project.
+    """
+    from scistudio.cli.mcp_bridge import _try_connect_attached
+
+    project = _make_project(tmp_path)
+    actual_socket = Path(tempfile.gettempdir()) / f"mcp-{os.getpid()}-{threading.get_ident()}.sock"
+    server_sock = socket_mod.socket(socket_mod.AF_UNIX, socket_mod.SOCK_STREAM)
+
+    client_sock = None
+    try:
+        if actual_socket.exists():
+            actual_socket.unlink()
+        server_sock.bind(str(actual_socket))
+        server_sock.listen(1)
+        (project / ".scistudio" / "mcp.sock.path").write_text(str(actual_socket), encoding="utf-8")
+        client_sock = _try_connect_attached(project)
+        assert client_sock is not None
+    finally:
+        if client_sock is not None:
+            client_sock.close()
+        server_sock.close()
+        if actual_socket.exists():
+            actual_socket.unlink()
 
 
 def test_attached_socket_path_matches_backend_convention(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- Publish the live MCP backend transport into each opened project so packaged desktop agent bridges attach to the running backend instead of falling back to standalone mode.
- Pin generated Claude/Codex hook commands to the SciStudio Python executable and repair older generated hook commands that relied on a PATH `python`.

## Root Cause

The packaged desktop backend can start MCP before a project is active, so the live POSIX socket may live outside `<project>/.scistudio/mcp.sock`. Project-scoped bridge processes only knew to probe the project socket location and therefore missed a healthy backend. Generated hook configs also invoked `python` by name, which is not guaranteed in packaged desktop shells.

## Validation

- `PYTHONPATH=src pytest -q --no-cov tests/cli/test_mcp_bridge.py tests/api/test_mcp_transport_publish.py tests/agent_provisioning/test_hooks.py tests/agent_provisioning/test_codex_config.py`
- `PYTHONPATH=src python -m ruff check src/scistudio/api/app.py src/scistudio/api/runtime/__init__.py src/scistudio/api/runtime/_projects.py src/scistudio/agent_provisioning/hooks.py src/scistudio/agent_provisioning/codex_config.py tests/cli/test_mcp_bridge.py tests/api/test_mcp_transport_publish.py tests/agent_provisioning/test_hooks.py tests/agent_provisioning/test_codex_config.py`
- `git diff --check`

Gate record: `.workflow/records/hotfix-live-bugs-20260619-live-bugs-20260619.json`

Closes #1705
