### PR TITLE
fix(#1779): register core first-party blocks as builtins, not entry points

### DIFF
--- a/.workflow/records/1779-guided-1779-core-blocks-builtin-registration.json
+++ b/.workflow/records/1779-guided-1779-core-blocks-builtin-registration.json
@@ -1,0 +1,1156 @@
+{
+  "branch": "guided/1779-core-blocks-builtin-registration",
+  "check_events": [
+    {
+      "at": "2026-06-26T03:05:08.607042Z",
+      "command": "pytest tests/architecture/ -v --no-cov",
+      "covered_surface": "architecture",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:1773d671bfd3e38f494d14b67543fd91d431e01f521a096ab15be0d324ba7c0e",
+      "name": "architecture_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/architecture_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-26T03:05:09.286987Z",
+      "command": "python scripts/deferral_scan.py --check docs/audit/baselines/deferral-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:11bb4a596cb1e1259b41201c21768caf258b4f8f7d3bec7ed33be8474ecc29b1",
+      "name": "deferral_discipline",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/deferral_discipline.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-26T03:05:09.629676Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:d37b22afff55d609ed3e52781ca6c35724c1b170f07ab8b2ecc2cfcc86d892f5",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-26T03:05:13.157667Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:4f0a741c46511be740601734d2cc79b759e85c783d4c872923355069d6416223",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-26T03:05:13.639631Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:98238511375296e1d00568854255f024125f4344b907ccb36c0a9fb031e81bf0",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-26T03:05:13.677437Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:2a24ddcb2ef0250c46f1a12a0b34ceb541a3556a311566cd5a53f78b9a5a189c",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-26T03:06:37.534633Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:379ea3b828b366506b2b068faf95cf33adb5e34c4ea99a0a316e29515251d206",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-26T03:08:22.831240Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:69244e8544adeee190307e4b7e93e6486d4c2ea46a44eb4a3ecba0c6662b292d",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-26T03:08:29.315623Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:da5ba78817052e4701e77ae0df8bd441dbe7f24dcd235bfa066486067fcef8f7",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    },
+    {
+      "at": "2026-06-26T03:08:32.065111Z",
+      "command": "python -m build --wheel",
+      "covered_surface": "packaging",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:df5a9fcfebbf6d272f46b2d3bc1978e6cf5807480098a66fb69ebe65ca74e1b2",
+      "name": "wheel_release_smoke",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/wheel_release_smoke.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    }
+  ],
+  "check_na": [],
+  "commit": {
+    "sha": "e5f778309deaadb54a52f30a8bb3b516766b037a",
+    "shas": [
+      "e5f778309deaadb54a52f30a8bb3b516766b037a"
+    ],
+    "trailers": []
+  },
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "src/scistudio/blocks/registry/_scan.py",
+      "pyproject.toml"
+    ]
+  },
+  "directive_events": [
+    {
+      "at": "2026-06-26T02:57:28.878362Z",
+      "owner_directive": "\u6388\u6743 admin-approved:core-change",
+      "reason": "owner authorized protected-core change to src/scistudio/blocks/**"
+    },
+    {
+      "at": "2026-06-26T02:59:47.700771Z",
+      "owner_directive": "\u5728 _scan_builtins \u76f4\u63a5 import \u6ce8\u518c\u7b2c\u4e00\u65b9 palette block(AppBlock/CodeBlock/DataRouter/MergeCollection/SplitCollection/FilterCollection/SliceCollection/PairEditor);\u4ece pyproject \u5220\u9664\u5bf9\u5e94 core scistudio.blocks entry points;dataframe \u7248 MergeBlock/SplitBlock \u4fdd\u6301\u53ef import \u4f46\u4e0d\u8fdb palette",
+      "reason": "plan"
+    }
+  ],
+  "docs_events": [
+    {
+      "at": "2026-06-26T03:03:56.759722Z",
+      "class": "architecture",
+      "kind": "na",
+      "path": null,
+      "rationale": "no doc states core blocks register via entry points; change is internal and documented in _scan_builtins docstring + pyproject",
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-26T03:03:56.760008Z",
+      "class": "guide",
+      "kind": "na",
+      "path": null,
+      "rationale": "block-development docs target third-party plugin authors; entry-point publishing flow is unchanged",
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": true,
+  "guard_events": [
+    {
+      "at": "2026-06-26T03:08:32.092117Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/registry/_scan.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/registry/_scan.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T03:08:32.101215Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T03:08:32.110998Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T03:08:32.120598Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T03:08:32.129983Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "pyproject.toml",
+          "finding_class": "governance",
+          "git_evidence": null,
+          "id": "governance.mod_guard.unauthorized-change",
+          "line": null,
+          "message": "governance-critical file changed without authorization; declare governance_touch in the ledger and obtain owner review",
+          "path": "pyproject.toml",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "governance.mod_guard.unauthorized-change",
+          "severity": "error",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "mod_guard",
+      "status": "fail"
+    },
+    {
+      "at": "2026-06-26T03:08:32.139211Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T03:08:32.148515Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T03:08:32.158375Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T03:08:32.168513Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T03:08:32.178395Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T03:09:07.386185Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/registry/_scan.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/registry/_scan.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T03:09:07.394761Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T03:09:07.403235Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T03:09:07.411547Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T03:09:07.420041Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T03:09:07.429041Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T03:09:07.437488Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T03:09:07.445900Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T03:09:07.454786Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T03:09:07.463492Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T03:09:38.491271Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/registry/_scan.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/registry/_scan.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T03:09:38.499806Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T03:09:38.508558Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T03:09:38.517590Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T03:09:38.526564Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T03:09:38.535295Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T03:09:38.543556Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T03:09:38.552225Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T03:09:38.560337Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T03:09:38.568882Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T03:09:52.927155Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/registry/_scan.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/registry/_scan.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T03:09:52.935698Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T03:09:52.945185Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T03:09:52.954698Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T03:09:52.964773Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T03:09:52.976090Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T03:09:52.985611Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T03:09:52.994399Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T03:09:53.002825Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T03:09:53.011969Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T03:10:17.354105Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/registry/_scan.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/registry/_scan.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T03:10:17.362650Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T03:10:17.372135Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T03:10:17.380994Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T03:10:17.389281Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T03:10:17.397492Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T03:10:17.406114Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T03:10:17.414803Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T03:10:17.423173Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T03:10:17.431773Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T03:10:29.555726Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/registry/_scan.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/registry/_scan.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T03:10:29.564651Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T03:10:29.574160Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T03:10:29.583790Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T03:10:29.593399Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T03:10:29.602569Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T03:10:29.611277Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T03:10:29.620000Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T03:10:29.628930Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T03:10:29.638152Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T03:10:40.322051Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/registry/_scan.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/registry/_scan.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T03:10:40.330557Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T03:10:40.339098Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T03:10:40.347527Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T03:10:40.356717Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T03:10:40.366704Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T03:10:40.375269Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T03:10:40.383688Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T03:10:40.392095Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T03:10:40.401434Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1779,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": {
+    "base": "f973b487adcdb4ffc490cb1439d64c7925bb2d1e",
+    "base_sha": "f973b487",
+    "changed_files": [
+      ".workflow/records/1779-guided-1779-core-blocks-builtin-registration.json",
+      "pyproject.toml",
+      "src/scistudio/blocks/registry/_scan.py",
+      "tests/blocks/test_registry.py",
+      "tests/blocks/test_tier1_dropin_subprocess.py",
+      "tests/integration/test_block_sdk_e2e.py"
+    ],
+    "diff_fingerprint": "sha256:6058e9c792cf8d27323c9e02a2e7979bb308bb1db5aead7054d26efdaa40efa8",
+    "head": "HEAD",
+    "head_sha": "e5f77830",
+    "surfaces": {
+      "docs": 0,
+      "frontend": 0,
+      "governance": 1,
+      "governed_docs": 0,
+      "implementation": 2,
+      "packaging": 1,
+      "protected_core": 1,
+      "sentrux": 4,
+      "test": 3,
+      "workflow_ci": 0
+    }
+  },
+  "owner_directive": "core \u81ea\u5e26 block \u5728\u6253\u5305\u684c\u9762 app \u91cc\u53ea\u5269 load/save/subworkflow;\u7edf\u4e00\u6539\u4e3a\u5728 _scan_builtins \u76f4\u63a5\u6ce8\u518c\u7b2c\u4e00\u65b9 block,\u5220\u9664 core \u7684 scistudio.blocks entry points;dataframe \u7248 Merge/Split \u4e0d\u8fdb palette",
+  "persona": "live_implementer",
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [
+      1779
+    ],
+    "number": 1780,
+    "url": null
+  },
+  "reconcile_events": [
+    {
+      "at": "2026-06-26T03:08:32.178430Z",
+      "diff_fingerprint": "sha256:8d27d166cfe1a7e10b1cbc2e86e1f14b350ca61272356959b6ce0fdafdf98fea",
+      "mode": "local",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "guard.mod_guard"
+      ]
+    },
+    {
+      "at": "2026-06-26T03:09:07.463522Z",
+      "diff_fingerprint": "sha256:8d27d166cfe1a7e10b1cbc2e86e1f14b350ca61272356959b6ce0fdafdf98fea",
+      "mode": "local",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-26T03:09:38.568907Z",
+      "diff_fingerprint": "sha256:feffce65e4f95646493ba5c5e4f48c1a12a93ff871141612a46c9357e10a47b7",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-26T03:09:53.012002Z",
+      "diff_fingerprint": "sha256:feffce65e4f95646493ba5c5e4f48c1a12a93ff871141612a46c9357e10a47b7",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-26T03:10:17.431816Z",
+      "diff_fingerprint": "sha256:6058e9c792cf8d27323c9e02a2e7979bb308bb1db5aead7054d26efdaa40efa8",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-26T03:10:29.638182Z",
+      "diff_fingerprint": "sha256:6058e9c792cf8d27323c9e02a2e7979bb308bb1db5aead7054d26efdaa40efa8",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-26T03:10:40.401463Z",
+      "diff_fingerprint": "sha256:6058e9c792cf8d27323c9e02a2e7979bb308bb1db5aead7054d26efdaa40efa8",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    }
+  ],
+  "record_id": "1779-guided-1779-core-blocks-builtin-registration",
+  "requested_admin_labels": [
+    {
+      "actor_permission": null,
+      "applied_at": null,
+      "applied_by": null,
+      "name": "admin-approved:core-change"
+    }
+  ],
+  "required_obligations": {
+    "admin_labels": [
+      "admin-approved:core-change"
+    ],
+    "checks": [
+      "architecture_tests",
+      "deferral_discipline",
+      "format_check",
+      "full_audit",
+      "import_contracts",
+      "lint_format",
+      "python_tests",
+      "semantic_dup",
+      "type_check",
+      "wheel_release_smoke"
+    ],
+    "docs": [
+      "docs_required_or_na"
+    ],
+    "guards": [
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": [
+      "changed_test_required"
+    ]
+  },
+  "runtime": "claude",
+  "schema_version": 2,
+  "scope_events": [
+    {
+      "action": "add-include",
+      "at": "2026-06-26T02:59:47.700917Z",
+      "pattern": "src/scistudio/blocks/registry/_scan.py",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-26T02:59:47.700924Z",
+      "pattern": "pyproject.toml",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-26T02:59:47.700926Z",
+      "pattern": "tests/blocks/test_registry.py",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-26T02:59:47.700928Z",
+      "pattern": "tests/blocks/test_tier1_dropin_subprocess.py",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-26T02:59:47.700929Z",
+      "pattern": "tests/integration/test_block_sdk_e2e.py",
+      "reason": "plan"
+    }
+  ],
+  "session_id": "366983c5-7234-4cfe-beeb-a76207ac0f77",
+  "strictness_tier": 1,
+  "task_kind": "guided",
+  "test_events": [
+    {
+      "at": "2026-06-26T02:59:47.700939Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/blocks/test_registry.py",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,27 +78,21 @@ dev = [
 [project.scripts]
 scistudio = "scistudio.cli.main:app"
 
+# Issue #1779: core's own first-party blocks are NOT declared here. They are
+# registered by direct import in ``scistudio.blocks.registry._scan._scan_builtins``
+# so the palette is environment-independent. Entry-point discovery depends on
+# installed ``*.dist-info`` metadata, which the desktop bundle does not carry
+# (it ships core as raw source on PYTHONPATH and strips build metadata —
+# ``desktop/scripts/stage-resources.sh``, #1775). Declaring first-party blocks
+# here made the entire process/code/app palette disappear in packaged builds.
+# This group is now reserved for third-party plugin packages only.
 [project.entry-points."scistudio.blocks"]
-load_data = "scistudio.blocks.io.loaders.load_data:LoadData"
-save_data = "scistudio.blocks.io.savers.save_data:SaveData"
-process_merge = "scistudio.blocks.process.builtins.merge:MergeBlock"
-process_split = "scistudio.blocks.process.builtins.split:SplitBlock"
-code_block = "scistudio.blocks.code:CodeBlock"
-app_block = "scistudio.blocks.app:AppBlock"
-ai_block = "scistudio.blocks.ai:AIBlock"
-subworkflow_block = "scistudio.blocks.subworkflow:SubWorkflowBlock"
-merge_collection = "scistudio.blocks.process.builtins.merge_collection:MergeCollection"
-split_collection = "scistudio.blocks.process.builtins.split_collection:SplitCollection"
-filter_collection = "scistudio.blocks.process.builtins.filter_collection:FilterCollection"
-slice_collection = "scistudio.blocks.process.builtins.slice_collection:SliceCollection"
-data_router = "scistudio.blocks.process.builtins.data_router:DataRouter"
-pair_editor = "scistudio.blocks.process.builtins.pair_editor:PairEditor"
 
 # T-TRK-004 / ADR-028 §D4: the ``scistudio.adapters`` entry-point group
 # has been removed. Plugin-owned IO blocks now register via the
 # ``scistudio.blocks`` entry-point group as ``IOBlock`` subclasses
-# (see ADR-028 §D1 + Addendum 1 §C). Core ``LoadData`` and ``SaveData``
-# entry-points will be added by T-TRK-007 / T-TRK-008.
+# (see ADR-028 §D1 + Addendum 1 §C). Core ``LoadData`` / ``SaveData`` are
+# first-party blocks registered in ``_scan_builtins`` (#1779), not here.
 
 # T-008 / ADR-027 D2: the previous entry-points here pointed at
 # core ``Image``, ``Spectrum``, and ``PeakTable`` classes that were

--- a/src/scistudio/blocks/registry/_scan.py
+++ b/src/scistudio/blocks/registry/_scan.py
@@ -99,18 +99,38 @@ def _validate_capability_registration(registry: BlockRegistry, spec: BlockSpec) 
 
 
 def _scan_builtins(registry: BlockRegistry) -> None:
-    """Register built-in core blocks used by the API/frontend.
+    """Register first-party core blocks shipped inside ``scistudio`` itself.
 
-    Only concrete, user-facing blocks are registered here.  Base
-    classes (AppBlock, CodeBlock, IOBlock) and non-functional process
-    placeholders (Merge, Split, …) are excluded from the palette so
-    end users see only the blocks they can actually use.  The
-    excluded classes remain importable for plugin development and
-    tests.
+    Issue #1779: core's own palette blocks are registered here by direct
+    import, **not** via ``scistudio.blocks`` entry points. Entry-point
+    discovery (:func:`_scan_tier2`) depends on installed ``*.dist-info``
+    metadata, which the desktop bundle does not carry — it ships core as raw
+    source on ``PYTHONPATH`` and strips build metadata (``stage-resources.sh``,
+    #1775). Relying on entry points for first-party blocks made the whole
+    process/code/app palette vanish in packaged builds, leaving only the
+    handful already hard-registered here. Direct registration is
+    environment-independent (source checkout, editable install, bundled
+    source, or frozen), so the ``scistudio.blocks`` entry-point group is now
+    reserved for third-party plugin packages only.
+
+    Only concrete, user-facing blocks are registered. The DataFrame-level
+    process placeholders ``MergeBlock`` (``Merge``) and ``SplitBlock``
+    (``Split``) are intentionally excluded from the palette — the
+    collection-level :class:`MergeCollection` / :class:`SplitCollection`
+    blocks are the user-facing equivalents. The excluded classes remain
+    importable for plugin development and tests.
     """
     from scistudio.blocks.ai.ai_block import AIBlock
+    from scistudio.blocks.app import AppBlock
+    from scistudio.blocks.code import CodeBlock
     from scistudio.blocks.io.loaders.load_data import LoadData
     from scistudio.blocks.io.savers.save_data import SaveData
+    from scistudio.blocks.process.builtins.data_router import DataRouter
+    from scistudio.blocks.process.builtins.filter_collection import FilterCollection
+    from scistudio.blocks.process.builtins.merge_collection import MergeCollection
+    from scistudio.blocks.process.builtins.pair_editor import PairEditor
+    from scistudio.blocks.process.builtins.slice_collection import SliceCollection
+    from scistudio.blocks.process.builtins.split_collection import SplitCollection
     from scistudio.blocks.registry._spec import _spec_from_class
     from scistudio.blocks.subworkflow.subworkflow_block import SubWorkflowBlock
 
@@ -119,6 +139,14 @@ def _scan_builtins(registry: BlockRegistry) -> None:
         SaveData,
         AIBlock,
         SubWorkflowBlock,
+        CodeBlock,
+        AppBlock,
+        DataRouter,
+        MergeCollection,
+        SplitCollection,
+        FilterCollection,
+        SliceCollection,
+        PairEditor,
     ):
         _register_spec(registry, _spec_from_class(cls, source="builtin"))
 
@@ -225,6 +253,11 @@ def _scan_tier1(registry: BlockRegistry) -> None:
 
 def _scan_tier2(registry: BlockRegistry) -> None:
     """Tier 2: scan ``scistudio.blocks`` entry-points using callable protocol.
+
+    This group is reserved for third-party plugin packages (#1779). Core's own
+    first-party blocks are registered directly in :func:`_scan_builtins` and do
+    not appear here, so a packaged build with no ``*.dist-info`` metadata still
+    gets the full core palette.
 
     Each entry-point resolves to a callable.  When invoked, it returns
     either:

--- a/tests/blocks/test_registry.py
+++ b/tests/blocks/test_registry.py
@@ -12,25 +12,69 @@ from scistudio.blocks.base.package_info import PackageInfo
 from scistudio.blocks.registry import BlockRegistry, BlockSpec
 
 
-class TestBlockRegistryTier2:
-    """Tier 2: entry_point discovery (always available from installed package)."""
+class TestBlockRegistryBuiltins:
+    """First-party core blocks are registered by direct import (#1779).
 
-    def test_scan_discovers_entry_points(self) -> None:
+    Core's palette no longer depends on ``scistudio.blocks`` entry points, so
+    these blocks appear even in a packaged build that carries no
+    ``*.dist-info`` metadata.
+    """
+
+    def test_scan_discovers_builtin_palette(self) -> None:
         reg = BlockRegistry()
         reg.scan()
         specs = reg.all_specs()
-        # Should find at least the built-in blocks from pyproject.toml entry_points.
-        assert len(specs) >= 3
         names = list(specs.keys())
-        assert "Merge" in names
-        assert "Split" in names
+        # First-party core blocks registered in _scan_builtins.
+        for expected in ("Load", "Save", "Data Router", "Merge Collection", "Split Collection"):
+            assert expected in names, f"{expected!r} missing from palette: {names}"
+        # All first-party blocks carry the sanitized 'builtin' source.
+        assert specs["Data Router"].source == "builtin"
+        # Base classes are never registered.
         assert "IOBlock" not in names
+        # #1779: DataFrame-level Merge/Split placeholders stay out of the palette;
+        # the collection-level blocks above are the user-facing equivalents.
+        assert "Merge" not in names
+        assert "Split" not in names
 
     def test_instantiate_by_name(self) -> None:
         reg = BlockRegistry()
         reg.scan()
-        block = reg.instantiate("Merge")
-        assert block.name == "Merge"
+        block = reg.instantiate("Merge Collection")
+        assert block.name == "Merge Collection"
+
+    def test_core_palette_survives_without_entry_point_metadata(self) -> None:
+        """Regression for #1779: the core palette must not depend on entry points.
+
+        The desktop bundle ships core as raw source on PYTHONPATH and carries no
+        ``*.dist-info`` metadata, so ``importlib.metadata.entry_points()`` finds
+        nothing for the ``scistudio.blocks`` group. Before #1779 the whole
+        process/code/app palette vanished in that environment, leaving only a
+        few hard-registered blocks. Simulate the metadata-less bundle by forcing
+        entry-point discovery to return an empty set and assert the first-party
+        palette is still complete.
+        """
+        empty_eps = MagicMock()
+        empty_eps.select.return_value = []
+
+        reg = BlockRegistry()
+        with patch("importlib.metadata.entry_points", return_value=empty_eps):
+            reg.scan()
+
+        names = set(reg.all_specs())
+        for expected in (
+            "Load",
+            "Save",
+            "Code Block",
+            "App Block",
+            "Data Router",
+            "Merge Collection",
+            "Split Collection",
+            "Filter Collection",
+            "Slice Collection",
+            "Pair Editor",
+        ):
+            assert expected in names, f"{expected!r} missing from metadata-less palette: {sorted(names)}"
 
     def test_instantiate_unknown_raises(self) -> None:
         reg = BlockRegistry()

--- a/tests/blocks/test_tier1_dropin_subprocess.py
+++ b/tests/blocks/test_tier1_dropin_subprocess.py
@@ -138,10 +138,11 @@ class TestRegistryStampsFilePath:
         """
         reg = BlockRegistry()
         reg.scan()
-        # ``Merge`` is a built-in entry-point block.
-        if "Merge" not in reg.all_specs():
-            pytest.skip("Merge block not registered; entry-points unavailable in this env")
-        block = reg.instantiate("Merge")
+        # ``Merge Collection`` is a first-party builtin (#1779), registered by
+        # direct import rather than an entry point.
+        if "Merge Collection" not in reg.all_specs():
+            pytest.skip("Merge Collection block not registered in this env")
+        block = reg.instantiate("Merge Collection")
         assert not hasattr(block.__class__, "_scistudio_file_path"), (
             "Tier-2 / builtin blocks must not be stamped with _scistudio_file_path"
         )

--- a/tests/integration/test_block_sdk_e2e.py
+++ b/tests/integration/test_block_sdk_e2e.py
@@ -545,9 +545,10 @@ class TestFullIntegration:
         reg = BlockRegistry()
         reg.scan()
 
-        # Merge block has type_name "merge_block".
-        spec_by_name = reg.get_spec("Merge")
-        spec_by_type = reg.get_spec("merge_block")
+        # Merge Collection (a first-party builtin, #1779) has type_name
+        # "mergecollection_block".
+        spec_by_name = reg.get_spec("Merge Collection")
+        spec_by_type = reg.get_spec("mergecollection_block")
         assert spec_by_name is not None
         assert spec_by_type is not None
         assert spec_by_name.name == spec_by_type.name


### PR DESCRIPTION
## Summary

Core's own process/code/app palette blocks were registered **only** via
`scistudio.blocks` entry points (`_scan_tier2`), which depend on installed
`*.dist-info` metadata. The desktop bundle ships core as raw source on
`PYTHONPATH` and strips build metadata (`desktop/scripts/stage-resources.sh`,
#1775), so `importlib.metadata.entry_points()` found nothing for the group and
the palette collapsed to the four hard-registered builtins
(Load / Save / AI Agent / Subworkflow) in packaged builds.

## Fix

- Register the first-party palette blocks directly in `_scan_builtins` so
  discovery is environment-independent (source checkout, editable install,
  bundled source, frozen): CodeBlock, AppBlock, DataRouter, MergeCollection,
  SplitCollection, FilterCollection, SliceCollection, PairEditor.
- Drop the redundant core `scistudio.blocks` entries from `pyproject.toml`. The
  group is now reserved for third-party plugin packages only.
- The DataFrame-level `MergeBlock` / `SplitBlock` placeholders stay importable
  but out of the palette — the collection-level blocks are the user-facing
  equivalents (owner decision).
- Regression test simulates the metadata-less bundle (empty entry-point
  discovery) and asserts the full core palette still registers.

## Testing

- `gate_record check --mode pre-pr` (Tier 1): architecture_tests,
  deferral_discipline, format_check, full_audit, import_contracts, lint_format,
  python_tests, semantic_dup, type_check, wheel_release_smoke — all pass;
  reconciliation passed.

## Notes

- Protected core path (`src/scistudio/blocks/**`) and `pyproject.toml`
  governed-surface edits are owner-authorized (`admin-approved:core-change`,
  `governance_touch`).

Gate record: .workflow/records/1779-guided-1779-core-blocks-builtin-registration.json

Closes #1779
