### PR TITLE
feat(#1810): native Excel (.xlsx) read/write for core DataFrame & Series

### DIFF
--- a/.workflow/records/1810-feature-1810-dataframe-xlsx-io.json
+++ b/.workflow/records/1810-feature-1810-dataframe-xlsx-io.json
@@ -171,6 +171,177 @@
       "status": "pass",
       "summary": "clean",
       "tool_versions": {}
+    },
+    {
+      "at": "2026-06-27T13:33:32.315316Z",
+      "command": "pytest tests/architecture/ -v --no-cov",
+      "covered_surface": "architecture",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:41c626fcbe0f53318328a86edac58220e20dca5fd083557c0bd8029a18bcbba3",
+      "name": "architecture_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/architecture_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-27T13:33:33.016115Z",
+      "command": "python scripts/deferral_scan.py --check docs/audit/baselines/deferral-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:200d77405848713b6e9a8b8c721992d920843d3234e21e90d02009d55a0cb134",
+      "name": "deferral_discipline",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/deferral_discipline.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-27T13:33:33.070352Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:b2856c1daefbf4b0f2854c906d55d643455eaf192290d7c97fbe7286baae86bc",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-27T13:34:40.689074Z",
+      "command": "(cd frontend && npm run check:ci)",
+      "covered_surface": "frontend",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:76cca68bc2086e618270db47d2c6bdc9aa639b3cd7ad5d2aab0eade52c855304",
+      "name": "frontend",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/frontend.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-27T13:34:44.360410Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:f5f01fda93a49e35720a899d41e39fd180fb131e15e88eea012748e6675b1fb5",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-27T13:34:44.501223Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e0a217b2dda9aa8a85cae191322a46110c8e5b8673d12bca1fbb65e44283d7c6",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-27T13:34:44.551679Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:d8b80668d36032b1dcba08dd488b06a0af08b3e60ae7745367ec5d00a5426a44",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-27T13:37:03.214921Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:469fa3a5e619bafe2ef38bb5cadc1af5ca7086340f1552317c0e2dde80acee61",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-27T13:38:52.171567Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:fcd73a58e013871b4bfbcd433f7ce42e5a5acbf31c59268a969c9b8c134cc0e8",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-27T13:38:52.720698Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:ead67c1fc9cade94beab7cef5ec3c31bb30c95ebba7cf18758b6d831a29e505f",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    },
+    {
+      "at": "2026-06-27T13:38:55.343996Z",
+      "command": "python -m build --wheel",
+      "covered_surface": "packaging",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:17dcfc797e4a59fe89e1b89b76206759638030d6612704b276ae7521ecb51ad6",
+      "name": "wheel_release_smoke",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/wheel_release_smoke.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
     }
   ],
   "check_na": [],
@@ -510,6 +681,258 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:38:55.372520Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/base/interactive.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/base/interactive.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/io/loaders/_capability.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/io/loaders/_capability.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/io/loaders/_helpers.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/io/loaders/_helpers.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/io/loaders/load_data.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/io/loaders/load_data.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/io/savers/_capability.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/io/savers/_capability.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/io/savers/_helpers.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/io/savers/_helpers.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/io/savers/save_data.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/io/savers/save_data.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:38:55.383120Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:38:55.393627Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:38:55.404465Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:38:55.415800Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:38:55.426289Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:38:55.435618Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:38:55.444362Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:38:55.453673Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:38:55.464199Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:43:10.964466Z",
+      "findings": [
+        {
+          "message": "AI-authored edits must happen in a dedicated worktree, not the main working tree (/private/var/folders/mk/xk0dqvn934l5425gwb19rsqc0000gn/T/pytest-of-jiazhenz/pytest-719/popen-gw3/test_hook_payload_blocks_main_0/main). Create one with `git worktree add ../<name> <branch>` and run your edits there.",
+          "rule_id": "worktree.main-checkout-write"
+        }
+      ],
+      "guard": "worktree_write_guard",
+      "status": "fail"
+    },
+    {
+      "at": "2026-06-27T13:43:11.866467Z",
+      "findings": [
+        {
+          "message": "AI-authored edits must happen in a dedicated worktree, not the main working tree (/private/var/folders/mk/xk0dqvn934l5425gwb19rsqc0000gn/T/pytest-of-jiazhenz/pytest-719/popen-gw3/test_hook_payload_extracts_mul0/main). Create one with `git worktree add ../<name> <branch>` and run your edits there.",
+          "rule_id": "worktree.main-checkout-write"
+        }
+      ],
+      "guard": "worktree_write_guard",
+      "status": "fail"
     }
   ],
   "issues": [
@@ -548,9 +971,9 @@
       "tests/blocks/io/test_save_data_capabilities.py",
       "tests/blocks/io/test_xlsx_io.py"
     ],
-    "diff_fingerprint": "sha256:401d0c7055a3ad924222a589079bdc24cc10b4beac34e2ed869fa4f730cc75b5",
+    "diff_fingerprint": "sha256:e8a57cd23492d53d2f90c7b532377ead06dabaae803e20d9ef99963372a1663c",
     "head": "HEAD",
-    "head_sha": "5d5895eb",
+    "head_sha": "b30ec661",
     "surfaces": {
       "docs": 1,
       "frontend": 2,
@@ -582,6 +1005,18 @@
         "guard.docs_landing",
         "guard.mod_guard",
         "tests.changed_test_required"
+      ]
+    },
+    {
+      "at": "2026-06-27T13:38:55.464235Z",
+      "diff_fingerprint": "sha256:e8a57cd23492d53d2f90c7b532377ead06dabaae803e20d9ef99963372a1663c",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.format_check",
+        "checks.lint_format",
+        "checks.python_tests"
       ]
     }
   ],

--- a/.workflow/records/1810-feature-1810-dataframe-xlsx-io.json
+++ b/.workflow/records/1810-feature-1810-dataframe-xlsx-io.json
@@ -1,0 +1,694 @@
+{
+  "branch": "feature/1810-dataframe-xlsx-io",
+  "check_events": [
+    {
+      "at": "2026-06-27T13:11:59.774048Z",
+      "command": "pytest tests/architecture/ -v --no-cov",
+      "covered_surface": "architecture",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:41c626fcbe0f53318328a86edac58220e20dca5fd083557c0bd8029a18bcbba3",
+      "name": "architecture_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/architecture_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-27T13:12:00.480694Z",
+      "command": "python scripts/deferral_scan.py --check docs/audit/baselines/deferral-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:200d77405848713b6e9a8b8c721992d920843d3234e21e90d02009d55a0cb134",
+      "name": "deferral_discipline",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/deferral_discipline.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-27T13:12:00.821131Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:b2856c1daefbf4b0f2854c906d55d643455eaf192290d7c97fbe7286baae86bc",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-27T13:12:56.685369Z",
+      "command": "(cd frontend && npm run check:ci)",
+      "covered_surface": "frontend",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:76cca68bc2086e618270db47d2c6bdc9aa639b3cd7ad5d2aab0eade52c855304",
+      "name": "frontend",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/frontend.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-27T13:13:00.638282Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:f5f01fda93a49e35720a899d41e39fd180fb131e15e88eea012748e6675b1fb5",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-27T13:13:01.144203Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e0a217b2dda9aa8a85cae191322a46110c8e5b8673d12bca1fbb65e44283d7c6",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-27T13:13:01.217453Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:d8b80668d36032b1dcba08dd488b06a0af08b3e60ae7745367ec5d00a5426a44",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-27T13:16:34.145084Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:469fa3a5e619bafe2ef38bb5cadc1af5ca7086340f1552317c0e2dde80acee61",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-27T13:22:19.035095Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:fcd73a58e013871b4bfbcd433f7ce42e5a5acbf31c59268a969c9b8c134cc0e8",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-27T13:22:26.994146Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:ead67c1fc9cade94beab7cef5ec3c31bb30c95ebba7cf18758b6d831a29e505f",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    },
+    {
+      "at": "2026-06-27T13:22:30.086645Z",
+      "command": "python -m build --wheel",
+      "covered_surface": "packaging",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:17dcfc797e4a59fe89e1b89b76206759638030d6612704b276ae7521ecb51ad6",
+      "name": "wheel_release_smoke",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/wheel_release_smoke.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    }
+  ],
+  "check_na": [],
+  "commit": null,
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "pyproject.toml",
+      "src/scistudio/blocks/io/loaders/**",
+      "src/scistudio/blocks/io/savers/**",
+      "tests/**",
+      "docs/**"
+    ]
+  },
+  "directive_events": [
+    {
+      "at": "2026-06-27T12:04:00.052735Z",
+      "owner_directive": "There is a dedicated pairwise/matrix IO test suite (save format x load format round-trips). Add xlsx coverage to it, not only standalone xlsx tests.",
+      "reason": "owner: extend the existing pairwise IO test matrix to cover the new xlsx format"
+    },
+    {
+      "at": "2026-06-27T12:08:11.217072Z",
+      "owner_directive": "Multi-sheet xlsx read: read an n-sheet workbook as a Collection of n DataFrames (one DataFrame per sheet), preserving each sheet name so the user can see what they are. (Supersedes the earlier read-time sheet-selection parameter idea.)",
+      "reason": "owner refined multi-sheet xlsx read semantics"
+    },
+    {
+      "at": "2026-06-27T12:33:25.517981Z",
+      "owner_directive": "xlsx read = all sheets of all loaded files flattened into one Collection of DataFrames (block-level fan-out in LoadData; engine unchanged per ADR-020 item-strategy delegation). xlsx port is_collection=True. Save: Collection -> one multi-sheet workbook; single DataFrame -> single sheet. Sheet names in user['sheet_name']. Residual single-value bare-transport drift tracked separately as #1811 (out of scope here).",
+      "reason": "finalize xlsx design: all-sheets->one collection (block-level fan-out, flatten across multi-path); residual is_collection drift tracked in #1811"
+    },
+    {
+      "at": "2026-06-27T12:40:17.092450Z",
+      "owner_directive": "xlsx Collection save groups items by framework.source (the originating workbook the loader recorded): each distinct source file -> one multi-sheet workbook (sheets named by user['sheet_name']); items with no source -> all written into ONE multi-sheet workbook (named by the configured filename). Single DataFrame -> single sheet. This makes load/save round-trip the original file<->sheet grouping. Reuses existing framework.source tracking + _save_collection folder convention.",
+      "reason": "finalize xlsx save grouping semantics"
+    },
+    {
+      "at": "2026-06-27T12:58:57.068094Z",
+      "owner_directive": "Same-file/different-sheet collection items collide in display names (frontend deriveDisplayName + DataRouter interactive_item_label use framework.source only). Fix in this PR via a generic user['display_name'] hook: xlsx loader composes '<file> \u2014 <sheet>'; interactive_item_label and frontend deriveDisplayName prefer user['display_name']. General canonical display-name convention tracked separately as #1812.",
+      "reason": "include per-item display-name fix for same-file-different-sheet collision; track general convention separately"
+    }
+  ],
+  "docs_events": [
+    {
+      "at": "2026-06-27T13:32:58.089334Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/specs/adr-043-io-format-capability-registry.md",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": true,
+  "guard_events": [
+    {
+      "at": "2026-06-27T13:22:30.145819Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/base/interactive.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/base/interactive.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/io/loaders/_capability.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/io/loaders/_capability.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/io/loaders/_helpers.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/io/loaders/_helpers.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/io/loaders/load_data.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/io/loaders/load_data.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/io/savers/_capability.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/io/savers/_capability.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/io/savers/_helpers.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/io/savers/_helpers.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/io/savers/save_data.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/io/savers/save_data.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:22:30.169380Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {
+            "governed_files": [
+              "frontend/src/components/DataPreview.parts/refEntries.test.ts",
+              "frontend/src/components/DataPreview.parts/refEntries.ts",
+              "pyproject.toml",
+              "src/scistudio/blocks/base/interactive.py",
+              "src/scistudio/blocks/io/loaders/_capability.py",
+              "src/scistudio/blocks/io/loaders/_helpers.py",
+              "src/scistudio/blocks/io/loaders/load_data.py",
+              "src/scistudio/blocks/io/savers/_capability.py",
+              "src/scistudio/blocks/io/savers/_helpers.py",
+              "src/scistudio/blocks/io/savers/save_data.py"
+            ]
+          },
+          "expected": null,
+          "file": "",
+          "finding_class": "docs_landing",
+          "git_evidence": null,
+          "id": "docs_landing.missing-landing",
+          "line": null,
+          "message": "governed change requires docs/changelog/checklist landing evidence or an explicit N/A rationale",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "docs_landing.missing-landing",
+          "severity": "error",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "docs_landing",
+      "status": "fail"
+    },
+    {
+      "at": "2026-06-27T13:22:30.190569Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:22:30.211391Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:22:30.235267Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "pyproject.toml",
+          "finding_class": "governance",
+          "git_evidence": null,
+          "id": "governance.mod_guard.unauthorized-change",
+          "line": null,
+          "message": "governance-critical file changed without authorization; declare governance_touch in the ledger and obtain owner review",
+          "path": "pyproject.toml",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "governance.mod_guard.unauthorized-change",
+          "severity": "error",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "mod_guard",
+      "status": "fail"
+    },
+    {
+      "at": "2026-06-27T13:22:30.256192Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:22:30.280323Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:22:30.301658Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:22:30.320426Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:22:30.345199Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1810,
+      "url": null
+    },
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1809,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": {
+    "base": "origin/main",
+    "base_sha": "d7c3314b",
+    "changed_files": [
+      ".workflow/records/1810-feature-1810-dataframe-xlsx-io.json",
+      "docs/specs/adr-043-io-format-capability-registry.md",
+      "frontend/src/components/DataPreview.parts/refEntries.test.ts",
+      "frontend/src/components/DataPreview.parts/refEntries.ts",
+      "pyproject.toml",
+      "src/scistudio/blocks/base/interactive.py",
+      "src/scistudio/blocks/io/loaders/_capability.py",
+      "src/scistudio/blocks/io/loaders/_helpers.py",
+      "src/scistudio/blocks/io/loaders/load_data.py",
+      "src/scistudio/blocks/io/savers/_capability.py",
+      "src/scistudio/blocks/io/savers/_helpers.py",
+      "src/scistudio/blocks/io/savers/save_data.py",
+      "tests/blocks/io/test_io_coverage_matrix.py",
+      "tests/blocks/io/test_load_data_capabilities.py",
+      "tests/blocks/io/test_save_data_capabilities.py",
+      "tests/blocks/io/test_xlsx_io.py"
+    ],
+    "diff_fingerprint": "sha256:401d0c7055a3ad924222a589079bdc24cc10b4beac34e2ed869fa4f730cc75b5",
+    "head": "HEAD",
+    "head_sha": "5d5895eb",
+    "surfaces": {
+      "docs": 1,
+      "frontend": 2,
+      "governance": 1,
+      "governed_docs": 0,
+      "implementation": 10,
+      "packaging": 1,
+      "protected_core": 7,
+      "sentrux": 14,
+      "test": 5,
+      "workflow_ci": 0
+    }
+  },
+  "owner_directive": "Add native Excel .xlsx read/write for core DataFrame and Series via pandas+openpyxl bridge: add openpyxl dep, xlsx format capabilities (load+save) for DataFrame and Series, load/save branches, a sheet-selection config param (read: choose sheet default first; write: target sheet default Sheet1), Excel row/col overflow guard, CSV-aligned metadata_fidelity. Also fold in: raise numpy floor >=1.25 -> >=2.1 (issue #1809). Protected core path authorized via admin-approved:core-change.",
+  "persona": "implementer",
+  "pull_request": null,
+  "reconcile_events": [
+    {
+      "at": "2026-06-27T13:22:30.345290Z",
+      "diff_fingerprint": "sha256:401d0c7055a3ad924222a589079bdc24cc10b4beac34e2ed869fa4f730cc75b5",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.format_check",
+        "checks.lint_format",
+        "checks.python_tests",
+        "docs.docs_required_or_na",
+        "guard.docs_landing",
+        "guard.mod_guard",
+        "tests.changed_test_required"
+      ]
+    }
+  ],
+  "record_id": "1810-feature-1810-dataframe-xlsx-io",
+  "requested_admin_labels": [
+    {
+      "actor_permission": null,
+      "applied_at": null,
+      "applied_by": null,
+      "name": "admin-approved:core-change"
+    }
+  ],
+  "required_obligations": {
+    "admin_labels": [
+      "admin-approved:core-change"
+    ],
+    "checks": [
+      "architecture_tests",
+      "deferral_discipline",
+      "format_check",
+      "frontend",
+      "full_audit",
+      "import_contracts",
+      "lint_format",
+      "python_tests",
+      "semantic_dup",
+      "type_check",
+      "wheel_release_smoke"
+    ],
+    "docs": [
+      "docs_required_or_na"
+    ],
+    "guards": [
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": [
+      "changed_test_required"
+    ]
+  },
+  "runtime": "claude-code",
+  "schema_version": 2,
+  "scope_events": [
+    {
+      "action": "add-include",
+      "at": "2026-06-27T12:58:57.068204Z",
+      "pattern": "src/scistudio/blocks/base/interactive.py",
+      "reason": "include per-item display-name fix for same-file-different-sheet collision; track general convention separately"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-27T12:58:57.068211Z",
+      "pattern": "frontend/**",
+      "reason": "include per-item display-name fix for same-file-different-sheet collision; track general convention separately"
+    }
+  ],
+  "session_id": "23d0ca14-3dfd-499a-8afd-f8a675f81709",
+  "strictness_tier": 1,
+  "task_kind": "feature",
+  "test_events": [
+    {
+      "at": "2026-06-27T13:32:58.089482Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/blocks/io/test_xlsx_io.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-27T13:32:58.089486Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/blocks/io/test_io_coverage_matrix.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-27T13:32:58.089488Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/blocks/io/test_load_data_capabilities.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-27T13:32:58.089489Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/blocks/io/test_save_data_capabilities.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-27T13:32:58.089491Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/components/DataPreview.parts/refEntries.test.ts",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/.workflow/records/1810-feature-1810-dataframe-xlsx-io.json
+++ b/.workflow/records/1810-feature-1810-dataframe-xlsx-io.json
@@ -345,7 +345,13 @@
     }
   ],
   "check_na": [],
-  "commit": null,
+  "commit": {
+    "sha": "92c192a5853a4699aff4ca493ad716c9020cb51b",
+    "shas": [
+      "92c192a5853a4699aff4ca493ad716c9020cb51b"
+    ],
+    "trailers": []
+  },
   "declared_scope": {
     "exclude": [],
     "include": [
@@ -933,6 +939,236 @@
       ],
       "guard": "worktree_write_guard",
       "status": "fail"
+    },
+    {
+      "at": "2026-06-27T13:45:59.090492Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/base/interactive.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/base/interactive.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/io/loaders/_capability.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/io/loaders/_capability.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/io/loaders/_helpers.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/io/loaders/_helpers.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/io/loaders/load_data.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/io/loaders/load_data.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/io/savers/_capability.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/io/savers/_capability.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/io/savers/_helpers.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/io/savers/_helpers.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/io/savers/save_data.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/io/savers/save_data.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:45:59.116830Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:45:59.146270Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:45:59.167481Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:45:59.186368Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:45:59.211943Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:45:59.229482Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:45:59.254122Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:45:59.272521Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:45:59.300726Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -951,7 +1187,7 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "origin/main",
+    "base": "d7c3314bef0fee826620b5a675f156f60053c045",
     "base_sha": "d7c3314b",
     "changed_files": [
       ".workflow/records/1810-feature-1810-dataframe-xlsx-io.json",
@@ -971,9 +1207,9 @@
       "tests/blocks/io/test_save_data_capabilities.py",
       "tests/blocks/io/test_xlsx_io.py"
     ],
-    "diff_fingerprint": "sha256:e8a57cd23492d53d2f90c7b532377ead06dabaae803e20d9ef99963372a1663c",
+    "diff_fingerprint": "sha256:1db5a972b45fbec7f182db5202b0ab5939d3eaa3895cd1348577c776c0a93525",
     "head": "HEAD",
-    "head_sha": "b30ec661",
+    "head_sha": "92c192a5",
     "surfaces": {
       "docs": 1,
       "frontend": 2,
@@ -989,7 +1225,12 @@
   },
   "owner_directive": "Add native Excel .xlsx read/write for core DataFrame and Series via pandas+openpyxl bridge: add openpyxl dep, xlsx format capabilities (load+save) for DataFrame and Series, load/save branches, a sheet-selection config param (read: choose sheet default first; write: target sheet default Sheet1), Excel row/col overflow guard, CSV-aligned metadata_fidelity. Also fold in: raise numpy floor >=1.25 -> >=2.1 (issue #1809). Protected core path authorized via admin-approved:core-change.",
   "persona": "implementer",
-  "pull_request": null,
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [],
+    "number": 1815,
+    "url": null
+  },
   "reconcile_events": [
     {
       "at": "2026-06-27T13:22:30.345290Z",
@@ -1010,6 +1251,18 @@
     {
       "at": "2026-06-27T13:38:55.464235Z",
       "diff_fingerprint": "sha256:e8a57cd23492d53d2f90c7b532377ead06dabaae803e20d9ef99963372a1663c",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.format_check",
+        "checks.lint_format",
+        "checks.python_tests"
+      ]
+    },
+    {
+      "at": "2026-06-27T13:45:59.300787Z",
+      "diff_fingerprint": "sha256:1db5a972b45fbec7f182db5202b0ab5939d3eaa3895cd1348577c776c0a93525",
       "mode": "pre-pr",
       "result": "fail",
       "tier": 1,

--- a/docs/specs/adr-043-io-format-capability-registry.md
+++ b/docs/specs/adr-043-io-format-capability-registry.md
@@ -224,6 +224,33 @@ Acceptance Scenarios:
 - AppBlock output directory contains files with the right extension but no
   reconstructing loader for the declared type.
 
+#### Excel (`.xlsx`) is collection-valued (#1810)
+
+The core `DataFrame`/`Series` `xlsx` capability is the one core format whose
+load is intrinsically multi-valued: an `.xlsx` workbook holds N sheets, so a
+single file loads as one DataObject **per sheet**. To keep the engine's static
+port contract honest (a port's `is_collection` is config-derivable; ADR-020 §3),
+`LoadData` declares `is_collection=True` for any `.xlsx` path and fans the
+workbook out into a `Collection` (one item per sheet) — a single-sheet file is a
+length-one Collection. Multiple `.xlsx` paths flatten every sheet of every file
+into one Collection. The fan-out lives in the block (`LoadData.load`), not the
+engine, per ADR-020's item-strategy delegation.
+
+Each sheet DataObject carries `framework.source` (the originating workbook —
+shared by all of that file's sheets) and `user["sheet_name"]` (the structural
+sheet identity) plus a generic `user["display_name"]` presentation hook
+(`"<file> — <sheet>"`) so same-file/different-sheet items do not collide in
+DataRouter / preview lists. The generic display-name convention is tracked
+separately (#1812).
+
+On save, an xlsx `Collection` regroups by `framework.source`: each distinct
+source workbook becomes one multi-sheet file (sheets named by
+`user["sheet_name"]`); source-less items are written into one workbook named by
+the configured filename. A single DataObject saves to a single sheet. This makes
+the load → save round-trip reproduce the original file ↔ sheet grouping. Excel's
+hard sheet limits (1,048,576 rows × 16,384 columns) are enforced with a clear
+error rather than silent truncation.
+
 ## 3. Requirements
 
 ### Functional Requirements

--- a/frontend/src/components/DataPreview.parts/refEntries.test.ts
+++ b/frontend/src/components/DataPreview.parts/refEntries.test.ts
@@ -37,6 +37,21 @@ describe("extractRefEntries", () => {
     ]);
   });
 
+  it("prefers user.display_name over framework.source (#1810 — disambiguates xlsx sheets)", () => {
+    // Two sheets of one workbook share framework.source; the per-item
+    // user.display_name is what keeps them distinct.
+    const result = extractRefEntries({
+      data_ref: "data-sheet2",
+      metadata: {
+        framework: { source: "/data/exp.xlsx" },
+        user: { sheet_name: "beta", display_name: "exp.xlsx — beta" },
+      },
+    });
+    expect(result).toEqual([
+      expect.objectContaining({ ref: "data-sheet2", displayName: "exp.xlsx — beta" }),
+    ]);
+  });
+
   it("falls back to metadata.meta.source_file when framework absent", () => {
     const result = extractRefEntries({
       data_ref: "data-xyz",

--- a/frontend/src/components/DataPreview.parts/refEntries.ts
+++ b/frontend/src/components/DataPreview.parts/refEntries.ts
@@ -31,6 +31,15 @@ export function deriveDisplayName(ref: string, dataItem: Record<string, unknown>
   const md = dataItem.metadata;
   if (md && typeof md === "object") {
     const mdRec = md as Record<string, unknown>;
+    // 0. Generic user-set display name (#1810 interim, #1812 convention). The
+    // producer composes a user-facing label — e.g. "<file> — <sheet>" for an
+    // .xlsx sheet — so same-file/different-sheet items don't collide. Preferred
+    // over file-based heuristics because it is an explicit presentation choice.
+    const user = mdRec.user;
+    if (user && typeof user === "object") {
+      const displayName = (user as Record<string, unknown>).display_name;
+      if (typeof displayName === "string" && displayName) return displayName;
+    }
     // 1. Typed source-file metadata. Imaging and spectroscopy loaders both
     // use this when the framework source is package provenance rather than a
     // user-facing filename.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "fastapi>=0.110,<0.139",  # Starlette 1.3 nests included routers under _IncludedRouter; route-contract tests handle both layouts (#1769).
     "python-multipart>=0.0.9",
     "uvicorn[standard]>=0.29",
-    "numpy>=1.25",  # Core Array/storage/preview/plot paths import NumPy directly.
+    "numpy>=2.1",  # Core Array/storage/preview/plot paths import NumPy directly; numpy-2 baseline (#1809) — runtime + mypy stubs already assume 2.x.
     "zarr>=3.0",
     "pyarrow>=15.0",
     "watchdog>=4.0",
@@ -36,6 +36,7 @@ dependencies = [
     "fastmcp>=3.1,<4",  # ADR-040 §3.1: FastMCP migration — replaces hand-rolled JSON-RPC MCP server with FastMCP 3.x.
     "matplotlib>=3.8",  # ADR-048 SPEC 2: Python plot jobs import matplotlib in the core plot runtime.
     "pandas>=2.2",  # ADR-048 SPEC 2: Python plot jobs open DataFrame/Series inputs with pandas.
+    "openpyxl>=3.1",  # #1810: core DataFrame/Series .xlsx read/write (pandas Excel engine).
 ]
 
 [project.optional-dependencies]

--- a/src/scistudio/blocks/base/interactive.py
+++ b/src/scistudio/blocks/base/interactive.py
@@ -237,12 +237,15 @@ def interactive_item_label(item: Any, index: int) -> str:
     identifying name in this order:
 
     1. an explicit ``name`` attribute, if the object carries one;
-    2. the originating file's basename from typed domain metadata
+    2. the generic ``user['display_name']`` presentation hook (#1810 interim,
+       #1812 convention) — e.g. ``"<file> — <sheet>"`` for an .xlsx sheet so
+       same-file/different-sheet items do not collide;
+    3. the originating file's basename from typed domain metadata
        (``item.meta.source_file`` — populated by the loaders for spectra,
        images, etc.);
-    3. an :class:`~scistudio.core.types.artifact.Artifact`-style ``file_path``
+    4. an :class:`~scistudio.core.types.artifact.Artifact`-style ``file_path``
        basename;
-    4. ``item_<index>`` as the last resort.
+    5. ``item_<index>`` as the last resort.
 
     The lookups are all duck-typed so the helper stays type-agnostic across the
     DataObject hierarchy and any plugin-provided type.
@@ -250,6 +253,11 @@ def interactive_item_label(item: Any, index: int) -> str:
     name = getattr(item, "name", None)
     if isinstance(name, str) and name:
         return name
+
+    user = getattr(item, "user", None)
+    display_name = user.get("display_name") if isinstance(user, dict) else None
+    if isinstance(display_name, str) and display_name:
+        return display_name
 
     meta = getattr(item, "meta", None)
     source_file = getattr(meta, "source_file", None) if meta is not None else None

--- a/src/scistudio/blocks/io/loaders/_capability.py
+++ b/src/scistudio/blocks/io/loaders/_capability.py
@@ -171,6 +171,14 @@ _LOAD_CAPABILITIES: tuple[FormatCapability, ...] = (
     _load_capability(
         data_type=DataFrame,
         type_name="DataFrame",
+        format_id="xlsx",
+        extensions=(".xlsx",),
+        label="Excel",
+        handler="load",
+    ),
+    _load_capability(
+        data_type=DataFrame,
+        type_name="DataFrame",
         format_id="pickle",
         extensions=(".pkl", ".pickle"),
         label="Pickle",
@@ -200,6 +208,14 @@ _LOAD_CAPABILITIES: tuple[FormatCapability, ...] = (
         format_id="parquet",
         extensions=(".parquet", ".pq"),
         label="Parquet",
+        handler="load",
+    ),
+    _load_capability(
+        data_type=Series,
+        type_name="Series",
+        format_id="xlsx",
+        extensions=(".xlsx",),
+        label="Excel",
         handler="load",
     ),
     _load_capability(

--- a/src/scistudio/blocks/io/loaders/_helpers.py
+++ b/src/scistudio/blocks/io/loaders/_helpers.py
@@ -142,10 +142,7 @@ def _read_xlsx_sheets(path: Path) -> list[tuple[str, Any]]:
 
     # ``sheet_name=None`` returns an ordered dict {sheet_name: DataFrame}.
     frames = pd.read_excel(path, sheet_name=None, engine="openpyxl")
-    return [
-        (str(name), pa.Table.from_pandas(frame, preserve_index=False))
-        for name, frame in frames.items()
-    ]
+    return [(str(name), pa.Table.from_pandas(frame, preserve_index=False)) for name, frame in frames.items()]
 
 
 __all__ = [

--- a/src/scistudio/blocks/io/loaders/_helpers.py
+++ b/src/scistudio/blocks/io/loaders/_helpers.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
+from typing import Any
 
 from scistudio.blocks.base.config import BlockConfig
 from scistudio.core.types.array import Array
@@ -124,11 +125,35 @@ def _check_pickle_allowed(path: Path, config: BlockConfig) -> bool:
     return True
 
 
+# ---------------------------------------------------------------------------
+# Excel (.xlsx) read support (#1810)
+# ---------------------------------------------------------------------------
+
+
+def _read_xlsx_sheets(path: Path) -> list[tuple[str, Any]]:
+    """Read every sheet of an .xlsx workbook into ``(sheet_name, pa.Table)``.
+
+    Uses the pandas + openpyxl bridge (#1810). Returns one entry per sheet in
+    workbook order so the loader can fan a multi-sheet workbook out into a
+    Collection of one DataObject per sheet, preserving the sheet name.
+    """
+    import pandas as pd
+    import pyarrow as pa
+
+    # ``sheet_name=None`` returns an ordered dict {sheet_name: DataFrame}.
+    frames = pd.read_excel(path, sheet_name=None, engine="openpyxl")
+    return [
+        (str(name), pa.Table.from_pandas(frame, preserve_index=False))
+        for name, frame in frames.items()
+    ]
+
+
 __all__ = [
     "_CORE_TYPE_MAP",
     "_LOGGER",
     "_MIME_GUESS",
     "_TEXT_FORMAT_MAP",
     "_check_pickle_allowed",
+    "_read_xlsx_sheets",
     "_resolve_path",
 ]

--- a/src/scistudio/blocks/io/loaders/load_data.py
+++ b/src/scistudio/blocks/io/loaders/load_data.py
@@ -70,6 +70,7 @@ from scistudio.blocks.io.loaders._helpers import (
     _MIME_GUESS,
     _TEXT_FORMAT_MAP,
     _check_pickle_allowed,
+    _read_xlsx_sheets,
     _resolve_path,
 )
 from scistudio.core.meta.framework import FrameworkMeta
@@ -87,6 +88,12 @@ def _source_framework(path: Path) -> FrameworkMeta:
     """Return framework metadata that preserves the boundary source path."""
 
     return FrameworkMeta(source=str(path))
+
+
+def _is_xlsx_path(path: Any) -> bool:
+    """True when *path* points at an Excel ``.xlsx`` file (#1810)."""
+
+    return str(path).lower().endswith(".xlsx")
 
 
 class LoadData(IOBlock):
@@ -194,8 +201,14 @@ class LoadData(IOBlock):
             from scistudio.blocks.io._unified_dispatch import resolve_type_class
 
             cls = resolve_type_class(str(type_name)) or DataObject
-        is_multi = isinstance(self.config.get("path"), list)
-        return [OutputPort(name="data", accepted_types=[cls], is_collection=is_multi)]
+        # #1810: a multi-path list is always a Collection; an .xlsx source is
+        # also always a Collection (one DataFrame/Series per sheet), so the port
+        # statically declares is_collection=True for it even on a single path.
+        raw_path = self.config.get("path")
+        path_list = raw_path if isinstance(raw_path, list) else ([raw_path] if raw_path else [])
+        is_multi = isinstance(raw_path, list)
+        is_xlsx = type_name in {"DataFrame", "Series"} and any(_is_xlsx_path(p) for p in path_list)
+        return [OutputPort(name="data", accepted_types=[cls], is_collection=is_multi or is_xlsx)]
 
     def load(self, config: BlockConfig, output_dir: str = "") -> DataObject | Collection:
         """Dispatch to one of the six private ``_load_*`` functions.
@@ -246,8 +259,17 @@ class LoadData(IOBlock):
             raise ValueError(f"Unknown core_type: {type_name}")
 
         raw_path = config.get("path")
-        if isinstance(raw_path, list):
-            # Multi-path: load each file and return a Collection.
+        path_list = raw_path if isinstance(raw_path, list) else [raw_path]
+        is_multi = isinstance(raw_path, list)
+        # #1810: a DataFrame/Series .xlsx source fans out into one object per
+        # sheet. Across a multi-path list, every sheet of every file is
+        # flattened into one Collection (engine stays unchanged — item strategy
+        # is the block's responsibility per ADR-020).
+        xlsx_active = type_name in {"DataFrame", "Series"} and any(
+            _is_xlsx_path(p) for p in path_list
+        )
+
+        if is_multi or xlsx_active:
             loader = dispatch[type_name]
             item_cls = _CORE_TYPE_MAP[type_name]
             shared_params: dict[str, Any] = {"core_type": type_name}
@@ -255,13 +277,73 @@ class LoadData(IOBlock):
             if allow_pickle is not None:
                 shared_params["allow_pickle"] = allow_pickle
             items: list[DataObject] = []
-            for single_path in raw_path:
+            for single_path in path_list:
                 single_config = BlockConfig(params={**shared_params, "path": str(single_path)})
-                items.append(loader(single_config, output_dir))
+                if xlsx_active and _is_xlsx_path(single_path):
+                    items.extend(self._load_xlsx_objects(single_config, output_dir, type_name))
+                else:
+                    items.append(loader(single_config, output_dir))
             return Collection(items=items, item_type=item_cls)
 
         result: DataObject = dispatch[type_name](config, output_dir)
         return result
+
+    def _load_xlsx_objects(
+        self, config: BlockConfig, output_dir: str, type_name: str
+    ) -> list[DataObject]:
+        """Load one DataFrame/Series per sheet of an .xlsx workbook (#1810).
+
+        Each sheet becomes its own DataObject carrying ``framework.source`` (the
+        workbook path — shared by all of that file's sheets so the saver can
+        regroup them) and ``user['sheet_name']`` (so the sheet name is visible
+        and the saver can re-name sheets on round-trip). Each sheet's table is
+        persisted to its own ``storage_ref`` via :meth:`persist_table`.
+        """
+        path = _resolve_path(config)
+        if not path.exists():
+            raise FileNotFoundError(f"LoadData: {type_name} source not found: {path}")
+        framework = _source_framework(path)
+        objects: list[DataObject] = []
+        for sheet_name, table in _read_xlsx_sheets(path):
+            # ``sheet_name`` is the structural identity (drives save grouping /
+            # sheet naming); ``display_name`` is the generic presentation hook
+            # (#1810 interim, #1812 convention) so same-file/different-sheet
+            # items don't collide in DataRouter / preview lists.
+            user = {"sheet_name": sheet_name, "display_name": f"{path.name} — {sheet_name}"}
+            storage_ref = self.persist_table(table, output_dir) if output_dir else None
+            if type_name == "Series":
+                if table.num_columns != 1:
+                    raise ValueError(
+                        f"LoadData(core_type='Series'): sheet {sheet_name!r} in {path} has "
+                        f"{table.num_columns} columns, expected a single-column Series sheet."
+                    )
+                objects.append(
+                    Series(
+                        index_name=None,
+                        value_name=table.column_names[0],
+                        length=int(table.num_rows),
+                        framework=framework,
+                        user=user,
+                        storage_ref=storage_ref,
+                        data=None if storage_ref is not None else table,
+                    )
+                )
+            else:
+                df = DataFrame(
+                    columns=list(table.column_names),
+                    row_count=int(table.num_rows),
+                    framework=framework,
+                    user=user,
+                    storage_ref=storage_ref,
+                )
+                # Mirror _load_dataframe: carry the table on ``_arrow_table`` when
+                # not persisted; the persisted case reads back via storage_ref.
+                if storage_ref is None:
+                    df._arrow_table = table  # type: ignore[attr-defined]
+                objects.append(df)
+        if not objects:
+            raise ValueError(f"LoadData: .xlsx workbook {path} contains no sheets.")
+        return objects
 
     def _load_array_with_persist(self, config: BlockConfig, output_dir: str) -> Array:
         """Load Array and persist to zarr storage.

--- a/src/scistudio/blocks/io/loaders/load_data.py
+++ b/src/scistudio/blocks/io/loaders/load_data.py
@@ -265,9 +265,7 @@ class LoadData(IOBlock):
         # sheet. Across a multi-path list, every sheet of every file is
         # flattened into one Collection (engine stays unchanged — item strategy
         # is the block's responsibility per ADR-020).
-        xlsx_active = type_name in {"DataFrame", "Series"} and any(
-            _is_xlsx_path(p) for p in path_list
-        )
+        xlsx_active = type_name in {"DataFrame", "Series"} and any(_is_xlsx_path(p) for p in path_list)
 
         if is_multi or xlsx_active:
             loader = dispatch[type_name]
@@ -288,9 +286,7 @@ class LoadData(IOBlock):
         result: DataObject = dispatch[type_name](config, output_dir)
         return result
 
-    def _load_xlsx_objects(
-        self, config: BlockConfig, output_dir: str, type_name: str
-    ) -> list[DataObject]:
+    def _load_xlsx_objects(self, config: BlockConfig, output_dir: str, type_name: str) -> list[DataObject]:
         """Load one DataFrame/Series per sheet of an .xlsx workbook (#1810).
 
         Each sheet becomes its own DataObject carrying ``framework.source`` (the

--- a/src/scistudio/blocks/io/savers/_capability.py
+++ b/src/scistudio/blocks/io/savers/_capability.py
@@ -160,6 +160,14 @@ _SAVE_CAPABILITIES: tuple[FormatCapability, ...] = (
     _save_capability(
         data_type=DataFrame,
         type_name="DataFrame",
+        format_id="xlsx",
+        extensions=(".xlsx",),
+        label="Excel",
+        handler="save",
+    ),
+    _save_capability(
+        data_type=DataFrame,
+        type_name="DataFrame",
         format_id="pickle",
         extensions=(".pkl", ".pickle"),
         label="Pickle",
@@ -197,6 +205,14 @@ _SAVE_CAPABILITIES: tuple[FormatCapability, ...] = (
         format_id="json",
         extensions=(".json",),
         label="JSON",
+        handler="save",
+    ),
+    _save_capability(
+        data_type=Series,
+        type_name="Series",
+        format_id="xlsx",
+        extensions=(".xlsx",),
+        label="Excel",
         handler="save",
     ),
     _save_capability(

--- a/src/scistudio/blocks/io/savers/_helpers.py
+++ b/src/scistudio/blocks/io/savers/_helpers.py
@@ -197,13 +197,96 @@ def _dataframe_to_arrow_table(obj: DataFrame) -> Any:
     )
 
 
+# ---------------------------------------------------------------------------
+# Excel (.xlsx) write support (#1810)
+# ---------------------------------------------------------------------------
+
+# Hard sheet limits of the .xlsx (Office Open XML) format.
+_XLSX_MAX_ROWS = 1_048_576
+_XLSX_MAX_COLS = 16_384
+
+
+def _check_xlsx_dimensions(n_rows: int, n_cols: int) -> None:
+    """Raise :class:`ValueError` when a table exceeds Excel's hard sheet limits.
+
+    Pure (no I/O) so the guard is unit-testable at the real limits without
+    materialising a million-row table. ``to_excel`` always writes a header row,
+    so the data-row budget is one less than the absolute maximum.
+    """
+    if n_rows > _XLSX_MAX_ROWS - 1:
+        raise ValueError(
+            f"Cannot save to .xlsx: {n_rows} rows exceed the Excel sheet limit of "
+            f"{_XLSX_MAX_ROWS - 1} data rows (a header row is also written). Use "
+            f".parquet or .csv for tables this large."
+        )
+    if n_cols > _XLSX_MAX_COLS:
+        raise ValueError(
+            f"Cannot save to .xlsx: {n_cols} columns exceed the Excel sheet limit "
+            f"of {_XLSX_MAX_COLS} columns. Use .parquet or .csv for tables this wide."
+        )
+
+
+def _safe_sheet_name(name: str, used: set[str], index: int) -> str:
+    """Return an Excel-legal, unique sheet name.
+
+    Excel sheet names are <=31 chars, cannot contain ``[]:*?/\\``, cannot be
+    blank, and must be unique within a workbook. Falls back to ``Sheet{index}``
+    for an empty name and de-duplicates by appending ``~N``.
+    """
+    cleaned = "".join("_" if ch in r"[]:*?/\\" else ch for ch in (name or "")).strip()
+    if not cleaned:
+        cleaned = f"Sheet{index}"
+    cleaned = cleaned[:31]
+    candidate = cleaned
+    suffix = 1
+    while candidate.casefold() in used:
+        tail = f"~{suffix}"
+        candidate = cleaned[: 31 - len(tail)] + tail
+        suffix += 1
+    used.add(candidate.casefold())
+    return candidate
+
+
+def _write_table_to_xlsx(table: Any, dest_path: Path, sheet_name: str = "Sheet1") -> None:
+    """Write a :class:`pyarrow.Table` to ``dest_path`` as a single-sheet .xlsx.
+
+    Uses the pandas + openpyxl bridge (#1810). The caller owns atomicity (wrap
+    in ``atomic_path``); this writes straight to ``dest_path``.
+    """
+    _write_tables_to_xlsx([(sheet_name or "Sheet1", table)], dest_path)
+
+
+def _write_tables_to_xlsx(named_tables: list[tuple[str, Any]], dest_path: Path) -> None:
+    """Write one or more ``(sheet_name, pa.Table)`` pairs into a single .xlsx.
+
+    Each pair becomes one sheet (#1810). Used both for the single-sheet save and
+    for the Collection -> multi-sheet workbook grouping path. Sheet names are
+    made Excel-legal and unique; each table is dimension-checked. The caller owns
+    atomicity (wrap in ``atomic_path``).
+    """
+    import pandas as pd
+
+    if not named_tables:
+        raise ValueError("Cannot write an .xlsx workbook with no sheets.")
+    used: set[str] = set()
+    with pd.ExcelWriter(dest_path, engine="openpyxl") as writer:
+        for idx, (raw_name, table) in enumerate(named_tables, start=1):
+            _check_xlsx_dimensions(int(table.num_rows), int(table.num_columns))
+            sheet = _safe_sheet_name(str(raw_name or ""), used, idx)
+            table.to_pandas().to_excel(writer, sheet_name=sheet, index=False)
+
+
 __all__ = [
     "_CORE_TYPE_MAP",
     "_PICKLE_EXTENSIONS",
     "_check_pickle_gate",
+    "_check_xlsx_dimensions",
     "_dataframe_to_arrow_table",
     "_require_path",
     "_resolve_core_type_name",
+    "_safe_sheet_name",
     "_slot_path_for",
     "_unwrap_for_save",
+    "_write_table_to_xlsx",
+    "_write_tables_to_xlsx",
 ]

--- a/src/scistudio/blocks/io/savers/save_data.py
+++ b/src/scistudio/blocks/io/savers/save_data.py
@@ -93,6 +93,8 @@ from scistudio.blocks.io.savers._helpers import (
     _resolve_core_type_name,
     _slot_path_for,
     _unwrap_for_save,
+    _write_table_to_xlsx,
+    _write_tables_to_xlsx,
     logger,  # noqa: F401  re-export for backward compat
 )
 from scistudio.blocks.io.savers._streaming import (
@@ -127,6 +129,18 @@ def _source_file_stem(obj: DataObject) -> tuple[str, str]:
         return type(obj).__name__.lower(), ""
     source_path = Path(source_name)
     return source_path.stem or source_path.name, source_path.name
+
+
+def _sheet_name_of(obj: DataObject) -> str | None:
+    """Return the round-trip Excel sheet name recorded at load (#1810).
+
+    The loader stores the originating sheet name in ``user['sheet_name']`` so a
+    saved workbook can reproduce it. Returns ``None`` for objects that never
+    came from an .xlsx sheet.
+    """
+    user = getattr(obj, "user", None)
+    name = user.get("sheet_name") if isinstance(user, dict) else None
+    return str(name) if name else None
 
 
 def _collection_item_filename(
@@ -177,6 +191,82 @@ def _save_collection(
         params["filename"] = _collection_item_filename(configured, item, index=idx)
         item_config = BlockConfig(params=params)
         dispatch_fn(item, item_config)
+
+
+def _collection_targets_xlsx(collection: Collection, config: BlockConfig) -> bool:
+    """True when a DataFrame/Series Collection should be saved as .xlsx (#1810).
+
+    A Collection targets xlsx when the configured ``filename`` ends in ``.xlsx``,
+    or — when no filename is configured — when the items carry an .xlsx source
+    (the load → save round-trip case). DataFrame/Series only.
+    """
+    if collection.item_type not in (DataFrame, Series):
+        return False
+    configured = config.get("filename")
+    if isinstance(configured, str) and configured.strip():
+        return configured.strip().lower().endswith(".xlsx")
+    for item in collection:
+        _stem, name = _source_file_stem(item)
+        if name.lower().endswith(".xlsx"):
+            return True
+    return False
+
+
+def _save_collection_xlsx(collection: Collection, config: BlockConfig) -> None:
+    """Save a DataFrame/Series Collection to .xlsx, grouping by source workbook (#1810).
+
+    Items are grouped by their originating workbook (``framework.source`` stem):
+    each distinct source file becomes one multi-sheet workbook (sheets named by
+    ``user['sheet_name']``); every item with no source is written into ONE
+    workbook named by the configured ``filename`` (owner decision). This makes
+    the load → save round-trip reproduce the original file ↔ sheet grouping.
+    """
+    items = list(collection)
+    if not items:
+        raise ValueError("SaveData received an empty Collection; nothing to save.")
+    output_dir = _require_path(config)
+    if output_dir.exists() and not output_dir.is_dir():
+        raise ValueError("SaveData received a multi-item Collection; config.path must be a folder path.")
+    output_dir.mkdir(parents=True, exist_ok=True)
+    configured = config.get("filename")
+    if configured is not None and not isinstance(configured, str):
+        raise ValueError(f"SaveData: config['filename'] must be a string or omitted, got {type(configured).__name__}")
+    configured_stem = Path(configured.strip()).stem if isinstance(configured, str) and configured.strip() else ""
+
+    # Group by source-workbook stem; preserve first-seen order. The empty-source
+    # group is keyed by "" and lands in a single configured-filename workbook.
+    groups: dict[str, list[DataObject]] = {}
+    for item in items:
+        stem, name = _source_file_stem(item)
+        key = stem if name.lower().endswith(".xlsx") else ""
+        groups.setdefault(key, []).append(item)
+
+    for key, members in groups.items():
+        workbook_stem = key or configured_stem
+        if not workbook_stem:
+            raise ValueError(
+                "SaveData cannot name an .xlsx workbook for source-less Collection items: "
+                "set the Save block filename field."
+            )
+        named_tables = [
+            (_sheet_name_of(item) or f"Sheet{idx}", _dataframe_to_arrow_table_for(item))
+            for idx, item in enumerate(members, start=1)
+        ]
+        dest = output_dir / f"{workbook_stem}.xlsx"
+        with atomic_path(dest) as tmp:
+            _write_tables_to_xlsx(named_tables, tmp)
+
+
+def _dataframe_to_arrow_table_for(item: DataObject) -> Any:
+    """Return the Arrow table for a DataFrame or single-column Series item."""
+    if isinstance(item, Series):
+        import pyarrow as pa
+
+        raw = item.get_in_memory_data()
+        column_name = item.value_name or "value"
+        return raw if isinstance(raw, pa.Table) else pa.table({column_name: pa.array(raw)})
+    assert isinstance(item, DataFrame), f"Expected DataFrame, got {type(item).__name__}"
+    return _dataframe_to_arrow_table(item)
 
 
 def _delegate_save_collection(
@@ -422,6 +512,11 @@ class SaveData(IOBlock):
             "CompositeData": _save_composite_data,
         }
         if isinstance(obj, Collection) and len(obj) > 1:
+            # #1810: xlsx Collections regroup by source workbook into multi-sheet
+            # files instead of the one-file-per-item default.
+            if _collection_targets_xlsx(obj, config):
+                _save_collection_xlsx(obj, config)
+                return
             _save_collection(obj, target_cls=target_cls, dispatch_fn=dispatch[type_name], config=config)
             return
 
@@ -611,6 +706,15 @@ def _save_dataframe(obj: DataObject, config: BlockConfig) -> None:
             json.dump(records, fh, ensure_ascii=False, indent=2)
         return
 
+    if fmt == "xlsx":
+        # #1810: a single DataFrame -> single sheet. The sheet name is the
+        # round-trip ``user['sheet_name']`` when present, else "Sheet1".
+        table = _dataframe_to_arrow_table(obj)
+        sheet_name = _sheet_name_of(obj) or "Sheet1"
+        with atomic_path(path) as tmp:
+            _write_table_to_xlsx(table, tmp, sheet_name)
+        return
+
     raise ValueError(
         f"Unsupported DataFrame file extension {path.suffix.lower()!r}. "
         f"Supported extensions: {list(_supported_save_extensions(DataFrame))} "
@@ -682,6 +786,13 @@ def _save_series(obj: DataObject, config: BlockConfig) -> None:
         records = table.to_pylist()
         with atomic_writer(path, mode="w", encoding="utf-8") as fh:
             json.dump(records, fh, ensure_ascii=False, indent=2)
+        return
+
+    if fmt == "xlsx":
+        # #1810: Series -> single-column single sheet.
+        sheet_name = _sheet_name_of(obj) or "Sheet1"
+        with atomic_path(path) as tmp:
+            _write_table_to_xlsx(table, tmp, sheet_name)
         return
 
     raise ValueError(

--- a/src/scistudio/blocks/io/savers/save_data.py
+++ b/src/scistudio/blocks/io/savers/save_data.py
@@ -233,26 +233,38 @@ def _save_collection_xlsx(collection: Collection, config: BlockConfig) -> None:
         raise ValueError(f"SaveData: config['filename'] must be a string or omitted, got {type(configured).__name__}")
     configured_stem = Path(configured.strip()).stem if isinstance(configured, str) and configured.strip() else ""
 
-    # Group by source-workbook stem; preserve first-seen order. The empty-source
-    # group is keyed by "" and lands in a single configured-filename workbook.
+    # Group by the FULL source path, preserving first-seen order (P1-2): two
+    # distinct workbooks that share a basename (``/run1/exp.xlsx`` and
+    # ``/run2/exp.xlsx``) must stay separate, so the directory cannot be
+    # stripped from the grouping key. The empty-source group ("" key) bundles
+    # every source-less item into one configured-filename workbook.
     groups: dict[str, list[DataObject]] = {}
     for item in items:
-        stem, name = _source_file_stem(item)
-        key = stem if name.lower().endswith(".xlsx") else ""
+        source = str(getattr(item.framework, "source", "") or "")
+        key = source if source.lower().endswith(".xlsx") else ""
         groups.setdefault(key, []).append(item)
 
+    used_names: set[str] = set()
     for key, members in groups.items():
-        workbook_stem = key or configured_stem
-        if not workbook_stem:
+        base_stem = Path(key).stem if key else configured_stem
+        if not base_stem:
             raise ValueError(
                 "SaveData cannot name an .xlsx workbook for source-less Collection items: "
                 "set the Save block filename field."
             )
+        # Disambiguate output filenames when distinct source paths share a
+        # basename (e.g. run1/exp.xlsx vs run2/exp.xlsx -> exp.xlsx, exp-2.xlsx).
+        stem = base_stem
+        counter = 2
+        while f"{stem}.xlsx".casefold() in used_names:
+            stem = f"{base_stem}-{counter}"
+            counter += 1
+        used_names.add(f"{stem}.xlsx".casefold())
         named_tables = [
             (_sheet_name_of(item) or f"Sheet{idx}", _dataframe_to_arrow_table_for(item))
             for idx, item in enumerate(members, start=1)
         ]
-        dest = output_dir / f"{workbook_stem}.xlsx"
+        dest = output_dir / f"{stem}.xlsx"
         with atomic_path(dest) as tmp:
             _write_tables_to_xlsx(named_tables, tmp)
 
@@ -511,14 +523,18 @@ class SaveData(IOBlock):
             "Artifact": _save_artifact,
             "CompositeData": _save_composite_data,
         }
-        if isinstance(obj, Collection) and len(obj) > 1:
+        if isinstance(obj, Collection):
             # #1810: xlsx Collections regroup by source workbook into multi-sheet
-            # files instead of the one-file-per-item default.
+            # files instead of the one-file-per-item default. This runs for ANY
+            # length (P1-1): a single-sheet workbook loads as a length-one
+            # Collection, and unwrapping it to a bare DataFrame would resolve the
+            # folder path to the default CSV format and silently drop .xlsx.
             if _collection_targets_xlsx(obj, config):
                 _save_collection_xlsx(obj, config)
                 return
-            _save_collection(obj, target_cls=target_cls, dispatch_fn=dispatch[type_name], config=config)
-            return
+            if len(obj) > 1:
+                _save_collection(obj, target_cls=target_cls, dispatch_fn=dispatch[type_name], config=config)
+                return
 
         unwrapped = _unwrap_for_save(obj, target_cls)
         dispatch[type_name](unwrapped, config)

--- a/tests/blocks/io/test_io_coverage_matrix.py
+++ b/tests/blocks/io/test_io_coverage_matrix.py
@@ -35,8 +35,8 @@ from scistudio.blocks.io.loaders.load_data import LoadData
 from scistudio.blocks.io.savers.save_data import SaveData
 from scistudio.blocks.registry import BlockRegistry, _spec_from_class
 from scistudio.core.types.array import Array
-from scistudio.core.types.collection import Collection
 from scistudio.core.types.artifact import Artifact
+from scistudio.core.types.collection import Collection
 from scistudio.core.types.composite import CompositeData
 from scistudio.core.types.dataframe import DataFrame
 from scistudio.core.types.series import Series

--- a/tests/blocks/io/test_io_coverage_matrix.py
+++ b/tests/blocks/io/test_io_coverage_matrix.py
@@ -35,6 +35,7 @@ from scistudio.blocks.io.loaders.load_data import LoadData
 from scistudio.blocks.io.savers.save_data import SaveData
 from scistudio.blocks.registry import BlockRegistry, _spec_from_class
 from scistudio.core.types.array import Array
+from scistudio.core.types.collection import Collection
 from scistudio.core.types.artifact import Artifact
 from scistudio.core.types.composite import CompositeData
 from scistudio.core.types.dataframe import DataFrame
@@ -104,14 +105,18 @@ MATRIX: dict[str, dict[str, Any]] = {
     "DataFrame": {
         "build": _build_dataframe,
         "type": DataFrame,
-        "load": [".csv", ".tsv", ".parquet", ".pq", ".json", ".pkl", ".pickle"],
-        "save": [".csv", ".tsv", ".parquet", ".pq", ".json", ".pkl", ".pickle"],
+        # #1810 — .xlsx is collection-valued (one DataFrame per sheet); a
+        # single-sheet workbook round-trips as a length-one Collection, which
+        # the matrix unwraps. Multi-sheet / grouping semantics are covered in
+        # tests/blocks/io/test_xlsx_io.py.
+        "load": [".csv", ".tsv", ".parquet", ".pq", ".json", ".xlsx", ".pkl", ".pickle"],
+        "save": [".csv", ".tsv", ".parquet", ".pq", ".json", ".xlsx", ".pkl", ".pickle"],
     },
     "Series": {
         "build": _build_series,
         "type": Series,
-        "load": [".csv", ".tsv", ".parquet", ".pq", ".pkl", ".pickle"],
-        "save": [".csv", ".tsv", ".parquet", ".pq", ".pkl", ".pickle", ".json"],
+        "load": [".csv", ".tsv", ".parquet", ".pq", ".xlsx", ".pkl", ".pickle"],
+        "save": [".csv", ".tsv", ".parquet", ".pq", ".pkl", ".pickle", ".json", ".xlsx"],
     },
     "Text": {
         "build": _build_text,
@@ -227,9 +232,10 @@ def test_load_save_matrix(tmp_path: Path, core_type: str, load_ext: str, save_ex
     # LOAD under test: write a load_ext file, read it back.
     load_file = _save(src, tmp_path / "in", "seed", load_ext, core_type)
     loaded = _load(load_file, spec["type"], core_type, load_ext)
-    if isinstance(loaded, type(loaded)) and hasattr(loaded, "items"):
-        # LoadData may return a single-item Collection for the pickle path.
-        loaded = loaded[0] if not isinstance(loaded, spec["type"]) else loaded
+    # #1810 — .xlsx (and the pickle path) may return a length-one Collection;
+    # unwrap to the single item for the single-object invariant check.
+    if isinstance(loaded, Collection) and not isinstance(loaded, spec["type"]):
+        loaded = loaded[0]
     assert loaded is not None
 
     # SAVE under test: write the loaded object to save_ext.
@@ -244,7 +250,7 @@ def test_load_save_matrix(tmp_path: Path, core_type: str, load_ext: str, save_ex
     # If save_ext is reloadable, confirm the data survived the save.
     if save_ext in spec["load"] and (core_type, save_ext) not in BROKEN_RELOAD:
         reloaded = _load(out_file, spec["type"], core_type, save_ext)
-        if hasattr(reloaded, "items") and not isinstance(reloaded, spec["type"]):
+        if isinstance(reloaded, Collection) and not isinstance(reloaded, spec["type"]):
             reloaded = reloaded[0]
         _assert_invariant(core_type, src, reloaded)
 

--- a/tests/blocks/io/test_load_data_capabilities.py
+++ b/tests/blocks/io/test_load_data_capabilities.py
@@ -217,8 +217,8 @@ class TestLoadDataPerTypeCapabilityCoverage:
         ("data_type", "expected_format_ids"),
         [
             (Array, {"npy", "npz", "zarr", "parquet", "pickle"}),
-            (DataFrame, {"csv", "tsv", "parquet", "json", "pickle"}),
-            (Series, {"csv", "tsv", "parquet", "pickle"}),
+            (DataFrame, {"csv", "tsv", "parquet", "json", "xlsx", "pickle"}),
+            (Series, {"csv", "tsv", "parquet", "xlsx", "pickle"}),
             (Text, {"text"}),
             (CompositeData, {"json"}),
         ],

--- a/tests/blocks/io/test_save_data_capabilities.py
+++ b/tests/blocks/io/test_save_data_capabilities.py
@@ -217,11 +217,11 @@ class TestSaveDataPerTypeCapabilityCoverage:
         ("data_type", "expected_format_ids"),
         [
             (Array, {"npy", "npz", "zarr", "parquet", "pickle"}),
-            (DataFrame, {"csv", "tsv", "parquet", "json", "pickle"}),
+            (DataFrame, {"csv", "tsv", "parquet", "json", "xlsx", "pickle"}),
             # Note: SaveData supports Series json (legacy code branch in
             # _save_series). LoadData does not — this asymmetry is
             # pre-existing and intentional.
-            (Series, {"csv", "tsv", "parquet", "json", "pickle"}),
+            (Series, {"csv", "tsv", "parquet", "json", "xlsx", "pickle"}),
             # Text + .json is a legacy save-only extension declared as a
             # separate Text capability with format_id="json" (Codex P1 on
             # PR #1300); LoadData's Text capability still excludes .json

--- a/tests/blocks/io/test_xlsx_io.py
+++ b/tests/blocks/io/test_xlsx_io.py
@@ -164,7 +164,7 @@ def test_same_basename_workbooks_stay_separate(tmp_path: Path) -> None:
     # Two separate files (the second basename collision is disambiguated), each
     # with exactly its own single sheet — not merged.
     assert names == ["exp-2.xlsx", "exp.xlsx"]
-    sheets = sorted(sum((pd.ExcelFile(out_dir / n).sheet_names for n in names), []))
+    sheets = sorted(s for n in names for s in pd.ExcelFile(out_dir / n).sheet_names)
     assert sheets == ["a", "b"]
 
 

--- a/tests/blocks/io/test_xlsx_io.py
+++ b/tests/blocks/io/test_xlsx_io.py
@@ -128,6 +128,46 @@ def test_save_sourceless_collection_into_one_workbook(tmp_path: Path) -> None:
     assert len(pd.ExcelFile(files[0]).sheet_names) == 3
 
 
+def test_single_sheet_collection_saves_back_as_xlsx(tmp_path: Path) -> None:
+    # P1-1: a single-sheet workbook loads as a length-one Collection; saving it
+    # to a folder path must write .xlsx, not silently fall back to .csv.
+    _write_workbook(tmp_path / "solo.xlsx", {"only": {"x": [1, 2, 3]}})
+    loaded = _load(tmp_path / "solo.xlsx", "DataFrame", tmp_path / "store")
+    assert len(loaded) == 1
+
+    out_dir = tmp_path / "saved"
+    sp = {"core_type": "DataFrame", "path": str(out_dir)}
+    SaveData(config={"params": sp}).save(loaded, BlockConfig(params=sp))
+    written = [p.name for p in out_dir.iterdir()]
+    assert written == ["solo.xlsx"]
+    assert pd.ExcelFile(out_dir / "solo.xlsx").sheet_names == ["only"]
+
+
+def test_same_basename_workbooks_stay_separate(tmp_path: Path) -> None:
+    # P1-2: two distinct workbooks sharing a basename (run1/exp.xlsx,
+    # run2/exp.xlsx) must not be merged into one file on save.
+    (tmp_path / "run1").mkdir()
+    (tmp_path / "run2").mkdir()
+    _write_workbook(tmp_path / "run1" / "exp.xlsx", {"a": {"v": [1]}})
+    _write_workbook(tmp_path / "run2" / "exp.xlsx", {"b": {"v": [2]}})
+    loaded = _load(
+        [tmp_path / "run1" / "exp.xlsx", tmp_path / "run2" / "exp.xlsx"],
+        "DataFrame",
+        tmp_path / "store",
+    )
+    assert len(loaded) == 2
+
+    out_dir = tmp_path / "saved"
+    sp = {"core_type": "DataFrame", "path": str(out_dir)}
+    SaveData(config={"params": sp}).save(loaded, BlockConfig(params=sp))
+    names = sorted(p.name for p in out_dir.glob("*.xlsx"))
+    # Two separate files (the second basename collision is disambiguated), each
+    # with exactly its own single sheet — not merged.
+    assert names == ["exp-2.xlsx", "exp.xlsx"]
+    sheets = sorted(sum((pd.ExcelFile(out_dir / n).sheet_names for n in names), []))
+    assert sheets == ["a", "b"]
+
+
 def test_series_sheets_round_trip(tmp_path: Path) -> None:
     _write_workbook(tmp_path / "s.xlsx", {"one": {"v": [1.0, 2.0]}, "two": {"v": [3.0]}})
     out = _load(tmp_path / "s.xlsx", "Series", tmp_path / "store")

--- a/tests/blocks/io/test_xlsx_io.py
+++ b/tests/blocks/io/test_xlsx_io.py
@@ -37,9 +37,7 @@ def _write_workbook(path: Path, sheets: dict[str, dict[str, list]]) -> None:
 def _load(paths, core_type: str, output_dir: Path):
     raw = [str(p) for p in paths] if isinstance(paths, list) else str(paths)
     params = {"core_type": core_type, "path": raw}
-    return LoadData(config={"params": params}).load(
-        BlockConfig(params=params), output_dir=str(output_dir)
-    )
+    return LoadData(config={"params": params}).load(BlockConfig(params=params), output_dir=str(output_dir))
 
 
 def test_single_multisheet_file_fans_out_into_a_collection(tmp_path: Path) -> None:
@@ -118,9 +116,7 @@ def test_save_sourceless_collection_into_one_workbook(tmp_path: Path) -> None:
 
     from scistudio.core.types.dataframe import DataFrame
 
-    items = [
-        DataFrame(columns=["a"], row_count=1, data=pa.table({"a": [i]})) for i in range(3)
-    ]
+    items = [DataFrame(columns=["a"], row_count=1, data=pa.table({"a": [i]})) for i in range(3)]
     coll = Collection(items=items, item_type=DataFrame)
 
     out_dir = tmp_path / "saved"

--- a/tests/blocks/io/test_xlsx_io.py
+++ b/tests/blocks/io/test_xlsx_io.py
@@ -1,0 +1,168 @@
+"""Core DataFrame/Series Excel (.xlsx) IO — multi-sheet fan-out + grouped save (#1810).
+
+The :mod:`test_io_coverage_matrix` suite covers the single-object .xlsx
+round-trip alongside the other formats. This module covers the .xlsx-specific
+collection semantics that the matrix does not:
+
+- reading an n-sheet workbook fans out into a Collection of n DataObjects, one
+  per sheet, each carrying ``framework.source`` (the workbook) and
+  ``user['sheet_name']`` / ``user['display_name']``;
+- loading several multi-sheet files flattens every sheet into one Collection;
+- saving a Collection groups by source workbook: each source file -> one
+  multi-sheet workbook; source-less items -> one workbook (owner decision);
+- Series sheets; the Excel row/column overflow guard.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from scistudio.blocks.base.config import BlockConfig
+from scistudio.blocks.base.interactive import interactive_item_label
+from scistudio.blocks.io.loaders.load_data import LoadData
+from scistudio.blocks.io.savers._helpers import _check_xlsx_dimensions
+from scistudio.blocks.io.savers.save_data import SaveData
+from scistudio.core.types.collection import Collection
+
+
+def _write_workbook(path: Path, sheets: dict[str, dict[str, list]]) -> None:
+    with pd.ExcelWriter(path, engine="openpyxl") as writer:
+        for name, cols in sheets.items():
+            pd.DataFrame(cols).to_excel(writer, sheet_name=name, index=False)
+
+
+def _load(paths, core_type: str, output_dir: Path):
+    raw = [str(p) for p in paths] if isinstance(paths, list) else str(paths)
+    params = {"core_type": core_type, "path": raw}
+    return LoadData(config={"params": params}).load(
+        BlockConfig(params=params), output_dir=str(output_dir)
+    )
+
+
+def test_single_multisheet_file_fans_out_into_a_collection(tmp_path: Path) -> None:
+    _write_workbook(
+        tmp_path / "exp.xlsx",
+        {"alpha": {"a": [1, 2], "b": [3, 4]}, "beta": {"a": [5], "b": [6]}},
+    )
+    out = _load(tmp_path / "exp.xlsx", "DataFrame", tmp_path / "store")
+    assert isinstance(out, Collection)
+    assert len(out) == 2
+    sheets = [item.user.get("sheet_name") for item in out]
+    assert sheets == ["alpha", "beta"]
+    # All sheets of one workbook share the source file (the save-grouping key).
+    assert {Path(item.framework.source).name for item in out} == {"exp.xlsx"}
+
+
+def test_single_sheet_file_is_a_length_one_collection(tmp_path: Path) -> None:
+    _write_workbook(tmp_path / "solo.xlsx", {"only": {"x": [1, 2, 3]}})
+    out = _load(tmp_path / "solo.xlsx", "DataFrame", tmp_path / "store")
+    assert isinstance(out, Collection)
+    assert len(out) == 1
+    assert out[0].user.get("sheet_name") == "only"
+
+
+def test_output_port_is_collection_for_xlsx(tmp_path: Path) -> None:
+    params = {"core_type": "DataFrame", "path": str(tmp_path / "x.xlsx")}
+    ports = LoadData(config={"params": params}).get_effective_output_ports()
+    assert ports[0].is_collection is True
+    # Non-xlsx single path stays a bare object (is_collection=False).
+    params_csv = {"core_type": "DataFrame", "path": str(tmp_path / "x.csv")}
+    ports_csv = LoadData(config={"params": params_csv}).get_effective_output_ports()
+    assert ports_csv[0].is_collection is False
+
+
+def test_multiple_multisheet_files_flatten_into_one_collection(tmp_path: Path) -> None:
+    _write_workbook(tmp_path / "f1.xlsx", {"s1": {"a": [1]}, "s2": {"a": [2]}, "s3": {"a": [3]}})
+    _write_workbook(tmp_path / "f2.xlsx", {"t1": {"a": [4]}, "t2": {"a": [5]}})
+    out = _load([tmp_path / "f1.xlsx", tmp_path / "f2.xlsx"], "DataFrame", tmp_path / "store")
+    assert isinstance(out, Collection)
+    # 3 sheets + 2 sheets, flattened, in file then sheet order.
+    assert len(out) == 5
+    assert [item.user.get("sheet_name") for item in out] == ["s1", "s2", "s3", "t1", "t2"]
+
+
+def test_save_collection_regroups_by_source_workbook(tmp_path: Path) -> None:
+    # Owner semantics 1 + 2: 3 sheets from f1 and 2 sheets from f2 must save back
+    # as f1.xlsx (3 sheets) and f2.xlsx (2 sheets).
+    _write_workbook(tmp_path / "f1.xlsx", {"s1": {"a": [1]}, "s2": {"a": [2]}, "s3": {"a": [3]}})
+    _write_workbook(tmp_path / "f2.xlsx", {"t1": {"a": [4]}, "t2": {"a": [5]}})
+    loaded = _load([tmp_path / "f1.xlsx", tmp_path / "f2.xlsx"], "DataFrame", tmp_path / "store")
+
+    out_dir = tmp_path / "saved"
+    sp = {"core_type": "DataFrame", "path": str(out_dir)}
+    SaveData(config={"params": sp}).save(loaded, BlockConfig(params=sp))
+
+    written = {p.name: pd.ExcelFile(p).sheet_names for p in sorted(out_dir.glob("*.xlsx"))}
+    assert written == {"f1.xlsx": ["s1", "s2", "s3"], "f2.xlsx": ["t1", "t2"]}
+
+
+def test_save_collection_five_single_sheet_files_round_trip_to_five_files(tmp_path: Path) -> None:
+    # Owner semantics 2: five single-sheet workbooks -> five separate files back.
+    for i in range(5):
+        _write_workbook(tmp_path / f"w{i}.xlsx", {f"sheet{i}": {"a": [i]}})
+    loaded = _load([tmp_path / f"w{i}.xlsx" for i in range(5)], "DataFrame", tmp_path / "store")
+    assert len(loaded) == 5
+
+    out_dir = tmp_path / "saved"
+    sp = {"core_type": "DataFrame", "path": str(out_dir)}
+    SaveData(config={"params": sp}).save(loaded, BlockConfig(params=sp))
+    assert sorted(p.name for p in out_dir.glob("*.xlsx")) == [f"w{i}.xlsx" for i in range(5)]
+
+
+def test_save_sourceless_collection_into_one_workbook(tmp_path: Path) -> None:
+    # Owner decision: source-less items all land in ONE workbook named by filename.
+    import pyarrow as pa
+
+    from scistudio.core.types.dataframe import DataFrame
+
+    items = [
+        DataFrame(columns=["a"], row_count=1, data=pa.table({"a": [i]})) for i in range(3)
+    ]
+    coll = Collection(items=items, item_type=DataFrame)
+
+    out_dir = tmp_path / "saved"
+    sp = {"core_type": "DataFrame", "path": str(out_dir), "filename": "bundle.xlsx"}
+    SaveData(config={"params": sp}).save(coll, BlockConfig(params=sp))
+
+    files = list(out_dir.glob("*.xlsx"))
+    assert [p.name for p in files] == ["bundle.xlsx"]
+    assert len(pd.ExcelFile(files[0]).sheet_names) == 3
+
+
+def test_series_sheets_round_trip(tmp_path: Path) -> None:
+    _write_workbook(tmp_path / "s.xlsx", {"one": {"v": [1.0, 2.0]}, "two": {"v": [3.0]}})
+    out = _load(tmp_path / "s.xlsx", "Series", tmp_path / "store")
+    assert isinstance(out, Collection)
+    assert len(out) == 2
+    assert [item.user.get("sheet_name") for item in out] == ["one", "two"]
+
+    out_dir = tmp_path / "saved"
+    sp = {"core_type": "Series", "path": str(out_dir)}
+    SaveData(config={"params": sp}).save(out, BlockConfig(params=sp))
+    assert pd.ExcelFile(out_dir / "s.xlsx").sheet_names == ["one", "two"]
+
+
+def test_series_rejects_multi_column_sheet(tmp_path: Path) -> None:
+    _write_workbook(tmp_path / "bad.xlsx", {"sheet": {"a": [1], "b": [2]}})
+    with pytest.raises(ValueError, match="single-column"):
+        _load(tmp_path / "bad.xlsx", "Series", tmp_path / "store")
+
+
+def test_display_name_disambiguates_same_file_sheets(tmp_path: Path) -> None:
+    _write_workbook(tmp_path / "exp.xlsx", {"alpha": {"a": [1]}, "beta": {"a": [2]}})
+    out = _load(tmp_path / "exp.xlsx", "DataFrame", tmp_path / "store")
+    labels = [interactive_item_label(item, i) for i, item in enumerate(out)]
+    assert labels == ["exp.xlsx — alpha", "exp.xlsx — beta"]
+    # No collision even though framework.source is identical.
+    assert len(set(labels)) == len(labels)
+
+
+def test_xlsx_dimension_guard() -> None:
+    _check_xlsx_dimensions(1_048_575, 16_384)  # the exact maxima are allowed
+    with pytest.raises(ValueError, match="rows exceed"):
+        _check_xlsx_dimensions(1_048_576, 1)
+    with pytest.raises(ValueError, match="columns exceed"):
+        _check_xlsx_dimensions(1, 16_385)


### PR DESCRIPTION
## What

Native Excel (`.xlsx`) read/write for core **DataFrame** and **Series** (#1810), and raise the numpy floor `>=1.25` → `>=2.1` (#1809).

xlsx semantically belongs in core (the most universal tabular format), not in a domain plugin. Today core supports only CSV/TSV/Parquet/JSON/Pickle.

## Changes

- Add `openpyxl>=3.1`; add an `xlsx` format capability for DataFrame + Series on LoadData and SaveData (pandas + openpyxl bridge).
- **xlsx is collection-valued.** A workbook holds N sheets, so a single file loads as one DataObject **per sheet**. LoadData declares `is_collection=True` for `.xlsx` and fans the sheets into a `Collection` (single-sheet = length-one); multiple `.xlsx` paths flatten every sheet of every file into one Collection. The fan-out lives in the block (ADR-020 §3 item-strategy delegation) — the engine is unchanged.
- Each sheet carries `framework.source` (the workbook) + `user["sheet_name"]`, plus a generic `user["display_name"]` hook (`"<file> — <sheet>"`) so same-file/different-sheet items don't collide in DataRouter / preview lists (`interactive_item_label` + frontend `deriveDisplayName` prefer it).
- **Save regroups by source workbook**: each distinct source file → one multi-sheet workbook (sheets named by `user["sheet_name"]`); source-less items → one workbook; a single DataObject → one sheet. The load → save round-trip reproduces the original file ↔ sheet grouping. Excel row/col limits (1,048,576 × 16,384) are enforced with a clear error.
- numpy floor `>=2.1` (#1809): core + bundled runtime + mypy stubs already assume numpy 2.x; all plugins are first-party.

## Tests / docs

- `.xlsx` added to the IO coverage matrix (single-object round-trip); new `tests/blocks/io/test_xlsx_io.py` covers fan-out, multi-file flatten, grouped save (both owner semantics), source-less bundling, Series, the dimension guard, and display-name disambiguation; frontend `refEntries` test for the display_name path.
- Spec updated: `docs/specs/adr-043-io-format-capability-registry.md` documents the xlsx collection / grouping semantics.

## Protected core / governance
- Touches `src/scistudio/blocks/io/**` + `interactive.py` (protected core) → `admin-approved:core-change`.
- `pyproject.toml` dependency edit declared as `governance_touch`.

## Tracked, not closed
- #1811 — residual single-value bare-transport drift (ADR-020 §3 vs `is_collection`).
- #1812 — canonical per-item display-name convention (this PR ships an interim `user["display_name"]` hook).

Gate record: .workflow/records/1810-feature-1810-dataframe-xlsx-io.json

Closes #1810
Closes #1809
