### PR TITLE
fix(#1787): ignore and clean up a stale OTA patch superseded by a newer bundle

### DIFF
--- a/.workflow/records/1787-guided-1787-ota-stale-patch-shadows-bundled.json
+++ b/.workflow/records/1787-guided-1787-ota-stale-patch-shadows-bundled.json
@@ -68,9 +68,9 @@
   ],
   "check_na": [],
   "commit": {
-    "sha": "4b0649d3e325c5b07f28ebcfbdb8e9825028c380",
+    "sha": "d1cf571f93bea6092b9726d4e2abe337eb470ee1",
     "shas": [
-      "4b0649d3e325c5b07f28ebcfbdb8e9825028c380"
+      "d1cf571f93bea6092b9726d4e2abe337eb470ee1"
     ],
     "trailers": []
   },
@@ -339,6 +339,88 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-06-26T21:42:30.216117Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T21:42:30.227969Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T21:42:30.239354Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T21:42:30.251014Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T21:42:30.262008Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T21:42:30.273989Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T21:42:30.287306Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T21:42:30.299063Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T21:42:30.308443Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T21:42:30.323322Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -351,7 +433,7 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "origin/main",
+    "base": "c2b85d49d76efd35aacf98a3cecdbebffe1cd4b8",
     "base_sha": "c2b85d49",
     "changed_files": [
       ".workflow/records/1787-guided-1787-ota-stale-patch-shadows-bundled.json",
@@ -360,9 +442,9 @@
       "desktop/test/ota.test.js",
       "docs/specs/desktop-ota-hot-update.md"
     ],
-    "diff_fingerprint": "sha256:16a1c2944fed42314929e5c4f355d7543404e9e9cd1cad2bb1c94b4eacfd1f05",
+    "diff_fingerprint": "sha256:548d863d721861a85243390834a9d52849011ae912230fd3fd2984bf61942196",
     "head": "HEAD",
-    "head_sha": "fbc41031",
+    "head_sha": "d1cf571f",
     "surfaces": {
       "docs": 1,
       "frontend": 0,
@@ -383,8 +465,8 @@
     "closes": [
       1787
     ],
-    "number": null,
-    "url": null
+    "number": 1788,
+    "url": "https://github.com/jiazhenz026/SciStudio/pull/1788"
   },
   "reconcile_events": [
     {
@@ -406,6 +488,14 @@
     {
       "at": "2026-06-26T21:41:56.532231Z",
       "diff_fingerprint": "sha256:16a1c2944fed42314929e5c4f355d7543404e9e9cd1cad2bb1c94b4eacfd1f05",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-26T21:42:30.323377Z",
+      "diff_fingerprint": "sha256:548d863d721861a85243390834a9d52849011ae912230fd3fd2984bf61942196",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 2,

--- a/.workflow/records/1787-guided-1787-ota-stale-patch-shadows-bundled.json
+++ b/.workflow/records/1787-guided-1787-ota-stale-patch-shadows-bundled.json
@@ -1,8 +1,79 @@
 {
   "branch": "guided/1787-ota-stale-patch-shadows-bundled",
-  "check_events": [],
+  "check_events": [
+    {
+      "at": "2026-06-26T21:39:11.379905Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:bee0017f30f552d2df2de1173f9ac14b9aee5192ca5e5c1de574bb119512b275",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-26T21:39:15.588238Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:a54411ec922b07f120c0672b69df624ad7163c43d7bb51ed8e0387e62e170ffb",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-26T21:39:15.625534Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e31351abfc33f0b3c0f28bc9f2f3d59ae3bc5d4925dc1159a7f931aa932441ed",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-26T21:41:20.364762Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:25ba9a25fe4a980b9965a3bcfcde124acda1207903a47486f7942076481f83cc",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    }
+  ],
   "check_na": [],
-  "commit": null,
+  "commit": {
+    "sha": "4b0649d3e325c5b07f28ebcfbdb8e9825028c380",
+    "shas": [
+      "4b0649d3e325c5b07f28ebcfbdb8e9825028c380"
+    ],
+    "trailers": []
+  },
   "declared_scope": {
     "exclude": [],
     "include": [
@@ -22,7 +93,172 @@
     }
   ],
   "governance_touch": false,
-  "guard_events": [],
+  "guard_events": [
+    {
+      "at": "2026-06-26T21:41:20.406109Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T21:41:20.417030Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T21:41:20.427644Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T21:41:20.439363Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T21:41:20.449127Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T21:41:20.458595Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T21:41:20.467993Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T21:41:20.478482Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T21:41:20.487740Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T21:41:20.497897Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T21:41:33.380091Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T21:41:33.388924Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T21:41:33.397778Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T21:41:33.406734Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T21:41:33.415623Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T21:41:33.425876Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T21:41:33.435973Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T21:41:33.445547Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T21:41:33.454691Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T21:41:33.464463Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
   "issues": [
     {
       "close_in_pr": true,
@@ -32,18 +268,83 @@
     }
   ],
   "observed_admin_labels": [],
-  "observed_diff": null,
+  "observed_diff": {
+    "base": "origin/main",
+    "base_sha": "c2b85d49",
+    "changed_files": [
+      ".workflow/records/1787-guided-1787-ota-stale-patch-shadows-bundled.json",
+      "desktop/main.js",
+      "desktop/ota.js",
+      "desktop/test/ota.test.js",
+      "docs/specs/desktop-ota-hot-update.md"
+    ],
+    "diff_fingerprint": "sha256:4eb3a27941805433a5ea87b7a841fe0f0f74dc05795395b21d80acb8dc2cae17",
+    "head": "HEAD",
+    "head_sha": "4b0649d3",
+    "surfaces": {
+      "docs": 1,
+      "frontend": 0,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 0,
+      "packaging": 0,
+      "protected_core": 0,
+      "sentrux": 1,
+      "test": 1,
+      "workflow_ci": 0
+    }
+  },
   "owner_directive": "Investigate and fix the OTA bug where an active OTA patch silently shadows any newly-installed bundled build regardless of build number; when the patch is stale (baseline build >= patch build) ignore it AND clean up the stale pointer/patch dir; open an issue and submit one PR.",
   "persona": "live_implementer",
-  "pull_request": null,
-  "reconcile_events": [],
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [
+      1787
+    ],
+    "number": null,
+    "url": null
+  },
+  "reconcile_events": [
+    {
+      "at": "2026-06-26T21:41:20.497935Z",
+      "diff_fingerprint": "sha256:4eb3a27941805433a5ea87b7a841fe0f0f74dc05795395b21d80acb8dc2cae17",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-26T21:41:33.464499Z",
+      "diff_fingerprint": "sha256:4eb3a27941805433a5ea87b7a841fe0f0f74dc05795395b21d80acb8dc2cae17",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    }
+  ],
   "record_id": "1787-guided-1787-ota-stale-patch-shadows-bundled",
   "requested_admin_labels": [],
   "required_obligations": {
     "admin_labels": [],
-    "checks": [],
+    "checks": [
+      "format_check",
+      "full_audit",
+      "lint_format",
+      "semantic_dup"
+    ],
     "docs": [],
-    "guards": [],
+    "guards": [
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
     "tests": []
   },
   "runtime": "claude-code",
@@ -63,7 +364,7 @@
     }
   ],
   "session_id": "7b55ddc7-9437-4360-aee9-ea3b7f8dd539",
-  "strictness_tier": null,
+  "strictness_tier": 2,
   "task_kind": "guided",
   "test_events": [
     {

--- a/.workflow/records/1787-guided-1787-ota-stale-patch-shadows-bundled.json
+++ b/.workflow/records/1787-guided-1787-ota-stale-patch-shadows-bundled.json
@@ -1,0 +1,78 @@
+{
+  "branch": "guided/1787-ota-stale-patch-shadows-bundled",
+  "check_events": [],
+  "check_na": [],
+  "commit": null,
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "desktop/main.js",
+      "desktop/test/ota.test.js"
+    ]
+  },
+  "directive_events": [],
+  "docs_events": [
+    {
+      "at": "2026-06-26T21:37:54.148825Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/specs/desktop-ota-hot-update.md",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": false,
+  "guard_events": [],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1787,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": null,
+  "owner_directive": "Investigate and fix the OTA bug where an active OTA patch silently shadows any newly-installed bundled build regardless of build number; when the patch is stale (baseline build >= patch build) ignore it AND clean up the stale pointer/patch dir; open an issue and submit one PR.",
+  "persona": "live_implementer",
+  "pull_request": null,
+  "reconcile_events": [],
+  "record_id": "1787-guided-1787-ota-stale-patch-shadows-bundled",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [],
+    "docs": [],
+    "guards": [],
+    "tests": []
+  },
+  "runtime": "claude-code",
+  "schema_version": 2,
+  "scope_events": [
+    {
+      "action": "add-include",
+      "at": "2026-06-26T21:37:54.148682Z",
+      "pattern": "desktop/ota.js",
+      "reason": "Centralized the stale-patch decision as pure ota.resolveActivePatch (unit-testable) and documented the supersession behavior in the OTA spec; both beyond the initial main.js/test include set."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-26T21:37:54.148818Z",
+      "pattern": "docs/specs/desktop-ota-hot-update.md",
+      "reason": "Centralized the stale-patch decision as pure ota.resolveActivePatch (unit-testable) and documented the supersession behavior in the OTA spec; both beyond the initial main.js/test include set."
+    }
+  ],
+  "session_id": "7b55ddc7-9437-4360-aee9-ea3b7f8dd539",
+  "strictness_tier": null,
+  "task_kind": "guided",
+  "test_events": [
+    {
+      "at": "2026-06-26T21:37:54.148840Z",
+      "class": null,
+      "kind": "path",
+      "path": "desktop/test/ota.test.js",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/.workflow/records/1787-guided-1787-ota-stale-patch-shadows-bundled.json
+++ b/.workflow/records/1787-guided-1787-ota-stale-patch-shadows-bundled.json
@@ -257,6 +257,88 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-06-26T21:41:56.424747Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T21:41:56.435326Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T21:41:56.447580Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T21:41:56.458925Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T21:41:56.472487Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T21:41:56.484643Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T21:41:56.496669Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T21:41:56.507995Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T21:41:56.519122Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-26T21:41:56.532193Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -278,9 +360,9 @@
       "desktop/test/ota.test.js",
       "docs/specs/desktop-ota-hot-update.md"
     ],
-    "diff_fingerprint": "sha256:4eb3a27941805433a5ea87b7a841fe0f0f74dc05795395b21d80acb8dc2cae17",
+    "diff_fingerprint": "sha256:16a1c2944fed42314929e5c4f355d7543404e9e9cd1cad2bb1c94b4eacfd1f05",
     "head": "HEAD",
-    "head_sha": "4b0649d3",
+    "head_sha": "fbc41031",
     "surfaces": {
       "docs": 1,
       "frontend": 0,
@@ -316,6 +398,14 @@
     {
       "at": "2026-06-26T21:41:33.464499Z",
       "diff_fingerprint": "sha256:4eb3a27941805433a5ea87b7a841fe0f0f74dc05795395b21d80acb8dc2cae17",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-26T21:41:56.532231Z",
+      "diff_fingerprint": "sha256:16a1c2944fed42314929e5c4f355d7543404e9e9cd1cad2bb1c94b4eacfd1f05",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 2,

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -184,18 +184,44 @@ function writeJsonAtomic(filePath, value) {
   fs.renameSync(tmp, filePath);
 }
 
-// Resolve the currently active patch, validating that its source tree exists.
+// #1787: remove a superseded patch directory and its active pointer so a stale
+// patch can never shadow a newer bundled baseline. Best-effort; getActivePatch
+// already treats a missing pointer or dir as "no active patch".
+function discardStalePatch(dir) {
+  try {
+    fs.rmSync(dir, { recursive: true, force: true });
+  } catch {
+    // Best-effort cleanup; a leftover dir is harmless once the pointer is gone.
+  }
+  try {
+    fs.rmSync(activePointerPath(), { force: true });
+  } catch {
+    // Best-effort; a stale pointer to a missing dir is ignored by getActivePatch.
+  }
+}
+
+// Resolve the currently active patch, validating that its source tree exists and
+// that it has not been superseded by a freshly installed bundle (see #1787). The
+// pure decision lives in ota.resolveActivePatch; here we gather the on-disk facts
+// and act on a "stale" verdict by discarding the patch.
 function getActivePatch() {
   const pointer = readJsonSafe(activePointerPath());
-  if (!pointer || typeof pointer.build !== "number") {
+  const build = pointer && typeof pointer.build === "number" ? pointer.build : null;
+  const dir = build !== null ? path.join(patchesRoot(), ota.patchDirName(build)) : null;
+  const srcDir = dir ? path.join(dir, "src") : null;
+  const srcExists = srcDir ? fs.existsSync(path.join(srcDir, "scistudio")) : false;
+  const decision = ota.resolveActivePatch(pointer, baselineVersion().build, srcExists);
+  if (decision.kind === "stale") {
+    // #1787: the installed bundle is >= the patch build, so honoring the patch
+    // would let its stale source shadow the newer bundled source (the patch
+    // srcDir sits first on PYTHONPATH). Discard it so the baseline wins.
+    discardStalePatch(dir);
     return null;
   }
-  const dir = path.join(patchesRoot(), ota.patchDirName(pointer.build));
-  const srcDir = path.join(dir, "src");
-  if (!fs.existsSync(path.join(srcDir, "scistudio"))) {
+  if (decision.kind !== "active") {
     return null;
   }
-  return { build: pointer.build, dir, srcDir };
+  return { build, dir, srcDir };
 }
 
 // Highest build the running app effectively serves: the applied patch if any,

--- a/desktop/ota.js
+++ b/desktop/ota.js
@@ -67,10 +67,39 @@ function evaluateUpdate(config, manifest, baseline, effectiveBuild) {
   return { kind: "patch", build: manifest.build };
 }
 
+// #1787: decide how to treat the persisted active-patch pointer given the
+// installed baseline build and whether the patch source tree still exists.
+//
+// Returns one of:
+//   { kind: "none" }            - no valid pointer; serve the bundled baseline
+//   { kind: "stale", build }    - patch build <= baseline; a reinstall (or a
+//                                 newer bundle) superseded it. The caller must
+//                                 discard it so the stale patch source can never
+//                                 shadow the newer bundled source on PYTHONPATH.
+//   { kind: "missing", build }  - pointer set, newer than baseline, but the
+//                                 patch src tree is gone; serve the baseline
+//   { kind: "active", build }   - honor the patch; it is newer than the baseline
+//
+// Staleness is checked before src existence so a superseded pointer is always
+// cleaned up, even if its directory was already partially removed.
+function resolveActivePatch(pointer, baselineBuild, srcExists) {
+  if (!pointer || typeof pointer.build !== "number") {
+    return { kind: "none" };
+  }
+  if (baselineBuild >= pointer.build) {
+    return { kind: "stale", build: pointer.build };
+  }
+  if (!srcExists) {
+    return { kind: "missing", build: pointer.build };
+  }
+  return { kind: "active", build: pointer.build };
+}
+
 module.exports = {
   VERSION_RE,
   parseVersion,
   compareBase,
   patchDirName,
-  evaluateUpdate
+  evaluateUpdate,
+  resolveActivePatch
 };

--- a/desktop/test/ota.test.js
+++ b/desktop/test/ota.test.js
@@ -79,3 +79,30 @@ test("evaluateUpdate: compares against effective build, not baseline", () => {
   const m = { build: 8, channel: "alpha", base: "0.2.1", requires: { min_base: "0.2.1" } };
   assert.equal(ota.evaluateUpdate(CONFIG, m, BASELINE, 9).reason, "up-to-date");
 });
+
+// #1787: an active patch must shadow the bundled baseline only when it is
+// strictly newer. A freshly installed bundle whose build is >= the patch build
+// supersedes it; otherwise a stale patch would silently shadow the new bundle.
+test("resolveActivePatch: no pointer => none", () => {
+  assert.deepEqual(ota.resolveActivePatch(null, 6, false), { kind: "none" });
+  assert.deepEqual(ota.resolveActivePatch({}, 6, true), { kind: "none" });
+  assert.deepEqual(ota.resolveActivePatch({ build: "9" }, 6, true), { kind: "none" });
+});
+
+test("resolveActivePatch: patch newer than baseline with src => active", () => {
+  assert.deepEqual(ota.resolveActivePatch({ build: 9 }, 6, true), { kind: "active", build: 9 });
+});
+
+test("resolveActivePatch: patch newer than baseline but src gone => missing", () => {
+  assert.deepEqual(ota.resolveActivePatch({ build: 9 }, 6, false), { kind: "missing", build: 9 });
+});
+
+test("resolveActivePatch: baseline >= patch build => stale (the #1787 bug)", () => {
+  // Newer bundle reinstalled over an old patch: baseline 12 supersedes patch 9.
+  assert.deepEqual(ota.resolveActivePatch({ build: 9 }, 12, true), { kind: "stale", build: 9 });
+  // Equal builds (reinstall of the same build) also supersede the patch.
+  assert.deepEqual(ota.resolveActivePatch({ build: 9 }, 9, true), { kind: "stale", build: 9 });
+  // Stale verdict wins even when the src tree is already gone, so the pointer
+  // still gets cleaned up.
+  assert.deepEqual(ota.resolveActivePatch({ build: 9 }, 9, false), { kind: "stale", build: 9 });
+});

--- a/docs/specs/desktop-ota-hot-update.md
+++ b/docs/specs/desktop-ota-hot-update.md
@@ -122,6 +122,14 @@ Update decision (pure logic in `desktop/ota.js`, `evaluateUpdate`):
 - `runtimeEnv()` prepends `userData/patches/build<N>/src` to `PYTHONPATH`; the
   app bundle is never modified (works under a read-only/signed bundle and avoids
   Windows `Program Files` permission issues).
+- **Supersession (#1787)**: an active patch shadows the bundled baseline only
+  while it is strictly newer. `getActivePatch()` consults
+  `ota.resolveActivePatch(pointer, baselineBuild, srcExists)`; when the installed
+  `baseline build >= active patch build` (e.g. a newer or equal bundle was
+  reinstalled over an older patch), the patch is treated as **stale**: it is
+  ignored and its `userData/patches/build<N>/` directory plus the `active.json`
+  pointer are discarded, so a fresh install always wins instead of being silently
+  shadowed by leftover patch source on `PYTHONPATH`.
 - **Rollback**: if the runtime fails to reach ready with an active patch, the
   client reverts to the last known-good patch (or the bundled baseline) and
   retries once, so a bad patch cannot brick the install. A patch is recorded


### PR DESCRIPTION
## Summary

On a machine with an active OTA patch, any newly installed bundled build was
silently shadowed by the old patch regardless of how high its build number was.
`getActivePatch()` honored `active.json` purely on the existence of
`src/scistudio`, and `runtimeEnv()` placed the patch `srcDir` first on
`PYTHONPATH`, so stale patch code shadowed the newer bundled source.
`effectiveBuild() = max(baseline, patch)` only fed the OTA update *decision*, so
the load layer and the decision layer disagreed.

## Fix

An active patch now shadows the bundled baseline only when its build is
**strictly greater** than the baseline build. The pure decision is centralized
in `ota.resolveActivePatch(pointer, baselineBuild, srcExists)`; `main.js`
gathers the on-disk facts and, on a `stale` verdict (`baseline build >= patch
build` — e.g. a newer or equal bundle reinstalled over an older patch), discards
the `userData/patches/build<N>/` directory and the `active.json` pointer so the
fresh install wins.

The two pre-existing escape hatches (OTA fetching a strictly higher build, or
crash-rollback removing the pointer) are unchanged.

## Tests

- `desktop/test/ota.test.js`: new `resolveActivePatch` cases covering
  none / active / missing / stale (including the equal-build and
  src-already-gone variants — the #1787 regression).

## Docs

- `docs/specs/desktop-ota-hot-update.md` §5: documented the supersession
  behavior.

Gate record: .workflow/records/1787-guided-1787-ota-stale-patch-shadows-bundled.json

Closes #1787
