### PR TITLE
chore(#1805): bump 0.3.1, friendlier OTA dialog, harden desktop staging

### DIFF
--- a/.workflow/records/1805-friendly-ota-dialog.json
+++ b/.workflow/records/1805-friendly-ota-dialog.json
@@ -1,0 +1,780 @@
+{
+  "branch": "guided/1805-friendly-ota-dialog",
+  "check_events": [
+    {
+      "at": "2026-06-27T10:41:19.500622Z",
+      "command": "pytest tests/architecture/ -v --no-cov",
+      "covered_surface": "architecture",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:da4f7b2ac2e7d888ffa04025a7b5a69aab94c26961457e474a7f501b37028506",
+      "name": "architecture_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/architecture_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-27T10:41:20.201723Z",
+      "command": "python scripts/deferral_scan.py --check docs/audit/baselines/deferral-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:181cc7a4070c0a42b254a1b4f1e465a33f21f3b6af79da5e5c8d1ddac7b7fc92",
+      "name": "deferral_discipline",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/deferral_discipline.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-27T10:41:20.543973Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:ee28bb68d6d8077150e186a38d8d6b6e3dcdf441528dc8c6d0226fdf6e94458a",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-27T10:42:09.056089Z",
+      "command": "(cd frontend && npm run check:ci)",
+      "covered_surface": "frontend",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e1a2523f683dfdaa615a0d41e9ade19429f94b6da376a4ba8e28750edfab5cb5",
+      "name": "frontend",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/frontend.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-27T10:42:12.934885Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:60b95e48cab3f24941555ef19eefad29c0fd7103e9816cb30b1630715b6ebe2e",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-27T10:42:13.459819Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:452f20829da461489e9b0e83375ef03517f5a2b84846256718d2956aff6429b7",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-27T10:42:13.524661Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:f000a09343a4bafc233a36b97407ca373c21c5c4cabed76bfbcb0f818ad8d496",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-27T10:44:35.289516Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:ce4f34f23e262b3da3229d900775e683e819045badca891922d6a21d5e82e857",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-27T10:46:32.663297Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:4e593688589a9c63778d6c34043316b3dba464b0771e51bb8768b7a56a9c2d58",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-27T10:46:39.581381Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cba8a48634bc6ce8bbd9400c16896edb07a9659b3f899b597c0f38a616910dd2",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    },
+    {
+      "at": "2026-06-27T10:46:42.281744Z",
+      "command": "python -m build --wheel",
+      "covered_surface": "packaging",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:0dad1eb5b7b09863a5b19add8d4e07ddd0a95c57903a7d6c04cb214c480a7e0b",
+      "name": "wheel_release_smoke",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/wheel_release_smoke.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-27T10:55:18.440302Z",
+      "command": "python scripts/deferral_scan.py --check docs/audit/baselines/deferral-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:10929aa0e1aaf9e015d625f39e66bae148fb707cb8dd7ab9adaf69b00901b81e",
+      "name": "deferral_discipline",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/deferral_discipline.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-27T10:55:22.145416Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:7b4f0d060e8c4e8471cde233d71106f26dc83cd4045e71440464e682e8ad49ef",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-27T10:57:44.191184Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:ce4f34f23e262b3da3229d900775e683e819045badca891922d6a21d5e82e857",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-27T11:03:10.361369Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:ce4f34f23e262b3da3229d900775e683e819045badca891922d6a21d5e82e857",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    }
+  ],
+  "check_na": [],
+  "commit": {
+    "sha": "523e09907b26bf173e143c6219d44e3eebcd9cd2",
+    "shas": [
+      "523e09907b26bf173e143c6219d44e3eebcd9cd2"
+    ],
+    "trailers": []
+  },
+  "declared_scope": {
+    "exclude": [],
+    "include": []
+  },
+  "directive_events": [
+    {
+      "at": "2026-06-27T10:40:06.087074Z",
+      "owner_directive": "0.3.0 not distributed (testers still on 0.2.x); bump 0.3.0 -> 0.3.1 (patch) and fold the friendly-dialog fix in. Distribute 0.3.1.",
+      "reason": "owner directive: bump 0.3.1 since 0.3.0 was never distributed"
+    },
+    {
+      "at": "2026-06-27T10:55:11.172954Z",
+      "owner_directive": "Harden stage-resources.sh/.ps1: pre-flight check for frontend/node_modules with an actionable error, and post-stage assert that scistudio/__init__.py + SPA index.html were staged. Root cause of the broken Windows package (#1805).",
+      "reason": "owner directive: harden stage scripts so a missing-frontend-deps build can't silently ship a broken installer"
+    }
+  ],
+  "docs_events": [
+    {
+      "at": "2026-06-27T10:47:13.353125Z",
+      "class": null,
+      "kind": "path",
+      "path": "CHANGELOG.md",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": true,
+  "guard_events": [
+    {
+      "at": "2026-06-27T10:46:42.315002Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T10:46:42.326346Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {
+            "governed_files": [
+              "frontend/package-lock.json",
+              "frontend/package.json",
+              "pyproject.toml",
+              "src/scistudio/_version.py"
+            ]
+          },
+          "expected": null,
+          "file": "",
+          "finding_class": "docs_landing",
+          "git_evidence": null,
+          "id": "docs_landing.missing-landing",
+          "line": null,
+          "message": "governed change requires docs/changelog/checklist landing evidence or an explicit N/A rationale",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "docs_landing.missing-landing",
+          "severity": "error",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "docs_landing",
+      "status": "fail"
+    },
+    {
+      "at": "2026-06-27T10:46:42.336325Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T10:46:42.346924Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T10:46:42.356090Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T10:46:42.366897Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T10:46:42.377603Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T10:46:42.388489Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T10:46:42.398451Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T10:46:42.407886Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T10:57:44.227511Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T10:57:44.236749Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T10:57:44.246052Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T10:57:44.256253Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T10:57:44.265882Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T10:57:44.275351Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T10:57:44.284498Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T10:57:44.295427Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T10:57:44.304624Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T10:57:44.314414Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T11:00:43.859544Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T11:00:43.874360Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T11:00:43.885013Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T11:00:43.894868Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T11:00:43.904881Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T11:00:43.914782Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T11:00:43.924470Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T11:00:43.935297Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T11:00:43.946479Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T11:00:43.957653Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T11:03:10.393346Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T11:03:10.403160Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T11:03:10.412302Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T11:03:10.421566Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T11:03:10.430893Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T11:03:10.440377Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T11:03:10.450834Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T11:03:10.461645Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T11:03:10.470957Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T11:03:10.481392Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1805,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": {
+    "base": "origin/main",
+    "base_sha": "d7c3314b",
+    "changed_files": [
+      "CHANGELOG.md",
+      "README.md",
+      "desktop/main.js",
+      "desktop/ota.js",
+      "desktop/package-lock.json",
+      "desktop/package.json",
+      "desktop/scripts/stage-resources.ps1",
+      "desktop/scripts/stage-resources.sh",
+      "desktop/test/ota.test.js",
+      "frontend/package-lock.json",
+      "frontend/package.json",
+      "pyproject.toml",
+      "src/scistudio/_version.py"
+    ],
+    "diff_fingerprint": "sha256:c419602992f83c0eeef0e183aee91b220966e6237118bfaafaaf6e06cbb4f276",
+    "head": "HEAD",
+    "head_sha": "523e0990",
+    "surfaces": {
+      "docs": 0,
+      "frontend": 2,
+      "governance": 1,
+      "governed_docs": 0,
+      "implementation": 4,
+      "packaging": 1,
+      "protected_core": 0,
+      "sentrux": 3,
+      "test": 1,
+      "workflow_ci": 0
+    }
+  },
+  "owner_directive": "OTA update dialog says 'Update to build 7' which is unfriendly; show a version string like 0.3.0.0007 (base + 4-digit build) instead. Pure displayBuildVersion in ota.js + use in main.js dialogs. Shell-only (new installer to take effect).",
+  "persona": "live_implementer",
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [
+      1805
+    ],
+    "number": null,
+    "url": null
+  },
+  "reconcile_events": [
+    {
+      "at": "2026-06-27T10:46:42.407926Z",
+      "diff_fingerprint": "sha256:b82088f9cb04d40f73978ecf6f0b73e76f54579a2cc7f1c3bcaf0a299a40f23c",
+      "mode": "local",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.python_tests",
+        "docs.docs_required_or_na",
+        "guard.docs_landing",
+        "tests.changed_test_required"
+      ]
+    },
+    {
+      "at": "2026-06-27T10:57:44.314442Z",
+      "diff_fingerprint": "sha256:c419602992f83c0eeef0e183aee91b220966e6237118bfaafaaf6e06cbb4f276",
+      "mode": "local",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.python_tests"
+      ]
+    },
+    {
+      "at": "2026-06-27T11:00:43.957682Z",
+      "diff_fingerprint": "sha256:c419602992f83c0eeef0e183aee91b220966e6237118bfaafaaf6e06cbb4f276",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.python_tests"
+      ]
+    },
+    {
+      "at": "2026-06-27T11:03:10.481431Z",
+      "diff_fingerprint": "sha256:c419602992f83c0eeef0e183aee91b220966e6237118bfaafaaf6e06cbb4f276",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.python_tests"
+      ]
+    }
+  ],
+  "record_id": "1805-friendly-ota-dialog",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [
+      "architecture_tests",
+      "deferral_discipline",
+      "format_check",
+      "frontend",
+      "full_audit",
+      "import_contracts",
+      "lint_format",
+      "python_tests",
+      "semantic_dup",
+      "type_check",
+      "wheel_release_smoke"
+    ],
+    "docs": [
+      "docs_required_or_na"
+    ],
+    "guards": [
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": [
+      "changed_test_required"
+    ]
+  },
+  "runtime": "claude",
+  "schema_version": 2,
+  "scope_events": [],
+  "session_id": "733ea6c0-5c29-412b-8f56-d4752b92f879",
+  "strictness_tier": 1,
+  "task_kind": "guided",
+  "test_events": [
+    {
+      "at": "2026-06-27T10:47:13.353287Z",
+      "class": null,
+      "kind": "path",
+      "path": "desktop/test/ota.test.js",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.3.1] - 2026-06-27
+
+Patch release; the first internally-distributed 0.3.x build (0.3.0 was never
+distributed — internal testers were still on 0.2.x). The committed version
+embeds build `0000`; the real build number is injected at installer build time.
+
 ### Changed
 
+- [#1805] OTA update dialog now shows a version string (e.g. `0.3.1.0008`) instead of the engineering-flavored `build 7`. A pure `displayBuildVersion(base, build)` helper (`desktop/ota.js`) formats `base + zero-padded build`; used in the patch-available and incompatible dialogs in `desktop/main.js`. Shell-only — reaches users via a new installer, not OTA. Tests: `desktop/test/ota.test.js`. (@claude, 2026-06-27, branch: guided/1805-friendly-ota-dialog)
 - [#1803] Welcome screen hero layout: the **SciStudio** title is larger (`text-7xl`) and the title + tagline are vertically centered in the hero column, with the New/Open Project buttons pinned to the bottom (the left/right layout and Recent Workspaces panel are unchanged). Styling only. (`frontend/src/components/WelcomeScreen.tsx`) (@claude, 2026-06-27, branch: guided/1803-welcome-hero-layout)
 
 ## [0.3.0] - 2026-06-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Patch release; the first internally-distributed 0.3.x build (0.3.0 was never
 distributed — internal testers were still on 0.2.x). The committed version
 embeds build `0000`; the real build number is injected at installer build time.
 
+### Fixed
+
+- [#1805] Desktop staging (`stage-resources.sh` / `.ps1`) no longer silently produces a broken installer when frontend dependencies are missing. It now (1) fails fast with an actionable message if `frontend/node_modules` is absent (instead of the cryptic `tsc: command not found` that aborted staging before the backend tree was copied, shipping an app whose runtime can't `import scistudio`), and (2) asserts the staged backend contains `scistudio/__init__.py` and the embedded SPA `index.html` before finishing. (@claude, 2026-06-27, branch: guided/1805-friendly-ota-dialog)
+
 ### Changed
 
 - [#1805] OTA update dialog now shows a version string (e.g. `0.3.1.0008`) instead of the engineering-flavored `build 7`. A pure `displayBuildVersion(base, build)` helper (`desktop/ota.js`) formats `base + zero-padded build`; used in the patch-available and incompatible dialogs in `desktop/main.js`. Shell-only — reaches users via a new installer, not OTA. Tests: `desktop/test/ota.test.js`. (@claude, 2026-06-27, branch: guided/1805-friendly-ota-dialog)

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ SciStudio is a **modality-agnostic, building-block workflow framework** where:
 - Multiple data modalities coexist in a **single workflow graph**, enabling true cross-modal fusion analysis.
 - The framework is **AI-native**: AI can generate blocks, synthesize workflows, and optimize parameters at runtime.
 
-> **Status**: SciStudio is in **pre-alpha** (v0.3.0a0). The core runtime, block system, execution engine, API layer, and frontend workflow editor are implemented and under active development. See [Current Status](#current-status) for details.
+> **Status**: SciStudio is in **pre-alpha** (v0.3.1a0). The core runtime, block system, execution engine, API layer, and frontend workflow editor are implemented and under active development. See [Current Status](#current-status) for details.
 
 ---
 
@@ -424,7 +424,7 @@ Significant design decisions are documented as ADRs in [`docs/adr/`](docs/adr/).
 
 ## Current Status
 
-SciStudio is in **pre-alpha** (v0.3.0a0). The following is implemented and under active development:
+SciStudio is in **pre-alpha** (v0.3.1a0). The following is implemented and under active development:
 
 **Implemented:**
 - Core data type hierarchy with six base types and domain-specific subtypes

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -430,8 +430,9 @@ async function maybeCheckForUpdate() {
       title: "Update available",
       message: "A newer SciStudio version is available.",
       detail:
-        `Build ${decision.build} requires a newer base version (${decision.minBase}) than ` +
-        `this installation (${baseline.base}). Please download and reinstall SciStudio to update.`,
+        `Version ${ota.displayBuildVersion(manifest.base, decision.build)} requires a newer base ` +
+        `version (${decision.minBase}) than this installation (${baseline.base}). ` +
+        `Please download and reinstall SciStudio to update.`,
       buttons: ["OK"],
       defaultId: 0
     });
@@ -444,7 +445,7 @@ async function maybeCheckForUpdate() {
   const choice = await dialog.showMessageBox(mainWindow || undefined, {
     type: "question",
     title: "Update available",
-    message: `Update SciStudio to build ${manifest.build}?`,
+    message: `Update SciStudio to ${ota.displayBuildVersion(manifest.base, manifest.build)}?`,
     detail:
       (manifest.notes ? `${manifest.notes}\n\n` : "") +
       "SciStudio will restart to apply the update.",

--- a/desktop/ota.js
+++ b/desktop/ota.js
@@ -40,6 +40,15 @@ function patchDirName(build) {
   return `build${build}`;
 }
 
+// #1805: a user-facing version string for the update dialogs — "0.3.1.0008"
+// (base + zero-padded build) instead of the engineering-flavored "build 8".
+// The build is zero-padded to 4 digits to match the display/SemVer form
+// (a.b.c-channel-buildNNNN) used elsewhere.
+function displayBuildVersion(base, build) {
+  const padded = String(Math.max(0, Number(build) || 0)).padStart(4, "0");
+  return `${base}.${padded}`;
+}
+
 // Decide what to do with a fetched manifest given local state.
 //
 // Returns one of:
@@ -123,5 +132,6 @@ module.exports = {
   patchDirName,
   evaluateUpdate,
   resolveActivePatch,
-  pythonPathFor
+  pythonPathFor,
+  displayBuildVersion
 };

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scistudio-desktop",
-  "version": "0.3.0-alpha-build0000",
+  "version": "0.3.1-alpha-build0000",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scistudio-desktop",
-      "version": "0.3.0-alpha-build0000",
+      "version": "0.3.1-alpha-build0000",
       "devDependencies": {
         "electron": "42.2.0",
         "electron-builder": "26.8.1"

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scistudio-desktop",
-  "version": "0.3.0-alpha-build0000",
+  "version": "0.3.1-alpha-build0000",
   "private": true,
   "description": "SciStudio ADR-037 desktop MVP shell",
   "author": "SciStudio",

--- a/desktop/scripts/stage-resources.ps1
+++ b/desktop/scripts/stage-resources.ps1
@@ -26,6 +26,15 @@ function Reset-Directory {
     New-Item -ItemType Directory -Path $Path | Out-Null
 }
 
+# Pre-flight: the frontend build below needs frontend/node_modules (tsc, vite).
+# Without them it fails with a cryptic "tsc: command not found", aborts this
+# script before the backend tree is staged, and the resulting installer ships a
+# broken app whose runtime cannot import scistudio (#1805). Fail early with the
+# fix instead.
+if (-not (Test-Path (Join-Path $RepoRoot "frontend\node_modules"))) {
+    throw "Frontend dependencies are not installed. Run 'npm --prefix frontend ci' (or 'npm --prefix frontend install') before staging."
+}
+
 Write-Host "Building frontend..."
 npm --prefix (Join-Path $RepoRoot "frontend") run build
 if ($LASTEXITCODE -ne 0) {
@@ -65,6 +74,16 @@ if (Test-Path $EggInfo) {
 $StagedSpa = Join-Path $SrcTarget "scistudio\api\static"
 Reset-Directory $StagedSpa
 Copy-Item -Path (Join-Path $FrontendDist "*") -Destination $StagedSpa -Recurse -Force
+
+# Fail loudly if the staged backend is incomplete instead of shipping a broken
+# installer (#1805): the bundled runtime imports scistudio from this tree on
+# PYTHONPATH and serves the SPA from scistudio/api/static.
+if (-not (Test-Path (Join-Path $SrcTarget "scistudio\__init__.py"))) {
+    throw "Staged backend is missing scistudio ($SrcTarget\scistudio\__init__.py)."
+}
+if (-not (Test-Path (Join-Path $StagedSpa "index.html"))) {
+    throw "Staged SPA is missing ($StagedSpa\index.html)."
+}
 
 Ensure-Directory (Join-Path $ResourcesRoot "packages")
 Ensure-Directory (Join-Path $ResourcesRoot "git")

--- a/desktop/scripts/stage-resources.sh
+++ b/desktop/scripts/stage-resources.sh
@@ -16,6 +16,17 @@ reset_dir() {
   mkdir -p "$1"
 }
 
+# Pre-flight: the frontend build below needs frontend/node_modules (tsc, vite).
+# Without them it fails with a cryptic "tsc: command not found", aborts this
+# script before the backend tree is staged, and the resulting installer ships a
+# broken app whose runtime cannot import scistudio (#1805). Fail early with the
+# fix instead.
+if [ ! -d "$REPO_ROOT/frontend/node_modules" ]; then
+  echo "error: frontend dependencies are not installed." >&2
+  echo "       Run 'npm --prefix frontend ci' (or 'npm --prefix frontend install') before staging." >&2
+  exit 1
+fi
+
 echo "Building frontend..."
 npm --prefix "$REPO_ROOT/frontend" run build
 
@@ -48,6 +59,18 @@ rm -rf "$SRC_TARGET/scistudio.egg-info"
 STAGED_SPA="$SRC_TARGET/scistudio/api/static"
 reset_dir "$STAGED_SPA"
 cp -R "$FRONTEND_DIST"/. "$STAGED_SPA"/
+
+# Fail loudly if the staged backend is incomplete instead of shipping a broken
+# installer (#1805): the bundled runtime imports scistudio from this tree on
+# PYTHONPATH and serves the SPA from scistudio/api/static.
+if [ ! -f "$SRC_TARGET/scistudio/__init__.py" ]; then
+  echo "error: staged backend is missing scistudio ($SRC_TARGET/scistudio/__init__.py)" >&2
+  exit 1
+fi
+if [ ! -f "$STAGED_SPA/index.html" ]; then
+  echo "error: staged SPA is missing ($STAGED_SPA/index.html)" >&2
+  exit 1
+fi
 
 mkdir -p "$RESOURCES_ROOT/packages" "$RESOURCES_ROOT/git" "$RESOURCES_ROOT/python"
 : > "$RESOURCES_ROOT/packages/.gitkeep"

--- a/desktop/test/ota.test.js
+++ b/desktop/test/ota.test.js
@@ -134,6 +134,14 @@ test("pythonPathFor: packaged without a patch drops the null patch entry", () =>
   );
 });
 
+// #1805: user-facing version string for the update dialogs.
+test("displayBuildVersion: base + zero-padded 4-digit build", () => {
+  assert.equal(ota.displayBuildVersion("0.3.1", 8), "0.3.1.0008");
+  assert.equal(ota.displayBuildVersion("0.3.1", 7), "0.3.1.0007");
+  assert.equal(ota.displayBuildVersion("0.3.0", 1234), "0.3.0.1234");
+  assert.equal(ota.displayBuildVersion("0.3.1", 0), "0.3.1.0000");
+});
+
 test("pythonPathFor: dev uses only the worktree checkout src", () => {
   // Even when a patch and a staged copy are present, dev must ignore both so
   // edits to the worktree src take effect (the #1801 dev-shadow bug).

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scistudio-frontend",
-  "version": "0.3.0-alpha-build0000",
+  "version": "0.3.1-alpha-build0000",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scistudio-frontend",
-      "version": "0.3.0-alpha-build0000",
+      "version": "0.3.1-alpha-build0000",
       "dependencies": {
         "@monaco-editor/react": "^4.6.0",
         "@radix-ui/react-dropdown-menu": "^2.1.16",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scistudio-frontend",
-  "version": "0.3.0-alpha-build0000",
+  "version": "0.3.1-alpha-build0000",
   "private": true,
   "type": "module",
   "scripts": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "scistudio"
-version = "0.3.0a0"
+version = "0.3.1a0"
 description = "AI-native, inclusive workflow runtime for multimodal scientific data"
 readme = "README.md"
 license = {text = "MIT"}
@@ -441,7 +441,7 @@ ancestors = ["scistudio.ai.agent.mcp.tools_inspection"]
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "0.3.0a0"
+version = "0.3.1a0"
 tag_format = "v$version"
 
 # Issue #1340 / ADR-042 code-quality stack: vulture runs as an informational

--- a/src/scistudio/_version.py
+++ b/src/scistudio/_version.py
@@ -15,7 +15,7 @@ Keep this module import-cheap and dependency-free: it is imported very early
 from __future__ import annotations
 
 #: Base semantic version ``a.b.c`` (no channel/build suffix).
-BASE_VERSION = "0.3.0"
+BASE_VERSION = "0.3.1"
 
 #: Release channel. One of ``"alpha"``, ``"beta"``, ``"stable"``.
 CHANNEL = "alpha"


### PR DESCRIPTION
## Summary

Release-prep for the first internally-distributed 0.3.x build (owner-directed; 0.3.0 was never distributed — testers are still on 0.2.x). Three parts:

1. **Bump 0.3.0 → 0.3.1** (patch). `BASE_VERSION` + `version.py sync`; CHANGELOG `[Unreleased] → [0.3.1]`; README version aligned. Committed build is `0000`; the real build number is injected at installer build time.
2. **Friendlier OTA update dialog** — replace `Update SciStudio to build 7?` with a version string `0.3.1.0008`. New pure `ota.displayBuildVersion(base, build)` (base + zero-padded build), used in the patch-available and incompatible dialogs in `desktop/main.js`. Shell-only → reaches users via a new installer, not OTA.
3. **Harden desktop staging** so a missing-frontend-deps build can't silently ship a broken installer. Root cause of a broken Windows package (runtime `No module named 'scistudio'`): `stage-resources` aborted at the frontend build (`tsc: command not found` when `frontend/node_modules` is absent) *before* copying the backend tree, so the installer shipped without scistudio source. Both `.sh` and `.ps1` now (a) pre-flight check for `frontend/node_modules` with an actionable message, and (b) assert `scistudio/__init__.py` + the embedded SPA `index.html` are staged before finishing.

## Tests

- `desktop/test/ota.test.js` — `displayBuildVersion` cases (20 pass).
- `stage-resources.sh` happy path verified locally (builds, stages, passes the new assertions).

## CI note

Local `python_tests` flaked on a plot/PTY test under `-n auto` xdist (a different test each run — `test_pty_process_extra_env` then `test_run_python_svg_success`, both pass in isolation and are unrelated to this diff). All other gate checks pass. CI is authoritative.

Closes #1805
