### PR TITLE
fix(#1772): installed plugin blocks resolve shared-site deps; fix external-app PATH and install hints

### DIFF
--- a/.workflow/records/1772-guided-plugin-shared-deps-20260625.json
+++ b/.workflow/records/1772-guided-plugin-shared-deps-20260625.json
@@ -1,0 +1,1201 @@
+{
+  "branch": "guided/plugin-shared-deps-20260625",
+  "check_events": [
+    {
+      "at": "2026-06-25T21:21:20.844670Z",
+      "command": "pytest tests/architecture/ -v --no-cov",
+      "covered_surface": "architecture",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:39b4f45d19abaf51ca2911ea8e22f4d20369bb4dee4a5f230b3d72da78e9690a",
+      "name": "architecture_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/architecture_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-25T21:21:21.526311Z",
+      "command": "python scripts/deferral_scan.py --check docs/audit/baselines/deferral-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:a9c28d8ba756edf8687dc4d8f95977be1c5fe1e49a687d72a02097c7bca37051",
+      "name": "deferral_discipline",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/deferral_discipline.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-25T21:21:21.887147Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:862b2b8991c78b1da54b06a1784abd2b8d27102ea1382bab809008a6408fa863",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-25T21:21:25.336718Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:56d738996f730ebfd7f8dfd761ac61e3a3eff5945f0d231d22aeff215461308f",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-25T21:21:25.824701Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:0242d8ca9b3ac282141f331ee630f2cd3c0ce0fd8ee575c9d9c495165497d96b",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-25T21:21:25.866064Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:d99fa8b9b78694cbbfa0468ebc03a1477e6da2b4666907eebeab74fb7ae1beaf",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-25T21:23:48.805747Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:eb3100963d5b15880edf31c691409ed7f0e479a55bfd753f968eabcbfaa3db97",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-25T21:25:36.121300Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:ce71c65e5752e622fe4a92fce1699d3b5f66301a108c268f5c81e522d786b2cc",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-25T21:25:42.767878Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:9f06e1e4be4d10993301973f0bf7ef05974cc5149ae0eb599208fa57d8b534d5",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    },
+    {
+      "at": "2026-06-25T21:26:26.345659Z",
+      "command": "pytest tests/architecture/ -v --no-cov",
+      "covered_surface": "architecture",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:730389eb79235727f1b97905f4803ed0867c29aeb3a9797f60ef027e66813049",
+      "name": "architecture_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/architecture_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-25T21:26:27.033301Z",
+      "command": "python scripts/deferral_scan.py --check docs/audit/baselines/deferral-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:8e6a469f17cac21f1d3970847053c103837f30d168f26dbe34b0f18a7c27a731",
+      "name": "deferral_discipline",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/deferral_discipline.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-25T21:26:27.081814Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:6785aa5ea2da94b56200c63807c8076e6c8cd8ca0e591032681284b706d91c53",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-25T21:26:30.668200Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:af80080dcc75a04108ed60fee514e6a31d9bec5ec11717c82bbdf11753ed3b46",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-25T21:26:30.777750Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:db93b86d7f2933ad9d63cb0f3fd052407c55b1950c3467ae9e685f02e29fd197",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-25T21:26:30.796538Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:7e21304e3d18a8521e2d919a015e0b7ce340d1f55811c946d3b8fb2dfce55c03",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-25T21:28:23.518901Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:332d04ac5ca3386ef163fb7bd0d6bc7af45c6a13310a89ff089cb122b32c33e5",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-25T21:30:14.587268Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:79f167c63a4fbb985b9c1b352f85a74d081b21dbae8fd4071e86a85af74ac678",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-25T21:30:15.344770Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:b04353b937d33fe14be9005947af582e2fe4b4d5f83261447fbf7868bf2dd285",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    }
+  ],
+  "check_na": [],
+  "commit": {
+    "sha": "168a8147f528a68ed5be57ff512ad814e3947b11",
+    "shas": [
+      "168a8147f528a68ed5be57ff512ad814e3947b11"
+    ],
+    "trailers": []
+  },
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "src/scistudio/blocks/registry/_scan.py",
+      "src/scistudio/blocks/app/bridge.py",
+      "packages/scistudio-blocks-imaging/src/scistudio_blocks_imaging/segmentation/cellpose_segment.py",
+      "packages/scistudio-blocks-imaging/src/scistudio_blocks_imaging/io/bioformats_handler.py"
+    ]
+  },
+  "directive_events": [
+    {
+      "at": "2026-06-25T21:10:40.922848Z",
+      "owner_directive": "PATH gap for external apps (napari) is in scope; fix the bioformats hint string too alongside cellpose.",
+      "reason": "Owner authorized protected-core changes to blocks/registry/_scan.py and blocks/app/bridge.py for the worker-import-roots and external-app PATH fixes (design 1)."
+    },
+    {
+      "at": "2026-06-25T21:20:28.485385Z",
+      "owner_directive": "Design 1 (worker reads shared site) + external-app PATH fix + correct cellpose/bioformats install hints.",
+      "reason": "plan"
+    }
+  ],
+  "docs_events": [
+    {
+      "at": "2026-06-25T21:18:50.412939Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/specs/adr-043-package-migration.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-25T21:18:50.412955Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/specs/phase11-imaging-block-spec.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-25T21:20:28.485517Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/specs/adr-043-package-migration.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-25T21:20:28.485530Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/specs/phase11-imaging-block-spec.md",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": false,
+  "guard_events": [
+    {
+      "at": "2026-06-25T21:25:42.821608Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/app/bridge.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/app/bridge.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/registry/_scan.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/registry/_scan.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T21:25:42.831391Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T21:25:42.840618Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T21:25:42.849419Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T21:25:42.858297Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T21:25:42.867127Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T21:25:42.875852Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T21:25:42.884482Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T21:25:42.892809Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T21:25:42.902854Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T21:30:15.397365Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/app/bridge.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/app/bridge.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/registry/_scan.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/registry/_scan.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T21:30:15.406885Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T21:30:15.416511Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T21:30:15.426572Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T21:30:15.436868Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T21:30:15.446703Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T21:30:15.456282Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T21:30:15.465274Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T21:30:15.474205Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T21:30:15.485537Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T21:36:09.854707Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/app/bridge.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/app/bridge.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/registry/_scan.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/registry/_scan.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T21:36:09.863079Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T21:36:09.871702Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T21:36:09.880409Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T21:36:09.889132Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T21:36:09.898360Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T21:36:09.907247Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T21:36:09.915869Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T21:36:09.928579Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T21:36:09.939987Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T21:36:48.117906Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/app/bridge.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/app/bridge.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/registry/_scan.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/registry/_scan.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T21:36:48.126286Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T21:36:48.134814Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T21:36:48.143296Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T21:36:48.151609Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T21:36:48.160267Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T21:36:48.168806Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T21:36:48.177013Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T21:36:48.185151Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T21:36:48.196325Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T21:37:41.972406Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/app/bridge.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/app/bridge.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/registry/_scan.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/registry/_scan.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T21:37:41.981560Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T21:37:41.990527Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T21:37:41.999509Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T21:37:42.009307Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T21:37:42.019382Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T21:37:42.028506Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T21:37:42.037290Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T21:37:42.046565Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T21:37:42.059280Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1772,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": {
+    "base": "91395b815aae8f937bdd91f08706a695a31b3061",
+    "base_sha": "91395b81",
+    "changed_files": [
+      ".workflow/records/1772-guided-plugin-shared-deps-20260625.json",
+      "docs/specs/adr-043-package-migration.md",
+      "docs/specs/phase11-imaging-block-spec.md",
+      "packages/scistudio-blocks-imaging/src/scistudio_blocks_imaging/io/bioformats_handler.py",
+      "packages/scistudio-blocks-imaging/src/scistudio_blocks_imaging/segmentation/cellpose_segment.py",
+      "packages/scistudio-blocks-imaging/tests/test_bioformats_handler.py",
+      "packages/scistudio-blocks-imaging/tests/test_cellpose_segment.py",
+      "src/scistudio/blocks/app/bridge.py",
+      "src/scistudio/blocks/registry/_scan.py",
+      "src/scistudio/desktop/paths.py",
+      "tests/blocks/test_bridge_extended.py",
+      "tests/blocks/test_desktop_package_discovery.py"
+    ],
+    "diff_fingerprint": "sha256:dbaa7600dd8c9607595442ed98daf89f0887c72c251678c0afd4e64537eef2ef",
+    "head": "HEAD",
+    "head_sha": "168a8147",
+    "surfaces": {
+      "docs": 2,
+      "frontend": 0,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 5,
+      "packaging": 0,
+      "protected_core": 2,
+      "sentrux": 11,
+      "test": 4,
+      "workflow_ci": 0
+    }
+  },
+  "owner_directive": "Fix installed plugin blocks so the worker reads the shared user site (design 1): add shared site to runtime import roots; fix external-app launch PATH so napari console scripts are found; correct the misleading cellpose and bioformats [extra] install-hint strings.",
+  "persona": "live_implementer",
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [
+      1772
+    ],
+    "number": 1774,
+    "url": null
+  },
+  "reconcile_events": [
+    {
+      "at": "2026-06-25T21:25:42.902917Z",
+      "diff_fingerprint": "sha256:605fae15647a07a5bce547762d288680232d15e06dfb0638e9e3fccba7c23927",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.format_check",
+        "scope.out-of-scope"
+      ]
+    },
+    {
+      "at": "2026-06-25T21:30:15.485566Z",
+      "diff_fingerprint": "sha256:570db200970fddaad2e6a301816fa316f1c247eb461b5c2d728a8a0c4fd8d30b",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-25T21:36:09.940014Z",
+      "diff_fingerprint": "sha256:570db200970fddaad2e6a301816fa316f1c247eb461b5c2d728a8a0c4fd8d30b",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-25T21:36:48.196357Z",
+      "diff_fingerprint": "sha256:78603256d4b227b265acae9c60a9725d8b0dd35ff827379025c80ed5862bfeb6",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-25T21:37:42.059324Z",
+      "diff_fingerprint": "sha256:dbaa7600dd8c9607595442ed98daf89f0887c72c251678c0afd4e64537eef2ef",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    }
+  ],
+  "record_id": "1772-guided-plugin-shared-deps-20260625",
+  "requested_admin_labels": [
+    {
+      "actor_permission": null,
+      "applied_at": null,
+      "applied_by": null,
+      "name": "admin-approved:core-change"
+    }
+  ],
+  "required_obligations": {
+    "admin_labels": [
+      "admin-approved:core-change"
+    ],
+    "checks": [
+      "architecture_tests",
+      "deferral_discipline",
+      "format_check",
+      "full_audit",
+      "import_contracts",
+      "lint_format",
+      "python_tests",
+      "semantic_dup",
+      "type_check"
+    ],
+    "docs": [
+      "docs_required_or_na"
+    ],
+    "guards": [
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": [
+      "changed_test_required"
+    ]
+  },
+  "runtime": "claude-code",
+  "schema_version": 2,
+  "scope_events": [
+    {
+      "action": "add-include",
+      "at": "2026-06-25T21:18:50.412782Z",
+      "pattern": "docs/specs/adr-043-package-migration.md",
+      "reason": "Specs codify the old misleading install command as contract; updating them to match the corrected runtime guidance keeps spec/code consistent."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-25T21:18:50.412931Z",
+      "pattern": "docs/specs/phase11-imaging-block-spec.md",
+      "reason": "Specs codify the old misleading install command as contract; updating them to match the corrected runtime guidance keeps spec/code consistent."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-25T21:25:59.972214Z",
+      "pattern": "src/scistudio/desktop/paths.py",
+      "reason": "Include test files and the desktop paths helper added for the import-roots/PATH fixes; they were recorded as test paths but not as scope includes."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-25T21:25:59.972343Z",
+      "pattern": "tests/blocks/test_desktop_package_discovery.py",
+      "reason": "Include test files and the desktop paths helper added for the import-roots/PATH fixes; they were recorded as test paths but not as scope includes."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-25T21:25:59.972345Z",
+      "pattern": "tests/blocks/test_bridge_extended.py",
+      "reason": "Include test files and the desktop paths helper added for the import-roots/PATH fixes; they were recorded as test paths but not as scope includes."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-25T21:25:59.972346Z",
+      "pattern": "packages/scistudio-blocks-imaging/tests/test_cellpose_segment.py",
+      "reason": "Include test files and the desktop paths helper added for the import-roots/PATH fixes; they were recorded as test paths but not as scope includes."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-25T21:25:59.972347Z",
+      "pattern": "packages/scistudio-blocks-imaging/tests/test_bioformats_handler.py",
+      "reason": "Include test files and the desktop paths helper added for the import-roots/PATH fixes; they were recorded as test paths but not as scope includes."
+    }
+  ],
+  "session_id": "64893ba2-efdd-4ac8-b579-76fff261ab56",
+  "strictness_tier": 1,
+  "task_kind": "guided",
+  "test_events": [
+    {
+      "at": "2026-06-25T21:20:28.485533Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/blocks/test_desktop_package_discovery.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-25T21:20:28.485536Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/blocks/test_bridge_extended.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-25T21:20:28.485538Z",
+      "class": null,
+      "kind": "path",
+      "path": "packages/scistudio-blocks-imaging/tests/test_cellpose_segment.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-25T21:20:28.485539Z",
+      "class": null,
+      "kind": "path",
+      "path": "packages/scistudio-blocks-imaging/tests/test_bioformats_handler.py",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/docs/specs/adr-043-package-migration.md
+++ b/docs/specs/adr-043-package-migration.md
@@ -416,10 +416,13 @@ persists `capability_id` on the port.
   optional install extra, following the existing `imaging[cellpose]` pattern. The
   handler module MUST defer the `python-bioformats` / `javabridge` / `ome-types`
   imports to lazy load time. When extras are missing, the handler MUST raise a
-  clear error naming the install command
-  `pip install scistudio-blocks-imaging[bioformats]`. The registry MUST hide
-  Bio-Formats capabilities from `list_format_capabilities` results when the
-  extras are not importable.
+  clear error naming an install command that works in the desktop runtime —
+  the in-app Python terminal command
+  `pip install python-bioformats python-javabridge` (the
+  `scistudio-blocks-imaging` distribution is not published to PyPI, so the
+  `[bioformats]` extras specifier is not installable by end users; see #1772).
+  The registry MUST hide Bio-Formats capabilities from
+  `list_format_capabilities` results when the extras are not importable.
 
 - **FR-009:** The spec codifies a ProcessBlock OME metadata propagation contract
   with three modes:

--- a/docs/specs/phase11-imaging-block-spec.md
+++ b/docs/specs/phase11-imaging-block-spec.md
@@ -3612,8 +3612,10 @@ class CellposeSegment(ProcessBlock):
     available; cellpose falls back to CPU automatically if CUDA is not
     present.
 
-    Optional dependency: install with
-    ``pip install scistudio-blocks-imaging[cellpose]``.
+    Optional dependency: install from the in-app Python terminal with
+    ``pip install cellpose`` (the ``scistudio-blocks-imaging`` distribution is
+    not on PyPI, so the ``[cellpose]`` extras specifier is not installable by
+    end users; see #1772).
     """
 
     type_name: ClassVar[str] = "imaging.cellpose_segment"
@@ -3649,8 +3651,9 @@ class CellposeSegment(ProcessBlock):
             from cellpose import models
         except ImportError as exc:
             raise ImportError(
-                "CellposeSegment requires the [cellpose] extra: "
-                "pip install scistudio-blocks-imaging[cellpose]"
+                "CellposeSegment requires the 'cellpose' package, which is not "
+                "installed. Open the Python terminal in SciStudio and run: "
+                "pip install cellpose"
             ) from exc
         model_name = config.get("model", "cyto3")
         use_gpu = bool(config.get("use_gpu", False))

--- a/packages/scistudio-blocks-imaging/src/scistudio_blocks_imaging/io/bioformats_handler.py
+++ b/packages/scistudio-blocks-imaging/src/scistudio_blocks_imaging/io/bioformats_handler.py
@@ -36,10 +36,12 @@ from scistudio.core.meta.framework import FrameworkMeta
 from scistudio_blocks_imaging.types import Image
 
 _MISSING_EXTRAS_HINT: str = (
-    "Bio-Formats handlers require the [bioformats] extra and a Java Runtime "
-    "Environment (JRE 8+). Install via:\n"
-    "    pip install scistudio-blocks-imaging[bioformats]\n"
-    "and ensure `java -version` resolves on PATH."
+    "Bio-Formats handlers require the 'python-bioformats' and "
+    "'python-javabridge' packages plus a Java Runtime Environment (JRE 8+). "
+    "Open the Python terminal in SciStudio and run:\n"
+    "    pip install python-bioformats python-javabridge\n"
+    "It installs into the SciStudio plugin environment this block runs in. "
+    "Also ensure `java -version` resolves on PATH."
 )
 
 

--- a/packages/scistudio-blocks-imaging/src/scistudio_blocks_imaging/segmentation/cellpose_segment.py
+++ b/packages/scistudio-blocks-imaging/src/scistudio_blocks_imaging/segmentation/cellpose_segment.py
@@ -187,7 +187,10 @@ def _import_cellpose_models() -> Any:
         from cellpose import models
     except ImportError as exc:
         raise ImportError(
-            "CellposeSegment requires the [cellpose] extra: pip install scistudio-blocks-imaging[cellpose]"
+            "CellposeSegment requires the 'cellpose' package, which is not installed. "
+            "Open the Python terminal in SciStudio and run:\n"
+            "    pip install cellpose\n"
+            "It installs into the SciStudio plugin environment this block runs in."
         ) from exc
     return models
 

--- a/packages/scistudio-blocks-imaging/tests/test_bioformats_handler.py
+++ b/packages/scistudio-blocks-imaging/tests/test_bioformats_handler.py
@@ -55,7 +55,9 @@ def test_import_bioformats_raises_clear_error_when_extras_missing(monkeypatch: p
     with pytest.raises(ImportError) as excinfo:
         bioformats_handler._import_bioformats()
     msg = str(excinfo.value)
-    assert "scistudio-blocks-imaging[bioformats]" in msg
+    assert "pip install python-bioformats python-javabridge" in msg
+    assert "Python terminal" in msg
+    assert "scistudio-blocks-imaging[bioformats]" not in msg
     assert "Java" in msg or "JVM" in msg or "JRE" in msg
 
 
@@ -75,14 +77,21 @@ def test_import_javabridge_raises_clear_error_when_extras_missing(monkeypatch: p
     with pytest.raises(ImportError) as excinfo:
         bioformats_handler._import_javabridge()
     msg = str(excinfo.value)
-    assert "scistudio-blocks-imaging[bioformats]" in msg
+    assert "pip install python-bioformats python-javabridge" in msg
+    assert "scistudio-blocks-imaging[bioformats]" not in msg
 
 
 def test_missing_extras_hint_names_install_command() -> None:
-    """The module-level hint constant names the canonical install command."""
+    """The module-level hint constant names an install command that works in
+    this runtime (#1772): the in-app Python terminal, not the non-existent
+    PyPI extras specifier."""
     from scistudio_blocks_imaging.io.bioformats_handler import _MISSING_EXTRAS_HINT
 
-    assert "pip install scistudio-blocks-imaging[bioformats]" in _MISSING_EXTRAS_HINT
+    assert "pip install python-bioformats python-javabridge" in _MISSING_EXTRAS_HINT
+    assert "Python terminal" in _MISSING_EXTRAS_HINT
+    # The old hint pointed at a package that is not published to PyPI and whose
+    # bracket form is shell-globbed; it must not reappear.
+    assert "scistudio-blocks-imaging[bioformats]" not in _MISSING_EXTRAS_HINT
 
 
 def test_handler_module_is_importable_without_extras() -> None:
@@ -124,7 +133,7 @@ def test_load_image_dispatch_to_missing_bioformats_yields_clear_error(
 
     with pytest.raises(ImportError) as excinfo:
         LoadImage().load(BlockConfig(params={"path": str(fake)}))
-    assert "scistudio-blocks-imaging[bioformats]" in str(excinfo.value)
+    assert "pip install python-bioformats python-javabridge" in str(excinfo.value)
 
 
 # ---------------------------------------------------------------------------
@@ -139,9 +148,9 @@ def _require_bioformats() -> None:
     pytest.importorskip(
         "bioformats",
         reason=(
-            "Requires the [bioformats] extra and a Java Runtime "
-            "Environment; install via "
-            "`pip install scistudio-blocks-imaging[bioformats]`."
+            "Requires python-bioformats / python-javabridge and a Java Runtime "
+            "Environment; install via the SciStudio Python terminal: "
+            "`pip install python-bioformats python-javabridge`."
         ),
     )
 

--- a/packages/scistudio-blocks-imaging/tests/test_cellpose_segment.py
+++ b/packages/scistudio-blocks-imaging/tests/test_cellpose_segment.py
@@ -251,8 +251,14 @@ def test_cellpose_missing_dependency_raises_friendly_import_error(monkeypatch: p
 
     monkeypatch.setattr(builtins, "__import__", _missing_cellpose)
 
-    with pytest.raises(ImportError, match=r"requires the \[cellpose\] extra"):
+    with pytest.raises(ImportError) as excinfo:
         CellposeSegment().setup(BlockConfig(params={}))
+    msg = str(excinfo.value)
+    # #1772: the hint must name an install command that works in this runtime
+    # (the in-app Python terminal), not the non-existent PyPI extras specifier.
+    assert "pip install cellpose" in msg
+    assert "Python terminal" in msg
+    assert "scistudio-blocks-imaging[cellpose]" not in msg
 
 
 def test_cellpose_diameter_param_passed_to_eval(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/src/scistudio/blocks/app/bridge.py
+++ b/src/scistudio/blocks/app/bridge.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -10,6 +11,34 @@ from typing import TYPE_CHECKING, Any, Protocol, cast, runtime_checkable
 
 if TYPE_CHECKING:
     from scistudio.blocks.registry import BlockRegistry
+
+
+def _external_app_launch_env() -> dict[str, str] | None:
+    """Return a process environment for launching an external app, or ``None``.
+
+    External-app blocks (e.g. :class:`NapariBlock`) launch user-installed GUI
+    commands by name. Console scripts installed through the in-app Python
+    terminal land in the shared user dependency site's script directory, which
+    is not on the backend's inherited ``PATH``. Prepend that directory so
+    commands like ``napari`` resolve at launch time (#1772).
+
+    Returns ``None`` when the script directory does not exist so the subprocess
+    inherits the parent environment unchanged (``env=None`` to ``Popen``).
+    """
+    try:
+        from scistudio.desktop.paths import user_python_script_dir
+    except Exception:  # pragma: no cover - desktop paths always importable here
+        return None
+    script_dir = user_python_script_dir()
+    if not script_dir.is_dir():
+        return None
+    env = dict(os.environ)
+    parts = [str(script_dir)]
+    for part in env.get("PATH", "").split(os.pathsep):
+        if part and part not in parts:
+            parts.append(part)
+    env["PATH"] = os.pathsep.join(parts)
+    return env
 
 
 @runtime_checkable
@@ -190,6 +219,7 @@ class FileExchangeBridge:
         return subprocess.Popen(
             cmd,
             cwd=str(exchange_dir),
+            env=_external_app_launch_env(),
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
             shell=False,

--- a/src/scistudio/blocks/registry/_scan.py
+++ b/src/scistudio/blocks/registry/_scan.py
@@ -308,6 +308,10 @@ def _scan_tier2(registry: BlockRegistry) -> None:
                     block_spec.module_path = cls.__module__
                     block_spec.class_name = cls.__name__
                     block_spec.package_name = pkg_name
+                    # #1772: surface shared user-site deps (installed via the
+                    # in-app Python terminal) to the worker for entry-point
+                    # blocks too, matching the source-package path.
+                    block_spec.runtime_import_roots = [str(path) for path in _desktop_user_python_import_roots()]
                     _register_spec(registry, block_spec)
                 elif isinstance(cls, type) and issubclass(cls, Block) and inspect.isabstract(cls):
                     logger.warning(
@@ -385,7 +389,14 @@ def _process_package_protocol_result(
         block_spec.module_path = cls.__module__
         block_spec.class_name = cls.__name__
         block_spec.package_name = pkg_name
-        block_spec.runtime_import_roots = [str(path) for path in runtime_import_roots or []]
+        # #1772: a worker running this block must also resolve dependencies the
+        # user installed through the in-app Python terminal, which land in the
+        # shared user dependency site. Append that site after the package's own
+        # roots so per-package deps keep precedence while shared-site extras
+        # (e.g. ``cellpose``) become importable.
+        block_spec.runtime_import_roots = list(
+            dict.fromkeys(str(path) for path in [*(runtime_import_roots or []), *_desktop_user_python_import_roots()])
+        )
         if block_spec.type_name in registry._aliases or block_spec.name in registry._registry:
             continue
         _register_spec(registry, block_spec)

--- a/src/scistudio/desktop/paths.py
+++ b/src/scistudio/desktop/paths.py
@@ -97,6 +97,20 @@ def user_python_bin_dir() -> Path:
     return user_python_dir() / ("Scripts" if sys.platform == "win32" else "bin")
 
 
+def user_python_script_dir() -> Path:
+    """Return the directory holding console scripts installed into the shared
+    user dependency site.
+
+    Dependencies installed through the in-app Python terminal land in the
+    shared user site via ``pip install --target`` (#1772). pip drops any
+    console-script launchers (e.g. the ``napari`` command) into a ``bin`` /
+    ``Scripts`` subdirectory of that target, which is distinct from the
+    command-wrapper directory returned by :func:`user_python_bin_dir`. External
+    app blocks need this directory on ``PATH`` to resolve user-installed GUI
+    launchers."""
+    return user_python_site_dir() / ("Scripts" if sys.platform == "win32" else "bin")
+
+
 def user_python_import_roots() -> list[Path]:
     """Return shared user dependency import roots that already exist."""
     site_dir = user_python_site_dir()

--- a/tests/blocks/test_bridge_extended.py
+++ b/tests/blocks/test_bridge_extended.py
@@ -2,14 +2,40 @@
 
 from __future__ import annotations
 
+import os
 import sys
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
+from scistudio.blocks.app import bridge as bridge_mod
 from scistudio.blocks.app.bridge import FileExchangeBridge, _guess_mime
 from scistudio.blocks.app.watcher import FileWatcher
+from scistudio.desktop import paths as desktop_paths
+
+
+class TestExternalAppLaunchEnv:
+    """#1772: external-app launch must surface shared-site console scripts on PATH."""
+
+    def test_prepends_shared_script_dir_when_present(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        monkeypatch.setattr(desktop_paths, "_platformdirs_dir", lambda kind: tmp_path / kind)
+        script_dir = desktop_paths.user_python_script_dir()
+        script_dir.mkdir(parents=True)
+        monkeypatch.setenv("PATH", "/usr/bin")
+
+        env = bridge_mod._external_app_launch_env()
+
+        assert env is not None
+        path_parts = env["PATH"].split(os.pathsep)
+        assert path_parts[0] == str(script_dir)
+        assert "/usr/bin" in path_parts
+
+    def test_returns_none_when_script_dir_absent(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        # Point the shared site at a location that does not exist; the launch
+        # subprocess should then inherit the parent env unchanged (env=None).
+        monkeypatch.setattr(desktop_paths, "_platformdirs_dir", lambda kind: tmp_path / kind)
+        assert bridge_mod._external_app_launch_env() is None
 
 
 class TestBridgeGuessMime:

--- a/tests/blocks/test_desktop_package_discovery.py
+++ b/tests/blocks/test_desktop_package_discovery.py
@@ -201,6 +201,40 @@ def test_scan_imports_source_package_with_per_package_runtime_dependencies(tmp_p
     assert str(runtime_dir) not in sys.path
 
 
+def test_scan_source_package_includes_shared_user_site_in_runtime_import_roots(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """#1772: installed plugin blocks must surface shared user-site deps
+    (installed via the in-app Python terminal) to the worker, after the
+    package's own roots so per-package deps keep precedence."""
+    monkeypatch.setattr(desktop_paths, "_platformdirs_dir", lambda kind: tmp_path / kind)
+    shared_site = desktop_paths.user_python_site_dir()
+    shared_site.mkdir(parents=True)
+
+    packages_dir = tmp_path / "installed-packages"
+    src_dir = _write_source_package(
+        packages_dir,
+        dist_name="scistudio-blocks-sharedprobe",
+        module_name="scistudio_blocks_sharedprobe",
+        block_name="SharedProbeBlock",
+        package_name="Shared Probe",
+    )
+
+    registry = BlockRegistry()
+    registry.add_package_src_dir(packages_dir)
+    registry.scan()
+
+    spec = registry.get_spec("SharedProbeBlock")
+    assert spec is not None
+    roots = spec.runtime_import_roots
+    assert str(shared_site.resolve()) in roots
+    assert str(src_dir.resolve()) in roots
+    # Per-package roots are ordered before the shared site.
+    assert roots.index(str(src_dir.resolve())) < roots.index(str(shared_site.resolve()))
+    # Shared site is not leaked into the parent interpreter's sys.path.
+    assert str(shared_site) not in sys.path
+
+
 def test_scan_does_not_leak_package_dependencies_to_global_pythonpath(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,


### PR DESCRIPTION
## Summary

Installed plugin-package blocks could not resolve dependencies the user installed through the in-app Python terminal. This fixes the two runtime gaps plus the misleading install hints.

### Changes

- **PYTHONPATH (design 1):** installed source/entry-point block `runtime_import_roots` now append the shared user dependency site after each package's own roots (per-package deps keep precedence). The worker can resolve shared-site deps (e.g. `cellpose`) instead of raising `ModuleNotFoundError`. — `src/scistudio/blocks/registry/_scan.py`
- **PATH:** external-app launch (`NapariBlock` etc.) now passes an env that prepends the shared user-site console-script dir, so user-installed GUI commands resolve. — `src/scistudio/blocks/app/bridge.py`, new `user_python_script_dir()` in `src/scistudio/desktop/paths.py`
- **Install hints:** `CellposeSegment` and the Bio-Formats handler told users to run `pip install scistudio-blocks-imaging[extra]`, which is not installable (distribution not on PyPI; bracket form shell-globbed). They now point at the in-app Python terminal. adr-043 / phase11 specs synced.

### Tests

- New: shared-site roots reconciliation (`tests/blocks/test_desktop_package_discovery.py`), external-app launch PATH (`tests/blocks/test_bridge_extended.py`).
- Updated: cellpose/bioformats hint assertions.

### Notes

- cellpose `>=3.0` admits v4, whose API is incompatible with the block code — tracked separately in #1773 (out of scope here).
- Touches protected core (`src/scistudio/blocks/**`); owner authorized via `admin-approved:core-change`.

Gate record: .workflow/records/1772-guided-plugin-shared-deps-20260625.json

Closes #1772
