### PR TITLE
test(#1813): xfail baseline for residual bare single-value transport drift

### DIFF
--- a/.workflow/records/1811-guided-1811-single-value-collection-xfail.json
+++ b/.workflow/records/1811-guided-1811-single-value-collection-xfail.json
@@ -1,0 +1,482 @@
+{
+  "branch": "guided/1811-single-value-collection-xfail",
+  "check_events": [
+    {
+      "at": "2026-06-27T13:16:48.580484Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:98493140540f590e7d1841edb101511c210d74ee79e486ec11b90f9103ee8642",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-27T13:16:54.735737Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:b5414b137fd3767e343d60a65e9143b27c236e720cdd7fe2ca0c4da795ceef34",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-27T13:16:54.801515Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:14308490a9e0c3c2b3aef65b4177fe540a874e3a668998cc82f8c7bbb70922c4",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-27T13:21:52.021466Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:5af20fdd000bc1fd03bd63b0ebaee7e1b04102d1668501741d073f12901010f2",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-27T13:23:57.228514Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:022644cfdd272a4b940b70b7824d7c3b2ea3a82efd77529d634c98197024d3bb",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    }
+  ],
+  "check_na": [],
+  "commit": null,
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "tests/engine/test_single_value_collection_contract.py"
+    ]
+  },
+  "directive_events": [
+    {
+      "at": "2026-06-27T12:56:32.823756Z",
+      "owner_directive": "Design xfail tests for the bare single-value DataObject path before discussing the root-cause fix.",
+      "reason": "plan"
+    },
+    {
+      "at": "2026-06-27T13:02:59.103352Z",
+      "owner_directive": "\u96c6\u6210xfail\u4e5f\u8865\u4e00\u4e0b",
+      "reason": "Owner directed adding a scheduler in-process integration xfail covering the second _normalize_outputs call site (_dispatch.py:325)."
+    }
+  ],
+  "docs_events": [
+    {
+      "at": "2026-06-27T12:56:32.823922Z",
+      "class": "spec",
+      "kind": "na",
+      "path": null,
+      "rationale": "no runtime/contract behavior changes yet; xfail tests document the ADR-020 \u00a73 gap in-place. Docs/ADR follow with the option (a) fix.",
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": false,
+  "guard_events": [
+    {
+      "at": "2026-06-27T13:23:57.271652Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:23:57.282321Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:23:57.293120Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:23:57.304013Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:23:57.314206Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:23:57.324114Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:23:57.333523Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:23:57.345274Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:23:57.356213Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:23:57.368666Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:24:51.647264Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:24:51.656035Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:24:51.664516Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:24:51.673603Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:24:51.682320Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:24:51.691016Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:24:51.699440Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:24:51.708053Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:24:51.716309Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:24:51.727169Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:25:03.815901Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:25:03.824349Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:25:03.833553Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:25:03.843375Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:25:03.852551Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:25:03.861376Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:25:03.869835Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:25:03.878558Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:25:03.886857Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:25:03.896382Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1813,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": {
+    "base": "origin/main",
+    "base_sha": "d7c3314b",
+    "changed_files": [
+      ".workflow/records/1811-guided-1811-single-value-collection-xfail.json",
+      "tests/engine/test_single_value_collection_contract.py"
+    ],
+    "diff_fingerprint": "sha256:e0a1ad87c4325116f388495c73ff3241c1dcd7d594e245a71e4087b18bd2f14d",
+    "head": "HEAD",
+    "head_sha": "c38e0d9a",
+    "surfaces": {
+      "docs": 0,
+      "frontend": 0,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 0,
+      "packaging": 0,
+      "protected_core": 0,
+      "sentrux": 1,
+      "test": 1,
+      "workflow_ci": 0
+    }
+  },
+  "owner_directive": "Design xfail tests pinning the residual bare single-value DataObject transport drift (ADR-020 \u00a73 says single value = length-one Collection); root-cause fix discussed separately afterward.",
+  "persona": "live_implementer",
+  "pull_request": null,
+  "reconcile_events": [
+    {
+      "at": "2026-06-27T13:23:57.368699Z",
+      "diff_fingerprint": "sha256:e0a1ad87c4325116f388495c73ff3241c1dcd7d594e245a71e4087b18bd2f14d",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.lint_format",
+        "checks.python_tests"
+      ]
+    },
+    {
+      "at": "2026-06-27T13:24:51.727196Z",
+      "diff_fingerprint": "sha256:e0a1ad87c4325116f388495c73ff3241c1dcd7d594e245a71e4087b18bd2f14d",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.lint_format",
+        "checks.python_tests"
+      ]
+    },
+    {
+      "at": "2026-06-27T13:25:03.896405Z",
+      "diff_fingerprint": "sha256:e0a1ad87c4325116f388495c73ff3241c1dcd7d594e245a71e4087b18bd2f14d",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.lint_format",
+        "checks.python_tests"
+      ]
+    }
+  ],
+  "record_id": "1811-guided-1811-single-value-collection-xfail",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [
+      "format_check",
+      "full_audit",
+      "lint_format",
+      "python_tests",
+      "semantic_dup"
+    ],
+    "docs": [],
+    "guards": [
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": []
+  },
+  "runtime": "claude-code",
+  "schema_version": 2,
+  "scope_events": [
+    {
+      "action": "add-include",
+      "at": "2026-06-27T12:56:32.823899Z",
+      "pattern": "tests/engine/test_single_value_collection_contract.py",
+      "reason": "plan"
+    }
+  ],
+  "session_id": "a0251190-d45b-451b-b60d-ddfaf96601a5",
+  "strictness_tier": 2,
+  "task_kind": "guided",
+  "test_events": [
+    {
+      "at": "2026-06-27T12:56:32.823940Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/engine/test_single_value_collection_contract.py",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/.workflow/records/1811-guided-1811-single-value-collection-xfail.json
+++ b/.workflow/records/1811-guided-1811-single-value-collection-xfail.json
@@ -82,7 +82,13 @@
     }
   ],
   "check_na": [],
-  "commit": null,
+  "commit": {
+    "sha": "e21be3f63be5f520a185d0f2c1a5eb4fa2fc8509",
+    "shas": [
+      "e21be3f63be5f520a185d0f2c1a5eb4fa2fc8509"
+    ],
+    "trailers": []
+  },
   "declared_scope": {
     "exclude": [],
     "include": [
@@ -358,6 +364,88 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:29:43.869693Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:29:43.878823Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:29:43.888030Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:29:43.897284Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:29:43.906416Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:29:43.915748Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:29:43.925305Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:29:43.935344Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:29:43.943826Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:29:43.954062Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -370,15 +458,15 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "origin/main",
+    "base": "d7c3314bef0fee826620b5a675f156f60053c045",
     "base_sha": "d7c3314b",
     "changed_files": [
       ".workflow/records/1811-guided-1811-single-value-collection-xfail.json",
       "tests/engine/test_single_value_collection_contract.py"
     ],
-    "diff_fingerprint": "sha256:e0a1ad87c4325116f388495c73ff3241c1dcd7d594e245a71e4087b18bd2f14d",
+    "diff_fingerprint": "sha256:173cbf2355e9de542f673c831c2ac3e0fdb8b3be72030325f6f14e9371497ac5",
     "head": "HEAD",
-    "head_sha": "c38e0d9a",
+    "head_sha": "e21be3f6",
     "surfaces": {
       "docs": 0,
       "frontend": 0,
@@ -394,7 +482,12 @@
   },
   "owner_directive": "Design xfail tests pinning the residual bare single-value DataObject transport drift (ADR-020 \u00a73 says single value = length-one Collection); root-cause fix discussed separately afterward.",
   "persona": "live_implementer",
-  "pull_request": null,
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [],
+    "number": 1814,
+    "url": null
+  },
   "reconcile_events": [
     {
       "at": "2026-06-27T13:23:57.368699Z",
@@ -427,6 +520,20 @@
       "unsatisfied": [
         "checks.lint_format",
         "checks.python_tests"
+      ]
+    },
+    {
+      "at": "2026-06-27T13:29:43.954086Z",
+      "diff_fingerprint": "sha256:173cbf2355e9de542f673c831c2ac3e0fdb8b3be72030325f6f14e9371497ac5",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.format_check",
+        "checks.full_audit",
+        "checks.lint_format",
+        "checks.python_tests",
+        "checks.semantic_dup"
       ]
     }
   ],

--- a/tests/engine/test_single_value_collection_contract.py
+++ b/tests/engine/test_single_value_collection_contract.py
@@ -1,0 +1,354 @@
+"""xfail baseline for the residual single-value transport drift (#1811).
+
+ADR-020 §3 states the runtime transport contract:
+
+    All values crossing a block boundary are represented as Collection
+    objects. A single item is represented as a length-one Collection; a
+    multi-file/multi-object input is a longer Collection.
+
+#1330 (closed) enforced this **only** on ports already declared
+``is_collection=True`` — :func:`_normalize_outputs` wraps a bare
+DataObject into a length-one Collection on those ports. It did *not* make
+single-value ports (``is_collection=False``) always-Collection. As a
+result the engine still:
+
+- serialises a single DataObject as a bare ``{backend, path, metadata}``
+  reference (no ``_collection`` envelope) on ``is_collection=False`` ports
+  (:func:`serialise_outputs`);
+- reconstructs that wire shape as a **bare** DataObject downstream
+  (:func:`reconstruct_inputs`); and
+- re-emits a bare value from :meth:`ProcessBlock.run` when the primary
+  input was itself bare (the non-Collection fallback branch).
+
+Per ADR-020 §3 every one of these single values should be a length-one
+Collection. The tests below pin that **target** behaviour. They are
+marked ``xfail(strict=True)`` because the residual drift means they fail
+today; when the #1811 root-cause fix lands (option (a): treat every
+DataObject port as a Collection), each will start passing and the strict
+marker forces us to delete it — a self-cleaning regression ratchet.
+
+These tests are intentionally distinct from
+``tests/engine/test_collection_wrap.py`` (the #1330 suite), whose
+``TestEngineLeavesNonCollectionPortAlone`` pins the *current* drift as
+intended #1330 behaviour. When #1811 lands, that #1330 test must be
+revisited in the same change; this file documents why.
+
+Completeness
+------------
+These boundaries are not a sample — they are the **closed set** of places a
+bare single value can enter or leave a block boundary. A bare DataObject can
+only exist where the transport codec produces or consumes one, and that codec
+is a small, greppable API:
+
+- In-memory raw objects enter ``DAGScheduler._block_outputs`` via exactly five
+  writers (``_dispatch.py`` 249/327/588, ``scheduler/__init__.py`` 452/461).
+  327/588 pass through ``_normalize_outputs`` first; 249 and 452/461 are
+  wire-format paths (worker terminal outputs and checkpoint restore) that carry
+  whatever the wire codec produced.
+- Wire-format single values are produced **only** by ``_serialise_one`` and
+  consumed **only** by ``_reconstruct_one``. At a port boundary the single-value
+  branches are ``worker.serialise_outputs`` (worker.py:383) and
+  ``worker.reconstruct_inputs`` (worker.py:176); every other caller is either
+  Collection-item recursion, CompositeData slot recursion, a deprecated
+  checkpoint deserialiser, or a metadata/preview side-channel.
+
+So the root-cause surface reduces to three engine locations — ``_normalize_outputs``
+(output produce), ``serialise_outputs`` (wire produce), ``reconstruct_inputs``
+(wire consume) — plus the ``ProcessBlock.run`` non-Collection fallback (in-memory
+consume + re-emit). The tests below pin all four. Checkpoint restore and worker
+terminal outputs inherit the same codec and are fixed transitively when it is;
+they are noted here so a future reviewer knows they were considered, not missed.
+A new leak would require adding a new call site to one of those three functions,
+which a grep-based guard can catch.
+
+References: ADR-020 §3, §5, §7.1; #1330 (closed); #1811.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, ClassVar
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from scistudio.blocks.base.block import Block
+from scistudio.blocks.base.config import BlockConfig
+from scistudio.blocks.base.ports import InputPort, OutputPort
+from scistudio.blocks.base.state import BlockState
+from scistudio.core.storage.ref import StorageReference
+from scistudio.core.types.array import Array
+from scistudio.core.types.base import DataObject
+from scistudio.core.types.collection import Collection
+from scistudio.engine.events import EventBus
+from scistudio.engine.runners.worker import (
+    _normalize_outputs,
+    reconstruct_inputs,
+    serialise_outputs,
+)
+from scistudio.engine.scheduler import DAGScheduler
+from scistudio.workflow.definition import NodeDef, WorkflowDefinition
+
+_XFAIL_REASON = (
+    "#1811: ADR-020 §3 requires single values on is_collection=False ports to "
+    "transport as length-one Collections; the engine still uses the bare "
+    "DataObject path. Remove this xfail when the option (a) fix lands."
+)
+
+
+def _ref(path: str = "/tmp/test.zarr", backend: str = "zarr") -> StorageReference:
+    """Minimal StorageReference so serialise_outputs skips auto-flush."""
+    return StorageReference(backend=backend, path=path)
+
+
+def _make_array() -> Array:
+    """Bare :class:`Array` with deterministic axes/shape and no storage."""
+    return Array(axes=["y", "x"], shape=(4, 4), dtype="uint8")
+
+
+# ---------------------------------------------------------------------------
+# Output boundary: _normalize_outputs on single-value (is_collection=False)
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeSingleValuePort:
+    """``_normalize_outputs`` should treat every DataObject port as Collection."""
+
+    @pytest.mark.xfail(reason=_XFAIL_REASON, strict=True)
+    def test_normalize_wraps_bare_dataobject_on_single_value_port(self) -> None:
+        """Bare DataObject on an ``is_collection=False`` port should become a
+        length-one Collection. Today ``_normalize_outputs`` early-returns for
+        non-Collection ports ([worker.py:257]) and leaves the bare object.
+        """
+        bare = _make_array()
+        ports = [OutputPort(name="out", accepted_types=[Array], is_collection=False)]
+        outputs: dict = {"out": bare}
+
+        _normalize_outputs(outputs, ports)
+
+        wrapped = outputs["out"]
+        assert isinstance(wrapped, Collection)
+        assert len(wrapped) == 1
+        assert wrapped[0] is bare
+        assert wrapped.item_type is Array
+
+    @pytest.mark.xfail(reason=_XFAIL_REASON, strict=True)
+    def test_normalize_packs_bare_list_on_single_value_port(self) -> None:
+        """A bare ``list[DataObject]`` on an ``is_collection=False`` port should
+        pack into a Collection (ADR-020 §3 "multi-object input is a longer
+        Collection"). Today the non-Collection port is skipped entirely.
+        """
+        a, b = _make_array(), _make_array()
+        ports = [OutputPort(name="out", accepted_types=[Array], is_collection=False)]
+        outputs: dict = {"out": [a, b]}
+
+        _normalize_outputs(outputs, ports)
+
+        packed = outputs["out"]
+        assert isinstance(packed, Collection)
+        assert len(packed) == 2
+        assert packed[0] is a
+        assert packed[1] is b
+        assert packed.item_type is Array
+
+
+# ---------------------------------------------------------------------------
+# Wire format: serialise_outputs / reconstruct_inputs for single values
+# ---------------------------------------------------------------------------
+
+
+class TestSingleValueWireFormat:
+    """A single DataObject should cross the wire as a ``_collection`` envelope."""
+
+    @pytest.mark.xfail(reason=_XFAIL_REASON, strict=True)
+    def test_serialise_single_dataobject_emits_collection_envelope(self, tmp_path) -> None:
+        """``serialise_outputs`` of a single DataObject should produce a
+        ``{"_collection": True, "items": [...], "item_type": ...}`` payload,
+        not a bare ``{backend, path, metadata}`` reference ([worker.py:383]).
+        """
+        import numpy as np
+        import zarr
+
+        zarr_path = str(tmp_path / "single.zarr")
+        zarr.save(zarr_path, np.zeros((4, 4), dtype="uint8"))
+        arr = Array(axes=["y", "x"], shape=(4, 4), dtype="uint8", storage_ref=_ref(zarr_path))
+
+        wire = serialise_outputs({"out": arr}, str(tmp_path))
+        payload = wire["out"]
+
+        assert payload.get("_collection") is True
+        assert payload["item_type"] == "Array"
+        assert len(payload["items"]) == 1
+
+    @pytest.mark.xfail(reason=_XFAIL_REASON, strict=True)
+    def test_reconstruct_bare_wire_dict_yields_length_one_collection(self, tmp_path) -> None:
+        """A bare ``{backend, path, metadata}`` wire dict should reconstruct as a
+        length-one Collection, not a bare DataObject ([worker.py:174-176]).
+
+        Builds the bare wire shape via the existing single-value serialiser so
+        the metadata is realistic, then asserts the target reconstruct result.
+        """
+        import numpy as np
+        import zarr
+
+        zarr_path = str(tmp_path / "bare.zarr")
+        zarr.save(zarr_path, np.zeros((4, 4), dtype="uint8"))
+        arr = Array(axes=["y", "x"], shape=(4, 4), dtype="uint8", storage_ref=_ref(zarr_path))
+
+        bare_wire = serialise_outputs({"out": arr}, str(tmp_path))["out"]
+        # Guard the test's own premise: today this is a bare reference, the
+        # exact shape #1811 is about. (If this key appears, the fix landed and
+        # this xfail test plus its premise must be revisited.)
+        assert "backend" in bare_wire and "_collection" not in bare_wire
+
+        rebuilt = reconstruct_inputs({"inputs": {"out": bare_wire}})["out"]
+
+        assert isinstance(rebuilt, Collection)
+        assert len(rebuilt) == 1
+        assert isinstance(rebuilt[0], Array)
+
+    @pytest.mark.xfail(reason=_XFAIL_REASON, strict=True)
+    def test_single_value_round_trip_is_length_one_collection(self, tmp_path) -> None:
+        """End-to-end ``serialise_outputs`` -> ``reconstruct_inputs`` of a single
+        value should hand the downstream block a length-one Collection.
+        """
+        import numpy as np
+        import zarr
+
+        zarr_path = str(tmp_path / "rt_single.zarr")
+        zarr.save(zarr_path, np.zeros((8, 8), dtype="float32"))
+        original = Array(axes=["y", "x"], shape=(8, 8), dtype="float32", storage_ref=_ref(zarr_path))
+
+        wire = serialise_outputs({"out": original}, str(tmp_path))
+        rebuilt = reconstruct_inputs({"inputs": wire})["out"]
+
+        assert isinstance(rebuilt, Collection)
+        assert len(rebuilt) == 1
+        assert rebuilt[0].shape == original.shape
+
+
+# ---------------------------------------------------------------------------
+# Consumer boundary: ProcessBlock.run must not re-emit bare on bare input
+# ---------------------------------------------------------------------------
+
+
+class TestProcessBlockSingleValueOutput:
+    """The non-Collection fallback in :meth:`ProcessBlock.run` propagates drift."""
+
+    @pytest.mark.xfail(reason=_XFAIL_REASON, strict=True)
+    def test_process_block_emits_collection_for_bare_input(self) -> None:
+        """When the primary input is a bare DataObject, ``ProcessBlock.run``
+        should still emit a Collection on its output port. Today the
+        non-Collection fallback ([process_block.py:174-177]) calls
+        ``process_item`` once and returns the bare result, so the drift
+        propagates transitively down the graph.
+        """
+        from scistudio.blocks.process.process_block import ProcessBlock
+
+        class _Passthrough(ProcessBlock):
+            type_name = "_test.single_value_passthrough"
+            input_ports: ClassVar = [InputPort(name="data", accepted_types=[DataObject])]
+            output_ports: ClassVar = [OutputPort(name="out", accepted_types=[DataObject])]
+
+            def process_item(self, item, config, state=None):  # type: ignore[no-untyped-def]
+                return item
+
+        block = _Passthrough()
+        bare = _make_array()
+
+        result = block.run({"data": bare}, block.config)
+
+        assert isinstance(result["out"], Collection)
+        assert len(result["out"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# Integration: scheduler in-process boundary (_dispatch.py:325)
+# ---------------------------------------------------------------------------
+
+
+class _BareSingleValueBlock(Block):
+    """Non-interactive block returning a bare Array on an is_collection=False port.
+
+    Mirrors the in-process drift: a runner returning a raw Python
+    :class:`DataObject` (not a wire dict) on a single-value port. The
+    engine's in-process ``_normalize_outputs`` call ([_dispatch.py:325])
+    skips non-Collection ports today, so the bare Array lands in
+    ``_block_outputs`` unwrapped.
+    """
+
+    name: ClassVar[str] = "BareSingleValue"
+    output_ports: ClassVar[list[OutputPort]] = [
+        OutputPort(name="out", accepted_types=[Array], is_collection=False),
+    ]
+
+    def __init__(self, config: dict[str, Any] | None = None) -> None:
+        super().__init__(config)
+        # DAGScheduler._instantiate_block assigns ``.id`` after construction.
+        self.id = ""
+
+    def run(self, inputs: dict[str, Any], config: BlockConfig) -> dict[str, Any]:  # type: ignore[override]
+        return {"out": _make_array()}
+
+
+def _make_single_value_scheduler() -> tuple[DAGScheduler, EventBus]:
+    """Build a DAGScheduler whose registry returns ``_BareSingleValueBlock``.
+
+    The mock runner returns the block's bare, un-normalised output so the
+    in-process finalize ``_normalize_outputs`` call is the only thing that
+    could honour ADR-020 §3 before the value lands in ``_block_outputs``.
+    """
+    wf = WorkflowDefinition(
+        id="wf-1811-single-value",
+        nodes=[NodeDef(id="a", block_type="bare-single-value", config={})],
+        edges=[],
+    )
+    event_bus = EventBus()
+    resource_manager = MagicMock()
+    resource_manager.can_dispatch.return_value = True
+    process_registry = MagicMock()
+    process_registry.get_handle.return_value = None
+
+    runner = AsyncMock()
+
+    async def _compute(block: Block, inputs: dict[str, Any], config: dict[str, Any]) -> dict[str, Any]:
+        return block.run(inputs, BlockConfig(**config))
+
+    runner.run.side_effect = _compute
+
+    registry = MagicMock()
+    registry.instantiate.side_effect = lambda name, config=None: _BareSingleValueBlock(config or {})
+    registry.get_spec.return_value = None
+
+    scheduler = DAGScheduler(
+        workflow=wf,
+        event_bus=event_bus,
+        resource_manager=resource_manager,
+        process_registry=process_registry,
+        runner=runner,
+        registry=registry,
+    )
+    return scheduler, event_bus
+
+
+class TestSchedulerInProcessSingleValueBoundary:
+    """The second ``_normalize_outputs`` call site must wrap single values too."""
+
+    @pytest.mark.xfail(reason=_XFAIL_REASON, strict=True)
+    def test_in_process_dispatch_wraps_bare_single_value(self) -> None:
+        """A bare Array produced in-process on an ``is_collection=False`` port
+        should land in ``_block_outputs`` as a length-one Collection. Today the
+        in-process boundary ([_dispatch.py:325]) skips non-Collection ports, so
+        the bare value propagates to downstream blocks unwrapped.
+        """
+        scheduler, _event_bus = _make_single_value_scheduler()
+
+        asyncio.run(scheduler.execute())
+
+        assert scheduler._block_states["a"] == BlockState.DONE
+        stored = scheduler._block_outputs["a"]
+        assert isinstance(stored, dict)
+        wrapped = stored["out"]
+        assert isinstance(wrapped, Collection)
+        assert len(wrapped) == 1
+        assert isinstance(wrapped[0], Array)


### PR DESCRIPTION
## Summary

ADR-020 §3 requires every value crossing a block boundary to transport as a
Collection — a single item as a **length-one Collection**. #1330 (closed)
enforced this only on ports already declared `is_collection=True`. Single-value
ports (`is_collection=False`) still serialize a single DataObject as a bare
`{backend, path, metadata}` reference and reconstruct it bare downstream
(#1811).

This PR does **not** fix the drift. It lands a strict-`xfail` regression
baseline that pins the residual drift so the root-cause fix (option (a):
treat every DataObject port as a Collection) can be verified as a clean
xfail→pass flip, and so the gap cannot silently regress in the meantime.

## What this adds

`tests/engine/test_single_value_collection_contract.py` — 7 `xfail(strict=True)`
tests covering the **closed codec set** of single-value transport boundaries:

- `_normalize_outputs` on an `is_collection=False` port (bare object + bare list)
- `serialise_outputs` of a single DataObject should emit a `_collection` envelope
- `reconstruct_inputs` of a bare wire dict should yield a length-one Collection
- single-value `serialise_outputs` → `reconstruct_inputs` round trip
- `ProcessBlock.run` non-Collection fallback should emit a Collection
- scheduler in-process boundary (`_dispatch.py:325`) integration via `DAGScheduler`

All 7 xfail today; `strict=True` flips them to failures (forcing marker removal)
when the fix lands. The module docstring records the completeness argument: a
bare DataObject can only exist at the transport codec (`_serialise_one` /
`_reconstruct_one` / `_block_outputs` writers), which is a small greppable set,
so these four boundaries are the full root-cause surface — checkpoint restore
and worker terminal outputs inherit the same codec and are fixed transitively.

## Note for the follow-up fix

When option (a) lands, `tests/engine/test_collection_wrap.py::TestEngineLeavesNonCollectionPortAlone`
(which pins the *current* drift as intended #1330 behaviour) must be revisited
in the same change; this is called out in the new file's docstring.

Gate record: .workflow/records/1811-guided-1811-single-value-collection-xfail.json

Closes #1813

Refs #1811 (parent drift issue — stays open for the root-cause fix)
