### PR TITLE
feat(#1758): View Source shows the selected block's source code

### DIFF
--- a/.workflow/records/1758-block-view-source.json
+++ b/.workflow/records/1758-block-view-source.json
@@ -1,0 +1,575 @@
+{
+  "branch": "guided/block-view-source-20260624",
+  "check_events": [
+    {
+      "at": "2026-06-24T22:14:10.701821Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:bfd60039d94763dd91f2f86f6836a9e63605cd20d490321158a1a183dbff39a6",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-24T22:14:49.343260Z",
+      "command": "(cd frontend && npm run check:ci)",
+      "covered_surface": "frontend",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:7b6e807d4b2bb977f884fdd4f224039c10ae9cccaa83635045d319fa95567d4d",
+      "name": "frontend",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/frontend.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-24T22:14:53.313172Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:1768ad67c11ac1edc3841bab7d410d55efe981fb16820823a2b2d90d062c16ed",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-24T22:14:53.816332Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:f4d5f6899fdbb1a088770e7c2b34552f2c7df521118d0c86ccd7fca4a24901eb",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-24T22:14:53.887108Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:c7eae0a9aea3f9a511ff2cecba08f14c67ab78c91ca50dac05befc6f324a1738",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-24T22:17:14.459606Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:7e7afa1a421c0e995f112fa651465f75e86b1ff43b191ce29b1f4bb8a45dee42",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-24T22:19:05.959376Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:294c766e3d63a5e8dc4a33523c123665c81f818c2a7a40fb3a78399661541907",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-24T22:19:11.898484Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:4ead03c7b4179d2e14c04a4b8d18095584442c2a91f8d5f1ecff1b1566e5bfd2",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    }
+  ],
+  "check_na": [],
+  "commit": {
+    "sha": "3141483a3a7c123cb838117bf253bcfd1df6b65e",
+    "shas": [
+      "3141483a3a7c123cb838117bf253bcfd1df6b65e"
+    ],
+    "trailers": []
+  },
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "src/scistudio/api/routes/blocks.py",
+      "src/scistudio/api/schemas.py",
+      "src/scistudio/ai/agent/mcp/tools_authoring.py",
+      "frontend/src/**",
+      "tests/api/**"
+    ]
+  },
+  "directive_events": [],
+  "docs_events": [
+    {
+      "at": "2026-06-24T22:13:11.848488Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/adr/ADR-036.md",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": false,
+  "guard_events": [
+    {
+      "at": "2026-06-24T22:19:11.940108Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-24T22:19:11.949327Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-24T22:19:11.958617Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-24T22:19:11.967821Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-24T22:19:11.977037Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-24T22:19:11.986431Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-24T22:19:11.995595Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-24T22:19:12.006177Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-24T22:19:12.015185Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-24T22:19:12.026366Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-24T22:19:51.639550Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-24T22:19:51.648600Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-24T22:19:51.657581Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-24T22:19:51.666781Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-24T22:19:51.675978Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-24T22:19:51.684676Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-24T22:19:51.693134Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-24T22:19:51.701749Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-24T22:19:51.710449Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-24T22:19:51.720714Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-24T22:20:02.384545Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-24T22:20:02.394544Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-24T22:20:02.404528Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-24T22:20:02.414548Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-24T22:20:02.424315Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-24T22:20:02.433970Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-24T22:20:02.443433Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-24T22:20:02.452802Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-24T22:20:02.461632Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-24T22:20:02.472142Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1758,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": {
+    "base": "origin/main",
+    "base_sha": "bc8279b9",
+    "changed_files": [
+      ".workflow/records/1758-block-view-source.json",
+      "docs/adr/ADR-036.md",
+      "frontend/src/App.parts/useCanvasHandlers.test.tsx",
+      "frontend/src/App.parts/useCanvasHandlers.ts",
+      "frontend/src/App.tsx",
+      "frontend/src/lib/api/blocks.ts",
+      "frontend/src/store/__tests__/tabState.test.ts",
+      "frontend/src/store/index.ts",
+      "frontend/src/store/tabSlice.parts/fileTabActions.ts",
+      "frontend/src/store/tabSlice.ts",
+      "frontend/src/store/types.ts",
+      "frontend/src/types/api.ts",
+      "src/scistudio/api/_block_source.py",
+      "src/scistudio/api/routes/blocks.py",
+      "src/scistudio/api/schemas.py",
+      "tests/api/test_blocks.py"
+    ],
+    "diff_fingerprint": "sha256:4870ea69f75cd3f2045c5f12b035d30001accfba226337bcac29138587966808",
+    "head": "HEAD",
+    "head_sha": "3141483a",
+    "surfaces": {
+      "docs": 1,
+      "frontend": 10,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 13,
+      "packaging": 0,
+      "protected_core": 0,
+      "sentrux": 15,
+      "test": 3,
+      "workflow_ci": 0
+    }
+  },
+  "owner_directive": "View Source: when a block is selected, show that block's source code (core/package/custom), read-only; no selection keeps workflow YAML. Owner confirmed all three origins read-only.",
+  "persona": "live_implementer",
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [
+      1758
+    ],
+    "number": null,
+    "url": null
+  },
+  "reconcile_events": [
+    {
+      "at": "2026-06-24T22:19:12.026401Z",
+      "diff_fingerprint": "sha256:4870ea69f75cd3f2045c5f12b035d30001accfba226337bcac29138587966808",
+      "mode": "local",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-24T22:19:51.720750Z",
+      "diff_fingerprint": "sha256:4870ea69f75cd3f2045c5f12b035d30001accfba226337bcac29138587966808",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-24T22:20:02.472177Z",
+      "diff_fingerprint": "sha256:4870ea69f75cd3f2045c5f12b035d30001accfba226337bcac29138587966808",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    }
+  ],
+  "record_id": "1758-block-view-source",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [
+      "format_check",
+      "frontend",
+      "full_audit",
+      "import_contracts",
+      "lint_format",
+      "python_tests",
+      "semantic_dup",
+      "type_check"
+    ],
+    "docs": [
+      "docs_required_or_na"
+    ],
+    "guards": [
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": [
+      "changed_test_required"
+    ]
+  },
+  "runtime": "claude-opus-4-8",
+  "schema_version": 2,
+  "scope_events": [
+    {
+      "action": "add-include",
+      "at": "2026-06-24T22:13:11.848277Z",
+      "pattern": "src/scistudio/api/_block_source.py",
+      "reason": "Record test evidence and docs for the block View Source feature"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-24T22:13:11.848476Z",
+      "pattern": "frontend/src/store/tabSlice.parts/fileTabActions.ts",
+      "reason": "Record test evidence and docs for the block View Source feature"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-24T22:13:11.848478Z",
+      "pattern": "docs/adr/ADR-036.md",
+      "reason": "Record test evidence and docs for the block View Source feature"
+    }
+  ],
+  "session_id": "57113877-18c9-4400-98a0-ba0eb6659be0",
+  "strictness_tier": 2,
+  "task_kind": "guided",
+  "test_events": [
+    {
+      "at": "2026-06-24T22:13:11.848498Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/api/test_blocks.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-24T22:13:11.848502Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/App.parts/useCanvasHandlers.test.tsx",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-24T22:13:11.848504Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/store/__tests__/tabState.test.ts",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/.workflow/records/1758-block-view-source.json
+++ b/.workflow/records/1758-block-view-source.json
@@ -126,6 +126,51 @@
       "tool_versions": {
         "mypy": "2.1.0"
       }
+    },
+    {
+      "at": "2026-06-24T22:38:25.745589Z",
+      "command": "(cd frontend && npm run check:ci)",
+      "covered_surface": "frontend",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cf7619048bbd1e15ae0e86f35605aca8a2ec81e92799f2e7c64e1b9ef48e5f32",
+      "name": "frontend",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/frontend.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-24T22:38:29.291889Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:a8a57d5774e0e7c52d0132d8bd48dfebb14bc7a6dd319125ada645fd4cb40d4d",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-24T22:40:13.772618Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:9f604cdffd92197470bc25dc7e4611db481bacf9ec2c5d611cf6f21d3f1aafd2",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
     }
   ],
   "check_na": [],
@@ -650,6 +695,88 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-06-24T22:40:13.817232Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-24T22:40:13.826199Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-24T22:40:13.836377Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-24T22:40:13.846200Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-24T22:40:13.855670Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-24T22:40:13.865051Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-24T22:40:13.874455Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-24T22:40:13.884041Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-24T22:40:13.892567Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-24T22:40:13.905181Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -662,7 +789,7 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "bc8279b99a73ad60f02f00d8cfedffe81f59fb26",
+    "base": "origin/main",
     "base_sha": "bc8279b9",
     "changed_files": [
       ".workflow/records/1758-block-view-source.json",
@@ -682,9 +809,9 @@
       "src/scistudio/api/schemas.py",
       "tests/api/test_blocks.py"
     ],
-    "diff_fingerprint": "sha256:e3a1e2d2223101a317284d37bb2f645480bee6a91bc8b01dad55f159d14f0d84",
+    "diff_fingerprint": "sha256:e9263837b9725ce2a13fad51115860786af64482a5b4bd43841014db66cbb3aa",
     "head": "HEAD",
-    "head_sha": "07421dcf",
+    "head_sha": "47a36005",
     "surfaces": {
       "docs": 1,
       "frontend": 10,
@@ -752,6 +879,14 @@
     {
       "at": "2026-06-24T22:20:58.921081Z",
       "diff_fingerprint": "sha256:e3a1e2d2223101a317284d37bb2f645480bee6a91bc8b01dad55f159d14f0d84",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-24T22:40:13.905216Z",
+      "diff_fingerprint": "sha256:e9263837b9725ce2a13fad51115860786af64482a5b4bd43841014db66cbb3aa",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 2,

--- a/.workflow/records/1758-block-view-source.json
+++ b/.workflow/records/1758-block-view-source.json
@@ -130,9 +130,9 @@
   ],
   "check_na": [],
   "commit": {
-    "sha": "3141483a3a7c123cb838117bf253bcfd1df6b65e",
+    "sha": "07421dcf651731ae8264d59bbd043ec9f9ed2a93",
     "shas": [
-      "3141483a3a7c123cb838117bf253bcfd1df6b65e"
+      "07421dcf651731ae8264d59bbd043ec9f9ed2a93"
     ],
     "trailers": []
   },
@@ -404,6 +404,252 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-06-24T22:20:35.552566Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-24T22:20:35.561153Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-24T22:20:35.569757Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-24T22:20:35.578073Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-24T22:20:35.586370Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-24T22:20:35.594608Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-24T22:20:35.603118Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-24T22:20:35.611824Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-24T22:20:35.620192Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-24T22:20:35.631521Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-24T22:20:46.646673Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-24T22:20:46.655235Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-24T22:20:46.663751Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-24T22:20:46.672411Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-24T22:20:46.680949Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-24T22:20:46.689451Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-24T22:20:46.697834Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-24T22:20:46.706536Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-24T22:20:46.714921Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-24T22:20:46.726273Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-24T22:20:58.845368Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-24T22:20:58.853484Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-24T22:20:58.861568Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-24T22:20:58.869683Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-24T22:20:58.877683Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-24T22:20:58.885620Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-24T22:20:58.893519Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-24T22:20:58.902054Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-24T22:20:58.910082Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-24T22:20:58.921053Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -416,7 +662,7 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "origin/main",
+    "base": "bc8279b99a73ad60f02f00d8cfedffe81f59fb26",
     "base_sha": "bc8279b9",
     "changed_files": [
       ".workflow/records/1758-block-view-source.json",
@@ -436,9 +682,9 @@
       "src/scistudio/api/schemas.py",
       "tests/api/test_blocks.py"
     ],
-    "diff_fingerprint": "sha256:4870ea69f75cd3f2045c5f12b035d30001accfba226337bcac29138587966808",
+    "diff_fingerprint": "sha256:e3a1e2d2223101a317284d37bb2f645480bee6a91bc8b01dad55f159d14f0d84",
     "head": "HEAD",
-    "head_sha": "3141483a",
+    "head_sha": "07421dcf",
     "surfaces": {
       "docs": 1,
       "frontend": 10,
@@ -459,7 +705,7 @@
     "closes": [
       1758
     ],
-    "number": null,
+    "number": 1759,
     "url": null
   },
   "reconcile_events": [
@@ -482,6 +728,30 @@
     {
       "at": "2026-06-24T22:20:02.472177Z",
       "diff_fingerprint": "sha256:4870ea69f75cd3f2045c5f12b035d30001accfba226337bcac29138587966808",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-24T22:20:35.631549Z",
+      "diff_fingerprint": "sha256:e3a1e2d2223101a317284d37bb2f645480bee6a91bc8b01dad55f159d14f0d84",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-24T22:20:46.726324Z",
+      "diff_fingerprint": "sha256:e3a1e2d2223101a317284d37bb2f645480bee6a91bc8b01dad55f159d14f0d84",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-24T22:20:58.921081Z",
+      "diff_fingerprint": "sha256:e3a1e2d2223101a317284d37bb2f645480bee6a91bc8b01dad55f159d14f0d84",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 2,

--- a/docs/adr/ADR-036.md
+++ b/docs/adr/ADR-036.md
@@ -126,6 +126,16 @@ New backend routes (project-scoped, `_safe_under` path protection from `routes/f
 - A "View source" affordance (toolbar button when a workflow tab is active) opens a **new read-only tab** whose `tabId` is `source:<workflow_id>` and whose display title is `<workflow_name> (source)`.
 - Re-clicking "View source" focuses the existing source-view tab instead of opening a duplicate (the `source:` prefix in `tabId` is the dedup key).
 - No two-way binding. Editing the source view is disabled. Users wanting to hand-edit a workflow YAML use an external editor or wait for a future "promote to editable" toggle (not in v1).
+- **Block-aware "View source" (#1758).** When a block (node) is selected on the
+  canvas, the same "View source" action opens that block's Python source code
+  instead of the workflow YAML — read-only, for core, package, and custom
+  blocks alike. The source is served by `GET /api/blocks/{block_type}/source`
+  (registry-gated; resolves a custom block's project-local file or a
+  core/package block's import-module file) and rendered inline in a read-only
+  tab with `tabId` `block-source:<block_type>`. Because the source can live
+  outside the project (core/package modules), it does not use the project-file
+  fetch path and the tab is intentionally not persisted across reload. With no
+  block selected, "View source" keeps the workflow-YAML behaviour above.
 
 #### 3.5 Auto-reload on save for `blocks/*.py` — **gated on lint pass**
 

--- a/frontend/src/App.parts/useCanvasHandlers.test.tsx
+++ b/frontend/src/App.parts/useCanvasHandlers.test.tsx
@@ -2,7 +2,7 @@
 // Collection item type. Each edge alone is type-valid (inputs accept
 // DataObject), so the cross-input check lives in handleCanvasConnect and
 // rejects with a banner ("can't connect + top banner" pattern).
-import { renderHook } from "@testing-library/react";
+import { act, renderHook } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { useCanvasHandlers, type CanvasHandlersDeps } from "./useCanvasHandlers";
@@ -97,5 +97,63 @@ describe("useCanvasHandlers — MergeCollection input type validation", () => {
     await result.current.handleCanvasConnect({ source: "load2:data", target: "merge:input_b" });
 
     expect(connectNodes).toHaveBeenCalled();
+  });
+});
+
+describe("useCanvasHandlers — View source routing (#1758)", () => {
+  afterEach(() => vi.clearAllMocks());
+
+  function renderView(overrides: Partial<CanvasHandlersDeps>) {
+    const openFileTab = vi.fn();
+    const openBlockSourceTab = vi.fn();
+    const saveWorkflow = vi.fn().mockResolvedValue(undefined);
+    const deps = {
+      currentProject: { id: "p" },
+      workflowId: "main",
+      workflowNodes: [],
+      workflowEdges: [],
+      activeFileTab: null,
+      addNode: vi.fn(),
+      connectNodes: vi.fn(),
+      openFileTab,
+      selectedNodeId: null,
+      openBlockSourceTab,
+      saveFileTab: vi.fn(),
+      saveWorkflow,
+      setLastError: vi.fn(),
+      schemas: {},
+      ...overrides,
+    } as unknown as CanvasHandlersDeps;
+    const { result } = renderHook(() => useCanvasHandlers(deps));
+    return { result, openFileTab, openBlockSourceTab, saveWorkflow };
+  }
+
+  it("opens the selected block's source instead of the workflow YAML", async () => {
+    const node = { id: "n1", block_type: "load_data" } as unknown as WorkflowNode;
+    const { result, openFileTab, openBlockSourceTab } = renderView({
+      workflowNodes: [node],
+      selectedNodeId: "n1",
+    });
+
+    await act(async () => {
+      await result.current.handleViewSource();
+    });
+
+    expect(openBlockSourceTab).toHaveBeenCalledWith("load_data");
+    expect(openFileTab).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the workflow YAML when no block is selected", async () => {
+    const { result, openFileTab, openBlockSourceTab, saveWorkflow } = renderView({
+      selectedNodeId: null,
+    });
+
+    await act(async () => {
+      await result.current.handleViewSource();
+    });
+
+    expect(saveWorkflow).toHaveBeenCalled();
+    expect(openFileTab).toHaveBeenCalledWith("workflows/main.yaml", { readOnly: true });
+    expect(openBlockSourceTab).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/App.parts/useCanvasHandlers.test.tsx
+++ b/frontend/src/App.parts/useCanvasHandlers.test.tsx
@@ -156,4 +156,22 @@ describe("useCanvasHandlers — View source routing (#1758)", () => {
     expect(openFileTab).toHaveBeenCalledWith("workflows/main.yaml", { readOnly: true });
     expect(openBlockSourceTab).not.toHaveBeenCalled();
   });
+
+  it("falls back to the workflow YAML when an annotation note is selected", async () => {
+    // _annotation nodes are canvas-only pseudo-nodes with no registered source;
+    // routing them to the block-source endpoint would 404 and strand the user.
+    const note = { id: "note1", block_type: "_annotation" } as unknown as WorkflowNode;
+    const { result, openFileTab, openBlockSourceTab, saveWorkflow } = renderView({
+      workflowNodes: [note],
+      selectedNodeId: "note1",
+    });
+
+    await act(async () => {
+      await result.current.handleViewSource();
+    });
+
+    expect(openBlockSourceTab).not.toHaveBeenCalled();
+    expect(saveWorkflow).toHaveBeenCalled();
+    expect(openFileTab).toHaveBeenCalledWith("workflows/main.yaml", { readOnly: true });
+  });
 });

--- a/frontend/src/App.parts/useCanvasHandlers.ts
+++ b/frontend/src/App.parts/useCanvasHandlers.ts
@@ -235,11 +235,14 @@ export function useCanvasHandlers(deps: CanvasHandlersDeps): CanvasHandlers {
 
   const handleViewSource = useCallback(async () => {
     if (!currentProject) return;
-    // #1758: when a block is selected, "View source" shows that block's source
-    // code (core / package / custom) instead of the workflow YAML.
+    // #1758: when a real block is selected, "View source" shows that block's
+    // source code (core / package / custom) instead of the workflow YAML.
+    // Annotation notes (block_type "_annotation") are canvas-only pseudo-nodes
+    // with no registered block source, so they fall through to the workflow
+    // YAML view rather than hitting the source endpoint with a 404.
     if (selectedNodeId) {
       const selected = workflowNodes.find((node) => node.id === selectedNodeId);
-      if (selected?.block_type) {
+      if (selected?.block_type && selected.block_type !== "_annotation") {
         openBlockSourceTab(selected.block_type);
         return;
       }

--- a/frontend/src/App.parts/useCanvasHandlers.ts
+++ b/frontend/src/App.parts/useCanvasHandlers.ts
@@ -62,6 +62,10 @@ export interface CanvasHandlersDeps {
   ) => void;
   connectNodes: (edge: WorkflowEdge) => void;
   openFileTab: (path: string, options?: { readOnly?: boolean }) => void;
+  // #1758: selected canvas node id (or null) + the read-only block-source
+  // opener. When a node is selected, "View source" shows that block's code.
+  selectedNodeId: string | null;
+  openBlockSourceTab: (blockType: string) => void;
   saveFileTab: (tabId: string) => Promise<void>;
   saveWorkflow: () => Promise<void>;
   setLastError: (message: string | null) => void;
@@ -117,6 +121,8 @@ export function useCanvasHandlers(deps: CanvasHandlersDeps): CanvasHandlers {
     addNode,
     connectNodes,
     openFileTab,
+    selectedNodeId,
+    openBlockSourceTab,
     saveFileTab,
     saveWorkflow,
     setLastError,
@@ -228,7 +234,17 @@ export function useCanvasHandlers(deps: CanvasHandlersDeps): CanvasHandlers {
   );
 
   const handleViewSource = useCallback(async () => {
-    if (!currentProject || !workflowId) return;
+    if (!currentProject) return;
+    // #1758: when a block is selected, "View source" shows that block's source
+    // code (core / package / custom) instead of the workflow YAML.
+    if (selectedNodeId) {
+      const selected = workflowNodes.find((node) => node.id === selectedNodeId);
+      if (selected?.block_type) {
+        openBlockSourceTab(selected.block_type);
+        return;
+      }
+    }
+    if (!workflowId) return;
     // #878: ensure the workflow exists on disk before opening its YAML.
     try {
       await saveWorkflow();
@@ -237,7 +253,15 @@ export function useCanvasHandlers(deps: CanvasHandlersDeps): CanvasHandlers {
       return;
     }
     openFileTab(`workflows/${workflowId}.yaml`, { readOnly: true });
-  }, [currentProject, openFileTab, saveWorkflow, workflowId]);
+  }, [
+    currentProject,
+    selectedNodeId,
+    workflowNodes,
+    openBlockSourceTab,
+    openFileTab,
+    saveWorkflow,
+    workflowId,
+  ]);
 
   const handleSave = useCallback(() => {
     // ADR-036 §3.7 — route Save by active tab kind.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -178,6 +178,7 @@ export default function App() {
   const saveFileTab = useAppStore((state) => state.saveFileTab);
   const updateFileTabContent = useAppStore((state) => state.updateFileTabContent);
   const openFileTab = useAppStore((state) => state.openFileTab);
+  const openBlockSourceTab = useAppStore((state) => state.openBlockSourceTab);
 
   // ADR-036 §3.7 — derive the active tab + its kind for the toolbar swap.
   const activeTab = useMemo<AnyTab | null>(() => {
@@ -219,7 +220,6 @@ export default function App() {
     () => workflowNodes.find((node) => node.id === selectedNodeId) ?? null,
     [selectedNodeId, workflowNodes],
   );
-  const selectedSchema = selectedNode ? blockSchemas[selectedNode.block_type] : undefined;
   const selectedNodeLabel =
     blocks.find((block) => block.type_name === selectedNode?.block_type)?.name ??
     selectedNode?.block_type ??
@@ -317,6 +317,8 @@ export default function App() {
       addNode,
       connectNodes,
       openFileTab,
+      selectedNodeId,
+      openBlockSourceTab,
       saveFileTab,
       saveWorkflow,
       setLastError,
@@ -484,7 +486,7 @@ export default function App() {
               logEntries={logEntries}
               unreadLogsCount={unreadLogsCount}
               selectedNode={selectedNode}
-              selectedSchema={selectedSchema}
+              selectedSchema={selectedNode ? blockSchemas[selectedNode.block_type] : undefined}
               selectedNodeLabel={selectedNodeLabel}
               setPanelSize={setPanelSize}
             />

--- a/frontend/src/lib/api/blocks.ts
+++ b/frontend/src/lib/api/blocks.ts
@@ -7,6 +7,7 @@
 import type {
   BlockListResponse,
   BlockSchemaResponse,
+  BlockSourceResponse,
   ConnectionValidationResponse,
 } from "../../types/api";
 import { apiFetch, JSON_HEADERS } from "./core";
@@ -15,6 +16,10 @@ export const blocksApi = {
   listBlocks: () => apiFetch<BlockListResponse>("/api/blocks/"),
   getBlockSchema: (blockType: string) =>
     apiFetch<BlockSchemaResponse>(`/api/blocks/${encodeURIComponent(blockType)}/schema`),
+  // #1758: read-only source for a selected block (core / package / custom),
+  // backing the homepage "View source" action when a block is selected.
+  getBlockSource: (blockType: string) =>
+    apiFetch<BlockSourceResponse>(`/api/blocks/${encodeURIComponent(blockType)}/source`),
   // #889: ``source_node_config`` / ``target_node_config`` let the
   // backend resolve effective ports for LoadData (``core_type``
   // chooses the output type) and variadic blocks (config-declared

--- a/frontend/src/store/__tests__/tabState.test.ts
+++ b/frontend/src/store/__tests__/tabState.test.ts
@@ -21,6 +21,7 @@ vi.mock("../../lib/api", async () => {
       ...actual.api,
       getProjectFile: vi.fn(),
       putProjectFile: vi.fn(),
+      getBlockSource: vi.fn(),
     },
   };
 });
@@ -29,6 +30,7 @@ import { api } from "../../lib/api";
 
 const getProjectFileMock = vi.mocked(api.getProjectFile);
 const putProjectFileMock = vi.mocked(api.putProjectFile);
+const getBlockSourceMock = vi.mocked(api.getBlockSource);
 
 function resetStore(): void {
   useAppStore.setState({
@@ -55,6 +57,7 @@ beforeEach(() => {
   resetStore();
   getProjectFileMock.mockReset();
   putProjectFileMock.mockReset();
+  getBlockSourceMock.mockReset();
 });
 
 afterEach(() => {
@@ -318,5 +321,75 @@ describe("saveFileTab (ADR-036 §3.10)", () => {
     expect(tab.content).toBe("y = 2\n");
     expect(tab.dirty).toBe(false);
     expect(tab.contentLoadedAt).toBe(42);
+  });
+});
+
+describe("openBlockSourceTab (#1758)", () => {
+  it("opens a read-only inline tab from the block source endpoint", async () => {
+    getBlockSourceMock.mockResolvedValue({
+      block_type: "load_data",
+      path: "/abs/src/scistudio/blocks/io/loaders/load_data.py",
+      source: "class LoadData:\n    pass\n",
+      language: "python",
+      origin: "builtin",
+    });
+
+    useAppStore.getState().openBlockSourceTab("load_data");
+    await new Promise((r) => setTimeout(r, 0));
+
+    const tab = useAppStore.getState().tabs.find((t) => t.id === "block-source:load_data");
+    expect(tab).toBeDefined();
+    expect(tab?.kind).toBe("file");
+    if (tab?.kind !== "file") throw new Error("expected file tab");
+    expect(tab.readOnly).toBe(true);
+    expect(tab.blockSourceType).toBe("load_data");
+    expect(tab.content).toContain("class LoadData");
+    expect(tab.displayName).toBe("load_data.py (source)");
+    expect(tab.loading).toBe(false);
+    expect(getBlockSourceMock).toHaveBeenCalledWith("load_data");
+  });
+
+  it("re-focuses an already-open block-source tab without refetching", async () => {
+    getBlockSourceMock.mockResolvedValue({
+      block_type: "load_data",
+      path: "/abs/load_data.py",
+      source: "class LoadData: ...",
+      language: "python",
+      origin: "builtin",
+    });
+
+    useAppStore.getState().openBlockSourceTab("load_data");
+    await new Promise((r) => setTimeout(r, 0));
+    useAppStore.getState().openBlockSourceTab("load_data");
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(getBlockSourceMock).toHaveBeenCalledTimes(1);
+    expect(useAppStore.getState().activeTabId).toBe("block-source:load_data");
+  });
+
+  it("is excluded from persistence so a reload does not strand it", () => {
+    // Block-source tabs are transient: persisting them would leave an empty,
+    // un-refetchable placeholder after reload.
+    const persisted = JSON.parse(localStorage.getItem("scistudio-studio-ui") ?? "{}");
+    useAppStore.setState({
+      tabs: [
+        {
+          kind: "file",
+          id: "block-source:load_data",
+          filePath: "/abs/load_data.py",
+          displayName: "load_data.py (source)",
+          language: "python",
+          content: "class LoadData: ...",
+          contentLoadedAt: 0,
+          dirty: false,
+          readOnly: true,
+          blockSourceType: "load_data",
+        },
+      ],
+    });
+    const after = JSON.parse(localStorage.getItem("scistudio-studio-ui") ?? "{}");
+    const tabs = after?.state?.tabs ?? [];
+    expect(tabs.some((t: { id: string }) => t.id === "block-source:load_data")).toBe(false);
+    void persisted;
   });
 });

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -39,7 +39,15 @@ function partializeFileTab(tab: FileTab): FileTab {
 }
 
 function partializeTabs(tabs: TabState[]): TabState[] {
-  return tabs.map((tab) => (tab.kind === "file" ? partializeFileTab(tab) : tab));
+  return (
+    tabs
+      // #1758: block-source ("View source") tabs are transient — their content
+      // comes from the block registry, not a project file, and has no
+      // rehydrate-refetch path. Drop them from persistence so a reload does not
+      // leave a permanently-empty placeholder.
+      .filter((tab) => !(tab.kind === "file" && tab.blockSourceType))
+      .map((tab) => (tab.kind === "file" ? partializeFileTab(tab) : tab))
+  );
 }
 
 // ADR-040 Addendum 5 / #1488: sentinel for the active-workflow sync

--- a/frontend/src/store/tabSlice.parts/fileTabActions.ts
+++ b/frontend/src/store/tabSlice.parts/fileTabActions.ts
@@ -105,14 +105,105 @@ export function createOpenFileTab(set: StoreSetter, get: StoreGetter): TabSlice[
       .catch((err) => {
         const message = err instanceof ApiError ? err.message : String(err);
         window.alert(`Failed to open ${filePath}: ${message}`);
+        removeFailedTab(get, set, id);
+      });
+  };
+}
+
+// #1758 — drop a placeholder tab whose content fetch failed, restoring focus
+// to the last remaining tab. Shared by the file and block-source open paths.
+function removeFailedTab(get: StoreGetter, set: StoreSetter, id: string): void {
+  const after = get();
+  const remaining = after.tabs.filter((t) => t.id !== id);
+  const fallback = remaining[remaining.length - 1] ?? null;
+  if (fallback) {
+    set({ tabs: remaining, ...restoreTab(fallback) });
+  } else {
+    set({ tabs: remaining, activeTabId: null });
+  }
+}
+
+/**
+ * #1758 — open a read-only tab showing a registered block's source code.
+ *
+ * Unlike {@link createOpenFileTab}, the source is fetched from
+ * ``GET /api/blocks/{blockType}/source`` and rendered inline: the block's file
+ * lives outside the project (core/package blocks resolve to importable module
+ * files), so it cannot go through the project-file fetch path. The tab is
+ * tagged with ``blockSourceType`` and is intentionally not persisted across
+ * reload (see ``partializeTabs``).
+ */
+export function createOpenBlockSourceTab(
+  set: StoreSetter,
+  get: StoreGetter,
+): TabSlice["openBlockSourceTab"] {
+  return (blockType) => {
+    const state = get();
+    const id = `block-source:${blockType}`;
+
+    const existing = state.tabs.find((t) => t.id === id);
+    const needsRefetch = Boolean(existing && existing.kind === "file" && existing.loading);
+    if (existing && !needsRefetch) {
+      state.switchTab(id);
+      return;
+    }
+
+    if (!existing) {
+      if (state.tabs.length >= 50) {
+        window.alert("Maximum 50 tabs reached.");
+        return;
+      }
+      const placeholder: FileTab = {
+        kind: "file",
+        id,
+        // Replaced with the resolved absolute path once the fetch resolves.
+        filePath: blockType,
+        displayName: `${blockType} (source)`,
+        language: "python",
+        content: "",
+        contentLoadedAt: 0,
+        baseVersion: null,
+        pendingVersion: null,
+        pendingSourceId: null,
+        conflict: null,
+        dirty: false,
+        readOnly: true,
+        loading: true,
+        blockSourceType: blockType,
+      };
+      const currentActive = state.tabs.find((t) => t.id === state.activeTabId) ?? null;
+      const updatedTabs = currentActive
+        ? state.tabs.map((t) => (t.id === state.activeTabId ? captureActiveTab(state, t) : t))
+        : [...state.tabs];
+      set({ tabs: [...updatedTabs, placeholder], activeTabId: id });
+    } else {
+      state.switchTab(id);
+    }
+
+    api
+      .getBlockSource(blockType)
+      .then((response) => {
         const after = get();
-        const remaining = after.tabs.filter((t) => t.id !== id);
-        const fallback = remaining[remaining.length - 1] ?? null;
-        if (fallback) {
-          set({ tabs: remaining, ...restoreTab(fallback) });
-        } else {
-          set({ tabs: remaining, activeTabId: null });
-        }
+        const current = after.tabs.find((t) => t.id === id);
+        if (!current || current.kind !== "file") return;
+        const populated: FileTab = {
+          ...current,
+          filePath: response.path,
+          displayName: `${basename(response.path)} (source)`,
+          content: response.source,
+          contentLoadedAt: 0,
+          baseVersion: null,
+          pendingVersion: null,
+          pendingSourceId: null,
+          conflict: null,
+          loading: false,
+        };
+        set(replaceTab(after, id, populated));
+      })
+      .catch((err) => {
+        const message = err instanceof ApiError ? err.message : String(err);
+        window.alert(`Failed to open source for ${blockType}: ${message}`);
+        removeFailedTab(get, set, id);
       });
   };
 }

--- a/frontend/src/store/tabSlice.ts
+++ b/frontend/src/store/tabSlice.ts
@@ -5,6 +5,7 @@ import {
   createApplyFileRemoteContent,
   createConfirmFileVersion,
   createMarkFileRemoteConflict,
+  createOpenBlockSourceTab,
   createOpenFileTab,
   createSaveFileTab,
   createUpdateFileTabContent,
@@ -26,6 +27,7 @@ export const createTabSlice: StateCreator<AppStore, [], [], TabSlice> = (set, ge
   syncActiveTab: createSyncActiveTab(set, get),
 
   openFileTab: createOpenFileTab(set, get),
+  openBlockSourceTab: createOpenBlockSourceTab(set, get),
   saveFileTab: createSaveFileTab(set, get),
   updateFileTabContent: createUpdateFileTabContent(set, get),
   confirmFileVersion: createConfirmFileVersion(set, get),

--- a/frontend/src/store/types.ts
+++ b/frontend/src/store/types.ts
@@ -414,6 +414,13 @@ export interface FileTab {
    * ``content`` is populated.
    */
   loading?: boolean;
+  /**
+   * #1758: set when this is a read-only "View source" tab for a registered
+   * block type (core / package / custom). Its ``content`` comes from
+   * ``GET /api/blocks/{blockType}/source`` rather than a project file, so the
+   * tab is not persisted across reload (see ``partializeTabs``).
+   */
+  blockSourceType?: string;
 }
 
 /**
@@ -455,6 +462,13 @@ export interface TabSlice {
    *      language from extension, build a FileTab, append to tabs, set active.
    */
   openFileTab: (filePath: string, opts?: { readOnly?: boolean }) => void;
+  /**
+   * #1758 — open a read-only tab showing a registered block's source code
+   * (core / package / custom). Fetches ``GET /api/blocks/{blockType}/source``
+   * and renders the returned source inline (the file lives outside the
+   * project, so it cannot use the project-file fetch path).
+   */
+  openBlockSourceTab: (blockType: string) => void;
   /**
    * ADR-036 §3.10 — save a file tab's content to disk.
    *

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -205,6 +205,15 @@ export interface BlockListResponse {
   blocks: BlockSummary[];
 }
 
+/** Read-only source code backing a registered block type (#1758). */
+export interface BlockSourceResponse {
+  block_type: string;
+  path: string;
+  source: string;
+  language: string;
+  origin: string;
+}
+
 export interface ConnectionValidationResponse {
   compatible: boolean;
   reason: string;

--- a/src/scistudio/api/_block_source.py
+++ b/src/scistudio/api/_block_source.py
@@ -1,0 +1,99 @@
+"""Resolve a registered block type to its on-disk Python source (read-only).
+
+Backs ``GET /api/blocks/{block_type}/source`` (#1758). The block's source
+file is resolved from its registry spec — the project-local file path for
+custom (tier-1) blocks, otherwise the import module's file for core and
+package blocks — so the homepage "View source" action can show a selected
+block's code regardless of origin. Resolution is read-only and limited to
+registered block types; no arbitrary filesystem path is ever exposed.
+"""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+from pathlib import Path
+from typing import Any
+
+
+class BlockSourceUnavailableError(Exception):
+    """A block type is registered but its source file cannot be located/read."""
+
+
+def map_block_origin(raw: str) -> str:
+    """Map an internal registry source label to a palette-friendly origin.
+
+    ``tier1`` -> ``custom`` (project-local hot-loaded blocks); ``entry_point``
+    / ``monorepo`` / ``package_src`` -> ``package`` (installed plugin blocks);
+    ``builtin`` -> ``builtin`` (core blocks). Unknown labels pass through.
+    """
+    if raw == "tier1":
+        return "custom"
+    if raw in ("entry_point", "monorepo", "package_src"):
+        return "package"
+    if raw == "builtin":
+        return "builtin"
+    return raw
+
+
+def resolve_block_source(registry: Any, block_type: str) -> dict[str, str]:
+    """Return ``{path, source, language, origin}`` for a registered block type.
+
+    Raises:
+        KeyError: the block type is not registered.
+        BlockSourceUnavailableError: the type is registered but its source file
+            cannot be located or read.
+    """
+    spec = registry.get_spec(block_type)
+    if spec is None:
+        raise KeyError(block_type)
+
+    path = _source_path(spec)
+    if path is None or not path.exists():
+        raise BlockSourceUnavailableError(f"no source file for block type '{block_type}'")
+    try:
+        source = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise BlockSourceUnavailableError(f"could not read source for '{block_type}': {exc}") from exc
+
+    return {
+        "path": str(path),
+        "source": source,
+        "language": "python",
+        "origin": _origin(spec),
+    }
+
+
+def _source_path(spec: Any) -> Path | None:
+    """Locate the ``.py`` file backing *spec*, or ``None`` if unresolvable."""
+    # Tier-1 custom blocks carry the concrete project-local file path.
+    file_path = getattr(spec, "file_path", None)
+    if file_path:
+        return Path(str(file_path))
+    # Core and package blocks resolve through their import module.
+    module_path = getattr(spec, "module_path", "") or ""
+    if module_path:
+        try:
+            module = importlib.import_module(module_path)
+            return Path(inspect.getfile(module))
+        except (ImportError, TypeError, OSError):
+            return None
+    return None
+
+
+def _origin(spec: Any) -> str:
+    """Best-effort block origin for display ("builtin" / "package" / "custom").
+
+    The import root is the authoritative core-vs-package signal: core blocks
+    live under ``scistudio.blocks.*`` while plugin packages import from their
+    own roots (e.g. ``scistudio_blocks_*``). The registry tier label is not
+    used for that split because core blocks are themselves registered through
+    entry points (source ``entry_point``), which would mislabel them as
+    ``package``. A project-local file path always means a custom block.
+    """
+    if getattr(spec, "file_path", None) or map_block_origin((getattr(spec, "source", "") or "").strip()) == "custom":
+        return "custom"
+    module_path = getattr(spec, "module_path", "") or ""
+    if module_path.startswith("scistudio.blocks.") or module_path == "scistudio.blocks":
+        return "builtin"
+    return "package"

--- a/src/scistudio/api/routes/blocks.py
+++ b/src/scistudio/api/routes/blocks.py
@@ -9,12 +9,20 @@ from typing import Annotated, Any, cast
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
+from scistudio.api._block_source import (
+    BlockSourceUnavailableError,
+    resolve_block_source,
+)
+from scistudio.api._block_source import (
+    map_block_origin as _map_source,
+)
 from scistudio.api.deps import get_block_registry, get_type_registry
 from scistudio.api.schemas import (
     BlockConnectionValidation,
     BlockListResponse,
     BlockPortResponse,
     BlockSchemaResponse,
+    BlockSourceResponse,
     BlockSummary,
     ConnectionValidationResponse,
     FormatCapabilityResponse,
@@ -65,22 +73,6 @@ def _config_schema_for_block(spec: Any, registry: Any = None, type_registry: Any
     AI agent (MCP ``get_block_schema`` / ``list_blocks``) stay in lockstep.
     """
     return enrich_io_config_schema(spec, registry, type_registry)
-
-
-def _map_source(raw: str) -> str:
-    """Map internal source labels to palette-friendly values.
-
-    tier1 -> "custom" (project-local hot-loaded blocks)
-    entry_point / monorepo / package_src -> "package" (installed plugin blocks)
-    builtin -> "builtin" (core blocks)
-    """
-    if raw == "tier1":
-        return "custom"
-    if raw in ("entry_point", "monorepo", "package_src"):
-        return "package"
-    if raw == "builtin":
-        return "builtin"
-    return raw
 
 
 def _format_capability_response(capability: Any) -> FormatCapabilityResponse:
@@ -351,6 +343,27 @@ async def get_block_schema(
         min_output_ports=getattr(spec, "min_output_ports", None),
         max_output_ports=getattr(spec, "max_output_ports", None),
     )
+
+
+@router.get("/{block_type}/source", response_model=BlockSourceResponse)
+async def get_block_source(
+    block_type: str,
+    registry: BlockRegistryDep,
+) -> BlockSourceResponse:
+    """Return the read-only Python source backing a registered block type.
+
+    Powers the homepage "View source" action when a block is selected on the
+    canvas (#1758): core, package, and custom blocks alike resolve to their
+    on-disk source file. Read-only and registry-gated — only a registered
+    block type resolves, never an arbitrary filesystem path.
+    """
+    try:
+        resolved = resolve_block_source(registry, block_type)
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail=f"Unknown block type: {block_type}") from exc
+    except BlockSourceUnavailableError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    return BlockSourceResponse(block_type=block_type, **resolved)
 
 
 def _resolve_effective_port(

--- a/src/scistudio/api/schemas.py
+++ b/src/scistudio/api/schemas.py
@@ -156,6 +156,16 @@ class BlockListResponse(BaseModel):
     blocks: list[BlockSummary] = Field(default_factory=list)
 
 
+class BlockSourceResponse(BaseModel):
+    """Read-only source code backing a registered block type (#1758)."""
+
+    block_type: str = Field(description="Registered block type name the source belongs to.")
+    path: str = Field(description="Absolute filesystem path of the block's source file.")
+    source: str = Field(description="Full source text of the block's file.")
+    language: str = Field(default="python", description="Source language (always 'python' today).")
+    origin: str = Field(description="Block origin: 'builtin' | 'package' | 'custom'.")
+
+
 class BlockSchemaResponse(BlockSummary):
     """Detailed schema payload for a single block type."""
 

--- a/tests/api/test_blocks.py
+++ b/tests/api/test_blocks.py
@@ -451,3 +451,22 @@ def test_lcms_srs_blocks_have_domain_prefix(client: TestClient) -> None:
         assert block["type_name"].startswith("srs."), (
             f"SRS block {block['name']} missing 'srs.' prefix: {block['type_name']}"
         )
+
+
+def test_block_source_endpoint_returns_core_block_source(client: TestClient) -> None:
+    """#1758: GET /api/blocks/{type}/source returns a core block's source."""
+    response = client.get("/api/blocks/load_data/source")
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["block_type"] == "load_data"
+    assert payload["language"] == "python"
+    assert payload["origin"] == "builtin"
+    assert payload["path"].endswith("load_data.py")
+    # The returned text is the real module source, not a placeholder.
+    assert "class LoadData" in payload["source"]
+
+
+def test_block_source_endpoint_unknown_type_is_404(client: TestClient) -> None:
+    """An unregistered block type resolves to 404, not a server error."""
+    response = client.get("/api/blocks/no_such_block_type/source")
+    assert response.status_code == 404


### PR DESCRIPTION
## Summary

The homepage **View Source** toolbar action previously only opened the workflow's source YAML. It is now block-aware: when a block (node) is selected on the canvas, "View Source" opens **that block's Python source code** — read-only — for core builtins, package/plugin blocks, and user custom (tier-1) blocks alike. With no block selected, the action keeps its current workflow-YAML behaviour.

## Changes

### Backend
- New `GET /api/blocks/{block_type}/source` → `{block_type, path, source, language, origin}`. Resolution (`src/scistudio/api/_block_source.py`) is registry-gated: a custom block resolves via its project-local `file_path`; core/package blocks resolve via their import module's file (`inspect.getfile`). Only a registered block type resolves — never an arbitrary filesystem path. `origin` is derived from the import root (`scistudio.blocks.*` → builtin) so core blocks are not mislabeled as `package` by their entry-point registration.
- The palette `_map_source` origin mapper moved into `_block_source.py` as the single source of truth (re-imported by the blocks route).

### Frontend
- `getBlockSource(blockType)` API client.
- `openBlockSourceTab(blockType)` store action: opens a read-only Monaco tab whose content comes inline from the endpoint (the block file lives outside the project, so it cannot use the project-file fetch path). Tab id `block-source:<type>`; re-clicking re-focuses without refetching.
- `handleViewSource` routes to the selected block's source when a node is selected, else the workflow YAML.
- Block-source tabs are excluded from tab persistence (`partializeTabs`) — they have no rehydrate-refetch path, so persisting would strand an empty placeholder after reload.

### Docs / tests
- ADR-036 §3.4 block-aware "View source" note.
- Endpoint tests (core block source + 404 for unknown), `handleViewSource` routing tests, and `openBlockSourceTab` store-action + persistence-exclusion tests.

## Notes

No protected core paths touched (resolution lives in the API layer and reads the registry; `src/scistudio/blocks/**` is unchanged).

Gate record: .workflow/records/1758-block-view-source.json

Closes #1758
