### PR TITLE
feat(#1775): desktop OTA hot-update for backend+frontend

### DIFF
--- a/.workflow/records/1775-guided-ota-hot-update-20260625.json
+++ b/.workflow/records/1775-guided-ota-hot-update-20260625.json
@@ -1,0 +1,648 @@
+{
+  "branch": "guided/ota-hot-update-20260625",
+  "check_events": [
+    {
+      "at": "2026-06-25T22:17:44.855264Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:b3e77aece49aefd7cbebc8419cc899475716220ed10bd08c31b351315d573cd1",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-25T22:17:48.926897Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:a35994c2ca2a56ccc303811a1e9f4296e5d467aff4095317665ab2d80d037844",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-25T22:17:48.983484Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:08ff21eac940b0e016c51c0b79bb742b1fc3f4487fbc70cec6d12684e977a094",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-25T22:20:11.572394Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:0905ec57d1c3241f46effe1684018a59906451888da1e884aef7785ce85994bf",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-25T22:22:02.447466Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:31c491b58517554e57c8f59b36585bb56adb15e8df9cf50c7f554bd92b20ba31",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-25T22:22:46.609438Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:2543f109f5e39c24e77567c1da25eb9793df16b8bc4ead9c83258380d9a4d8f8",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-25T22:22:50.409929Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cf7a275d8a98c43cba4e44b6d51b2c4862204c865696ff058dc946e0d47685cd",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-25T22:22:50.432254Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:97e8be25f7de616cdfaf29a11e33fec507ee2adcc1a6b9e93fbb7215988e1750",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-25T22:24:46.185562Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:c629b55c79bd66f6c3b81c05decde9cc01eab8dd289f269537599ffe848a3360",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    }
+  ],
+  "check_na": [],
+  "commit": {
+    "sha": "2ef088c6b869684d47083a66d663299b0717646a",
+    "shas": [
+      "2ef088c6b869684d47083a66d663299b0717646a"
+    ],
+    "trailers": []
+  },
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "desktop/main.js",
+      "desktop/scripts/**",
+      "scripts/ota_publish.py",
+      "docs/specs/desktop-ota-hot-update.md"
+    ]
+  },
+  "directive_events": [],
+  "docs_events": [],
+  "governance_touch": false,
+  "guard_events": [
+    {
+      "at": "2026-06-25T22:22:02.499647Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T22:22:02.510255Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T22:22:02.521482Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T22:22:02.532282Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T22:22:02.544053Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T22:22:02.554671Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T22:22:02.564760Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T22:22:02.576848Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T22:22:02.587471Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T22:22:02.603321Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T22:24:46.225965Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T22:24:46.235187Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T22:24:46.244472Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T22:24:46.254311Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T22:24:46.264211Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T22:24:46.274268Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T22:24:46.283673Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T22:24:46.294026Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T22:24:46.303074Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T22:24:46.315578Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T22:24:59.318265Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T22:24:59.326998Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T22:24:59.335607Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T22:24:59.345124Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T22:24:59.354437Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T22:24:59.363359Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T22:24:59.371739Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T22:24:59.380483Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T22:24:59.389103Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T22:24:59.401322Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T22:25:41.936611Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T22:25:41.945808Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T22:25:41.955902Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T22:25:41.965739Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T22:25:41.974746Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T22:25:41.983367Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T22:25:41.991586Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T22:25:42.000326Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T22:25:42.009109Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T22:25:42.020882Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1775,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": {
+    "base": "origin/main",
+    "base_sha": "6bf0ac27",
+    "changed_files": [
+      ".workflow/records/1775-guided-ota-hot-update-20260625.json",
+      "desktop/main.js",
+      "desktop/ota.js",
+      "desktop/package.json",
+      "desktop/scripts/build-python-runtime-macos.sh",
+      "desktop/scripts/build-python-runtime.ps1",
+      "desktop/scripts/stage-resources.ps1",
+      "desktop/scripts/stage-resources.sh",
+      "desktop/test/ota.test.js",
+      "docs/specs/desktop-ota-hot-update.md",
+      "scripts/ota_publish.py",
+      "tests/scripts/test_ota_publish.py"
+    ],
+    "diff_fingerprint": "sha256:e5d5fd6f1bc90d2d1129a2c491d4b5b93624ca46d5e2fea1bf1d1066ad90210a",
+    "head": "HEAD",
+    "head_sha": "2ef088c6",
+    "surfaces": {
+      "docs": 1,
+      "frontend": 0,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 0,
+      "packaging": 0,
+      "protected_core": 0,
+      "sentrux": 2,
+      "test": 2,
+      "workflow_ci": 0
+    }
+  },
+  "owner_directive": "Add desktop OTA hot-update for backend plus frontend (full-snapshot patches via public-repo rolling pre-release); fold in removal of the duplicate bundled-interpreter scistudio copy; local dev builds skip OTA; single PR; no ADR, lightweight spec.",
+  "persona": "live_implementer",
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [
+      1775
+    ],
+    "number": null,
+    "url": null
+  },
+  "reconcile_events": [
+    {
+      "at": "2026-06-25T22:22:02.603377Z",
+      "diff_fingerprint": "sha256:95610db2e8877055023254a9f617c3b8035e222f5d0a55a62edc365a85705736",
+      "mode": "local",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.format_check",
+        "checks.lint_format",
+        "scope.out-of-scope"
+      ]
+    },
+    {
+      "at": "2026-06-25T22:24:46.315630Z",
+      "diff_fingerprint": "sha256:e5d5fd6f1bc90d2d1129a2c491d4b5b93624ca46d5e2fea1bf1d1066ad90210a",
+      "mode": "local",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "scope.out-of-scope"
+      ]
+    },
+    {
+      "at": "2026-06-25T22:24:59.401348Z",
+      "diff_fingerprint": "sha256:e5d5fd6f1bc90d2d1129a2c491d4b5b93624ca46d5e2fea1bf1d1066ad90210a",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-25T22:25:42.020908Z",
+      "diff_fingerprint": "sha256:e5d5fd6f1bc90d2d1129a2c491d4b5b93624ca46d5e2fea1bf1d1066ad90210a",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    }
+  ],
+  "record_id": "1775-guided-ota-hot-update-20260625",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [
+      "format_check",
+      "full_audit",
+      "lint_format",
+      "python_tests",
+      "semantic_dup"
+    ],
+    "docs": [],
+    "guards": [
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": []
+  },
+  "runtime": "claude-code:opus-4-8",
+  "schema_version": 2,
+  "scope_events": [
+    {
+      "action": "add-include",
+      "at": "2026-06-25T22:24:54.699489Z",
+      "pattern": "desktop/ota.js",
+      "reason": "OTA decision logic extracted to a testable module + its tests + package.json wiring (packaged files list, test script) are part of the same feature"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-25T22:24:54.699688Z",
+      "pattern": "desktop/package.json",
+      "reason": "OTA decision logic extracted to a testable module + its tests + package.json wiring (packaged files list, test script) are part of the same feature"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-25T22:24:54.699691Z",
+      "pattern": "desktop/test/**",
+      "reason": "OTA decision logic extracted to a testable module + its tests + package.json wiring (packaged files list, test script) are part of the same feature"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-25T22:24:54.699692Z",
+      "pattern": "tests/scripts/test_ota_publish.py",
+      "reason": "OTA decision logic extracted to a testable module + its tests + package.json wiring (packaged files list, test script) are part of the same feature"
+    }
+  ],
+  "session_id": "34e8becc-48f0-4a78-9356-4f9c1b6e76c5",
+  "strictness_tier": 2,
+  "task_kind": "guided",
+  "test_events": []
+}

--- a/.workflow/records/1775-guided-ota-hot-update-20260625.json
+++ b/.workflow/records/1775-guided-ota-hot-update-20260625.json
@@ -147,9 +147,9 @@
   ],
   "check_na": [],
   "commit": {
-    "sha": "2ef088c6b869684d47083a66d663299b0717646a",
+    "sha": "20d877dadf783f6e825e2a012291f62a59b8433c",
     "shas": [
-      "2ef088c6b869684d47083a66d663299b0717646a"
+      "20d877dadf783f6e825e2a012291f62a59b8433c"
     ],
     "trailers": []
   },
@@ -493,6 +493,170 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-06-25T22:25:57.737527Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T22:25:57.746055Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T22:25:57.754835Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T22:25:57.763877Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T22:25:57.772857Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T22:25:57.782791Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T22:25:57.792863Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T22:25:57.801832Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T22:25:57.810456Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T22:25:57.823117Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T22:26:05.716796Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T22:26:05.726546Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T22:26:05.735818Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T22:26:05.744341Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T22:26:05.752688Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T22:26:05.761046Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T22:26:05.769800Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T22:26:05.778659Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T22:26:05.787509Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-25T22:26:05.800017Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -505,7 +669,7 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "origin/main",
+    "base": "6bf0ac272ff08d1918277e07c9afe1fe6c54fdb6",
     "base_sha": "6bf0ac27",
     "changed_files": [
       ".workflow/records/1775-guided-ota-hot-update-20260625.json",
@@ -521,9 +685,9 @@
       "scripts/ota_publish.py",
       "tests/scripts/test_ota_publish.py"
     ],
-    "diff_fingerprint": "sha256:e5d5fd6f1bc90d2d1129a2c491d4b5b93624ca46d5e2fea1bf1d1066ad90210a",
+    "diff_fingerprint": "sha256:0c78e846ac5fd8855134a08435e524197e7e5dd03fe91bf3a465c3e0251e2ad7",
     "head": "HEAD",
-    "head_sha": "2ef088c6",
+    "head_sha": "20d877da",
     "surfaces": {
       "docs": 1,
       "frontend": 0,
@@ -544,7 +708,7 @@
     "closes": [
       1775
     ],
-    "number": null,
+    "number": 1776,
     "url": null
   },
   "reconcile_events": [
@@ -581,6 +745,22 @@
     {
       "at": "2026-06-25T22:25:42.020908Z",
       "diff_fingerprint": "sha256:e5d5fd6f1bc90d2d1129a2c491d4b5b93624ca46d5e2fea1bf1d1066ad90210a",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-25T22:25:57.823156Z",
+      "diff_fingerprint": "sha256:0c78e846ac5fd8855134a08435e524197e7e5dd03fe91bf3a465c3e0251e2ad7",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-25T22:26:05.800044Z",
+      "diff_fingerprint": "sha256:0c78e846ac5fd8855134a08435e524197e7e5dd03fe91bf3a465c3e0251e2ad7",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 2,

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -1,5 +1,6 @@
 const { app, BrowserWindow, dialog, session } = require("electron");
 const { spawn, spawnSync } = require("child_process");
+const crypto = require("crypto");
 const fs = require("fs");
 const http = require("http");
 const https = require("https");
@@ -7,10 +8,17 @@ const os = require("os");
 const path = require("path");
 const readline = require("readline");
 
+const ota = require("./ota");
+
 const READY_EVENT = "scistudio.ready";
 const READY_TIMEOUT_MS = 120000;
 const HTTP_READY_TIMEOUT_MS = 30000;
 const DEFAULT_DEV_FRONTEND_URL = "http://127.0.0.1:5173";
+
+// #1775: OTA hot-update (backend + embedded frontend).
+const OTA_MANIFEST_TIMEOUT_MS = 8000;
+const OTA_DOWNLOAD_TIMEOUT_MS = 120000;
+const OTA_MAX_REDIRECTS = 5;
 
 let mainWindow = null;
 let runtimeProcess = null;
@@ -107,6 +115,344 @@ function repoRoot() {
 
 function appIconPath() {
   return path.join(__dirname, "assets", "icon.png");
+}
+
+// --------------------------------------------------------------------------- //
+// #1775: OTA hot-update for the backend source tree (which embeds the frontend).
+//
+// Patches are full snapshots published per channel (see scripts/ota_publish.py).
+// We stage them under userData/patches/build<N>/src and point PYTHONPATH there,
+// never touching the read-only app bundle. A pointer (active.json) selects the
+// live patch; a known-good marker enables rollback if a patch fails to boot.
+// --------------------------------------------------------------------------- //
+function baselineVersion() {
+  try {
+    return (
+      ota.parseVersion(require("./package.json").version) || {
+        base: "0.0.0",
+        channel: "stable",
+        build: 0
+      }
+    );
+  } catch {
+    return { base: "0.0.0", channel: "stable", build: 0 };
+  }
+}
+
+function loadOtaConfig() {
+  const cfg = readJsonSafe(path.join(resourcesDir(), "ota-config.json"));
+  if (!cfg || typeof cfg !== "object") {
+    return { enabled: false, channel: "dev", manifestUrl: null };
+  }
+  return cfg;
+}
+
+function patchesRoot() {
+  return path.join(app.getPath("userData"), "patches");
+}
+
+function activePointerPath() {
+  return path.join(patchesRoot(), "active.json");
+}
+
+function knownGoodPath() {
+  return path.join(patchesRoot(), "known-good.json");
+}
+
+function readJsonSafe(filePath) {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function writeJsonAtomic(filePath, value) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  const tmp = `${filePath}.${process.pid}.tmp`;
+  fs.writeFileSync(tmp, JSON.stringify(value));
+  fs.renameSync(tmp, filePath);
+}
+
+// Resolve the currently active patch, validating that its source tree exists.
+function getActivePatch() {
+  const pointer = readJsonSafe(activePointerPath());
+  if (!pointer || typeof pointer.build !== "number") {
+    return null;
+  }
+  const dir = path.join(patchesRoot(), ota.patchDirName(pointer.build));
+  const srcDir = path.join(dir, "src");
+  if (!fs.existsSync(path.join(srcDir, "scistudio"))) {
+    return null;
+  }
+  return { build: pointer.build, dir, srcDir };
+}
+
+// Highest build the running app effectively serves: the applied patch if any,
+// otherwise the installer baseline.
+function effectiveBuild() {
+  const active = getActivePatch();
+  return Math.max(baselineVersion().build, active ? active.build : 0);
+}
+
+function recordKnownGood(build) {
+  try {
+    writeJsonAtomic(knownGoodPath(), { build });
+  } catch (error) {
+    safeError(`[scistudio] failed to record known-good build: ${error.message}`);
+  }
+}
+
+// Roll back the active pointer to the last known-good patch, or remove it so the
+// runtime falls back to the bundled baseline. Returns the build rolled back to,
+// or null when falling back to baseline.
+function revertActivePatch() {
+  const known = readJsonSafe(knownGoodPath());
+  const active = readJsonSafe(activePointerPath());
+  if (known && typeof known.build === "number" && (!active || known.build !== active.build)) {
+    const dir = path.join(patchesRoot(), ota.patchDirName(known.build));
+    if (fs.existsSync(path.join(dir, "src", "scistudio"))) {
+      writeJsonAtomic(activePointerPath(), { build: known.build });
+      return known.build;
+    }
+  }
+  try {
+    fs.rmSync(activePointerPath(), { force: true });
+  } catch {
+    // Best-effort; a stale pointer to a missing dir is already ignored by
+    // getActivePatch().
+  }
+  return null;
+}
+
+// GET with redirect following (GitHub release asset URLs redirect to a CDN).
+function otaHttpGet(url, timeoutMs, redirectsLeft, callback) {
+  let parsed = null;
+  try {
+    parsed = new URL(url);
+  } catch (error) {
+    callback(error);
+    return;
+  }
+  const client = parsed.protocol === "https:" ? https : http;
+  const req = client.get(parsed, { timeout: timeoutMs }, (res) => {
+    const status = res.statusCode || 0;
+    if ([301, 302, 303, 307, 308].includes(status) && res.headers.location) {
+      res.resume();
+      if (redirectsLeft <= 0) {
+        callback(new Error("too many redirects"));
+        return;
+      }
+      otaHttpGet(new URL(res.headers.location, parsed).toString(), timeoutMs, redirectsLeft - 1, callback);
+      return;
+    }
+    if (status < 200 || status >= 300) {
+      res.resume();
+      callback(new Error(`HTTP ${status} for ${url}`));
+      return;
+    }
+    callback(null, res);
+  });
+  req.on("timeout", () => req.destroy(new Error("request timed out")));
+  req.on("error", callback);
+}
+
+function fetchText(url, timeoutMs) {
+  return new Promise((resolve, reject) => {
+    otaHttpGet(url, timeoutMs, OTA_MAX_REDIRECTS, (err, res) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+      let data = "";
+      res.setEncoding("utf8");
+      res.on("data", (chunk) => {
+        data += chunk;
+      });
+      res.on("end", () => resolve(data));
+      res.on("error", reject);
+    });
+  });
+}
+
+function downloadTo(url, destPath, timeoutMs) {
+  return new Promise((resolve, reject) => {
+    otaHttpGet(url, timeoutMs, OTA_MAX_REDIRECTS, (err, res) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+      const out = fs.createWriteStream(destPath);
+      out.on("error", reject);
+      out.on("finish", () => out.close(() => resolve()));
+      res.on("error", reject);
+      res.pipe(out);
+    });
+  });
+}
+
+function sha256File(filePath) {
+  return new Promise((resolve, reject) => {
+    const hash = crypto.createHash("sha256");
+    const stream = fs.createReadStream(filePath);
+    stream.on("data", (chunk) => hash.update(chunk));
+    stream.on("end", () => resolve(hash.digest("hex")));
+    stream.on("error", reject);
+  });
+}
+
+function extractTarGz(tarPath, destDir) {
+  return new Promise((resolve, reject) => {
+    const tarCmd = process.platform === "win32" ? "tar.exe" : "tar";
+    const child = spawn(tarCmd, ["-xzf", tarPath, "-C", destDir], {
+      windowsHide: true,
+      stdio: ["ignore", "ignore", "pipe"]
+    });
+    let stderr = "";
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk.toString();
+    });
+    child.on("error", reject);
+    child.on("exit", (code) => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+      reject(new Error(`tar exited ${code}${stderr.trim() ? `: ${stderr.trim()}` : ""}`));
+    });
+  });
+}
+
+// Download, verify, and stage a patch into userData; flip the active pointer.
+async function downloadAndApply(manifest) {
+  const root = patchesRoot();
+  fs.mkdirSync(root, { recursive: true });
+  const tmpDir = fs.mkdtempSync(path.join(root, ".dl-"));
+  try {
+    const tarPath = path.join(tmpDir, "patch.tar.gz");
+    await downloadTo(manifest.url, tarPath, OTA_DOWNLOAD_TIMEOUT_MS);
+
+    const digest = await sha256File(tarPath);
+    if (manifest.sha256 && digest.toLowerCase() !== String(manifest.sha256).toLowerCase()) {
+      throw new Error(`sha256 mismatch (expected ${manifest.sha256}, got ${digest})`);
+    }
+
+    const stageDir = path.join(tmpDir, "stage");
+    fs.mkdirSync(stageDir, { recursive: true });
+    await extractTarGz(tarPath, stageDir);
+    if (!fs.existsSync(path.join(stageDir, "src", "scistudio"))) {
+      throw new Error("patch archive missing src/scistudio");
+    }
+
+    const finalDir = path.join(root, ota.patchDirName(manifest.build));
+    fs.rmSync(finalDir, { recursive: true, force: true });
+    fs.renameSync(stageDir, finalDir);
+    writeJsonAtomic(activePointerPath(), { build: manifest.build });
+  } finally {
+    try {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    } catch {
+      // Temp cleanup is best-effort.
+    }
+  }
+}
+
+// Launch-time update check. Silent on dev builds and when offline.
+async function maybeCheckForUpdate() {
+  const config = loadOtaConfig();
+  if (!config.enabled || !config.manifestUrl) {
+    safeLog("[scistudio] OTA disabled; skipping update check");
+    return;
+  }
+
+  let manifest = null;
+  try {
+    manifest = JSON.parse(await fetchText(config.manifestUrl, OTA_MANIFEST_TIMEOUT_MS));
+  } catch (error) {
+    safeLog(`[scistudio] update check skipped: ${error.message}`);
+    return;
+  }
+
+  const baseline = baselineVersion();
+  const local = effectiveBuild();
+  const decision = ota.evaluateUpdate(config, manifest, baseline, local);
+  safeLog(
+    `[scistudio] update decision=${decision.kind} local build=${local} remote build=${manifest.build}`
+  );
+
+  if (decision.kind === "incompatible") {
+    await dialog.showMessageBox(mainWindow || undefined, {
+      type: "info",
+      title: "Update available",
+      message: "A newer SciStudio version is available.",
+      detail:
+        `Build ${decision.build} requires a newer base version (${decision.minBase}) than ` +
+        `this installation (${baseline.base}). Please download and reinstall SciStudio to update.`,
+      buttons: ["OK"],
+      defaultId: 0
+    });
+    return;
+  }
+  if (decision.kind !== "patch") {
+    return;
+  }
+
+  const choice = await dialog.showMessageBox(mainWindow || undefined, {
+    type: "question",
+    title: "Update available",
+    message: `Update SciStudio to build ${manifest.build}?`,
+    detail:
+      (manifest.notes ? `${manifest.notes}\n\n` : "") +
+      "SciStudio will restart to apply the update.",
+    buttons: ["Update now", "Later"],
+    defaultId: 0,
+    cancelId: 1
+  });
+  if (choice.response !== 0) {
+    return;
+  }
+
+  try {
+    await downloadAndApply(manifest);
+  } catch (error) {
+    safeError(`[scistudio] update apply failed: ${error.message}`);
+    await dialog.showMessageBox(mainWindow || undefined, {
+      type: "error",
+      title: "Update failed",
+      message: "SciStudio could not apply the update.",
+      detail: error.message,
+      buttons: ["OK"],
+      defaultId: 0
+    });
+    return;
+  }
+
+  safeLog(`[scistudio] applied OTA build ${manifest.build}; relaunching`);
+  isQuitting = true;
+  stopRuntime();
+  app.relaunch();
+  app.exit(0);
+}
+
+// Start the runtime; if an applied OTA patch fails to boot, roll back and retry
+// once so a bad patch can never brick the install.
+async function startRuntimeWithRollback() {
+  const active = getActivePatch();
+  try {
+    return await startRuntime();
+  } catch (error) {
+    if (!active) {
+      throw error;
+    }
+    safeError(
+      `[scistudio] runtime failed with OTA patch build ${active.build}; rolling back: ${error.message}`
+    );
+    const fellBackTo = revertActivePatch();
+    safeError(
+      `[scistudio] rolled back to ${fellBackTo !== null ? `build ${fellBackTo}` : "bundled baseline"}; retrying runtime`
+    );
+    return startRuntime();
+  }
 }
 
 function pythonCandidates() {
@@ -255,7 +601,12 @@ function runtimeEnv() {
   const resources = resourcesDir();
   const stagedSrc = path.join(resources, "backend", "src");
   const checkoutSrc = path.join(repoRoot(), "src");
-  const pythonPathEntries = [stagedSrc, checkoutSrc].filter(Boolean);
+  // #1775: an applied OTA patch shadows the bundled baseline by sitting first on
+  // PYTHONPATH; the bundle is never modified.
+  const activePatch = getActivePatch();
+  const pythonPathEntries = [activePatch ? activePatch.srcDir : null, stagedSrc, checkoutSrc].filter(
+    Boolean
+  );
   const loginShellEnv = macLoginShellEnv();
   const baseEnv = {
     ...loginShellEnv,
@@ -278,6 +629,9 @@ function runtimeEnv() {
     PYTHONPATH: pythonPathEntries.join(path.delimiter),
     SCISTUDIO_BUNDLED: "1",
     SCISTUDIO_DESKTOP_RESOURCES: resources,
+    // #1775: report the effective (post-patch) build via the #1742 version
+    // override so /version and --version reflect the applied OTA patch.
+    SCISTUDIO_BUILD_NUMBER: String(effectiveBuild()),
     // #1741: route backend logs to the same directory as the desktop log so the
     // diagnostic bundle captures both the Electron and Python sides.
     SCISTUDIO_LOG_DIR: desktopLogDir()
@@ -648,13 +1002,21 @@ function stopRuntime() {
 app.whenReady().then(async () => {
   try {
     safeLog("[scistudio] electron ready");
-    const { ready } = await startRuntime();
+    const { ready } = await startRuntimeWithRollback();
     safeLog(`[scistudio] waiting for HTTP readiness at ${ready.url}`);
     await waitForHttpReady(ready.url);
+    // #1775: the runtime reached ready, so whatever patch is active booted
+    // cleanly; remember it as the rollback target for future launches.
+    recordKnownGood(effectiveBuild());
     await session.defaultSession.clearCache();
     const url = launchUrl(ready.url);
     safeLog(`[scistudio] creating window for ${url}`);
     createWindow(url);
+    // #1775: check for an OTA update after the window is up so startup is never
+    // blocked on the network. Fire-and-forget; failures are logged, not fatal.
+    maybeCheckForUpdate().catch((error) => {
+      safeError(`[scistudio] update check error: ${error.message}`);
+    });
   } catch (error) {
     safeError(`[scistudio] startup failed: ${error instanceof Error ? error.stack : String(error)}`);
     await dialog.showMessageBox({

--- a/desktop/ota.js
+++ b/desktop/ota.js
@@ -1,0 +1,76 @@
+"use strict";
+
+// Pure OTA decision logic for the SciStudio desktop client (issue #1775).
+//
+// This module has no Electron or filesystem dependencies so it can be unit
+// tested directly (see test/ota.test.js). main.js owns all IO: fetching the
+// manifest, downloading/verifying/extracting the snapshot, and restarting the
+// runtime. The rules here decide *whether* an update applies.
+
+// Matches the #1742 version display/SemVer form: "a.b.c-<channel>-build<NNNN>"
+// for prereleases, or a bare "a.b.c" for stable.
+const VERSION_RE = /^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z]+)-build(\d+))?$/;
+
+function parseVersion(version) {
+  const match = VERSION_RE.exec(String(version == null ? "" : version).trim());
+  if (!match) {
+    return null;
+  }
+  return {
+    base: `${match[1]}.${match[2]}.${match[3]}`,
+    channel: match[4] || "stable",
+    build: match[5] ? parseInt(match[5], 10) : 0
+  };
+}
+
+// Numeric compare of two "a.b.c" base strings. Returns -1, 0, or 1.
+function compareBase(a, b) {
+  const pa = String(a).split(".").map((n) => parseInt(n, 10) || 0);
+  const pb = String(b).split(".").map((n) => parseInt(n, 10) || 0);
+  for (let i = 0; i < 3; i += 1) {
+    const diff = (pa[i] || 0) - (pb[i] || 0);
+    if (diff !== 0) {
+      return diff < 0 ? -1 : 1;
+    }
+  }
+  return 0;
+}
+
+function patchDirName(build) {
+  return `build${build}`;
+}
+
+// Decide what to do with a fetched manifest given local state.
+//
+// Returns one of:
+//   { kind: "none", reason }          - nothing to do
+//   { kind: "invalid", reason }       - manifest is malformed; ignore it
+//   { kind: "incompatible", build, minBase } - newer, but needs a new installer
+//   { kind: "patch", build }          - newer and hot-patchable
+function evaluateUpdate(config, manifest, baseline, effectiveBuild) {
+  if (!config || !config.enabled) {
+    return { kind: "none", reason: "ota-disabled" };
+  }
+  if (!manifest || typeof manifest.build !== "number") {
+    return { kind: "invalid", reason: "bad-manifest" };
+  }
+  if (manifest.channel && config.channel && manifest.channel !== config.channel) {
+    return { kind: "none", reason: "channel-mismatch" };
+  }
+  if (manifest.build <= effectiveBuild) {
+    return { kind: "none", reason: "up-to-date" };
+  }
+  const minBase = (manifest.requires && manifest.requires.min_base) || manifest.base;
+  if (minBase && baseline && compareBase(baseline.base, minBase) < 0) {
+    return { kind: "incompatible", build: manifest.build, minBase };
+  }
+  return { kind: "patch", build: manifest.build };
+}
+
+module.exports = {
+  VERSION_RE,
+  parseVersion,
+  compareBase,
+  patchDirName,
+  evaluateUpdate
+};

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -14,6 +14,7 @@
     "stage:sh": "sh ./scripts/stage-resources.sh",
     "start": "node scripts/start-electron.js",
     "dev": "node scripts/start-dev.js",
+    "test": "node --test test/*.test.js",
     "dist:dir": "powershell -ExecutionPolicy Bypass -Command \"Remove-Item -LiteralPath dist\\win-unpacked -Recurse -Force -ErrorAction SilentlyContinue\" && electron-builder --dir",
     "dist:win": "powershell -ExecutionPolicy Bypass -Command \"if (Test-Path 'dist\\win-unpacked') { Remove-Item -LiteralPath 'dist\\win-unpacked' -Recurse -Force }; if (Test-Path 'dist') { Get-ChildItem -Path 'dist' -Filter '*.exe' -File -ErrorAction SilentlyContinue | Remove-Item -Force }\" && electron-builder --win nsis --x64",
     "dist:dmg": "electron-builder --mac dmg --arm64"
@@ -32,6 +33,7 @@
     },
     "files": [
       "main.js",
+      "ota.js",
       "preload.js",
       "package.json",
       "assets/icon.png"

--- a/desktop/scripts/build-python-runtime-macos.sh
+++ b/desktop/scripts/build-python-runtime-macos.sh
@@ -79,5 +79,15 @@ PYTHON_BIN="$PYTHON_ROOT/bin/python3"
 "$PYTHON_BIN" -m pip install --no-warn-script-location "$REPO_ROOT"
 "$PYTHON_BIN" -c "import scistudio, fastapi, uvicorn, pty; print('SciStudio macOS portable Python ready:', scistudio.__version__)"
 
+# #1775: The bundled runtime loads scistudio from resources/backend/src via
+# PYTHONPATH (desktop/main.js runtimeEnv), and OTA patches load it from a
+# userData directory. The pip install above is only needed to resolve the
+# third-party dependencies into the interpreter; the scistudio package it also
+# installs is a redundant second copy that wastes space and can shadow the
+# source tree if PYTHONPATH ordering ever changes. Remove just scistudio,
+# keeping its dependencies, so the source tree is the single source of truth.
+"$PYTHON_BIN" -m pip uninstall -y scistudio
+"$PYTHON_BIN" -c "import fastapi, uvicorn, pty; print('SciStudio macOS runtime deps verified (scistudio loads from source/OTA)')"
+
 : > "$PYTHON_ROOT/.scistudio-python-runtime"
 echo "Portable macOS Python runtime is ready at $PYTHON_ROOT"

--- a/desktop/scripts/build-python-runtime.ps1
+++ b/desktop/scripts/build-python-runtime.ps1
@@ -79,5 +79,22 @@ if ($LASTEXITCODE -ne 0) {
     throw "Portable Python runtime verification failed with exit code $LASTEXITCODE"
 }
 
+# #1775: The bundled runtime loads scistudio from resources/backend/src via
+# PYTHONPATH (desktop/main.js runtimeEnv), and OTA patches load it from a
+# userData directory. The pip install above is only needed to resolve the
+# third-party dependencies into the interpreter; the scistudio package it also
+# installs is a redundant second copy that wastes space and can shadow the
+# source tree if PYTHONPATH ordering ever changes. Remove just scistudio,
+# keeping its dependencies, so the source tree is the single source of truth.
+& $PythonExe -m pip uninstall -y scistudio
+if ($LASTEXITCODE -ne 0) {
+    throw "Failed to remove the redundant bundled scistudio package (exit $LASTEXITCODE)"
+}
+
+& $PythonExe -c "import fastapi, uvicorn, winpty; print('SciStudio runtime deps verified (scistudio loads from source/OTA)')"
+if ($LASTEXITCODE -ne 0) {
+    throw "Portable Python runtime dependency verification failed with exit code $LASTEXITCODE"
+}
+
 "" | Set-Content -NoNewline -Encoding ASCII (Join-Path $PythonRoot ".scistudio-python-runtime")
 Write-Host "Portable Python runtime is ready at $PythonRoot"

--- a/desktop/scripts/stage-resources.ps1
+++ b/desktop/scripts/stage-resources.ps1
@@ -47,6 +47,14 @@ Ensure-Directory $BackendRoot
 Reset-Directory $SrcTarget
 Copy-Item -Path (Join-Path $SrcSource "*") -Destination $SrcTarget -Recurse -Force
 
+# #1775: Drop build metadata that may ride along from a local editable install.
+# It is not needed at runtime (scistudio loads from this source tree on
+# PYTHONPATH) and only leaks paths into the bundle and OTA snapshot.
+$EggInfo = Join-Path $SrcTarget "scistudio.egg-info"
+if (Test-Path $EggInfo) {
+    Remove-Item -LiteralPath $EggInfo -Recurse -Force
+}
+
 # Refresh the packaged SPA (scistudio/api/static) from the frontend build we just
 # produced. This is the ONLY frontend a bundled desktop app serves
 # (scistudio.api.app._resolve_spa_static_dir, SCISTUDIO_BUNDLED=1). The repo copy
@@ -82,5 +90,28 @@ Both locations are scanned by the same package discovery path. User-installed
 packages may resolve Python runtime dependencies with the bundled interpreter,
 but dependency files stay in the user-scoped plugin directory.
 "@ | Set-Content -Encoding ASCII (Join-Path $ResourcesRoot "packages\README.md")
+
+# #1775: Stamp the OTA channel config the desktop client reads at launch
+# (main.js loadOtaConfig). A local/dev build leaves SCISTUDIO_OTA_CHANNEL unset
+# and gets OTA disabled, so a developer testing a local build is never disturbed
+# or overwritten by a published patch. A release build sets the channel (and
+# optionally the manifest URL) to enable launch-time update checks. Mirrors
+# stage-resources.sh.
+$OtaChannel = $env:SCISTUDIO_OTA_CHANNEL
+$OtaConfigPath = Join-Path $ResourcesRoot "ota-config.json"
+if (-not [string]::IsNullOrEmpty($OtaChannel)) {
+    $OtaManifestUrl = if (-not [string]::IsNullOrEmpty($env:SCISTUDIO_OTA_MANIFEST_URL)) {
+        $env:SCISTUDIO_OTA_MANIFEST_URL
+    } else {
+        "https://github.com/jiazhenz026/SciStudio/releases/download/ota-$OtaChannel/manifest.json"
+    }
+    $OtaConfig = [ordered]@{ enabled = $true; channel = $OtaChannel; manifestUrl = $OtaManifestUrl }
+    ($OtaConfig | ConvertTo-Json) | Set-Content -Encoding ASCII $OtaConfigPath
+    Write-Host "OTA enabled for channel '$OtaChannel' (manifest: $OtaManifestUrl)"
+} else {
+    $OtaConfig = [ordered]@{ enabled = $false; channel = "dev"; manifestUrl = $null }
+    ($OtaConfig | ConvertTo-Json) | Set-Content -Encoding ASCII $OtaConfigPath
+    Write-Host "OTA disabled (local/dev build; set SCISTUDIO_OTA_CHANNEL to enable)"
+}
 
 Write-Host "Staged desktop resources under $ResourcesRoot"

--- a/desktop/scripts/stage-resources.sh
+++ b/desktop/scripts/stage-resources.sh
@@ -33,6 +33,11 @@ mkdir -p "$BACKEND_ROOT"
 reset_dir "$SRC_TARGET"
 cp -R "$REPO_ROOT/src"/. "$SRC_TARGET"/
 
+# #1775: Drop build metadata that may ride along from a local editable install.
+# It is not needed at runtime (scistudio loads from this source tree on
+# PYTHONPATH) and only leaks paths into the bundle and OTA snapshot.
+rm -rf "$SRC_TARGET/scistudio.egg-info"
+
 # Refresh the packaged SPA (scistudio/api/static) from the frontend build we
 # just produced. This is the ONLY frontend a bundled desktop app serves
 # (scistudio.api.app._resolve_spa_static_dir, SCISTUDIO_BUNDLED=1). The repo
@@ -64,5 +69,32 @@ Both locations are scanned by the same package discovery path. User-installed
 packages may resolve Python runtime dependencies with the bundled interpreter,
 but dependency files stay in the user-scoped plugin directory.
 EOF
+
+# #1775: Stamp the OTA channel config the desktop client reads at launch
+# (main.js loadOtaConfig). A local/dev build leaves SCISTUDIO_OTA_CHANNEL unset
+# and gets OTA disabled, so a developer testing a local build is never disturbed
+# or overwritten by a published patch. A release build sets the channel (and
+# optionally the manifest URL) to enable launch-time update checks.
+OTA_CHANNEL="${SCISTUDIO_OTA_CHANNEL:-}"
+if [ -n "$OTA_CHANNEL" ]; then
+  OTA_MANIFEST_URL="${SCISTUDIO_OTA_MANIFEST_URL:-https://github.com/jiazhenz026/SciStudio/releases/download/ota-$OTA_CHANNEL/manifest.json}"
+  cat > "$RESOURCES_ROOT/ota-config.json" <<EOF
+{
+  "enabled": true,
+  "channel": "$OTA_CHANNEL",
+  "manifestUrl": "$OTA_MANIFEST_URL"
+}
+EOF
+  echo "OTA enabled for channel '$OTA_CHANNEL' (manifest: $OTA_MANIFEST_URL)"
+else
+  cat > "$RESOURCES_ROOT/ota-config.json" <<'EOF'
+{
+  "enabled": false,
+  "channel": "dev",
+  "manifestUrl": null
+}
+EOF
+  echo "OTA disabled (local/dev build; set SCISTUDIO_OTA_CHANNEL to enable)"
+fi
 
 echo "Staged desktop resources under $RESOURCES_ROOT"

--- a/desktop/test/ota.test.js
+++ b/desktop/test/ota.test.js
@@ -1,0 +1,81 @@
+"use strict";
+
+// Unit tests for the pure OTA decision logic (desktop/ota.js, issue #1775).
+// Run with: npm --prefix desktop test   (uses the Node built-in test runner).
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const ota = require("../ota");
+
+test("parseVersion: prerelease form", () => {
+  assert.deepEqual(ota.parseVersion("0.2.1-alpha-build0006"), {
+    base: "0.2.1",
+    channel: "alpha",
+    build: 6
+  });
+});
+
+test("parseVersion: stable form", () => {
+  assert.deepEqual(ota.parseVersion("1.4.0"), { base: "1.4.0", channel: "stable", build: 0 });
+});
+
+test("parseVersion: invalid returns null", () => {
+  assert.equal(ota.parseVersion("nope"), null);
+  assert.equal(ota.parseVersion(null), null);
+});
+
+test("compareBase: numeric, not lexical", () => {
+  assert.equal(ota.compareBase("0.2.1", "0.2.1"), 0);
+  assert.equal(ota.compareBase("0.2.1", "0.2.2"), -1);
+  assert.equal(ota.compareBase("0.10.0", "0.9.9"), 1); // lexical would be wrong
+});
+
+test("patchDirName", () => {
+  assert.equal(ota.patchDirName(7), "build7");
+});
+
+const CONFIG = { enabled: true, channel: "alpha", manifestUrl: "https://x/m.json" };
+const BASELINE = { base: "0.2.1", channel: "alpha", build: 6 };
+
+test("evaluateUpdate: disabled config short-circuits", () => {
+  const d = ota.evaluateUpdate({ enabled: false }, { build: 99 }, BASELINE, 6);
+  assert.equal(d.kind, "none");
+  assert.equal(d.reason, "ota-disabled");
+});
+
+test("evaluateUpdate: malformed manifest is invalid", () => {
+  assert.equal(ota.evaluateUpdate(CONFIG, {}, BASELINE, 6).kind, "invalid");
+  assert.equal(ota.evaluateUpdate(CONFIG, null, BASELINE, 6).kind, "invalid");
+});
+
+test("evaluateUpdate: channel mismatch is ignored", () => {
+  const m = { build: 99, channel: "beta", base: "0.2.1" };
+  assert.equal(ota.evaluateUpdate(CONFIG, m, BASELINE, 6).reason, "channel-mismatch");
+});
+
+test("evaluateUpdate: same or lower build is up-to-date", () => {
+  const m = { build: 6, channel: "alpha", base: "0.2.1" };
+  assert.equal(ota.evaluateUpdate(CONFIG, m, BASELINE, 6).reason, "up-to-date");
+  const older = { build: 5, channel: "alpha", base: "0.2.1" };
+  assert.equal(ota.evaluateUpdate(CONFIG, older, BASELINE, 6).reason, "up-to-date");
+});
+
+test("evaluateUpdate: newer, compatible base => patch", () => {
+  const m = { build: 7, channel: "alpha", base: "0.2.1", requires: { min_base: "0.2.1" } };
+  const d = ota.evaluateUpdate(CONFIG, m, BASELINE, 6);
+  assert.equal(d.kind, "patch");
+  assert.equal(d.build, 7);
+});
+
+test("evaluateUpdate: newer but base too old => incompatible", () => {
+  const m = { build: 8, channel: "alpha", base: "0.3.0", requires: { min_base: "0.3.0" } };
+  const d = ota.evaluateUpdate(CONFIG, m, BASELINE, 6);
+  assert.equal(d.kind, "incompatible");
+  assert.equal(d.minBase, "0.3.0");
+});
+
+test("evaluateUpdate: compares against effective build, not baseline", () => {
+  // Installed baseline build 6, but an applied patch made effective build 9.
+  const m = { build: 8, channel: "alpha", base: "0.2.1", requires: { min_base: "0.2.1" } };
+  assert.equal(ota.evaluateUpdate(CONFIG, m, BASELINE, 9).reason, "up-to-date");
+});

--- a/docs/specs/desktop-ota-hot-update.md
+++ b/docs/specs/desktop-ota-hot-update.md
@@ -1,0 +1,163 @@
+---
+spec_id: desktop-ota-hot-update
+title: "Desktop OTA Hot-Update: Full-Snapshot Backend+Frontend Patches"
+status: Implemented
+feature_branch: guided/ota-hot-update-20260625
+created: 2026-06-25
+input: "Issue #1775 — internal alpha testers should receive backend + frontend fixes without re-downloading the full installer. Owner-directed guided session 2026-06-25."
+owners:
+  - "@jiazhenz026"
+related_adrs: []
+related_specs:
+  - alpha-version-management
+scope:
+  in:
+    - Launch-time OTA update check in the Electron desktop client.
+    - Full-snapshot patches of the staged backend source tree (which embeds the frontend SPA at scistudio/api/static).
+    - A per-channel rolling GitHub pre-release as the manifest + asset host.
+    - A publish CLI (scripts/ota_publish.py) that packs, hashes, numbers, and uploads a patch.
+    - userData-staged patches with PYTHONPATH redirection, atomic apply, and boot-failure rollback.
+    - A build-time dev marker (ota-config.json) that disables OTA for local/dev builds.
+    - Removal of the duplicate bundled-interpreter scistudio copy left by the runtime build.
+  out:
+    - OTA of the Electron JS shell, the Electron/Chromium binary, the Python interpreter, or native dependencies (these require a new installer; the client only prompts).
+    - Cryptographic signing of patches (sha256 + HTTPS only for now; Ed25519 deferred to release).
+    - A manual "check for updates" UI entry and background polling (launch-time check only).
+    - CI auto-publish on merge (manual publish for now).
+    - An ADR (owner decision; this spec is the design record).
+governs:
+  modules: []
+  contracts: []
+  entry_points: []
+  files:
+    - docs/specs/desktop-ota-hot-update.md
+    - desktop/main.js
+    - desktop/ota.js
+    - desktop/scripts/stage-resources.sh
+    - desktop/scripts/stage-resources.ps1
+    - desktop/scripts/build-python-runtime-macos.sh
+    - desktop/scripts/build-python-runtime.ps1
+    - scripts/ota_publish.py
+  excludes: []
+tests:
+  - tests/scripts/test_ota_publish.py
+  - desktop/test/ota.test.js
+acceptance_source: issue
+language_source: en
+---
+
+# Desktop OTA Hot-Update: Full-Snapshot Backend+Frontend Patches
+
+## 1. Change Summary
+
+From issue #1775. The desktop app ships a bundled Python interpreter plus the
+backend **source tree** on `PYTHONPATH` (`resources/backend/src`), and that tree
+embeds the built frontend SPA at `scistudio/api/static`, which the bundled
+backend serves over HTTP. Because the runtime executes source (not compiled
+artifacts), the backend **and** frontend can be updated by swapping one
+directory — without re-running the installer.
+
+This spec adds an OTA mechanism that does exactly that: at launch the client
+checks a per-channel manifest, and if a newer compatible **build** exists it
+downloads a full-snapshot tarball, verifies it, stages it under `userData`, and
+restarts the runtime pointed at the new source. The Electron shell, the Python
+interpreter, and native dependencies are **not** hot-updatable; a patch that
+needs a newer baseline asks the user to reinstall.
+
+It also removes a pre-existing redundancy: the runtime build `pip install`s
+scistudio into the bundled interpreter in addition to staging the source tree,
+shipping two plaintext copies. Only the `PYTHONPATH` copy is used; the installed
+one is removed (dependencies are kept).
+
+## 2. Layered update model
+
+| Layer | Hot-updatable? | Mechanism |
+|---|---|---|
+| Backend source (`backend/src`) | Yes | OTA full-snapshot swap |
+| Frontend SPA (`scistudio/api/static`, inside the backend tree) | Yes | rides in the same snapshot |
+| Electron JS, Electron/Chromium binary, Python interpreter, native deps | No | new installer (client prompts only) |
+
+## 3. Versioning (extends [alpha-version-management](alpha-version-management.md))
+
+Two independently-moving parts:
+
+- **`base`** (`a.b.c`, from `desktop/package.json`) — the installer baseline:
+  Electron + interpreter + native deps.
+- **`build`** (integer) — the patch sequence for the hot-updatable source layer.
+  Source of truth is the published manifest, not the local counter.
+
+The client's **effective build** is `max(baseline build, applied patch build)`
+and is reported to the backend via the existing `SCISTUDIO_BUILD_NUMBER`
+override so `/version` reflects the applied patch.
+
+Update decision (pure logic in `desktop/ota.js`, `evaluateUpdate`):
+
+1. `manifest.channel == config.channel` (else ignore).
+2. `manifest.build > effective build` (else up-to-date).
+3. `base >= manifest.requires.min_base` → **patch**; otherwise **incompatible**
+   (prompt to reinstall). The client always targets the latest build; a client
+   several builds behind jumps straight to it in one snapshot download.
+
+## 4. Distribution
+
+- Host: a public-repo, per-channel rolling GitHub **pre-release** tagged
+  `ota-<channel>`, with assets `manifest.json` and `backend-build<N>.tar.gz`.
+  Anonymous download (repo is public); pre-release is visible but not "latest".
+- `manifest.json`:
+  `{channel, base, build, requires:{min_base}, url, sha256, size, notes, published_at}`.
+- Publish: `scripts/ota_publish.py` packs `desktop/resources/backend/src` into a
+  gzip tarball rooted at `src/` (excluding `__pycache__`/`.pyc`/`egg-info`),
+  computes sha256, sets `build = max(latest_published, baseline) + 1`, and
+  uploads with `gh release upload --clobber`. `--dry-run` builds locally only.
+
+## 5. Client behavior (`desktop/main.js`)
+
+- **Launch-time only**, after the window is shown (never blocks startup); offline
+  failures are logged and ignored.
+- Reads `resources/ota-config.json`. `{enabled:false, channel:"dev"}` (the
+  default for local builds) disables OTA entirely.
+- On a `patch` decision: native dialog → download → sha256 verify → `tar -xzf`
+  into a temp dir → atomic rename to `userData/patches/build<N>/` → write
+  `active.json` pointer → `app.relaunch()`.
+- `runtimeEnv()` prepends `userData/patches/build<N>/src` to `PYTHONPATH`; the
+  app bundle is never modified (works under a read-only/signed bundle and avoids
+  Windows `Program Files` permission issues).
+- **Rollback**: if the runtime fails to reach ready with an active patch, the
+  client reverts to the last known-good patch (or the bundled baseline) and
+  retries once, so a bad patch cannot brick the install. A patch is recorded
+  known-good only after the runtime reaches HTTP readiness.
+
+## 6. Local/dev isolation
+
+Local builds (`npm run dist:dmg`) leave `SCISTUDIO_OTA_CHANNEL` unset; the stage
+step writes `ota-config.json` with `enabled:false`, so a developer testing a
+local build is never disturbed or overwritten. A release build sets
+`SCISTUDIO_OTA_CHANNEL` (and optionally `SCISTUDIO_OTA_MANIFEST_URL`) to enable
+checks. Publishing is a separate explicit step; run it from the same checkout
+that was built and tested.
+
+## 7. Security
+
+Internal alpha threat model: HTTPS + sha256 integrity (detects corruption, not
+MITM). Patches are open-source code on a public repo. Ed25519 signing is
+deferred to a release-grade channel.
+
+## 8. Verification
+
+- `tests/scripts/test_ota_publish.py`: version parse, monotonic build numbering,
+  manifest shape, naming/URLs, sha256, snapshot packing + exclusions.
+- `desktop/test/ota.test.js`: `parseVersion`, numeric `compareBase`, and every
+  `evaluateUpdate` branch (disabled, invalid, channel-mismatch, up-to-date,
+  patch, incompatible, effective-build comparison).
+- Manual: `python scripts/ota_publish.py --channel alpha --dry-run`; build a
+  dev DMG and confirm OTA is skipped; build with `SCISTUDIO_OTA_CHANNEL=alpha`
+  and confirm the launch-time dialog, apply, relaunch, and `/version` update.
+
+## 9. Assumptions
+
+- Repo `jiazhenz026/SciStudio` is public; OTA assets are anonymously downloadable
+  (source: owner).
+- Single combined PR; no ADR; this spec is the design record (source: owner).
+- `gh` is available and authenticated when publishing (source: inferred).
+- System `tar` (bsdtar) is present on macOS and Windows 10+ for extraction
+  (source: inferred).

--- a/scripts/ota_publish.py
+++ b/scripts/ota_publish.py
@@ -1,0 +1,309 @@
+#!/usr/bin/env python3
+"""Publish a SciStudio desktop OTA hot-update patch.
+
+A patch is a *full snapshot* of the staged backend source tree
+(``desktop/resources/backend/src``, which already embeds the built frontend at
+``scistudio/api/static``). It is uploaded as an asset on a rolling, per-channel
+GitHub pre-release together with a ``manifest.json`` that the desktop client
+(``desktop/main.js``) reads at launch.
+
+Design (issue #1775):
+
+* Patches are full snapshots, never deltas. A client several builds behind
+  downloads the latest snapshot and replaces its source tree in one step.
+* The build number is the patch sequence. Its source of truth is the published
+  manifest, not any local counter: the next build is
+  ``max(latest_published_build, installer_baseline_build) + 1`` so it is always
+  strictly greater than what any shipped installer reports.
+* ``base`` (the ``a.b.c`` from ``desktop/package.json``) is the installer
+  baseline. The patch records ``requires.min_base = base``; a client whose
+  installer base is older must reinstall instead of hot-patching.
+
+Publishing is intentionally decoupled from local/dev builds: a developer builds
+and tests locally (OTA disabled, see ``stage-resources`` ``ota-config.json``),
+then runs this script from the *same checkout* to publish what was tested.
+
+Usage::
+
+    python scripts/ota_publish.py --channel alpha
+    python scripts/ota_publish.py --channel alpha --dry-run
+    python scripts/ota_publish.py --channel alpha --notes "Fix Export logs dialog"
+
+Requires the GitHub CLI (``gh``) authenticated with write access to the repo,
+except under ``--dry-run`` which only builds the snapshot and manifest locally.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import hashlib
+import json
+import re
+import subprocess
+import tarfile
+import tempfile
+from pathlib import Path
+
+DEFAULT_REPO = "jiazhenz026/SciStudio"
+REPO_ROOT = Path(__file__).resolve().parent.parent
+STAGED_SRC = REPO_ROOT / "desktop" / "resources" / "backend" / "src"
+DESKTOP_PACKAGE_JSON = REPO_ROOT / "desktop" / "package.json"
+
+_VERSION_RE = re.compile(r"^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z]+)-build(\d+))?$")
+
+
+# --------------------------------------------------------------------------- #
+# Pure helpers (unit-tested in tests/scripts/test_ota_publish.py)
+# --------------------------------------------------------------------------- #
+def parse_version(version: str) -> dict:
+    """Parse a SciStudio display/SemVer version into base/channel/build.
+
+    Accepts ``a.b.c-<channel>-build<NNNN>`` (prerelease) or ``a.b.c`` (stable).
+    """
+    match = _VERSION_RE.match(version.strip())
+    if not match:
+        raise ValueError(f"Unrecognized version string: {version!r}")
+    major, minor, patch, channel, build = match.groups()
+    return {
+        "base": f"{major}.{minor}.{patch}",
+        "channel": channel or "stable",
+        "build": int(build) if build is not None else 0,
+    }
+
+
+def next_build_number(latest_published_build: int | None, baseline_build: int) -> int:
+    """Return the next monotonic patch build number.
+
+    The patch sequence must stay strictly above both the latest already-published
+    patch and the installer baseline, so a fresh install (whose effective build is
+    the baseline) always sees the first patch as newer.
+    """
+    candidates = [baseline_build]
+    if latest_published_build is not None:
+        candidates.append(latest_published_build)
+    return max(candidates) + 1
+
+
+def asset_name(build: int) -> str:
+    return f"backend-build{build}.tar.gz"
+
+
+def asset_url(repo: str, tag: str, name: str) -> str:
+    return f"https://github.com/{repo}/releases/download/{tag}/{name}"
+
+
+def channel_tag(channel: str) -> str:
+    return f"ota-{channel}"
+
+
+def build_manifest(
+    *,
+    channel: str,
+    base: str,
+    build: int,
+    url: str,
+    sha256: str,
+    size: int,
+    notes: str,
+    published_at: str,
+) -> dict:
+    """Assemble the manifest document the desktop client compares against."""
+    return {
+        "channel": channel,
+        "base": base,
+        "build": build,
+        "requires": {"min_base": base},
+        "url": url,
+        "sha256": sha256,
+        "size": size,
+        "notes": notes,
+        "published_at": published_at,
+    }
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def make_snapshot(src_dir: Path, out_path: Path) -> None:
+    """Pack ``src_dir`` into ``out_path`` as a gzip tarball rooted at ``src/``.
+
+    Extracting the archive yields ``<dest>/src/scistudio/...`` so the client can
+    point ``PYTHONPATH`` at ``<dest>/src``. ``__pycache__`` is skipped to keep
+    the snapshot lean and interpreter-agnostic.
+    """
+
+    def _filter(info: tarfile.TarInfo) -> tarfile.TarInfo | None:
+        parts = Path(info.name).parts
+        if "__pycache__" in parts or info.name.endswith(".pyc"):
+            return None
+        if "scistudio.egg-info" in parts:
+            return None
+        return info
+
+    with tarfile.open(out_path, "w:gz") as tar:
+        tar.add(src_dir, arcname="src", filter=_filter)
+
+
+# --------------------------------------------------------------------------- #
+# gh / IO side
+# --------------------------------------------------------------------------- #
+def _run(cmd: list[str], **kwargs) -> subprocess.CompletedProcess:
+    return subprocess.run(cmd, text=True, capture_output=True, **kwargs)
+
+
+def fetch_latest_build(repo: str, tag: str) -> int | None:
+    """Return the build number of the currently published manifest, or None."""
+    with tempfile.TemporaryDirectory() as tmp:
+        out = Path(tmp) / "manifest.json"
+        result = _run(
+            [
+                "gh",
+                "release",
+                "download",
+                tag,
+                "--repo",
+                repo,
+                "--pattern",
+                "manifest.json",
+                "--output",
+                str(out),
+                "--clobber",
+            ]
+        )
+        if result.returncode != 0 or not out.exists():
+            return None
+        try:
+            return int(json.loads(out.read_text())["build"])
+        except (ValueError, KeyError, json.JSONDecodeError):
+            return None
+
+
+def ensure_release(repo: str, tag: str, channel: str) -> None:
+    """Create the rolling per-channel pre-release if it does not exist yet."""
+    exists = _run(["gh", "release", "view", tag, "--repo", repo]).returncode == 0
+    if exists:
+        return
+    result = _run(
+        [
+            "gh",
+            "release",
+            "create",
+            tag,
+            "--repo",
+            repo,
+            "--prerelease",
+            "--title",
+            f"SciStudio OTA ({channel})",
+            "--notes",
+            f"Rolling OTA channel for '{channel}'. Assets are managed by scripts/ota_publish.py; do not edit manually.",
+        ]
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"Failed to create release {tag}: {result.stderr.strip()}")
+
+
+def upload_assets(repo: str, tag: str, files: list[Path]) -> None:
+    result = _run(["gh", "release", "upload", tag, "--repo", repo, "--clobber", *map(str, files)])
+    if result.returncode != 0:
+        raise RuntimeError(f"Asset upload failed: {result.stderr.strip()}")
+
+
+# --------------------------------------------------------------------------- #
+# main
+# --------------------------------------------------------------------------- #
+def _utc_now_iso() -> str:
+    return _dt.datetime.now(_dt.UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Publish a SciStudio desktop OTA patch.")
+    parser.add_argument(
+        "--channel",
+        help="OTA channel (e.g. alpha, beta). Defaults to the channel in desktop/package.json.",
+    )
+    parser.add_argument("--repo", default=DEFAULT_REPO, help="owner/name of the GitHub repo.")
+    parser.add_argument("--notes", default="", help="Human-readable patch notes for the manifest.")
+    parser.add_argument(
+        "--src",
+        type=Path,
+        default=STAGED_SRC,
+        help="Staged backend source tree to snapshot (default: the desktop build output).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Build the snapshot and manifest locally without creating/uploading a release.",
+    )
+    parser.add_argument("--yes", action="store_true", help="Skip the confirmation prompt before uploading.")
+    args = parser.parse_args(argv)
+
+    src_dir: Path = args.src
+    if not (src_dir / "scistudio").is_dir():
+        parser.error(
+            f"No staged source at {src_dir} (expected a 'scistudio' package). Run the desktop build/stage step first."
+        )
+
+    baseline = parse_version(json.loads(DESKTOP_PACKAGE_JSON.read_text())["version"])
+    channel = args.channel or baseline["channel"]
+    if channel == "stable":
+        parser.error("Refusing to publish an OTA patch on the 'stable' channel; pass --channel.")
+    tag = channel_tag(channel)
+
+    latest = None if args.dry_run else fetch_latest_build(args.repo, tag)
+    build = next_build_number(latest, baseline["build"])
+    name = asset_name(build)
+
+    workdir = Path(tempfile.mkdtemp(prefix="scistudio-ota-"))
+    tarball = workdir / name
+    print(f"Packing snapshot of {src_dir} -> {tarball.name} ...")
+    make_snapshot(src_dir, tarball)
+
+    digest = sha256_file(tarball)
+    size = tarball.stat().st_size
+    manifest = build_manifest(
+        channel=channel,
+        base=baseline["base"],
+        build=build,
+        url=asset_url(args.repo, tag, name),
+        sha256=digest,
+        size=size,
+        notes=args.notes,
+        published_at=_utc_now_iso(),
+    )
+    manifest_path = workdir / "manifest.json"
+    manifest_path.write_text(json.dumps(manifest, indent=2) + "\n")
+
+    print(
+        f"\nchannel={channel} base={baseline['base']} build={build} "
+        f"(baseline build {baseline['build']}, latest published "
+        f"{latest if latest is not None else 'none'})"
+    )
+    print(f"  asset : {name} ({size} bytes)")
+    print(f"  sha256: {digest}")
+    print(f"  url   : {manifest['url']}")
+
+    if args.dry_run:
+        print(f"\n[dry-run] artifacts left in {workdir}")
+        print(f"[dry-run] manifest:\n{manifest_path.read_text()}")
+        return 0
+
+    if not args.yes:
+        reply = input(f"\nUpload build {build} to {args.repo} ({tag})? [y/N] ").strip().lower()
+        if reply not in {"y", "yes"}:
+            print("Aborted.")
+            return 1
+
+    ensure_release(args.repo, tag, channel)
+    upload_assets(args.repo, tag, [tarball, manifest_path])
+    print(f"\nPublished OTA build {build} to {args.repo} release {tag}.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_ota_publish.py
+++ b/tests/scripts/test_ota_publish.py
@@ -1,0 +1,142 @@
+"""Tests for ``scripts/ota_publish.py``.
+
+Covers the pure pieces: version parsing, monotonic build numbering, manifest
+assembly, asset naming/URLs, sha256, and snapshot packing (including the
+__pycache__ / egg-info exclusions). The gh/IO side is not exercised here.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import tarfile
+from pathlib import Path
+
+import pytest
+
+_SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "ota_publish.py"
+
+
+@pytest.fixture(scope="module")
+def mod():
+    spec = importlib.util.spec_from_file_location("ota_publish", _SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+# --------------------------------------------------------------------------- #
+# parse_version
+# --------------------------------------------------------------------------- #
+def test_parse_version_prerelease(mod):
+    assert mod.parse_version("0.2.1-alpha-build0006") == {
+        "base": "0.2.1",
+        "channel": "alpha",
+        "build": 6,
+    }
+
+
+def test_parse_version_stable(mod):
+    assert mod.parse_version("1.4.0") == {"base": "1.4.0", "channel": "stable", "build": 0}
+
+
+def test_parse_version_beta_large_build(mod):
+    assert mod.parse_version("0.2.1-beta-build0123")["build"] == 123
+
+
+def test_parse_version_invalid_raises(mod):
+    with pytest.raises(ValueError):
+        mod.parse_version("not-a-version")
+
+
+# --------------------------------------------------------------------------- #
+# next_build_number
+# --------------------------------------------------------------------------- #
+def test_next_build_from_baseline_when_no_published(mod):
+    # First patch must exceed the installer baseline build.
+    assert mod.next_build_number(None, 6) == 7
+
+
+def test_next_build_increments_latest_published(mod):
+    assert mod.next_build_number(11, 6) == 12
+
+
+def test_next_build_never_below_baseline(mod):
+    # A stale/low published number must not let a patch regress past baseline.
+    assert mod.next_build_number(3, 9) == 10
+
+
+# --------------------------------------------------------------------------- #
+# naming / urls
+# --------------------------------------------------------------------------- #
+def test_asset_and_url_and_tag(mod):
+    assert mod.asset_name(12) == "backend-build12.tar.gz"
+    assert mod.channel_tag("alpha") == "ota-alpha"
+    assert mod.asset_url("o/r", "ota-alpha", "backend-build12.tar.gz") == (
+        "https://github.com/o/r/releases/download/ota-alpha/backend-build12.tar.gz"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# build_manifest
+# --------------------------------------------------------------------------- #
+def test_build_manifest_shape(mod):
+    manifest = mod.build_manifest(
+        channel="alpha",
+        base="0.2.1",
+        build=7,
+        url="https://example/backend-build7.tar.gz",
+        sha256="abc",
+        size=1234,
+        notes="hi",
+        published_at="2026-06-25T00:00:00Z",
+    )
+    assert manifest["channel"] == "alpha"
+    assert manifest["build"] == 7
+    assert manifest["requires"] == {"min_base": "0.2.1"}
+    assert manifest["sha256"] == "abc"
+    assert manifest["size"] == 1234
+    # Round-trips as JSON (it is written to the release asset verbatim).
+    assert json.loads(json.dumps(manifest))["url"].endswith("backend-build7.tar.gz")
+
+
+# --------------------------------------------------------------------------- #
+# sha256_file
+# --------------------------------------------------------------------------- #
+def test_sha256_file(mod, tmp_path):
+    target = tmp_path / "blob.bin"
+    target.write_bytes(b"scistudio")
+    import hashlib
+
+    assert mod.sha256_file(target) == hashlib.sha256(b"scistudio").hexdigest()
+
+
+# --------------------------------------------------------------------------- #
+# make_snapshot
+# --------------------------------------------------------------------------- #
+def test_make_snapshot_roots_at_src_and_excludes_caches(mod, tmp_path):
+    src = tmp_path / "backend" / "src"
+    pkg = src / "scistudio"
+    pkg.mkdir(parents=True)
+    (pkg / "__init__.py").write_text("x = 1\n")
+    (pkg / "module.py").write_text("y = 2\n")
+    # Noise that must be excluded from the snapshot.
+    cache = pkg / "__pycache__"
+    cache.mkdir()
+    (cache / "module.cpython-312.pyc").write_bytes(b"\x00")
+    egg = src / "scistudio.egg-info"
+    egg.mkdir()
+    (egg / "PKG-INFO").write_text("meta\n")
+
+    out = tmp_path / "snap.tar.gz"
+    mod.make_snapshot(src, out)
+
+    with tarfile.open(out, "r:gz") as tar:
+        names = set(tar.getnames())
+
+    assert "src/scistudio/__init__.py" in names
+    assert "src/scistudio/module.py" in names
+    assert not any("__pycache__" in n for n in names)
+    assert not any(n.endswith(".pyc") for n in names)
+    assert not any("egg-info" in n for n in names)


### PR DESCRIPTION
## Summary

Adds a launch-time **OTA hot-update** for the desktop app so internal alpha
testers receive backend + frontend (embedded SPA) fixes without re-downloading
the installer. Patches are **full snapshots** of the staged backend source tree,
hosted on a per-channel rolling GitHub pre-release. The Electron shell, Python
interpreter, and native deps are not hot-updatable (the client only prompts to
reinstall when a patch needs a newer baseline).

Closes #1775.

## What changed

- **`desktop/ota.js`** (new): pure update-decision logic — version parse, numeric
  base compare, `evaluateUpdate` (none / invalid / patch / incompatible).
- **`desktop/main.js`**: launch-time manifest check + native dialog; download →
  sha256 verify → `tar` extract → atomic stage to `userData/patches/build<N>`;
  `PYTHONPATH` redirect to the active patch + `SCISTUDIO_BUILD_NUMBER` set to the
  effective build; boot-failure rollback to last known-good or bundled baseline.
- **`scripts/ota_publish.py`** (new): pack full `backend/src` snapshot, sha256,
  monotonic build numbering (`max(latest_published, baseline) + 1`), upload to a
  per-channel pre-release via `gh`. `--dry-run` supported.
- **`stage-resources.{sh,ps1}`**: write `ota-config.json` (local/dev builds get
  OTA **disabled**); strip staged `scistudio.egg-info`.
- **`build-python-runtime-macos.sh` / `.ps1`**: `pip uninstall` the redundant
  bundled `scistudio` copy after install (deps kept) — the source tree is now the
  single source of truth and the OTA target.
- **`docs/specs/desktop-ota-hot-update.md`** (new): design record (no ADR per
  owner).

## Versioning

Two parts: `base` (`a.b.c`, installer baseline) and `build` (patch sequence,
manifest is source of truth). Effective build = `max(baseline, applied patch)`,
reported via the existing `SCISTUDIO_BUILD_NUMBER` override so `/version`
reflects the patch. Update determined by `build`; `requires.min_base` gates
hot-patch vs reinstall.

## Local/dev isolation

Local builds leave `SCISTUDIO_OTA_CHANNEL` unset → OTA disabled, so testing a
local build is never disturbed. Release builds set the channel to enable checks;
publishing is a separate explicit step.

## Security

Internal threat model: HTTPS + sha256 integrity. Ed25519 signing deferred to a
release-grade channel.

## Tests

- `tests/scripts/test_ota_publish.py` — version parse, build numbering, manifest
  shape, naming/URLs, sha256, snapshot packing + exclusions (11 tests).
- `desktop/test/ota.test.js` — `parseVersion`, numeric `compareBase`, all
  `evaluateUpdate` branches (12 tests, `npm --prefix desktop test`).
- Manual: `python scripts/ota_publish.py --channel alpha --dry-run` verified.

## Out of scope

OTA of the Electron JS/binary, Python interpreter, or native deps (require a new
installer); cryptographic signing; manual "check for updates" UI / background
polling; CI auto-publish.
