### PR TITLE
hotfix(#1709): convert R-unreadable plot inputs to CSV for R harness

### DIFF
--- a/.workflow/records/1709-hotfix-r-parquet-dataframe.json
+++ b/.workflow/records/1709-hotfix-r-parquet-dataframe.json
@@ -303,6 +303,228 @@
       "status": "pass",
       "summary": "clean",
       "tool_versions": {}
+    },
+    {
+      "at": "2026-06-20T03:57:32.415453Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:e6faee48cc2aa1d67ca783cef7124d1e365c2a36fb6da225f5e83f831996a8d7",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-20T03:57:36.124629Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:18f10e0aa7539457b83c1b0e26a93a167c412b9ea361c69fb09d77ecd4a12a14",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-20T03:57:36.237551Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:43a12495db0bd5b6c8a714dc8d4e713c38dee807371841e7c49e2b4212224828",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-20T03:57:36.259465Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:3d16cbb2041ee7abcc1e1406d326bf9b318359c324ada813da2221e6939f7b69",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-20T03:59:12.340468Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:a0a36e31865819617c2f067717151be057969f97b0d45ae710a140a1142c6b4d",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-20T04:01:01.291892Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:52cee75e836f4e81f6567c708fdd552476996ff49dbd08f9cf7031da265bef76",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-20T04:01:02.213048Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:dbd31c79709bf3d621a761712f56f09032aa5ee7245c7210061e8822ed98406e",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    },
+    {
+      "at": "2026-06-20T04:01:22.098113Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:235cad639b456690e96865f50d5fd5ecb8bf253491e783e122fef64d79ca4c98",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-20T04:01:25.855492Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:b6d335dbe0ad54ce4dd592fd54eb271d6bcbcaf730bf93424b22fc4bf4b97508",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-20T04:01:25.963463Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:8a3808cf0b200c50314975eafab83ba58c2cbb9a7428fbb77bfa98d2c5702fc2",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-20T04:01:25.986675Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:2c151b16309fad204c0559da2bd1d6e7eb2b6dddf4ca085d23c05a0ea190dd03",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-20T04:03:04.854237Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:93d8f8397ed10c39466896845faacf2197b8d0bb79a05c9597fb90c88139354b",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-20T04:04:56.517446Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:504ff874d32efa671530389836b2f2b8e0ed51e3eb6f314e62c83ab52b0fd9b1",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-20T04:04:57.488354Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:9abb5ee9080566c86f2167ba9ced8130093139d7ea4dc6b84b5dccf44f2ee096",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
     }
   ],
   "check_na": [],
@@ -317,7 +539,8 @@
     "exclude": [],
     "include": [
       "src/scistudio/ai/agent/mcp/tools_plot/runtime.py",
-      "tests/ai/test_mcp_tools_plot.py"
+      "tests/ai/test_mcp_tools_plot.py",
+      "docs/block-development/previewers-and-plots.md"
     ]
   },
   "directive_events": [
@@ -1114,6 +1337,252 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-06-20T03:57:03.338817Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T03:57:03.347738Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T03:57:03.356471Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T03:57:03.365443Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T03:57:03.374355Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T03:57:03.383490Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T03:57:03.392947Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T03:57:03.403470Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T03:57:03.412153Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T03:57:03.425226Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T04:01:02.252916Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T04:01:02.262274Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T04:01:02.271437Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T04:01:02.280606Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T04:01:02.289844Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T04:01:02.299746Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T04:01:02.309286Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T04:01:02.318776Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T04:01:02.327603Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T04:01:02.340755Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T04:04:57.534674Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T04:04:57.545773Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T04:04:57.556730Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T04:04:57.567816Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T04:04:57.578248Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T04:04:57.588702Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T04:04:57.599469Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T04:04:57.610489Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T04:04:57.621193Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T04:04:57.636664Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -1126,7 +1595,7 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "0f7dc3f3beaf84b45a3c844387cada429e14a5ed",
+    "base": "origin/main",
     "base_sha": "0f7dc3f3",
     "changed_files": [
       ".workflow/records/1709-hotfix-r-parquet-dataframe.json",
@@ -1134,9 +1603,9 @@
       "src/scistudio/ai/agent/mcp/tools_plot/runtime.py",
       "tests/ai/test_mcp_tools_plot.py"
     ],
-    "diff_fingerprint": "sha256:7282ff70e80b7153d9bd50930ffb1a5979b78f03c42ba1c53557bc7417e8c88f",
+    "diff_fingerprint": "sha256:edc82ea5419596df45ef7ee373f24d8cded7ed56721c4904e78fcffe6a7c6f8b",
     "head": "HEAD",
-    "head_sha": "72e9f6f7",
+    "head_sha": "340245eb",
     "surfaces": {
       "docs": 1,
       "frontend": 0,
@@ -1250,6 +1719,32 @@
     {
       "at": "2026-06-20T02:40:12.863545Z",
       "diff_fingerprint": "sha256:7282ff70e80b7153d9bd50930ffb1a5979b78f03c42ba1c53557bc7417e8c88f",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-20T03:57:03.425255Z",
+      "diff_fingerprint": "sha256:ba28f093ad0197ca4b75913920b3e630f26a6261ad6deddfa76e6213637f21e1",
+      "mode": "local",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-20T04:01:02.340781Z",
+      "diff_fingerprint": "sha256:c2bd1d39e8508580d056dbc4f3e151d12656d3257c074f5afd3dd8debee8ade4",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.format_check"
+      ]
+    },
+    {
+      "at": "2026-06-20T04:04:57.636712Z",
+      "diff_fingerprint": "sha256:edc82ea5419596df45ef7ee373f24d8cded7ed56721c4904e78fcffe6a7c6f8b",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 2,

--- a/.workflow/records/1709-hotfix-r-parquet-dataframe.json
+++ b/.workflow/records/1709-hotfix-r-parquet-dataframe.json
@@ -529,9 +529,9 @@
   ],
   "check_na": [],
   "commit": {
-    "sha": "72e9f6f7bfcdb7e17e33d6f0fa8c80e2f3379d87",
+    "sha": "e6e79f2c7302693dc2704fb4ca65b2d4ac273f35",
     "shas": [
-      "72e9f6f7bfcdb7e17e33d6f0fa8c80e2f3379d87"
+      "e6e79f2c7302693dc2704fb4ca65b2d4ac273f35"
     ],
     "trailers": []
   },
@@ -1583,6 +1583,88 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-06-20T04:05:52.074602Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T04:05:52.087275Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T04:05:52.099186Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T04:05:52.113619Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T04:05:52.129119Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T04:05:52.142983Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T04:05:52.154591Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T04:05:52.167467Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T04:05:52.178533Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T04:05:52.194765Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -1595,7 +1677,7 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "origin/main",
+    "base": "0f7dc3f3beaf84b45a3c844387cada429e14a5ed",
     "base_sha": "0f7dc3f3",
     "changed_files": [
       ".workflow/records/1709-hotfix-r-parquet-dataframe.json",
@@ -1603,9 +1685,9 @@
       "src/scistudio/ai/agent/mcp/tools_plot/runtime.py",
       "tests/ai/test_mcp_tools_plot.py"
     ],
-    "diff_fingerprint": "sha256:edc82ea5419596df45ef7ee373f24d8cded7ed56721c4904e78fcffe6a7c6f8b",
+    "diff_fingerprint": "sha256:4c5c134c256fd5c316cdd843370ec09393102515ea3bef3030470af2a71f05ad",
     "head": "HEAD",
-    "head_sha": "340245eb",
+    "head_sha": "e6e79f2c",
     "surfaces": {
       "docs": 1,
       "frontend": 0,
@@ -1745,6 +1827,14 @@
     {
       "at": "2026-06-20T04:04:57.636712Z",
       "diff_fingerprint": "sha256:edc82ea5419596df45ef7ee373f24d8cded7ed56721c4904e78fcffe6a7c6f8b",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-20T04:05:52.194799Z",
+      "diff_fingerprint": "sha256:4c5c134c256fd5c316cdd843370ec09393102515ea3bef3030470af2a71f05ad",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 2,

--- a/.workflow/records/1709-hotfix-r-parquet-dataframe.json
+++ b/.workflow/records/1709-hotfix-r-parquet-dataframe.json
@@ -307,9 +307,9 @@
   ],
   "check_na": [],
   "commit": {
-    "sha": "b6b4096a12bb606eda7ea36ae3c615bf184ae0a1",
+    "sha": "72e9f6f7bfcdb7e17e33d6f0fa8c80e2f3379d87",
     "shas": [
-      "b6b4096a12bb606eda7ea36ae3c615bf184ae0a1"
+      "72e9f6f7bfcdb7e17e33d6f0fa8c80e2f3379d87"
     ],
     "trailers": []
   },
@@ -950,6 +950,170 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:39:56.158359Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:39:56.168271Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:39:56.177944Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:39:56.186656Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:39:56.196308Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:39:56.205341Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:39:56.213810Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:39:56.222338Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:39:56.231149Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:39:56.243915Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:40:12.766538Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:40:12.777507Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:40:12.788369Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:40:12.799889Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:40:12.810775Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:40:12.821608Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:40:12.831226Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:40:12.841143Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:40:12.851069Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:40:12.863517Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -962,7 +1126,7 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "origin/main",
+    "base": "0f7dc3f3beaf84b45a3c844387cada429e14a5ed",
     "base_sha": "0f7dc3f3",
     "changed_files": [
       ".workflow/records/1709-hotfix-r-parquet-dataframe.json",
@@ -970,9 +1134,9 @@
       "src/scistudio/ai/agent/mcp/tools_plot/runtime.py",
       "tests/ai/test_mcp_tools_plot.py"
     ],
-    "diff_fingerprint": "sha256:f60a23e717dcd4aa56fefc50339575f9bb9c3706bfd028229198094f1fb2d75a",
+    "diff_fingerprint": "sha256:7282ff70e80b7153d9bd50930ffb1a5979b78f03c42ba1c53557bc7417e8c88f",
     "head": "HEAD",
-    "head_sha": "b6b4096a",
+    "head_sha": "72e9f6f7",
     "surfaces": {
       "docs": 1,
       "frontend": 0,
@@ -993,7 +1157,7 @@
     "closes": [
       1709
     ],
-    "number": null,
+    "number": 1710,
     "url": null
   },
   "reconcile_events": [
@@ -1070,6 +1234,22 @@
     {
       "at": "2026-06-20T02:39:15.329351Z",
       "diff_fingerprint": "sha256:f60a23e717dcd4aa56fefc50339575f9bb9c3706bfd028229198094f1fb2d75a",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-20T02:39:56.243942Z",
+      "diff_fingerprint": "sha256:7282ff70e80b7153d9bd50930ffb1a5979b78f03c42ba1c53557bc7417e8c88f",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-20T02:40:12.863545Z",
+      "diff_fingerprint": "sha256:7282ff70e80b7153d9bd50930ffb1a5979b78f03c42ba1c53557bc7417e8c88f",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 2,

--- a/.workflow/records/1709-hotfix-r-parquet-dataframe.json
+++ b/.workflow/records/1709-hotfix-r-parquet-dataframe.json
@@ -307,9 +307,9 @@
   ],
   "check_na": [],
   "commit": {
-    "sha": "b8439ee4c768aa864f0ad1f82445f02e8f539465",
+    "sha": "b6b4096a12bb606eda7ea36ae3c615bf184ae0a1",
     "shas": [
-      "b8439ee4c768aa864f0ad1f82445f02e8f539465"
+      "b6b4096a12bb606eda7ea36ae3c615bf184ae0a1"
     ],
     "trailers": []
   },
@@ -868,6 +868,88 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:39:15.248243Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:39:15.256945Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:39:15.265394Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:39:15.274051Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:39:15.282619Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:39:15.291329Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:39:15.300254Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:39:15.309116Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:39:15.317697Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:39:15.329324Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -888,9 +970,9 @@
       "src/scistudio/ai/agent/mcp/tools_plot/runtime.py",
       "tests/ai/test_mcp_tools_plot.py"
     ],
-    "diff_fingerprint": "sha256:a08407ffec1e155f4e8dd10cedbe6b2730cd9a3e350899c9ab7bdae1fa4919f1",
+    "diff_fingerprint": "sha256:f60a23e717dcd4aa56fefc50339575f9bb9c3706bfd028229198094f1fb2d75a",
     "head": "HEAD",
-    "head_sha": "961e3c92",
+    "head_sha": "b6b4096a",
     "surfaces": {
       "docs": 1,
       "frontend": 0,
@@ -980,6 +1062,14 @@
     {
       "at": "2026-06-20T02:39:04.522709Z",
       "diff_fingerprint": "sha256:a08407ffec1e155f4e8dd10cedbe6b2730cd9a3e350899c9ab7bdae1fa4919f1",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-20T02:39:15.329351Z",
+      "diff_fingerprint": "sha256:f60a23e717dcd4aa56fefc50339575f9bb9c3706bfd028229198094f1fb2d75a",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 2,

--- a/.workflow/records/1709-hotfix-r-parquet-dataframe.json
+++ b/.workflow/records/1709-hotfix-r-parquet-dataframe.json
@@ -1,0 +1,1056 @@
+{
+  "branch": "hotfix/r-parquet-dataframe",
+  "check_events": [
+    {
+      "at": "2026-06-20T02:26:49.038429Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:bee0017f30f552d2df2de1173f9ac14b9aee5192ca5e5c1de574bb119512b275",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-20T02:26:52.918202Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:d2016153ffe72f6d9588cf72b647d8f545261ca64eb63f312f104e3c66e7d074",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-20T02:26:52.962464Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:e31351abfc33f0b3c0f28bc9f2f3d59ae3bc5d4925dc1159a7f931aa932441ed",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-20T02:27:08.029118Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e31351abfc33f0b3c0f28bc9f2f3d59ae3bc5d4925dc1159a7f931aa932441ed",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-20T02:28:07.717196Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:0b00f9b703b223e2ee833fa1ea9013ab6f992556a79a0c52c15de46129c49b06",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-20T02:28:10.891302Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:a0bba11cc53bd48c91dbed82b58ac0915f22ed23fdde1931bfc77a3618c78505",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-20T02:28:11.389437Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:9614d0fb520579cb84650bcfd74fbcd701f7ea4a76dd6a798f142963173f47ac",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-20T02:28:11.403361Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:5f27baa814658173fd82e670c0490f590b1a8a5bec51aeae952720f68d254cc5",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-20T02:30:07.229826Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:bb15e7ceb2387b836f4914b1eefc4b22085698f4c07c2e791399e4699a0b9c6c",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-20T02:31:54.854778Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:63b9f6bf921231a1cd4cb2f7330ef12b7c068885a5813822e8a5a50c1d29138e",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-20T02:32:02.194439Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:568c0eeef6fecd543830296afb2d53ca6787715c07bbd2790820a6c586405649",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    },
+    {
+      "at": "2026-06-20T02:32:40.927741Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:11e981f8f1e8cdab90d41662aa6855610c3176413fdb30adf3efd32eca8fbbae",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-20T02:32:44.867792Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:083c46ebeb142837130722f26a521def31188c791da6abf0255fe198c2167025",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-20T02:32:44.997956Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:84c07854d16a88411959f4fc9b93a50832298e93c39c4a62e681a5a375c4916c",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-20T02:32:45.021103Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:fe0f7cd1f64d11a8d13d12d3cb27d35916cd143e4d912b1628b0fcb9d5d4f55e",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-20T02:34:23.091819Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:96467aca33ee1a498a0b6c3ab9b1cc698a0ecae0963e210b058eb9697338ad59",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-20T02:36:14.967324Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:d3bd21ad165b279bd9d0668785ef8336de2a6fa624f5fcbc648c63a76059be28",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-20T02:36:15.881847Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:409d654770efff9ef6d279f1d691c2aef76fbdd99030d51a800b84493624dd4f",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    },
+    {
+      "at": "2026-06-20T02:38:53.514998Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:96467aca33ee1a498a0b6c3ab9b1cc698a0ecae0963e210b058eb9697338ad59",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    }
+  ],
+  "check_na": [],
+  "commit": {
+    "sha": "b8439ee4c768aa864f0ad1f82445f02e8f539465",
+    "shas": [
+      "b8439ee4c768aa864f0ad1f82445f02e8f539465"
+    ],
+    "trailers": []
+  },
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "src/scistudio/ai/agent/mcp/tools_plot/runtime.py",
+      "tests/ai/test_mcp_tools_plot.py"
+    ]
+  },
+  "directive_events": [
+    {
+      "at": "2026-06-20T02:26:08.892744Z",
+      "owner_directive": "\u65b9\u6848A\uff1aruntime.py \u52a0 R \u8f93\u5165\u7269\u5316 shim\uff0c\u628a parquet/npy/npz/zarr \u8f6c CSV\uff1b\u52a0\u5355\u6d4b+R\u7aef\u5230\u7aef\u56de\u5f52\u6d4b\u8bd5\uff1b\u66f4\u65b0 previewers-and-plots.md \u8bf4\u660e R \u514d arrow\u3002",
+      "reason": "plan"
+    }
+  ],
+  "docs_events": [
+    {
+      "at": "2026-06-20T02:26:08.892884Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/block-development/previewers-and-plots.md",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": false,
+  "guard_events": [
+    {
+      "at": "2026-06-20T02:26:52.983847Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:26:52.992742Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:26:53.001852Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:26:53.011196Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:26:53.020128Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:26:53.028751Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:26:53.037116Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:26:53.046111Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:26:53.055266Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:26:53.063913Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:27:08.049562Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:27:08.059051Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:27:08.068244Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:27:08.077539Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:27:08.086224Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:27:08.096337Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:27:08.105401Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:27:08.114519Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:27:08.123242Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:27:08.132157Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:27:55.610322Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:27:55.618732Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:27:55.627372Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:27:55.635799Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:27:55.643871Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:27:55.651977Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:27:55.659934Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:27:55.668120Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:27:55.676024Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:27:55.685738Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:32:02.227832Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:32:02.237509Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:32:02.247627Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:32:02.257812Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:32:02.267541Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:32:02.278282Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:32:02.288536Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:32:02.299450Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:32:02.309484Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:32:02.321003Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:36:15.920991Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:36:15.930771Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:36:15.940456Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:36:15.950075Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:36:15.960016Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:36:15.969749Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:36:15.979019Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:36:15.988399Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:36:15.997445Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:36:16.008902Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:38:53.551842Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:38:53.563077Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:38:53.574475Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:38:53.585541Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:38:53.596308Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:38:53.607722Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:38:53.618612Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:38:53.629716Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:38:53.639738Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:38:53.651839Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:39:04.438171Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:39:04.448251Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:39:04.457763Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:39:04.466965Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:39:04.475778Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:39:04.484554Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:39:04.493197Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:39:04.502175Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:39:04.511035Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-20T02:39:04.522676Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1709,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": {
+    "base": "origin/main",
+    "base_sha": "0f7dc3f3",
+    "changed_files": [
+      ".workflow/records/1709-hotfix-r-parquet-dataframe.json",
+      "docs/block-development/previewers-and-plots.md",
+      "src/scistudio/ai/agent/mcp/tools_plot/runtime.py",
+      "tests/ai/test_mcp_tools_plot.py"
+    ],
+    "diff_fingerprint": "sha256:a08407ffec1e155f4e8dd10cedbe6b2730cd9a3e350899c9ab7bdae1fa4919f1",
+    "head": "HEAD",
+    "head_sha": "961e3c92",
+    "surfaces": {
+      "docs": 1,
+      "frontend": 0,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 1,
+      "packaging": 0,
+      "protected_core": 0,
+      "sentrux": 2,
+      "test": 1,
+      "workflow_ci": 0
+    }
+  },
+  "owner_directive": "\u5f00\u59cbhotfix\u6a21\u5f0f\u3002R plot \u65e0\u6cd5\u8fd0\u884c\uff0c\u62a5 'unsupported DataFrame storage for plot open(): <id>.parquet'\uff08Python \u6b63\u5e38\uff09\u3002\u8c03\u67e5\u6839\u56e0\u5e76\u7528\u65b9\u6848A\uff08plot \u4fa7 Python \u628a parquet/npy/zarr \u8f6c CSV \u5582\u7ed9 R harness\uff09\u4fee\u590d\u3002",
+  "persona": "implementer",
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [
+      1709
+    ],
+    "number": null,
+    "url": null
+  },
+  "reconcile_events": [
+    {
+      "at": "2026-06-20T02:26:53.063961Z",
+      "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "mode": "local",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.lint_format"
+      ]
+    },
+    {
+      "at": "2026-06-20T02:27:08.132196Z",
+      "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "mode": "local",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-20T02:27:55.685762Z",
+      "diff_fingerprint": "sha256:7011f1c289d36011644fcdb7965ec92a609f38df78385424d924cbd404bca4c6",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.format_check",
+        "checks.full_audit",
+        "checks.import_contracts",
+        "checks.lint_format",
+        "checks.python_tests",
+        "checks.semantic_dup",
+        "checks.type_check"
+      ]
+    },
+    {
+      "at": "2026-06-20T02:32:02.321036Z",
+      "diff_fingerprint": "sha256:7011f1c289d36011644fcdb7965ec92a609f38df78385424d924cbd404bca4c6",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.type_check"
+      ]
+    },
+    {
+      "at": "2026-06-20T02:36:16.008942Z",
+      "diff_fingerprint": "sha256:a08407ffec1e155f4e8dd10cedbe6b2730cd9a3e350899c9ab7bdae1fa4919f1",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.python_tests"
+      ]
+    },
+    {
+      "at": "2026-06-20T02:38:53.651876Z",
+      "diff_fingerprint": "sha256:a08407ffec1e155f4e8dd10cedbe6b2730cd9a3e350899c9ab7bdae1fa4919f1",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-20T02:39:04.522709Z",
+      "diff_fingerprint": "sha256:a08407ffec1e155f4e8dd10cedbe6b2730cd9a3e350899c9ab7bdae1fa4919f1",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    }
+  ],
+  "record_id": "1709-hotfix-r-parquet-dataframe",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [
+      "format_check",
+      "full_audit",
+      "import_contracts",
+      "lint_format",
+      "python_tests",
+      "semantic_dup",
+      "type_check"
+    ],
+    "docs": [
+      "docs_required_or_na"
+    ],
+    "guards": [
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": [
+      "changed_test_required"
+    ]
+  },
+  "runtime": "claude-code",
+  "schema_version": 2,
+  "scope_events": [
+    {
+      "action": "add-include",
+      "at": "2026-06-20T02:26:08.892866Z",
+      "pattern": "src/scistudio/ai/agent/mcp/tools_plot/runtime.py",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-20T02:26:08.892872Z",
+      "pattern": "tests/ai/test_mcp_tools_plot.py",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-20T02:26:08.892873Z",
+      "pattern": "docs/block-development/previewers-and-plots.md",
+      "reason": "plan"
+    }
+  ],
+  "session_id": "a84fbf67-3c7f-4338-a823-9c20c9f89ac4",
+  "strictness_tier": 2,
+  "task_kind": "hotfix",
+  "test_events": [
+    {
+      "at": "2026-06-20T02:26:08.893045Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/ai/test_mcp_tools_plot.py",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/docs/block-development/previewers-and-plots.md
+++ b/docs/block-development/previewers-and-plots.md
@@ -491,6 +491,14 @@ metadata or storage size to enforce the plot input memory cap. If the input is
 too large, `open()` fails and the user should write an explicit storage-aware
 reader for that plot.
 
+R plots do not require the R `arrow` package. The R harness reads base formats
+(csv/tsv/txt/json) only, so DataFrame/Series stored as parquet and Array stored
+as npy/npz/zarr — the runtime defaults — are transparently converted to CSV
+before R runs and the harness reads the CSV copy. The conversion is preview-only
+and does not touch persisted storage; Python plots read the original storage
+directly. Values round-trip through CSV, so rely on column names and numeric
+content rather than exact binary dtype fidelity in R render code.
+
 seaborn works when the project environment provides it; ggplot2 works when R +
 ggplot2 are installed. Only `svg`, `pdf`, `png`, `jpeg` are accepted output
 formats.

--- a/src/scistudio/ai/agent/mcp/tools_plot/runtime.py
+++ b/src/scistudio/ai/agent/mcp/tools_plot/runtime.py
@@ -357,14 +357,45 @@ def _is_r_readable_path(path_str: str | None) -> bool:
     return Path(path_str).suffix.lower() in _R_NATIVE_INPUT_EXTS
 
 
-def _materialize_inputs_for_r(envelope: dict[str, Any], dest_dir: Path) -> dict[str, Any]:
+def _input_nbytes(item: dict[str, Any], src: Path) -> int | None:
+    """Materialized-size estimate for an input: metadata shape*dtype, else disk bytes.
+
+    Reuses the same metadata fields the harness reads at ``open()`` time so the
+    shim can refuse to load an over-cap input into the MCP process. The harness
+    still enforces the cap lazily; this only stops the eager conversion from
+    bypassing it.
+    """
+    md = item.get("metadata")
+    if isinstance(md, dict):
+        shape = md.get("shape") or md.get("array_shape")
+        dtype = md.get("dtype") or md.get("array_dtype")
+        if isinstance(shape, (list, tuple)) and dtype is not None:
+            try:
+                import numpy as np
+
+                count = 1
+                for raw in shape:
+                    count *= int(raw)
+                return max(0, count) * int(np.dtype(dtype).itemsize)
+            except Exception:
+                pass
+    if src.is_file():
+        return src.stat().st_size
+    if src.is_dir():
+        return sum(c.stat().st_size for c in src.rglob("*") if c.is_file())
+    return None
+
+
+def _materialize_inputs_for_r(envelope: dict[str, Any], dest_dir: Path, max_input_bytes: int) -> dict[str, Any]:
     """Convert R-unreadable input storage (parquet/npy/npz/zarr) to CSV in-place.
 
     Walks the harness input envelope (including nested ``CompositeData`` slots)
     and, for each DataFrame/Series/Array item whose ``_path`` is not a base-R
     format, writes a CSV copy under ``dest_dir`` and repoints the item at it.
-    Conversion failures fall back to the original path so behaviour is never
-    worse than before the shim.
+    Inputs whose estimated size exceeds ``max_input_bytes`` are left unconverted
+    so the harness's own open()-time guard raises the standard memory-cap error
+    instead of this shim loading them into the MCP process. Conversion failures
+    fall back to the original path so behaviour is never worse than before.
     """
     collection = envelope.get("collection")
     if not isinstance(collection, dict):
@@ -374,11 +405,11 @@ def _materialize_inputs_for_r(envelope: dict[str, Any], dest_dir: Path) -> dict[
         return envelope
     counter = [0]
     for item in items:
-        _convert_item_for_r(item, dest_dir, counter)
+        _convert_item_for_r(item, dest_dir, counter, max_input_bytes)
     return envelope
 
 
-def _convert_item_for_r(item: Any, dest_dir: Path, counter: list[int]) -> None:
+def _convert_item_for_r(item: Any, dest_dir: Path, counter: list[int], max_input_bytes: int) -> None:
     if not isinstance(item, dict):
         return
     # Recurse into CompositeData slots first (each slot is a normalised item).
@@ -387,15 +418,22 @@ def _convert_item_for_r(item: Any, dest_dir: Path, counter: list[int]) -> None:
         slots = md.get("slots")
         if isinstance(slots, dict):
             for slot in slots.values():
-                _convert_item_for_r(slot, dest_dir, counter)
+                _convert_item_for_r(slot, dest_dir, counter, max_input_bytes)
     typ = str(item.get("type") or "DataObject")
     if typ not in _R_CONVERTIBLE_TYPES:
         return
     path_str = item.get("_path")
     if _is_r_readable_path(path_str):
         return
+    src = Path(str(path_str))
+    nbytes = _input_nbytes(item, src)
+    if nbytes is not None and nbytes > max_input_bytes:
+        # Over the plot input memory cap: do not load it here. Leave the original
+        # path so the harness raises the standard cap error lazily at open().
+        logger.debug("R plot input %r (~%d bytes) exceeds cap %d; left unconverted", path_str, nbytes, max_input_bytes)
+        return
     try:
-        csv_path = _convert_storage_to_csv(Path(str(path_str)), typ, dest_dir, counter)
+        csv_path = _convert_storage_to_csv(src, typ, dest_dir, counter)
     except Exception as exc:  # defensive: never regress, fall back to original path
         logger.warning("R plot input conversion failed for %r: %s", path_str, exc)
         return
@@ -572,8 +610,9 @@ def run_plot_job(plot_id: str, run_id: str | None = None, timeout_seconds: float
     envelope = _input_envelope(resolved.refs, type_registry=getattr(ctx, "type_registry", None))
     if manifest.script.language == "r":
         # The R harness cannot read parquet (needs `arrow`) or npy/npz/zarr at
-        # all; convert those inputs to CSV before R runs. See _materialize_inputs_for_r.
-        envelope = _materialize_inputs_for_r(envelope, work_dir / "_r_inputs")
+        # all; convert those inputs to CSV before R runs, but never above the
+        # input memory cap. See _materialize_inputs_for_r.
+        envelope = _materialize_inputs_for_r(envelope, work_dir / "_r_inputs", max_input_bytes)
     (work_dir / _INPUTS_NAME).write_text(json.dumps(envelope), encoding="utf-8")
 
     allowed_csv = ",".join(manifest.outputs.allowed_formats)

--- a/src/scistudio/ai/agent/mcp/tools_plot/runtime.py
+++ b/src/scistudio/ai/agent/mcp/tools_plot/runtime.py
@@ -330,6 +330,143 @@ def _registered_core_base(type_registry: Any | None, type_name: str) -> str | No
     return None
 
 
+# ---------------------------------------------------------------------------
+# R input materialization shim.
+#
+# The R plot harness can only read DataFrame/Series/Array storage in formats
+# base R understands without optional packages: csv / tsv / txt / json. SciStudio
+# persists DataFrame/Series as parquet and Array as npy/npz/zarr by default, and
+# parquet needs the R ``arrow`` package (not bundled) while npy/npz/zarr are
+# unreadable in R at all. Without this shim every R plot that ``open()``s such an
+# input fails with "unsupported ... storage for plot open()". Python is always
+# available preview-side (pandas/numpy/zarr), so we convert each R-unreadable
+# input to CSV here and repoint the harness item at it. Python plots are
+# unaffected; they read the original storage directly.
+# ---------------------------------------------------------------------------
+
+# Extensions base R reads without the optional ``arrow`` package.
+_R_NATIVE_INPUT_EXTS = frozenset({".csv", ".tsv", ".txt", ".json"})
+# Core types whose storage we can losslessly enough convert to CSV for R.
+_R_CONVERTIBLE_TYPES = frozenset({"DataFrame", "Series", "Array"})
+
+
+def _is_r_readable_path(path_str: str | None) -> bool:
+    """True when the path needs no conversion for the R harness (or is absent)."""
+    if not path_str:
+        return True
+    return Path(path_str).suffix.lower() in _R_NATIVE_INPUT_EXTS
+
+
+def _materialize_inputs_for_r(envelope: dict[str, Any], dest_dir: Path) -> dict[str, Any]:
+    """Convert R-unreadable input storage (parquet/npy/npz/zarr) to CSV in-place.
+
+    Walks the harness input envelope (including nested ``CompositeData`` slots)
+    and, for each DataFrame/Series/Array item whose ``_path`` is not a base-R
+    format, writes a CSV copy under ``dest_dir`` and repoints the item at it.
+    Conversion failures fall back to the original path so behaviour is never
+    worse than before the shim.
+    """
+    collection = envelope.get("collection")
+    if not isinstance(collection, dict):
+        return envelope
+    items = collection.get("items")
+    if not isinstance(items, list):
+        return envelope
+    counter = [0]
+    for item in items:
+        _convert_item_for_r(item, dest_dir, counter)
+    return envelope
+
+
+def _convert_item_for_r(item: Any, dest_dir: Path, counter: list[int]) -> None:
+    if not isinstance(item, dict):
+        return
+    # Recurse into CompositeData slots first (each slot is a normalised item).
+    md = item.get("metadata")
+    if isinstance(md, dict):
+        slots = md.get("slots")
+        if isinstance(slots, dict):
+            for slot in slots.values():
+                _convert_item_for_r(slot, dest_dir, counter)
+    typ = str(item.get("type") or "DataObject")
+    if typ not in _R_CONVERTIBLE_TYPES:
+        return
+    path_str = item.get("_path")
+    if _is_r_readable_path(path_str):
+        return
+    try:
+        csv_path = _convert_storage_to_csv(Path(str(path_str)), typ, dest_dir, counter)
+    except Exception as exc:  # defensive: never regress, fall back to original path
+        logger.warning("R plot input conversion failed for %r: %s", path_str, exc)
+        return
+    item["_path"] = str(csv_path)
+    item["_format"] = "csv"
+    item["_backend"] = "file"
+
+
+def _convert_storage_to_csv(src: Path, typ: str, dest_dir: Path, counter: list[int]) -> Path:
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    counter[0] += 1
+    out = dest_dir / f"input_{counter[0]:03d}.csv"
+    if typ in {"DataFrame", "Series"}:
+        # DataFrame/Series CSV keeps the header row; R read_dataframe reads with
+        # header so column names (e.g. "lambda"/"intensity") survive the trip.
+        _load_dataframe_any(src).to_csv(out, index=False)
+    else:  # Array: R read_array reads header=FALSE, so write a headerless grid.
+        _save_array_csv(_load_array_any(src), out)
+    return out
+
+
+def _load_dataframe_any(src: Path) -> Any:
+    import pandas as pd
+
+    suffix = src.suffix.lower()
+    if suffix in {".parquet", ".pq"}:
+        return pd.read_parquet(src)
+    if suffix in {".csv", ".txt"}:
+        return pd.read_csv(src)
+    if suffix == ".tsv":
+        return pd.read_csv(src, sep="\t")
+    if suffix == ".json":
+        return pd.read_json(src)
+    raise ValueError(f"cannot convert DataFrame storage to CSV: {src.name}")
+
+
+def _load_array_any(src: Path) -> Any:
+    import numpy as np
+
+    suffix = src.suffix.lower()
+    if suffix == ".npy":
+        return np.asarray(np.load(src, mmap_mode="r"))
+    if suffix == ".npz":
+        loaded = np.load(src)
+        if not loaded.files:
+            raise ValueError("NPZ Array input contains no arrays")
+        return np.asarray(loaded[loaded.files[0]])
+    if suffix == ".zarr" or src.is_dir():
+        import zarr
+
+        node = zarr.open(str(src), mode="r")
+        handle = node if isinstance(node, zarr.Array) else node.get("data")
+        if handle is None:
+            raise ValueError("Zarr Array input has no top-level array or 'data' dataset")
+        return np.asarray(handle[...])
+    raise ValueError(f"cannot convert Array storage to CSV: {src.name}")
+
+
+def _save_array_csv(arr: Any, out: Path) -> None:
+    import numpy as np
+
+    a = np.asarray(arr)
+    if a.ndim == 0:
+        a = a.reshape(1, 1)
+    elif a.ndim == 1:
+        a = a.reshape(-1, 1)
+    elif a.ndim > 2:
+        raise ValueError(f"cannot convert {a.ndim}-D Array to CSV for R plot input")
+    np.savetxt(out, a, delimiter=",")
+
+
 def _interpreter_for(loaded: LoadedPlot) -> list[str] | None:
     """Resolve interpreter argv prefix for the harness, or None if unavailable."""
     language = loaded.manifest.script.language
@@ -432,10 +569,12 @@ def run_plot_job(plot_id: str, run_id: str | None = None, timeout_seconds: float
         (work_dir / _R_HARNESS_NAME).write_text(R_HARNESS, encoding="utf-8")
     user_script_name = Path(manifest.script.path).name
     shutil.copy2(loaded.script_path, work_dir / user_script_name)
-    (work_dir / _INPUTS_NAME).write_text(
-        json.dumps(_input_envelope(resolved.refs, type_registry=getattr(ctx, "type_registry", None))),
-        encoding="utf-8",
-    )
+    envelope = _input_envelope(resolved.refs, type_registry=getattr(ctx, "type_registry", None))
+    if manifest.script.language == "r":
+        # The R harness cannot read parquet (needs `arrow`) or npy/npz/zarr at
+        # all; convert those inputs to CSV before R runs. See _materialize_inputs_for_r.
+        envelope = _materialize_inputs_for_r(envelope, work_dir / "_r_inputs")
+    (work_dir / _INPUTS_NAME).write_text(json.dumps(envelope), encoding="utf-8")
 
     allowed_csv = ",".join(manifest.outputs.allowed_formats)
     argv = [

--- a/tests/ai/test_mcp_tools_plot.py
+++ b/tests/ai/test_mcp_tools_plot.py
@@ -30,6 +30,7 @@ from scistudio.ai.agent.mcp.tools_plot import (
     scaffold_plot,
     validate_plot,
 )
+from scistudio.ai.agent.mcp.tools_plot import runtime as plot_runtime
 
 pytest.importorskip("pandas")
 pytest.importorskip("matplotlib")
@@ -992,3 +993,149 @@ def test_run_r_returned_path_does_not_count_blank_base_device(project: Path, csv
     assert res.status == "succeeded", res.errors
     assert len(res.artifact_paths) == 1
     assert Path(res.artifact_paths[0]).name == "current.pdf"
+
+
+# ---------------------------------------------------------------------------
+# R input materialization shim: convert R-unreadable storage to CSV so the R
+# harness (which lacks the `arrow` package and cannot read npy/npz/zarr) can
+# open DataFrame/Series/Array inputs. SciStudio persists DataFrame/Series as
+# parquet and Array as npy/zarr by default, so without this every R plot that
+# opens such an input fails with "unsupported ... storage for plot open()".
+# ---------------------------------------------------------------------------
+
+
+def test_is_r_readable_path_recognises_base_formats() -> None:
+    for ok in ("a.csv", "a.tsv", "a.txt", "a.json", "/x/Y.CSV", None, ""):
+        assert plot_runtime._is_r_readable_path(ok) is True
+    for bad in ("a.parquet", "a.pq", "a.npy", "a.npz", "a.zarr"):
+        assert plot_runtime._is_r_readable_path(bad) is False
+
+
+def _df_item(path: Path, typ: str = "DataFrame", fmt: str = "parquet") -> dict[str, Any]:
+    return {"type": typ, "_backend": "filesystem", "_path": str(path), "_format": fmt, "metadata": {}}
+
+
+def _envelope(items: list[dict[str, Any]]) -> dict[str, Any]:
+    return {"schema_version": 1, "collection": {"types": [], "items": items}}
+
+
+def test_materialize_converts_parquet_dataframe_keeping_header(tmp_path: Path) -> None:
+    src = tmp_path / "frame.parquet"
+    import pandas as pd
+
+    pd.DataFrame({"lambda": [400.0, 401.0], "intensity": [1.5, 2.5]}).to_parquet(src)
+    env = _envelope([_df_item(src)])
+    out = plot_runtime._materialize_inputs_for_r(env, tmp_path / "_r_inputs")
+    new_path = Path(out["collection"]["items"][0]["_path"])
+    assert new_path.suffix == ".csv" and new_path.exists()
+    assert out["collection"]["items"][0]["_format"] == "csv"
+    round_trip = pd.read_csv(new_path)
+    assert list(round_trip.columns) == ["lambda", "intensity"]
+    assert round_trip["intensity"].tolist() == [1.5, 2.5]
+
+
+def test_materialize_converts_npy_array_to_headerless_csv(tmp_path: Path) -> None:
+    src = tmp_path / "arr.npy"
+    np.save(src, np.arange(6, dtype="float64").reshape(2, 3))
+    env = _envelope([_df_item(src, typ="Array", fmt="npy")])
+    out = plot_runtime._materialize_inputs_for_r(env, tmp_path / "_r_inputs")
+    new_path = Path(out["collection"]["items"][0]["_path"])
+    assert new_path.suffix == ".csv" and new_path.exists()
+    grid = np.loadtxt(new_path, delimiter=",")
+    assert grid.shape == (2, 3)
+    assert float(grid.sum()) == 15.0
+
+
+def test_materialize_leaves_r_readable_and_unconvertible_types_untouched(tmp_path: Path) -> None:
+    csv_src = tmp_path / "already.csv"
+    csv_src.write_text("x,y\n1,2\n", encoding="utf-8")
+    text_src = tmp_path / "note.parquet"  # Text type is never converted
+    text_src.write_text("hello", encoding="utf-8")
+    env = _envelope([_df_item(csv_src, fmt="csv"), _df_item(text_src, typ="Text", fmt="parquet")])
+    out = plot_runtime._materialize_inputs_for_r(env, tmp_path / "_r_inputs")
+    assert out["collection"]["items"][0]["_path"] == str(csv_src)
+    assert out["collection"]["items"][1]["_path"] == str(text_src)
+
+
+def test_materialize_recurses_into_composite_slots(tmp_path: Path) -> None:
+    src = tmp_path / "slot.parquet"
+    import pandas as pd
+
+    pd.DataFrame({"a": [1, 2]}).to_parquet(src)
+    composite = {
+        "type": "CompositeData",
+        "_path": None,
+        "metadata": {"slots": {"inner": _df_item(src)}},
+    }
+    out = plot_runtime._materialize_inputs_for_r(_envelope([composite]), tmp_path / "_r_inputs")
+    inner = out["collection"]["items"][0]["metadata"]["slots"]["inner"]
+    assert Path(inner["_path"]).suffix == ".csv" and Path(inner["_path"]).exists()
+
+
+def test_materialize_falls_back_to_original_on_conversion_failure(tmp_path: Path) -> None:
+    missing = tmp_path / "nope.parquet"  # never created → read raises
+    env = _envelope([_df_item(missing)])
+    out = plot_runtime._materialize_inputs_for_r(env, tmp_path / "_r_inputs")
+    # No regression: the item keeps its original (unreadable) path; the R harness
+    # then produces its normal "unsupported storage" error instead of crashing here.
+    assert out["collection"]["items"][0]["_path"] == str(missing)
+
+
+@pytest.fixture
+def parquet_output(tmp_path: Path) -> Path:
+    import pandas as pd
+
+    path = tmp_path / "spectrum.parquet"
+    pd.DataFrame(
+        {"lambda": [float(i) for i in range(400, 410)], "intensity": [float(i % 3) for i in range(10)]}
+    ).to_parquet(path)
+    return path
+
+
+@pytest.mark.requires_r
+def test_run_r_reads_parquet_dataframe_output(project: Path, parquet_output: Path) -> None:
+    """Regression: an R plot opening a parquet-backed DataFrame succeeds without `arrow`."""
+    if shutil.which("Rscript") is None:
+        pytest.skip("Rscript not on PATH")
+    runtime = _make_runtime(project)
+    runtime.workflow_runs["run_1"] = _StubRun(
+        {
+            "node_a": {
+                "measurements": {
+                    "backend": "arrow",
+                    "path": str(parquet_output),
+                    "format": "parquet",
+                    "metadata": {"type_chain": ["DataFrame"]},
+                }
+            }
+        }
+    )
+    _set_ctx(runtime)
+    tid = _target_id(project)
+    _run(scaffold_plot(plot_id="r_parquet", target_id=tid, language="r"))
+    # Use a pdf device: svg/cairo is not guaranteed in every R build, but the
+    # point of this regression is that the parquet input is *readable* in R.
+    manifest = project / "plots" / "r_parquet" / "plot.yaml"
+    manifest.write_text(
+        manifest.read_text(encoding="utf-8")
+        .replace("preferred_format: svg", "preferred_format: pdf")
+        .replace("max_files: 8", "max_files: 1"),
+        encoding="utf-8",
+    )
+    (project / "plots" / "r_parquet" / "render.R").write_text(
+        (
+            "render <- function(collection) {\n"
+            "  df <- collection$items[[1]]$open()\n"
+            "  stopifnot(is.data.frame(df))\n"
+            "  stopifnot(all(c('lambda', 'intensity') %in% names(df)))\n"
+            "  grDevices::pdf('spectrum.pdf')\n"
+            "  plot(df[['lambda']], df[['intensity']], type = 'l')\n"
+            "  grDevices::dev.off()\n"
+            "  'spectrum.pdf'\n"
+            "}\n"
+        ),
+        encoding="utf-8",
+    )
+    res = _run(run_plot_job(plot_id="r_parquet"))
+    assert res.status == "succeeded", res.errors
+    assert res.artifact_paths

--- a/tests/ai/test_mcp_tools_plot.py
+++ b/tests/ai/test_mcp_tools_plot.py
@@ -1025,7 +1025,7 @@ def test_materialize_converts_parquet_dataframe_keeping_header(tmp_path: Path) -
 
     pd.DataFrame({"lambda": [400.0, 401.0], "intensity": [1.5, 2.5]}).to_parquet(src)
     env = _envelope([_df_item(src)])
-    out = plot_runtime._materialize_inputs_for_r(env, tmp_path / "_r_inputs")
+    out = plot_runtime._materialize_inputs_for_r(env, tmp_path / "_r_inputs", 10**9)
     new_path = Path(out["collection"]["items"][0]["_path"])
     assert new_path.suffix == ".csv" and new_path.exists()
     assert out["collection"]["items"][0]["_format"] == "csv"
@@ -1038,7 +1038,7 @@ def test_materialize_converts_npy_array_to_headerless_csv(tmp_path: Path) -> Non
     src = tmp_path / "arr.npy"
     np.save(src, np.arange(6, dtype="float64").reshape(2, 3))
     env = _envelope([_df_item(src, typ="Array", fmt="npy")])
-    out = plot_runtime._materialize_inputs_for_r(env, tmp_path / "_r_inputs")
+    out = plot_runtime._materialize_inputs_for_r(env, tmp_path / "_r_inputs", 10**9)
     new_path = Path(out["collection"]["items"][0]["_path"])
     assert new_path.suffix == ".csv" and new_path.exists()
     grid = np.loadtxt(new_path, delimiter=",")
@@ -1052,7 +1052,7 @@ def test_materialize_leaves_r_readable_and_unconvertible_types_untouched(tmp_pat
     text_src = tmp_path / "note.parquet"  # Text type is never converted
     text_src.write_text("hello", encoding="utf-8")
     env = _envelope([_df_item(csv_src, fmt="csv"), _df_item(text_src, typ="Text", fmt="parquet")])
-    out = plot_runtime._materialize_inputs_for_r(env, tmp_path / "_r_inputs")
+    out = plot_runtime._materialize_inputs_for_r(env, tmp_path / "_r_inputs", 10**9)
     assert out["collection"]["items"][0]["_path"] == str(csv_src)
     assert out["collection"]["items"][1]["_path"] == str(text_src)
 
@@ -1067,7 +1067,7 @@ def test_materialize_recurses_into_composite_slots(tmp_path: Path) -> None:
         "_path": None,
         "metadata": {"slots": {"inner": _df_item(src)}},
     }
-    out = plot_runtime._materialize_inputs_for_r(_envelope([composite]), tmp_path / "_r_inputs")
+    out = plot_runtime._materialize_inputs_for_r(_envelope([composite]), tmp_path / "_r_inputs", 10**9)
     inner = out["collection"]["items"][0]["metadata"]["slots"]["inner"]
     assert Path(inner["_path"]).suffix == ".csv" and Path(inner["_path"]).exists()
 
@@ -1075,10 +1075,39 @@ def test_materialize_recurses_into_composite_slots(tmp_path: Path) -> None:
 def test_materialize_falls_back_to_original_on_conversion_failure(tmp_path: Path) -> None:
     missing = tmp_path / "nope.parquet"  # never created → read raises
     env = _envelope([_df_item(missing)])
-    out = plot_runtime._materialize_inputs_for_r(env, tmp_path / "_r_inputs")
+    out = plot_runtime._materialize_inputs_for_r(env, tmp_path / "_r_inputs", 10**9)
     # No regression: the item keeps its original (unreadable) path; the R harness
     # then produces its normal "unsupported storage" error instead of crashing here.
     assert out["collection"]["items"][0]["_path"] == str(missing)
+
+
+def test_materialize_skips_over_cap_input_without_loading(tmp_path: Path) -> None:
+    """An over-cap input is left unconverted so the harness guard fires lazily.
+
+    The shim must not read an over-cap parquet/npy/zarr into the MCP process; it
+    leaves the original path so the R harness raises its standard memory-cap
+    error at open() time (mirrors the Python harness guard).
+    """
+    src = tmp_path / "big.npy"
+    np.save(src, np.arange(1000, dtype="float64"))  # 8000 bytes on disk
+    dest = tmp_path / "_r_inputs"
+    env = _envelope([_df_item(src, typ="Array", fmt="npy")])
+    out = plot_runtime._materialize_inputs_for_r(env, dest, 4096)  # cap below file size
+    # Left unconverted (original path) and nothing materialized under dest.
+    assert out["collection"]["items"][0]["_path"] == str(src)
+    assert not dest.exists() or not any(dest.iterdir())
+
+
+def test_materialize_uses_metadata_estimate_for_cap(tmp_path: Path) -> None:
+    """A small-on-disk input with an over-cap metadata estimate is not converted."""
+    import pandas as pd
+
+    src = tmp_path / "frame.parquet"
+    pd.DataFrame({"a": [1.0, 2.0]}).to_parquet(src)  # tiny on disk
+    item = _df_item(src)
+    item["metadata"] = {"shape": [10_000_000], "dtype": "float64"}  # ~80 MB estimate
+    out = plot_runtime._materialize_inputs_for_r(_envelope([item]), tmp_path / "_r_inputs", 64 * 1024 * 1024)
+    assert out["collection"]["items"][0]["_path"] == str(src)
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

R plot previews failed for default-stored inputs with `render failed: unsupported DataFrame storage for plot open(): <id>.parquet`, while the equivalent Python plot worked.

**Root cause:** SciStudio persists DataFrame/Series block outputs as parquet and Array outputs as npy/npz/zarr by default. The R plot harness can only read base formats (csv/tsv/txt/json) — parquet needs the R `arrow` package (not bundled; `requireNamespace('arrow') == FALSE`) and npy/npz/zarr are unreadable in R at all. So every R plot that `open()`s such an input failed. Python plots work because pandas/numpy/zarr are always available preview-side. Not Spectrum-specific — it affects all core data types in R plots.

## Fix (plot side only)

Add a Python-side input materialization shim in `tools_plot/runtime.py`: when the plot language is R, convert each R-unreadable input (parquet/npy/npz/zarr) to CSV in the confined work dir and repoint the harness item at it. DataFrame/Series keep a header row; Array is written headerless; CompositeData slots recurse; conversion failures fall back to the original path (no regression). Zero new R dependencies; covers DataFrame/Series/Array. Python plots are untouched.

## Tests

- 6 unit tests for the shim (run in CI without R): parquet→CSV with header, npy→headerless CSV, csv/Text passthrough, CompositeData slot recursion, conversion-failure fallback.
- 1 `requires_r` end-to-end regression: an R plot opening a parquet-backed DataFrame succeeds.
- Full `tests/ai/test_mcp_tools_plot.py` passes (44/44).

## Docs

Updated `docs/block-development/previewers-and-plots.md`: R plots do not require `arrow`; non-base inputs are transparently converted to CSV (preview-only; CSV round-trip fidelity caveat).

## Out of scope (follow-up)

CodeBlock R execution uses a separate per-port exchange mechanism (ADR-017); its R package environment is user-managed. Tracked separately.

Gate record: .workflow/records/1709-hotfix-r-parquet-dataframe.json

Closes #1709
