### PR TITLE
test(alpha): IO load+save coverage matrix + builtin-block behavior suite

### DIFF
--- a/.workflow/records/1737-alpha-test-cases.json
+++ b/.workflow/records/1737-alpha-test-cases.json
@@ -1,16 +1,1146 @@
 {
   "branch": "guided/alpha-test-cases-20260621",
-  "check_events": [],
+  "check_events": [
+    {
+      "at": "2026-06-21T09:03:03.167163Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:bdfa2cb35c65c6c2c28003e347e3a9df8e6a19617900836f865107e64517ce4b",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-21T09:03:07.319497Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:2f87df81e24c28d18a64d50737045cd079d2d87595bda62e1855d9b80e6801e1",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-21T09:03:07.371796Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:bc964f4adefdbe58add98a6d882f11322bd0c885d4022bd9e4768f829cf48060",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-21T09:05:16.726544Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:c0f3f0e931ebb86fbdc3b19a119d09b2a9b94c7bc63620cf804444b31eb03f52",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-21T09:07:15.841978Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:9e543f4bb277e5ca369a039e0c30cba6c7269daa923e918944ea20d34bcab0a5",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-21T09:11:56.009468Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:dd2b22fbe83bac426b394136b87c4d800802e2023f902e563153cada77fd4377",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-21T09:12:00.132930Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:0392872b8e9629ab4bdefd203095c9293f28c1e9cda90f9b32a1fedaee53ddee",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-21T09:12:00.150728Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:42c5a8d4247f014cdb109f497b9ead38a4243533f946f754e08f9de30de0013a",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-21T09:14:53.474527Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:51302ded2764f58e819444e21796d02e9ff65c676053332bad8ec5c3ecd040f4",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-21T09:18:01.424325Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:a8e1bc80d83650ce123658f0b04e022aea6871f51224dc8b03afbef54494487f",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-21T09:27:05.064876Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:2d69a798e5073369c71d98cf32bf46a5afba5d8e13618e35c9280d34085ddb78",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-21T09:27:08.654666Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:23e2867c6421a9e4a6265ef26e7305b04fe7d2524611aeae3ef03fba75c83e54",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-21T09:27:08.672890Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:5268fb934a005cbce17f7c8e122d6712b46cfa0bad9bc50ceb7e87b8c79935fd",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-21T09:28:46.159912Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:ff719e3278bd866eba4ca4b77150d99c863cf40668d321cab52b7842ab32c340",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-21T09:30:41.756022Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:1cbf33f360670d4482009306a62729f92be8d7e7b1aa43527536a5bf8d646f51",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-21T09:45:13.487437Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:ca154933068b3399265f98f60408214e4220476f303a50ef85a06bf815d5ff83",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-21T09:45:18.722865Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:783a44b6429805517d1682cd2f4d950fe748a0cca685b2c1d81ee36e95d1e60d",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-21T09:45:18.747364Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:9f7d786ba5d08905f4e8cb8d1abb1d28de4d2ecdcdc6cc937607d19d6759b384",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-21T09:47:48.806674Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:68e9f27d8a10b0b1e8fd903f78dc74f0a586c57c2358b7b37b27a1e74693f982",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-21T09:49:40.379899Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:5827337dc6b32ae69b9e913b590172f022d6978170961eb0de166bce95a0c15e",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-21T09:55:55.805763Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:a5fe95d5c4d5096843a1840b37763624d8bf99746510c19aaa121638304da976",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-21T09:55:59.305039Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:2bf24c474bea2f17e307d9a21a16422654766fb67e1fedc5f909c0e03e44fac7",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-21T09:55:59.321781Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:1addf3b72bb80fa2debac410b3fb51d52a39e77b92ea41ced6008f1ad78b0381",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-21T09:57:41.280411Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:d50ec5ce86b966e2513d8537967f41446032db6c63a858712c7099cd5d6ec987",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-21T09:59:22.299494Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:2874c278035dabd8234d0b6a2cbdd7bc95ee1d22b1d47f930a5bcd42ed8ab911",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-21T10:02:01.027409Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:d50ec5ce86b966e2513d8537967f41446032db6c63a858712c7099cd5d6ec987",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    }
+  ],
   "check_na": [],
-  "commit": null,
+  "commit": {
+    "sha": "bb7d01c36e2658d1900de85dbdf13d3319bf3046",
+    "shas": [
+      "bb7d01c36e2658d1900de85dbdf13d3319bf3046"
+    ],
+    "trailers": []
+  },
   "declared_scope": {
     "exclude": [],
     "include": []
   },
-  "directive_events": [],
+  "directive_events": [
+    {
+      "at": "2026-06-21T09:02:22.267187Z",
+      "owner_directive": "Round 5 alpha test suite: IO load+save coverage tests (core in repo, packages in package tests); CodeBlock python/R end-to-end tests; data/goldens in the test project. Repo diff is tests-only.",
+      "reason": "Refine Round-5 alpha test-suite directive (3 tasks) explaining the test-only diff."
+    }
+  ],
   "docs_events": [],
   "governance_touch": false,
-  "guard_events": [],
+  "guard_events": [
+    {
+      "at": "2026-06-21T09:07:15.878134Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T09:07:15.887808Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T09:07:15.897806Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T09:07:15.907195Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T09:07:15.916321Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T09:07:15.925559Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T09:07:15.934935Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T09:07:15.944094Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T09:07:15.953550Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T09:07:15.966032Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T09:18:01.500422Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T09:18:01.518456Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T09:18:01.539451Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T09:18:01.563578Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T09:18:01.586158Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T09:18:01.606937Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T09:18:01.627327Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T09:18:01.652515Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T09:18:01.673069Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T09:18:01.701899Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T09:20:19.293430Z",
+      "findings": [
+        {
+          "message": "AI-authored edits must happen in a dedicated worktree, not the main working tree (/private/var/folders/mk/xk0dqvn934l5425gwb19rsqc0000gn/T/pytest-of-jiazhenz/pytest-399/popen-gw9/test_hook_payload_extracts_mul0/main). Create one with `git worktree add ../<name> <branch>` and run your edits there.",
+          "rule_id": "worktree.main-checkout-write"
+        }
+      ],
+      "guard": "worktree_write_guard",
+      "status": "fail"
+    },
+    {
+      "at": "2026-06-21T09:20:19.566149Z",
+      "findings": [
+        {
+          "message": "AI-authored edits must happen in a dedicated worktree, not the main working tree (/private/var/folders/mk/xk0dqvn934l5425gwb19rsqc0000gn/T/pytest-of-jiazhenz/pytest-399/popen-gw2/test_hook_payload_blocks_main_0/main). Create one with `git worktree add ../<name> <branch>` and run your edits there.",
+          "rule_id": "worktree.main-checkout-write"
+        }
+      ],
+      "guard": "worktree_write_guard",
+      "status": "fail"
+    },
+    {
+      "at": "2026-06-21T09:21:35.159947Z",
+      "findings": [
+        {
+          "message": "AI-authored edits must happen in a dedicated worktree, not the main working tree (/private/var/folders/mk/xk0dqvn934l5425gwb19rsqc0000gn/T/pytest-of-jiazhenz/pytest-400/popen-gw11/test_hook_payload_blocks_main_0/main). Create one with `git worktree add ../<name> <branch>` and run your edits there.",
+          "rule_id": "worktree.main-checkout-write"
+        }
+      ],
+      "guard": "worktree_write_guard",
+      "status": "fail"
+    },
+    {
+      "at": "2026-06-21T09:21:36.023905Z",
+      "findings": [
+        {
+          "message": "AI-authored edits must happen in a dedicated worktree, not the main working tree (/private/var/folders/mk/xk0dqvn934l5425gwb19rsqc0000gn/T/pytest-of-jiazhenz/pytest-400/popen-gw11/test_hook_payload_extracts_mul0/main). Create one with `git worktree add ../<name> <branch>` and run your edits there.",
+          "rule_id": "worktree.main-checkout-write"
+        }
+      ],
+      "guard": "worktree_write_guard",
+      "status": "fail"
+    },
+    {
+      "at": "2026-06-21T09:30:41.794203Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T09:30:41.804637Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T09:30:41.814657Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T09:30:41.823997Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T09:30:41.834038Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T09:30:41.846413Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T09:30:41.857341Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T09:30:41.867469Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T09:30:41.876932Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T09:30:41.888415Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T09:32:57.144161Z",
+      "findings": [
+        {
+          "message": "AI-authored edits must happen in a dedicated worktree, not the main working tree (/private/var/folders/mk/xk0dqvn934l5425gwb19rsqc0000gn/T/pytest-of-jiazhenz/pytest-412/popen-gw0/test_hook_payload_blocks_main_0/main). Create one with `git worktree add ../<name> <branch>` and run your edits there.",
+          "rule_id": "worktree.main-checkout-write"
+        }
+      ],
+      "guard": "worktree_write_guard",
+      "status": "fail"
+    },
+    {
+      "at": "2026-06-21T09:32:57.979679Z",
+      "findings": [
+        {
+          "message": "AI-authored edits must happen in a dedicated worktree, not the main working tree (/private/var/folders/mk/xk0dqvn934l5425gwb19rsqc0000gn/T/pytest-of-jiazhenz/pytest-412/popen-gw0/test_hook_payload_extracts_mul0/main). Create one with `git worktree add ../<name> <branch>` and run your edits there.",
+          "rule_id": "worktree.main-checkout-write"
+        }
+      ],
+      "guard": "worktree_write_guard",
+      "status": "fail"
+    },
+    {
+      "at": "2026-06-21T09:36:02.964329Z",
+      "findings": [
+        {
+          "message": "AI-authored edits must happen in a dedicated worktree, not the main working tree (/private/var/folders/mk/xk0dqvn934l5425gwb19rsqc0000gn/T/pytest-of-jiazhenz/pytest-415/popen-gw9/test_hook_payload_blocks_main_0/main). Create one with `git worktree add ../<name> <branch>` and run your edits there.",
+          "rule_id": "worktree.main-checkout-write"
+        }
+      ],
+      "guard": "worktree_write_guard",
+      "status": "fail"
+    },
+    {
+      "at": "2026-06-21T09:36:04.162082Z",
+      "findings": [
+        {
+          "message": "AI-authored edits must happen in a dedicated worktree, not the main working tree (/private/var/folders/mk/xk0dqvn934l5425gwb19rsqc0000gn/T/pytest-of-jiazhenz/pytest-415/popen-gw9/test_hook_payload_extracts_mul0/main). Create one with `git worktree add ../<name> <branch>` and run your edits there.",
+          "rule_id": "worktree.main-checkout-write"
+        }
+      ],
+      "guard": "worktree_write_guard",
+      "status": "fail"
+    },
+    {
+      "at": "2026-06-21T09:39:12.473248Z",
+      "findings": [
+        {
+          "message": "AI-authored edits must happen in a dedicated worktree, not the main working tree (/private/var/folders/mk/xk0dqvn934l5425gwb19rsqc0000gn/T/pytest-of-jiazhenz/pytest-416/popen-gw3/test_hook_payload_blocks_main_0/main). Create one with `git worktree add ../<name> <branch>` and run your edits there.",
+          "rule_id": "worktree.main-checkout-write"
+        }
+      ],
+      "guard": "worktree_write_guard",
+      "status": "fail"
+    },
+    {
+      "at": "2026-06-21T09:39:13.360382Z",
+      "findings": [
+        {
+          "message": "AI-authored edits must happen in a dedicated worktree, not the main working tree (/private/var/folders/mk/xk0dqvn934l5425gwb19rsqc0000gn/T/pytest-of-jiazhenz/pytest-416/popen-gw3/test_hook_payload_extracts_mul0/main). Create one with `git worktree add ../<name> <branch>` and run your edits there.",
+          "rule_id": "worktree.main-checkout-write"
+        }
+      ],
+      "guard": "worktree_write_guard",
+      "status": "fail"
+    },
+    {
+      "at": "2026-06-21T09:41:06.029528Z",
+      "findings": [
+        {
+          "message": "AI-authored edits must happen in a dedicated worktree, not the main working tree (/private/var/folders/mk/xk0dqvn934l5425gwb19rsqc0000gn/T/pytest-of-jiazhenz/pytest-417/popen-gw8/test_hook_payload_extracts_mul0/main). Create one with `git worktree add ../<name> <branch>` and run your edits there.",
+          "rule_id": "worktree.main-checkout-write"
+        }
+      ],
+      "guard": "worktree_write_guard",
+      "status": "fail"
+    },
+    {
+      "at": "2026-06-21T09:41:06.711285Z",
+      "findings": [
+        {
+          "message": "AI-authored edits must happen in a dedicated worktree, not the main working tree (/private/var/folders/mk/xk0dqvn934l5425gwb19rsqc0000gn/T/pytest-of-jiazhenz/pytest-417/popen-gw1/test_hook_payload_blocks_main_0/main). Create one with `git worktree add ../<name> <branch>` and run your edits there.",
+          "rule_id": "worktree.main-checkout-write"
+        }
+      ],
+      "guard": "worktree_write_guard",
+      "status": "fail"
+    },
+    {
+      "at": "2026-06-21T09:49:40.412481Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T09:49:40.423350Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T09:49:40.433834Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T09:49:40.447089Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T09:49:40.457484Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T09:49:40.468184Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T09:49:40.479908Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T09:49:40.492819Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T09:49:40.505370Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T09:49:40.517712Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T09:59:22.339405Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T09:59:22.348234Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T09:59:22.357209Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T09:59:22.365856Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T09:59:22.374522Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T09:59:22.383121Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T09:59:22.391943Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T09:59:22.400670Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T09:59:22.409250Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T09:59:22.419697Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T10:02:01.062239Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T10:02:01.071733Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T10:02:01.081181Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T10:02:01.090092Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T10:02:01.099347Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T10:02:01.108671Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T10:02:01.118020Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T10:02:01.127523Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T10:02:01.136648Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T10:02:01.147539Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T10:02:22.425670Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T10:02:22.435158Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T10:02:22.444656Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T10:02:22.455107Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T10:02:22.464896Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T10:02:22.474684Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T10:02:22.483578Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T10:02:22.493075Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T10:02:22.502175Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T10:02:22.512567Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
   "issues": [
     {
       "close_in_pr": true,
@@ -20,25 +1150,144 @@
     }
   ],
   "observed_admin_labels": [],
-  "observed_diff": null,
+  "observed_diff": {
+    "base": "main",
+    "base_sha": "b06f54d0",
+    "changed_files": [
+      ".workflow/records/1737-alpha-test-cases.json",
+      "packages/scistudio-blocks-imaging/tests/test_io_coverage_image.py",
+      "packages/scistudio-blocks-spectroscopy/tests/test_io_coverage_spectroscopy.py",
+      "tests/blocks/code/test_alpha_codeblock_python.py",
+      "tests/blocks/code/test_alpha_codeblock_r.py",
+      "tests/blocks/io/test_io_coverage_matrix.py"
+    ],
+    "diff_fingerprint": "sha256:6dc05b7df57952aa50ed2c3ac61f48bc939106d3bb2052773451d49b6280e85e",
+    "head": "HEAD",
+    "head_sha": "bb7d01c3",
+    "surfaces": {
+      "docs": 0,
+      "frontend": 0,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 0,
+      "packaging": 0,
+      "protected_core": 0,
+      "sentrux": 5,
+      "test": 5,
+      "workflow_ci": 0
+    }
+  },
   "owner_directive": "Build alpha pre-release manual + automated test suite: (1) IO load+save coverage data + roundtrip tests for all in-scope core/imaging/spectroscopy types x extensions, 10 samples/slot single+collection; (2) AppBlock/CodeBlock builtin block cases; (3) 67 process-block behavior cases + goldens. Data in test project; automated tests in repo PR.",
   "persona": "live_implementer",
-  "pull_request": null,
-  "reconcile_events": [],
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [
+      1737
+    ],
+    "number": null,
+    "url": null
+  },
+  "reconcile_events": [
+    {
+      "at": "2026-06-21T09:07:15.966071Z",
+      "diff_fingerprint": "sha256:4b31339cff61b566143b8737aa67db2b7450baab4cc513e995374ddce3c9047f",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.format_check",
+        "checks.lint_format",
+        "checks.python_tests"
+      ]
+    },
+    {
+      "at": "2026-06-21T09:18:01.701954Z",
+      "diff_fingerprint": "sha256:c46af11e4aec44e0340da04099ed6c0d9d08c3e0e07b01eb717790b744b51efe",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.python_tests"
+      ]
+    },
+    {
+      "at": "2026-06-21T09:30:41.888437Z",
+      "diff_fingerprint": "sha256:13d0795f78fecafc259637cb530498fb904fe24705070a07b5d94fac0a07f565",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.python_tests"
+      ]
+    },
+    {
+      "at": "2026-06-21T09:49:40.517738Z",
+      "diff_fingerprint": "sha256:27544c4d2653a98ed2a43be7364649391a8a9f5c8379ec34cc0695ab93eae1ed",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.python_tests"
+      ]
+    },
+    {
+      "at": "2026-06-21T09:59:22.419719Z",
+      "diff_fingerprint": "sha256:6dc05b7df57952aa50ed2c3ac61f48bc939106d3bb2052773451d49b6280e85e",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.python_tests"
+      ]
+    },
+    {
+      "at": "2026-06-21T10:02:01.147570Z",
+      "diff_fingerprint": "sha256:6dc05b7df57952aa50ed2c3ac61f48bc939106d3bb2052773451d49b6280e85e",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-21T10:02:22.512600Z",
+      "diff_fingerprint": "sha256:6dc05b7df57952aa50ed2c3ac61f48bc939106d3bb2052773451d49b6280e85e",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    }
+  ],
   "record_id": "1737-alpha-test-cases",
   "requested_admin_labels": [],
   "required_obligations": {
     "admin_labels": [],
-    "checks": [],
+    "checks": [
+      "format_check",
+      "full_audit",
+      "lint_format",
+      "python_tests",
+      "semantic_dup"
+    ],
     "docs": [],
-    "guards": [],
+    "guards": [
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
     "tests": []
   },
   "runtime": "claude",
   "schema_version": 2,
   "scope_events": [],
   "session_id": "a546c144-dd20-46e1-8097-c6eaa932b9e4",
-  "strictness_tier": null,
+  "strictness_tier": 2,
   "task_kind": "guided",
   "test_events": []
 }

--- a/.workflow/records/1737-alpha-test-cases.json
+++ b/.workflow/records/1737-alpha-test-cases.json
@@ -414,9 +414,9 @@
   ],
   "check_na": [],
   "commit": {
-    "sha": "bb7d01c36e2658d1900de85dbdf13d3319bf3046",
+    "sha": "7c42b7d177dde01c1922488691511d487be74596",
     "shas": [
-      "bb7d01c36e2658d1900de85dbdf13d3319bf3046"
+      "7c42b7d177dde01c1922488691511d487be74596"
     ],
     "trailers": []
   },
@@ -1221,6 +1221,88 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-06-21T10:03:05.213280Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T10:03:05.221958Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T10:03:05.230453Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T10:03:05.239656Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T10:03:05.248019Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T10:03:05.256887Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T10:03:05.265520Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T10:03:05.275146Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T10:03:05.283954Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T10:03:05.296520Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -1233,8 +1315,8 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "origin/main",
-    "base_sha": "1948ab2c",
+    "base": "b06f54d0e253bf682fb01cc623b787c0adbd0c57",
+    "base_sha": "b06f54d0",
     "changed_files": [
       ".workflow/records/1737-alpha-test-cases.json",
       ".workflow/records/1737-pr-body.md",
@@ -1244,9 +1326,9 @@
       "tests/blocks/code/test_alpha_codeblock_r.py",
       "tests/blocks/io/test_io_coverage_matrix.py"
     ],
-    "diff_fingerprint": "sha256:e8a0f6a3b18717f4bad4cf813287c23917014223f75a861e223e150b6084731e",
+    "diff_fingerprint": "sha256:e4bc9d54bd26148fba7cab9235e326a71602f5a95cd3847be7f2276261b96698",
     "head": "HEAD",
-    "head_sha": "bc924726",
+    "head_sha": "7c42b7d1",
     "surfaces": {
       "docs": 0,
       "frontend": 0,
@@ -1267,8 +1349,8 @@
     "closes": [
       1737
     ],
-    "number": null,
-    "url": null
+    "number": 1739,
+    "url": "https://github.com/zjzcpj/SciStudio/pull/1739"
   },
   "reconcile_events": [
     {
@@ -1342,6 +1424,14 @@
     {
       "at": "2026-06-21T10:02:51.273955Z",
       "diff_fingerprint": "sha256:e8a0f6a3b18717f4bad4cf813287c23917014223f75a861e223e150b6084731e",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-21T10:03:05.296548Z",
+      "diff_fingerprint": "sha256:e4bc9d54bd26148fba7cab9235e326a71602f5a95cd3847be7f2276261b96698",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 2,

--- a/.workflow/records/1737-alpha-test-cases.json
+++ b/.workflow/records/1737-alpha-test-cases.json
@@ -1139,6 +1139,88 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-06-21T10:02:51.189974Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T10:02:51.198913Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T10:02:51.208409Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T10:02:51.217250Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T10:02:51.225699Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T10:02:51.234948Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T10:02:51.244148Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T10:02:51.253139Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T10:02:51.261677Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T10:02:51.273931Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -1151,19 +1233,20 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "main",
-    "base_sha": "b06f54d0",
+    "base": "origin/main",
+    "base_sha": "1948ab2c",
     "changed_files": [
       ".workflow/records/1737-alpha-test-cases.json",
+      ".workflow/records/1737-pr-body.md",
       "packages/scistudio-blocks-imaging/tests/test_io_coverage_image.py",
       "packages/scistudio-blocks-spectroscopy/tests/test_io_coverage_spectroscopy.py",
       "tests/blocks/code/test_alpha_codeblock_python.py",
       "tests/blocks/code/test_alpha_codeblock_r.py",
       "tests/blocks/io/test_io_coverage_matrix.py"
     ],
-    "diff_fingerprint": "sha256:6dc05b7df57952aa50ed2c3ac61f48bc939106d3bb2052773451d49b6280e85e",
+    "diff_fingerprint": "sha256:e8a0f6a3b18717f4bad4cf813287c23917014223f75a861e223e150b6084731e",
     "head": "HEAD",
-    "head_sha": "bb7d01c3",
+    "head_sha": "bc924726",
     "surfaces": {
       "docs": 0,
       "frontend": 0,
@@ -1251,6 +1334,14 @@
     {
       "at": "2026-06-21T10:02:22.512600Z",
       "diff_fingerprint": "sha256:6dc05b7df57952aa50ed2c3ac61f48bc939106d3bb2052773451d49b6280e85e",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-21T10:02:51.273955Z",
+      "diff_fingerprint": "sha256:e8a0f6a3b18717f4bad4cf813287c23917014223f75a861e223e150b6084731e",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 2,

--- a/.workflow/records/1737-alpha-test-cases.json
+++ b/.workflow/records/1737-alpha-test-cases.json
@@ -1,0 +1,44 @@
+{
+  "branch": "guided/alpha-test-cases-20260621",
+  "check_events": [],
+  "check_na": [],
+  "commit": null,
+  "declared_scope": {
+    "exclude": [],
+    "include": []
+  },
+  "directive_events": [],
+  "docs_events": [],
+  "governance_touch": false,
+  "guard_events": [],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1737,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": null,
+  "owner_directive": "Build alpha pre-release manual + automated test suite: (1) IO load+save coverage data + roundtrip tests for all in-scope core/imaging/spectroscopy types x extensions, 10 samples/slot single+collection; (2) AppBlock/CodeBlock builtin block cases; (3) 67 process-block behavior cases + goldens. Data in test project; automated tests in repo PR.",
+  "persona": "live_implementer",
+  "pull_request": null,
+  "reconcile_events": [],
+  "record_id": "1737-alpha-test-cases",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [],
+    "docs": [],
+    "guards": [],
+    "tests": []
+  },
+  "runtime": "claude",
+  "schema_version": 2,
+  "scope_events": [],
+  "session_id": "a546c144-dd20-46e1-8097-c6eaa932b9e4",
+  "strictness_tier": null,
+  "task_kind": "guided",
+  "test_events": []
+}

--- a/.workflow/records/1737-alpha-test-cases.json
+++ b/.workflow/records/1737-alpha-test-cases.json
@@ -414,9 +414,9 @@
   ],
   "check_na": [],
   "commit": {
-    "sha": "7c42b7d177dde01c1922488691511d487be74596",
+    "sha": "f425770f3e833f552277c478c88314f3b59a7d5d",
     "shas": [
-      "7c42b7d177dde01c1922488691511d487be74596"
+      "f425770f3e833f552277c478c88314f3b59a7d5d"
     ],
     "trailers": []
   },
@@ -1303,6 +1303,88 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-06-21T20:31:16.939675Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T20:31:16.961285Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T20:31:16.978682Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T20:31:16.997534Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T20:31:17.040650Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T20:31:17.060148Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T20:31:17.082699Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T20:31:17.104678Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T20:31:17.121390Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-21T20:31:17.145854Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -1320,15 +1402,18 @@
     "changed_files": [
       ".workflow/records/1737-alpha-test-cases.json",
       ".workflow/records/1737-pr-body.md",
+      "packages/scistudio-blocks-imaging/tests/test_alpha_findings_imaging.py",
       "packages/scistudio-blocks-imaging/tests/test_io_coverage_image.py",
       "packages/scistudio-blocks-spectroscopy/tests/test_io_coverage_spectroscopy.py",
       "tests/blocks/code/test_alpha_codeblock_python.py",
       "tests/blocks/code/test_alpha_codeblock_r.py",
+      "tests/blocks/code/test_alpha_findings_codeblock.py",
+      "tests/blocks/io/test_alpha_findings.py",
       "tests/blocks/io/test_io_coverage_matrix.py"
     ],
-    "diff_fingerprint": "sha256:e4bc9d54bd26148fba7cab9235e326a71602f5a95cd3847be7f2276261b96698",
+    "diff_fingerprint": "sha256:c84451c8cfc579950652836aa490c1af8093c48e73010fd8e7fe8aa53f0addcc",
     "head": "HEAD",
-    "head_sha": "7c42b7d1",
+    "head_sha": "f425770f",
     "surfaces": {
       "docs": 0,
       "frontend": 0,
@@ -1337,8 +1422,8 @@
       "implementation": 0,
       "packaging": 0,
       "protected_core": 0,
-      "sentrux": 5,
-      "test": 5,
+      "sentrux": 8,
+      "test": 8,
       "workflow_ci": 0
     }
   },
@@ -1436,6 +1521,20 @@
       "result": "pass",
       "tier": 2,
       "unsatisfied": []
+    },
+    {
+      "at": "2026-06-21T20:31:17.145888Z",
+      "diff_fingerprint": "sha256:c84451c8cfc579950652836aa490c1af8093c48e73010fd8e7fe8aa53f0addcc",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.format_check",
+        "checks.full_audit",
+        "checks.lint_format",
+        "checks.python_tests",
+        "checks.semantic_dup"
+      ]
     }
   ],
   "record_id": "1737-alpha-test-cases",

--- a/.workflow/records/1737-pr-body.md
+++ b/.workflow/records/1737-pr-body.md
@@ -1,0 +1,55 @@
+## Summary
+
+Pre-alpha automated test suite for **data IO** and **builtin block**
+behavior (owner-directed `guided` session). This PR carries the
+**self-contained automated tests**; the curated sample data, golden
+answers, generation scripts, and the owner-facing manual checklist live
+in the separate test project (`~/Desktop/scistudio-tests`,
+`alpha-test-suite/`).
+
+Closes #1737.
+
+## What's in this PR (tests only)
+
+- `tests/blocks/io/test_io_coverage_matrix.py` — core IO load+save
+  matrix for Array/DataFrame/Series/Text/CompositeData over every
+  `load_ext × save_ext`, plus 10-item collection round-trips and N-D
+  Array coverage. **232 pass / 30 xfail** (xfail = engine findings).
+  Runs in CI (core deps only, scoped `LoadData`/`SaveData` registry).
+- `packages/scistudio-blocks-imaging/tests/test_io_coverage_image.py` —
+  Image format matrix (tif/png/jpg/zarr) + collection. **42 pass.**
+- `packages/scistudio-blocks-spectroscopy/tests/test_io_coverage_spectroscopy.py`
+  — Spectrum + SpectralDataset matrix + collection. **69 pass.**
+- `tests/blocks/code/test_alpha_codeblock_python.py` /
+  `test_alpha_codeblock_r.py` — real file-exchange CodeBlock runs
+  (Python `out=in*2+1`; R adds `scaled=value*10`, `requires Rscript`).
+
+> Package tests (`packages/*/tests`) are not collected by the repo's
+> `testpaths = ["tests"]`, so they run locally / for the owner, not in
+> the main CI job. They need `tifffile`, `ome-types`, `scikit-image`,
+> `imageio` in the env.
+
+## Findings surfaced while building the suite
+
+Documented in the test project's `alpha-test-suite/FINDINGS.md`; covered
+by `xfail` here so they stay visible without failing CI:
+
+| ID | What |
+|---|---|
+| FIND-A | `CompositeData` `.json` saver writes slot key `file`, loader reads `path` → core composite save/load broken |
+| FIND-B | `DataFrame`/`Series` pickle saves the Arrow Table; loader expects the wrapped object |
+| FIND-C | Full-registry extension ambiguity (`.zarr`→Image, `.json`→SpectralDataset, ambiguous `.csv`) |
+| FIND-D | `Array` `.zarr` reload restores data but drops `shape`/`axes` metadata |
+| FIND-E | `Render Movie` uses `tifffile` `fps=` kwarg removed in 2026 |
+| FIND-F | Python CodeBlock backend injects no `SCISTUDIO_*_DIR` env; scripts can't locate exchange dirs (R/shell do) |
+
+These are **test findings, not fixes** — this PR does not touch engine
+code. Follow-up issues can be filed per finding.
+
+## Out of scope (per owner)
+
+LCMS + SRS packages (future refactor), vendor binaries
+(.czi/.lif/.nd2/.oib/.oir/.raw/.d/.mzml), legacy `.xls`, ProcessBlock +
+AIBlock manual cases, Subworkflow.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/packages/scistudio-blocks-imaging/tests/test_alpha_findings_imaging.py
+++ b/packages/scistudio-blocks-imaging/tests/test_alpha_findings_imaging.py
@@ -1,0 +1,56 @@
+"""Imaging/full-registry engine findings — tracked as strict xfails.
+
+These need the imaging plugin importable, so they live in the package
+suite (not collected by the core repo ``testpaths``). See
+``~/Desktop/scistudio-tests/alpha-test-suite/FINDINGS.md``.
+
+* FIND-E: ``Render Movie`` calls ``TiffWriter.write(..., fps=...)``;
+  ``tifffile`` 2026 removed the ``fps`` kwarg, so the block raises.
+* FIND-C: with a full (plugin) registry, ``reconstruct_from_file`` picks
+  a sibling type by extension despite an explicit ``target_type`` —
+  e.g. an ``Array`` saved to ``.zarr`` reloads as ``Image``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+from scistudio_blocks_imaging.types import Image
+
+from scistudio.blocks.base.config import BlockConfig
+from scistudio.blocks.registry import BlockRegistry
+from scistudio.core.types.array import Array
+from scistudio.core.types.collection import Collection
+from scistudio.engine.materialisation import materialise_to_file, reconstruct_from_file
+
+
+def _full_registry() -> BlockRegistry:
+    reg = BlockRegistry()
+    reg.scan(include_monorepo=True)
+    return reg
+
+
+@pytest.mark.xfail(strict=True, reason="FIND-E: Render Movie uses tifffile fps= kwarg removed in 2026")
+def test_find_e_render_movie_runs(tmp_path: Path) -> None:
+    pytest.importorskip("tifffile")
+    reg = _full_registry()
+    cls = BlockRegistry._resolve_class(reg._registry["Render Movie"])
+    assert cls is not None
+    arr = np.stack([(np.arange(64).reshape(8, 8) + k).astype(np.float32) for k in range(3)], axis=0)
+    img = Image(axes=["t", "y", "x"], shape=arr.shape, dtype=str(arr.dtype))
+    img._data = arr
+    out = cls().run({"image": Collection(items=[img], item_type=Image)}, BlockConfig(params={}))
+    assert any(len(list(coll)) for coll in out.values())
+
+
+@pytest.mark.xfail(strict=True, reason="FIND-C: full-registry reconstruct picks Image for an Array .zarr")
+def test_find_c_array_zarr_reconstructs_as_array(tmp_path: Path) -> None:
+    reg = _full_registry()
+    data = np.arange(12, dtype=np.float64).reshape(3, 4)
+    src = Array(axes=["y", "x"], shape=(3, 4), dtype="float64", data=data)
+    path = materialise_to_file(src, tmp_path, ".zarr", filename_stem="a", registry=reg)
+    back = reconstruct_from_file(path, Array, registry=reg)
+    # Image IS-A Array, so check the exact type: the bug returns an Image.
+    assert type(back) is Array

--- a/packages/scistudio-blocks-imaging/tests/test_io_coverage_image.py
+++ b/packages/scistudio-blocks-imaging/tests/test_io_coverage_image.py
@@ -1,0 +1,85 @@
+"""Alpha IO load+save coverage matrix for the imaging ``Image`` type.
+
+Exercises the full ``load_ext × save_ext`` matrix over the in-scope
+image formats (vendor binaries .czi/.lif/.nd2/.oib/.oir are out of scope
+for alpha) plus a 10-item collection round-trip via ``LoadImage``
+multi-path loading.
+
+Lossy formats (.jpg/.jpeg) are verified by shape (not exact pixels).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from scistudio.blocks.base.config import BlockConfig
+from scistudio_blocks_imaging.io.load_image import LoadImage
+from scistudio_blocks_imaging.io.save_image import SaveImage
+from scistudio_blocks_imaging.types import Image
+
+# Lossless + lossy in-scope formats. Build a 2-D uint8 image so every
+# format (incl. PNG/JPEG which require uint8) accepts it.
+IMAGE_EXTS = [".tif", ".tiff", ".png", ".jpg", ".jpeg", ".zarr"]
+LOSSLESS = {".tif", ".tiff", ".png", ".zarr"}
+
+
+def _make_image(i: int = 0) -> Image:
+    arr = (((np.arange(64) + i * 3) % 251).astype(np.uint8)).reshape(8, 8)
+    img = Image(axes=["y", "x"], shape=arr.shape, dtype=str(arr.dtype))
+    img._data = arr
+    return img
+
+
+def _save(img: Image, path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    SaveImage().save(img, BlockConfig(params={"path": str(path)}))
+
+
+def _load_one(path: Path) -> Image:
+    result = LoadImage().load(BlockConfig(params={"path": str(path)}))
+    return result[0]
+
+
+@pytest.mark.parametrize("save_ext", IMAGE_EXTS)
+@pytest.mark.parametrize("load_ext", IMAGE_EXTS)
+def test_image_load_save_matrix(tmp_path: Path, load_ext: str, save_ext: str) -> None:
+    src = _make_image()
+    src_arr = np.asarray(src._data)
+
+    # LOAD under test.
+    in_path = tmp_path / f"in{load_ext}"
+    _save(src, in_path)
+    loaded = _load_one(in_path)
+
+    # SAVE under test.
+    out_path = tmp_path / f"out{save_ext}"
+    _save(loaded, out_path)
+    assert out_path.exists()
+    if out_path.is_file():
+        assert out_path.stat().st_size > 0
+    else:  # .zarr store directory
+        assert any(out_path.rglob("*"))
+
+    # Reload and verify. Exact pixels only for lossless load+save chains.
+    reloaded = _load_one(out_path)
+    out_arr = np.asarray(reloaded.get_in_memory_data())
+    assert out_arr.shape == src_arr.shape
+    if load_ext in LOSSLESS and save_ext in LOSSLESS:
+        np.testing.assert_array_equal(out_arr, src_arr)
+
+
+@pytest.mark.parametrize("ext", IMAGE_EXTS)
+def test_image_collection_roundtrip_10(tmp_path: Path, ext: str) -> None:
+    paths: list[str] = []
+    for i in range(10):
+        p = tmp_path / f"img_{i:02d}{ext}"
+        _save(_make_image(i), p)
+        paths.append(str(p))
+    result = LoadImage().load(BlockConfig(params={"path": paths}))
+    items = list(result)
+    assert len(items) == 10
+    for item in items:
+        assert isinstance(item, Image)

--- a/packages/scistudio-blocks-imaging/tests/test_io_coverage_image.py
+++ b/packages/scistudio-blocks-imaging/tests/test_io_coverage_image.py
@@ -1,6 +1,6 @@
 """Alpha IO load+save coverage matrix for the imaging ``Image`` type.
 
-Exercises the full ``load_ext × save_ext`` matrix over the in-scope
+Exercises the full ``load_ext x save_ext`` matrix over the in-scope
 image formats (vendor binaries .czi/.lif/.nd2/.oib/.oir are out of scope
 for alpha) plus a 10-item collection round-trip via ``LoadImage``
 multi-path loading.
@@ -14,11 +14,11 @@ from pathlib import Path
 
 import numpy as np
 import pytest
-
-from scistudio.blocks.base.config import BlockConfig
 from scistudio_blocks_imaging.io.load_image import LoadImage
 from scistudio_blocks_imaging.io.save_image import SaveImage
 from scistudio_blocks_imaging.types import Image
+
+from scistudio.blocks.base.config import BlockConfig
 
 # Lossless + lossy in-scope formats. Build a 2-D uint8 image so every
 # format (incl. PNG/JPEG which require uint8) accepts it.

--- a/packages/scistudio-blocks-spectroscopy/tests/test_io_coverage_spectroscopy.py
+++ b/packages/scistudio-blocks-spectroscopy/tests/test_io_coverage_spectroscopy.py
@@ -1,0 +1,123 @@
+"""Alpha IO load+save coverage matrix for spectroscopy types.
+
+Covers the full ``load_ext × save_ext`` matrix for ``Spectrum`` and
+``SpectralDataset`` over the in-scope formats (legacy ``.xls`` is out of
+scope for alpha) plus a 10-item ``Spectrum`` collection round-trip via
+``LoadSpectrum`` multi-path loading.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from scistudio.blocks.base.config import BlockConfig
+from scistudio_blocks_spectroscopy import _support
+from scistudio_blocks_spectroscopy.blocks.utilities import (
+    LoadSpectralDataset,
+    LoadSpectrum,
+    SaveSpectralDataset,
+    SaveSpectrum,
+)
+from scistudio_blocks_spectroscopy.types import Spectrum, SpectralDataset
+
+SPECTRUM_EXTS = [".csv", ".tsv", ".txt", ".xlsx", ".dx", ".jcamp", ".jdx", ".spectrum.json"]
+DATASET_EXTS = [".json", ".xlsx"]
+
+
+def _spectrum(i: int = 0) -> Spectrum:
+    lam = np.linspace(400.0, 800.0, 32)
+    inten = (np.cos(lam / 50.0) + 2.0) * (1.0 + 0.1 * i)
+    meta = Spectrum.Meta(
+        lambda_unit="nm", intensity_unit="a.u.", lambda_kind="wavelength",
+        modality="uvvis", sample_label=f"sample{i}",
+    )
+    return _support.build_spectrum(lam, inten, meta=meta)
+
+
+def _dataset(i: int = 0) -> SpectralDataset:
+    ids = [f"spec_{i}_{k}" for k in range(3)]
+    index_rows, spectra_rows = [], []
+    for k, sid in enumerate(ids):
+        lam = np.linspace(400.0 + k, 410.0 + k, 5)
+        inten = np.arange(5, dtype=float) + k * 10.0 + i
+        index_rows.append({"spectrum_id": sid, "material": f"mat{k}", "replicate": k})
+        for x, y in zip(lam, inten, strict=True):
+            spectra_rows.append({"spectrum_id": sid, "lambda": float(x), "intensity": float(y)})
+    meta = SpectralDataset.Meta(
+        dataset_name=f"DS{i}", dataset_role="experiment", lambda_unit="nm",
+        intensity_unit="counts", modality="raman", schema_version="1",
+    )
+    return _support.build_spectral_dataset(
+        _support.dataframe_from_rows(index_rows),
+        _support.dataframe_from_rows(spectra_rows),
+        meta=meta,
+    )
+
+
+def _save_spectrum(spec: Spectrum, path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    SaveSpectrum().save(_support.spectra_collection([spec]), BlockConfig(params={"path": str(path)}))
+
+
+def _load_spectrum_one(path: Path) -> Spectrum:
+    return list(LoadSpectrum().load(BlockConfig(params={"path": str(path)})))[0]
+
+
+@pytest.mark.parametrize("save_ext", SPECTRUM_EXTS)
+@pytest.mark.parametrize("load_ext", SPECTRUM_EXTS)
+def test_spectrum_load_save_matrix(tmp_path: Path, load_ext: str, save_ext: str) -> None:
+    src = _spectrum()
+    _, src_inten = _support.spectrum_arrays(src)
+
+    in_path = tmp_path / f"in{load_ext}"
+    _save_spectrum(src, in_path)
+    loaded = _load_spectrum_one(in_path)
+
+    out_path = tmp_path / f"out{save_ext}"
+    _save_spectrum(loaded, out_path)
+    assert out_path.exists() and out_path.stat().st_size > 0
+
+    reloaded = _load_spectrum_one(out_path)
+    _, out_inten = _support.spectrum_arrays(reloaded)
+    assert out_inten.shape == src_inten.shape
+    np.testing.assert_allclose(out_inten, src_inten, rtol=1e-4, atol=1e-4)
+
+
+@pytest.mark.parametrize("save_ext", DATASET_EXTS)
+@pytest.mark.parametrize("load_ext", DATASET_EXTS)
+def test_spectral_dataset_load_save_matrix(tmp_path: Path, load_ext: str, save_ext: str) -> None:
+    src = _dataset()
+
+    in_path = tmp_path / f"in{load_ext}"
+    SaveSpectralDataset().save(src, BlockConfig(params={"path": str(in_path)}))
+    loaded = LoadSpectralDataset().load(BlockConfig(params={"path": str(in_path)}))
+    if hasattr(loaded, "items") and not isinstance(loaded, SpectralDataset):
+        loaded = list(loaded)[0]
+
+    out_path = tmp_path / f"out{save_ext}"
+    SaveSpectralDataset().save(loaded, BlockConfig(params={"path": str(out_path)}))
+    assert out_path.exists() and out_path.stat().st_size > 0
+
+    reloaded = LoadSpectralDataset().load(BlockConfig(params={"path": str(out_path)}))
+    if hasattr(reloaded, "items") and not isinstance(reloaded, SpectralDataset):
+        reloaded = list(reloaded)[0]
+    assert isinstance(reloaded, SpectralDataset)
+    idx, spectra = _support.dataset_frames(reloaded)
+    assert idx.num_rows == 3
+    assert spectra.num_rows == 15
+
+
+def test_spectrum_collection_roundtrip_10(tmp_path: Path) -> None:
+    paths: list[str] = []
+    for i in range(10):
+        p = tmp_path / f"spec_{i:02d}.csv"
+        _save_spectrum(_spectrum(i), p)
+        paths.append(str(p))
+    result = LoadSpectrum().load(BlockConfig(params={"path": paths}))
+    items = list(result)
+    assert len(items) == 10
+    for item in items:
+        assert isinstance(item, Spectrum)

--- a/packages/scistudio-blocks-spectroscopy/tests/test_io_coverage_spectroscopy.py
+++ b/packages/scistudio-blocks-spectroscopy/tests/test_io_coverage_spectroscopy.py
@@ -73,6 +73,38 @@ def _load_spectrum_one(path: Path) -> Spectrum:
     return next(iter(LoadSpectrum().load(BlockConfig(params={"path": str(path)}))))
 
 
+def _assert_table_values(loaded_tbl, src_tbl) -> None:
+    """Compare two Arrow tables by column names AND values (numeric-tolerant)."""
+    assert sorted(loaded_tbl.column_names) == sorted(src_tbl.column_names), (
+        f"columns {loaded_tbl.column_names} != {src_tbl.column_names}"
+    )
+    for col in src_tbl.column_names:
+        got = loaded_tbl.column(col).to_pylist()
+        want = src_tbl.column(col).to_pylist()
+        assert len(got) == len(want), f"column {col}: length {len(got)} != {len(want)}"
+        non_null = [x for x in want if x is not None]
+        if non_null and all(isinstance(x, (int, float)) for x in non_null):
+            np.testing.assert_allclose(
+                [float(x) for x in got],
+                [float(x) for x in want],
+                rtol=1e-6,
+                atol=1e-9,
+                err_msg=f"column {col!r} values differ",
+            )
+        else:
+            assert got == want, f"column {col!r} values differ: {got} != {want}"
+
+
+def _assert_dataset_equiv(src: SpectralDataset, reloaded: SpectralDataset) -> None:
+    """Index + spectra tables AND typed Meta must survive the round-trip."""
+    src_idx, src_spectra = _support.dataset_frames(src)
+    got_idx, got_spectra = _support.dataset_frames(reloaded)
+    _assert_table_values(got_idx, src_idx)
+    _assert_table_values(got_spectra, src_spectra)
+    for field in ("dataset_name", "dataset_role", "lambda_unit", "intensity_unit", "modality", "schema_version"):
+        assert getattr(reloaded.meta, field) == getattr(src.meta, field), f"meta.{field} differs"
+
+
 @pytest.mark.parametrize("save_ext", SPECTRUM_EXTS)
 @pytest.mark.parametrize("load_ext", SPECTRUM_EXTS)
 def test_spectrum_load_save_matrix(tmp_path: Path, load_ext: str, save_ext: str) -> None:
@@ -112,9 +144,7 @@ def test_spectral_dataset_load_save_matrix(tmp_path: Path, load_ext: str, save_e
     if hasattr(reloaded, "items") and not isinstance(reloaded, SpectralDataset):
         reloaded = next(iter(reloaded))
     assert isinstance(reloaded, SpectralDataset)
-    idx, spectra = _support.dataset_frames(reloaded)
-    assert idx.num_rows == 3
-    assert spectra.num_rows == 15
+    _assert_dataset_equiv(src, reloaded)
 
 
 def test_spectrum_collection_roundtrip_10(tmp_path: Path) -> None:

--- a/packages/scistudio-blocks-spectroscopy/tests/test_io_coverage_spectroscopy.py
+++ b/packages/scistudio-blocks-spectroscopy/tests/test_io_coverage_spectroscopy.py
@@ -1,6 +1,6 @@
 """Alpha IO load+save coverage matrix for spectroscopy types.
 
-Covers the full ``load_ext × save_ext`` matrix for ``Spectrum`` and
+Covers the full ``load_ext x save_ext`` matrix for ``Spectrum`` and
 ``SpectralDataset`` over the in-scope formats (legacy ``.xls`` is out of
 scope for alpha) plus a 10-item ``Spectrum`` collection round-trip via
 ``LoadSpectrum`` multi-path loading.
@@ -12,8 +12,6 @@ from pathlib import Path
 
 import numpy as np
 import pytest
-
-from scistudio.blocks.base.config import BlockConfig
 from scistudio_blocks_spectroscopy import _support
 from scistudio_blocks_spectroscopy.blocks.utilities import (
     LoadSpectralDataset,
@@ -21,7 +19,9 @@ from scistudio_blocks_spectroscopy.blocks.utilities import (
     SaveSpectralDataset,
     SaveSpectrum,
 )
-from scistudio_blocks_spectroscopy.types import Spectrum, SpectralDataset
+from scistudio_blocks_spectroscopy.types import SpectralDataset, Spectrum
+
+from scistudio.blocks.base.config import BlockConfig
 
 SPECTRUM_EXTS = [".csv", ".tsv", ".txt", ".xlsx", ".dx", ".jcamp", ".jdx", ".spectrum.json"]
 DATASET_EXTS = [".json", ".xlsx"]
@@ -31,8 +31,11 @@ def _spectrum(i: int = 0) -> Spectrum:
     lam = np.linspace(400.0, 800.0, 32)
     inten = (np.cos(lam / 50.0) + 2.0) * (1.0 + 0.1 * i)
     meta = Spectrum.Meta(
-        lambda_unit="nm", intensity_unit="a.u.", lambda_kind="wavelength",
-        modality="uvvis", sample_label=f"sample{i}",
+        lambda_unit="nm",
+        intensity_unit="a.u.",
+        lambda_kind="wavelength",
+        modality="uvvis",
+        sample_label=f"sample{i}",
     )
     return _support.build_spectrum(lam, inten, meta=meta)
 
@@ -47,8 +50,12 @@ def _dataset(i: int = 0) -> SpectralDataset:
         for x, y in zip(lam, inten, strict=True):
             spectra_rows.append({"spectrum_id": sid, "lambda": float(x), "intensity": float(y)})
     meta = SpectralDataset.Meta(
-        dataset_name=f"DS{i}", dataset_role="experiment", lambda_unit="nm",
-        intensity_unit="counts", modality="raman", schema_version="1",
+        dataset_name=f"DS{i}",
+        dataset_role="experiment",
+        lambda_unit="nm",
+        intensity_unit="counts",
+        modality="raman",
+        schema_version="1",
     )
     return _support.build_spectral_dataset(
         _support.dataframe_from_rows(index_rows),
@@ -63,7 +70,7 @@ def _save_spectrum(spec: Spectrum, path: Path) -> None:
 
 
 def _load_spectrum_one(path: Path) -> Spectrum:
-    return list(LoadSpectrum().load(BlockConfig(params={"path": str(path)})))[0]
+    return next(iter(LoadSpectrum().load(BlockConfig(params={"path": str(path)}))))
 
 
 @pytest.mark.parametrize("save_ext", SPECTRUM_EXTS)
@@ -95,7 +102,7 @@ def test_spectral_dataset_load_save_matrix(tmp_path: Path, load_ext: str, save_e
     SaveSpectralDataset().save(src, BlockConfig(params={"path": str(in_path)}))
     loaded = LoadSpectralDataset().load(BlockConfig(params={"path": str(in_path)}))
     if hasattr(loaded, "items") and not isinstance(loaded, SpectralDataset):
-        loaded = list(loaded)[0]
+        loaded = next(iter(loaded))
 
     out_path = tmp_path / f"out{save_ext}"
     SaveSpectralDataset().save(loaded, BlockConfig(params={"path": str(out_path)}))
@@ -103,7 +110,7 @@ def test_spectral_dataset_load_save_matrix(tmp_path: Path, load_ext: str, save_e
 
     reloaded = LoadSpectralDataset().load(BlockConfig(params={"path": str(out_path)}))
     if hasattr(reloaded, "items") and not isinstance(reloaded, SpectralDataset):
-        reloaded = list(reloaded)[0]
+        reloaded = next(iter(reloaded))
     assert isinstance(reloaded, SpectralDataset)
     idx, spectra = _support.dataset_frames(reloaded)
     assert idx.num_rows == 3

--- a/packages/scistudio-blocks-spectroscopy/tests/test_io_coverage_spectroscopy.py
+++ b/packages/scistudio-blocks-spectroscopy/tests/test_io_coverage_spectroscopy.py
@@ -109,7 +109,7 @@ def _assert_dataset_equiv(src: SpectralDataset, reloaded: SpectralDataset) -> No
 @pytest.mark.parametrize("load_ext", SPECTRUM_EXTS)
 def test_spectrum_load_save_matrix(tmp_path: Path, load_ext: str, save_ext: str) -> None:
     src = _spectrum()
-    _, src_inten = _support.spectrum_arrays(src)
+    src_lam, src_inten = _support.spectrum_arrays(src)
 
     in_path = tmp_path / f"in{load_ext}"
     _save_spectrum(src, in_path)
@@ -120,8 +120,11 @@ def test_spectrum_load_save_matrix(tmp_path: Path, load_ext: str, save_ext: str)
     assert out_path.exists() and out_path.stat().st_size > 0
 
     reloaded = _load_spectrum_one(out_path)
-    _, out_inten = _support.spectrum_arrays(reloaded)
-    assert out_inten.shape == src_inten.shape
+    out_lam, out_inten = _support.spectrum_arrays(reloaded)
+    # Compare BOTH axes: a format that scrambles wavelengths but keeps
+    # intensities (or vice versa) must fail.
+    assert out_lam.shape == src_lam.shape and out_inten.shape == src_inten.shape
+    np.testing.assert_allclose(out_lam, src_lam, rtol=1e-4, atol=1e-4)
     np.testing.assert_allclose(out_inten, src_inten, rtol=1e-4, atol=1e-4)
 
 

--- a/tests/blocks/code/test_alpha_codeblock_python.py
+++ b/tests/blocks/code/test_alpha_codeblock_python.py
@@ -22,7 +22,9 @@ import numpy as np
 
 from scistudio.blocks.code.code_block import CodeBlock
 from scistudio.blocks.code.exchange import create_codeblock_exchange_layout
-from scistudio.blocks.registry import BlockRegistry
+from scistudio.blocks.io.loaders.load_data import LoadData
+from scistudio.blocks.io.savers.save_data import SaveData
+from scistudio.blocks.registry import BlockRegistry, _spec_from_class
 from scistudio.core.types.array import Array
 from scistudio.core.types.collection import Collection
 
@@ -59,8 +61,11 @@ def test_python_codeblock_scales_array(tmp_path: Path) -> None:
     data = np.arange(12, dtype=np.float64).reshape(3, 4)
     src = Array(axes=["y", "x"], shape=data.shape, dtype="float64", data=data)
 
+    # Minimal, hermetic registry (no plugin scan) so the test does not touch
+    # the global type registry shared with the rest of the -n auto suite.
     registry = BlockRegistry()
-    registry.scan(include_monorepo=False)
+    registry._register_spec(_spec_from_class(LoadData, source="alpha-suite"))
+    registry._register_spec(_spec_from_class(SaveData, source="alpha-suite"))
 
     # Pin the exchange dirs the runtime will use so the script is leak-immune.
     layout = create_codeblock_exchange_layout(project / "exchange", block_id="alpha-py", run_id="run-1", create=False)

--- a/tests/blocks/code/test_alpha_codeblock_python.py
+++ b/tests/blocks/code/test_alpha_codeblock_python.py
@@ -1,0 +1,83 @@
+"""Alpha Task-2 Case 4: Python CodeBlock end-to-end (load Array -> script -> save).
+
+Runs a real Python CodeBlock through file exchange: an Array input is
+materialised to ``inputs/values/*.npy``; the script computes
+``out = in*2 + 1`` and writes ``outputs/scaled/*.npy``; the runtime
+reconstructs the output Array. Verifies the transform round-trips.
+
+The script discovers the exchange dirs via ``SCISTUDIO_*_DIR`` env vars
+when present and otherwise globs the newest exchange dir under cwd
+(workaround for FIND-F: the Python backend injects no exchange env).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from scistudio.blocks.base.config import BlockConfig
+from scistudio.blocks.code.code_block import CodeBlock
+from scistudio.blocks.registry import BlockRegistry
+from scistudio.core.types.array import Array
+from scistudio.core.types.collection import Collection
+
+SCRIPT = '''\
+import os
+from pathlib import Path
+import numpy as np
+
+
+def _exchange(kind):
+    env = os.environ.get(f"SCISTUDIO_{kind.upper()}_DIR")
+    if env:
+        return Path(env)
+    cands = sorted(Path("exchange").glob(f"*/*/{kind}"), key=lambda p: p.stat().st_mtime)
+    if not cands:
+        raise SystemExit(f"no {kind} dir")
+    return cands[-1]
+
+
+inputs, outputs = _exchange("inputs"), _exchange("outputs")
+out_dir = outputs / "scaled"
+out_dir.mkdir(parents=True, exist_ok=True)
+for src in sorted((inputs / "values").glob("*.npy")):
+    arr = np.load(src)
+    np.save(out_dir / f"{src.stem}.npy", arr.astype("float64") * 2.0 + 1.0)
+'''
+
+
+@pytest.fixture
+def _registry() -> BlockRegistry:
+    reg = BlockRegistry()
+    reg.scan(include_monorepo=False)
+    return reg
+
+
+def test_python_codeblock_scales_array(tmp_path: Path, _registry: BlockRegistry) -> None:
+    project = tmp_path
+    (project / "scripts").mkdir()
+    (project / "scripts" / "process_array.py").write_text(SCRIPT, encoding="utf-8")
+
+    data = np.arange(12, dtype=np.float64).reshape(3, 4)
+    src = Array(axes=["y", "x"], shape=data.shape, dtype="float64", data=data)
+
+    block = CodeBlock(config={"params": {
+        "project_dir": str(project),
+        "script_path": "scripts/process_array.py",
+        "interpreter_mode": "existing",
+        "interpreter_path": sys.executable,
+        "exchange_root": "exchange",
+        "block_id": "alpha-py", "run_id": "run-1",
+        "inputs": [{"name": "values", "direction": "input", "data_type": "Array", "extension": ".npy"}],
+        "outputs": [{"name": "scaled", "direction": "output", "data_type": "Array", "extension": ".npy"}],
+        "registry": _registry,
+    }})
+
+    outputs = block.run({"values": Collection([src])}, block.config)
+
+    result = outputs["scaled"][0]
+    assert isinstance(result, Array)
+    np.testing.assert_allclose(np.asarray(result.to_memory()), data * 2.0 + 1.0)

--- a/tests/blocks/code/test_alpha_codeblock_python.py
+++ b/tests/blocks/code/test_alpha_codeblock_python.py
@@ -18,26 +18,28 @@ from pathlib import Path
 import numpy as np
 import pytest
 
-from scistudio.blocks.base.config import BlockConfig
 from scistudio.blocks.code.code_block import CodeBlock
 from scistudio.blocks.registry import BlockRegistry
 from scistudio.core.types.array import Array
 from scistudio.core.types.collection import Collection
 
-SCRIPT = '''\
+SCRIPT = """\
 import os
 from pathlib import Path
 import numpy as np
 
 
 def _exchange(kind):
+    # FIND-F: the Python backend injects no SCISTUDIO_*_DIR env, so glob the
+    # exchange dir under the project cwd first. A SCISTUDIO_*_DIR in the env is
+    # only a stale leak from another run, so fall back to it last.
+    cands = sorted(Path("exchange").glob(f"*/*/{kind}"), key=lambda p: p.stat().st_mtime)
+    if cands:
+        return cands[-1]
     env = os.environ.get(f"SCISTUDIO_{kind.upper()}_DIR")
     if env:
         return Path(env)
-    cands = sorted(Path("exchange").glob(f"*/*/{kind}"), key=lambda p: p.stat().st_mtime)
-    if not cands:
-        raise SystemExit(f"no {kind} dir")
-    return cands[-1]
+    raise SystemExit(f"no {kind} dir")
 
 
 inputs, outputs = _exchange("inputs"), _exchange("outputs")
@@ -46,7 +48,7 @@ out_dir.mkdir(parents=True, exist_ok=True)
 for src in sorted((inputs / "values").glob("*.npy")):
     arr = np.load(src)
     np.save(out_dir / f"{src.stem}.npy", arr.astype("float64") * 2.0 + 1.0)
-'''
+"""
 
 
 @pytest.fixture
@@ -64,17 +66,22 @@ def test_python_codeblock_scales_array(tmp_path: Path, _registry: BlockRegistry)
     data = np.arange(12, dtype=np.float64).reshape(3, 4)
     src = Array(axes=["y", "x"], shape=data.shape, dtype="float64", data=data)
 
-    block = CodeBlock(config={"params": {
-        "project_dir": str(project),
-        "script_path": "scripts/process_array.py",
-        "interpreter_mode": "existing",
-        "interpreter_path": sys.executable,
-        "exchange_root": "exchange",
-        "block_id": "alpha-py", "run_id": "run-1",
-        "inputs": [{"name": "values", "direction": "input", "data_type": "Array", "extension": ".npy"}],
-        "outputs": [{"name": "scaled", "direction": "output", "data_type": "Array", "extension": ".npy"}],
-        "registry": _registry,
-    }})
+    block = CodeBlock(
+        config={
+            "params": {
+                "project_dir": str(project),
+                "script_path": "scripts/process_array.py",
+                "interpreter_mode": "existing",
+                "interpreter_path": sys.executable,
+                "exchange_root": "exchange",
+                "block_id": "alpha-py",
+                "run_id": "run-1",
+                "inputs": [{"name": "values", "direction": "input", "data_type": "Array", "extension": ".npy"}],
+                "outputs": [{"name": "scaled", "direction": "output", "data_type": "Array", "extension": ".npy"}],
+                "registry": _registry,
+            }
+        }
+    )
 
     outputs = block.run({"values": Collection([src])}, block.config)
 

--- a/tests/blocks/code/test_alpha_codeblock_python.py
+++ b/tests/blocks/code/test_alpha_codeblock_python.py
@@ -28,28 +28,59 @@ from scistudio.blocks.registry import BlockRegistry, _spec_from_class
 from scistudio.core.types.array import Array
 from scistudio.core.types.collection import Collection
 
-SCRIPT = """\
+# Stdlib-only .npy read/write: the CodeBlock subprocess interpreter may not
+# share the parent's third-party site-packages (the local gate parity venv
+# resolves the interpreter to a base python without numpy), so the script must
+# not import numpy. Real CI (system install) and the app both have numpy, but
+# stdlib keeps the test robust everywhere.
+SCRIPT = r"""
+import ast
 import os
+import struct
 from pathlib import Path
-import numpy as np
 
 
 def _exchange(kind):
-    env = os.environ.get(f"SCISTUDIO_{kind.upper()}_DIR")
+    env = os.environ.get("SCISTUDIO_%s_DIR" % kind.upper())
     if env:
         return Path(env)
-    cands = sorted(Path("exchange").glob(f"*/*/{kind}"), key=lambda p: p.stat().st_mtime)
+    cands = sorted(Path("exchange").glob("*/*/%s" % kind), key=lambda p: p.stat().st_mtime)
     if cands:
         return cands[-1]
-    raise SystemExit(f"no {kind} dir")
+    raise SystemExit("no %s dir" % kind)
+
+
+def read_npy_f8(path):
+    with open(path, "rb") as f:
+        assert f.read(6) == b"\x93NUMPY"
+        f.read(2)  # version
+        hlen = struct.unpack("<H", f.read(2))[0]
+        meta = ast.literal_eval(f.read(hlen).decode("latin1"))
+        shape = meta["shape"]
+        n = 1
+        for s in shape:
+            n *= s
+        vals = list(struct.unpack("<%dd" % n, f.read(n * 8)))
+    return shape, vals
+
+
+def write_npy_f8(path, shape, vals):
+    header = "{'descr': '<f8', 'fortran_order': False, 'shape': %s, }" % (repr(tuple(shape)),)
+    pad = (64 - (10 + len(header) + 1) % 64) % 64
+    header = header + " " * pad + "\n"
+    with open(path, "wb") as f:
+        f.write(b"\x93NUMPY\x01\x00")
+        f.write(struct.pack("<H", len(header)))
+        f.write(header.encode("latin1"))
+        f.write(struct.pack("<%dd" % len(vals), *vals))
 
 
 inputs, outputs = _exchange("inputs"), _exchange("outputs")
 out_dir = outputs / "scaled"
 out_dir.mkdir(parents=True, exist_ok=True)
 for src in sorted((inputs / "values").glob("*.npy")):
-    arr = np.load(src)
-    np.save(out_dir / f"{src.stem}.npy", arr.astype("float64") * 2.0 + 1.0)
+    shape, vals = read_npy_f8(src)
+    write_npy_f8(out_dir / (src.stem + ".npy"), shape, [v * 2.0 + 1.0 for v in vals])
 """
 
 

--- a/tests/blocks/code/test_alpha_codeblock_python.py
+++ b/tests/blocks/code/test_alpha_codeblock_python.py
@@ -5,9 +5,12 @@ materialised to ``inputs/values/*.npy``; the script computes
 ``out = in*2 + 1`` and writes ``outputs/scaled/*.npy``; the runtime
 reconstructs the output Array. Verifies the transform round-trips.
 
-The script discovers the exchange dirs via ``SCISTUDIO_*_DIR`` env vars
-when present and otherwise globs the newest exchange dir under cwd
-(workaround for FIND-F: the Python backend injects no exchange env).
+The Python backend injects no ``SCISTUDIO_*_DIR`` env (FIND-F), so the
+script reads those vars when present and otherwise globs the exchange
+dir under cwd. This test pins them deterministically (via the runtime's
+own layout helper) through ``environment_variables`` so it is immune to
+``SCISTUDIO_*`` leaked into ``os.environ`` by sibling tests under
+``pytest -n auto``.
 """
 
 from __future__ import annotations
@@ -16,9 +19,9 @@ import sys
 from pathlib import Path
 
 import numpy as np
-import pytest
 
 from scistudio.blocks.code.code_block import CodeBlock
+from scistudio.blocks.code.exchange import create_codeblock_exchange_layout
 from scistudio.blocks.registry import BlockRegistry
 from scistudio.core.types.array import Array
 from scistudio.core.types.collection import Collection
@@ -30,15 +33,12 @@ import numpy as np
 
 
 def _exchange(kind):
-    # FIND-F: the Python backend injects no SCISTUDIO_*_DIR env, so glob the
-    # exchange dir under the project cwd first. A SCISTUDIO_*_DIR in the env is
-    # only a stale leak from another run, so fall back to it last.
-    cands = sorted(Path("exchange").glob(f"*/*/{kind}"), key=lambda p: p.stat().st_mtime)
-    if cands:
-        return cands[-1]
     env = os.environ.get(f"SCISTUDIO_{kind.upper()}_DIR")
     if env:
         return Path(env)
+    cands = sorted(Path("exchange").glob(f"*/*/{kind}"), key=lambda p: p.stat().st_mtime)
+    if cands:
+        return cands[-1]
     raise SystemExit(f"no {kind} dir")
 
 
@@ -51,20 +51,19 @@ for src in sorted((inputs / "values").glob("*.npy")):
 """
 
 
-@pytest.fixture
-def _registry() -> BlockRegistry:
-    reg = BlockRegistry()
-    reg.scan(include_monorepo=False)
-    return reg
-
-
-def test_python_codeblock_scales_array(tmp_path: Path, _registry: BlockRegistry) -> None:
+def test_python_codeblock_scales_array(tmp_path: Path) -> None:
     project = tmp_path
     (project / "scripts").mkdir()
     (project / "scripts" / "process_array.py").write_text(SCRIPT, encoding="utf-8")
 
     data = np.arange(12, dtype=np.float64).reshape(3, 4)
     src = Array(axes=["y", "x"], shape=data.shape, dtype="float64", data=data)
+
+    registry = BlockRegistry()
+    registry.scan(include_monorepo=False)
+
+    # Pin the exchange dirs the runtime will use so the script is leak-immune.
+    layout = create_codeblock_exchange_layout(project / "exchange", block_id="alpha-py", run_id="run-1", create=False)
 
     block = CodeBlock(
         config={
@@ -76,9 +75,13 @@ def test_python_codeblock_scales_array(tmp_path: Path, _registry: BlockRegistry)
                 "exchange_root": "exchange",
                 "block_id": "alpha-py",
                 "run_id": "run-1",
+                "environment_variables": {
+                    "SCISTUDIO_INPUTS_DIR": str(layout.inputs_dir),
+                    "SCISTUDIO_OUTPUTS_DIR": str(layout.outputs_dir),
+                },
                 "inputs": [{"name": "values", "direction": "input", "data_type": "Array", "extension": ".npy"}],
                 "outputs": [{"name": "scaled", "direction": "output", "data_type": "Array", "extension": ".npy"}],
-                "registry": _registry,
+                "registry": registry,
             }
         }
     )

--- a/tests/blocks/code/test_alpha_codeblock_r.py
+++ b/tests/blocks/code/test_alpha_codeblock_r.py
@@ -1,0 +1,73 @@
+"""Alpha Task-2 Case 5: R CodeBlock end-to-end (load DataFrame -> R script -> save).
+
+Runs a real R CodeBlock through file exchange: a DataFrame input is
+materialised to ``inputs/table/*.csv``; the R script adds a derived
+column (``scaled = value * 10``) and writes ``outputs/result/*.csv``;
+the runtime reconstructs the output DataFrame.
+
+Requires ``Rscript`` on PATH (skipped otherwise / in CI). The R/Quarto
+backend injects ``SCISTUDIO_INPUTS_DIR`` / ``SCISTUDIO_OUTPUTS_DIR`` so
+the script needs no FIND-F workaround.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pyarrow as pa
+import pytest
+
+from scistudio.blocks.code.code_block import CodeBlock
+from scistudio.blocks.registry import BlockRegistry
+from scistudio.core.types.collection import Collection
+from scistudio.core.types.dataframe import DataFrame
+
+pytestmark = pytest.mark.skipif(shutil.which("Rscript") is None, reason="requires Rscript on PATH")
+
+R_SCRIPT = '''\
+inputs <- Sys.getenv("SCISTUDIO_INPUTS_DIR")
+outputs <- Sys.getenv("SCISTUDIO_OUTPUTS_DIR")
+in_files <- list.files(file.path(inputs, "table"), pattern = "\\\\.csv$", full.names = TRUE)
+out_dir <- file.path(outputs, "result")
+dir.create(out_dir, recursive = TRUE, showWarnings = FALSE)
+for (src in in_files) {
+  df <- read.csv(src)
+  df$scaled <- df$value * 10
+  write.csv(df, file.path(out_dir, basename(src)), row.names = FALSE)
+}
+'''
+
+
+def test_r_codeblock_adds_scaled_column(tmp_path: Path) -> None:
+    project = tmp_path
+    (project / "scripts").mkdir()
+    (project / "scripts" / "process_table.R").write_text(R_SCRIPT, encoding="utf-8")
+
+    table = pa.table({"id": [1, 2, 3], "value": [1.0, 2.0, 3.0]})
+    src = DataFrame(columns=["id", "value"], row_count=3, data=table)
+
+    reg = BlockRegistry()
+    reg.scan(include_monorepo=False)
+
+    block = CodeBlock(config={"params": {
+        "project_dir": str(project),
+        "script_path": "scripts/process_table.R",
+        "interpreter_mode": "existing",
+        "interpreter_path": shutil.which("Rscript"),
+        "exchange_root": "exchange",
+        "block_id": "alpha-r", "run_id": "run-1",
+        "inputs": [{"name": "table", "direction": "input", "data_type": "DataFrame", "extension": ".csv"}],
+        "outputs": [{"name": "result", "direction": "output", "data_type": "DataFrame", "extension": ".csv"}],
+        "registry": reg,
+    }})
+
+    outputs = block.run({"table": Collection([src])}, block.config)
+
+    result = outputs["result"][0]
+    assert isinstance(result, DataFrame)
+    out_table = result.get_in_memory_data()
+    cols = out_table.column_names
+    assert "scaled" in cols, f"expected a 'scaled' column, got {cols}"
+    scaled = out_table.column("scaled").to_pylist()
+    assert scaled == [10.0, 20.0, 30.0]

--- a/tests/blocks/code/test_alpha_codeblock_r.py
+++ b/tests/blocks/code/test_alpha_codeblock_r.py
@@ -19,7 +19,9 @@ import pyarrow as pa
 import pytest
 
 from scistudio.blocks.code.code_block import CodeBlock
-from scistudio.blocks.registry import BlockRegistry
+from scistudio.blocks.io.loaders.load_data import LoadData
+from scistudio.blocks.io.savers.save_data import SaveData
+from scistudio.blocks.registry import BlockRegistry, _spec_from_class
 from scistudio.core.types.collection import Collection
 from scistudio.core.types.dataframe import DataFrame
 
@@ -47,8 +49,11 @@ def test_r_codeblock_adds_scaled_column(tmp_path: Path) -> None:
     table = pa.table({"id": [1, 2, 3], "value": [1.0, 2.0, 3.0]})
     src = DataFrame(columns=["id", "value"], row_count=3, data=table)
 
+    # Minimal hermetic registry (no plugin scan) to avoid the global type
+    # registry shared with the rest of the -n auto suite.
     reg = BlockRegistry()
-    reg.scan(include_monorepo=False)
+    reg._register_spec(_spec_from_class(LoadData, source="alpha-suite"))
+    reg._register_spec(_spec_from_class(SaveData, source="alpha-suite"))
 
     block = CodeBlock(
         config={

--- a/tests/blocks/code/test_alpha_codeblock_r.py
+++ b/tests/blocks/code/test_alpha_codeblock_r.py
@@ -25,7 +25,7 @@ from scistudio.core.types.dataframe import DataFrame
 
 pytestmark = pytest.mark.skipif(shutil.which("Rscript") is None, reason="requires Rscript on PATH")
 
-R_SCRIPT = '''\
+R_SCRIPT = """\
 inputs <- Sys.getenv("SCISTUDIO_INPUTS_DIR")
 outputs <- Sys.getenv("SCISTUDIO_OUTPUTS_DIR")
 in_files <- list.files(file.path(inputs, "table"), pattern = "\\\\.csv$", full.names = TRUE)
@@ -36,7 +36,7 @@ for (src in in_files) {
   df$scaled <- df$value * 10
   write.csv(df, file.path(out_dir, basename(src)), row.names = FALSE)
 }
-'''
+"""
 
 
 def test_r_codeblock_adds_scaled_column(tmp_path: Path) -> None:
@@ -50,17 +50,22 @@ def test_r_codeblock_adds_scaled_column(tmp_path: Path) -> None:
     reg = BlockRegistry()
     reg.scan(include_monorepo=False)
 
-    block = CodeBlock(config={"params": {
-        "project_dir": str(project),
-        "script_path": "scripts/process_table.R",
-        "interpreter_mode": "existing",
-        "interpreter_path": shutil.which("Rscript"),
-        "exchange_root": "exchange",
-        "block_id": "alpha-r", "run_id": "run-1",
-        "inputs": [{"name": "table", "direction": "input", "data_type": "DataFrame", "extension": ".csv"}],
-        "outputs": [{"name": "result", "direction": "output", "data_type": "DataFrame", "extension": ".csv"}],
-        "registry": reg,
-    }})
+    block = CodeBlock(
+        config={
+            "params": {
+                "project_dir": str(project),
+                "script_path": "scripts/process_table.R",
+                "interpreter_mode": "existing",
+                "interpreter_path": shutil.which("Rscript"),
+                "exchange_root": "exchange",
+                "block_id": "alpha-r",
+                "run_id": "run-1",
+                "inputs": [{"name": "table", "direction": "input", "data_type": "DataFrame", "extension": ".csv"}],
+                "outputs": [{"name": "result", "direction": "output", "data_type": "DataFrame", "extension": ".csv"}],
+                "registry": reg,
+            }
+        }
+    )
 
     outputs = block.run({"table": Collection([src])}, block.config)
 

--- a/tests/blocks/code/test_alpha_findings_codeblock.py
+++ b/tests/blocks/code/test_alpha_findings_codeblock.py
@@ -1,0 +1,63 @@
+"""CodeBlock engine findings — tracked as strict xfails (see FINDINGS.md).
+
+FIND-F: the Python CodeBlock backend injects no ``SCISTUDIO_*_DIR`` env
+vars (the R/shell backends do via their exchange wrappers), so a script
+has no supported way to locate its exchange inputs/outputs. The test runs
+a CodeBlock with NO ``environment_variables`` (probing the backend's
+native behaviour) and asserts the subprocess sees ``SCISTUDIO_INPUTS_DIR``
+— which fails today and will xpass once the backend injects it.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from scistudio.blocks.code.code_block import CodeBlock
+from scistudio.blocks.io.loaders.load_data import LoadData
+from scistudio.blocks.io.savers.save_data import SaveData
+from scistudio.blocks.registry import BlockRegistry, _spec_from_class
+
+# Stdlib only: writes the inherited SCISTUDIO_INPUTS_DIR to a cwd-relative
+# file (cwd is the project dir), so it needs neither numpy nor the env to
+# locate its output.
+PROBE = (
+    "import os\n"
+    "from pathlib import Path\n"
+    "Path('env_probe.txt').write_text(os.environ.get('SCISTUDIO_INPUTS_DIR', 'MISSING'))\n"
+)
+
+
+@pytest.mark.xfail(strict=True, reason="FIND-F: Python CodeBlock backend injects no SCISTUDIO_*_DIR env")
+def test_find_f_python_backend_injects_exchange_env(tmp_path: Path) -> None:
+    project = tmp_path
+    (project / "scripts").mkdir()
+    (project / "scripts" / "probe.py").write_text(PROBE, encoding="utf-8")
+
+    reg = BlockRegistry()
+    reg._register_spec(_spec_from_class(LoadData, source="alpha-findings"))
+    reg._register_spec(_spec_from_class(SaveData, source="alpha-findings"))
+
+    block = CodeBlock(
+        config={
+            "params": {
+                "project_dir": str(project),
+                "script_path": "scripts/probe.py",
+                "interpreter_mode": "existing",
+                "interpreter_path": sys.executable,
+                "exchange_root": "exchange",
+                "block_id": "find-f",
+                "run_id": "run-1",
+                # Deliberately NO environment_variables: probe the backend itself.
+                "inputs": [],
+                "outputs": [],
+                "registry": reg,
+            }
+        }
+    )
+    block.run({}, block.config)
+
+    probe = (project / "env_probe.txt").read_text(encoding="utf-8")
+    assert probe != "MISSING", "Python backend should inject SCISTUDIO_INPUTS_DIR"

--- a/tests/blocks/io/test_alpha_findings.py
+++ b/tests/blocks/io/test_alpha_findings.py
@@ -1,0 +1,74 @@
+"""Engine round-trip findings surfaced by the alpha IO suite — tracked as
+strict xfails so each defect stays visible and a fix is detected.
+
+Every test here asserts the *correct* (post-fix) behaviour and is marked
+``xfail(strict=True)``: it shows as ``xfailed`` while the bug exists, and
+turns into a hard ``xpass`` failure the moment the engine is fixed —
+prompting removal of the marker (and the matching workaround in
+``test_io_coverage_matrix.py`` / the generator). See
+``~/Desktop/scistudio-tests/alpha-test-suite/FINDINGS.md``.
+
+Scope: core ``LoadData`` / ``SaveData`` only (no plugin scan).
+FIND-A / FIND-B are also exercised as xfails in the coverage matrix; they
+are restated here so this file is the single registry of engine defects.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pyarrow as pa
+import pytest
+
+from scistudio.blocks.base.config import BlockConfig
+from scistudio.blocks.io.loaders.load_data import LoadData
+from scistudio.blocks.io.savers.save_data import SaveData
+from scistudio.blocks.registry import BlockRegistry, _spec_from_class
+from scistudio.core.types.array import Array
+from scistudio.core.types.composite import CompositeData
+from scistudio.core.types.dataframe import DataFrame
+from scistudio.engine.materialisation import materialise_to_file, reconstruct_from_file
+
+
+def _core_registry() -> BlockRegistry:
+    reg = BlockRegistry()
+    reg._register_spec(_spec_from_class(LoadData, source="alpha-findings"))
+    reg._register_spec(_spec_from_class(SaveData, source="alpha-findings"))
+    return reg
+
+
+REG = _core_registry()
+
+
+@pytest.mark.xfail(strict=True, reason="FIND-A: composite .json saver writes slot key 'file', loader reads 'path'")
+def test_find_a_composite_json_roundtrips(tmp_path: Path) -> None:
+    """A core ``CompositeData`` should round-trip through its only IO format."""
+    sub = Array(axes=["x"], shape=(3,), dtype="float64", data=np.array([1.0, 2.0, 3.0]))
+    comp = CompositeData(slots={"array_slot": sub})
+    path = materialise_to_file(comp, tmp_path, ".json", filename_stem="c", registry=REG)
+    back = reconstruct_from_file(path, CompositeData, registry=REG)
+    assert isinstance(back, CompositeData)
+
+
+@pytest.mark.xfail(strict=True, reason="FIND-B: tabular pickle saves the Arrow Table, loader expects the object")
+def test_find_b_dataframe_pickle_roundtrips(tmp_path: Path) -> None:
+    """``DataFrame`` ``.pkl`` (allow_pickle) should reload to a DataFrame."""
+    df = DataFrame(columns=["a"], row_count=3, data=pa.table({"a": [1, 2, 3]}))
+    params = {"path": str(tmp_path / "df.pkl"), "core_type": "DataFrame", "allow_pickle": True}
+    SaveData(config={"params": params}).save(df, BlockConfig(params=params))
+    back = LoadData(config={"params": params}).load(BlockConfig(params=params))
+    if hasattr(back, "items") and not isinstance(back, DataFrame):
+        back = next(iter(back))
+    assert isinstance(back, DataFrame)
+
+
+@pytest.mark.xfail(strict=True, reason="FIND-D: Array .zarr reload restores data but drops shape/axes metadata")
+def test_find_d_array_zarr_preserves_shape_metadata(tmp_path: Path) -> None:
+    """Reloading an ``Array`` from ``.zarr`` should restore ``shape``/``axes``."""
+    data = np.arange(12, dtype=np.float64).reshape(3, 4)
+    src = Array(axes=["y", "x"], shape=(3, 4), dtype="float64", data=data)
+    path = materialise_to_file(src, tmp_path, ".zarr", filename_stem="a", registry=REG)
+    back = reconstruct_from_file(path, Array, registry=REG)
+    assert back.shape == (3, 4)
+    assert back.axes == ["y", "x"]

--- a/tests/blocks/io/test_alpha_findings.py
+++ b/tests/blocks/io/test_alpha_findings.py
@@ -49,6 +49,7 @@ def test_find_a_composite_json_roundtrips(tmp_path: Path) -> None:
     path = materialise_to_file(comp, tmp_path, ".json", filename_stem="c", registry=REG)
     back = reconstruct_from_file(path, CompositeData, registry=REG)
     assert isinstance(back, CompositeData)
+    np.testing.assert_array_equal(np.asarray(back.get("array_slot").to_memory()), np.array([1.0, 2.0, 3.0]))
 
 
 @pytest.mark.xfail(strict=True, reason="FIND-B: tabular pickle saves the Arrow Table, loader expects the object")

--- a/tests/blocks/io/test_io_coverage_matrix.py
+++ b/tests/blocks/io/test_io_coverage_matrix.py
@@ -153,17 +153,39 @@ def _load(path: Path, target: type, core_type: str, ext: str) -> Any:
     return reconstruct_from_file(path, target, registry=REG)
 
 
+def _assert_table_values(loaded_tbl: Any, src_tbl: Any) -> None:
+    """Compare two Arrow tables by column names AND values (numeric-tolerant)."""
+    assert isinstance(loaded_tbl, pa.Table), f"reload payload is {type(loaded_tbl).__name__}, not a Table"
+    assert isinstance(src_tbl, pa.Table)
+    assert sorted(loaded_tbl.column_names) == sorted(src_tbl.column_names), (
+        f"columns {loaded_tbl.column_names} != {src_tbl.column_names}"
+    )
+    for col in src_tbl.column_names:
+        got = loaded_tbl.column(col).to_pylist()
+        want = src_tbl.column(col).to_pylist()
+        assert len(got) == len(want), f"column {col}: length {len(got)} != {len(want)}"
+        non_null = [x for x in want if x is not None]
+        if non_null and all(isinstance(x, (int, float)) for x in non_null):
+            np.testing.assert_allclose(
+                [float(x) for x in got],
+                [float(x) for x in want],
+                rtol=1e-6,
+                atol=1e-9,
+                err_msg=f"column {col!r} values differ",
+            )
+        else:
+            assert got == want, f"column {col!r} values differ: {got} != {want}"
+
+
 def _assert_invariant(core_type: str, src: Any, loaded: Any) -> None:
     assert type(loaded).__name__ == core_type, f"{core_type}: reload type {type(loaded).__name__}"
     if core_type == "Array":
-        # Compare the materialised payload: zarr reload restores data via
-        # to_memory() but not the .shape attribute (FIND-D in FINDINGS.md).
-        assert np.asarray(loaded.to_memory()).shape == np.asarray(src.to_memory()).shape
-    elif core_type == "DataFrame":
-        assert sorted(loaded.columns or []) == sorted(src.columns or [])
-        assert loaded.row_count == src.row_count
-    elif core_type == "Series":
-        assert loaded.length == src.length
+        # Compare payload values, not just shape: a saver that preserves shape
+        # but corrupts values must fail. zarr restores data via to_memory() even
+        # though it drops the .shape attribute (FIND-D); the data must be intact.
+        np.testing.assert_array_equal(np.asarray(loaded.to_memory()), np.asarray(src.to_memory()))
+    elif core_type in ("DataFrame", "Series"):
+        _assert_table_values(loaded.get_in_memory_data(), src.get_in_memory_data())
     elif core_type == "Text":
         assert loaded.content == src.content
 

--- a/tests/blocks/io/test_io_coverage_matrix.py
+++ b/tests/blocks/io/test_io_coverage_matrix.py
@@ -1,6 +1,6 @@
 """Alpha IO load+save coverage matrix for the six core types.
 
-For every core type this exercises the full ``load_ext × save_ext``
+For every core type this exercises the full ``load_ext x save_ext``
 matrix the alpha readiness plan asks for:
 
     for load_ext in type.load_extensions:
@@ -73,7 +73,7 @@ REG = _core_registry()
 def _build_array(ext: str, i: int = 0) -> Array:
     # 1-D so every save extension works: Array .parquet is single-column-only
     # by design. N-D coverage for .npy/.npz/.zarr is in test_array_nd_roundtrip.
-    arr = (np.arange(8, dtype=np.float64) + i)
+    arr = np.arange(8, dtype=np.float64) + i
     return Array(axes=["x"], shape=arr.shape, dtype=str(arr.dtype), data=arr)
 
 
@@ -179,8 +179,13 @@ def _matrix_params() -> list[Any]:
                 if (core_type, load_ext) in BROKEN_RELOAD:
                     marks.append(pytest.mark.xfail(reason=f"FINDINGS: load {core_type}{load_ext}", strict=False))
                 params.append(
-                    pytest.param(core_type, load_ext, save_ext, marks=marks,
-                                 id=f"{core_type}:{load_ext.lstrip('.')}->{save_ext.lstrip('.')}")
+                    pytest.param(
+                        core_type,
+                        load_ext,
+                        save_ext,
+                        marks=marks,
+                        id=f"{core_type}:{load_ext.lstrip('.')}->{save_ext.lstrip('.')}",
+                    )
                 )
     return params
 
@@ -234,8 +239,11 @@ _COLLECTION_EXT = {
     [
         pytest.param(
             ct,
-            marks=([pytest.mark.xfail(reason="FINDINGS FIND-A composite .json", strict=False)]
-                   if (ct, _COLLECTION_EXT[ct]) in BROKEN_RELOAD else []),
+            marks=(
+                [pytest.mark.xfail(reason="FINDINGS FIND-A composite .json", strict=False)]
+                if (ct, _COLLECTION_EXT[ct]) in BROKEN_RELOAD
+                else []
+            ),
             id=ct,
         )
         for ct in MATRIX

--- a/tests/blocks/io/test_io_coverage_matrix.py
+++ b/tests/blocks/io/test_io_coverage_matrix.py
@@ -34,6 +34,7 @@ from scistudio.blocks.io.loaders.load_data import LoadData
 from scistudio.blocks.io.savers.save_data import SaveData
 from scistudio.blocks.registry import BlockRegistry, _spec_from_class
 from scistudio.core.types.array import Array
+from scistudio.core.types.artifact import Artifact
 from scistudio.core.types.composite import CompositeData
 from scistudio.core.types.dataframe import DataFrame
 from scistudio.core.types.series import Series
@@ -188,6 +189,16 @@ def _assert_invariant(core_type: str, src: Any, loaded: Any) -> None:
         _assert_table_values(loaded.get_in_memory_data(), src.get_in_memory_data())
     elif core_type == "Text":
         assert loaded.content == src.content
+    elif core_type == "CompositeData":
+        # Forward-looking (the only composite IO path is broken — FIND-A — so
+        # this is reached only once that is fixed and unmarked): every child
+        # slot's values must survive.
+        assert set(loaded._slots) == set(src._slots)
+        for name in src._slots:
+            np.testing.assert_array_equal(
+                np.asarray(loaded.get(name).to_memory()),
+                np.asarray(src.get(name).to_memory()),
+            )
 
 
 # Build the parametrized (core_type, load_ext, save_ext) id-list.
@@ -305,3 +316,22 @@ def test_array_nd_roundtrip(tmp_path: Path, shape: tuple[int, ...], ext: str) ->
     # Verify the materialised payload (zarr reload restores data but not the
     # .shape attribute — FIND-D); to_memory() is the authoritative readback.
     np.testing.assert_array_equal(np.asarray(back.to_memory()), data)
+
+
+# ---------------------------------------------------------------------------
+# Artifact (opaque passthrough): bytes in must equal bytes out
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("ext", [".bin", ".dat", ".json", ".csv", ".png", ".txt"])
+def test_artifact_passthrough_preserves_bytes(tmp_path: Path, ext: str) -> None:
+    raw = b"\x00\x01OPAQUE-" + ext.encode("ascii") + b"\xfe\xff\n"
+    src_path = tmp_path / f"in{ext}"
+    src_path.write_bytes(raw)
+    art = Artifact(file_path=src_path, mime_type="application/octet-stream")
+
+    out = materialise_to_file(art, tmp_path / "out", ext, filename_stem="a", registry=REG)
+    back = reconstruct_from_file(out, Artifact, registry=REG)
+
+    assert type(back).__name__ == "Artifact"
+    assert back.get_in_memory_data() == raw, f"{ext}: artifact bytes changed in round-trip"

--- a/tests/blocks/io/test_io_coverage_matrix.py
+++ b/tests/blocks/io/test_io_coverage_matrix.py
@@ -1,0 +1,277 @@
+"""Alpha IO load+save coverage matrix for the six core types.
+
+For every core type this exercises the full ``load_ext × save_ext``
+matrix the alpha readiness plan asks for:
+
+    for load_ext in type.load_extensions:
+        obj = load(write(build(), load_ext), load_ext)   # LOAD under test
+        for save_ext in type.save_extensions:
+            path = save(obj, save_ext)                    # SAVE under test
+            assert path is a correct, non-empty file
+            if save_ext is reloadable: assert data survives
+
+It also verifies each type round-trips as a **10-item collection** via
+``LoadData`` multi-path loading (single-file and collection forms are
+both required for alpha).
+
+Scoped to the core ``LoadData`` / ``SaveData`` registry (no plugin
+scan), mirroring ``tests/engine/test_materialisation.py``. Slots with a
+known engine round-trip break are ``xfail`` and documented in the test
+project's ``alpha-test-suite/FINDINGS.md``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pyarrow as pa
+import pytest
+
+from scistudio.blocks.base.config import BlockConfig
+from scistudio.blocks.io.loaders.load_data import LoadData
+from scistudio.blocks.io.savers.save_data import SaveData
+from scistudio.blocks.registry import BlockRegistry, _spec_from_class
+from scistudio.core.types.array import Array
+from scistudio.core.types.composite import CompositeData
+from scistudio.core.types.dataframe import DataFrame
+from scistudio.core.types.series import Series
+from scistudio.core.types.text import Text
+from scistudio.engine.materialisation import materialise_to_file, reconstruct_from_file
+
+PICKLE_EXTS = {".pkl", ".pickle"}
+
+# (core_type, extension) slots that SAVE but cannot RELOAD due to engine
+# round-trip defects. See alpha-test-suite/FINDINGS.md.
+#   FIND-A: composite .json saver writes slot key 'file', loader reads 'path'.
+#   FIND-B: tabular .pkl/.pickle saves the Arrow Table, loader wants the object.
+BROKEN_RELOAD: set[tuple[str, str]] = {
+    ("CompositeData", ".json"),
+    ("DataFrame", ".pkl"),
+    ("DataFrame", ".pickle"),
+    ("Series", ".pkl"),
+    ("Series", ".pickle"),
+}
+
+
+def _core_registry() -> BlockRegistry:
+    reg = BlockRegistry()
+    reg._register_spec(_spec_from_class(LoadData, source="alpha-suite"))
+    reg._register_spec(_spec_from_class(SaveData, source="alpha-suite"))
+    return reg
+
+
+REG = _core_registry()
+
+
+# ---------------------------------------------------------------------------
+# Builders (self-contained; mirror the generator construction contracts)
+# ---------------------------------------------------------------------------
+
+
+def _build_array(ext: str, i: int = 0) -> Array:
+    # 1-D so every save extension works: Array .parquet is single-column-only
+    # by design. N-D coverage for .npy/.npz/.zarr is in test_array_nd_roundtrip.
+    arr = (np.arange(8, dtype=np.float64) + i)
+    return Array(axes=["x"], shape=arr.shape, dtype=str(arr.dtype), data=arr)
+
+
+def _build_dataframe(ext: str, i: int = 0) -> DataFrame:
+    table = pa.table({"id": [0 + i, 1 + i, 2 + i], "value": [0.5, 1.5, 2.5]})
+    return DataFrame(columns=["id", "value"], row_count=3, data=table)
+
+
+def _build_series(ext: str, i: int = 0) -> Series:
+    table = pa.table({"value": pa.array([1.0 + i, 2.0 + i, 3.0 + i], type=pa.float64())})
+    return Series(value_name="value", length=3, data=table)
+
+
+def _build_text(ext: str, i: int = 0) -> Text:
+    return Text(content=f"sample {i} content\nsecond line\n", format="plain")
+
+
+def _build_composite(ext: str, i: int = 0) -> CompositeData:
+    sub = Array(axes=["x"], shape=(3,), dtype="float64", data=np.array([1.0, 2.0, 3.0]) + i)
+    return CompositeData(slots={"array_slot": sub})
+
+
+# core_type -> (builder, type, load_exts, save_exts)
+MATRIX: dict[str, dict[str, Any]] = {
+    "Array": {
+        "build": _build_array,
+        "type": Array,
+        "load": [".npy", ".npz", ".zarr", ".parquet", ".pq", ".pkl", ".pickle"],
+        "save": [".npy", ".npz", ".zarr", ".parquet", ".pq", ".pkl", ".pickle"],
+    },
+    "DataFrame": {
+        "build": _build_dataframe,
+        "type": DataFrame,
+        "load": [".csv", ".tsv", ".parquet", ".pq", ".json", ".pkl", ".pickle"],
+        "save": [".csv", ".tsv", ".parquet", ".pq", ".json", ".pkl", ".pickle"],
+    },
+    "Series": {
+        "build": _build_series,
+        "type": Series,
+        "load": [".csv", ".tsv", ".parquet", ".pq", ".pkl", ".pickle"],
+        "save": [".csv", ".tsv", ".parquet", ".pq", ".pkl", ".pickle", ".json"],
+    },
+    "Text": {
+        "build": _build_text,
+        "type": Text,
+        "load": [".txt", ".md", ".markdown", ".html", ".htm", ".xml", ".yaml", ".yml", ".toml", ".log"],
+        "save": [".txt", ".md", ".markdown", ".html", ".htm", ".xml", ".yaml", ".yml", ".toml", ".log", ".json"],
+    },
+    "CompositeData": {
+        "build": _build_composite,
+        "type": CompositeData,
+        "load": [".json"],
+        "save": [".json"],
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# IO helpers (pickle needs the allow_pickle opt-in on both ends)
+# ---------------------------------------------------------------------------
+
+
+def _save(obj: Any, dest_dir: Path, stem: str, ext: str, core_type: str) -> Path:
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    if ext in PICKLE_EXTS:
+        path = dest_dir / f"{stem}{ext}"
+        params = {"path": str(path), "core_type": core_type, "allow_pickle": True}
+        SaveData(config={"params": params}).save(obj, BlockConfig(params=params))
+        return path
+    return materialise_to_file(obj, dest_dir, ext, filename_stem=stem, registry=REG)
+
+
+def _load(path: Path, target: type, core_type: str, ext: str) -> Any:
+    if ext in PICKLE_EXTS:
+        params = {"path": str(path), "core_type": core_type, "allow_pickle": True}
+        return LoadData(config={"params": params}).load(BlockConfig(params=params))
+    return reconstruct_from_file(path, target, registry=REG)
+
+
+def _assert_invariant(core_type: str, src: Any, loaded: Any) -> None:
+    assert type(loaded).__name__ == core_type, f"{core_type}: reload type {type(loaded).__name__}"
+    if core_type == "Array":
+        # Compare the materialised payload: zarr reload restores data via
+        # to_memory() but not the .shape attribute (FIND-D in FINDINGS.md).
+        assert np.asarray(loaded.to_memory()).shape == np.asarray(src.to_memory()).shape
+    elif core_type == "DataFrame":
+        assert sorted(loaded.columns or []) == sorted(src.columns or [])
+        assert loaded.row_count == src.row_count
+    elif core_type == "Series":
+        assert loaded.length == src.length
+    elif core_type == "Text":
+        assert loaded.content == src.content
+
+
+# Build the parametrized (core_type, load_ext, save_ext) id-list.
+def _matrix_params() -> list[Any]:
+    params: list[Any] = []
+    for core_type, spec in MATRIX.items():
+        for load_ext in spec["load"]:
+            for save_ext in spec["save"]:
+                marks = []
+                # Cannot LOAD the source file -> whole combo is expected-broken.
+                if (core_type, load_ext) in BROKEN_RELOAD:
+                    marks.append(pytest.mark.xfail(reason=f"FINDINGS: load {core_type}{load_ext}", strict=False))
+                params.append(
+                    pytest.param(core_type, load_ext, save_ext, marks=marks,
+                                 id=f"{core_type}:{load_ext.lstrip('.')}->{save_ext.lstrip('.')}")
+                )
+    return params
+
+
+@pytest.mark.parametrize(("core_type", "load_ext", "save_ext"), _matrix_params())
+def test_load_save_matrix(tmp_path: Path, core_type: str, load_ext: str, save_ext: str) -> None:
+    spec = MATRIX[core_type]
+    src = spec["build"](load_ext)
+
+    # LOAD under test: write a load_ext file, read it back.
+    load_file = _save(src, tmp_path / "in", "seed", load_ext, core_type)
+    loaded = _load(load_file, spec["type"], core_type, load_ext)
+    if isinstance(loaded, type(loaded)) and hasattr(loaded, "items"):
+        # LoadData may return a single-item Collection for the pickle path.
+        loaded = loaded[0] if not isinstance(loaded, spec["type"]) else loaded
+    assert loaded is not None
+
+    # SAVE under test: write the loaded object to save_ext.
+    out_file = _save(loaded, tmp_path / "out", "out", save_ext, core_type)
+    assert out_file.exists(), f"{core_type} save to {save_ext} produced no file"
+    # zarr is a directory store; everything else is a non-empty file.
+    if out_file.is_file():
+        assert out_file.stat().st_size > 0
+    else:
+        assert any(out_file.rglob("*")), f"{core_type} {save_ext} store is empty"
+
+    # If save_ext is reloadable, confirm the data survived the save.
+    if save_ext in spec["load"] and (core_type, save_ext) not in BROKEN_RELOAD:
+        reloaded = _load(out_file, spec["type"], core_type, save_ext)
+        if hasattr(reloaded, "items") and not isinstance(reloaded, spec["type"]):
+            reloaded = reloaded[0]
+        _assert_invariant(core_type, src, reloaded)
+
+
+# ---------------------------------------------------------------------------
+# Collection (10-item) round-trip via LoadData multi-path
+# ---------------------------------------------------------------------------
+
+# Representative loadable extension per type for the collection check.
+_COLLECTION_EXT = {
+    "Array": ".npy",
+    "DataFrame": ".csv",
+    "Series": ".csv",
+    "Text": ".txt",
+    "CompositeData": ".json",  # xfail: FIND-A
+}
+
+
+@pytest.mark.parametrize(
+    "core_type",
+    [
+        pytest.param(
+            ct,
+            marks=([pytest.mark.xfail(reason="FINDINGS FIND-A composite .json", strict=False)]
+                   if (ct, _COLLECTION_EXT[ct]) in BROKEN_RELOAD else []),
+            id=ct,
+        )
+        for ct in MATRIX
+    ],
+)
+def test_collection_roundtrip_10(tmp_path: Path, core_type: str) -> None:
+    spec = MATRIX[core_type]
+    ext = _COLLECTION_EXT[core_type]
+    paths: list[str] = []
+    for i in range(10):
+        obj = spec["build"](ext, i)
+        p = _save(obj, tmp_path / "coll", f"item_{i:02d}", ext, core_type)
+        paths.append(str(p))
+
+    # LoadData multi-path -> Collection of 10.
+    params = {"core_type": core_type, "path": paths}
+    result = LoadData(config={"params": params}).load(BlockConfig(params=params))
+    items = list(result)
+    assert len(items) == 10, f"{core_type}: collection load returned {len(items)} of 10"
+    for item in items:
+        assert type(item).__name__ == core_type
+
+
+# ---------------------------------------------------------------------------
+# N-D Array coverage (the matrix uses 1-D; .parquet is single-column-only)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("shape", [(3, 4), (2, 3, 4)], ids=["2d", "3d"])
+@pytest.mark.parametrize("ext", [".npy", ".npz", ".zarr"])
+def test_array_nd_roundtrip(tmp_path: Path, shape: tuple[int, ...], ext: str) -> None:
+    axes = ["y", "x"] if len(shape) == 2 else ["z", "y", "x"]
+    data = np.arange(int(np.prod(shape)), dtype=np.float64).reshape(shape)
+    src = Array(axes=axes, shape=shape, dtype="float64", data=data)
+    path = _save(src, tmp_path, "nd", ext, "Array")
+    back = reconstruct_from_file(path, Array, registry=REG)
+    # Verify the materialised payload (zarr reload restores data but not the
+    # .shape attribute — FIND-D); to_memory() is the authoritative readback.
+    np.testing.assert_array_equal(np.asarray(back.to_memory()), data)


### PR DESCRIPTION
## Summary

Pre-alpha automated test suite for **data IO** and **builtin block**
behavior (owner-directed `guided` session). This PR carries the
**self-contained automated tests**; the curated sample data, golden
answers, generation scripts, and the owner-facing manual checklist live
in the separate test project (`~/Desktop/scistudio-tests`,
`alpha-test-suite/`).

Closes #1737.

## What's in this PR (tests only)

- `tests/blocks/io/test_io_coverage_matrix.py` — core IO load+save
  matrix for Array/DataFrame/Series/Text/CompositeData over every
  `load_ext × save_ext`, plus 10-item collection round-trips and N-D
  Array coverage. **232 pass / 30 xfail** (xfail = engine findings).
  Runs in CI (core deps only, scoped `LoadData`/`SaveData` registry).
- `packages/scistudio-blocks-imaging/tests/test_io_coverage_image.py` —
  Image format matrix (tif/png/jpg/zarr) + collection. **42 pass.**
- `packages/scistudio-blocks-spectroscopy/tests/test_io_coverage_spectroscopy.py`
  — Spectrum + SpectralDataset matrix + collection. **69 pass.**
- `tests/blocks/code/test_alpha_codeblock_python.py` /
  `test_alpha_codeblock_r.py` — real file-exchange CodeBlock runs
  (Python `out=in*2+1`; R adds `scaled=value*10`, `requires Rscript`).

> Package tests (`packages/*/tests`) are not collected by the repo's
> `testpaths = ["tests"]`, so they run locally / for the owner, not in
> the main CI job. They need `tifffile`, `ome-types`, `scikit-image`,
> `imageio` in the env.

## Findings surfaced while building the suite

Documented in the test project's `alpha-test-suite/FINDINGS.md`; covered
by `xfail` here so they stay visible without failing CI:

| ID | What |
|---|---|
| FIND-A | `CompositeData` `.json` saver writes slot key `file`, loader reads `path` → core composite save/load broken |
| FIND-B | `DataFrame`/`Series` pickle saves the Arrow Table; loader expects the wrapped object |
| FIND-C | Full-registry extension ambiguity (`.zarr`→Image, `.json`→SpectralDataset, ambiguous `.csv`) |
| FIND-D | `Array` `.zarr` reload restores data but drops `shape`/`axes` metadata |
| FIND-E | `Render Movie` uses `tifffile` `fps=` kwarg removed in 2026 |
| FIND-F | Python CodeBlock backend injects no `SCISTUDIO_*_DIR` env; scripts can't locate exchange dirs (R/shell do) |

These are **test findings, not fixes** — this PR does not touch engine
code. Follow-up issues can be filed per finding.

## Out of scope (per owner)

LCMS + SRS packages (future refactor), vendor binaries
(.czi/.lif/.nd2/.oib/.oir/.raw/.d/.mzml), legacy `.xls`, ProcessBlock +
AIBlock manual cases, Subworkflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
