### PR TITLE
feat(#1797): redesign block palette — category grid, pinned Data I/O, hover detail, reload flash

### DIFF
--- a/.workflow/records/1797-feat-1797-palette-grid-redesign.json
+++ b/.workflow/records/1797-feat-1797-palette-grid-redesign.json
@@ -174,7 +174,13 @@
     }
   ],
   "check_na": [],
-  "commit": null,
+  "commit": {
+    "sha": "71003f7ae27b6c69a90870731bb604075950940f",
+    "shas": [
+      "71003f7ae27b6c69a90870731bb604075950940f"
+    ],
+    "trailers": []
+  },
   "declared_scope": {
     "exclude": [],
     "include": [
@@ -396,6 +402,88 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-06-27T05:05:45.035746Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T05:05:45.044777Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T05:05:45.053280Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T05:05:45.061726Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T05:05:45.069921Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T05:05:45.078288Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T05:05:45.086698Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T05:05:45.095823Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T05:05:45.103938Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T05:05:45.117500Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -424,9 +512,9 @@
       "frontend/src/hooks/__tests__/useReloadFlash.test.ts",
       "frontend/src/hooks/useReloadFlash.ts"
     ],
-    "diff_fingerprint": "sha256:988909d70eabf39a07e4bcdd4af7476fcc1155efb2920052081a64a5fe5d7fee",
+    "diff_fingerprint": "sha256:064ebd068d57520c9dd6ca47ebb68ef07466ee6a9f3ddcfc74dc27330ac4b8c9",
     "head": "HEAD",
-    "head_sha": "af170e0e",
+    "head_sha": "71003f7a",
     "surfaces": {
       "docs": 1,
       "frontend": 10,
@@ -442,7 +530,14 @@
   },
   "owner_directive": "Redesign block palette: 2-up category-colored grid (reuse canvas categoryVisuals), pinned Data I/O (Load/Save), top type filter chips, drop description/in-out text/category layer, hover detail popover. Owner wants a small frontend spec to fix the design first, then implement.",
   "persona": "implementer",
-  "pull_request": null,
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [
+      1797
+    ],
+    "number": null,
+    "url": null
+  },
   "reconcile_events": [
     {
       "at": "2026-06-27T05:02:02.426746Z",
@@ -458,6 +553,14 @@
       "at": "2026-06-27T05:05:05.431267Z",
       "diff_fingerprint": "sha256:988909d70eabf39a07e4bcdd4af7476fcc1155efb2920052081a64a5fe5d7fee",
       "mode": "local",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-27T05:05:45.117531Z",
+      "diff_fingerprint": "sha256:064ebd068d57520c9dd6ca47ebb68ef07466ee6a9f3ddcfc74dc27330ac4b8c9",
+      "mode": "pre-pr",
       "result": "pass",
       "tier": 1,
       "unsatisfied": []

--- a/.workflow/records/1797-feat-1797-palette-grid-redesign.json
+++ b/.workflow/records/1797-feat-1797-palette-grid-redesign.json
@@ -1,6 +1,178 @@
 {
   "branch": "feat/1797-palette-grid-redesign",
-  "check_events": [],
+  "check_events": [
+    {
+      "at": "2026-06-27T04:56:50.849666Z",
+      "command": "pytest tests/architecture/ -v --no-cov",
+      "covered_surface": "architecture",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:25c194b3c9805f8fb51d0b8c2710ce363720c816de500734929a3ecc31d5466b",
+      "name": "architecture_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/architecture_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-27T04:56:51.539940Z",
+      "command": "python scripts/deferral_scan.py --check docs/audit/baselines/deferral-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:74f7e96b3e6e59864dbfe5bf863817337f526f739a974d70ac213251d8075985",
+      "name": "deferral_discipline",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/deferral_discipline.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-27T04:56:51.598654Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:bee0017f30f552d2df2de1173f9ac14b9aee5192ca5e5c1de574bb119512b275",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-27T04:57:39.287864Z",
+      "command": "(cd frontend && npm run check:ci)",
+      "covered_surface": "frontend",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:2b492bfdabc016ab84564aa56b4128d4a0db00ba112f2f292870adbd043d12e3",
+      "name": "frontend",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/frontend.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-27T04:57:43.079463Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:9ee7e49cec8bce3296061aacb6c347488861abf9a52569ab2df27d9dff44cb90",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-27T04:57:43.223362Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:179b1cba851dd153ae0ab07e4f5ff8b2a735cc2c3d6d4494d3c0100847360442",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-27T04:57:43.273121Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e31351abfc33f0b3c0f28bc9f2f3d59ae3bc5d4925dc1159a7f931aa932441ed",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-27T05:00:00.265103Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:47eac75ed95c8abfde2e5868831e97df5202e82116cf9c4a1b1122e549884f6c",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-27T05:01:55.296218Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:75bb0a1941a68287ac37b984f5486bdd0747fef022f27ce762ecb9aaf024825b",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-27T05:02:02.295814Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e94394e48009cd8fbd5108426e57662cdd3e4d99e817a3b4494b7e53776b5c37",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    },
+    {
+      "at": "2026-06-27T05:05:05.294536Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:47eac75ed95c8abfde2e5868831e97df5202e82116cf9c4a1b1122e549884f6c",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    }
+  ],
   "check_na": [],
   "commit": null,
   "declared_scope": {
@@ -60,6 +232,170 @@
       ],
       "guard": "worktree_write_guard",
       "status": "fail"
+    },
+    {
+      "at": "2026-06-27T05:02:02.338393Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T05:02:02.347786Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T05:02:02.357423Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T05:02:02.366619Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T05:02:02.375881Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T05:02:02.384972Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T05:02:02.393906Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T05:02:02.404912Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T05:02:02.413900Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T05:02:02.426723Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T05:05:05.336519Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T05:05:05.347616Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T05:05:05.358425Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T05:05:05.367808Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T05:05:05.377199Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T05:05:05.386822Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T05:05:05.396619Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T05:05:05.409064Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T05:05:05.418455Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T05:05:05.431228Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -71,19 +407,96 @@
     }
   ],
   "observed_admin_labels": [],
-  "observed_diff": null,
+  "observed_diff": {
+    "base": "origin/main",
+    "base_sha": "3224cd80",
+    "changed_files": [
+      ".workflow/records/1797-feat-1797-palette-grid-redesign.json",
+      "docs/specs/frontend-block-palette.md",
+      "frontend/src/components/BlockPalette.parts/BlockDetailPopover.tsx",
+      "frontend/src/components/BlockPalette.parts/BlockTile.tsx",
+      "frontend/src/components/BlockPalette.parts/CategoryChips.tsx",
+      "frontend/src/components/BlockPalette.parts/__tests__/paletteModel.test.ts",
+      "frontend/src/components/BlockPalette.parts/paletteModel.ts",
+      "frontend/src/components/BlockPalette.test.tsx",
+      "frontend/src/components/BlockPalette.tsx",
+      "frontend/src/components/ProjectTree.tsx",
+      "frontend/src/hooks/__tests__/useReloadFlash.test.ts",
+      "frontend/src/hooks/useReloadFlash.ts"
+    ],
+    "diff_fingerprint": "sha256:988909d70eabf39a07e4bcdd4af7476fcc1155efb2920052081a64a5fe5d7fee",
+    "head": "HEAD",
+    "head_sha": "af170e0e",
+    "surfaces": {
+      "docs": 1,
+      "frontend": 10,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 10,
+      "packaging": 0,
+      "protected_core": 0,
+      "sentrux": 11,
+      "test": 3,
+      "workflow_ci": 0
+    }
+  },
   "owner_directive": "Redesign block palette: 2-up category-colored grid (reuse canvas categoryVisuals), pinned Data I/O (Load/Save), top type filter chips, drop description/in-out text/category layer, hover detail popover. Owner wants a small frontend spec to fix the design first, then implement.",
   "persona": "implementer",
   "pull_request": null,
-  "reconcile_events": [],
+  "reconcile_events": [
+    {
+      "at": "2026-06-27T05:02:02.426746Z",
+      "diff_fingerprint": "sha256:988909d70eabf39a07e4bcdd4af7476fcc1155efb2920052081a64a5fe5d7fee",
+      "mode": "local",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.python_tests"
+      ]
+    },
+    {
+      "at": "2026-06-27T05:05:05.431267Z",
+      "diff_fingerprint": "sha256:988909d70eabf39a07e4bcdd4af7476fcc1155efb2920052081a64a5fe5d7fee",
+      "mode": "local",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    }
+  ],
   "record_id": "1797-feat-1797-palette-grid-redesign",
   "requested_admin_labels": [],
   "required_obligations": {
     "admin_labels": [],
-    "checks": [],
-    "docs": [],
-    "guards": [],
-    "tests": []
+    "checks": [
+      "architecture_tests",
+      "deferral_discipline",
+      "format_check",
+      "frontend",
+      "full_audit",
+      "import_contracts",
+      "lint_format",
+      "python_tests",
+      "semantic_dup",
+      "type_check"
+    ],
+    "docs": [
+      "docs_required_or_na"
+    ],
+    "guards": [
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": [
+      "changed_test_required"
+    ]
   },
   "runtime": "claude-code:claude-opus-4-8",
   "schema_version": 2,
@@ -132,7 +545,7 @@
     }
   ],
   "session_id": "9a26c789-e5bc-4e2c-89c0-d376657eac6b",
-  "strictness_tier": null,
+  "strictness_tier": 1,
   "task_kind": "feature",
   "test_events": [
     {

--- a/.workflow/records/1797-feat-1797-palette-grid-redesign.json
+++ b/.workflow/records/1797-feat-1797-palette-grid-redesign.json
@@ -38,7 +38,30 @@
     }
   ],
   "governance_touch": false,
-  "guard_events": [],
+  "guard_events": [
+    {
+      "at": "2026-06-27T04:28:19.923882Z",
+      "findings": [
+        {
+          "message": "AI-authored edits must happen in a dedicated worktree, not the main working tree (/private/var/folders/mk/xk0dqvn934l5425gwb19rsqc0000gn/T/pytest-of-jiazhenz/pytest-664/popen-gw3/test_hook_payload_blocks_main_0/main). Create one with `git worktree add ../<name> <branch>` and run your edits there.",
+          "rule_id": "worktree.main-checkout-write"
+        }
+      ],
+      "guard": "worktree_write_guard",
+      "status": "fail"
+    },
+    {
+      "at": "2026-06-27T04:28:21.190135Z",
+      "findings": [
+        {
+          "message": "AI-authored edits must happen in a dedicated worktree, not the main working tree (/private/var/folders/mk/xk0dqvn934l5425gwb19rsqc0000gn/T/pytest-of-jiazhenz/pytest-664/popen-gw3/test_hook_payload_extracts_mul0/main). Create one with `git worktree add ../<name> <branch>` and run your edits there.",
+          "rule_id": "worktree.main-checkout-write"
+        }
+      ],
+      "guard": "worktree_write_guard",
+      "status": "fail"
+    }
+  ],
   "issues": [
     {
       "close_in_pr": true,
@@ -88,6 +111,24 @@
       "at": "2026-06-27T04:17:26.524027Z",
       "pattern": "docs/specs/frontend-block-palette.md",
       "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-27T04:52:25.622574Z",
+      "pattern": "frontend/src/hooks/useReloadFlash.ts",
+      "reason": "Owner directive: reuse the palette reload flash on the project tree refresh too; extract a shared useReloadFlash hook."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-27T04:52:25.622735Z",
+      "pattern": "frontend/src/hooks/__tests__/useReloadFlash.test.ts",
+      "reason": "Owner directive: reuse the palette reload flash on the project tree refresh too; extract a shared useReloadFlash hook."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-27T04:52:25.622737Z",
+      "pattern": "frontend/src/components/ProjectTree.tsx",
+      "reason": "Owner directive: reuse the palette reload flash on the project tree refresh too; extract a shared useReloadFlash hook."
     }
   ],
   "session_id": "9a26c789-e5bc-4e2c-89c0-d376657eac6b",
@@ -107,6 +148,14 @@
       "class": null,
       "kind": "path",
       "path": "frontend/src/components/BlockPalette.parts/__tests__/paletteModel.test.ts",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-27T04:52:25.622744Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/hooks/__tests__/useReloadFlash.test.ts",
       "rationale": null,
       "verified_in_diff": null
     }

--- a/.workflow/records/1797-feat-1797-palette-grid-redesign.json
+++ b/.workflow/records/1797-feat-1797-palette-grid-redesign.json
@@ -1,0 +1,114 @@
+{
+  "branch": "feat/1797-palette-grid-redesign",
+  "check_events": [],
+  "check_na": [],
+  "commit": null,
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "frontend/src/components/BlockPalette.tsx",
+      "frontend/src/components/BlockPalette.test.tsx",
+      "frontend/src/components/BlockPalette.parts/**",
+      "docs/specs/frontend-block-palette.md"
+    ]
+  },
+  "directive_events": [
+    {
+      "at": "2026-06-27T04:17:26.523615Z",
+      "owner_directive": "Frontend-only: rewrite BlockPalette into 2-up category grid reusing canvas categoryVisuals; pinned Data I/O; category filter chips; hover detail popover. Extract pure ordering/detection/filter logic into BlockPalette.parts/paletteModel.ts for unit testing. Spec docs/specs/frontend-block-palette.md fixes the design.",
+      "reason": "plan"
+    }
+  ],
+  "docs_events": [
+    {
+      "at": "2026-06-27T04:17:26.524036Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/specs/frontend-block-palette.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-27T04:17:26.524805Z",
+      "class": "adr",
+      "kind": "na",
+      "path": null,
+      "rationale": "Reuses ADR-050 categoryVisuals; no new architectural decision. changelog:frontend UX refinement tracked by spec+issue.",
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": false,
+  "guard_events": [],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1797,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": null,
+  "owner_directive": "Redesign block palette: 2-up category-colored grid (reuse canvas categoryVisuals), pinned Data I/O (Load/Save), top type filter chips, drop description/in-out text/category layer, hover detail popover. Owner wants a small frontend spec to fix the design first, then implement.",
+  "persona": "implementer",
+  "pull_request": null,
+  "reconcile_events": [],
+  "record_id": "1797-feat-1797-palette-grid-redesign",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [],
+    "docs": [],
+    "guards": [],
+    "tests": []
+  },
+  "runtime": "claude-code:claude-opus-4-8",
+  "schema_version": 2,
+  "scope_events": [
+    {
+      "action": "add-include",
+      "at": "2026-06-27T04:17:26.524014Z",
+      "pattern": "frontend/src/components/BlockPalette.tsx",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-27T04:17:26.524024Z",
+      "pattern": "frontend/src/components/BlockPalette.test.tsx",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-27T04:17:26.524026Z",
+      "pattern": "frontend/src/components/BlockPalette.parts/**",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-27T04:17:26.524027Z",
+      "pattern": "docs/specs/frontend-block-palette.md",
+      "reason": "plan"
+    }
+  ],
+  "session_id": "9a26c789-e5bc-4e2c-89c0-d376657eac6b",
+  "strictness_tier": null,
+  "task_kind": "feature",
+  "test_events": [
+    {
+      "at": "2026-06-27T04:17:26.524813Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/components/BlockPalette.test.tsx",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-27T04:17:26.524822Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/components/BlockPalette.parts/__tests__/paletteModel.test.ts",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/.workflow/records/1797-feat-1797-palette-grid-redesign.json
+++ b/.workflow/records/1797-feat-1797-palette-grid-redesign.json
@@ -175,9 +175,9 @@
   ],
   "check_na": [],
   "commit": {
-    "sha": "71003f7ae27b6c69a90870731bb604075950940f",
+    "sha": "09a80c583e895b0e559d54dd1fd8d286592bad74",
     "shas": [
-      "71003f7ae27b6c69a90870731bb604075950940f"
+      "09a80c583e895b0e559d54dd1fd8d286592bad74"
     ],
     "trailers": []
   },
@@ -484,6 +484,252 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-06-27T05:06:32.178885Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T05:06:32.187310Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T05:06:32.196495Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T05:06:32.205171Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T05:06:32.213591Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T05:06:32.221899Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T05:06:32.230336Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T05:06:32.239708Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T05:06:32.248545Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T05:06:32.262093Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T05:07:00.036324Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T05:07:00.045884Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T05:07:00.054925Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T05:07:00.063403Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T05:07:00.071918Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T05:07:00.080546Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T05:07:00.089047Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T05:07:00.097836Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T05:07:00.106271Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T05:07:00.119130Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T05:07:13.188534Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T05:07:13.196906Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T05:07:13.205213Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T05:07:13.213577Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T05:07:13.221730Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T05:07:13.230002Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T05:07:13.238437Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T05:07:13.247112Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T05:07:13.255540Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T05:07:13.268431Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -496,7 +742,7 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "origin/main",
+    "base": "3224cd809f4b1ee09453188ce8007ed0101fadb8",
     "base_sha": "3224cd80",
     "changed_files": [
       ".workflow/records/1797-feat-1797-palette-grid-redesign.json",
@@ -512,9 +758,9 @@
       "frontend/src/hooks/__tests__/useReloadFlash.test.ts",
       "frontend/src/hooks/useReloadFlash.ts"
     ],
-    "diff_fingerprint": "sha256:064ebd068d57520c9dd6ca47ebb68ef07466ee6a9f3ddcfc74dc27330ac4b8c9",
+    "diff_fingerprint": "sha256:25cef5e774bba70175e12d9805546ac8db561bfe9c78f495c0fe20b133829dc1",
     "head": "HEAD",
-    "head_sha": "71003f7a",
+    "head_sha": "09a80c58",
     "surfaces": {
       "docs": 1,
       "frontend": 10,
@@ -535,7 +781,7 @@
     "closes": [
       1797
     ],
-    "number": null,
+    "number": 1798,
     "url": null
   },
   "reconcile_events": [
@@ -560,6 +806,30 @@
     {
       "at": "2026-06-27T05:05:45.117531Z",
       "diff_fingerprint": "sha256:064ebd068d57520c9dd6ca47ebb68ef07466ee6a9f3ddcfc74dc27330ac4b8c9",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-27T05:06:32.262133Z",
+      "diff_fingerprint": "sha256:25cef5e774bba70175e12d9805546ac8db561bfe9c78f495c0fe20b133829dc1",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-27T05:07:00.119167Z",
+      "diff_fingerprint": "sha256:25cef5e774bba70175e12d9805546ac8db561bfe9c78f495c0fe20b133829dc1",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-27T05:07:13.268458Z",
+      "diff_fingerprint": "sha256:25cef5e774bba70175e12d9805546ac8db561bfe9c78f495c0fe20b133829dc1",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 1,

--- a/docs/specs/frontend-block-palette.md
+++ b/docs/specs/frontend-block-palette.md
@@ -19,6 +19,7 @@ scope:
     - Section ordering — Data I/O, then Built-in (core), then Custom, then plugin packages A→Z.
     - A hover detail popover anchored to the right of a tile showing icon, name, full description, and typed port signature.
     - The category sub-grouping layer, the always-on description line, and the "X in / Y out" text line are removed from the tile.
+    - A one-shot opacity blink confirming a completed Reload, via a shared `useReloadFlash` hook also wired to the project tree Refresh.
   out:
     - Backend or schema changes (none — base_category, subcategory, ports, direction already exist on BlockSummary).
     - Per-block custom icons (still tracked as the categoryVisuals follow-up; palette keeps the category-icon fallback).
@@ -34,11 +35,14 @@ governs:
     - docs/specs/frontend-block-palette.md
     - frontend/src/components/BlockPalette.tsx
     - frontend/src/components/BlockPalette.parts
+    - frontend/src/hooks/useReloadFlash.ts
+    - frontend/src/components/ProjectTree.tsx
   excludes:
     - frontend/src/components/nodes/BlockNode.parts/categoryVisuals.ts
 tests:
   - frontend/src/components/BlockPalette.test.tsx
   - frontend/src/components/BlockPalette.parts/__tests__/paletteModel.test.ts
+  - frontend/src/hooks/__tests__/useReloadFlash.test.ts
 acceptance_source: issue
 language_source: en
 ---
@@ -103,7 +107,9 @@ category-free ordering. Top to bottom:
    `input_ports.length === 0`) and Save (io sink, `output_ports.length === 0`)
    blocks, lifted out of their package group so they never appear twice.
 2. **Built-in** — the remaining core blocks (`derivePackage` → "SciStudio Core"),
-   as one flat grid with **no category sub-grouping**.
+   as one flat grid with **no category sub-grouping**. Core blocks that use a
+   dotted namespace but ship with core (the `ai.` namespace, e.g. `ai.agent`)
+   resolve to Built-in rather than a standalone package.
 3. **Custom** — user `source === "custom"` blocks.
 4. **Plugin packages** — every other package, sorted **A→Z** by display name.
 
@@ -166,3 +172,22 @@ Component behavior is covered by the rewritten `BlockPalette.test.tsx`:
 - Data I/O section renders Load and Save pinned at the top.
 - Activating a category chip filters the visible tiles.
 - Hovering a tile reveals the detail popover with description and port signature.
+
+## 9. Reload Flash
+
+The palette Reload control gives an at-a-glance confirmation that the catalog
+refreshed: a single fast opacity blink (1 → 0 → 1 over ~100ms, like a browser
+refresh) across the whole palette body (search + chips + grid).
+
+The blink is driven by a shared `useReloadFlash` hook. The hook arms on the
+Reload click and fires only when the watched data (`blocks`) next changes — so
+it confirms the refresh actually landed and does not fire on mount, on
+background catalog syncs, or on a failed reload. It uses the Web Animations API
+so the subtree is not remounted (section-collapse state is preserved), guarded
+for environments without `Element.animate`.
+
+The same hook is wired to the project tree Refresh control (watching the tree
+nodes), so both side panels share one consistent reload feedback.
+
+The hook is covered by `frontend/src/hooks/__tests__/useReloadFlash.test.ts`;
+the palette wiring is covered by `BlockPalette.test.tsx`.

--- a/docs/specs/frontend-block-palette.md
+++ b/docs/specs/frontend-block-palette.md
@@ -1,0 +1,168 @@
+---
+spec_id: frontend-block-palette
+title: "Block Palette — Category-Colored 2-Up Grid With Pinned Data I/O And Hover Detail"
+status: Draft
+feature_branch: feat/1797-palette-grid-redesign
+created: 2026-06-27
+input: "Issue #1797 — owner-directed redesign of the left BlockPalette (compact 2-up grid, reuse canvas category visuals, pinned Data I/O, type filter chips, hover detail popover)."
+owners:
+  - "@jiazhenz026"
+related_adrs:
+  - 50
+related_specs: []
+scope:
+  in:
+    - Left BlockPalette switches from tall full-width cards to a 2-column grid of compact mini-node tiles.
+    - Each tile reuses the canvas per-category visual language (macaron swatch + lucide icon) via getCategoryVisual().
+    - A pinned "Data I/O" section (core Load source + Save sink) renders at the top, never collapsed, lifted out of package grouping.
+    - Top-of-panel category filter chips (io / process / code / app / ai / subworkflow) toggle a category filter.
+    - Section ordering — Data I/O, then Built-in (core), then Custom, then plugin packages A→Z.
+    - A hover detail popover anchored to the right of a tile showing icon, name, full description, and typed port signature.
+    - The category sub-grouping layer, the always-on description line, and the "X in / Y out" text line are removed from the tile.
+  out:
+    - Backend or schema changes (none — base_category, subcategory, ports, direction already exist on BlockSummary).
+    - Per-block custom icons (still tracked as the categoryVisuals follow-up; palette keeps the category-icon fallback).
+    - Plugin-shipped loader/saver blocks as distinct palette entries (consolidated into the unified core Load/Save).
+    - Canvas BlockNode rendering (unchanged; this spec only consumes its categoryVisuals table).
+    - Collapsed/rail palette mode redesign (the collapsed prop is preserved as-is, not re-themed).
+governs:
+  modules:
+    - frontend/src/components/BlockPalette
+  contracts: []
+  entry_points: []
+  files:
+    - docs/specs/frontend-block-palette.md
+    - frontend/src/components/BlockPalette.tsx
+    - frontend/src/components/BlockPalette.parts
+  excludes:
+    - frontend/src/components/nodes/BlockNode.parts/categoryVisuals.ts
+tests:
+  - frontend/src/components/BlockPalette.test.tsx
+  - frontend/src/components/BlockPalette.parts/__tests__/paletteModel.test.ts
+acceptance_source: issue
+language_source: en
+---
+
+# Block Palette — Category-Colored 2-Up Grid With Pinned Data I/O And Hover Detail
+
+## 1. Change Summary
+
+The left BlockPalette renders each block as a tall, full-width white card carrying
+the block name, an always-on description, and a `X in / Y out` text line, grouped
+three levels deep (package → category → block). The list grows very long, and the
+block's category (io / process / code / app / ai / subworkflow) is not visible at a
+glance — the category appears only as an uppercase text badge on a sub-group header.
+
+Meanwhile the canvas node (ADR-050, `categoryVisuals.ts`) already encodes category
+with a distinct macaron color + lucide icon per `base_category`. The palette does
+not reuse it, so browsing and the canvas speak different visual languages.
+
+This change rebuilds the palette to be compact and category-recognizable at a
+glance by **reusing the canvas category visuals**: the palette becomes a 2-up grid
+of mini-node tiles (the same swatch + icon you get on the canvas), with category
+filter chips, a pinned Data I/O section, and a hover popover for detail. This is a
+**frontend-only presentation change** — no schema, contract, or backend dependency.
+
+## 2. Data Model — No Changes Needed
+
+All inputs already exist on `BlockSummary` (`frontend/src/types/api.ts`):
+
+| Need | Source field |
+|---|---|
+| Category color + icon | `base_category` via `getCategoryVisual()` |
+| Package grouping | `package_name` / `type_name` prefix / `source` (existing `derivePackage`) |
+| Load / Save detection | `base_category === "io"` and `input_ports.length === 0` (source) / `output_ports.length === 0` (sink) |
+| Hover description | `description` |
+| Hover port signature | `input_ports[] / output_ports[]` (`name`, `accepted_types[]`) |
+
+The canvas visual table `categoryVisuals.ts` is consumed read-only via its existing
+`getCategoryVisual(category)` export. No new schema field is introduced.
+
+## 3. Tile (Grid Cell)
+
+Each block renders as a compact mini-node tile, visually a shrunk canvas node:
+
+- A square color **swatch** (~36px) using `visual.bg` / `visual.border`, containing
+  the category **lucide icon** (~22px) in `visual.fg`. `visual` = `getCategoryVisual(block.base_category)`.
+- The block **name** below the swatch, centered, `font-display`, 2-line clamp.
+- The whole tile is `draggable` (unchanged drag payload contract) and a click adds
+  the block (`onAddBlock`), preserving current behavior.
+- Removed from the tile: the always-on `description` paragraph and the
+  `X in / Y out` text line.
+
+Tiles lay out in a 2-column grid (`grid-cols-2`) within each section. The existing
+`collapsed` (rail) prop is preserved: when collapsed the panel keeps its current
+minimal behavior and does not render the grid/chips/popover.
+
+## 4. Sections And Ordering
+
+The three-level package → category → block tree is replaced by a flat,
+category-free ordering. Top to bottom:
+
+1. **Data I/O** — pinned, never collapsed. Contains the core Load (io source,
+   `input_ports.length === 0`) and Save (io sink, `output_ports.length === 0`)
+   blocks, lifted out of their package group so they never appear twice.
+2. **Built-in** — the remaining core blocks (`derivePackage` → "SciStudio Core"),
+   as one flat grid with **no category sub-grouping**.
+3. **Custom** — user `source === "custom"` blocks.
+4. **Plugin packages** — every other package, sorted **A→Z** by display name.
+
+Built-in and plugin sections remain collapsible (existing package-collapse
+behavior); Data I/O is always shown. Within every section, tiles sort
+alphabetically by block name.
+
+## 5. Category Filter Chips
+
+A row of six chips (`io`, `process`, `code`, `app`, `ai`, `subworkflow`) renders
+above the sections, each styled with that category's `bg`/`fg`/`border` from
+`categoryVisuals`. Chips are a multi-select toggle:
+
+- No chip active → show all categories (default).
+- One or more active → show only blocks whose `base_category` is in the active set.
+- The chip filter composes with the text search (AND): a block must satisfy both.
+- The pinned Data I/O section follows the same filter (e.g. filtering to `process`
+  hides Load/Save), but its **pinned position does not change**.
+
+## 6. Hover Detail Popover
+
+Hovering a tile opens a detail popover anchored to the **right** of the tile (the
+palette is on the left edge, so the popover opens toward the canvas and does not
+cover sibling tiles). It shows:
+
+- The category swatch + icon and the block **name** (header).
+- The full **description**.
+- A **typed port signature**: one line per port as `name : Type`, where `Type` is
+  the first entry of `accepted_types` (or `Any` when empty / the any-type marker),
+  under `in` and `out` groupings.
+
+The popover is hover-triggered with a short open delay (~150ms) and is
+non-interactive (display only). It replaces the information previously shown
+always-on (description) and adds the typed port contract, which the old text
+`X in / Y out` line did not convey.
+
+## 7. Out Of Scope
+
+- No backend, schema, or `BlockSummary` contract change.
+- No change to `categoryVisuals.ts` (consumed read-only) or to the canvas node.
+- Per-block custom icons remain the separately tracked `categoryVisuals` follow-up.
+- Collapsed/rail palette mode keeps its current minimal rendering; only the
+  expanded palette is redesigned.
+
+## 8. Test Plan
+
+Pure ordering/detection/filter logic is extracted into a testable model module
+(`BlockPalette.parts/paletteModel.ts`) and covered by
+`BlockPalette.parts/__tests__/paletteModel.test.ts`:
+
+- Load/Save detection by io + zero-port structural signal (not by name).
+- Section ordering: Data I/O → Built-in → Custom → plugin packages A→Z.
+- Data I/O lifted out of its package group (no duplicate rendering).
+- Category-chip filter composes with text search (AND).
+
+Component behavior is covered by the rewritten `BlockPalette.test.tsx`:
+
+- Grid tiles render the category icon/swatch and the block name (no always-on
+  description, no `in / out` text line).
+- Data I/O section renders Load and Save pinned at the top.
+- Activating a category chip filters the visible tiles.
+- Hovering a tile reveals the detail popover with description and port signature.

--- a/frontend/src/components/BlockPalette.parts/BlockDetailPopover.tsx
+++ b/frontend/src/components/BlockPalette.parts/BlockDetailPopover.tsx
@@ -1,0 +1,67 @@
+// Hover detail popover — anchored to the right of a tile, showing the block's
+// icon + name, full description, and typed port signature. Display-only.
+//
+// Spec: docs/specs/frontend-block-palette.md §6 Hover Detail Popover.
+
+import { getCategoryVisual } from "../nodes/BlockNode.parts/categoryVisuals";
+import type { BlockSummary } from "../../types/api";
+import { portSignature } from "./paletteModel";
+
+export interface PopoverAnchor {
+  /** Viewport-space left edge for the popover (tile right + gap). */
+  left: number;
+  /** Viewport-space top edge for the popover. */
+  top: number;
+}
+
+export interface BlockDetailPopoverProps {
+  block: BlockSummary;
+  anchor: PopoverAnchor;
+}
+
+export function BlockDetailPopover({ block, anchor }: BlockDetailPopoverProps) {
+  const visual = getCategoryVisual(block.base_category);
+  const Icon = visual.Icon;
+  const inputs = portSignature(block.input_ports);
+  const outputs = portSignature(block.output_ports);
+
+  return (
+    <div
+      className="pointer-events-none fixed z-50 w-64 rounded-xl border border-stone-200 bg-white p-3 shadow-panel"
+      data-testid="palette-detail-popover"
+      style={{ left: anchor.left, top: anchor.top }}
+    >
+      <div className="flex items-center gap-2">
+        <span
+          aria-hidden="true"
+          className="flex h-6 w-6 items-center justify-center rounded-md border"
+          style={{ backgroundColor: visual.bg, borderColor: visual.border }}
+        >
+          <Icon color={visual.fg} size={14} strokeWidth={1.9} />
+        </span>
+        <span className="font-display text-sm font-semibold text-ink">{block.name}</span>
+      </div>
+
+      {block.description ? (
+        <p className="mt-2 text-xs leading-snug text-stone-600">{block.description}</p>
+      ) : null}
+
+      {inputs.length > 0 || outputs.length > 0 ? (
+        <div className="mt-2 space-y-0.5 border-t border-stone-100 pt-2 font-mono text-[11px] text-stone-500">
+          {inputs.map((port) => (
+            <div key={`in-${port.name}`}>
+              <span className="font-semibold text-pine">in</span> {port.name} :{" "}
+              <span className="text-ink">{port.type}</span>
+            </div>
+          ))}
+          {outputs.map((port) => (
+            <div key={`out-${port.name}`}>
+              <span className="font-semibold text-ember">out</span> {port.name} :{" "}
+              <span className="text-ink">{port.type}</span>
+            </div>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/components/BlockPalette.parts/BlockTile.tsx
+++ b/frontend/src/components/BlockPalette.parts/BlockTile.tsx
@@ -39,10 +39,10 @@ export function BlockTile({ block, onDragStart, onAddBlock, onEnter, onLeave }: 
       >
         <span
           aria-hidden="true"
-          className="flex h-9 w-9 items-center justify-center rounded-lg border shadow-sm"
+          className="flex h-[72px] w-[72px] items-center justify-center rounded-xl border shadow-sm"
           style={{ backgroundColor: visual.bg, borderColor: visual.border }}
         >
-          <Icon color={visual.fg} size={22} strokeWidth={1.75} />
+          <Icon color={visual.fg} size={44} strokeWidth={1.6} />
         </span>
         <span className="line-clamp-2 text-center font-display text-[12px] font-medium leading-tight text-ink">
           {block.name}

--- a/frontend/src/components/BlockPalette.parts/BlockTile.tsx
+++ b/frontend/src/components/BlockPalette.parts/BlockTile.tsx
@@ -1,0 +1,53 @@
+// A single palette grid cell — a compact mini canvas-node (macaron swatch +
+// lucide category icon on top, 2-line block name below). Reuses the canvas
+// category visual language via getCategoryVisual().
+//
+// Spec: docs/specs/frontend-block-palette.md §3 Tile.
+
+import { getCategoryVisual } from "../nodes/BlockNode.parts/categoryVisuals";
+import type { BlockSummary } from "../../types/api";
+
+export interface BlockTileProps {
+  block: BlockSummary;
+  onDragStart: (event: React.DragEvent, block: BlockSummary) => void;
+  onAddBlock: (block: BlockSummary) => void;
+  onEnter: (block: BlockSummary, rect: DOMRect) => void;
+  onLeave: () => void;
+}
+
+export function BlockTile({ block, onDragStart, onAddBlock, onEnter, onLeave }: BlockTileProps) {
+  const visual = getCategoryVisual(block.base_category);
+  const Icon = visual.Icon;
+
+  return (
+    <div
+      className="rounded-xl border border-transparent p-1.5 transition hover:-translate-y-0.5 hover:border-stone-200 hover:bg-white/70 hover:shadow-sm"
+      data-testid="palette-block-tile"
+      draggable
+      onDragStart={(event) => {
+        onLeave();
+        onDragStart(event, block);
+      }}
+      onMouseEnter={(event) => onEnter(block, event.currentTarget.getBoundingClientRect())}
+      onMouseLeave={onLeave}
+    >
+      <button
+        className="flex w-full flex-col items-center gap-1.5"
+        onClick={() => onAddBlock(block)}
+        title={block.name}
+        type="button"
+      >
+        <span
+          aria-hidden="true"
+          className="flex h-9 w-9 items-center justify-center rounded-lg border shadow-sm"
+          style={{ backgroundColor: visual.bg, borderColor: visual.border }}
+        >
+          <Icon color={visual.fg} size={22} strokeWidth={1.75} />
+        </span>
+        <span className="line-clamp-2 text-center font-display text-[12px] font-medium leading-tight text-ink">
+          {block.name}
+        </span>
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/components/BlockPalette.parts/CategoryChips.tsx
+++ b/frontend/src/components/BlockPalette.parts/CategoryChips.tsx
@@ -1,0 +1,41 @@
+// Top-of-panel category filter chips, styled with the canvas per-category
+// color language. Multi-select toggle; an empty active set means "all".
+//
+// Spec: docs/specs/frontend-block-palette.md §5 Category Filter Chips.
+
+import { categoryVisuals } from "../nodes/BlockNode.parts/categoryVisuals";
+import { CATEGORY_KEYS } from "./paletteModel";
+
+export interface CategoryChipsProps {
+  active: readonly string[];
+  onToggle: (key: string) => void;
+}
+
+export function CategoryChips({ active, onToggle }: CategoryChipsProps) {
+  const activeSet = new Set(active);
+
+  return (
+    <div className="mt-3 flex flex-wrap gap-1" data-testid="palette-category-chips">
+      {CATEGORY_KEYS.map((key) => {
+        const visual = categoryVisuals[key];
+        const on = activeSet.has(key);
+        return (
+          <button
+            aria-pressed={on}
+            className="rounded-full border px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide transition"
+            key={key}
+            onClick={() => onToggle(key)}
+            style={
+              on
+                ? { backgroundColor: visual.bg, borderColor: visual.border, color: visual.fg }
+                : { backgroundColor: "transparent", borderColor: "#e7e5e4", color: "#78716c" }
+            }
+            type="button"
+          >
+            {visual.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/components/BlockPalette.parts/__tests__/paletteModel.test.ts
+++ b/frontend/src/components/BlockPalette.parts/__tests__/paletteModel.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it } from "vitest";
+
+import type { BlockSummary } from "../../../types/api";
+import {
+  buildPaletteSections,
+  DATA_IO_SECTION_ID,
+  derivePackage,
+  filterBlocks,
+  isDataIoBlock,
+  isIoSink,
+  isIoSource,
+  portSignature,
+} from "../paletteModel";
+
+function makeBlock(
+  overrides: Partial<BlockSummary> & { type_name: string; name: string },
+): BlockSummary {
+  return {
+    name: overrides.name,
+    type_name: overrides.type_name,
+    base_category: overrides.base_category ?? "process",
+    subcategory: overrides.subcategory ?? "",
+    description: overrides.description ?? "A block",
+    version: "0.1.0",
+    input_ports: overrides.input_ports ?? [],
+    output_ports: overrides.output_ports ?? [],
+    source: overrides.source,
+    package_name: overrides.package_name,
+    direction: overrides.direction,
+  };
+}
+
+function port(name: string, types: string[] = []): BlockSummary["input_ports"][number] {
+  return {
+    name,
+    direction: "input",
+    accepted_types: types,
+    required: true,
+    description: "",
+    constraint_description: "",
+    is_collection: false,
+  };
+}
+
+const load = makeBlock({
+  type_name: "load_data",
+  name: "Load",
+  base_category: "io",
+  direction: "input",
+  input_ports: [],
+  output_ports: [port("data", ["Image"])],
+});
+const save = makeBlock({
+  type_name: "save_data",
+  name: "Save",
+  base_category: "io",
+  direction: "output",
+  input_ports: [port("data", ["Image"])],
+  output_ports: [],
+});
+
+describe("Load/Save detection by structural signal", () => {
+  it("detects io source (Load) and io sink (Save) by zero-port shape, not by name", () => {
+    expect(isIoSource(load)).toBe(true);
+    expect(isIoSink(save)).toBe(true);
+    expect(isDataIoBlock(load)).toBe(true);
+    expect(isDataIoBlock(save)).toBe(true);
+  });
+
+  it("a process block is never a Data I/O block", () => {
+    const filter = makeBlock({ type_name: "filter", name: "Filter", base_category: "process" });
+    expect(isDataIoBlock(filter)).toBe(false);
+  });
+
+  it("an io block with both ports is not pinned (mid-pipeline io)", () => {
+    const passthrough = makeBlock({
+      type_name: "io.passthrough",
+      name: "Passthrough",
+      base_category: "io",
+      input_ports: [port("in")],
+      output_ports: [port("out")],
+    });
+    expect(isDataIoBlock(passthrough)).toBe(false);
+  });
+});
+
+describe("derivePackage", () => {
+  it("maps builtin (no dot) to SciStudio Core and custom source to Custom", () => {
+    expect(derivePackage(load)).toBe("SciStudio Core");
+    expect(derivePackage(makeBlock({ type_name: "x", name: "X", source: "custom" }))).toBe(
+      "Custom",
+    );
+  });
+
+  it("uppercases short prefixes and title-cases longer ones", () => {
+    expect(derivePackage(makeBlock({ type_name: "lcms.peak", name: "Peak" }))).toBe("LCMS");
+    expect(derivePackage(makeBlock({ type_name: "imaging.seg", name: "Seg" }))).toBe("Imaging");
+  });
+});
+
+describe("buildPaletteSections ordering", () => {
+  const blocks: BlockSummary[] = [
+    makeBlock({ type_name: "spectroscopy.baseline", name: "Baseline" }),
+    makeBlock({ type_name: "imaging.cellpose", name: "Cellpose", base_category: "process" }),
+    makeBlock({ type_name: "filter", name: "Filter", base_category: "process" }),
+    makeBlock({ type_name: "custom_x", name: "My Custom", source: "custom" }),
+    load,
+    save,
+  ];
+
+  it("orders Data I/O → Built-in → Custom → plugin packages A→Z", () => {
+    const sections = buildPaletteSections(blocks, "", []);
+    expect(sections.map((s) => s.title)).toEqual([
+      "Data I/O",
+      "Built-in",
+      "Custom",
+      "Imaging",
+      "Spectroscopy",
+    ]);
+    expect(sections[0].id).toBe(DATA_IO_SECTION_ID);
+    expect(sections[0].pinned).toBe(true);
+  });
+
+  it("lifts Load/Save into Data I/O and out of their package group (no duplicate)", () => {
+    const sections = buildPaletteSections(blocks, "", []);
+    const dataIo = sections.find((s) => s.id === DATA_IO_SECTION_ID)!;
+    expect(dataIo.blocks.map((b) => b.name)).toEqual(["Load", "Save"]);
+    const builtin = sections.find((s) => s.title === "Built-in")!;
+    expect(builtin.blocks.some((b) => b.name === "Load" || b.name === "Save")).toBe(false);
+  });
+
+  it("omits empty sections", () => {
+    const sections = buildPaletteSections([load], "", []);
+    expect(sections.map((s) => s.title)).toEqual(["Data I/O"]);
+  });
+});
+
+describe("filterBlocks — search AND category chips", () => {
+  const blocks: BlockSummary[] = [
+    makeBlock({ type_name: "imaging.cellpose", name: "Cellpose", base_category: "process" }),
+    makeBlock({ type_name: "ai.annotate", name: "Annotate", base_category: "ai" }),
+    load,
+  ];
+
+  it("text search alone filters by name/description", () => {
+    expect(filterBlocks(blocks, "cellpose", []).map((b) => b.name)).toEqual(["Cellpose"]);
+  });
+
+  it("category chips alone filter by base_category", () => {
+    expect(filterBlocks(blocks, "", ["ai"]).map((b) => b.name)).toEqual(["Annotate"]);
+  });
+
+  it("composes search AND category (both must pass)", () => {
+    expect(filterBlocks(blocks, "annotate", ["process"])).toEqual([]);
+    expect(filterBlocks(blocks, "annotate", ["ai"]).map((b) => b.name)).toEqual(["Annotate"]);
+  });
+
+  it("empty category set means all categories", () => {
+    expect(filterBlocks(blocks, "", []).length).toBe(3);
+  });
+});
+
+describe("portSignature", () => {
+  it("renders name : primary type, falling back to Any when untyped", () => {
+    expect(portSignature([port("image", ["Image", "Array"]), port("mask", [])])).toEqual([
+      { name: "image", type: "Image" },
+      { name: "mask", type: "Any" },
+    ]);
+  });
+});

--- a/frontend/src/components/BlockPalette.parts/__tests__/paletteModel.test.ts
+++ b/frontend/src/components/BlockPalette.parts/__tests__/paletteModel.test.ts
@@ -96,6 +96,12 @@ describe("derivePackage", () => {
     expect(derivePackage(makeBlock({ type_name: "lcms.peak", name: "Peak" }))).toBe("LCMS");
     expect(derivePackage(makeBlock({ type_name: "imaging.seg", name: "Seg" }))).toBe("Imaging");
   });
+
+  it("treats the core ai namespace as Built-in (not a plugin package)", () => {
+    expect(
+      derivePackage(makeBlock({ type_name: "ai.agent", name: "Agent", base_category: "ai" })),
+    ).toBe("SciStudio Core");
+  });
 });
 
 describe("buildPaletteSections ordering", () => {

--- a/frontend/src/components/BlockPalette.parts/paletteModel.ts
+++ b/frontend/src/components/BlockPalette.parts/paletteModel.ts
@@ -9,7 +9,7 @@ import { primaryTypeName } from "../../config/typeColorMap";
 import type { BlockPortResponse, BlockSummary } from "../../types/api";
 
 /** Base categories shown as filter chips, in display order. */
-export const CATEGORY_KEYS = ["io", "process", "code", "app", "ai", "subworkflow"] as const;
+export const CATEGORY_KEYS = ["io", "process", "code", "app", "ai"] as const;
 export type CategoryKey = (typeof CATEGORY_KEYS)[number];
 
 /** Stable id for the pinned Data I/O section (not a real package name). */
@@ -18,6 +18,15 @@ export const DATA_IO_SECTION_ID = "__data_io__";
 export const BUILTIN_PACKAGE = "SciStudio Core";
 /** Package name custom user blocks resolve to. */
 export const CUSTOM_PACKAGE = "Custom";
+
+/**
+ * Dotted type_name namespaces that ship with core and must be treated as
+ * Built-in rather than as a standalone plugin package. The core AI block
+ * (`ai.agent`) uses the `ai.` namespace but is not a decoupled plugin, so it
+ * belongs under Built-in. Real plugins (imaging / lcms / spectroscopy / srs)
+ * are not listed here.
+ */
+const CORE_NAMESPACES = new Set(["ai"]);
 
 export interface PaletteSection {
   /** Stable key for React + collapse state. */
@@ -49,6 +58,9 @@ export function derivePackage(block: BlockSummary): string {
   const dotIndex = block.type_name.indexOf(".");
   if (dotIndex > 0) {
     const prefix = block.type_name.slice(0, dotIndex);
+    if (CORE_NAMESPACES.has(prefix)) {
+      return BUILTIN_PACKAGE;
+    }
     if (prefix.length <= 4) {
       return prefix.toUpperCase();
     }

--- a/frontend/src/components/BlockPalette.parts/paletteModel.ts
+++ b/frontend/src/components/BlockPalette.parts/paletteModel.ts
@@ -1,0 +1,167 @@
+// Pure palette model — ordering, Load/Save detection, filtering, and port
+// signatures for the BlockPalette grid. Kept free of React/JSX so the ordering
+// and detection rules are unit-testable in isolation.
+//
+// Spec: docs/specs/frontend-block-palette.md
+//   §4 Sections And Ordering, §5 Category Filter, §6 Hover Detail.
+
+import { primaryTypeName } from "../../config/typeColorMap";
+import type { BlockPortResponse, BlockSummary } from "../../types/api";
+
+/** Base categories shown as filter chips, in display order. */
+export const CATEGORY_KEYS = ["io", "process", "code", "app", "ai", "subworkflow"] as const;
+export type CategoryKey = (typeof CATEGORY_KEYS)[number];
+
+/** Stable id for the pinned Data I/O section (not a real package name). */
+export const DATA_IO_SECTION_ID = "__data_io__";
+/** Package name the core built-in blocks resolve to via `derivePackage`. */
+export const BUILTIN_PACKAGE = "SciStudio Core";
+/** Package name custom user blocks resolve to. */
+export const CUSTOM_PACKAGE = "Custom";
+
+export interface PaletteSection {
+  /** Stable key for React + collapse state. */
+  id: string;
+  /** Header label shown to the user. */
+  title: string;
+  blocks: BlockSummary[];
+  /** Pinned sections (Data I/O) always render and never collapse. */
+  pinned: boolean;
+}
+
+/**
+ * Derive the display package name for a block.
+ *
+ * Priority:
+ *   1. block.package_name (explicit backend field)
+ *   2. "Custom" for blocks with source === "custom"
+ *   3. prefix before the first dot in type_name (e.g. "Imaging" from
+ *      "imaging.cellpose_segment"); short prefixes (≤4 chars) are uppercased.
+ *   4. "SciStudio Core" for builtin blocks / no dot in type_name
+ */
+export function derivePackage(block: BlockSummary): string {
+  if (block.package_name) {
+    return block.package_name;
+  }
+  if (block.source === "custom") {
+    return CUSTOM_PACKAGE;
+  }
+  const dotIndex = block.type_name.indexOf(".");
+  if (dotIndex > 0) {
+    const prefix = block.type_name.slice(0, dotIndex);
+    if (prefix.length <= 4) {
+      return prefix.toUpperCase();
+    }
+    return prefix.charAt(0).toUpperCase() + prefix.slice(1);
+  }
+  return BUILTIN_PACKAGE;
+}
+
+/** io source (e.g. Load) — an io block that consumes nothing. */
+export function isIoSource(block: BlockSummary): boolean {
+  return block.base_category === "io" && block.input_ports.length === 0;
+}
+
+/** io sink (e.g. Save) — an io block that produces nothing. */
+export function isIoSink(block: BlockSummary): boolean {
+  return block.base_category === "io" && block.output_ports.length === 0;
+}
+
+/** Load/Save blocks pinned to the top Data I/O section. */
+export function isDataIoBlock(block: BlockSummary): boolean {
+  return isIoSource(block) || isIoSink(block);
+}
+
+function matchesSearch(block: BlockSummary, search: string): boolean {
+  if (!search) {
+    return true;
+  }
+  const haystack =
+    `${block.name} ${block.description} ${block.subcategory || block.base_category}`.toLowerCase();
+  return haystack.includes(search.toLowerCase());
+}
+
+function matchesCategory(block: BlockSummary, active: ReadonlySet<string>): boolean {
+  return active.size === 0 || active.has(block.base_category);
+}
+
+/** Apply text search AND category-chip filter (both must pass). */
+export function filterBlocks(
+  blocks: BlockSummary[],
+  search: string,
+  activeCategories: readonly string[],
+): BlockSummary[] {
+  const active = new Set(activeCategories);
+  return blocks.filter((block) => matchesSearch(block, search) && matchesCategory(block, active));
+}
+
+const byName = (a: BlockSummary, b: BlockSummary): number => a.name.localeCompare(b.name);
+
+/**
+ * Build the ordered palette sections from the visible blocks.
+ *
+ * Order (spec §4): Data I/O (pinned) → Built-in (core) → Custom → plugin
+ * packages A→Z. Data I/O blocks are lifted out of their package group so they
+ * never render twice. Empty sections are omitted.
+ */
+export function buildPaletteSections(
+  blocks: BlockSummary[],
+  search: string,
+  activeCategories: readonly string[],
+): PaletteSection[] {
+  const visible = filterBlocks(blocks, search, activeCategories);
+
+  const dataIo = visible.filter(isDataIoBlock).sort(byName);
+  const rest = visible.filter((block) => !isDataIoBlock(block));
+
+  const packageMap = new Map<string, BlockSummary[]>();
+  for (const block of rest) {
+    const pkg = derivePackage(block);
+    if (!packageMap.has(pkg)) {
+      packageMap.set(pkg, []);
+    }
+    packageMap.get(pkg)!.push(block);
+  }
+
+  const sections: PaletteSection[] = [];
+
+  if (dataIo.length > 0) {
+    sections.push({ id: DATA_IO_SECTION_ID, title: "Data I/O", blocks: dataIo, pinned: true });
+  }
+
+  const takeSection = (pkg: string, title: string): void => {
+    const pkgBlocks = packageMap.get(pkg);
+    if (pkgBlocks && pkgBlocks.length > 0) {
+      sections.push({ id: pkg, title, blocks: [...pkgBlocks].sort(byName), pinned: false });
+    }
+    packageMap.delete(pkg);
+  };
+
+  takeSection(BUILTIN_PACKAGE, "Built-in");
+  takeSection(CUSTOM_PACKAGE, CUSTOM_PACKAGE);
+
+  for (const pkg of [...packageMap.keys()].sort((a, b) => a.localeCompare(b))) {
+    sections.push({
+      id: pkg,
+      title: pkg,
+      blocks: [...packageMap.get(pkg)!].sort(byName),
+      pinned: false,
+    });
+  }
+
+  return sections;
+}
+
+export interface PortSignatureEntry {
+  name: string;
+  /** Primary accepted type name, or "Any" when untyped. */
+  type: string;
+}
+
+/** Build `name : Type` port rows for the hover detail popover (spec §6). */
+export function portSignature(ports: BlockPortResponse[]): PortSignatureEntry[] {
+  return ports.map((port) => ({
+    name: port.name,
+    type: primaryTypeName(port.accepted_types ?? []),
+  }));
+}

--- a/frontend/src/components/BlockPalette.test.tsx
+++ b/frontend/src/components/BlockPalette.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, within } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { BlockPalette } from "./BlockPalette";
@@ -6,22 +6,33 @@ import type { BlockSummary } from "../types/api";
 
 afterEach(() => {
   cleanup();
+  vi.useRealTimers();
 });
+
+function port(name: string, types: string[] = []): BlockSummary["input_ports"][number] {
+  return {
+    name,
+    direction: "input",
+    accepted_types: types,
+    required: true,
+    description: "",
+    constraint_description: "",
+    is_collection: false,
+  };
+}
 
 function makeBlock(
   overrides: Partial<BlockSummary> & { type_name: string; name: string },
 ): BlockSummary {
-  const base_category = overrides.base_category ?? "process";
-  const subcategory = overrides.subcategory ?? "";
   return {
     name: overrides.name,
     type_name: overrides.type_name,
-    base_category,
-    subcategory,
+    base_category: overrides.base_category ?? "process",
+    subcategory: overrides.subcategory ?? "",
     description: overrides.description ?? "A block",
     version: "0.1.0",
-    input_ports: [],
-    output_ports: [],
+    input_ports: overrides.input_ports ?? [],
+    output_ports: overrides.output_ports ?? [],
     source: overrides.source,
     package_name: overrides.package_name,
     direction: overrides.direction,
@@ -36,145 +47,110 @@ const defaultProps = {
   onAddBlock: vi.fn(),
 };
 
-describe("BlockPalette — Stage 10.1 Part 2", () => {
-  it("renders a 3-level tree (package -> category -> block)", () => {
-    const blocks: BlockSummary[] = [
-      makeBlock({
-        type_name: "imaging.cellpose_segment",
-        name: "Cellpose Segment",
-        base_category: "process",
-        subcategory: "segmentation",
-      }),
-      makeBlock({
-        type_name: "lcms.load_peak_table",
-        name: "Load Peak Table",
-        base_category: "io",
-        subcategory: "io",
-      }),
-      makeBlock({ type_name: "load_data", name: "Load", base_category: "io" }),
-    ];
+const load = makeBlock({
+  type_name: "load_data",
+  name: "Load",
+  base_category: "io",
+  direction: "input",
+  output_ports: [port("data", ["Image"])],
+});
+const save = makeBlock({
+  type_name: "save_data",
+  name: "Save",
+  base_category: "io",
+  direction: "output",
+  input_ports: [port("data", ["Image"])],
+});
+const cellpose = makeBlock({
+  type_name: "imaging.cellpose_segment",
+  name: "Cellpose Segment",
+  base_category: "process",
+  description: "Run Cellpose model on an image to produce instance masks.",
+  input_ports: [port("image", ["Image"])],
+  output_ports: [port("masks", ["Mask"])],
+});
+const annotate = makeBlock({
+  type_name: "ai.annotate",
+  name: "Annotate",
+  base_category: "ai",
+});
 
-    render(<BlockPalette {...defaultProps} blocks={blocks} />);
+describe("BlockPalette — grid redesign (#1797)", () => {
+  it("renders blocks as grid tiles with name but no always-on description or in/out text", () => {
+    render(<BlockPalette {...defaultProps} blocks={[cellpose]} />);
 
-    // Package headers — CSS uppercases visually; text in DOM is as-derived.
-    expect(screen.getByText("Imaging")).toBeInTheDocument();
-    expect(screen.getByText("LCMS")).toBeInTheDocument();
-    expect(screen.getByText("SciStudio Core")).toBeInTheDocument();
-
-    // Category headers nested under packages (lowercase in DOM, uppercase via CSS)
-    expect(screen.getByText("segmentation")).toBeInTheDocument();
-
-    // Block cards
+    const tiles = screen.getAllByTestId("palette-block-tile");
+    expect(tiles).toHaveLength(1);
     expect(screen.getByText("Cellpose Segment")).toBeInTheDocument();
-    expect(screen.getByText("Load Peak Table")).toBeInTheDocument();
+    // Description is hover-only now, not rendered inline.
+    expect(
+      screen.queryByText("Run Cellpose model on an image to produce instance masks."),
+    ).not.toBeInTheDocument();
+    // No "X in / Y out" text line on the tile.
+    expect(screen.queryByText(/\bin\s*\/\s*\d+\s*out\b/i)).not.toBeInTheDocument();
   });
 
-  it('"Custom" package always sorts to the bottom', () => {
-    const blocks: BlockSummary[] = [
-      makeBlock({ type_name: "imaging.foo", name: "Foo", source: undefined }),
-      makeBlock({ type_name: "custom_block", name: "My Custom Block", source: "custom" }),
-    ];
+  it("pins Load and Save in a Data I/O section at the top", () => {
+    render(<BlockPalette {...defaultProps} blocks={[cellpose, load, save]} />);
 
-    render(<BlockPalette {...defaultProps} blocks={blocks} />);
+    const dataIoHeader = screen.getByText("Data I/O");
+    expect(dataIoHeader).toBeInTheDocument();
 
-    const allButtons = Array.from(document.querySelectorAll("button"));
-    const imagingIndex = allButtons.findIndex((btn) => btn.textContent?.includes("Imaging"));
-    const customIndex = allButtons.findIndex((btn) => btn.textContent?.includes("Custom"));
-    expect(imagingIndex).toBeGreaterThanOrEqual(0);
-    expect(customIndex).toBeGreaterThanOrEqual(0);
-    expect(imagingIndex).toBeLessThan(customIndex);
+    const section = dataIoHeader.closest("section")!;
+    expect(within(section).getByText("Load")).toBeInTheDocument();
+    expect(within(section).getByText("Save")).toBeInTheDocument();
+
+    // Data I/O appears before the Built-in section in DOM order.
+    const headers = screen.getAllByText(/Data I\/O|Built-in/);
+    expect(headers[0].textContent).toBe("Data I/O");
   });
 
-  it("packages and categories are collapsible", () => {
-    const blocks: BlockSummary[] = [
-      makeBlock({
-        type_name: "imaging.segment",
-        name: "Segment Block",
-        base_category: "process",
-        subcategory: "segmentation",
-      }),
-    ];
-
-    render(<BlockPalette {...defaultProps} blocks={blocks} />);
-
-    // Block is visible initially
-    expect(screen.getByText("Segment Block")).toBeInTheDocument();
-
-    // Collapse the package by clicking the package header button.
-    const allButtons = screen.getAllByRole("button");
-    const packageButton = allButtons.find((btn) => btn.textContent?.includes("Imaging"));
-    expect(packageButton).toBeDefined();
-    fireEvent.click(packageButton!);
-
-    // Block should no longer be visible
-    expect(screen.queryByText("Segment Block")).not.toBeInTheDocument();
-
-    // Re-expand
-    fireEvent.click(packageButton!);
-    expect(screen.getByText("Segment Block")).toBeInTheDocument();
+  it("renders the six category filter chips", () => {
+    render(<BlockPalette {...defaultProps} blocks={[cellpose]} />);
+    const chips = screen.getByTestId("palette-category-chips");
+    ["IO", "Process", "Code", "App", "AI", "Subworkflow"].forEach((label) => {
+      expect(within(chips).getByText(label)).toBeInTheDocument();
+    });
   });
 
-  it("search expands matching branches automatically", () => {
-    const blocks: BlockSummary[] = [
-      makeBlock({
-        type_name: "imaging.cellpose_segment",
-        name: "Cellpose Segment",
-        base_category: "process",
-        subcategory: "segmentation",
-      }),
-      makeBlock({
-        type_name: "lcms.load_peak",
-        name: "Load Peak",
-        base_category: "io",
-        subcategory: "io",
-      }),
-    ];
-
-    // With a search filter that only matches the imaging block, the lcms block
-    // should not appear. Both matching blocks and their parents are rendered.
-    render(<BlockPalette {...defaultProps} blocks={blocks} search="cellpose" />);
-
+  it("activating a category chip filters the visible tiles", () => {
+    render(<BlockPalette {...defaultProps} blocks={[cellpose, annotate]} />);
     expect(screen.getByText("Cellpose Segment")).toBeInTheDocument();
-    expect(screen.queryByText("Load Peak")).not.toBeInTheDocument();
-    // Parent package header still rendered
-    expect(screen.getAllByText("Imaging").length).toBeGreaterThan(0);
-  });
+    expect(screen.getByText("Annotate")).toBeInTheDocument();
 
-  it("empty categories are hidden when filtered", () => {
-    const blocks: BlockSummary[] = [
-      makeBlock({
-        type_name: "imaging.cellpose_segment",
-        name: "Cellpose Segment",
-        base_category: "process",
-        subcategory: "segmentation",
-      }),
-      makeBlock({
-        type_name: "imaging.load_image",
-        name: "Load Image",
-        base_category: "io",
-        subcategory: "io",
-      }),
-    ];
+    const chips = screen.getByTestId("palette-category-chips");
+    fireEvent.click(within(chips).getByText("AI"));
 
-    // Search that matches only the io category block
-    render(<BlockPalette {...defaultProps} blocks={blocks} search="load image" />);
-
-    expect(screen.getByText("Load Image")).toBeInTheDocument();
     expect(screen.queryByText("Cellpose Segment")).not.toBeInTheDocument();
-    // segmentation category should not appear
-    expect(screen.queryByText("segmentation")).not.toBeInTheDocument();
+    expect(screen.getByText("Annotate")).toBeInTheDocument();
   });
 
-  it("blocks render as-is without IO expansion", () => {
-    const blocks: BlockSummary[] = [
-      makeBlock({ type_name: "load_data", name: "Load", base_category: "io", direction: "input" }),
-      makeBlock({ type_name: "save_data", name: "Save", base_category: "io", direction: "output" }),
-    ];
+  it("hovering a tile opens the detail popover with description and typed ports", () => {
+    vi.useFakeTimers();
+    render(<BlockPalette {...defaultProps} blocks={[cellpose]} />);
 
-    render(<BlockPalette {...defaultProps} blocks={blocks} />);
+    expect(screen.queryByTestId("palette-detail-popover")).not.toBeInTheDocument();
 
-    // Blocks render with their actual names — no expansion
-    expect(screen.getAllByText("Load").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("Save").length).toBeGreaterThan(0);
+    fireEvent.mouseEnter(screen.getByTestId("palette-block-tile"));
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+
+    const popover = screen.getByTestId("palette-detail-popover");
+    expect(
+      within(popover).getByText("Run Cellpose model on an image to produce instance masks."),
+    ).toBeInTheDocument();
+    // Typed port signature is split across text nodes; check the type names.
+    expect(within(popover).getByText("Image")).toBeInTheDocument();
+    expect(within(popover).getByText("Mask")).toBeInTheDocument();
+  });
+
+  it("collapsed (rail) mode renders icon-only swatches", () => {
+    render(<BlockPalette {...defaultProps} blocks={[cellpose]} collapsed />);
+    // No grid tiles / chips in rail mode.
+    expect(screen.queryByTestId("palette-block-tile")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("palette-category-chips")).not.toBeInTheDocument();
+    // The block is still reachable by its title attribute.
+    expect(screen.getByTitle("Cellpose Segment")).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/BlockPalette.test.tsx
+++ b/frontend/src/components/BlockPalette.test.tsx
@@ -105,12 +105,13 @@ describe("BlockPalette — grid redesign (#1797)", () => {
     expect(headers[0].textContent).toBe("Data I/O");
   });
 
-  it("renders the six category filter chips", () => {
+  it("renders the category filter chips (no Subworkflow chip)", () => {
     render(<BlockPalette {...defaultProps} blocks={[cellpose]} />);
     const chips = screen.getByTestId("palette-category-chips");
-    ["IO", "Process", "Code", "App", "AI", "Subworkflow"].forEach((label) => {
+    ["IO", "Process", "Code", "App", "AI"].forEach((label) => {
       expect(within(chips).getByText(label)).toBeInTheDocument();
     });
+    expect(within(chips).queryByText("Subworkflow")).not.toBeInTheDocument();
   });
 
   it("activating a category chip filters the visible tiles", () => {
@@ -143,6 +144,41 @@ describe("BlockPalette — grid redesign (#1797)", () => {
     // Typed port signature is split across text nodes; check the type names.
     expect(within(popover).getByText("Image")).toBeInTheDocument();
     expect(within(popover).getByText("Mask")).toBeInTheDocument();
+  });
+
+  it("pulses the whole palette content after a Reload resolves into a refreshed catalog", () => {
+    const animateMock = vi.fn();
+    const original = HTMLElement.prototype.animate;
+    HTMLElement.prototype.animate = animateMock as unknown as typeof original;
+    try {
+      const { rerender } = render(<BlockPalette {...defaultProps} blocks={[cellpose]} />);
+      fireEvent.click(screen.getByText("Reload"));
+      expect(defaultProps.onReload).toHaveBeenCalled();
+      expect(animateMock).not.toHaveBeenCalled();
+
+      // Parent's refreshBlocks resolved -> a new blocks array is passed down.
+      rerender(<BlockPalette {...defaultProps} blocks={[{ ...cellpose }]} />);
+
+      expect(animateMock).toHaveBeenCalledTimes(1);
+      // Opacity keyframes pulse the whole content element.
+      const keyframes = animateMock.mock.calls[0][0];
+      expect(keyframes).toEqual([{ opacity: 1 }, { opacity: 0 }, { opacity: 1 }]);
+    } finally {
+      HTMLElement.prototype.animate = original;
+    }
+  });
+
+  it("does not pulse when the catalog changes without a Reload click", () => {
+    const animateMock = vi.fn();
+    const original = HTMLElement.prototype.animate;
+    HTMLElement.prototype.animate = animateMock as unknown as typeof original;
+    try {
+      const { rerender } = render(<BlockPalette {...defaultProps} blocks={[cellpose]} />);
+      rerender(<BlockPalette {...defaultProps} blocks={[{ ...cellpose }]} />);
+      expect(animateMock).not.toHaveBeenCalled();
+    } finally {
+      HTMLElement.prototype.animate = original;
+    }
   });
 
   it("collapsed (rail) mode renders icon-only swatches", () => {

--- a/frontend/src/components/BlockPalette.tsx
+++ b/frontend/src/components/BlockPalette.tsx
@@ -1,6 +1,11 @@
 import { useRef, useState } from "react";
 
 import type { BlockSummary } from "../types/api";
+import { getCategoryVisual } from "./nodes/BlockNode.parts/categoryVisuals";
+import { BlockDetailPopover, type PopoverAnchor } from "./BlockPalette.parts/BlockDetailPopover";
+import { BlockTile } from "./BlockPalette.parts/BlockTile";
+import { CategoryChips } from "./BlockPalette.parts/CategoryChips";
+import { buildPaletteSections, type PaletteSection } from "./BlockPalette.parts/paletteModel";
 
 interface BlockPaletteProps {
   blocks: BlockSummary[];
@@ -11,209 +16,67 @@ interface BlockPaletteProps {
   onAddBlock: (block: BlockSummary) => void;
 }
 
-/**
- * Derive the display package name for a block.
- *
- * Priority:
- *   1. block.package_name (explicit backend field)
- *   2. prefix before the first dot in type_name (e.g. "Imaging" from "imaging.cellpose_segment")
- *      Short prefixes (≤4 chars) are uppercased (e.g. "LCMS", "SRS").
- *   3. "SciStudio Core" for blocks with source === "builtin" or no dot in type_name
- *   4. "Custom" for blocks with source === "custom"
- */
-function derivePackage(block: BlockSummary): string {
-  if (block.package_name) {
-    return block.package_name;
-  }
-  if (block.source === "custom") {
-    return "Custom";
-  }
-  const dotIndex = block.type_name.indexOf(".");
-  if (dotIndex > 0) {
-    const prefix = block.type_name.slice(0, dotIndex);
-    // Uppercase short acronym-like prefixes (≤4 chars), otherwise title-case.
-    if (prefix.length <= 4) {
-      return prefix.toUpperCase();
-    }
-    return prefix.charAt(0).toUpperCase() + prefix.slice(1);
-  }
-  return "SciStudio Core";
-}
+/** Gap (px) between a tile's right edge and the detail popover. */
+const POPOVER_GAP = 8;
+/** Hover dwell before the detail popover opens (spec §6). */
+const POPOVER_OPEN_DELAY_MS = 150;
+/** Rough popover height used to keep it inside the viewport. */
+const POPOVER_MAX_HEIGHT = 240;
 
-interface BlockCardProps {
-  block: BlockSummary;
-  collapsed: boolean;
+interface SectionViewProps {
+  section: PaletteSection;
+  forceOpen: boolean;
   onDragStart: (event: React.DragEvent, block: BlockSummary) => void;
   onAddBlock: (block: BlockSummary) => void;
-  index: number;
+  onEnter: (block: BlockSummary, rect: DOMRect) => void;
+  onLeave: () => void;
 }
 
-function BlockCard({ block, collapsed, onDragStart, onAddBlock, index }: BlockCardProps) {
-  return (
-    <div
-      className="rounded-[1.4rem] border border-stone-200 bg-white p-3 shadow-sm transition hover:-translate-y-0.5 hover:border-ember"
-      draggable
-      key={`${block.type_name}-${block.name}-${index}`}
-      onDragStart={(event) => onDragStart(event, block)}
-    >
-      <button className="w-full text-left" onClick={() => onAddBlock(block)} type="button">
-        <p className="font-medium text-ink">{collapsed ? block.name.slice(0, 2) : block.name}</p>
-        {collapsed ? null : (
-          <>
-            <p className="mt-1 text-xs text-stone-500">{block.description}</p>
-            <p className="mt-2 text-[11px] uppercase tracking-[0.25em] text-stone-500">
-              {block.input_ports.length} in / {block.output_ports.length} out
-            </p>
-          </>
-        )}
-      </button>
-    </div>
-  );
-}
-
-interface CategorySectionProps {
-  category: string;
-  blocks: BlockSummary[];
-  paletteCollapsed: boolean;
-  onDragStart: (event: React.DragEvent, block: BlockSummary) => void;
-  onAddBlock: (block: BlockSummary) => void;
-}
-
-function CategorySection({
-  category,
-  blocks,
-  paletteCollapsed,
+function SectionView({
+  section,
+  forceOpen,
   onDragStart,
   onAddBlock,
-}: CategorySectionProps) {
-  const [isCollapsed, setIsCollapsed] = useState(false);
-
-  return (
-    <div>
-      {paletteCollapsed ? null : (
-        <button
-          className="mb-1 flex w-full items-center gap-1 text-left"
-          onClick={() => setIsCollapsed((prev) => !prev)}
-          type="button"
-        >
-          <span className="text-[10px] text-stone-500">{isCollapsed ? "▶" : "▼"}</span>
-          <span className="rounded-md border border-stone-300 bg-stone-100 px-1.5 py-0.5 text-[10px] uppercase tracking-[0.25em] text-stone-600">
-            {category}
-          </span>
-        </button>
-      )}
-      {isCollapsed && !paletteCollapsed ? null : (
-        <div className="space-y-2 pl-2">
-          {blocks.map((block, index) => (
-            <BlockCard
-              block={block}
-              collapsed={paletteCollapsed}
-              index={index}
-              key={`${block.type_name}-${block.name}-${index}`}
-              onAddBlock={onAddBlock}
-              onDragStart={onDragStart}
-            />
-          ))}
-        </div>
-      )}
-    </div>
-  );
-}
-
-interface PackageSectionProps {
-  packageName: string;
-  categories: { category: string; blocks: BlockSummary[] }[];
-  paletteCollapsed: boolean;
-  onDragStart: (event: React.DragEvent, block: BlockSummary) => void;
-  onAddBlock: (block: BlockSummary) => void;
-}
-
-function PackageSection({
-  packageName,
-  categories,
-  paletteCollapsed,
-  onDragStart,
-  onAddBlock,
-}: PackageSectionProps) {
-  const [isCollapsed, setIsCollapsed] = useState(false);
+  onEnter,
+  onLeave,
+}: SectionViewProps) {
+  const [collapsed, setCollapsed] = useState(false);
+  const open = section.pinned || forceOpen || !collapsed;
 
   return (
     <section>
-      {paletteCollapsed ? null : (
+      {section.pinned ? (
+        <p className="mb-2 text-[11px] font-semibold uppercase tracking-[0.3em] text-stone-700">
+          {section.title}
+        </p>
+      ) : (
         <button
           className="mb-2 flex w-full items-center gap-1 text-left"
-          onClick={() => setIsCollapsed((prev) => !prev)}
+          onClick={() => setCollapsed((prev) => !prev)}
           type="button"
         >
-          <span className="text-[11px] text-stone-600">{isCollapsed ? "▶" : "▼"}</span>
+          <span className="text-[11px] text-stone-600">{open ? "▼" : "▶"}</span>
           <span className="text-[11px] font-semibold uppercase tracking-[0.3em] text-stone-700">
-            {packageName}
+            {section.title}
           </span>
         </button>
       )}
-      {isCollapsed && !paletteCollapsed ? null : (
-        <div className="space-y-3">
-          {categories.map(({ category, blocks }) => (
-            <CategorySection
-              blocks={blocks}
-              category={category}
-              key={category}
+      {open ? (
+        <div className="grid grid-cols-2 gap-1">
+          {section.blocks.map((block) => (
+            <BlockTile
+              block={block}
+              key={`${block.type_name}-${block.name}`}
               onAddBlock={onAddBlock}
               onDragStart={onDragStart}
-              paletteCollapsed={paletteCollapsed}
+              onEnter={onEnter}
+              onLeave={onLeave}
             />
           ))}
         </div>
-      )}
+      ) : null}
     </section>
   );
-}
-
-/**
- * Build a 3-level grouping: package → category → blocks.
- *
- * - "Custom" package sorts to the bottom.
- * - Other packages sort alphabetically.
- * - Categories within a package sort alphabetically.
- * - Blocks within a category sort alphabetically by name.
- * - Empty categories/packages are excluded (guaranteed by the filter caller).
- */
-function groupBlocks(blocks: BlockSummary[]): {
-  packageName: string;
-  categories: { category: string; blocks: BlockSummary[] }[];
-}[] {
-  const packageMap = new Map<string, Map<string, BlockSummary[]>>();
-
-  for (const block of blocks) {
-    const pkg = derivePackage(block);
-    const cat = block.subcategory || block.base_category || "general";
-
-    if (!packageMap.has(pkg)) {
-      packageMap.set(pkg, new Map());
-    }
-    const catMap = packageMap.get(pkg)!;
-    if (!catMap.has(cat)) {
-      catMap.set(cat, []);
-    }
-    catMap.get(cat)!.push(block);
-  }
-
-  const sorted = [...packageMap.keys()].sort((a, b) => {
-    if (a === "Custom") return 1;
-    if (b === "Custom") return -1;
-    return a.localeCompare(b);
-  });
-
-  return sorted.map((pkg) => {
-    const catMap = packageMap.get(pkg)!;
-    const categories = [...catMap.keys()]
-      .sort((a, b) => a.localeCompare(b))
-      .map((cat) => ({
-        category: cat,
-        blocks: [...catMap.get(cat)!].sort((a, b) => a.name.localeCompare(b.name)),
-      }));
-    return { packageName: pkg, categories };
-  });
 }
 
 export function BlockPalette({
@@ -225,16 +88,44 @@ export function BlockPalette({
   onAddBlock,
 }: BlockPaletteProps) {
   const dragImageRef = useRef<HTMLDivElement | null>(null);
+  const hoverTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // When a search query is active, auto-expand all matching branches by filtering
-  // to only blocks that match. groupBlocks then produces only the non-empty groups.
-  const filtered = blocks.filter((block) => {
-    const value =
-      `${block.name} ${block.description} ${block.subcategory || block.base_category}`.toLowerCase();
-    return value.includes(search.toLowerCase());
-  });
+  const [activeCategories, setActiveCategories] = useState<string[]>([]);
+  const [hovered, setHovered] = useState<{ block: BlockSummary; anchor: PopoverAnchor } | null>(
+    null,
+  );
 
-  const grouped = groupBlocks(filtered);
+  const sections = buildPaletteSections(blocks, search, activeCategories);
+  const forceOpen = search.trim().length > 0 || activeCategories.length > 0;
+
+  const toggleCategory = (key: string) => {
+    setActiveCategories((prev) =>
+      prev.includes(key) ? prev.filter((k) => k !== key) : [...prev, key],
+    );
+  };
+
+  const clearHover = () => {
+    if (hoverTimer.current) {
+      clearTimeout(hoverTimer.current);
+      hoverTimer.current = null;
+    }
+    setHovered(null);
+  };
+
+  const handleTileEnter = (block: BlockSummary, rect: DOMRect) => {
+    if (hoverTimer.current) {
+      clearTimeout(hoverTimer.current);
+    }
+    const maxTop =
+      typeof window === "undefined"
+        ? rect.top
+        : Math.max(8, window.innerHeight - POPOVER_MAX_HEIGHT);
+    const anchor: PopoverAnchor = {
+      left: rect.right + POPOVER_GAP,
+      top: Math.min(rect.top, maxTop),
+    };
+    hoverTimer.current = setTimeout(() => setHovered({ block, anchor }), POPOVER_OPEN_DELAY_MS);
+  };
 
   const handleDragStart = (event: React.DragEvent, block: BlockSummary) => {
     const payload = { ...block };
@@ -254,43 +145,77 @@ export function BlockPalette({
     }
   };
 
+  // Collapsed (rail) mode: a single column of icon-only swatches; no chips,
+  // search, or popover. Behavior preserved as-is per spec §3.
+  if (collapsed) {
+    const railBlocks = sections.flatMap((section) => section.blocks);
+    return (
+      <aside className="flex h-full flex-col overflow-hidden border-r border-stone-200 bg-[linear-gradient(180deg,_rgba(255,255,255,0.95),_rgba(245,241,232,0.98))] p-2">
+        <button className="toolbar-button mb-2 self-center" onClick={onReload} type="button">
+          {"↻"}
+        </button>
+        <div className="flex min-h-0 flex-1 flex-col items-center gap-2 overflow-y-auto scrollbar-thin">
+          {railBlocks.map((block) => {
+            const visual = getCategoryVisual(block.base_category);
+            const Icon = visual.Icon;
+            return (
+              <button
+                className="flex h-9 w-9 items-center justify-center rounded-lg border shadow-sm"
+                key={`${block.type_name}-${block.name}`}
+                onClick={() => onAddBlock(block)}
+                style={{ backgroundColor: visual.bg, borderColor: visual.border }}
+                title={block.name}
+                type="button"
+              >
+                <Icon color={visual.fg} size={20} strokeWidth={1.75} />
+              </button>
+            );
+          })}
+        </div>
+      </aside>
+    );
+  }
+
   return (
     <aside className="flex h-full flex-col overflow-hidden border-r border-stone-200 bg-[linear-gradient(180deg,_rgba(255,255,255,0.95),_rgba(245,241,232,0.98))] p-4">
       {/* Drag ghost element (offscreen) */}
       <div
-        ref={dragImageRef}
         className="pointer-events-none fixed -left-[9999px] -top-[9999px] rounded-xl border border-ember bg-white px-4 py-2 text-sm font-medium text-ink shadow-lg"
+        ref={dragImageRef}
         style={{ display: "none" }}
       />
 
       <div className="flex items-center justify-between gap-2">
-        {collapsed ? null : <p className="font-display text-xl text-ink">Palette</p>}
+        <p className="font-display text-xl text-ink">Palette</p>
         <button className="toolbar-button" onClick={onReload} type="button">
-          {collapsed ? "\u21BB" : "Reload"}
+          Reload
         </button>
       </div>
 
-      {collapsed ? null : (
-        <input
-          className="mt-4 w-full rounded-2xl border border-stone-300 bg-white px-4 py-3 text-sm outline-none transition focus:border-ember"
-          onChange={(event) => onSearch(event.target.value)}
-          placeholder="Search blocks"
-          value={search}
-        />
-      )}
+      <input
+        className="mt-4 w-full rounded-2xl border border-stone-300 bg-white px-4 py-3 text-sm outline-none transition focus:border-ember"
+        onChange={(event) => onSearch(event.target.value)}
+        placeholder="Search blocks"
+        value={search}
+      />
+
+      <CategoryChips active={activeCategories} onToggle={toggleCategory} />
 
       <div className="mt-4 min-h-0 flex-1 space-y-4 overflow-y-auto pb-6 scrollbar-thin">
-        {grouped.map(({ packageName, categories }) => (
-          <PackageSection
-            categories={categories}
-            key={packageName}
+        {sections.map((section) => (
+          <SectionView
+            forceOpen={forceOpen}
+            key={section.id}
             onAddBlock={onAddBlock}
             onDragStart={handleDragStart}
-            packageName={packageName}
-            paletteCollapsed={collapsed}
+            onEnter={handleTileEnter}
+            onLeave={clearHover}
+            section={section}
           />
         ))}
       </div>
+
+      {hovered ? <BlockDetailPopover anchor={hovered.anchor} block={hovered.block} /> : null}
     </aside>
   );
 }

--- a/frontend/src/components/BlockPalette.tsx
+++ b/frontend/src/components/BlockPalette.tsx
@@ -1,5 +1,6 @@
 import { useRef, useState } from "react";
 
+import { useReloadFlash } from "../hooks/useReloadFlash";
 import type { BlockSummary } from "../types/api";
 import { getCategoryVisual } from "./nodes/BlockNode.parts/categoryVisuals";
 import { BlockDetailPopover, type PopoverAnchor } from "./BlockPalette.parts/BlockDetailPopover";
@@ -89,11 +90,20 @@ export function BlockPalette({
 }: BlockPaletteProps) {
   const dragImageRef = useRef<HTMLDivElement | null>(null);
   const hoverTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Blink the palette body (search + chips + grid) once a Reload actually lands.
+  const { ref: contentRef, trigger: triggerFlash } = useReloadFlash<HTMLDivElement, BlockSummary[]>(
+    blocks,
+  );
 
   const [activeCategories, setActiveCategories] = useState<string[]>([]);
   const [hovered, setHovered] = useState<{ block: BlockSummary; anchor: PopoverAnchor } | null>(
     null,
   );
+
+  const handleReload = () => {
+    triggerFlash();
+    onReload();
+  };
 
   const sections = buildPaletteSections(blocks, search, activeCategories);
   const forceOpen = search.trim().length > 0 || activeCategories.length > 0;
@@ -151,10 +161,13 @@ export function BlockPalette({
     const railBlocks = sections.flatMap((section) => section.blocks);
     return (
       <aside className="flex h-full flex-col overflow-hidden border-r border-stone-200 bg-[linear-gradient(180deg,_rgba(255,255,255,0.95),_rgba(245,241,232,0.98))] p-2">
-        <button className="toolbar-button mb-2 self-center" onClick={onReload} type="button">
+        <button className="toolbar-button mb-2 self-center" onClick={handleReload} type="button">
           {"↻"}
         </button>
-        <div className="flex min-h-0 flex-1 flex-col items-center gap-2 overflow-y-auto scrollbar-thin">
+        <div
+          className="flex min-h-0 flex-1 flex-col items-center gap-2 overflow-y-auto scrollbar-thin"
+          ref={contentRef}
+        >
           {railBlocks.map((block) => {
             const visual = getCategoryVisual(block.base_category);
             const Icon = visual.Icon;
@@ -187,32 +200,34 @@ export function BlockPalette({
 
       <div className="flex items-center justify-between gap-2">
         <p className="font-display text-xl text-ink">Palette</p>
-        <button className="toolbar-button" onClick={onReload} type="button">
+        <button className="toolbar-button" onClick={handleReload} type="button">
           Reload
         </button>
       </div>
 
-      <input
-        className="mt-4 w-full rounded-2xl border border-stone-300 bg-white px-4 py-3 text-sm outline-none transition focus:border-ember"
-        onChange={(event) => onSearch(event.target.value)}
-        placeholder="Search blocks"
-        value={search}
-      />
+      <div className="flex min-h-0 flex-1 flex-col" data-testid="palette-content" ref={contentRef}>
+        <input
+          className="mt-4 w-full rounded-2xl border border-stone-300 bg-white px-4 py-3 text-sm outline-none transition focus:border-ember"
+          onChange={(event) => onSearch(event.target.value)}
+          placeholder="Search blocks"
+          value={search}
+        />
 
-      <CategoryChips active={activeCategories} onToggle={toggleCategory} />
+        <CategoryChips active={activeCategories} onToggle={toggleCategory} />
 
-      <div className="mt-4 min-h-0 flex-1 space-y-4 overflow-y-auto pb-6 scrollbar-thin">
-        {sections.map((section) => (
-          <SectionView
-            forceOpen={forceOpen}
-            key={section.id}
-            onAddBlock={onAddBlock}
-            onDragStart={handleDragStart}
-            onEnter={handleTileEnter}
-            onLeave={clearHover}
-            section={section}
-          />
-        ))}
+        <div className="mt-4 min-h-0 flex-1 space-y-4 overflow-y-auto pb-6 scrollbar-thin">
+          {sections.map((section) => (
+            <SectionView
+              forceOpen={forceOpen}
+              key={section.id}
+              onAddBlock={onAddBlock}
+              onDragStart={handleDragStart}
+              onEnter={handleTileEnter}
+              onLeave={clearHover}
+              section={section}
+            />
+          ))}
+        </div>
       </div>
 
       {hovered ? <BlockDetailPopover anchor={hovered.anchor} block={hovered.block} /> : null}

--- a/frontend/src/components/ProjectTree.tsx
+++ b/frontend/src/components/ProjectTree.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useState } from "react";
 
+import { useReloadFlash } from "../hooks/useReloadFlash";
 import { api } from "../lib/api";
 import { useAppStore } from "../store";
 import type { TreeEntry } from "../types/api";
@@ -119,6 +120,15 @@ export function ProjectTree({
 }: ProjectTreeProps) {
   const { rootNodes, loading, refresh, handleToggle } = useTreeNodes(projectId);
   const [contextMenu, setContextMenu] = useState<ContextMenuState | null>(null);
+  // Blink the tree once a Refresh actually lands (same feedback as the palette).
+  const { ref: treeRef, trigger: triggerFlash } = useReloadFlash<HTMLDivElement, TreeNodeData[]>(
+    rootNodes,
+  );
+
+  const handleRefresh = useCallback(() => {
+    triggerFlash();
+    void refresh();
+  }, [refresh, triggerFlash]);
 
   const handleDoubleClick = useCallback(
     (node: TreeNodeData) => {
@@ -165,17 +175,12 @@ export function ProjectTree({
     <aside className="flex h-full flex-col overflow-hidden border-r border-stone-200 bg-[linear-gradient(180deg,_rgba(255,255,255,0.95),_rgba(245,241,232,0.98))] p-4">
       <div className="flex items-center justify-between gap-2">
         <p className="font-display text-xl text-ink">Project</p>
-        <button
-          className="toolbar-button"
-          disabled={loading}
-          onClick={() => void refresh()}
-          type="button"
-        >
+        <button className="toolbar-button" disabled={loading} onClick={handleRefresh} type="button">
           {loading ? "..." : "Refresh"}
         </button>
       </div>
 
-      <div className="mt-4 min-h-0 flex-1 overflow-y-auto pb-6 scrollbar-thin">
+      <div className="mt-4 min-h-0 flex-1 overflow-y-auto pb-6 scrollbar-thin" ref={treeRef}>
         {rootNodes.length === 0 && !loading ? (
           <p className="text-xs text-stone-400">No files found</p>
         ) : null}

--- a/frontend/src/hooks/__tests__/useReloadFlash.test.ts
+++ b/frontend/src/hooks/__tests__/useReloadFlash.test.ts
@@ -1,0 +1,58 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { useReloadFlash } from "../useReloadFlash";
+
+function attachElement(ref: { current: HTMLDivElement | null }) {
+  const el = document.createElement("div");
+  const animate = vi.fn();
+  (el as unknown as { animate: typeof animate }).animate = animate;
+  ref.current = el;
+  return animate;
+}
+
+describe("useReloadFlash", () => {
+  it("blinks only after trigger() and a subsequent data change", () => {
+    const { result, rerender } = renderHook(
+      ({ data }) => useReloadFlash<HTMLDivElement, number>(data),
+      { initialProps: { data: 0 } },
+    );
+    const animate = attachElement(result.current.ref);
+
+    // Data change without a trigger does not blink.
+    rerender({ data: 1 });
+    expect(animate).not.toHaveBeenCalled();
+
+    // Trigger, then the next data change blinks once.
+    result.current.trigger();
+    rerender({ data: 2 });
+    expect(animate).toHaveBeenCalledTimes(1);
+
+    const [keyframes, options] = animate.mock.calls[0];
+    expect(keyframes).toEqual([{ opacity: 1 }, { opacity: 0 }, { opacity: 1 }]);
+    expect(options).toMatchObject({ duration: 100 });
+  });
+
+  it("does not blink on mount", () => {
+    const { result } = renderHook(() => useReloadFlash<HTMLDivElement, number>(0));
+    const animate = attachElement(result.current.ref);
+    // No data change yet → no blink even though the element is attached.
+    expect(animate).not.toHaveBeenCalled();
+  });
+
+  it("consumes the trigger so a later unrelated data change does not blink again", () => {
+    const { result, rerender } = renderHook(
+      ({ data }) => useReloadFlash<HTMLDivElement, number>(data),
+      { initialProps: { data: 0 } },
+    );
+    const animate = attachElement(result.current.ref);
+
+    result.current.trigger();
+    rerender({ data: 1 });
+    expect(animate).toHaveBeenCalledTimes(1);
+
+    // A subsequent change with no new trigger must not blink.
+    rerender({ data: 2 });
+    expect(animate).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/hooks/useReloadFlash.ts
+++ b/frontend/src/hooks/useReloadFlash.ts
@@ -1,0 +1,37 @@
+import { useEffect, useRef } from "react";
+
+/**
+ * One-shot "browser-refresh" opacity blink for a panel after a user-initiated
+ * reload actually lands.
+ *
+ * Call `trigger()` on the reload/refresh click, attach `ref` to the element to
+ * blink, and pass the freshly loaded data as `watched`. The blink fires only
+ * when `watched` next changes after a `trigger()` — so it confirms the refresh
+ * really happened, and never fires on mount, on background syncs, or on a
+ * failed reload.
+ *
+ * The Web Animations API replays cleanly without remounting the subtree (which
+ * would drop transient UI state like expand/collapse). It is guarded for jsdom,
+ * which does not implement `Element.animate`.
+ */
+export function useReloadFlash<E extends HTMLElement, T>(watched: T) {
+  const ref = useRef<E | null>(null);
+  const requested = useRef(false);
+
+  useEffect(() => {
+    if (!requested.current) {
+      return;
+    }
+    requested.current = false;
+    ref.current?.animate?.([{ opacity: 1 }, { opacity: 0 }, { opacity: 1 }], {
+      duration: 100,
+      easing: "ease-out",
+    });
+  }, [watched]);
+
+  const trigger = () => {
+    requested.current = true;
+  };
+
+  return { ref, trigger };
+}


### PR DESCRIPTION
## Summary

Redesigns the left **BlockPalette** from tall full-width cards into a compact,
category-recognizable **2-up grid** that reuses the canvas per-category visual
language (`categoryVisuals` macaron swatch + lucide icon), so the palette and
the canvas speak one visual identity (the icon you see in the palette is the
icon you get on the canvas).

Design is fixed in `docs/specs/frontend-block-palette.md`. Frontend-only — no
schema/contract/backend change (reuses ADR-050 `categoryVisuals` read-only).

## What changed

- **2-up grid tiles** — each block is a mini canvas-node (color swatch + category
  icon on top, 2-line name below); enlarged icon (72px swatch / 44px glyph).
- **Pinned "Data I/O"** section at the top (core Load = io source / Save = io
  sink, detected by `base_category` + zero-port structural signal), lifted out
  of package grouping.
- **Category filter chips** (io / process / code / app / ai) composing with text
  search. No Subworkflow chip (subworkflow blocks still render).
- **Ordering**: Data I/O → Built-in → Custom → plugin packages A→Z; the category
  sub-grouping layer is removed. The core `ai.` namespace (e.g. `ai.agent`)
  resolves to Built-in rather than a standalone package.
- **Hover detail popover** — icon + name + full description + typed port
  signature, replacing the always-on description and the `X in / Y out` text.
- **Reload flash** — a fast one-shot opacity blink confirming a completed
  Reload, via a shared `useReloadFlash` hook also wired to the project tree
  Refresh.

## Tests

- `frontend/src/components/BlockPalette.parts/__tests__/paletteModel.test.ts` —
  Load/Save detection, section ordering, ai→Built-in, search+chip filtering.
- `frontend/src/components/BlockPalette.test.tsx` — grid tiles, pinned Data I/O,
  chip filter, hover popover, reload flash.
- `frontend/src/hooks/__tests__/useReloadFlash.test.ts` — flash fires only after
  a trigger + data change.

Gate record: .workflow/records/1797-feat-1797-palette-grid-redesign.json

Closes #1797
