### PR TITLE
hotfix(#1707): bind MCP server to active project

### DIFF
--- a/.workflow/records/1707-mcp-project-socket.json
+++ b/.workflow/records/1707-mcp-project-socket.json
@@ -1,0 +1,1191 @@
+{
+  "branch": "hotfix/mcp-project-socket-20260619",
+  "check_events": [
+    {
+      "at": "2026-06-20T00:44:41.325144Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-20T00:44:45.123958Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-20T00:44:45.169124Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-20T00:44:54.557071Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-20T00:44:57.852243Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-20T00:44:57.866858Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-20T00:45:41.632453Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-20T00:45:45.321666Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-20T00:45:45.337752Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-20T00:46:11.460221Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:48cfcfe827b950b9cbfde625d7d971a379ce4e230186d6d6672c68e3885b00f5",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-20T00:46:15.073762Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:48cfcfe827b950b9cbfde625d7d971a379ce4e230186d6d6672c68e3885b00f5",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-20T00:46:15.566012Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:48cfcfe827b950b9cbfde625d7d971a379ce4e230186d6d6672c68e3885b00f5",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-20T00:46:15.580416Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:48cfcfe827b950b9cbfde625d7d971a379ce4e230186d6d6672c68e3885b00f5",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-20T00:48:31.798319Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:48cfcfe827b950b9cbfde625d7d971a379ce4e230186d6d6672c68e3885b00f5",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-20T00:50:28.112138Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:48cfcfe827b950b9cbfde625d7d971a379ce4e230186d6d6672c68e3885b00f5",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-20T00:50:35.657405Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:48cfcfe827b950b9cbfde625d7d971a379ce4e230186d6d6672c68e3885b00f5",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    },
+    {
+      "at": "2026-06-20T00:51:08.757835Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:48cfcfe827b950b9cbfde625d7d971a379ce4e230186d6d6672c68e3885b00f5",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-20T00:51:12.543777Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:48cfcfe827b950b9cbfde625d7d971a379ce4e230186d6d6672c68e3885b00f5",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-20T00:51:12.651248Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:48cfcfe827b950b9cbfde625d7d971a379ce4e230186d6d6672c68e3885b00f5",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-20T00:51:12.666881Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:48cfcfe827b950b9cbfde625d7d971a379ce4e230186d6d6672c68e3885b00f5",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-20T00:53:06.803730Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:48cfcfe827b950b9cbfde625d7d971a379ce4e230186d6d6672c68e3885b00f5",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-20T00:55:04.697341Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:48cfcfe827b950b9cbfde625d7d971a379ce4e230186d6d6672c68e3885b00f5",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-20T00:55:05.221810Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:48cfcfe827b950b9cbfde625d7d971a379ce4e230186d6d6672c68e3885b00f5",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    },
+    {
+      "at": "2026-06-20T00:57:27.811680Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:a04d004ea0fbf8444f568749664c0589fcb64803a64bcc143e74d7291e6c34fa",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-20T00:57:31.715051Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:a04d004ea0fbf8444f568749664c0589fcb64803a64bcc143e74d7291e6c34fa",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-20T00:57:31.826313Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:a04d004ea0fbf8444f568749664c0589fcb64803a64bcc143e74d7291e6c34fa",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-20T00:57:31.847269Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:a04d004ea0fbf8444f568749664c0589fcb64803a64bcc143e74d7291e6c34fa",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-20T00:59:22.293927Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:a04d004ea0fbf8444f568749664c0589fcb64803a64bcc143e74d7291e6c34fa",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-20T01:01:12.404626Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:a04d004ea0fbf8444f568749664c0589fcb64803a64bcc143e74d7291e6c34fa",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-20T01:01:12.958459Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:a04d004ea0fbf8444f568749664c0589fcb64803a64bcc143e74d7291e6c34fa",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    }
+  ],
+  "check_na": [],
+  "commit": null,
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "src/scistudio/api/app.py",
+      "src/scistudio/api/mcp_lifecycle.py",
+      "src/scistudio/api/routes/projects.py",
+      "src/scistudio/api/runtime/_projects.py",
+      "tests/api/test_mcp_transport_publish.py"
+    ]
+  },
+  "directive_events": [
+    {
+      "at": "2026-06-20T00:43:33.574299Z",
+      "owner_directive": "Bind the app-owned MCP server only after a project is opened and publish/repair the project-local MCP transport for packaged desktop bridges.",
+      "reason": "plan"
+    },
+    {
+      "at": "2026-06-20T00:56:26.896305Z",
+      "owner_directive": "Stabilize CI by restoring CLI-mutated desktop environment variables between tests; no product behavior change.",
+      "reason": "Full pre-pr python_tests exposed CLI test env leakage: gui --bundled mutates process env under Typer CliRunner, which can make later TypeRegistry tests run as bundled desktop."
+    }
+  ],
+  "docs_events": [
+    {
+      "at": "2026-06-20T00:43:33.574588Z",
+      "class": "product-docs",
+      "kind": "na",
+      "path": null,
+      "rationale": "No public workflow or API contract changes; this is a packaged desktop backend lifecycle bugfix covered by regression tests.",
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": false,
+  "guard_events": [
+    {
+      "at": "2026-06-20T00:44:45.190579Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:44:45.199835Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:44:45.208851Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:44:45.217295Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:44:45.226045Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:44:45.235121Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:44:45.243678Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:44:45.252552Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:44:45.261518Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:44:45.271894Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:44:57.886940Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:44:57.896132Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:44:57.904851Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:44:57.913478Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:44:57.922351Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:44:57.930992Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:44:57.939295Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:44:57.948272Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:44:57.957062Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:44:57.965422Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:45:33.855940Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:45:33.866705Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:45:33.877257Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:45:33.886579Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:45:33.895913Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:45:33.905168Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:45:33.913895Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:45:33.922721Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:45:33.931347Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:45:33.940300Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:45:45.359240Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:45:45.369024Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:45:45.378980Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:45:45.388617Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:45:45.397735Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:45:45.407093Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:45:45.416598Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:45:45.425528Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:45:45.434846Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:45:45.444123Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:50:35.687214Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:50:35.696699Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:50:35.706153Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:50:35.715161Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:50:35.725038Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:50:35.735537Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:50:35.744638Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:50:35.753570Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:50:35.762408Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:50:35.773749Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:55:05.257146Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:55:05.266891Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:55:05.277657Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:55:05.287234Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:55:05.296256Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:55:05.305598Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:55:05.314900Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:55:05.324811Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:55:05.333580Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T00:55:05.345010Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T01:01:12.996838Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T01:01:13.007326Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T01:01:13.017500Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T01:01:13.027505Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T01:01:13.037495Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T01:01:13.047773Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T01:01:13.058081Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T01:01:13.068340Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T01:01:13.078917Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T01:01:13.092630Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1707,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": {
+    "base": "origin/hotfix/live-bugs-20260619",
+    "base_sha": "481ecaf0",
+    "changed_files": [
+      ".workflow/records/1707-mcp-project-socket.json",
+      "src/scistudio/api/app.py",
+      "src/scistudio/api/mcp_lifecycle.py",
+      "src/scistudio/api/routes/projects.py",
+      "src/scistudio/api/runtime/_projects.py",
+      "tests/api/test_mcp_transport_publish.py",
+      "tests/cli/test_cli.py"
+    ],
+    "diff_fingerprint": "sha256:4972602cf268908c5f937952e5ccb04aa10a6c321db157ea6434fa4e894a5d3c",
+    "head": "HEAD",
+    "head_sha": "398bea44",
+    "surfaces": {
+      "docs": 0,
+      "frontend": 0,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 4,
+      "packaging": 0,
+      "protected_core": 0,
+      "sentrux": 6,
+      "test": 2,
+      "workflow_ci": 0
+    }
+  },
+  "owner_directive": "Owner requested a new PR for the packaged desktop MCP backend discovery failure after the agent still reported no backend.",
+  "persona": "implementer",
+  "pull_request": null,
+  "reconcile_events": [
+    {
+      "at": "2026-06-20T00:44:45.271969Z",
+      "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.format_check"
+      ]
+    },
+    {
+      "at": "2026-06-20T00:44:57.965461Z",
+      "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-20T00:45:33.940346Z",
+      "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-20T00:45:45.444182Z",
+      "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-20T00:50:35.773811Z",
+      "diff_fingerprint": "sha256:3985f28b691c7ae8fa260e8b203fb88d8b0021454ae10243035fc2a44f25d6c0",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.python_tests"
+      ]
+    },
+    {
+      "at": "2026-06-20T00:55:05.345082Z",
+      "diff_fingerprint": "sha256:3985f28b691c7ae8fa260e8b203fb88d8b0021454ae10243035fc2a44f25d6c0",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.python_tests"
+      ]
+    },
+    {
+      "at": "2026-06-20T01:01:13.092738Z",
+      "diff_fingerprint": "sha256:4972602cf268908c5f937952e5ccb04aa10a6c321db157ea6434fa4e894a5d3c",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    }
+  ],
+  "record_id": "1707-mcp-project-socket",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [
+      "format_check",
+      "full_audit",
+      "import_contracts",
+      "lint_format",
+      "python_tests",
+      "semantic_dup",
+      "type_check"
+    ],
+    "docs": [
+      "docs_required_or_na"
+    ],
+    "guards": [
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": [
+      "changed_test_required"
+    ]
+  },
+  "runtime": "codex",
+  "schema_version": 2,
+  "scope_events": [
+    {
+      "action": "add-include",
+      "at": "2026-06-20T00:56:26.896456Z",
+      "pattern": "tests/cli/test_cli.py",
+      "reason": "Full pre-pr python_tests exposed CLI test env leakage: gui --bundled mutates process env under Typer CliRunner, which can make later TypeRegistry tests run as bundled desktop."
+    }
+  ],
+  "session_id": "bd6b0a2e-f995-4377-bf88-976c20454978",
+  "strictness_tier": 2,
+  "task_kind": "hotfix",
+  "test_events": [
+    {
+      "at": "2026-06-20T00:43:33.574789Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/api/test_mcp_transport_publish.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-20T00:43:33.574794Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/api/test_projects.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-20T00:43:33.574796Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/cli/test_mcp_bridge.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-20T00:56:26.896468Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/cli/test_cli.py",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/.workflow/records/1707-mcp-project-socket.json
+++ b/.workflow/records/1707-mcp-project-socket.json
@@ -480,10 +480,127 @@
       "tool_versions": {
         "mypy": "2.1.0"
       }
+    },
+    {
+      "at": "2026-06-20T01:01:43.485798Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:a04d004ea0fbf8444f568749664c0589fcb64803a64bcc143e74d7291e6c34fa",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-20T01:01:47.600788Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:a04d004ea0fbf8444f568749664c0589fcb64803a64bcc143e74d7291e6c34fa",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-20T01:01:47.708584Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:a04d004ea0fbf8444f568749664c0589fcb64803a64bcc143e74d7291e6c34fa",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-20T01:01:47.724262Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:a04d004ea0fbf8444f568749664c0589fcb64803a64bcc143e74d7291e6c34fa",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-20T01:03:53.752313Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:a04d004ea0fbf8444f568749664c0589fcb64803a64bcc143e74d7291e6c34fa",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-20T01:05:45.169316Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:a04d004ea0fbf8444f568749664c0589fcb64803a64bcc143e74d7291e6c34fa",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-20T01:05:45.710721Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:a04d004ea0fbf8444f568749664c0589fcb64803a64bcc143e74d7291e6c34fa",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
     }
   ],
   "check_na": [],
-  "commit": null,
+  "commit": {
+    "sha": "ca2cc80793ad135ba2b0762f87c49672a99742f6",
+    "shas": [
+      "ca2cc80793ad135ba2b0762f87c49672a99742f6"
+    ],
+    "trailers": []
+  },
   "declared_scope": {
     "exclude": [],
     "include": [
@@ -1003,6 +1120,170 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-06-20T01:05:45.748031Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T01:05:45.758840Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T01:05:45.768619Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T01:05:45.778341Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T01:05:45.787717Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T01:05:45.798162Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T01:05:45.807989Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T01:05:45.818274Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T01:05:45.829385Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T01:05:45.844025Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T01:06:25.355617Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T01:06:25.364463Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T01:06:25.373992Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T01:06:25.384172Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T01:06:25.393472Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T01:06:25.402667Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T01:06:25.411760Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T01:06:25.420897Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T01:06:25.429756Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T01:06:25.442346Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -1026,9 +1307,9 @@
       "tests/api/test_mcp_transport_publish.py",
       "tests/cli/test_cli.py"
     ],
-    "diff_fingerprint": "sha256:4972602cf268908c5f937952e5ccb04aa10a6c321db157ea6434fa4e894a5d3c",
+    "diff_fingerprint": "sha256:7a6ac453fec3c7739e4d5de2c778f9f9e52f99c6f4defdb17e1f3fe06488941b",
     "head": "HEAD",
-    "head_sha": "398bea44",
+    "head_sha": "ca2cc807",
     "surfaces": {
       "docs": 0,
       "frontend": 0,
@@ -1044,7 +1325,14 @@
   },
   "owner_directive": "Owner requested a new PR for the packaged desktop MCP backend discovery failure after the agent still reported no backend.",
   "persona": "implementer",
-  "pull_request": null,
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [
+      1707
+    ],
+    "number": null,
+    "url": null
+  },
   "reconcile_events": [
     {
       "at": "2026-06-20T00:44:45.271969Z",
@@ -1107,6 +1395,30 @@
       "result": "pass",
       "tier": 2,
       "unsatisfied": []
+    },
+    {
+      "at": "2026-06-20T01:05:45.844103Z",
+      "diff_fingerprint": "sha256:7a6ac453fec3c7739e4d5de2c778f9f9e52f99c6f4defdb17e1f3fe06488941b",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-20T01:06:25.442387Z",
+      "diff_fingerprint": "sha256:7a6ac453fec3c7739e4d5de2c778f9f9e52f99c6f4defdb17e1f3fe06488941b",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.format_check",
+        "checks.full_audit",
+        "checks.import_contracts",
+        "checks.lint_format",
+        "checks.python_tests",
+        "checks.semantic_dup",
+        "checks.type_check"
+      ]
     }
   ],
   "record_id": "1707-mcp-project-socket",

--- a/src/scistudio/api/app.py
+++ b/src/scistudio/api/app.py
@@ -12,6 +12,7 @@ from fastapi import FastAPI, Request, WebSocket
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import RedirectResponse
 
+from scistudio.api.mcp_lifecycle import stop_project_mcp_server
 from scistudio.api.routes import (
     ai,
     ai_pty,
@@ -92,11 +93,15 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     # ``routes/projects.py::_restart_workflow_watcher``, so a separate
     # git-watcher lifecycle hook is no longer required.
 
-    # ---- Phase 2: MCP server lifecycle ----
-    mcp_server: object | None = None
+    # ---- Phase 2: MCP context lifecycle ----
+    #
+    # The actual MCP server binds after a project is opened, through
+    # ``api.mcp_lifecycle.ensure_project_mcp_server``. Binding here before
+    # an active project exists would force every desktop instance to share
+    # the same home-scoped fallback socket, which is not safe across stale
+    # packaged backend processes.
     try:
         from scistudio.ai.agent.mcp import _context as _mcp_context
-        from scistudio.ai.agent.mcp.server import MCPServer
 
         # ApiRuntime structurally satisfies the MCPContext Protocol once
         # we expose ``project_dir`` as a property — wrap it in a small
@@ -160,22 +165,11 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
                 )
 
         _mcp_context.set_context(_RuntimeAdapter(runtime))  # type: ignore[arg-type]
-        # Pick a per-process socket path. Without an active project we
-        # fall back to a temp-dir sentinel so the server still starts
-        # and can be inspected via tools/list.
-        project_dir = Path(runtime.active_project.path) if runtime.active_project else Path.home() / ".scistudio"
-        socket_path = project_dir / ".scistudio" / "mcp.sock"
-        mcp_server = MCPServer(socket_path=socket_path, project_dir=project_dir)
-        await mcp_server.start()  # type: ignore[attr-defined]
-        app.state.mcp_server = mcp_server
-        # ADR-034: publish the live MCP port into the active project's
-        # .scistudio/ so the per-project mcp-bridge can find it on (re)open.
-        runtime.set_mcp_port(mcp_server.port, socket_path=mcp_server.socket_path)
+        app.state.mcp_server = None
     except Exception:
         import logging
 
-        logging.getLogger(__name__).error("MCP server failed to start", exc_info=True)
-        mcp_server = None
+        logging.getLogger(__name__).error("MCP context failed to initialize", exc_info=True)
         app.state.mcp_server = None
 
     try:
@@ -201,13 +195,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         if pending_run_tasks:
             await asyncio.gather(*pending_run_tasks, return_exceptions=True)
         app.state.registry.terminate_all(grace_period_sec=5.0)
-        if mcp_server is not None:
-            try:
-                await mcp_server.stop()  # type: ignore[attr-defined]
-            except Exception:
-                import logging
-
-                logging.getLogger(__name__).warning("MCP server stop raised", exc_info=True)
+        await stop_project_mcp_server(app, runtime)
         # Clear the global context so a subsequent app instance starts clean.
         try:
             from scistudio.ai.agent.mcp import _context as _mcp_context

--- a/src/scistudio/api/mcp_lifecycle.py
+++ b/src/scistudio/api/mcp_lifecycle.py
@@ -1,0 +1,77 @@
+"""MCP server lifecycle helpers for the FastAPI app."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+from scistudio.api.runtime import ApiRuntime
+
+logger = logging.getLogger(__name__)
+
+
+def _server_requested_socket(server: object) -> Path | None:
+    raw = getattr(server, "_requested_socket_path", None)
+    return raw if isinstance(raw, Path) else None
+
+
+def _server_bound_socket(server: object) -> Path | None:
+    raw = getattr(server, "socket_path", None)
+    return raw if isinstance(raw, Path) else None
+
+
+async def ensure_project_mcp_server(app: Any, runtime: ApiRuntime, project_dir: Path) -> None:
+    """Ensure the live MCP server is reachable through the active project."""
+    target_socket = project_dir / ".scistudio" / "mcp.sock"
+    current = getattr(app.state, "mcp_server", None)
+
+    bound_socket = _server_bound_socket(current) if current is not None else None
+    if current is not None and _server_requested_socket(current) == target_socket and bound_socket is not None:
+        if bound_socket.exists():
+            runtime.set_mcp_port(getattr(current, "port", None), socket_path=bound_socket)
+            return
+        logger.warning("MCP server socket path disappeared; rebinding %s", target_socket)
+
+    if (
+        current is not None
+        and _server_requested_socket(current) == target_socket
+        and getattr(current, "port", None) is not None
+    ):
+        runtime.set_mcp_port(getattr(current, "port", None), socket_path=target_socket)
+        return
+
+    if current is not None:
+        try:
+            await current.stop()
+        except Exception:
+            logger.warning("MCP server stop before project rebind raised", exc_info=True)
+        finally:
+            app.state.mcp_server = None
+
+    try:
+        from scistudio.ai.agent.mcp.server import MCPServer
+
+        server = MCPServer(socket_path=target_socket, project_dir=project_dir)
+        await server.start()
+        app.state.mcp_server = server
+        runtime.set_mcp_port(server.port, socket_path=server.socket_path)
+    except Exception:
+        logger.error("MCP server failed to start for project %s", project_dir, exc_info=True)
+        app.state.mcp_server = None
+        runtime.set_mcp_port(None)
+
+
+async def stop_project_mcp_server(app: Any, runtime: ApiRuntime) -> None:
+    """Stop the app-owned MCP server and clear project transport files."""
+    current = getattr(app.state, "mcp_server", None)
+    if current is None:
+        runtime.set_mcp_port(None)
+        return
+    try:
+        await current.stop()
+    except Exception:
+        logger.warning("MCP server stop raised", exc_info=True)
+    finally:
+        app.state.mcp_server = None
+        runtime.set_mcp_port(None)

--- a/src/scistudio/api/routes/projects.py
+++ b/src/scistudio/api/routes/projects.py
@@ -14,6 +14,7 @@ from pydantic import BaseModel
 
 from scistudio.api.deps import get_runtime
 from scistudio.api.file_contracts import ADR036_FILE_ALLOWLIST, FILE_CHANGED_EVENT_TYPE
+from scistudio.api.mcp_lifecycle import ensure_project_mcp_server
 from scistudio.api.runtime import FILE_ENTITY_CLASS, ApiRuntime
 from scistudio.api.schemas import ProjectCreate, ProjectResponse, ProjectUpdate
 from scistudio.engine.events import EngineEvent
@@ -32,12 +33,13 @@ RuntimeDep = Annotated[ApiRuntime, Depends(get_runtime)]
 
 
 @router.post("/", response_model=ProjectResponse)
-async def create_project(body: ProjectCreate, runtime: RuntimeDep) -> ProjectResponse:
+async def create_project(request: Request, body: ProjectCreate, runtime: RuntimeDep) -> ProjectResponse:
     """Create a new project workspace."""
     try:
         project = runtime.create_project(body.name, body.description, body.path)
     except FileExistsError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
+    await ensure_project_mcp_server(request.app, runtime, Path(project.path))
     return ProjectResponse(**runtime.project_response(project))
 
 
@@ -521,12 +523,13 @@ async def _maybe_reload_blocks_after_save(runtime: ApiRuntime, target: Path, con
 
 
 @router.get("/{project_id:path}", response_model=ProjectResponse)
-async def get_project(project_id: str, runtime: RuntimeDep) -> ProjectResponse:
+async def get_project(request: Request, project_id: str, runtime: RuntimeDep) -> ProjectResponse:
     """Retrieve and open a project by identifier or filesystem path."""
     try:
         project = runtime.open_project(project_id)
     except FileNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
+    await ensure_project_mcp_server(request.app, runtime, Path(project.path))
     # ADR-034 Phase 2: refresh the workflow filesystem watcher to point at
     # the newly active project. ``start_for_project`` is idempotent 鈥?if the
     # caller re-opens the same project it returns immediately without

--- a/src/scistudio/api/runtime/_projects.py
+++ b/src/scistudio/api/runtime/_projects.py
@@ -394,7 +394,12 @@ def _publish_mcp_port(self: ApiRuntime, project_dir: Path) -> None:
             if path_file.exists():
                 path_file.unlink()
         elif self._mcp_socket_path is not None:
-            path_file.write_text(str(self._mcp_socket_path), encoding="utf-8")
+            conventional_socket = target_dir / "mcp.sock"
+            if self._mcp_socket_path == conventional_socket:
+                if path_file.exists():
+                    path_file.unlink()
+            else:
+                path_file.write_text(str(self._mcp_socket_path), encoding="utf-8")
             if port_file.exists():
                 port_file.unlink()
         else:

--- a/tests/api/test_mcp_transport_publish.py
+++ b/tests/api/test_mcp_transport_publish.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import socket
 from pathlib import Path
+
+from fastapi.testclient import TestClient
 
 
 def _make_project(root: Path) -> Path:
@@ -44,3 +47,62 @@ def test_open_project_publishes_tcp_mcp_port(tmp_path: Path) -> None:
     port_file = project / ".scistudio" / "mcp.sock.port"
     assert port_file.read_text(encoding="utf-8") == "49152"
     assert not (project / ".scistudio" / "mcp.sock.path").exists()
+
+
+def test_open_project_clears_pointer_for_conventional_posix_socket(tmp_path: Path) -> None:
+    """Project-local POSIX sockets do not need an extra pointer file."""
+    from scistudio.api.runtime import ApiRuntime
+
+    runtime = ApiRuntime()
+    project = _make_project(tmp_path)
+    runtime.set_mcp_port(None, socket_path=project / ".scistudio" / "mcp.sock")
+
+    runtime.open_project(str(project))
+
+    assert not (project / ".scistudio" / "mcp.sock.path").exists()
+
+
+def _mcp_connect_path(project: Path) -> Path:
+    socket_path = project / ".scistudio" / "mcp.sock"
+    pointer_path = project / ".scistudio" / "mcp.sock.path"
+    if pointer_path.exists():
+        return Path(pointer_path.read_text(encoding="utf-8").strip())
+    return socket_path
+
+
+def test_project_open_route_starts_project_mcp_socket(client: TestClient, project_parent: Path) -> None:
+    """Packaged desktop opens a project after startup; MCP must bind there."""
+    response = client.post(
+        "/api/projects/",
+        json={"name": "MCP Project", "description": "", "path": str(project_parent)},
+    )
+    assert response.status_code == 200
+    project = Path(response.json()["path"])
+    connect_path = _mcp_connect_path(project)
+
+    assert connect_path.exists()
+
+    client_sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    try:
+        client_sock.settimeout(2.0)
+        client_sock.connect(str(connect_path))
+    finally:
+        client_sock.close()
+
+
+def test_project_open_route_rebinds_missing_project_mcp_socket(client: TestClient, project_parent: Path) -> None:
+    """If a stale process unlinks the socket path, reopening repairs it."""
+    response = client.post(
+        "/api/projects/",
+        json={"name": "MCP Rebind", "description": "", "path": str(project_parent)},
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    project = Path(payload["path"])
+    original_connect_path = _mcp_connect_path(project)
+    original_connect_path.unlink()
+
+    reopened = client.get(f"/api/projects/{payload['id']}")
+
+    assert reopened.status_code == 200
+    assert _mcp_connect_path(project).exists()

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -2,14 +2,29 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
+import pytest
 import yaml
 from typer.testing import CliRunner
 
 from scistudio.cli.main import app
 
 runner = CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def _restore_cli_environment() -> object:
+    """Keep in-process CLI env mutations from leaking across tests."""
+    keys = ("SCISTUDIO_BUNDLED", "SCISTUDIO_ENGINE_API_URL")
+    previous = {key: os.environ.get(key) for key in keys}
+    yield
+    for key, value in previous.items():
+        if value is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = value
 
 
 class TestCLIHelp:


### PR DESCRIPTION
## Summary

- Bind the app-owned MCP server only after a project is opened or created.
- Publish the actual project MCP transport from the active project, and repair it when a stale socket path disappears.
- Stop writing `mcp.sock.path` for the conventional project-local POSIX socket so the bridge probes the stable default path.
- Restore CLI-mutated desktop environment variables between CLI tests, preventing `gui --bundled` from leaking packaged-desktop mode into later TypeRegistry tests under xdist.

## Root Cause

Packaged desktop startup created the MCP server before `ApiRuntime.active_project` existed. That forced desktop backend processes to share the home-scoped fallback socket. When old packaged backend processes were still alive, they could unlink or replace that shared fallback path, while newly opened projects still published a pointer to it. The embedded MCP bridge then failed attached-mode discovery and fell back to standalone mode, so live-backend tools reported the backend as unavailable.

## Validation

- `gate_record check --mode pre-pr` completed with `format_check`, `full_audit`, `import_contracts`, `lint_format`, `python_tests`, `semantic_dup`, and `type_check` passing before the branch was rebased onto merged `main`.
- `gate_record finalize --closes "#1707"` completed successfully before the branch was rebased onto merged `main`.
- `PYTHONPATH=src pytest -q --no-cov tests/api/test_projects.py tests/api/test_mcp_transport_publish.py tests/cli/test_mcp_bridge.py`
- `PYTHONPATH=src pytest -q --no-cov tests/cli/test_cli.py::TestCLIGui::test_gui_bundled_uses_loopback_and_emits_ready_json tests/integration/test_block_sdk_e2e.py::TestTypeRegistryEntryPoints::test_scan_all_discovers_builtins tests/core/test_types.py::TestTypeRegistryEntryPoints::test_scan_all_works_with_no_entrypoints`

Closes #1707
