### PR TITLE
feat(#1795): add maximize pop-out window to Data Preview panel

### DIFF
--- a/.workflow/records/1795-guided-1795-preview-popout-window.json
+++ b/.workflow/records/1795-guided-1795-preview-popout-window.json
@@ -128,9 +128,9 @@
   ],
   "check_na": [],
   "commit": {
-    "sha": "317abf4d62a2c40025bcd3581daebc8004be99d3",
+    "sha": "b85c610b687a048d639b17503349659f96f28681",
     "shas": [
-      "317abf4d62a2c40025bcd3581daebc8004be99d3"
+      "b85c610b687a048d639b17503349659f96f28681"
     ],
     "trailers": []
   },
@@ -405,6 +405,170 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-06-27T03:51:07.924111Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T03:51:07.934040Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T03:51:07.944599Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T03:51:07.957117Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T03:51:07.967520Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T03:51:07.979293Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T03:51:07.994124Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T03:51:08.006574Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T03:51:08.016417Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T03:51:08.028758Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T03:51:20.761987Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T03:51:20.775076Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T03:51:20.788051Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T03:51:20.803328Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T03:51:20.815279Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T03:51:20.826551Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T03:51:20.840298Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T03:51:20.852090Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T03:51:20.865405Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T03:51:20.881706Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -417,16 +581,16 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "origin/main",
+    "base": "85271be74076db87196068944a51c04c900b6d6e",
     "base_sha": "85271be7",
     "changed_files": [
       ".workflow/records/1795-guided-1795-preview-popout-window.json",
       "frontend/src/components/DataPreview.test.tsx",
       "frontend/src/components/DataPreview.tsx"
     ],
-    "diff_fingerprint": "sha256:1a864fbed35c482419b9bd8041da060338bfc4e4824f4c9e868f866f61560ceb",
+    "diff_fingerprint": "sha256:b5103a1c266e4b22cedd4ef33a0eb5c9c487aae7c35eff1de3c5e136d2855f71",
     "head": "HEAD",
-    "head_sha": "317abf4d",
+    "head_sha": "b85c610b",
     "surfaces": {
       "docs": 0,
       "frontend": 2,
@@ -447,8 +611,8 @@
     "closes": [
       1795
     ],
-    "number": null,
-    "url": null
+    "number": 1796,
+    "url": "https://github.com/jiazhenz026/SciStudio/pull/1796"
   },
   "reconcile_events": [
     {
@@ -472,6 +636,22 @@
     {
       "at": "2026-06-27T03:50:31.503200Z",
       "diff_fingerprint": "sha256:1a864fbed35c482419b9bd8041da060338bfc4e4824f4c9e868f866f61560ceb",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-27T03:51:08.028798Z",
+      "diff_fingerprint": "sha256:b5103a1c266e4b22cedd4ef33a0eb5c9c487aae7c35eff1de3c5e136d2855f71",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-27T03:51:20.881781Z",
+      "diff_fingerprint": "sha256:b5103a1c266e4b22cedd4ef33a0eb5c9c487aae7c35eff1de3c5e136d2855f71",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 2,

--- a/.workflow/records/1795-guided-1795-preview-popout-window.json
+++ b/.workflow/records/1795-guided-1795-preview-popout-window.json
@@ -173,9 +173,9 @@
   ],
   "check_na": [],
   "commit": {
-    "sha": "b85c610b687a048d639b17503349659f96f28681",
+    "sha": "3c7b3861e5e35100508af2f4f8683609dcede18f",
     "shas": [
-      "b85c610b687a048d639b17503349659f96f28681"
+      "3c7b3861e5e35100508af2f4f8683609dcede18f"
     ],
     "trailers": []
   },
@@ -701,6 +701,88 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-06-27T04:16:58.840186Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T04:16:58.849540Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T04:16:58.858913Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T04:16:58.868147Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T04:16:58.877313Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T04:16:58.886525Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T04:16:58.895593Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T04:16:58.905096Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T04:16:58.913805Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T04:16:58.926140Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -713,16 +795,16 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "origin/main",
+    "base": "85271be74076db87196068944a51c04c900b6d6e",
     "base_sha": "85271be7",
     "changed_files": [
       ".workflow/records/1795-guided-1795-preview-popout-window.json",
       "frontend/src/components/DataPreview.test.tsx",
       "frontend/src/components/DataPreview.tsx"
     ],
-    "diff_fingerprint": "sha256:5e5d8c59e5b66cd927a3ff6c3c28d6c9ae39a571f0ec6e632f3f760d8e589dcf",
+    "diff_fingerprint": "sha256:d19550076fc3d7f330c325a0e892174e44137c6f747e4627c4bc5c6a4ebb2f32",
     "head": "HEAD",
-    "head_sha": "0e52c5bb",
+    "head_sha": "3c7b3861",
     "surfaces": {
       "docs": 0,
       "frontend": 2,
@@ -744,7 +826,7 @@
       1795
     ],
     "number": 1796,
-    "url": "https://github.com/jiazhenz026/SciStudio/pull/1796"
+    "url": null
   },
   "reconcile_events": [
     {
@@ -792,6 +874,14 @@
     {
       "at": "2026-06-27T04:16:42.341091Z",
       "diff_fingerprint": "sha256:5e5d8c59e5b66cd927a3ff6c3c28d6c9ae39a571f0ec6e632f3f760d8e589dcf",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-27T04:16:58.926172Z",
+      "diff_fingerprint": "sha256:d19550076fc3d7f330c325a0e892174e44137c6f747e4627c4bc5c6a4ebb2f32",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 2,

--- a/.workflow/records/1795-guided-1795-preview-popout-window.json
+++ b/.workflow/records/1795-guided-1795-preview-popout-window.json
@@ -1,0 +1,534 @@
+{
+  "branch": "guided/1795-preview-popout-window",
+  "check_events": [
+    {
+      "at": "2026-06-27T03:44:15.598026Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:bee0017f30f552d2df2de1173f9ac14b9aee5192ca5e5c1de574bb119512b275",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-27T03:44:20.352038Z",
+      "command": "(cd frontend && npm run check:ci)",
+      "covered_surface": "frontend",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:a8e9250c1437c9d45dcc185adc05c6f56e11423d23a2f1b4b7a9b2da8a401f7f",
+      "name": "frontend",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/frontend.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-27T03:44:24.163567Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:43333d1345e34936efff0e99e0d71cfd6ba5de27dea43ae0ca86b7f03c828cc4",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-27T03:44:24.207122Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e31351abfc33f0b3c0f28bc9f2f3d59ae3bc5d4925dc1159a7f931aa932441ed",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-27T03:46:18.803818Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:c57ed1cc7faac458d58040b8fc275d032700c670c4076327c339bc74baac2358",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-27T03:47:55.786753Z",
+      "command": "(cd frontend && npm run check:ci)",
+      "covered_surface": "frontend",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:55c52bab27a29e7d999ac695b89368376983b30408b872e8ba5b9e2d952cf1d9",
+      "name": "frontend",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/frontend.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-27T03:47:59.821068Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:753ecf5b4c6f73f259a60ff29b8bffcb14f253fa1a468d453864fc399efa334d",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-27T03:49:53.254047Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:2cc038e54f1c655f1e944e3ec10bb499b6546769f397f6680aa04736f9423427",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    }
+  ],
+  "check_na": [],
+  "commit": {
+    "sha": "317abf4d62a2c40025bcd3581daebc8004be99d3",
+    "shas": [
+      "317abf4d62a2c40025bcd3581daebc8004be99d3"
+    ],
+    "trailers": []
+  },
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "frontend/src/components/DataPreview.tsx",
+      "frontend/src/components/DataPreview.parts/**"
+    ]
+  },
+  "directive_events": [
+    {
+      "at": "2026-06-27T03:43:25.297022Z",
+      "owner_directive": "Submit the PR directly; I'll test later.",
+      "reason": "Owner directed: implement maximize pop-out window and submit PR now; include the DataPreview test file in scope and record docs N/A"
+    }
+  ],
+  "docs_events": [
+    {
+      "at": "2026-06-27T03:43:25.297194Z",
+      "class": "user-guide",
+      "kind": "na",
+      "path": null,
+      "rationale": "Additive frontend UI affordance (maximize/pop-out preview window). No change to previewer contracts, PreviewHost API, envelope kinds, preview routing, schemas, storage, or runtime behavior; nothing in docs/block-development or architecture describes the host panel chrome.",
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": false,
+  "guard_events": [
+    {
+      "at": "2026-06-27T03:46:18.847203Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T03:46:18.856901Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T03:46:18.866648Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T03:46:18.875821Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T03:46:18.884941Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T03:46:18.893748Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T03:46:18.902895Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T03:46:18.915176Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T03:46:18.925045Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T03:46:18.937250Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T03:49:53.303994Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T03:49:53.313378Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T03:49:53.322923Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T03:49:53.332040Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T03:49:53.341679Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T03:49:53.351489Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T03:49:53.360544Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T03:49:53.371139Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T03:49:53.380668Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T03:49:53.391416Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T03:50:31.417284Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T03:50:31.426146Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T03:50:31.435405Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T03:50:31.445305Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T03:50:31.454384Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T03:50:31.463295Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T03:50:31.473080Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T03:50:31.482831Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T03:50:31.492254Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T03:50:31.503168Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1795,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": {
+    "base": "origin/main",
+    "base_sha": "85271be7",
+    "changed_files": [
+      ".workflow/records/1795-guided-1795-preview-popout-window.json",
+      "frontend/src/components/DataPreview.test.tsx",
+      "frontend/src/components/DataPreview.tsx"
+    ],
+    "diff_fingerprint": "sha256:1a864fbed35c482419b9bd8041da060338bfc4e4824f4c9e868f866f61560ceb",
+    "head": "HEAD",
+    "head_sha": "317abf4d",
+    "surfaces": {
+      "docs": 0,
+      "frontend": 2,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 2,
+      "packaging": 0,
+      "protected_core": 0,
+      "sentrux": 2,
+      "test": 1,
+      "workflow_ci": 0
+    }
+  },
+  "owner_directive": "Preview is too small in the narrow right sidebar. Add a maximize button that pops the preview into a separate floating window over the canvas area; support Esc to close.",
+  "persona": "live_implementer",
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [
+      1795
+    ],
+    "number": null,
+    "url": null
+  },
+  "reconcile_events": [
+    {
+      "at": "2026-06-27T03:46:18.937285Z",
+      "diff_fingerprint": "sha256:250bef4a7a9697b57cedba4f43bd3ec0a1a527d1506e7bbb3d7823a50acc7b1e",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.frontend"
+      ]
+    },
+    {
+      "at": "2026-06-27T03:49:53.391453Z",
+      "diff_fingerprint": "sha256:658d2be5572952bd0f134ee0a1f416b739e02f82533b64eb338e9086ed937454",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-27T03:50:31.503200Z",
+      "diff_fingerprint": "sha256:1a864fbed35c482419b9bd8041da060338bfc4e4824f4c9e868f866f61560ceb",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    }
+  ],
+  "record_id": "1795-guided-1795-preview-popout-window",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [
+      "format_check",
+      "frontend",
+      "full_audit",
+      "lint_format",
+      "semantic_dup"
+    ],
+    "docs": [
+      "docs_required_or_na"
+    ],
+    "guards": [
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": [
+      "changed_test_required"
+    ]
+  },
+  "runtime": "claude-code",
+  "schema_version": 2,
+  "scope_events": [
+    {
+      "action": "add-include",
+      "at": "2026-06-27T03:43:25.297179Z",
+      "pattern": "frontend/src/components/DataPreview.test.tsx",
+      "reason": "Owner directed: implement maximize pop-out window and submit PR now; include the DataPreview test file in scope and record docs N/A"
+    }
+  ],
+  "session_id": "cd9d8252-4a4d-460c-b719-268c979e2c1a",
+  "strictness_tier": 2,
+  "task_kind": "guided",
+  "test_events": [
+    {
+      "at": "2026-06-27T03:43:25.297212Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/components/DataPreview.test.tsx",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/.workflow/records/1795-guided-1795-preview-popout-window.json
+++ b/.workflow/records/1795-guided-1795-preview-popout-window.json
@@ -124,6 +124,51 @@
       "status": "pass",
       "summary": "clean",
       "tool_versions": {}
+    },
+    {
+      "at": "2026-06-27T04:14:39.356583Z",
+      "command": "(cd frontend && npm run check:ci)",
+      "covered_surface": "frontend",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:aa37094d07550b3d01bdf087ec15519d5f6de868f8bfdb8308b18b5966cf4f76",
+      "name": "frontend",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/frontend.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-27T04:14:43.096512Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:3e9579d3263588779425c9e4fb7bed2082c7c88a177492eb087caf5c218d49d4",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-27T04:16:42.217330Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:0063bf25a2589925b3dc9da87cc33955d89239a2ca6e382ffdc00ec746fac51a",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
     }
   ],
   "check_na": [],
@@ -146,6 +191,11 @@
       "at": "2026-06-27T03:43:25.297022Z",
       "owner_directive": "Submit the PR directly; I'll test later.",
       "reason": "Owner directed: implement maximize pop-out window and submit PR now; include the DataPreview test file in scope and record docs N/A"
+    },
+    {
+      "at": "2026-06-27T04:09:16.964924Z",
+      "owner_directive": "Fix the audit: preserve the existing PreviewHost (its query/drill-down/session state) when maximizing instead of remounting a fresh one.",
+      "reason": "Audit P2: maximizing remounts PreviewHost (placeholder inline + fresh host in overlay), resetting query/drill-down/session state. Owner approved fix on the open PR before merge."
     }
   ],
   "docs_events": [
@@ -569,6 +619,88 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-06-27T04:16:42.253517Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T04:16:42.263030Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T04:16:42.273157Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T04:16:42.283079Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T04:16:42.292430Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T04:16:42.301789Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T04:16:42.310841Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T04:16:42.320171Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T04:16:42.329268Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T04:16:42.341048Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -581,16 +713,16 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "85271be74076db87196068944a51c04c900b6d6e",
+    "base": "origin/main",
     "base_sha": "85271be7",
     "changed_files": [
       ".workflow/records/1795-guided-1795-preview-popout-window.json",
       "frontend/src/components/DataPreview.test.tsx",
       "frontend/src/components/DataPreview.tsx"
     ],
-    "diff_fingerprint": "sha256:b5103a1c266e4b22cedd4ef33a0eb5c9c487aae7c35eff1de3c5e136d2855f71",
+    "diff_fingerprint": "sha256:5e5d8c59e5b66cd927a3ff6c3c28d6c9ae39a571f0ec6e632f3f760d8e589dcf",
     "head": "HEAD",
-    "head_sha": "b85c610b",
+    "head_sha": "0e52c5bb",
     "surfaces": {
       "docs": 0,
       "frontend": 2,
@@ -652,6 +784,14 @@
     {
       "at": "2026-06-27T03:51:20.881781Z",
       "diff_fingerprint": "sha256:b5103a1c266e4b22cedd4ef33a0eb5c9c487aae7c35eff1de3c5e136d2855f71",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-27T04:16:42.341091Z",
+      "diff_fingerprint": "sha256:5e5d8c59e5b66cd927a3ff6c3c28d6c9ae39a571f0ec6e632f3f760d8e589dcf",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 2,

--- a/frontend/src/components/DataPreview.test.tsx
+++ b/frontend/src/components/DataPreview.test.tsx
@@ -236,4 +236,60 @@ describe("DataPreview", () => {
     // Fallback when no metadata source: truncated ref.
     expect(screen.getByRole("button", { name: "data-xyz78" })).toBeInTheDocument();
   });
+
+  // #1795 — the maximize control pops the active preview into a floating window
+  // so a cramped right-sidebar preview can be inspected at a larger size.
+  it("offers no maximize control without previewable output (#1795)", () => {
+    render(
+      <DataPreview
+        blockOutputs={{ "node-1": {} }}
+        selectedNodeId="node-1"
+        selectedNodeLabel="Empty Block"
+      />,
+    );
+    expect(screen.queryByRole("button", { name: "Maximize preview" })).not.toBeInTheDocument();
+  });
+
+  it("maximizes the active preview into an overlay window and closes on Escape (#1795)", async () => {
+    render(
+      <DataPreview
+        blockOutputs={{ "node-1": { output: { data_ref: "data-123" } } }}
+        selectedNodeId="node-1"
+        selectedNodeLabel="Process Block"
+      />,
+    );
+
+    const maximize = await screen.findByRole("button", { name: "Maximize preview" });
+    expect(screen.queryByTestId("preview-maximized-overlay")).not.toBeInTheDocument();
+
+    fireEvent.click(maximize);
+    expect(screen.getByTestId("preview-maximized-overlay")).toBeInTheDocument();
+    // The maximized window keeps the routed preview alive (its own host mounts).
+    await waitFor(() => expect(screen.getByTestId("preview-host")).toBeInTheDocument());
+
+    fireEvent.keyDown(document, { key: "Escape" });
+    await waitFor(() =>
+      expect(screen.queryByTestId("preview-maximized-overlay")).not.toBeInTheDocument(),
+    );
+  });
+
+  it("closes the maximized window via the close control and backdrop (#1795)", async () => {
+    render(
+      <DataPreview
+        blockOutputs={{ "node-1": { output: { data_ref: "data-123" } } }}
+        selectedNodeId="node-1"
+        selectedNodeLabel="Process Block"
+      />,
+    );
+
+    // Close control dismisses it.
+    fireEvent.click(await screen.findByRole("button", { name: "Maximize preview" }));
+    fireEvent.click(screen.getByRole("button", { name: "Close preview window" }));
+    expect(screen.queryByTestId("preview-maximized-overlay")).not.toBeInTheDocument();
+
+    // Re-open, then a backdrop click dismisses it.
+    fireEvent.click(screen.getByRole("button", { name: "Maximize preview" }));
+    fireEvent.click(screen.getByTestId("preview-maximized-overlay"));
+    expect(screen.queryByTestId("preview-maximized-overlay")).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/DataPreview.test.tsx
+++ b/frontend/src/components/DataPreview.test.tsx
@@ -264,13 +264,45 @@ describe("DataPreview", () => {
 
     fireEvent.click(maximize);
     expect(screen.getByTestId("preview-maximized-overlay")).toBeInTheDocument();
-    // The maximized window keeps the routed preview alive (its own host mounts).
+    // The same host stays mounted inside the maximized window.
     await waitFor(() => expect(screen.getByTestId("preview-host")).toBeInTheDocument());
 
     fireEvent.keyDown(document, { key: "Escape" });
     await waitFor(() =>
       expect(screen.queryByTestId("preview-maximized-overlay")).not.toBeInTheDocument(),
     );
+  });
+
+  // #1795 audit P2 — maximizing must NOT remount PreviewHost. PreviewHost owns
+  // the query/drill-down state and creates the preview session on mount, so a
+  // remount would reset the active preview (paging, slice, drill-down) and open
+  // a fresh session. The single host is reconciled in place, so its DOM node is
+  // reused and no extra session is created when popping out and back.
+  it("preserves the same PreviewHost instance across maximize/restore (#1795)", async () => {
+    render(
+      <DataPreview
+        blockOutputs={{ "node-1": { output: { data_ref: "data-123" } } }}
+        selectedNodeId="node-1"
+        selectedNodeLabel="Process Block"
+      />,
+    );
+
+    const hostBefore = await screen.findByTestId("preview-host");
+    const sessionsAfterMount = createPreviewSession.mock.calls.length;
+
+    // Maximize: the host DOM node is reused (in-place reconcile, not remount)
+    // and no new preview session is opened.
+    fireEvent.click(screen.getByRole("button", { name: "Maximize preview" }));
+    const hostMaximized = screen.getByTestId("preview-host");
+    expect(hostMaximized).toBe(hostBefore);
+
+    // Restore (Esc): still the same node, still no extra session.
+    fireEvent.keyDown(document, { key: "Escape" });
+    await waitFor(() =>
+      expect(screen.queryByTestId("preview-maximized-overlay")).not.toBeInTheDocument(),
+    );
+    expect(screen.getByTestId("preview-host")).toBe(hostBefore);
+    expect(createPreviewSession.mock.calls.length).toBe(sessionsAfterMount);
   });
 
   it("closes the maximized window via the close control and backdrop (#1795)", async () => {

--- a/frontend/src/components/DataPreview.tsx
+++ b/frontend/src/components/DataPreview.tsx
@@ -188,9 +188,14 @@ export function DataPreview({
     </div>
   ) : null;
 
-  // The routed preview host. Only one instance mounts at a time (inline OR the
-  // maximized window) so a single preview session is active.
-  const renderHost = () => (
+  // #1795 — a SINGLE PreviewHost instance backs both the inline panel and the
+  // maximized window. PreviewHost owns the query / drill-down state and creates
+  // the preview session on mount, so it is rendered exactly once at a stable
+  // position in the element tree. Maximizing only restyles its wrapper (inline
+  // flow ⇄ fixed overlay window); the host is never unmounted, so the active
+  // preview (table paging/sort, array slice, child-resource drill-down, dynamic
+  // previewer state, session) is preserved when popping out instead of reset.
+  const host = (
     <PreviewHost
       target={activePlot ?? target}
       initialQuery={activePlot ? undefined : activeEntry?.initialQuery}
@@ -200,89 +205,112 @@ export function DataPreview({
     />
   );
 
-  return (
-    <>
-      <aside className="flex h-full flex-col overflow-hidden border-l border-stone-200 bg-[linear-gradient(180deg,_rgba(255,255,255,0.94),_rgba(245,241,232,0.98))] p-4">
-        <div className="flex items-start justify-between gap-3">
-          <div>
-            <p className="text-xs uppercase tracking-[0.35em] text-stone-500">Preview</p>
-            <h2 className="mt-2 font-display text-2xl text-ink">
-              {selectedNodeId ? selectedNodeLabel : "Select a block"}
-            </h2>
-          </div>
-          {hasPreviewContent ? (
-            <button
-              aria-label="Maximize preview"
-              className="mt-1 shrink-0 rounded-full p-1.5 text-stone-500 hover:bg-white hover:text-ink"
-              onClick={() => setIsMaximized(true)}
-              title="Maximize preview"
-              type="button"
-            >
-              <Maximize2 className="h-4 w-4" />
-            </button>
-          ) : null}
-        </div>
-
-        {/* #1713 — the workflow-wide plot list moved to the dedicated Plots tab
-            (BottomPanel). This panel renders preview content: the selected node's
-            outputs and/or the persisted plot Run result, toggled by the "Plot
-            artifact" pill. The result stays put when switching blocks. */}
-        {!selectedNodeId ? (
-          <div className="mt-6 rounded-[1.8rem] border border-dashed border-stone-300 px-4 py-6 text-sm text-stone-500">
-            Pick a block to inspect its latest outputs and cached previews.
-          </div>
-        ) : (
-          <>
-            {pillsRow ? <div className="mt-5">{pillsRow}</div> : null}
-            <div className="mt-4 min-h-0 flex-1 overflow-y-auto scrollbar-thin">
-              {isMaximized ? (
-                <div className="flex h-full items-center justify-center px-4 text-center text-sm text-stone-400">
-                  Preview opened in a separate window.
-                </div>
-              ) : (
-                renderHost()
-              )}
-            </div>
-          </>
-        )}
-        {portPanel}
-      </aside>
-
-      {/* #1795 — maximized preview window. Reuses the shared overlay pattern
-          (DataRouterModal / PairEditorModal). Backdrop click, the close
-          control, and Escape all dismiss it. */}
-      {isMaximized ? (
+  // The preview surface keeps an identical element structure in both modes so
+  // React reconciles in place and never remounts the host. Only class names and
+  // the maximize chrome change. Stable keys keep the host's identity even if the
+  // pills row appears/disappears as outputs arrive. When maximized the surface
+  // itself becomes the fixed backdrop (reusing the DataRouterModal /
+  // PairEditorModal overlay pattern); backdrop click, the close control, and
+  // Escape all dismiss it. The aside ancestors are flexbox panels with no
+  // transform, so the fixed overlay positions against the viewport correctly.
+  const previewSurface = (
+    <div
+      className={
+        isMaximized
+          ? "fixed inset-0 z-[9999] flex items-center justify-center bg-black/40 p-6"
+          : "mt-4 flex min-h-0 flex-1 flex-col"
+      }
+      data-testid={isMaximized ? "preview-maximized-overlay" : undefined}
+      onClick={isMaximized ? () => setIsMaximized(false) : undefined}
+    >
+      <div
+        className={
+          isMaximized
+            ? "flex h-[88vh] w-[88vw] flex-col rounded-2xl border border-stone-200 bg-white shadow-2xl"
+            : "flex min-h-0 flex-1 flex-col"
+        }
+        onClick={isMaximized ? (event) => event.stopPropagation() : undefined}
+      >
         <div
-          className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/40 p-6"
-          onClick={() => setIsMaximized(false)}
-          data-testid="preview-maximized-overlay"
+          key="max-header"
+          className={
+            isMaximized
+              ? "flex items-center justify-between gap-3 border-b border-stone-100 px-5 py-3"
+              : "hidden"
+          }
         >
-          <div
-            className="flex h-[88vh] w-[88vw] flex-col rounded-2xl border border-stone-200 bg-white shadow-2xl"
-            onClick={(event) => event.stopPropagation()}
-          >
-            <div className="flex items-center justify-between gap-3 border-b border-stone-100 px-5 py-3">
-              <div className="flex min-w-0 flex-col">
-                <span className="text-xs uppercase tracking-[0.35em] text-stone-500">Preview</span>
-                <span className="truncate font-display text-lg text-ink">{selectedNodeLabel}</span>
-              </div>
-              <button
-                aria-label="Close preview window"
-                className="shrink-0 rounded-full p-1.5 text-stone-500 hover:bg-stone-100 hover:text-ink"
-                onClick={() => setIsMaximized(false)}
-                title="Close (Esc)"
-                type="button"
-              >
-                <X className="h-4 w-4" />
-              </button>
-            </div>
-            {pillsRow ? (
-              <div className="border-b border-stone-100 px-5 py-3">{pillsRow}</div>
-            ) : null}
-            <div className="min-h-0 flex-1 overflow-y-auto scrollbar-thin p-5">{renderHost()}</div>
+          <div className="flex min-w-0 flex-col">
+            <span className="text-xs uppercase tracking-[0.35em] text-stone-500">Preview</span>
+            <span className="truncate font-display text-lg text-ink">{selectedNodeLabel}</span>
           </div>
+          <button
+            aria-label="Close preview window"
+            className="shrink-0 rounded-full p-1.5 text-stone-500 hover:bg-stone-100 hover:text-ink"
+            onClick={() => setIsMaximized(false)}
+            title="Close (Esc)"
+            type="button"
+          >
+            <X className="h-4 w-4" />
+          </button>
         </div>
-      ) : null}
-    </>
+        {pillsRow ? (
+          <div
+            key="pills"
+            className={
+              isMaximized ? "shrink-0 border-b border-stone-100 px-5 py-3" : "mb-3 shrink-0"
+            }
+          >
+            {pillsRow}
+          </div>
+        ) : null}
+        <div
+          key="host"
+          className={
+            isMaximized
+              ? "min-h-0 flex-1 overflow-y-auto scrollbar-thin p-5"
+              : "min-h-0 flex-1 overflow-y-auto scrollbar-thin"
+          }
+        >
+          {host}
+        </div>
+      </div>
+    </div>
+  );
+
+  return (
+    <aside className="flex h-full flex-col overflow-hidden border-l border-stone-200 bg-[linear-gradient(180deg,_rgba(255,255,255,0.94),_rgba(245,241,232,0.98))] p-4">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <p className="text-xs uppercase tracking-[0.35em] text-stone-500">Preview</p>
+          <h2 className="mt-2 font-display text-2xl text-ink">
+            {selectedNodeId ? selectedNodeLabel : "Select a block"}
+          </h2>
+        </div>
+        {hasPreviewContent && !isMaximized ? (
+          <button
+            aria-label="Maximize preview"
+            className="mt-1 shrink-0 rounded-full p-1.5 text-stone-500 hover:bg-white hover:text-ink"
+            onClick={() => setIsMaximized(true)}
+            title="Maximize preview"
+            type="button"
+          >
+            <Maximize2 className="h-4 w-4" />
+          </button>
+        ) : null}
+      </div>
+
+      {/* #1713 — the workflow-wide plot list moved to the dedicated Plots tab
+          (BottomPanel). This panel renders preview content: the selected node's
+          outputs and/or the persisted plot Run result, toggled by the "Plot
+          artifact" pill. The result stays put when switching blocks. */}
+      {!selectedNodeId ? (
+        <div className="mt-6 rounded-[1.8rem] border border-dashed border-stone-300 px-4 py-6 text-sm text-stone-500">
+          Pick a block to inspect its latest outputs and cached previews.
+        </div>
+      ) : (
+        previewSurface
+      )}
+      {portPanel}
+    </aside>
   );
 }

--- a/frontend/src/components/DataPreview.tsx
+++ b/frontend/src/components/DataPreview.tsx
@@ -1,3 +1,4 @@
+import { Maximize2, X } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 
 import { useAppStore } from "../store";
@@ -100,9 +101,28 @@ export function DataPreview({
   // pills turn it off; the "Plot artifact" pill turns it back on.
   const [showPlotResult, setShowPlotResult] = useState(false);
 
+  // #1795 — maximize the active preview into a floating window over the canvas
+  // so a cramped right-sidebar preview can be inspected at a larger size.
+  // PreviewHost adapts to its container, so the larger window renders a
+  // correspondingly larger preview with no host changes.
+  const [isMaximized, setIsMaximized] = useState(false);
+
   useEffect(() => {
     setPickedEntryId(null);
+    // A new selection retargets the preview; close any stale maximized window.
+    setIsMaximized(false);
   }, [selectedNodeId]);
+
+  // #1795 — close the maximized window on Escape. The listener is attached only
+  // while maximized so it never shadows canvas/editor shortcuts otherwise.
+  useEffect(() => {
+    if (!isMaximized) return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setIsMaximized(false);
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [isMaximized]);
 
   // A fresh plot Run (new plotPreviewTarget) switches the view to the result.
   useEffect(() => {
@@ -135,67 +155,134 @@ export function DataPreview({
       </div>
     ) : null;
 
-  return (
-    <aside className="flex h-full flex-col overflow-hidden border-l border-stone-200 bg-[linear-gradient(180deg,_rgba(255,255,255,0.94),_rgba(245,241,232,0.98))] p-4">
-      <div className="flex items-start justify-between gap-3">
-        <div>
-          <p className="text-xs uppercase tracking-[0.35em] text-stone-500">Preview</p>
-          <h2 className="mt-2 font-display text-2xl text-ink">
-            {selectedNodeId ? selectedNodeLabel : "Select a block"}
-          </h2>
-        </div>
-      </div>
+  // #1795 — the output/plot pills are shared by the inline panel and the
+  // maximized window, so extract them once. ``hasPreviewContent`` also gates
+  // the maximize control: there is nothing to enlarge until an output exists.
+  const hasPreviewContent = outputEntryIds.length > 0 || plotBelongsToSelected;
+  const pillsRow = hasPreviewContent ? (
+    <div className="flex flex-wrap gap-2">
+      {refEntries.map((entry) => (
+        <button
+          className={`rounded-full px-3 py-1 text-xs ${!activePlot && activeEntry?.id === entry.id ? "bg-ink text-white" : "bg-white text-stone-600"}`}
+          key={entry.id}
+          onClick={() => {
+            setPickedEntryId(entry.id);
+            setShowPlotResult(false);
+          }}
+          title={entry.ref}
+          type="button"
+        >
+          {entry.displayName}
+        </button>
+      ))}
+      {plotBelongsToSelected ? (
+        <button
+          className={`rounded-full px-3 py-1 text-xs ${showPlotResult ? "bg-ink text-white" : "bg-white text-stone-600"}`}
+          onClick={() => setShowPlotResult(true)}
+          title={plotPreviewTarget?.ref}
+          type="button"
+        >
+          Plot artifact
+        </button>
+      ) : null}
+    </div>
+  ) : null;
 
-      {/* #1713 — the workflow-wide plot list moved to the dedicated Plots tab
-          (BottomPanel). This panel renders preview content: the selected node's
-          outputs and/or the persisted plot Run result, toggled by the "Plot
-          artifact" pill. The result stays put when switching blocks. */}
-      {!selectedNodeId ? (
-        <div className="mt-6 rounded-[1.8rem] border border-dashed border-stone-300 px-4 py-6 text-sm text-stone-500">
-          Pick a block to inspect its latest outputs and cached previews.
-        </div>
-      ) : (
-        <>
-          {outputEntryIds.length > 0 || plotBelongsToSelected ? (
-            <div className="mt-5 flex flex-wrap gap-2">
-              {refEntries.map((entry) => (
-                <button
-                  className={`rounded-full px-3 py-1 text-xs ${!activePlot && activeEntry?.id === entry.id ? "bg-ink text-white" : "bg-white text-stone-600"}`}
-                  key={entry.id}
-                  onClick={() => {
-                    setPickedEntryId(entry.id);
-                    setShowPlotResult(false);
-                  }}
-                  title={entry.ref}
-                  type="button"
-                >
-                  {entry.displayName}
-                </button>
-              ))}
-              {plotBelongsToSelected ? (
-                <button
-                  className={`rounded-full px-3 py-1 text-xs ${showPlotResult ? "bg-ink text-white" : "bg-white text-stone-600"}`}
-                  onClick={() => setShowPlotResult(true)}
-                  title={plotPreviewTarget?.ref}
-                  type="button"
-                >
-                  Plot artifact
-                </button>
-              ) : null}
-            </div>
-          ) : null}
-          <div className="mt-4 min-h-0 flex-1 overflow-y-auto scrollbar-thin">
-            <PreviewHost
-              target={activePlot ?? target}
-              initialQuery={activePlot ? undefined : activeEntry?.initialQuery}
-              getCachedEnvelope={(key) => previewEnvelopeCache[key]}
-              cacheEnvelope={cachePreviewEnvelope}
-              buildCacheKey={(t, q, opts) => buildPreviewCacheKey(t, q, opts)}
-            />
+  // The routed preview host. Only one instance mounts at a time (inline OR the
+  // maximized window) so a single preview session is active.
+  const renderHost = () => (
+    <PreviewHost
+      target={activePlot ?? target}
+      initialQuery={activePlot ? undefined : activeEntry?.initialQuery}
+      getCachedEnvelope={(key) => previewEnvelopeCache[key]}
+      cacheEnvelope={cachePreviewEnvelope}
+      buildCacheKey={(t, q, opts) => buildPreviewCacheKey(t, q, opts)}
+    />
+  );
+
+  return (
+    <>
+      <aside className="flex h-full flex-col overflow-hidden border-l border-stone-200 bg-[linear-gradient(180deg,_rgba(255,255,255,0.94),_rgba(245,241,232,0.98))] p-4">
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <p className="text-xs uppercase tracking-[0.35em] text-stone-500">Preview</p>
+            <h2 className="mt-2 font-display text-2xl text-ink">
+              {selectedNodeId ? selectedNodeLabel : "Select a block"}
+            </h2>
           </div>
-        </>
-      )}
-      {portPanel}
-    </aside>
+          {hasPreviewContent ? (
+            <button
+              aria-label="Maximize preview"
+              className="mt-1 shrink-0 rounded-full p-1.5 text-stone-500 hover:bg-white hover:text-ink"
+              onClick={() => setIsMaximized(true)}
+              title="Maximize preview"
+              type="button"
+            >
+              <Maximize2 className="h-4 w-4" />
+            </button>
+          ) : null}
+        </div>
+
+        {/* #1713 — the workflow-wide plot list moved to the dedicated Plots tab
+            (BottomPanel). This panel renders preview content: the selected node's
+            outputs and/or the persisted plot Run result, toggled by the "Plot
+            artifact" pill. The result stays put when switching blocks. */}
+        {!selectedNodeId ? (
+          <div className="mt-6 rounded-[1.8rem] border border-dashed border-stone-300 px-4 py-6 text-sm text-stone-500">
+            Pick a block to inspect its latest outputs and cached previews.
+          </div>
+        ) : (
+          <>
+            {pillsRow ? <div className="mt-5">{pillsRow}</div> : null}
+            <div className="mt-4 min-h-0 flex-1 overflow-y-auto scrollbar-thin">
+              {isMaximized ? (
+                <div className="flex h-full items-center justify-center px-4 text-center text-sm text-stone-400">
+                  Preview opened in a separate window.
+                </div>
+              ) : (
+                renderHost()
+              )}
+            </div>
+          </>
+        )}
+        {portPanel}
+      </aside>
+
+      {/* #1795 — maximized preview window. Reuses the shared overlay pattern
+          (DataRouterModal / PairEditorModal). Backdrop click, the close
+          control, and Escape all dismiss it. */}
+      {isMaximized ? (
+        <div
+          className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/40 p-6"
+          onClick={() => setIsMaximized(false)}
+          data-testid="preview-maximized-overlay"
+        >
+          <div
+            className="flex h-[88vh] w-[88vw] flex-col rounded-2xl border border-stone-200 bg-white shadow-2xl"
+            onClick={(event) => event.stopPropagation()}
+          >
+            <div className="flex items-center justify-between gap-3 border-b border-stone-100 px-5 py-3">
+              <div className="flex min-w-0 flex-col">
+                <span className="text-xs uppercase tracking-[0.35em] text-stone-500">Preview</span>
+                <span className="truncate font-display text-lg text-ink">{selectedNodeLabel}</span>
+              </div>
+              <button
+                aria-label="Close preview window"
+                className="shrink-0 rounded-full p-1.5 text-stone-500 hover:bg-stone-100 hover:text-ink"
+                onClick={() => setIsMaximized(false)}
+                title="Close (Esc)"
+                type="button"
+              >
+                <X className="h-4 w-4" />
+              </button>
+            </div>
+            {pillsRow ? (
+              <div className="border-b border-stone-100 px-5 py-3">{pillsRow}</div>
+            ) : null}
+            <div className="min-h-0 flex-1 overflow-y-auto scrollbar-thin p-5">{renderHost()}</div>
+          </div>
+        </div>
+      ) : null}
+    </>
   );
 }


### PR DESCRIPTION
## Summary

The right-hand Data Preview panel is narrow by default (22% width) and the PortInfoPanel takes ~38% of its height, so rendered previews (plots/tables/images) come out cramped. This adds a **maximize / pop-out** control to the preview header that opens the active preview in a larger floating window over the canvas, without permanently widening the sidebar.

## What changed

- `frontend/src/components/DataPreview.tsx`
  - New `Maximize2` button in the preview header, shown only when there is previewable output.
  - Clicking it pops the active preview (output pills + `PreviewHost`) into a centered floating window (88vw × 88vh) overlaid on the canvas.
  - **Esc**, a close (✕) control, and a backdrop click all dismiss it.
  - Reuses the shared overlay pattern (`DataRouterModal` / `PairEditorModal`).
  - The output/plot pills and the routed host render are extracted so the inline panel and the maximized window share one definition; only **one** `PreviewHost` mounts at a time (inline OR maximized), so a single preview session stays active.
- `frontend/src/components/DataPreview.test.tsx`
  - Tests: maximize control hidden without output; open + Esc closes; close control + backdrop click close.

`PreviewHost` itself is unchanged — it adapts to its container, so the larger window renders a correspondingly larger preview.

## Out of scope

- Moving AI chat to the right sidebar (separate idea, deferred by owner).
- Changing default panel sizes.

## Testing

- `vitest` DataPreview suite: 10/10 pass (3 new).
- `tsc --noEmit`, eslint, prettier `--check`, and the gate `check --mode pre-pr` (format_check, frontend, full_audit, lint_format, semantic_dup) all pass.

Docs: N/A — additive frontend UI affordance; no change to previewer contracts, `PreviewHost` API, envelope kinds, preview routing, schemas, storage, or runtime behavior.

Gate record: .workflow/records/1795-guided-1795-preview-popout-window.json

Closes #1795
