### PR TITLE
docs(#1781): ADR-051 interactive data-processing blocks + spec

### DIFF
--- a/.workflow/records/1781-adr-051-interactive-blocks.json
+++ b/.workflow/records/1781-adr-051-interactive-blocks.json
@@ -1,0 +1,545 @@
+{
+  "branch": "docs/adr-051-interactive-blocks",
+  "check_events": [
+    {
+      "at": "2026-06-26T03:57:26.147643Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:d32875a367926f2517731f29351bc67d78c8d882651ee6dd038a7a1f3ddae219",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-26T03:59:14.179403Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:9db133ae8b2d0fc2196e720ce3398ab56f9981d048f98dc5e89923d7c1999983",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-26T04:00:28.867760Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:d32875a367926f2517731f29351bc67d78c8d882651ee6dd038a7a1f3ddae219",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-26T04:03:38.427152Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:1e7012bc16dbd79fb6681e3f291c768c13f8cfcaeb546341764119ad170e3b59",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-26T04:05:24.048566Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:54586c1f1ce008fadf04a86b5d5cbe712337fd1f96d15bb5fcf3dc9c3c6aa4d5",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    }
+  ],
+  "check_na": [],
+  "commit": {
+    "sha": "0373d2b0c9890c07323442433a9281af1fb825b9",
+    "shas": [
+      "0373d2b0c9890c07323442433a9281af1fb825b9"
+    ],
+    "trailers": []
+  },
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "docs/adr/ADR-051.md"
+    ]
+  },
+  "directive_events": [],
+  "docs_events": [],
+  "governance_touch": false,
+  "guard_events": [
+    {
+      "at": "2026-06-26T03:59:14.219320Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T03:59:14.229299Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T03:59:14.238816Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T03:59:14.247986Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T03:59:14.256764Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T03:59:14.265503Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T03:59:14.274078Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T03:59:14.283983Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T03:59:14.292504Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T03:59:14.303139Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T04:00:28.890518Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T04:00:28.899347Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T04:00:28.908225Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T04:00:28.916874Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T04:00:28.925725Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T04:00:28.934277Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T04:00:28.942933Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T04:00:28.952101Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T04:00:28.961883Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T04:00:28.973191Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T04:05:24.093167Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T04:05:24.102961Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T04:05:24.112309Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T04:05:24.121956Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T04:05:24.130743Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T04:05:24.139610Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T04:05:24.148178Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T04:05:24.158082Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T04:05:24.166756Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T04:05:24.177692Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T04:05:53.235924Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T04:05:53.245654Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T04:05:53.255515Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T04:05:53.265646Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T04:05:53.275211Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T04:05:53.284969Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T04:05:53.295474Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T04:05:53.305302Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T04:05:53.314965Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T04:05:53.328759Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1781,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": {
+    "base": "origin/main",
+    "base_sha": "e383122f",
+    "changed_files": [
+      ".workflow/records/1781-adr-051-interactive-blocks.json",
+      "docs/adr/ADR-051.md",
+      "docs/specs/adr-051-interactive-blocks.md"
+    ],
+    "diff_fingerprint": "sha256:cef29e1847281a987f4d687406ecf1bf7bc4cf81dfbed0515f410df57fbe33d2",
+    "head": "HEAD",
+    "head_sha": "0373d2b0",
+    "surfaces": {
+      "docs": 2,
+      "frontend": 0,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 0,
+      "packaging": 0,
+      "protected_core": 0,
+      "sentrux": 2,
+      "test": 0,
+      "workflow_ci": 0
+    }
+  },
+  "owner_directive": "Author ADR-051: interactive data-processing block contract \u2014 InteractiveMixin capability (not a base class), two-phase subprocess orchestration under ADR-017, engine-side intermediate-artifact channel, separate-window panel injected via previewer-style manifest, migrate Data Router + Pair Editor as core examples; package blocks out of scope.",
+  "persona": "adr_author",
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [
+      1781
+    ],
+    "number": null,
+    "url": null
+  },
+  "reconcile_events": [
+    {
+      "at": "2026-06-26T03:59:14.303170Z",
+      "diff_fingerprint": "sha256:ebff3dd92e252684ecbffed47f08e1f0bc9b6b2f3844b5ef7a0991ec4b415282",
+      "mode": "local",
+      "result": "fail",
+      "tier": 3,
+      "unsatisfied": [
+        "checks.full_audit"
+      ]
+    },
+    {
+      "at": "2026-06-26T04:00:28.973217Z",
+      "diff_fingerprint": "sha256:ebff3dd92e252684ecbffed47f08e1f0bc9b6b2f3844b5ef7a0991ec4b415282",
+      "mode": "local",
+      "result": "fail",
+      "tier": 3,
+      "unsatisfied": [
+        "checks.full_audit"
+      ]
+    },
+    {
+      "at": "2026-06-26T04:05:24.177728Z",
+      "diff_fingerprint": "sha256:652c398f8b8a3c509952c37da675bb4f66ec237f5684b756c37a083b42d97f2b",
+      "mode": "local",
+      "result": "pass",
+      "tier": 3,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-26T04:05:53.328803Z",
+      "diff_fingerprint": "sha256:cef29e1847281a987f4d687406ecf1bf7bc4cf81dfbed0515f410df57fbe33d2",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 3,
+      "unsatisfied": []
+    }
+  ],
+  "record_id": "1781-adr-051-interactive-blocks",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [
+      "full_audit",
+      "semantic_dup"
+    ],
+    "docs": [],
+    "guards": [
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": []
+  },
+  "runtime": "claude",
+  "schema_version": 2,
+  "scope_events": [
+    {
+      "action": "add-include",
+      "at": "2026-06-26T03:45:17.784401Z",
+      "pattern": "docs/specs/adr-051-interactive-blocks.md",
+      "reason": "Add the ADR-051 companion spec to scope (owner-approved: write the corresponding spec in the same PR)."
+    }
+  ],
+  "session_id": "3a476f6f-b051-4a4e-a2aa-726952857bd5",
+  "strictness_tier": 3,
+  "task_kind": "docs",
+  "test_events": []
+}

--- a/.workflow/records/1781-adr-051-interactive-blocks.json
+++ b/.workflow/records/1781-adr-051-interactive-blocks.json
@@ -79,9 +79,9 @@
   ],
   "check_na": [],
   "commit": {
-    "sha": "0373d2b0c9890c07323442433a9281af1fb825b9",
+    "sha": "926d3e17de03cbe5780e8d9f73c28ca86b93f777",
     "shas": [
-      "0373d2b0c9890c07323442433a9281af1fb825b9"
+      "926d3e17de03cbe5780e8d9f73c28ca86b93f777"
     ],
     "trailers": []
   },
@@ -422,6 +422,252 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-06-26T04:06:58.910614Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T04:06:58.919100Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T04:06:58.927524Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T04:06:58.936079Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T04:06:58.944691Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T04:06:58.953058Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T04:06:58.961671Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T04:06:58.970506Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T04:06:58.981219Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T04:06:58.995309Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T04:07:05.776074Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T04:07:05.784386Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T04:07:05.792815Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T04:07:05.801156Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T04:07:05.809220Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T04:07:05.817596Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T04:07:05.825936Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T04:07:05.834239Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T04:07:05.842639Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T04:07:05.854813Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T04:07:18.532124Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T04:07:18.540527Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T04:07:18.549461Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T04:07:18.557848Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T04:07:18.566810Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T04:07:18.575655Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T04:07:18.584463Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T04:07:18.593090Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T04:07:18.601304Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T04:07:18.612350Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -434,16 +680,16 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "origin/main",
-    "base_sha": "e383122f",
+    "base": "f973b487adcdb4ffc490cb1439d64c7925bb2d1e",
+    "base_sha": "f973b487",
     "changed_files": [
       ".workflow/records/1781-adr-051-interactive-blocks.json",
       "docs/adr/ADR-051.md",
       "docs/specs/adr-051-interactive-blocks.md"
     ],
-    "diff_fingerprint": "sha256:cef29e1847281a987f4d687406ecf1bf7bc4cf81dfbed0515f410df57fbe33d2",
+    "diff_fingerprint": "sha256:945290b934a33c0b9c18c2004713e15aed670c750be472d17989505b2fa6abe8",
     "head": "HEAD",
-    "head_sha": "0373d2b0",
+    "head_sha": "926d3e17",
     "surfaces": {
       "docs": 2,
       "frontend": 0,
@@ -464,7 +710,7 @@
     "closes": [
       1781
     ],
-    "number": null,
+    "number": 1782,
     "url": null
   },
   "reconcile_events": [
@@ -499,6 +745,30 @@
     {
       "at": "2026-06-26T04:05:53.328803Z",
       "diff_fingerprint": "sha256:cef29e1847281a987f4d687406ecf1bf7bc4cf81dfbed0515f410df57fbe33d2",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 3,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-26T04:06:58.995363Z",
+      "diff_fingerprint": "sha256:945290b934a33c0b9c18c2004713e15aed670c750be472d17989505b2fa6abe8",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 3,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-26T04:07:05.854843Z",
+      "diff_fingerprint": "sha256:945290b934a33c0b9c18c2004713e15aed670c750be472d17989505b2fa6abe8",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 3,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-26T04:07:18.612381Z",
+      "diff_fingerprint": "sha256:945290b934a33c0b9c18c2004713e15aed670c750be472d17989505b2fa6abe8",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 3,

--- a/docs/adr/ADR-051.md
+++ b/docs/adr/ADR-051.md
@@ -1,0 +1,371 @@
+---
+adr: 51
+title: "Interactive Data-Processing Blocks"
+status: Proposed
+date_created: 2026-06-25
+date_accepted: null
+date_superseded: null
+
+supersedes: []
+superseded_by: null
+related: [17, 18, 19, 20, 27, 29, 31, 48]
+closes_issues: [1781]
+tracking_issue: 1781
+
+is_code_implementation: true
+governs:
+  modules:
+    - scistudio.engine.scheduler
+    - scistudio.engine.runners
+    - scistudio.blocks.base
+    - scistudio.blocks.process.builtins
+  contracts:
+    - scistudio.blocks.base.state.ExecutionMode
+    - scistudio.engine.runners.local.LocalRunner
+    - scistudio.engine.runners.worker.main
+  entry_points: []
+  files:
+    - docs/adr/ADR-051.md
+    - docs/specs/adr-051-interactive-blocks.md
+    - src/scistudio/blocks/base/block.py
+    - src/scistudio/blocks/base/state.py
+    - src/scistudio/blocks/process/builtins/data_router.py
+    - src/scistudio/blocks/process/builtins/pair_editor.py
+    - src/scistudio/engine/scheduler/_dispatch.py
+    - src/scistudio/engine/scheduler/_events.py
+    - src/scistudio/engine/runners/local.py
+    - src/scistudio/engine/runners/worker.py
+    - src/scistudio/engine/events.py
+    - src/scistudio/api/ws.py
+    - frontend/src/App.parts/InteractiveModals.tsx
+    - frontend/src/components/DataRouterModal.tsx
+    - frontend/src/components/PairEditorModal.tsx
+    - docs/architecture/ARCHITECTURE.md
+    - docs/block-development/block-contract.md
+    - docs/block-development/architecture-for-block-devs.md
+    - docs/block-development/quickstart.md
+  excludes:
+    - docs/user/reference/**
+    - docs/user/llms.txt
+planned_governs:
+  modules:
+    - scistudio.blocks.base.interactive
+  contracts:
+    - scistudio.blocks.base.interactive.InteractiveMixin
+    - scistudio.blocks.base.interactive.InteractivePrompt
+  entry_points: []
+  files:
+    - src/scistudio/blocks/base/interactive.py
+  excludes: []
+tests:
+  - tests/blocks/test_interactive_mixin.py
+  - tests/engine/test_interactive_two_phase.py
+  - tests/blocks/test_data_router.py
+  - tests/blocks/test_pair_editor.py
+agent_editable: false
+assisted_by:
+  - "Claude:claude-opus-4-8"
+
+phase: planning
+tags:
+  - blocks
+  - interactive
+  - runtime
+  - subprocess
+  - block-contract
+  - frontend-runtime
+owner: "@jiazhenz026"
+co_authors:
+  - "@claude"
+language_source: en
+translations: []
+---
+
+# ADR-051: Interactive Data-Processing Blocks
+
+## 1. Decision Summary
+
+A scientific workflow is not always something that can be fully specified before
+it runs. Many processing steps depend on what the data actually looks like: which
+run is the blank, where a peak sits, which objects are real, which region to keep.
+The correct operation only becomes clear once a person sees the data. SciStudio's
+blocks, until now, decide everything from static configuration set before the run
+and then execute to completion on their own. There is no point in a workflow where
+it stops, shows the scientist the real data, and lets them make that decision.
+
+This ADR introduces **interactive data-processing blocks**: blocks that pause in
+the middle of a running workflow, open a window onto their real input data, take a
+data-dependent decision from the user, and compute their outputs from it. The
+interaction becomes a recorded part of the workflow rather than something the
+scientist does outside SciStudio in an ad-hoc notebook.
+
+The ADR is built around three design choices, each addressed by a later section:
+interaction is a **capability** any block can carry rather than a new kind of
+block (Section 2); an interactive block stays **as safe and isolated as any other
+block** even while a human is in the loop (Section 3); and the **window belongs to
+the block**, so the view of the data can be as domain-specific as the data demands
+(Section 4).
+
+This ADR tightens ADR-017, which had left interactive flows as the one execution
+path allowed to run in-process. ADR-029 remains governing for the variadic ports
+the existing interactive blocks use. ADR-048 remains governing for previewers;
+this ADR borrows its component-injection pattern but is otherwise independent of
+the read-only preview subsystem.
+
+### 1.1 Problems Addressed
+
+| Problem | Risk | ADR response | Detailed section |
+|---|---|---|---|
+| The right processing operation often depends on what the data shows, but a block decides everything from static config before it runs | Scientists guess parameters blindly or leave SciStudio to inspect and decide, so the decision never enters the workflow | Make interaction a capability a block carries, so it can pause and compute from the user's decision | Section 2 |
+| A step that waits on a human still runs block code that can hang, leak, or resist cancellation | A paused step pins memory and resources, or wedges the engine, for as long as the person takes | Run the block only inside isolated subprocesses, with nothing resident during the wait | Section 3 |
+| The view that makes data actionable is specific to each scientific domain | If core owns the view, every domain need waits on core and domain UI accumulates in the main app | Give the block its own window, injected like a previewer component | Section 4 |
+
+## 2. Interaction Is A Block Capability
+
+The question an interactive step asks — which run is the blank, where the region
+is, which objects to keep — is inseparable from the data and the science. The
+component that understands the data is the block, not the runtime. It is the block
+that knows what to show the scientist and how to turn their answer into a result.
+The design follows from this: interaction is given to the block, and it is given
+as a capability rather than as a new category of block.
+
+This matters because a block already *is* something. The blank-subtraction case is
+a processing block; an interactive loader would be an IO block. Interactivity is
+not another kind of block alongside these — it is something an existing kind of
+block can need. So a block becomes interactive by keeping its category and gaining
+a capability, expressed by mixing in `InteractiveMixin` and declaring its
+execution mode as `INTERACTIVE`. There is deliberately no `InteractiveBlock` base
+class, because a base class would force interactivity onto the category axis where
+it does not belong and would multiply into one base per category.
+
+The capability gives the block the three things an interaction needs: a way to say
+what the window shows, a way to build that view from the real data, and a way to
+compute once the answer comes back.
+
+```python
+@dataclass(frozen=True)
+class InteractivePrompt:
+    # What the window renders: a JSON-safe, panel-sized view of the data.
+    panel_payload: dict[str, Any]
+    # Optional heavy intermediate work the block wants to reuse after the pause,
+    # carried as storage references, never as in-memory data (Section 3).
+    intermediate: tuple[StorageRef, ...] = ()
+
+
+class InteractiveMixin:
+    # The window this block opens (Section 4).
+    interactive_panel: ClassVar[PanelManifest]
+
+    def prepare_prompt(
+        self, inputs: dict[str, Collection], config: BlockConfig
+    ) -> InteractivePrompt:
+        """Turn the real input data into what the window should show."""
+        ...
+
+    # run() is the block's own, inherited from its category. When the answer
+    # returns it reads config["interactive_response"] (and any intermediate
+    # references) and produces the block's outputs.
+```
+
+The view the block builds and the answer it receives both travel out to a browser,
+so both are ordinary JSON and both are sized for a window rather than for the full
+dataset — a downsampled trace, a summary table, a set of selectable items. Reducing
+the data to something a person can look at is part of the block's job, because only
+the block knows which reduction is meaningful. Because the capability and the
+execution mode are two halves of the same intent, the registry treats them as one
+declaration and refuses, at load time, a block that claims one without the other or
+that omits the window it promises to open.
+
+An interaction spans a whole input, not one item at a time. `prepare_prompt`
+receives the block's full collections and the block forms one view over all of
+them, just as a block already iterates its own collections internally rather than
+having the engine iterate for it (ADR-020). A collection of many files is therefore
+one interaction with one decision, not one pause per file — the alternative would
+turn a single human decision into a sequence of identical interruptions.
+
+## 3. An Interactive Block Stays An Isolated Block
+
+The defining constraint of an interactive step is that it waits on a person, and a
+person may take a second or an afternoon. The design's central concern is that this
+wait must cost nothing and weaken nothing. A workflow that has stopped for a human
+must not hold the block's code or data resident, must not surrender the isolation
+that protects the engine from block code, and must remain cancelable throughout.
+ADR-017 already guarantees these properties for ordinary blocks by running them in
+isolated subprocesses; an interactive block must not become the exception that
+gives them up.
+
+The way to keep the guarantee is to ensure a block is only ever running while it is
+inside a subprocess that runs to completion — never while it is paused. The work
+therefore divides into two subprocess runs on either side of the wait. The first
+turns the real data into the view for the window and then exits; the engine holds
+the pause with no block code resident; when the answer returns, a fresh subprocess
+computes the block's outputs. The block never executes in the engine, and nothing
+of the block survives the wait inside a live process.
+
+```text
+  engine                          subprocess: build the view
+  ------                          --------------------------
+  start  -------------------->    prepare_prompt(inputs, config)
+  <----------------------------   the view (+ optional intermediate refs), exit
+
+  block is PAUSED; the engine holds the wait with nothing resident
+  show the view  ----------->     the scientist looks at real data and decides
+  <----------------------------   the decision
+
+  block is RUNNING                subprocess: compute (a fresh process)
+  start  -------------------->    run(inputs, config + decision + intermediate)
+  <----------------------------   outputs, exit
+  block is DONE
+```
+
+Because nothing carries over in memory, the computing run rebuilds what it needs
+from its inputs, its configuration, and the decision — the same inputs are still on
+disk, and reading them again is cheap next to the time a person spent deciding. The
+one thing worth not redoing is genuinely expensive intermediate work, and the
+design lets that cross the pause the same way all large data moves in SciStudio: on
+disk, by reference. The first run can persist such work through the storage layer
+and hand its references forward; the engine keeps them and gives them to the
+computing run, which loads them instead of recomputing. The reference channel and
+the window are kept apart on purpose — the view goes to the browser, the references
+stay between the engine and the block — so heavy data is never pushed through the
+browser and the ADR-017 invariant that only references cross a process boundary
+still holds.
+
+The scientist's answer is an input to the computing run, not a side effect of it.
+It is merged into the resolved configuration the run executes with and recorded in
+lineage through the same `block_config_resolved` field that captures every block's
+resolved config (ADR-038) — which is the deeper reason the answer must be plain,
+bounded JSON: it has to be recordable as provenance. An interactive run is
+therefore as reproducible and auditable as an automatic one, its record showing
+exactly what the person decided. The ephemeral intermediate work above is
+deliberately kept out of that record: it is scratch deleted after the run, not
+provenance, so lineage captures the decision and never the optimization.
+
+The interaction is a single round by intent, not a live loop: the window opens, the
+scientist decides once, and the block computes once from that decision. A scientist
+who closes the window instead of confirming cancels the step; the engine releases
+any intermediate work the first run left behind, so a cancellation leaves nothing
+on disk, and no computing run is started. Throughout, the pause is a real state of
+the block — `PAUSED` while it waits, then `RUNNING`, `DONE`, or `CANCELLED` —
+reusing the lifecycle and cancellation semantics of ADR-018 and ADR-019.
+
+## 4. The Window Belongs To The Block
+
+What makes data actionable is a domain-specific view: a chromatogram with a region
+to brush, an image with objects to pick, a spectrum with a baseline to place. Core
+cannot anticipate the right view for every kind of science, and should not become
+the place where every domain's interaction UI accumulates. So the window an
+interactive block opens is owned by the block, and core's role is only to host it.
+
+The window is a dedicated surface for the interaction, separate from the canvas and
+from the read-only preview pane. The block describes its window through a manifest
+that names a frontend component, and SciStudio reaches that component exactly the
+way it reaches previewer components under ADR-048: the backend serves and validates
+it from same-origin storage, and the frontend loads it from the manifest. Choosing
+the window is therefore a property of the block, resolved from its declaration,
+rather than a branch the core frontend has to grow for each new interactive block.
+
+This ADR delivers only core, but it deliberately gives core blocks no special path:
+they declare and load their windows through the same manifest mechanism a package
+would use. That keeps the contract honest and means a decoupled domain package can
+later ship its own interactive data-processing block, with its own window, against
+the contract defined here — though no package work is in scope now.
+
+Because the block owns the window, it also owns how a many-item input is laid out
+there — tabs, a grid, a list, an overlay — since the meaningful arrangement is as
+domain-specific as the view itself. The contract asks only that the window be
+self-contained: everything it shows is in the payload the build phase produced, so
+moving between items is a frontend act that never reaches back to the engine. That
+self-containment is what lets the engine hold the pause with nothing resident.
+
+## 5. The Existing Interactive Blocks
+
+`Data Router` and `Pair Editor` are the only interactive blocks in core today. They
+are interactive in a narrower sense than this ADR's subject — they let a user
+reorganize items rather than act on data values — but they are real interactions,
+and they become the reference implementations of the contract. Each stays the
+processing block it is, carries the interaction capability, runs through the
+two-phase subprocess path instead of executing inside the engine, and opens its
+window through the manifest rather than a hardcoded branch, while its existing
+behaviour — item routing, pair reordering — is unchanged. They are migrated rather
+than rewritten, and this ADR adds no new core interactive block of its own.
+
+## 6. Scope
+
+In scope: the interaction capability and its contract; the registry check that
+binds the capability to the interactive execution mode; the two-phase subprocess
+runtime that replaces the current in-engine interactive path, including the pause
+state, the reference-carried intermediate channel, and cancellation cleanup; the
+block-owned window and its manifest-based injection; the migration of `Data Router`
+and `Pair Editor`; and the affected docs and tests.
+
+Out of scope: any domain package interactive block, including an LCMS
+blank-subtraction block, which is a downstream consumer of this contract; a live
+re-computation loop while the window is open; a generic runtime-rendered widget
+schema in place of injected windows; the subprocess-to-engine status channel for
+the `PAUSED` distinction and progress (issue #56); the policy for re-running a
+workflow over a recorded decision, whether it replays the decision deterministically
+or re-prompts, which the recorded provenance enables but this ADR does not settle;
+and any change to the read-only previewer subsystem beyond reusing its injection
+pattern.
+
+## 7. Verification And Tooling Impact
+
+The decision is verified where its guarantees live. The registry check is exercised
+by confirming that an interactive declaration missing its capability, its prompt
+builder, or its window is rejected at load time, as is a capability left without an
+interactive execution mode. The runtime guarantee is exercised by confirming that
+both phases run in subprocesses, that the computing run receives the decision and
+depends on nothing left in memory, that intermediate work crosses the pause only by
+reference and never reaches the browser, and that cancellation releases that work
+and starts no computing run. The window contract is exercised by confirming a panel
+resolves from its manifest rather than a hardcoded branch. The migration is
+verified by confirming `Data Router` and `Pair Editor` keep their existing
+behaviour under the new model.
+
+This ADR is documentation-only; the implementation and its tests land in the
+follow-up PR, and the architecture documentation is updated then so the runtime
+description no longer states that interactive blocks run in-process.
+
+## 8. Consequences And Risks
+
+The runtime gains a single execution model: every block, interactive or not, runs
+in an isolated subprocess, and the in-engine special case disappears. Interaction
+becomes a property a block declares and a window a block ships, so new interactive
+blocks — and, later, package-provided ones — need no core frontend changes.
+
+The cost is two subprocess starts and a pause where there was once one in-engine
+call, but interactive steps are paced by a human, so the start cost is negligible
+against the time a person spends deciding. The two phases can repeat shared work;
+the reference-carried intermediate channel exists precisely so expensive work is
+done once and reused. Authors carry the responsibility of reducing data to a
+window-sized view, which the contract requires and the runtime enforces by
+rejecting payloads that are not plain JSON. The window injection adds a loading
+surface, which is mitigated by reusing ADR-048's validated same-origin serving
+rather than introducing a second mechanism.
+
+## 9. Alternatives Considered
+
+**A dedicated interactive block category.** Making interactivity its own base class
+was rejected because interactivity is not a kind of block but a need an existing
+kind of block can have; a base class would either fight the category axis or
+multiply into one interactive base per category.
+
+**Keeping interaction in-engine.** Leaving the current in-process path was rejected
+because it lets a paused human step hold block code and data resident, gives up the
+isolation ADR-017 guarantees, and cannot be process-killed — acceptable for a small
+routing widget, untenable for blocks that read real scientific data.
+
+**A long-lived worker across the pause.** Holding the first subprocess open so
+in-memory state could carry over was rejected because it pins resources and storage
+handles for the entire human wait and complicates cancellation; carrying expensive
+work by storage reference achieves the same reuse without keeping anything resident.
+
+**A live re-computation loop.** Letting the window repeatedly recompute to show a
+live preview was rejected as unnecessary complexity for the target workflows; the
+block computes once, after the scientist confirms.
+
+**A core-rendered widget schema.** Describing windows declaratively for core to
+render was rejected because it would keep all interaction UI in core and cap how
+domain-specific a window can be; an injected, block-owned window keeps domain UI
+with the domain.

--- a/docs/specs/adr-051-interactive-blocks.md
+++ b/docs/specs/adr-051-interactive-blocks.md
@@ -1,0 +1,439 @@
+---
+spec_id: adr-051-interactive-blocks
+title: "ADR-051 Interactive Data-Processing Blocks Implementation Specification"
+status: Planned
+feature_branch: docs/adr-051-interactive-blocks
+created: 2026-06-25
+input: "Owner-approved ADR-051 direction: interactive data-processing blocks that pause mid-workflow, open a block-owned window onto real data, take a data-dependent decision, and compute from it — as a block capability, under ADR-017 subprocess isolation, with the decision recorded in lineage."
+owners:
+  - "@jiazhenz026"
+related_adrs:
+  - 51
+related_specs: []
+scope:
+  in:
+    - The interaction capability (`InteractiveMixin`), the `InteractivePrompt` contract, and the `SupportsInteraction` protocol used for validation.
+    - Registry scan-time validation binding the capability to `execution_mode = INTERACTIVE`.
+    - Two-phase subprocess orchestration replacing the in-process `_run_interactive` scheduler path, including the `PAUSED` pause, the engine-held intermediate-reference channel, and cancellation cleanup.
+    - The block-owned panel window and manifest-based frontend component injection reusing the ADR-048 asset-serving mechanism.
+    - Recording the user decision in lineage through the existing `block_config_resolved` field and excluding intermediate scratch from lineage.
+    - Migration of `Data Router` and `Pair Editor` to the capability, including their panel components.
+  out:
+    - Any domain package interactive block, including an LCMS blank-subtraction block.
+    - A live re-computation loop or backend reads while the window is open.
+    - A generic runtime-rendered declarative widget schema in place of injected windows.
+    - The subprocess-to-engine `RUNNING`/`PAUSED`/progress status channel (issue #56).
+    - The re-run policy for a recorded decision (deterministic replay versus re-prompt).
+    - Any change to the read-only previewer subsystem beyond reusing its injection mechanism.
+governs:
+  modules:
+    - scistudio.engine.scheduler
+    - scistudio.engine.runners
+    - scistudio.blocks.base
+    - scistudio.blocks.process.builtins
+  contracts:
+    - scistudio.blocks.base.state.ExecutionMode
+    - scistudio.engine.runners.local.LocalRunner
+    - scistudio.engine.runners.worker.main
+  entry_points: []
+  files:
+    - docs/specs/adr-051-interactive-blocks.md
+    - src/scistudio/blocks/base/block.py
+    - src/scistudio/blocks/base/state.py
+    - src/scistudio/blocks/process/builtins/data_router.py
+    - src/scistudio/blocks/process/builtins/pair_editor.py
+    - src/scistudio/engine/scheduler/_dispatch.py
+    - src/scistudio/engine/scheduler/_events.py
+    - src/scistudio/engine/runners/local.py
+    - src/scistudio/engine/runners/worker.py
+    - src/scistudio/engine/events.py
+    - src/scistudio/api/ws.py
+    - frontend/src/App.parts/InteractiveModals.tsx
+    - frontend/src/components/DataRouterModal.tsx
+    - frontend/src/components/PairEditorModal.tsx
+    - docs/architecture/ARCHITECTURE.md
+    - docs/block-development/block-contract.md
+    - docs/block-development/architecture-for-block-devs.md
+    - docs/block-development/quickstart.md
+  excludes:
+    - docs/user/reference/**
+    - docs/user/llms.txt
+planned_governs:
+  modules:
+    - scistudio.blocks.base.interactive
+  contracts:
+    - scistudio.blocks.base.interactive.InteractiveMixin
+    - scistudio.blocks.base.interactive.InteractivePrompt
+    - scistudio.blocks.base.interactive.PanelManifest
+  entry_points: []
+  files:
+    - src/scistudio/blocks/base/interactive.py
+  excludes: []
+tests:
+  - tests/blocks/test_interactive_mixin.py
+  - tests/blocks/test_interactive_registry_validation.py
+  - tests/engine/test_interactive_two_phase.py
+  - tests/engine/test_interactive_lineage.py
+  - tests/engine/test_interactive_cancellation.py
+  - tests/blocks/test_data_router.py
+  - tests/blocks/test_pair_editor.py
+acceptance_source: adr
+language_source: en
+---
+
+# ADR-051 Interactive Data-Processing Blocks Implementation Specification
+
+## 1. Change Summary
+
+This spec implements ADR-051. It adds interactive data-processing blocks: blocks
+that pause mid-workflow, open a block-owned window onto their real input data, take
+a data-dependent decision from the user, and compute their outputs from it. The
+decision is recorded in lineage, and execution stays under the ADR-017 subprocess
+isolation contract throughout.
+
+The change has three parts. First, interaction becomes a block capability —
+`InteractiveMixin` plus `execution_mode = INTERACTIVE` — validated at registry
+scan time. Second, the runtime executes an interactive block as two worker-
+subprocess phases around an engine-managed pause, replacing the current in-process
+`_run_interactive` path. Third, the panel window is owned by the block and injected
+through the ADR-048 manifest/asset-serving mechanism instead of being hardcoded per
+block type in the frontend. The existing `Data Router` and `Pair Editor` blocks are
+migrated onto this model as the reference implementations.
+
+This spec is derived from ADR-051 (owner-approved). It closes #1781.
+
+## 2. User Scenarios & Testing
+
+### User Story 1 - Decide on real data inside a running workflow (Priority: P1)
+
+A scientist runs a workflow containing an interactive data-processing block. When
+the block is reached, the workflow pauses and a window opens showing the block's
+real input data. The scientist makes a data-dependent decision (for example
+selecting which run is the blank and which region to subtract), confirms, and the
+block computes its outputs from that decision. The decision is saved with the run.
+
+**Why this priority**: This is the core capability ADR-051 exists to deliver. It is
+the minimum that makes interactive data processing usable end-to-end.
+
+**Independent Test**: Define a minimal test interactive block (a `ProcessBlock`
+with `InteractiveMixin`) whose decision selects an item; run a workflow over a
+multi-item collection; assert the block pauses, the prompt is built in a
+subprocess, the panel payload is delivered, the injected response drives a fresh
+subprocess that produces the expected outputs, and the decision appears in the
+lineage record.
+
+**Acceptance Scenarios**:
+
+1. **Given** a workflow with an interactive block whose inputs are ready, **When**
+   the scheduler reaches the block, **Then** the block transitions to `PAUSED`, its
+   `prepare_prompt` runs in a worker subprocess, and the JSON-safe panel payload is
+   emitted to the frontend.
+2. **Given** a paused interactive block, **When** the scientist confirms a
+   decision, **Then** the block transitions to `RUNNING`, `run` executes in a fresh
+   worker subprocess with the decision injected, and the block transitions to
+   `DONE` with outputs.
+3. **Given** a completed interactive block, **When** the run's lineage is read,
+   **Then** the decision is present in the block's `block_config_resolved` record
+   and no intermediate scratch reference is present.
+4. **Given** an input collection with many items, **When** the block is reached,
+   **Then** the workflow pauses exactly once and the decision covers all items.
+
+### User Story 2 - Existing interactive blocks keep working (Priority: P2)
+
+A scientist already using `Data Router` or `Pair Editor` continues to use them with
+unchanged behaviour after the runtime change. Their windows still open, their item
+routing and pair reordering still work, and their results are identical, now under
+subprocess isolation.
+
+**Why this priority**: Removing the in-process path would break the only interactive
+blocks in core if they are not migrated in the same change. Behaviour preservation
+protects existing workflows.
+
+**Independent Test**: Run representative workflows that use `Data Router` and
+`Pair Editor`; assert the produced routing/reordering outputs match the pre-change
+behaviour and that both blocks now execute through the two-phase subprocess path.
+
+**Acceptance Scenarios**:
+
+1. **Given** a workflow using `Data Router`, **When** it runs and the user assigns
+   items to outputs, **Then** the output collections match the pre-migration
+   behaviour.
+2. **Given** a workflow using `Pair Editor`, **When** the user reorders items,
+   **Then** the reordered collections match the pre-migration behaviour.
+3. **Given** either migrated block, **When** it executes, **Then** neither
+   `prepare_prompt` nor `run` runs in the scheduler process, and the panel is
+   resolved from the block's manifest rather than a hardcoded branch.
+
+### User Story 3 - Safe failure and clean cancellation (Priority: P3)
+
+A block author who declares an interactive block incorrectly is told at load time,
+not at runtime. A scientist who closes the window instead of deciding cancels the
+step cleanly, with no leftover scratch and no computation performed.
+
+**Why this priority**: These guardrails make the feature robust but are not required
+for the primary happy path to deliver value.
+
+**Independent Test**: Attempt to register malformed interactive blocks and assert
+each is rejected at scan time; cancel a paused interaction and assert the block is
+`CANCELLED`, no compute phase ran, and any intermediate scratch is removed.
+
+**Acceptance Scenarios**:
+
+1. **Given** a block with `execution_mode = INTERACTIVE` but no `InteractiveMixin`,
+   missing `prepare_prompt`, or no valid panel manifest, **When** the registry
+   scans it, **Then** registration fails with a clear error.
+2. **Given** a block that mixes in `InteractiveMixin` but is not `INTERACTIVE`,
+   **When** the registry scans it, **Then** registration fails with a clear error.
+3. **Given** a paused interactive block whose `prepare_prompt` persisted
+   intermediate scratch, **When** the scientist cancels, **Then** the block is
+   `CANCELLED`, no compute-phase subprocess is spawned, and the scratch is removed.
+
+### Edge Cases
+
+- A non-JSON-safe `panel_payload` or `interactive_response` is rejected by the
+  runtime rather than pickled or truncated.
+- An interactive block produces no intermediate references; the compute phase
+  rebuilds entirely from inputs, config, and the decision.
+- `prepare_prompt` or `run` crashes in its subprocess; the failure is isolated as a
+  block error and the engine is unaffected.
+- The workflow run is cancelled at engine level while a block is paused; the paused
+  interaction is torn down and its scratch removed.
+- An interactive block sits paused indefinitely; because nothing is resident, the
+  pause has no resource cost and there is no timeout.
+
+## 3. Requirements
+
+### Functional Requirements
+
+- **FR-001**: A block is interactive if and only if its `execution_mode` is
+  `ExecutionMode.INTERACTIVE` and it inherits `InteractiveMixin`.
+- **FR-002**: The block registry MUST reject at scan time any block that sets
+  `execution_mode = INTERACTIVE` without inheriting `InteractiveMixin`, without
+  defining `prepare_prompt`, or without declaring a valid panel manifest, and MUST
+  reject any block that inherits `InteractiveMixin` without `execution_mode = INTERACTIVE`.
+- **FR-003**: `prepare_prompt` MUST run in an isolated worker subprocess, receive
+  the block's full input collections and resolved config, and return an
+  `InteractivePrompt` carrying a `panel_payload` and optional intermediate storage
+  references.
+- **FR-004**: `panel_payload` and `interactive_response` MUST be JSON-safe; the
+  runtime MUST reject values that are not.
+- **FR-005**: One interaction MUST cover the whole input. The runtime MUST NOT
+  iterate the collection into per-item pauses.
+- **FR-006**: On reaching an interactive block the engine MUST transition it to
+  `PAUSED`, deliver the `panel_payload` to the frontend, and hold the pause with no
+  block process resident.
+- **FR-007**: The panel component MUST be resolved and loaded from the block's
+  manifest through the ADR-048 same-origin asset-serving mechanism; the frontend
+  MUST NOT select panels by hardcoded `blockType` branching.
+- **FR-008**: The interaction MUST be a single round; the runtime MUST NOT
+  re-invoke block computation to refresh the window while it is open.
+- **FR-009**: On confirmation the engine MUST transition the block to `RUNNING` and
+  execute `run` in a fresh worker subprocess with `interactive_response` (and any
+  intermediate references) merged into the resolved config.
+- **FR-010**: Intermediate results that cross the pause MUST be carried as storage
+  references held engine-side, MUST NOT be sent to the browser or routed through the
+  user response, and MAY be loaded by reference in the compute phase.
+- **FR-011**: The `interactive_response` MUST be recorded in lineage through the
+  existing `block_config_resolved` field (ADR-038); intermediate references MUST NOT
+  be recorded in lineage.
+- **FR-012**: Cancelling an interaction MUST transition the block to `CANCELLED`
+  under ADR-019 semantics, release any intermediate scratch, and spawn no compute
+  phase.
+- **FR-013**: The in-process `_run_interactive` scheduler path MUST be removed;
+  interactive blocks MUST NOT execute in the scheduler process.
+- **FR-014**: `Data Router` and `Pair Editor` MUST be migrated to inherit
+  `InteractiveMixin`, keep `execution_mode = INTERACTIVE` and their ADR-029 variadic
+  ports, execute through the two-phase path, resolve their panels via manifest, and
+  preserve their existing user-visible behaviour.
+- **FR-015**: The interactive prompt delivered to the frontend MUST carry the block
+  identity needed to resolve the panel manifest, independent of whether other
+  lifecycle events carry `block_type` (the known #1452/#1454 drift).
+
+### Key Entities
+
+- **InteractiveMixin**: The capability mixed into a block to make it interactive.
+  Declares `interactive_panel` (a panel manifest), `prepare_prompt`, and relies on
+  the category base's `run`. Relationship: layered onto a category base such as
+  `ProcessBlock`; paired with `execution_mode = INTERACTIVE`.
+- **InteractivePrompt**: The return of `prepare_prompt`. Attributes:
+  `panel_payload` (JSON-safe, window-sized view of the data) and `intermediate`
+  (tuple of storage references for reuse by the compute phase). Relationship:
+  produced in the prompt phase; `panel_payload` flows to the browser, `intermediate`
+  flows engine-side to the compute phase.
+- **PanelManifest**: The declaration of a block's window frontend component
+  (module URL, export name, optional CSS, version), following the ADR-048
+  `FrontendManifest` shape, extended only as the panel requires (for example a
+  declared response shape). Relationship: served and validated by the backend;
+  resolved by the frontend to load the panel.
+- **interactive_response**: The JSON-safe decision returned by the panel.
+  Relationship: merged into the resolved config for the compute phase and recorded
+  in lineage.
+- **interactive_intermediate**: The engine-held storage references threaded into
+  the compute phase config. Relationship: derived from `InteractivePrompt.intermediate`;
+  excluded from lineage; cleaned up on completion or cancellation.
+
+## 4. Implementation Plan
+
+### 4.1 Technical Approach
+
+A new module `scistudio.blocks.base.interactive` defines `InteractiveMixin`, the
+`SupportsInteraction` protocol, `InteractivePrompt`, and `PanelManifest`. The block
+registry gains a scan-time check that binds `execution_mode = INTERACTIVE` and the
+mixin together and validates the panel manifest, in the same import-time style as
+existing dynamic-port validation.
+
+The worker entry point gains a phase marker in its invocation payload so a single
+worker program can dispatch either `prepare_prompt` (prompt phase) or `run`
+(compute phase); both reconstruct typed inputs exactly as today (ADR-017/ADR-027).
+The prompt phase returns the `InteractivePrompt` as a JSON result envelope and
+exits; the compute phase returns outputs and exits.
+
+The scheduler's interactive handling replaces `_run_interactive` with a two-phase
+orchestration: spawn the prompt-phase worker, transition the block to `PAUSED`,
+hold the returned `panel_payload` and intermediate references engine-side, emit the
+panel payload over the existing event/WebSocket surface, await the
+`interactive_response`, then spawn a fresh compute-phase worker with the response
+and intermediate references merged into config, and finalize as for any block. The
+engine owns the intermediate scratch lifecycle and releases it on completion or
+cancellation. The decision reaches lineage automatically because it is part of the
+resolved config the compute phase runs with (ADR-038 `block_config_resolved`),
+while intermediate references are stripped from the recorded config.
+
+The frontend replaces the hardcoded `InteractiveModals` `blockType` branching with
+a panel host that resolves the component from the block's manifest and loads it via
+the ADR-048 asset-serving route and validator. `DataRouterModal` and
+`PairEditorModal` are repackaged as manifest-served components and their blocks
+declare manifests. Their `prepare_prompt` implementations are aligned to return
+`InteractivePrompt`.
+
+### 4.2 Affected Files
+
+| File or glob | Action | Rationale |
+|---|---|---|
+| `src/scistudio/blocks/base/interactive.py` | create | New `InteractiveMixin`, `SupportsInteraction`, `InteractivePrompt`, `PanelManifest`. |
+| `src/scistudio/blocks/base/state.py` | modify | Document `INTERACTIVE` as the capability-gated mode; no enum value change. |
+| `src/scistudio/blocks/base/block.py` | modify | Surface the panel manifest on block metadata for API/registry consumption. |
+| `src/scistudio/blocks/registry/**` | modify | Scan-time validation pairing capability and execution mode and validating the manifest. |
+| `src/scistudio/engine/scheduler/_dispatch.py` | modify | Replace `_run_interactive` with two-phase prompt/compute orchestration. |
+| `src/scistudio/engine/scheduler/_events.py` | modify | Wire response handling and cancellation to the two-phase flow. |
+| `src/scistudio/engine/scheduler/_lineage.py` | modify | Ensure the decision is recorded and intermediate references are excluded. |
+| `src/scistudio/engine/runners/worker.py` | modify | Phase marker dispatching `prepare_prompt` vs `run`. |
+| `src/scistudio/engine/runners/local.py` | modify | Spawn prompt and compute phases; thread intermediate references. |
+| `src/scistudio/engine/runners/process_handle.py` | modify | Carry the phase marker in the worker payload. |
+| `src/scistudio/engine/events.py` | modify | Reuse/adjust interactive prompt/response events for the two-phase flow. |
+| `src/scistudio/api/ws.py` | modify | Deliver panel payload and receive the decision under the new flow. |
+| `src/scistudio/blocks/process/builtins/data_router.py` | modify | Migrate to `InteractiveMixin`; return `InteractivePrompt`; declare manifest. |
+| `src/scistudio/blocks/process/builtins/pair_editor.py` | modify | Same migration. |
+| `frontend/src/App.parts/InteractiveModals.tsx` | modify | Replace `blockType` branching with manifest-driven panel host. |
+| `frontend/src/components/DataRouterModal.tsx` | modify | Repackage as a manifest-served panel component. |
+| `frontend/src/components/PairEditorModal.tsx` | modify | Repackage as a manifest-served panel component. |
+| `docs/architecture/ARCHITECTURE.md` | modify | Rewrite §5.2.4 (PAUSED), §5.3 (subprocess isolation), and §5.3.1 ("Interactive blocks run in-process") so interactive blocks are described as two-phase subprocess execution, not an in-process exception. |
+| `docs/block-development/block-contract.md` | modify | Document `execution_mode = INTERACTIVE` together with the `InteractiveMixin` capability and the prompt/response/manifest contract. |
+| `docs/block-development/architecture-for-block-devs.md` | modify | Correct the statement that interactive blocks run outside subprocess isolation. |
+| `docs/block-development/quickstart.md` | modify | Remove the claim that interactive blocks are the in-process exception. |
+| `tests/blocks/test_interactive_mixin.py` | create | Capability contract tests. |
+| `tests/blocks/test_interactive_registry_validation.py` | create | Scan-time validation tests. |
+| `tests/engine/test_interactive_two_phase.py` | create | Two-phase subprocess round-trip tests. |
+| `tests/engine/test_interactive_lineage.py` | create | Decision recorded, scratch excluded. |
+| `tests/engine/test_interactive_cancellation.py` | create | Clean cancellation tests. |
+| `tests/blocks/test_data_router.py` | modify | Behaviour preserved under migration. |
+| `tests/blocks/test_pair_editor.py` | modify | Behaviour preserved under migration. |
+
+### 4.3 Implementation Sequence
+
+1. **T-001**: Add `scistudio.blocks.base.interactive` (`InteractiveMixin`,
+   `SupportsInteraction`, `InteractivePrompt`, `PanelManifest`). (US1, foundation)
+2. **T-002**: Add registry scan-time validation pairing capability and mode and
+   validating the manifest; surface the manifest in block metadata. (US3, US1)
+3. **T-003**: Add the worker phase marker and dispatch for `prepare_prompt` vs
+   `run`. (US1, foundation)
+4. **T-004**: Replace `_run_interactive` with the two-phase scheduler
+   orchestration, including PAUSED handling, engine-held intermediate references,
+   and finalize. (US1)
+5. **T-005**: Wire lineage to record the decision and exclude intermediate
+   references. (US1)
+6. **T-006**: Add cancellation teardown that releases scratch and spawns no compute
+   phase. (US3)
+7. **T-007**: Replace frontend `blockType` branching with a manifest-driven panel
+   host reusing ADR-048 asset serving. (US1)
+8. **T-008**: Migrate `Data Router` and `Pair Editor` blocks and repackage their
+   panel components as manifest-served. (US2)
+9. **T-009**: Update architecture documentation. (cross-cutting)
+
+### 4.4 Verification Plan
+
+Backend unit tests cover the capability contract and registry validation
+(`test_interactive_mixin`, `test_interactive_registry_validation`). Engine tests
+cover the two-phase subprocess round-trip with response injection and no in-memory
+carryover, intermediate-reference threading that never reaches the browser, lineage
+recording of the decision with scratch excluded, and clean cancellation
+(`test_interactive_two_phase`, `test_interactive_lineage`,
+`test_interactive_cancellation`). Migration is verified by the existing
+`test_data_router` and `test_pair_editor` suites updated to run under the new model
+with unchanged behaviour. Frontend tests cover manifest-driven panel resolution and
+the migrated panels. Lint, type, full audit, and the tier-selected check surface
+run through `gate_record check`.
+
+### 4.5 Risks And Rollback
+
+The largest risk is that removing `_run_interactive` and migrating the two blocks
+must land together, since the blocks break if the in-process path is removed
+without migration; the sequence keeps them in one change and the migration tests
+gate it. The worker phase marker touches the ADR-017 worker payload, so its tests
+must confirm the existing single-phase path is unchanged. Repackaging core panels
+as manifest-served components is new frontend wiring; reusing the ADR-048 serving
+path limits new surface. Rollback is reverting the branch: there is no persisted
+data migration, and lineage gains a field value within the existing
+`block_config_resolved`, not a schema change.
+
+The interactive event flow this change reworks is the same EventBus lifecycle
+surface as the known #1452/#1454 drift, where `BLOCK_READY`/`BLOCK_RUNNING` do not
+carry `block_type`. That drift does not block this work: the panel is resolved from
+the prompt event and the block manifest, not from those events. The implementation
+must keep block identity on the prompt event (FR-015) so manifest resolution holds
+regardless of when #1452/#1454 is addressed, and must avoid regressing the passing
+scheduler state-machine cancellation contract that ADR-051's cancellation relies
+on.
+
+## 5. Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: An interactive block completes the pause-decide-compute loop end to
+  end, with `prepare_prompt` and `run` each observed running in a worker subprocess
+  and neither in the scheduler process.
+- **SC-002**: 100% of malformed interactive declarations in the validation test
+  matrix are rejected at registry scan time rather than at runtime.
+- **SC-003**: The user decision is present in the run's `block_config_resolved`
+  lineage record, and no intermediate scratch reference appears in lineage, in the
+  lineage test.
+- **SC-004**: Cancelling a paused interaction results in `CANCELLED`, zero
+  compute-phase subprocess spawns, and zero residual intermediate scratch files.
+- **SC-005**: `Data Router` and `Pair Editor` produce outputs identical to their
+  pre-migration behaviour across the migration test suites.
+- **SC-006**: Panel components are resolved from manifests with no remaining
+  `blockType`-branching panel selection in the frontend.
+
+## 6. Assumptions
+
+- The ADR-048 asset-serving route and `FrontendManifest` validator are reusable for
+  interactive panel components; interactive panels extend that shape only where the
+  interaction requires (source: adr).
+- The existing worker payload can carry a phase marker without changing the
+  single-phase AUTO execution behaviour (source: existing-system).
+- Recording the decision needs no lineage schema change because it already travels
+  inside the resolved config captured by `block_config_resolved` (source:
+  existing-system).
+- An indefinite pause is acceptable because the engine holds it with nothing
+  resident, so no interaction timeout is required (source: adr).
+- The migration of `Data Router` and `Pair Editor` and the runtime change ship in
+  the same PR (source: owner).
+- The architecture and block-development docs that currently describe interactive
+  blocks as running in-process (`docs/architecture/ARCHITECTURE.md` §5.2.4/§5.3/§5.3.1,
+  `docs/block-development/block-contract.md`, `architecture-for-block-devs.md`,
+  `quickstart.md`) are updated in the implementation PR, not the planning-doc PR,
+  because their in-process description is still accurate until the runtime changes
+  (source: existing-system).
+- The known EventBus lifecycle drift #1452/#1454 (`BLOCK_READY`/`BLOCK_RUNNING`
+  missing `block_type`) is not a prerequisite; ADR-051 resolves panels from the
+  prompt event and the manifest (source: existing-system).


### PR DESCRIPTION
## Summary

Adds **ADR-051: Interactive Data-Processing Blocks** and its implementation
spec. Records the decision and contract for blocks that pause mid-workflow, open
a block-owned window onto real data, take a data-dependent decision from the
user, and compute from it.

Key decisions:
- **Interaction is a block capability** (`InteractiveMixin` + `execution_mode = INTERACTIVE`), not a new block category; validated at registry scan time.
- **Two-phase subprocess execution** under ADR-017: a prompt phase builds the panel payload from real data and exits, the engine holds the `PAUSED` wait with nothing resident, and a fresh compute phase runs after a single confirmation.
- **Cross-phase data by reference**, engine-side only; in-memory state never carries over.
- **The window belongs to the block**, injected via the ADR-048 manifest mechanism (core-only delivery, package-ready contract).
- **The decision is provenance**, recorded in lineage through `block_config_resolved` (ADR-038); ephemeral scratch is excluded.
- **`Data Router` and `Pair Editor` migrate** onto the contract as the core reference implementations.

This PR delivers the planning documents only (ADR + spec). The runtime,
capability, frontend injection, block migration, and the affected
architecture/block-development docs land in the follow-up implementation PR.

## Documents
- `docs/adr/ADR-051.md`
- `docs/specs/adr-051-interactive-blocks.md`

Gate record: .workflow/records/1781-adr-051-interactive-blocks.json

Closes #1781

🤖 Generated with [Claude Code](https://claude.com/claude-code)
