### PR TITLE
fix(#1750 #1751 #1752 #1753): production hotfix batch (live owner-guided)

### DIFF
--- a/.workflow/records/1750-hotfix-live-session-20260622.json
+++ b/.workflow/records/1750-hotfix-live-session-20260622.json
@@ -1,0 +1,1294 @@
+{
+  "branch": "hotfix/live-session-20260622",
+  "check_events": [
+    {
+      "at": "2026-06-22T22:04:56.771179Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:c1485753d651159d41dde410a3f243506a2a9eb3209371c4870fa85b562a3f6d",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-22T22:05:01.324274Z",
+      "command": "(cd frontend && npm run check:ci)",
+      "covered_surface": "frontend",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:050a73d18a4b8d9a54dbb1185833c84888fd821f08b601ccf2734f5cbddd2742",
+      "name": "frontend",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/frontend.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-22T22:05:04.754096Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:5da7a8b39738a05c7dfcf4b09379356aafa242d3ed86ba92959a5134b7d0a856",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-22T22:05:05.226663Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:eda3b99d5784897acb03db1f70dfcbca44a1792cef884a6865544ca192e3e994",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-22T22:05:05.272922Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:f2ae71a5f057a6d64cea1fb9317c32fa09a9d8f71d500667588356578dd392e7",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-22T22:07:04.830139Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:4cda2bada48b151956ee1710ef413fd2160b8228b9f2f4edf2db9acf2362f2ab",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-22T22:08:51.935235Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:c93fe3908f5ac130f498085fd93f002d5e194490ad60f7dff715287909a62b0e",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-22T22:08:58.030106Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:47670e5e5cb52a51102dd7b090414d9cf9a250634c53b2b832c03fcb8272d63a",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    },
+    {
+      "at": "2026-06-22T22:10:14.472037Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:2cf5c32580fa443f7ee6661447ed98e517fcd45f5b5325428642929dd3f4f9a4",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-22T22:10:48.590087Z",
+      "command": "(cd frontend && npm run check:ci)",
+      "covered_surface": "frontend",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:dc41b725767e8dbcbd3e9f415a8d86d93065d70ace04f76dcdc63925494f6803",
+      "name": "frontend",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/frontend.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-22T22:10:51.914761Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:6ecedf5e206d4e631d8e19695fdcd64dab65dda4aba0e38e34cb184a67d754bd",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-22T22:10:52.010403Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:76130c467b745f532b284d7c11f5e89a21c0601488c41ab3b955b0bdd7acf862",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-22T22:10:52.047614Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:7803323605162aca180ba932a4a620735c4c0768f64842163323bde496f81b9e",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-22T22:12:30.047574Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:ffb97a5cd12c1e695b2ecd511ce28f2ce766583a71f48c9685b2307eabb87acb",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-22T22:14:16.624633Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:f3b3b92fdcbee45a13ded10b86271771923f9e6dcdeb78e0047ab54d9d16c635",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-22T22:14:17.022927Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:41a0d3e369d6a5a3f280806e972d9ca4286ed463dca275b3ed5a4b430718ffda",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    }
+  ],
+  "check_na": [],
+  "commit": {
+    "sha": "0b39eb3280098b6c793ac367a6e22db4e888541b",
+    "shas": [
+      "0b39eb3280098b6c793ac367a6e22db4e888541b"
+    ],
+    "trailers": []
+  },
+  "declared_scope": {
+    "exclude": [],
+    "include": []
+  },
+  "directive_events": [
+    {
+      "at": "2026-06-22T22:01:39.617568Z",
+      "owner_directive": "spectrum \u7c7b\u578b plot \u8c03 item.open \u5b8c\u5168\u4e22\u5931 intensity\uff1b\u68c0\u67e5\u6240\u6709 type \u662f\u5426\u90fd\u6709\u6570\u636e\u4e22\u5931\u5e76\u4fee\u590d",
+      "reason": "owner reported spectrum item.open drops intensity; audit all types and fix"
+    },
+    {
+      "at": "2026-06-22T22:01:39.745194Z",
+      "owner_directive": "\u8fd0\u884c workflow \u540e\u5de6\u4fa7 project panel \u6587\u4ef6\u6811\u6296\u52a8\uff0c\u53ea\u6709\u5de6\u4fa7\u6811\u3001\u548c refresh \u65e0\u5173\uff1b\u6309\u7ed3\u6784\u6027\u53d8\u5316\u95e8\u63a7\u6811\u5237\u65b0",
+      "reason": "owner reported project file-tree jitter after a run (tree-only); gate refresh on structural change"
+    },
+    {
+      "at": "2026-06-22T22:01:39.873427Z",
+      "owner_directive": "\u5176\u4ed6 Mac \u4e0a spectroscopy previewer \u663e\u793a\u70b9\u7ebf\u56fe\uff1b\u8ba9 entry-point \u6210\u4e3a\u53ef\u9760\u7684\u9996\u9009\u53d1\u73b0\u8def\u5f84",
+      "reason": "owner: make previewer entry-point discovery the reliable preferred path"
+    },
+    {
+      "at": "2026-06-22T22:01:40.001921Z",
+      "owner_directive": "load \u8def\u5f84\u5df2\u6709\u5185\u5bb9\u65f6\u518d\u70b9 browse \u62a5 500\uff1b\u6392\u67e5\u6240\u6709\u5e26 ... \u7684\u6d4f\u89c8\u6846\u5e76\u4fee\u590d",
+      "reason": "owner reported browse 500 with a multi-file path; reproduced ENAMETOOLONG, fix backend+frontend"
+    },
+    {
+      "at": "2026-06-22T22:02:35.743591Z",
+      "owner_directive": "\u6536\u53e3\uff1a\u6279\u91cf\u63d0\u4ea4\u56db\u4e2a\u751f\u4ea7 bug \u4fee\u590d #1750/#1751/#1752/#1753",
+      "reason": "plan"
+    }
+  ],
+  "docs_events": [
+    {
+      "at": "2026-06-22T22:02:35.743757Z",
+      "class": "spec",
+      "kind": "na",
+      "path": null,
+      "rationale": "bugfix batch \u2014 no schema/contract/storage/API-shape change; #1750 updates the in-product plot scaffold docstring inline (item.open Series shape), governed by no separate spec/ADR doc",
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": false,
+  "guard_events": [
+    {
+      "at": "2026-06-22T22:08:58.078689Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-22T22:08:58.087348Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-22T22:08:58.096034Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-22T22:08:58.105567Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-22T22:08:58.114170Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-22T22:08:58.123770Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-22T22:08:58.132135Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-22T22:08:58.140365Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-22T22:08:58.149488Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-22T22:08:58.160400Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-22T22:14:17.074443Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-22T22:14:17.085844Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-22T22:14:17.096741Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-22T22:14:17.107463Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-22T22:14:17.118663Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-22T22:14:17.130269Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-22T22:14:17.141052Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-22T22:14:17.153134Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-22T22:14:17.164878Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-22T22:14:17.182600Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-22T22:14:53.238909Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-22T22:14:53.247144Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-22T22:14:53.256058Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-22T22:14:53.264584Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-22T22:14:53.273749Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-22T22:14:53.282611Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-22T22:14:53.291044Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-22T22:14:53.299339Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-22T22:14:53.308339Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-22T22:14:53.318911Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-22T22:15:37.462439Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-22T22:15:37.470520Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-22T22:15:37.478299Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-22T22:15:37.486436Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-22T22:15:37.494188Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-22T22:15:37.501961Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-22T22:15:37.510483Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-22T22:15:37.519039Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-22T22:15:37.527162Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-22T22:15:37.538357Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-22T22:17:08.910229Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-22T22:17:08.918313Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-22T22:17:08.926236Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-22T22:17:08.934169Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-22T22:17:08.942118Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-22T22:17:08.950583Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-22T22:17:08.959192Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-22T22:17:08.967120Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-22T22:17:08.974832Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-22T22:17:08.985881Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-22T22:19:16.385706Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-22T22:19:16.394914Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-22T22:19:16.404076Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-22T22:19:16.412537Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-22T22:19:16.421003Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-22T22:19:16.429327Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-22T22:19:16.437634Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-22T22:19:16.445888Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-22T22:19:16.454071Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-22T22:19:16.465846Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-22T22:20:52.370652Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-22T22:20:52.379245Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-22T22:20:52.388214Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-22T22:20:52.397392Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-22T22:20:52.406890Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-22T22:20:52.415290Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-22T22:20:52.423531Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-22T22:20:52.431907Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-22T22:20:52.440354Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-22T22:20:52.452394Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-22T22:22:35.353915Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-22T22:22:35.363124Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-22T22:22:35.371829Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-22T22:22:35.380645Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-22T22:22:35.389055Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-22T22:22:35.397484Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-22T22:22:35.405624Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-22T22:22:35.413931Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-22T22:22:35.422144Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-22T22:22:35.433705Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1750,
+      "url": null
+    },
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1751,
+      "url": null
+    },
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1752,
+      "url": null
+    },
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1753,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": {
+    "base": "4993a811621e89f3c887792d571f9300add95f38",
+    "base_sha": "4993a811",
+    "changed_files": [
+      ".workflow/records/1750-hotfix-live-session-20260622.json",
+      "frontend/src/components/BottomPanel.parts/ConfigField.tsx",
+      "frontend/src/components/BottomPanel.parts/ConfigPanel.test.tsx",
+      "frontend/src/components/ProjectTree.parts/useTreeNodes.ts",
+      "frontend/src/components/__tests__/ProjectTree.test.tsx",
+      "frontend/src/hooks/__tests__/useWebSocket.versionVector.test.ts",
+      "frontend/src/hooks/useWebSocket.parts/handleFileChanged.ts",
+      "frontend/src/hooks/useWebSocket.parts/handleWorkflowChanged.ts",
+      "frontend/src/hooks/useWebSocket.parts/helpers.ts",
+      "src/scistudio/ai/agent/mcp/tools_plot/_harness.py",
+      "src/scistudio/ai/agent/mcp/tools_plot/scaffold.py",
+      "src/scistudio/api/routes/filesystem.py",
+      "src/scistudio/previewers/registry.py",
+      "tests/ai/test_mcp_tools_plot.py",
+      "tests/api/test_filesystem_browse.py",
+      "tests/previewers/test_preview_registry.py"
+    ],
+    "diff_fingerprint": "sha256:97ea183251a320326cabd52c28ec91c61f4727ca336211e98c5f6a3776714257",
+    "head": "HEAD",
+    "head_sha": "0b39eb32",
+    "surfaces": {
+      "docs": 0,
+      "frontend": 8,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 12,
+      "packaging": 0,
+      "protected_core": 0,
+      "sentrux": 15,
+      "test": 6,
+      "workflow_ci": 0
+    }
+  },
+  "owner_directive": "\u8fdb\u5165hotfix\u6a21\u5f0f\uff0c\u4fee\u590d\u5b9e\u9645\u7528\u6237\u751f\u4ea7\u8fc7\u7a0b\u4e2d\u7684\u591a\u4e2a bug\uff08live \u6d4b\u8bd5\u9010\u4e2a\u4e0a\u62a5\uff09",
+  "persona": "live_implementer",
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [
+      1750,
+      1751,
+      1752,
+      1753
+    ],
+    "number": 1754,
+    "url": null
+  },
+  "reconcile_events": [
+    {
+      "at": "2026-06-22T22:08:58.160447Z",
+      "diff_fingerprint": "sha256:9c761747f86cc40ca852351e9a049ee0269dd52e03fe036a1d9a5b2f34a05edb",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.frontend",
+        "checks.lint_format",
+        "scope.out-of-scope"
+      ]
+    },
+    {
+      "at": "2026-06-22T22:14:17.182653Z",
+      "diff_fingerprint": "sha256:40857e3bee4ab34b202bdf01d971a4cd508770c4f37ddafda76366c6d40e5aec",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "scope.out-of-scope"
+      ]
+    },
+    {
+      "at": "2026-06-22T22:14:53.318939Z",
+      "diff_fingerprint": "sha256:40857e3bee4ab34b202bdf01d971a4cd508770c4f37ddafda76366c6d40e5aec",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-22T22:15:37.538380Z",
+      "diff_fingerprint": "sha256:4dfd750f805834a8d341a6cd1c6d8ac1803084ba63ef0ebaca4e56826ec5ff6e",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-22T22:17:08.985908Z",
+      "diff_fingerprint": "sha256:b5909f63f0a0bb753d96fa99cfd825cb6e6ba52aedcb80b335d19ca63326b79b",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-22T22:19:16.465877Z",
+      "diff_fingerprint": "sha256:97ea183251a320326cabd52c28ec91c61f4727ca336211e98c5f6a3776714257",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-22T22:20:52.452422Z",
+      "diff_fingerprint": "sha256:97ea183251a320326cabd52c28ec91c61f4727ca336211e98c5f6a3776714257",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-22T22:22:35.433726Z",
+      "diff_fingerprint": "sha256:97ea183251a320326cabd52c28ec91c61f4727ca336211e98c5f6a3776714257",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    }
+  ],
+  "record_id": "1750-hotfix-live-session-20260622",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [
+      "format_check",
+      "frontend",
+      "full_audit",
+      "import_contracts",
+      "lint_format",
+      "python_tests",
+      "semantic_dup",
+      "type_check"
+    ],
+    "docs": [
+      "docs_required_or_na"
+    ],
+    "guards": [
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": [
+      "changed_test_required"
+    ]
+  },
+  "runtime": "claude-code",
+  "schema_version": 2,
+  "scope_events": [
+    {
+      "action": "add-include",
+      "at": "2026-06-22T22:01:39.617720Z",
+      "pattern": "src/scistudio/ai/agent/mcp/tools_plot/_harness.py",
+      "reason": "owner reported spectrum item.open drops intensity; audit all types and fix"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-22T22:01:39.617729Z",
+      "pattern": "src/scistudio/ai/agent/mcp/tools_plot/scaffold.py",
+      "reason": "owner reported spectrum item.open drops intensity; audit all types and fix"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-22T22:01:39.745316Z",
+      "pattern": "frontend/src/hooks/useWebSocket.parts/helpers.ts",
+      "reason": "owner reported project file-tree jitter after a run (tree-only); gate refresh on structural change"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-22T22:01:39.745319Z",
+      "pattern": "frontend/src/hooks/useWebSocket.parts/handleWorkflowChanged.ts",
+      "reason": "owner reported project file-tree jitter after a run (tree-only); gate refresh on structural change"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-22T22:01:39.745321Z",
+      "pattern": "frontend/src/hooks/useWebSocket.parts/handleFileChanged.ts",
+      "reason": "owner reported project file-tree jitter after a run (tree-only); gate refresh on structural change"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-22T22:01:39.745322Z",
+      "pattern": "frontend/src/components/ProjectTree.parts/useTreeNodes.ts",
+      "reason": "owner reported project file-tree jitter after a run (tree-only); gate refresh on structural change"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-22T22:01:39.873536Z",
+      "pattern": "src/scistudio/previewers/registry.py",
+      "reason": "owner: make previewer entry-point discovery the reliable preferred path"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-22T22:01:40.002035Z",
+      "pattern": "src/scistudio/api/routes/filesystem.py",
+      "reason": "owner reported browse 500 with a multi-file path; reproduced ENAMETOOLONG, fix backend+frontend"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-22T22:01:40.002040Z",
+      "pattern": "frontend/src/components/BottomPanel.parts/ConfigField.tsx",
+      "reason": "owner reported browse 500 with a multi-file path; reproduced ENAMETOOLONG, fix backend+frontend"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-22T22:14:52.826218Z",
+      "pattern": "tests/ai/test_mcp_tools_plot.py",
+      "reason": "test files belong to this batch's scope (recorded as test paths; declare as include scope too)"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-22T22:14:52.826366Z",
+      "pattern": "tests/api/test_filesystem_browse.py",
+      "reason": "test files belong to this batch's scope (recorded as test paths; declare as include scope too)"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-22T22:14:52.826369Z",
+      "pattern": "tests/previewers/test_preview_registry.py",
+      "reason": "test files belong to this batch's scope (recorded as test paths; declare as include scope too)"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-22T22:14:52.826370Z",
+      "pattern": "frontend/src/components/BottomPanel.parts/ConfigPanel.test.tsx",
+      "reason": "test files belong to this batch's scope (recorded as test paths; declare as include scope too)"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-22T22:14:52.826372Z",
+      "pattern": "frontend/src/components/__tests__/ProjectTree.test.tsx",
+      "reason": "test files belong to this batch's scope (recorded as test paths; declare as include scope too)"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-22T22:14:52.826373Z",
+      "pattern": "frontend/src/hooks/__tests__/useWebSocket.versionVector.test.ts",
+      "reason": "test files belong to this batch's scope (recorded as test paths; declare as include scope too)"
+    }
+  ],
+  "session_id": "a79fbc20-0806-4fa1-90d3-57c091657874",
+  "strictness_tier": 2,
+  "task_kind": "guided",
+  "test_events": [
+    {
+      "at": "2026-06-22T22:01:39.617823Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/ai/test_mcp_tools_plot.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-22T22:01:39.745403Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/hooks/__tests__/useWebSocket.versionVector.test.ts",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-22T22:01:39.745411Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/components/__tests__/ProjectTree.test.tsx",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-22T22:01:39.873631Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/previewers/test_preview_registry.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-22T22:01:40.002124Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/api/test_filesystem_browse.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-22T22:01:40.002128Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/components/BottomPanel.parts/ConfigPanel.test.tsx",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/frontend/src/components/BottomPanel.parts/ConfigField.tsx
+++ b/frontend/src/components/BottomPanel.parts/ConfigField.tsx
@@ -13,6 +13,21 @@ function browseModeFor(uiWidget: string | undefined): BrowseMode {
   return null;
 }
 
+/**
+ * Pick a single representative path from a field value for seeding the browse
+ * dialog. A multi-file field holds an array; browsing must start from the first
+ * selected path, NOT `String(array)` (a comma-joined concatenation of every
+ * path), which builds an over-length, non-existent path and 500s the backend
+ * filesystem endpoints (#1753).
+ */
+function firstPathOf(value: unknown): string {
+  if (Array.isArray(value)) {
+    const first = value.find((v) => typeof v === "string" && v.length > 0);
+    return typeof first === "string" ? first : "";
+  }
+  return value == null ? "" : String(value);
+}
+
 function nativeInitialDir(
   browseMode: NonNullable<BrowseMode>,
   current: string,
@@ -153,7 +168,7 @@ function ScalarField({
     try {
       const result = await api.openNativeDialog(
         browseMode,
-        nativeInitialDir(browseMode, String(currentValue ?? "")),
+        nativeInitialDir(browseMode, firstPathOf(currentValue)),
       );
       applySelectedPath(result.paths);
     } catch (err) {
@@ -191,7 +206,7 @@ function ScalarField({
       {browseOpen && browseMode && (
         <FileBrowserModal
           mode={browseMode === "directory" ? "directory_browser" : "file_browser"}
-          initialPath={modalInitialPath(browseMode, String(currentValue ?? ""))}
+          initialPath={modalInitialPath(browseMode, firstPathOf(currentValue))}
           onSelect={(selectedPath) => {
             applySelectedPath([selectedPath]);
             setBrowseOpen(false);

--- a/frontend/src/components/BottomPanel.parts/ConfigPanel.test.tsx
+++ b/frontend/src/components/BottomPanel.parts/ConfigPanel.test.tsx
@@ -124,6 +124,63 @@ describe("ConfigPanel", () => {
     expect(apiMocks.browseFilesystem).not.toHaveBeenCalled();
   });
 
+  it("seeds browse from the first path when a multi-file field holds an array (#1753)", async () => {
+    // A multi-select file field stores an array. Re-browsing must start from the
+    // first file's directory, NOT String(array) — a comma-joined concatenation
+    // of every path that builds an over-length path and 500s the backend.
+    apiMocks.openNativeDialog.mockResolvedValueOnce({ paths: [] });
+
+    render(
+      <ConfigPanel
+        onUpdateConfig={vi.fn()}
+        selectedNode={{
+          id: "load-1",
+          block_type: "load_data",
+          config: {
+            params: {
+              path: [
+                "/data/imaging/LA0Hr.txt",
+                "/data/imaging/LA1Hr.txt",
+                "/data/imaging/LA2Hr.txt",
+              ],
+            },
+          },
+        }}
+        schema={{
+          name: "Load",
+          type_name: "load_data",
+          base_category: "io",
+          subcategory: "",
+          description: "",
+          version: "0.1.0",
+          input_ports: [],
+          output_ports: [],
+          direction: "input",
+          config_schema: {
+            properties: {
+              path: {
+                type: "array",
+                title: "Path",
+                ui_priority: 0,
+                ui_widget: "file_browser",
+              },
+            },
+          },
+          type_hierarchy: [],
+        }}
+      />,
+    );
+
+    fireEvent.click(screen.getByTitle("Browse filesystem"));
+
+    await waitFor(() =>
+      expect(apiMocks.openNativeDialog).toHaveBeenCalledWith("file", "/data/imaging"),
+    );
+    // The seeded directory must be a single real path, never a comma-joined blob.
+    const [, initialDir] = apiMocks.openNativeDialog.mock.calls[0];
+    expect(initialDir).not.toContain(",");
+  });
+
   it("falls back to the in-app file browser when native dialog fails", async () => {
     const { ApiError } = await import("../../lib/api");
     apiMocks.openNativeDialog.mockRejectedValueOnce(

--- a/frontend/src/components/ProjectTree.parts/useTreeNodes.ts
+++ b/frontend/src/components/ProjectTree.parts/useTreeNodes.ts
@@ -2,7 +2,7 @@
  * Tree-state hook for ProjectTree (lazy-loaded children, expand/collapse,
  * refresh wiring). Extracted in #1413 so the parent function stays small.
  */
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import { api } from "../../lib/api";
 import { useAppStore } from "../../store";
@@ -22,6 +22,25 @@ function updateNode(
   });
 }
 
+/**
+ * Collect the paths of currently-expanded directories in shallow→deep order
+ * (a parent always precedes its descendants). Used by `refresh()` to restore
+ * expansion state after a watcher-driven reload instead of wiping it (#1751).
+ */
+function collectExpandedPaths(nodes: TreeNodeData[]): string[] {
+  const out: string[] = [];
+  const walk = (ns: TreeNodeData[]) => {
+    for (const node of ns) {
+      if (node.type === "directory" && node.expanded) {
+        out.push(node.path);
+        if (node.children) walk(node.children);
+      }
+    }
+  };
+  walk(nodes);
+  return out;
+}
+
 export interface UseTreeNodesResult {
   rootNodes: TreeNodeData[];
   loading: boolean;
@@ -32,6 +51,12 @@ export interface UseTreeNodesResult {
 export function useTreeNodes(projectId: string): UseTreeNodesResult {
   const [rootNodes, setRootNodes] = useState<TreeNodeData[]>([]);
   const [loading, setLoading] = useState(false);
+  // Mirror the latest tree so `refresh()` (a stable callback) can read the
+  // current expansion state without depending on `rootNodes` and re-running.
+  const rootNodesRef = useRef<TreeNodeData[]>([]);
+  useEffect(() => {
+    rootNodesRef.current = rootNodes;
+  }, [rootNodes]);
 
   const loadChildren = useCallback(
     async (parentPath: string): Promise<TreeNodeData[]> => {
@@ -50,8 +75,22 @@ export function useTreeNodes(projectId: string): UseTreeNodesResult {
   const refresh = useCallback(async () => {
     setLoading(true);
     try {
-      const children = await loadChildren("");
-      setRootNodes(children);
+      // Reload the root, then re-open the directories that were expanded before
+      // the refresh so the watcher tick (ADR-034) does not collapse the tree on
+      // every run (#1751). Paths are shallow→deep, so each parent's children are
+      // loaded before a descendant is merged into them; folders that vanished
+      // since the last load are skipped and simply stay collapsed.
+      const expandedPaths = collectExpandedPaths(rootNodesRef.current);
+      let tree = await loadChildren("");
+      for (const path of expandedPaths) {
+        try {
+          const children = await loadChildren(path);
+          tree = updateNode(tree, path, (n) => ({ ...n, expanded: true, loaded: true, children }));
+        } catch {
+          // directory removed or unreadable since last load -- leave collapsed
+        }
+      }
+      setRootNodes(tree);
     } catch {
       // silently ignore -- project may not be ready
     } finally {

--- a/frontend/src/components/__tests__/ProjectTree.test.tsx
+++ b/frontend/src/components/__tests__/ProjectTree.test.tsx
@@ -9,7 +9,7 @@
  *   - <name>.tiff (not in editable set) -> NO action
  */
 
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type * as ApiModule from "../../lib/api";
@@ -120,5 +120,41 @@ describe("ProjectTree — ADR-036 §3.5 double-click wiring (I36c)", () => {
     // Wait long enough for the handler to run if it were going to.
     await new Promise((r) => setTimeout(r, 5));
     expect(openFileTab).not.toHaveBeenCalled();
+  });
+});
+
+describe("ProjectTree — expansion persists across a watcher refresh (#1751)", () => {
+  it("keeps an expanded folder open when projectTreeRefreshCounter bumps", async () => {
+    // Root lists one directory; expanding it lists one child file. Any other
+    // path (the watcher reload of the root) returns the directory again.
+    getProjectTreeMock.mockImplementation((async (_projectId: string, path: string) => {
+      if (path === "plots") {
+        return { entries: [{ name: "spectrum.svg", type: "file", size: 10 }] };
+      }
+      return { entries: [{ name: "plots", type: "directory" }] };
+    }) as any);
+
+    render(
+      <ProjectTree
+        projectId="proj-1"
+        projectPath="/tmp/proj-1"
+        onLoadWorkflow={vi.fn()}
+        onReloadBlocks={vi.fn()}
+      />,
+    );
+
+    // Expand "plots" and confirm its child renders.
+    fireEvent.click(await screen.findByText("plots"));
+    await screen.findByText("spectrum.svg");
+
+    // Simulate a workflow run's filesystem-watcher tick (ADR-034), which bumps
+    // the refresh counter and previously rebuilt the tree fully collapsed.
+    await act(async () => {
+      useAppStore.setState({ projectTreeRefreshCounter: 1 });
+    });
+
+    // Regression (#1751): the folder must stay expanded — its child is still
+    // visible — instead of collapsing on every run.
+    await waitFor(() => expect(screen.getByText("spectrum.svg")).toBeInTheDocument());
   });
 });

--- a/frontend/src/hooks/__tests__/useWebSocket.versionVector.test.ts
+++ b/frontend/src/hooks/__tests__/useWebSocket.versionVector.test.ts
@@ -471,4 +471,68 @@ describe("useWorkflowWebSocket ADR-045 reconcile", () => {
     expect(tab.conflict?.remoteContent).toBe("remote\n");
     expect(tab.conflict?.remoteVersion).toBe(7);
   });
+
+  // -------------------------------------------------------------------------
+  // #1751 — the project tree must refresh only on a STRUCTURAL change
+  // (created / deleted / renamed), never on a content "modified" event. The
+  // app's own repeated workflow-YAML saves during a run (and watcher echoes of
+  // them, amplified on cloud-synced project dirs) are "modified" and previously
+  // thrashed the tree even though the canvas correctly ignored them — the
+  // "only the left file tree jitters after a run" symptom.
+  // -------------------------------------------------------------------------
+  function pushWorkflowChanged(kind: string, version: number): void {
+    pushMessage({
+      type: "workflow.changed",
+      workflow_id: "demo",
+      timestamp: "2026-06-22T00:00:00Z",
+      data: {
+        workflow_id: "demo",
+        entity_class: "workflow",
+        entity_id: "demo",
+        version,
+        source: "canvas",
+        source_id: "workflow-source-1",
+        kind,
+      },
+    });
+  }
+
+  function pushFileChanged(kind: string): void {
+    pushMessage({
+      type: "file.changed",
+      timestamp: "2026-06-22T00:00:00Z",
+      data: {
+        path: "data/out.parquet",
+        entity_class: "file",
+        entity_id: "data/out.parquet",
+        version: 1,
+        source: "external",
+        source_id: null,
+        kind,
+      },
+    });
+  }
+
+  it("does NOT refresh the project tree on a workflow content 'modified' echo (#1751)", () => {
+    useAppStore.getState().setWorkflow(versionedWorkflow(10, "base"));
+    renderHook(() => useWorkflowWebSocket(true));
+    // Stale version so the reconcile path no-ops; we only assert the tree gate.
+    pushWorkflowChanged("modified", 5);
+    expect(useAppStore.getState().projectTreeRefreshCounter).toBe(0);
+  });
+
+  it("refreshes the project tree on a structural workflow 'deleted' event (#1751)", () => {
+    useAppStore.getState().setWorkflow(versionedWorkflow(10, "base"));
+    renderHook(() => useWorkflowWebSocket(true));
+    pushWorkflowChanged("deleted", 5);
+    expect(useAppStore.getState().projectTreeRefreshCounter).toBe(1);
+  });
+
+  it("refreshes the tree on a file 'created' but not on a file 'modified' (#1751)", () => {
+    renderHook(() => useWorkflowWebSocket(true));
+    pushFileChanged("modified");
+    expect(useAppStore.getState().projectTreeRefreshCounter).toBe(0);
+    pushFileChanged("created");
+    expect(useAppStore.getState().projectTreeRefreshCounter).toBe(1);
+  });
 });

--- a/frontend/src/hooks/useWebSocket.parts/handleFileChanged.ts
+++ b/frontend/src/hooks/useWebSocket.parts/handleFileChanged.ts
@@ -12,7 +12,14 @@ import { useAppStore } from "../../store";
 import type { FileTab, VersionConflictState } from "../../store/types";
 import type { LogEntry, WorkflowEventMessage } from "../../types/api";
 
-import { eventSource, fileIsDirty, numberOrNull, stringOrNull, versionedData } from "./helpers";
+import {
+  eventSource,
+  fileIsDirty,
+  isStructuralTreeChange,
+  numberOrNull,
+  stringOrNull,
+  versionedData,
+} from "./helpers";
 
 export interface FileChangedDeps {
   appendLog: (entry: LogEntry) => void;
@@ -147,7 +154,13 @@ export function handleFileChanged(payload: WorkflowEventMessage, deps: FileChang
   const path = stringOrNull(data.path) ?? stringOrNull(data.entity_id);
   if (!path) return;
 
-  useAppStore.getState().bumpProjectTreeRefresh();
+  // Refresh the project tree only on a structural change (created/deleted/
+  // renamed). A "modified" content event leaves the tree structure unchanged
+  // and must not thrash it during a run's repeated saves (#1751).
+  const kind = (data.kind as string | undefined) ?? "modified";
+  if (isStructuralTreeChange(kind)) {
+    useAppStore.getState().bumpProjectTreeRefresh();
+  }
   const state = useAppStore.getState();
   const projectId = state.currentProject?.id;
   const matchingTabs = state.tabs.filter((tab) => tab.kind === "file" && tab.filePath === path);
@@ -155,7 +168,7 @@ export function handleFileChanged(payload: WorkflowEventMessage, deps: FileChang
 
   const ctx: FileEventContext = {
     path,
-    kind: (data.kind as string | undefined) ?? "modified",
+    kind,
     eventVersion: numberOrNull(data.version),
     source: eventSource(data),
     sourceId: stringOrNull(data.source_id),

--- a/frontend/src/hooks/useWebSocket.parts/handleWorkflowChanged.ts
+++ b/frontend/src/hooks/useWebSocket.parts/handleWorkflowChanged.ts
@@ -13,7 +13,14 @@ import { useAppStore } from "../../store";
 import type { VersionConflictState } from "../../store/types";
 import type { LogEntry, WorkflowEventMessage } from "../../types/api";
 
-import { eventSource, numberOrNull, stringOrNull, versionedData, workflowIsDirty } from "./helpers";
+import {
+  eventSource,
+  isStructuralTreeChange,
+  numberOrNull,
+  stringOrNull,
+  versionedData,
+  workflowIsDirty,
+} from "./helpers";
 
 export interface WorkflowChangedDeps {
   appendLog: (entry: LogEntry) => void;
@@ -222,8 +229,13 @@ export function handleWorkflowChanged(
   deps: WorkflowChangedDeps,
 ): void {
   const ctx = parseWorkflowChangedPayload(payload);
-  // Any workflow YAML touch on disk is also a project-tree change.
-  useAppStore.getState().bumpProjectTreeRefresh();
+  // Only a structural change (a workflow file created/deleted/renamed) changes
+  // the project tree. A "modified" event is just a content re-save — the app's
+  // own repeated workflow saves during a run (and watcher echoes of them) must
+  // not thrash the tree, which has no version-vector guard like the canvas (#1751).
+  if (isStructuralTreeChange(ctx?.kind)) {
+    useAppStore.getState().bumpProjectTreeRefresh();
+  }
   if (!ctx) return;
 
   // ADR-034: agent-driven ``write_workflow`` (kind=created) for an

--- a/frontend/src/hooks/useWebSocket.parts/helpers.ts
+++ b/frontend/src/hooks/useWebSocket.parts/helpers.ts
@@ -46,3 +46,20 @@ export function fileIsDirty(tabId: string): boolean {
       tab.pendingVersion > tab.baseVersion)
   );
 }
+
+/**
+ * Whether a ``workflow.changed`` / ``file.changed`` event represents a change
+ * to the project tree's *structure* (and so warrants a tree refresh) rather
+ * than a pure content edit.
+ *
+ * A ``"modified"`` event rewrites an existing file's contents — the tree
+ * structure is unchanged. Only created / deleted / renamed / moved entries
+ * change it. Gating the project-tree refresh on this stops the app's own
+ * repeated workflow-YAML saves during a run — and filesystem-watcher echoes of
+ * them (amplified on cloud-synced project dirs that delete+recreate the file) —
+ * from thrashing the project tree (#1751). The canvas already ignores those
+ * echoes via the version-vector guards; the tree refresh had no such gate.
+ */
+export function isStructuralTreeChange(kind: string | null | undefined): boolean {
+  return kind !== "modified";
+}

--- a/src/scistudio/ai/agent/mcp/tools_plot/_harness.py
+++ b/src/scistudio/ai/agent/mcp/tools_plot/_harness.py
@@ -251,7 +251,15 @@ def _read_series(ref, limit):
     if hasattr(value, "iloc"):
         if len(value.columns) == 0:
             raise ValueError("Series item table has no columns")
-        return value.iloc[:, 0]
+        # A Series item is persisted as an index+value table (e.g. a Spectrum is
+        # ``{lambda, intensity}``). Returning only ``iloc[:, 0]`` dropped every
+        # column after the first — for a spectrum that silently discarded the
+        # intensity axis and plotted the wavelengths instead (#1750). Keep the
+        # full table whenever it carries more than one column so no axis is lost;
+        # a genuinely single-column series still opens as a 1-D Series.
+        if len(value.columns) == 1:
+            return value.iloc[:, 0]
+        return value
     raise ValueError("unsupported Series storage for plot open()")
 
 
@@ -722,7 +730,11 @@ read_array <- function(ref) {
 read_series <- function(ref) {
   df <- read_dataframe(ref)
   if (ncol(df) < 1) stop("Series item table has no columns")
-  df[[1]]
+  # A Series item is persisted as an index+value table (e.g. a Spectrum is
+  # {lambda, intensity}). Returning only df[[1]] dropped the value axis and
+  # plotted the wavelengths instead (#1750). Keep the full data.frame when it
+  # has more than one column; a single-column series still opens as a vector.
+  if (ncol(df) == 1) df[[1]] else df
 }
 
 read_text <- function(ref) {

--- a/src/scistudio/ai/agent/mcp/tools_plot/scaffold.py
+++ b/src/scistudio/ai/agent/mcp/tools_plot/scaffold.py
@@ -54,6 +54,8 @@ def render(collection):
       * collection.items[index].type      -> normalized core base type
       * collection.items[index].metadata  -> read-only non-storage metadata
       * collection.items[index].open()    -> one native value
+        (a Series-backed item such as a spectrum opens to its full
+        {index, value} table, e.g. a DataFrame with lambda + intensity columns)
 
     Figure size / aspect ratio:
       The default figure is 6.4 x 4.8 inches (4:3). To use a different size or
@@ -127,6 +129,8 @@ _R_TEMPLATE = """# Render script created by SciStudio.
 #   * collection$items[[index]]$type        -> normalized core base type
 #   * collection$items[[index]]$metadata    -> non-storage metadata
 #   * collection$items[[index]]$open()      -> one native value
+#     (a Series-backed item such as a spectrum opens to its full
+#     {index, value} table, e.g. a data.frame with lambda + intensity columns)
 #
 # Figure size / aspect ratio:
 #   The plot defaults to 6.4 x 4.8 inches (4:3), matching the Python renderer.

--- a/src/scistudio/api/routes/filesystem.py
+++ b/src/scistudio/api/routes/filesystem.py
@@ -65,6 +65,20 @@ def _resolve_safe_path(user_path: str | Path) -> Path:
     raise ValueError(f"path must be under user home or system temp; got {candidate}")
 
 
+def _safe_is_dir(path: str | Path) -> bool:
+    """``Path.is_dir()`` that never raises (#1753).
+
+    A path longer than the platform ``PATH_MAX`` (``ENAMETOOLONG``) or an item on
+    an offline cloud/network File Provider mount (Box, iCloud — ``ENOTCONN`` /
+    ``ETIMEDOUT``) makes ``stat`` raise ``OSError``. Treat any such failure as
+    "not a usable directory" so dialog/browse callers degrade instead of 500ing.
+    """
+    try:
+        return Path(path).is_dir()
+    except OSError:
+        return False
+
+
 # ---------------------------------------------------------------------------
 # Shared models
 # ---------------------------------------------------------------------------
@@ -247,14 +261,21 @@ async def browse_filesystem(
     # (e.g. ``?path=/etc``).
     try:
         target = _resolve_safe_path(path)
+        if not target.exists():
+            raise HTTPException(status_code=404, detail=f"Path does not exist: {path}")
+        if not target.is_dir():
+            raise HTTPException(status_code=400, detail=f"Path is not a directory: {path}")
+        entries = _list_directory(target)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
-    if not target.exists():
-        raise HTTPException(status_code=404, detail=f"Path does not exist: {path}")
-    if not target.is_dir():
-        raise HTTPException(status_code=400, detail=f"Path is not a directory: {path}")
-
-    entries = _list_directory(target)
+    except OSError as exc:
+        # An over-length path (ENAMETOOLONG) or an offline cloud/network mount
+        # (ENOTCONN/ETIMEDOUT) makes exists()/is_dir()/iterdir() raise OSError.
+        # Return a clean 400 instead of letting it become a 500 (#1753).
+        raise HTTPException(
+            status_code=400,
+            detail=f"Could not read path (too long, offline, or unreadable): {path[:120]}",
+        ) from exc
     return FilesystemBrowseResponse(path=str(target), entries=entries)
 
 
@@ -268,15 +289,15 @@ async def stat_filesystem(
         target = _resolve_safe_path(path)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
-    if not target.exists():
+    try:
+        if not target.exists():
+            return FilesystemStatResponse(path=str(target), exists=False)
+        kind = "directory" if target.is_dir() else "file"
+        size = target.stat().st_size if target.is_file() else None
+    except OSError:
+        # Over-length (ENAMETOOLONG) or offline cloud/network path: report as
+        # not-present rather than raising a 500 (#1753).
         return FilesystemStatResponse(path=str(target), exists=False)
-    kind = "directory" if target.is_dir() else "file"
-    size: int | None = None
-    if target.is_file():
-        try:
-            size = target.stat().st_size
-        except OSError:
-            size = None
     return FilesystemStatResponse(path=str(target), exists=True, type=kind, size=size)
 
 
@@ -290,9 +311,13 @@ async def reveal_in_explorer(body: RevealRequest) -> dict[str, str]:
     """Open the native file explorer and select/reveal the given path."""
     try:
         target = _resolve_safe_path(body.path)
+        exists = target.exists()
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
-    if not target.exists():
+    except OSError as exc:
+        # Over-length or offline path: clean 400 rather than a 500 (#1753).
+        raise HTTPException(status_code=400, detail="Path is too long or unreadable") from exc
+    if not exists:
         raise HTTPException(status_code=404, detail="Path does not exist")
 
     system = platform.system()
@@ -626,11 +651,13 @@ async def native_file_dialog(body: NativeDialogRequest) -> NativeDialogResponse:
     """
     global _last_used_directory
 
-    # Determine starting directory: request param > last-used > home
+    # Determine starting directory: request param > last-used > home.
+    # ``_safe_is_dir`` swallows OSError so an over-length or offline ``initial_dir``
+    # falls back to home instead of raising a 500 (#1753).
     initial_dir = body.initial_dir
-    if not initial_dir or not Path(initial_dir).is_dir():
+    if not initial_dir or not _safe_is_dir(initial_dir):
         initial_dir = _last_used_directory
-    if not initial_dir or not Path(initial_dir).is_dir():
+    if not initial_dir or not _safe_is_dir(initial_dir):
         initial_dir = str(Path.home())
 
     system = platform.system()

--- a/src/scistudio/previewers/registry.py
+++ b/src/scistudio/previewers/registry.py
@@ -31,6 +31,7 @@ from typing import Any
 
 from scistudio.desktop.paths import (
     candidate_package_dirs,
+    installed_package_import_roots,
     iter_source_package_module_candidates,
     prepended_sys_paths,
 )
@@ -150,9 +151,25 @@ class PreviewerRegistry:
             self.register(spec)
 
     def load_packages(self, *, include_monorepo: bool = False) -> None:
-        """Load package previewers from entry points + monorepo fallback (FR-002/FR-030)."""
-        self._scan_entry_points()
-        self._scan_companion_entry_point_packages()
+        """Load package previewers from entry points + monorepo fallback (FR-002/FR-030).
+
+        The entry-point scans run with the user-installed plugin import roots
+        activated on ``sys.path`` (their ``site-packages`` carry the dist-info),
+        so ``importlib.metadata.entry_points()`` can actually see installed
+        plugins' ``scistudio.previewers`` entry points. Without this the
+        canonical entry-point path silently finds nothing in the packaged app —
+        the plugin ``site-packages`` is off ``sys.path`` — and previewer
+        discovery falls entirely to the source-dir scan fallback (#1752). The
+        block/type registries already activate these roots the same way.
+        """
+        try:
+            plugin_roots = tuple(installed_package_import_roots())
+        except Exception:  # pragma: no cover - defensive; never fail discovery
+            logger.debug("Failed to resolve installed plugin import roots", exc_info=True)
+            plugin_roots = ()
+        with prepended_sys_paths(plugin_roots):
+            self._scan_entry_points()
+            self._scan_companion_entry_point_packages()
         self._scan_package_src_dirs()
         if include_monorepo:
             self._scan_monorepo_packages()

--- a/tests/ai/test_mcp_tools_plot.py
+++ b/tests/ai/test_mcp_tools_plot.py
@@ -1245,6 +1245,47 @@ def test_materialize_uses_metadata_estimate_for_cap(tmp_path: Path) -> None:
     assert out["collection"]["items"][0]["_path"] == str(src)
 
 
+def _python_harness_namespace() -> dict[str, Any]:
+    """Exec the embedded ``PYTHON_HARNESS`` source so its internal readers
+    (``_open_ref`` etc.) can be exercised exactly as the plot subprocess runs
+    them. ``__name__`` is set to a non-``__main__`` value so the harness entry
+    ``main()`` does not execute on import."""
+    from scistudio.ai.agent.mcp.tools_plot import _harness
+
+    ns: dict[str, Any] = {"__name__": "_python_harness_undertest"}
+    exec(compile(_harness.PYTHON_HARNESS, "<python_harness>", "exec"), ns)
+    return ns
+
+
+def test_series_open_preserves_value_column(tmp_path: Path) -> None:
+    """Regression (#1750): a Series item (e.g. a spectrum) must not drop its
+    value column.
+
+    ``_read_series`` previously returned only the first column, so a Spectrum
+    persisted as ``{lambda, intensity}`` opened to the lambda axis alone — the
+    intensity was unreachable and the default plot drew the wavelengths.
+    """
+    import pandas as pd
+
+    src = tmp_path / "spectrum.parquet"
+    pd.DataFrame({"lambda": [400.0, 401.0, 402.0], "intensity": [1.5, 2.5, 3.5]}).to_parquet(src)
+    value = _python_harness_namespace()["_open_ref"](_df_item(src, typ="Series"), 10**9)
+    assert hasattr(value, "columns"), "a multi-column Series must open to its full table"
+    assert list(value.columns) == ["lambda", "intensity"]
+    assert value["intensity"].tolist() == [1.5, 2.5, 3.5]
+
+
+def test_single_column_series_open_returns_1d(tmp_path: Path) -> None:
+    """A genuinely single-column Series still opens as a 1-D Series (#1750)."""
+    import pandas as pd
+
+    src = tmp_path / "single.parquet"
+    pd.DataFrame({"value": [1.0, 2.0, 3.0]}).to_parquet(src)
+    value = _python_harness_namespace()["_open_ref"](_df_item(src, typ="Series"), 10**9)
+    assert not hasattr(value, "columns"), "a single-column Series stays 1-D"
+    assert value.tolist() == [1.0, 2.0, 3.0]
+
+
 @pytest.fixture
 def parquet_output(tmp_path: Path) -> Path:
     import pandas as pd

--- a/tests/api/test_filesystem_browse.py
+++ b/tests/api/test_filesystem_browse.py
@@ -106,6 +106,30 @@ class TestBrowseFilesystem:
         )
         assert resp.status_code == 400
 
+    def test_overlength_path_returns_400_not_500(self, client: TestClient, browse_dir: Path) -> None:
+        # Regression (#1753): a multi-file field stringifies to a comma-joined
+        # value thousands of characters long. ``os.stat`` on such a path raises
+        # ``OSError(ENAMETOOLONG)``; the endpoint must surface a clean 400 rather
+        # than letting it become a 500 "Internal Server Error".
+        #
+        # Use an over-length *component* (> NAME_MAX 255) rather than a long path
+        # of short components: the latter stays under Linux's 4096 PATH_MAX and
+        # only 404s there, while an over-length component raises ENAMETOOLONG on
+        # both Linux and macOS.
+        long_path = str(browse_dir) + "/" + ("x" * 600)
+        resp = client.get("/api/filesystem/browse", params={"path": long_path})
+        assert resp.status_code == 400
+
+    def test_safe_is_dir_swallows_oserror_on_overlength_path(self) -> None:
+        # Regression (#1753): the native-dialog ``initial_dir`` guard must treat
+        # an over-length / unreadable path as "not a directory" instead of
+        # letting ``Path.is_dir()`` raise OSError up into a 500.
+        from scistudio.api.routes.filesystem import _safe_is_dir
+
+        overlong_component = "/" + ("a" * 300) + "/sub"  # 300 > NAME_MAX -> OSError
+        assert _safe_is_dir(overlong_component) is False
+        assert _safe_is_dir("/nonexistent/place/xyz") is False
+
     def test_entries_sorted_alphabetically(self, client: TestClient, browse_dir: Path) -> None:
         resp = client.get(
             "/api/filesystem/browse",

--- a/tests/previewers/test_preview_registry.py
+++ b/tests/previewers/test_preview_registry.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import importlib.metadata
 import sys
 import types
+from pathlib import Path
 
 import pytest
 
@@ -138,6 +139,57 @@ def test_companion_package_entry_point_discovers_get_previewers(
 
     assert reg.get("pkg.fake.viewer") is not None
     assert reg.diagnostics == []
+
+
+def test_load_packages_activates_installed_plugin_roots_for_entry_points(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#1752: entry-point discovery must activate user-installed plugin import
+    roots so ``importlib.metadata`` sees their dist-info.
+
+    Mirrors a packaged install where a plugin's ``scistudio.previewers`` entry
+    point is only visible while the plugin root is on ``sys.path``. Before the
+    fix, the registry scanned entry points without activating the plugin roots,
+    so the canonical entry-point path found nothing.
+    """
+    sentinel = str(tmp_path)
+
+    fake_module = types.ModuleType("scistudio_blocks_fake")
+    fake_module.get_previewers = lambda: [_spec("pkg.fake.viewer")]  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "scistudio_blocks_fake", fake_module)
+
+    prev_ep = importlib.metadata.EntryPoint(
+        name="fake",
+        value="scistudio_blocks_fake:get_previewers",
+        group="scistudio.previewers",
+    )
+    real_entry_points = importlib.metadata.entry_points
+
+    def _entry_points(*args: object, **kwargs: object) -> object:
+        group = kwargs.get("group")
+        if group == "scistudio.previewers":
+            # The plugin's dist-info is only "visible" once its root is on sys.path.
+            return (prev_ep,) if sentinel in sys.path else ()
+        if group in ("scistudio.blocks", "scistudio.types"):
+            return ()
+        return real_entry_points(*args, **kwargs)
+
+    monkeypatch.setattr(importlib.metadata, "entry_points", _entry_points)
+    monkeypatch.setattr(
+        "scistudio.previewers.registry.installed_package_import_roots",
+        lambda: [tmp_path],
+    )
+
+    reg = PreviewerRegistry()
+    reg.load_packages(include_monorepo=False)
+
+    # Discovered via the entry-point path — only possible if the plugin root was
+    # activated on sys.path during the scan.
+    assert reg.get("pkg.fake.viewer") is not None
+    assert reg.diagnostics == []
+    # The scoped activation must restore sys.path afterwards.
+    assert sentinel not in sys.path
 
 
 def test_project_default_declaration_roundtrips() -> None:


### PR DESCRIPTION
Production hotfix batch from a 2026-06-22 owner-guided live (`live_implementer`) session. Four bugs were found while the owner reproduced real user-production issues, including a collaborator running the packaged app against a Box-synced project.

## #1750 — Spectrum/Series `item.open()` dropped the intensity column
The AI plot harness `_read_series` (Python + R) returned only the first column, so a `{lambda, intensity}` spectrum opened to the lambda axis alone — intensity was unreachable and the default plot drew the wavelengths. It now returns the full table when there is more than one column; a genuinely single-column series still opens 1-D. Cross-type audit: only the Series reader lost data. The built-in spectroscopy previewer was unaffected.

## #1751 — Project file tree jittered after a run (tree only)
`bumpProjectTreeRefresh()` fired unconditionally on every `workflow.changed` / `file.changed` event — including the app's own `modified` workflow-save echoes, which the canvas already ignores via the version-vector guards (so only the tree thrashed). The tree refresh is now gated on **structural** changes (created/deleted/renamed); a content `modified` event no longer refreshes the tree. `useTreeNodes` also preserves expansion across a refresh. Only reproduces where the file-watcher event storm occurs (e.g. cloud-synced project dirs), which is why it was invisible on a local disk.

## #1752 — Spectroscopy previewer fell back to the core point-line plot on packaged installs
Previewer entry-point discovery never activated the user-installed plugin import roots, so `importlib.metadata.entry_points()` saw no dist-info and the canonical discovery path returned nothing (block discovery has its own dir-scan, so blocks still worked — the registration asymmetry). `PreviewerRegistry.load_packages` now activates `installed_package_import_roots()` around the entry-point scans. Verified end-to-end in the real packaged-app environment.

## #1753 — Browse returned 500 (ENAMETOOLONG) when re-browsing a multi-file field
A multi-file field's value is an array; `String(array)` built a comma-joined path thousands of characters long, and `os.stat` on a path past `PATH_MAX` raised an uncaught `OSError`. The filesystem endpoints now degrade to a clean 400 for over-length / offline cloud paths; the frontend seeds the browse from the first selected path. Reproduced with the owner's exact path (500 → 400).

Tests added or updated for every fix; the full local pre-PR gate check (lint/format, type, python tests, frontend, audit, import contracts, semantic dup) passed.

Gate record: .workflow/records/1750-hotfix-live-session-20260622.json

Closes #1750
Closes #1751
Closes #1752
Closes #1753
