### PR TITLE
feat(#1816): richer custom-block starter template for non-programmer authors

### DIFF
--- a/.workflow/records/1816-guided-1816-custom-block-template.json
+++ b/.workflow/records/1816-guided-1816-custom-block-template.json
@@ -426,7 +426,13 @@
     }
   ],
   "check_na": [],
-  "commit": null,
+  "commit": {
+    "sha": "cbde3827a5a03606fbf11bc42313e45dc5ffefbd",
+    "shas": [
+      "cbde3827a5a03606fbf11bc42313e45dc5ffefbd"
+    ],
+    "trailers": []
+  },
   "declared_scope": {
     "exclude": [],
     "include": [
@@ -875,6 +881,110 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:13:40.609877Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/_templates/block_base_template.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/_templates/block_base_template.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:13:40.618555Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:13:40.626874Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:13:40.635156Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:13:40.643451Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:13:40.651658Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:13:40.659957Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:13:40.668976Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:13:40.678085Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:13:40.690007Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -894,9 +1004,9 @@
       "src/scistudio/blocks/_templates/block_base_template.py",
       "tests/api/test_blocks_template.py"
     ],
-    "diff_fingerprint": "sha256:a592ad08dd1a275ae0cb967f54dd3266c63b8fa6d22e74b7057a49644be251c6",
+    "diff_fingerprint": "sha256:5355258b4238964568cfc07f33049e1a1b7945e61b523509bb8a1798cd36cc67",
     "head": "HEAD",
-    "head_sha": "defd2e66",
+    "head_sha": "cbde3827",
     "surfaces": {
       "docs": 0,
       "frontend": 0,
@@ -912,7 +1022,14 @@
   },
   "owner_directive": "Rewrite the GUI custom-block starter template to be friendly to non-programmer authors: put teaching content in the template docstring (block family, data types + to_memory returns + construction, ports/params, Collection/item/helpers, how to write run(), where package types/helpers come from). Expose Collection directly (batch is fundamental). Default ports use a concrete type, not []. Provide batch-processing minimal examples for both Array and DataFrame.",
   "persona": "live_implementer",
-  "pull_request": null,
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [
+      1816
+    ],
+    "number": null,
+    "url": null
+  },
   "reconcile_events": [
     {
       "at": "2026-06-27T15:02:43.749180Z",
@@ -949,6 +1066,14 @@
     {
       "at": "2026-06-27T15:12:58.166524Z",
       "diff_fingerprint": "sha256:a592ad08dd1a275ae0cb967f54dd3266c63b8fa6d22e74b7057a49644be251c6",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-27T15:13:40.690066Z",
+      "diff_fingerprint": "sha256:5355258b4238964568cfc07f33049e1a1b7945e61b523509bb8a1798cd36cc67",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 1,

--- a/.workflow/records/1816-guided-1816-custom-block-template.json
+++ b/.workflow/records/1816-guided-1816-custom-block-template.json
@@ -1,0 +1,1032 @@
+{
+  "branch": "guided/1816-custom-block-template",
+  "check_events": [
+    {
+      "at": "2026-06-27T14:58:07.059936Z",
+      "command": "pytest tests/architecture/ -v --no-cov",
+      "covered_surface": "architecture",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:8805ed974716fcefdafc4dac07601e2e3100b8baa4579ac7c029a32d1fb8f419",
+      "name": "architecture_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/architecture_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-27T14:58:07.761125Z",
+      "command": "python scripts/deferral_scan.py --check docs/audit/baselines/deferral-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:43292c823f63468d17b1b3604e26bb934088db61b57dd1d0786a7e0b7a105579",
+      "name": "deferral_discipline",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/deferral_discipline.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-27T14:58:08.110945Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:1be4f0bcf5c45fe6d4abe5e478b15393469c28dc9590d2f3988423e7c244506e",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-27T14:58:11.564340Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:0e59df27c24580111efaa5655132147ce984e07387f2679349b43b2e29b4dbc2",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-27T14:58:12.060246Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:85965108c28cdc871edb10f964fff3e86bca372989ffcbcb64ec80a0bfe27c46",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-27T14:58:12.096300Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:a775bdabaa96d65cb472fc459703b3fac4a56fcc90470eaa486dfec043e47370",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-27T15:00:51.100910Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:df84b590d13b012ab11518f83587960c981e867fc5e0322b689afc8c89573250",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-27T15:02:36.953890Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:0e60cf998c8cfc41ff18ab05e1708199ca57d43b71649832708338f59547db36",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-27T15:02:43.624200Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e490506d367e8727516118b36ad34f9f67c76dd3005fd5e8b127acb15e0541b4",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    },
+    {
+      "at": "2026-06-27T15:04:01.797872Z",
+      "command": "pytest tests/architecture/ -v --no-cov",
+      "covered_surface": "architecture",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:8805ed974716fcefdafc4dac07601e2e3100b8baa4579ac7c029a32d1fb8f419",
+      "name": "architecture_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/architecture_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-27T15:04:02.504639Z",
+      "command": "python scripts/deferral_scan.py --check docs/audit/baselines/deferral-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:43292c823f63468d17b1b3604e26bb934088db61b57dd1d0786a7e0b7a105579",
+      "name": "deferral_discipline",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/deferral_discipline.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-27T15:04:02.546192Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:1be4f0bcf5c45fe6d4abe5e478b15393469c28dc9590d2f3988423e7c244506e",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-27T15:04:06.211319Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:0e59df27c24580111efaa5655132147ce984e07387f2679349b43b2e29b4dbc2",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-27T15:04:06.325061Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:85965108c28cdc871edb10f964fff3e86bca372989ffcbcb64ec80a0bfe27c46",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-27T15:04:06.350032Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:a775bdabaa96d65cb472fc459703b3fac4a56fcc90470eaa486dfec043e47370",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-27T15:05:52.603058Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:df84b590d13b012ab11518f83587960c981e867fc5e0322b689afc8c89573250",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-27T15:08:11.681680Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:0e60cf998c8cfc41ff18ab05e1708199ca57d43b71649832708338f59547db36",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-27T15:08:12.210503Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e490506d367e8727516118b36ad34f9f67c76dd3005fd5e8b127acb15e0541b4",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    },
+    {
+      "at": "2026-06-27T15:08:49.670024Z",
+      "command": "pytest tests/architecture/ -v --no-cov",
+      "covered_surface": "architecture",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:8805ed974716fcefdafc4dac07601e2e3100b8baa4579ac7c029a32d1fb8f419",
+      "name": "architecture_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/architecture_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-27T15:08:50.391688Z",
+      "command": "python scripts/deferral_scan.py --check docs/audit/baselines/deferral-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:dab9444ac813cc25e4c7062e2012903db1d1476ac7c7c1392289ec811e9f2ded",
+      "name": "deferral_discipline",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/deferral_discipline.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-27T15:08:50.442267Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:415818ee30843d6d5a2ee515e69060f3a89b4c21f3901a0c57580896c1970631",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-27T15:08:54.330961Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:38a0eb0183bde9d310888166e85871c10b1975f1b845516e9762d239ec3e074f",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-27T15:08:54.449765Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:9769dcd1def6d1b3467beeb5f0b7a2255f5d0c19034662fbf6dc75c64ec83b10",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-27T15:08:54.471001Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:a921bb9cf155eda8d222713eca2e62cedcba30b6ed771259e71323e3541826a5",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-27T15:11:04.285491Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:c676f3dac11161cf8e840ec9465ef6f4bb6dd9403df121247ec08f0bd6f1f312",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-27T15:12:57.492974Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:bbc941d608d9ba2ad6d9a5a54602745a42057a03fe055ba16205fa04f56e3e43",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-27T15:12:58.035713Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:939596264a8812788035f62e293806af664f60c28bdfd0590b188a86b1fc085b",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    }
+  ],
+  "check_na": [],
+  "commit": null,
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "src/scistudio/blocks/_templates/block_base_template.py"
+    ]
+  },
+  "directive_events": [
+    {
+      "at": "2026-06-27T14:53:54.281602Z",
+      "owner_directive": "Authorized core-change scope on the template file. Provide TWO minimal batch examples: one Array, one DataFrame.",
+      "reason": "Owner authorized admin-approved:core-change for the protected blocks/_templates path and asked for a second worked example in DataFrame (in addition to Array)."
+    }
+  ],
+  "docs_events": [
+    {
+      "at": "2026-06-27T14:57:01.789609Z",
+      "class": "guide",
+      "kind": "na",
+      "path": null,
+      "rationale": "Teaching content is shipped inside the starter template itself (owner directive: target users read the template, not the docs); no contract/schema/runtime/API/UI change to document.",
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-27T14:57:01.789764Z",
+      "class": "changelog",
+      "kind": "na",
+      "path": null,
+      "rationale": "Internal starter-template copy + test change; no user-facing runtime behavior change.",
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": false,
+  "guard_events": [
+    {
+      "at": "2026-06-27T15:02:43.662315Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/_templates/block_base_template.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/_templates/block_base_template.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:02:43.671966Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:02:43.681315Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:02:43.690475Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:02:43.699352Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:02:43.708382Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:02:43.717308Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:02:43.727110Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:02:43.737238Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:02:43.749123Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:03:13.290806Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/_templates/block_base_template.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/_templates/block_base_template.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:03:13.300619Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:03:13.309481Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:03:13.318380Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:03:13.327245Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:03:13.336013Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:03:13.344810Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:03:13.353875Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:03:13.362527Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:03:13.372254Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:08:12.263162Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/_templates/block_base_template.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/_templates/block_base_template.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:08:12.272330Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:08:12.281901Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:08:12.291525Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:08:12.301553Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:08:12.311193Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:08:12.320158Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:08:12.329496Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:08:12.338990Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:08:12.351145Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:12:58.076453Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/_templates/block_base_template.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/_templates/block_base_template.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:12:58.086523Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:12:58.096117Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:12:58.106379Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:12:58.116475Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:12:58.126827Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:12:58.136176Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:12:58.145255Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:12:58.154053Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:12:58.166491Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1816,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": {
+    "base": "origin/main",
+    "base_sha": "647bf05e",
+    "changed_files": [
+      ".workflow/records/1816-guided-1816-custom-block-template.json",
+      "src/scistudio/blocks/_templates/block_base_template.py",
+      "tests/api/test_blocks_template.py"
+    ],
+    "diff_fingerprint": "sha256:a592ad08dd1a275ae0cb967f54dd3266c63b8fa6d22e74b7057a49644be251c6",
+    "head": "HEAD",
+    "head_sha": "defd2e66",
+    "surfaces": {
+      "docs": 0,
+      "frontend": 0,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 1,
+      "packaging": 0,
+      "protected_core": 1,
+      "sentrux": 2,
+      "test": 1,
+      "workflow_ci": 0
+    }
+  },
+  "owner_directive": "Rewrite the GUI custom-block starter template to be friendly to non-programmer authors: put teaching content in the template docstring (block family, data types + to_memory returns + construction, ports/params, Collection/item/helpers, how to write run(), where package types/helpers come from). Expose Collection directly (batch is fundamental). Default ports use a concrete type, not []. Provide batch-processing minimal examples for both Array and DataFrame.",
+  "persona": "live_implementer",
+  "pull_request": null,
+  "reconcile_events": [
+    {
+      "at": "2026-06-27T15:02:43.749180Z",
+      "diff_fingerprint": "sha256:333e680154d86c2c458b28b5fa56e2f15438f5b3a584cb6828b8d23fa6e7c3a9",
+      "mode": "local",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.lint_format",
+        "checks.python_tests",
+        "scope.out-of-scope"
+      ]
+    },
+    {
+      "at": "2026-06-27T15:03:13.372288Z",
+      "diff_fingerprint": "sha256:333e680154d86c2c458b28b5fa56e2f15438f5b3a584cb6828b8d23fa6e7c3a9",
+      "mode": "local",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "scope.out-of-scope"
+      ]
+    },
+    {
+      "at": "2026-06-27T15:08:12.351465Z",
+      "diff_fingerprint": "sha256:333e680154d86c2c458b28b5fa56e2f15438f5b3a584cb6828b8d23fa6e7c3a9",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.lint_format"
+      ]
+    },
+    {
+      "at": "2026-06-27T15:12:58.166524Z",
+      "diff_fingerprint": "sha256:a592ad08dd1a275ae0cb967f54dd3266c63b8fa6d22e74b7057a49644be251c6",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    }
+  ],
+  "record_id": "1816-guided-1816-custom-block-template",
+  "requested_admin_labels": [
+    {
+      "actor_permission": null,
+      "applied_at": null,
+      "applied_by": null,
+      "name": "admin-approved:core-change"
+    }
+  ],
+  "required_obligations": {
+    "admin_labels": [
+      "admin-approved:core-change"
+    ],
+    "checks": [
+      "architecture_tests",
+      "deferral_discipline",
+      "format_check",
+      "full_audit",
+      "import_contracts",
+      "lint_format",
+      "python_tests",
+      "semantic_dup",
+      "type_check"
+    ],
+    "docs": [
+      "docs_required_or_na"
+    ],
+    "guards": [
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": [
+      "changed_test_required"
+    ]
+  },
+  "runtime": "claude-code",
+  "schema_version": 2,
+  "scope_events": [
+    {
+      "action": "add-include",
+      "at": "2026-06-27T15:03:33.101466Z",
+      "pattern": "tests/api/test_blocks_template.py",
+      "reason": "The test file that exercises the rewritten template belongs in scope; declare it as include (was only recorded as --test-path)."
+    }
+  ],
+  "session_id": "bf076305-8934-403c-b4f6-09f6e3f73c3e",
+  "strictness_tier": 1,
+  "task_kind": "guided",
+  "test_events": [
+    {
+      "at": "2026-06-27T14:53:54.281713Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/api/test_blocks_template.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-27T14:57:01.789769Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/api/test_blocks_template.py",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/.workflow/records/1816-guided-1816-custom-block-template.json
+++ b/.workflow/records/1816-guided-1816-custom-block-template.json
@@ -423,6 +423,147 @@
       "tool_versions": {
         "mypy": "2.1.0"
       }
+    },
+    {
+      "at": "2026-06-27T15:29:10.225492Z",
+      "command": "pytest tests/architecture/ -v --no-cov",
+      "covered_surface": "architecture",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:ed276dc95dda43f2ffe9e1ac2a14d5a439fe872efb84467ea6e06e834ad45e93",
+      "name": "architecture_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/architecture_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-27T15:29:11.024047Z",
+      "command": "python scripts/deferral_scan.py --check docs/audit/baselines/deferral-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:801335a21edce75df619b9d9b7d7824530208dfb6d51b08d95adce5d914e8eab",
+      "name": "deferral_discipline",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/deferral_discipline.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-27T15:29:11.078708Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:4a63178637f96810f57ca428ac7d4b2daa57ac548279387785dc5560e0ac7897",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-27T15:29:16.286426Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:c4c5225594e01cbfdd554fa76111a06635008b030de968bca5ac450cbf5080fa",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-27T15:29:16.445424Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:859976867a3e2301ac498515821b15ae794567bb37dbb4c8b52ddd22497f368b",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-27T15:29:16.470065Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:3815fb0aa4439ada1967b18a988acca43685010db5912e6fc114a80cfe94fd1a",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-27T15:33:15.397756Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:5c898a4f9f6aeee03e8712d204f5cc8ae5efbb7aa0d96bd1bb202408614ad345",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-27T15:36:03.945383Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:d0410f4bb5981be2cf5297abe42892a068e6a86cece027c894e673f32dea473a",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-27T15:36:04.564680Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e7c0a6d275316506db953a86ed780a6cbe90889aee9d4093dfcad67f2e3014b0",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
     }
   ],
   "check_na": [],
@@ -444,6 +585,11 @@
       "at": "2026-06-27T14:53:54.281602Z",
       "owner_directive": "Authorized core-change scope on the template file. Provide TWO minimal batch examples: one Array, one DataFrame.",
       "reason": "Owner authorized admin-approved:core-change for the protected blocks/_templates path and asked for a second worked example in DataFrame (in addition to Array)."
+    },
+    {
+      "at": "2026-06-27T15:27:35.543732Z",
+      "owner_directive": "Import all basic data types in the starter template so authors can switch port types without adding imports.",
+      "reason": "PR #1818 review (P2): template advertises switching accepted_types to DataFrame/Series/Text/Artifact but the executable only imports Array, so a non-programmer's copied module NameErrors at registry import. Pre-import all base types."
     }
   ],
   "docs_events": [
@@ -1193,6 +1339,110 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:36:04.596698Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/_templates/block_base_template.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/_templates/block_base_template.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:36:04.606448Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:36:04.616847Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:36:04.626552Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:36:04.636239Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:36:04.646525Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:36:04.656183Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:36:04.666180Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:36:04.675813Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:36:04.689998Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -1205,16 +1455,16 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "647bf05ed1eb985b18055e5574f0d8649e5c3dbb",
+    "base": "origin/main",
     "base_sha": "647bf05e",
     "changed_files": [
       ".workflow/records/1816-guided-1816-custom-block-template.json",
       "src/scistudio/blocks/_templates/block_base_template.py",
       "tests/api/test_blocks_template.py"
     ],
-    "diff_fingerprint": "sha256:be77eb6097bc9980450df3170dc1b273128f2c50be87715a026b349cb06caee1",
+    "diff_fingerprint": "sha256:8a34c47735ed1ba6dcd89ce661ae49c6b170c0b984f91a46ea76f64e43505457",
     "head": "HEAD",
-    "head_sha": "2e5bf235",
+    "head_sha": "f7fc1d66",
     "surfaces": {
       "docs": 0,
       "frontend": 0,
@@ -1302,6 +1552,16 @@
       "result": "pass",
       "tier": 1,
       "unsatisfied": []
+    },
+    {
+      "at": "2026-06-27T15:36:04.690029Z",
+      "diff_fingerprint": "sha256:8a34c47735ed1ba6dcd89ce661ae49c6b170c0b984f91a46ea76f64e43505457",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.python_tests"
+      ]
     }
   ],
   "record_id": "1816-guided-1816-custom-block-template",

--- a/.workflow/records/1816-guided-1816-custom-block-template.json
+++ b/.workflow/records/1816-guided-1816-custom-block-template.json
@@ -427,9 +427,9 @@
   ],
   "check_na": [],
   "commit": {
-    "sha": "cbde3827a5a03606fbf11bc42313e45dc5ffefbd",
+    "sha": "2e5bf2356d2279baacd3ace0e0dc3a1e4d3f99b8",
     "shas": [
-      "cbde3827a5a03606fbf11bc42313e45dc5ffefbd"
+      "2e5bf2356d2279baacd3ace0e0dc3a1e4d3f99b8"
     ],
     "trailers": []
   },
@@ -985,6 +985,214 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:14:13.329439Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/_templates/block_base_template.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/_templates/block_base_template.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:14:13.338367Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:14:13.347143Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:14:13.356175Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:14:13.365544Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:14:13.374707Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:14:13.384692Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:14:13.395840Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:14:13.405518Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:14:13.421307Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:14:25.530354Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/_templates/block_base_template.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/_templates/block_base_template.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:14:25.540846Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:14:25.550963Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:14:25.561439Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:14:25.571599Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:14:25.581869Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:14:25.592106Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:14:25.602597Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:14:25.612895Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:14:25.626712Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -997,16 +1205,16 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "origin/main",
+    "base": "647bf05ed1eb985b18055e5574f0d8649e5c3dbb",
     "base_sha": "647bf05e",
     "changed_files": [
       ".workflow/records/1816-guided-1816-custom-block-template.json",
       "src/scistudio/blocks/_templates/block_base_template.py",
       "tests/api/test_blocks_template.py"
     ],
-    "diff_fingerprint": "sha256:5355258b4238964568cfc07f33049e1a1b7945e61b523509bb8a1798cd36cc67",
+    "diff_fingerprint": "sha256:be77eb6097bc9980450df3170dc1b273128f2c50be87715a026b349cb06caee1",
     "head": "HEAD",
-    "head_sha": "cbde3827",
+    "head_sha": "2e5bf235",
     "surfaces": {
       "docs": 0,
       "frontend": 0,
@@ -1027,7 +1235,7 @@
     "closes": [
       1816
     ],
-    "number": null,
+    "number": 1818,
     "url": null
   },
   "reconcile_events": [
@@ -1074,6 +1282,22 @@
     {
       "at": "2026-06-27T15:13:40.690066Z",
       "diff_fingerprint": "sha256:5355258b4238964568cfc07f33049e1a1b7945e61b523509bb8a1798cd36cc67",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-27T15:14:13.421344Z",
+      "diff_fingerprint": "sha256:be77eb6097bc9980450df3170dc1b273128f2c50be87715a026b349cb06caee1",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-27T15:14:25.626747Z",
+      "diff_fingerprint": "sha256:be77eb6097bc9980450df3170dc1b273128f2c50be87715a026b349cb06caee1",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 1,

--- a/src/scistudio/blocks/_templates/block_base_template.py
+++ b/src/scistudio/blocks/_templates/block_base_template.py
@@ -1,53 +1,165 @@
 """Starter template for a custom SciStudio block.
 
-The "New custom block" toolbar action copies this file into
-``<project>/blocks/<name>.py`` and opens it for editing. Rename ``MyBlock``,
-declare your ports and parameters, then fill in ``run()``.
+The "New custom block" action copies this file into
+``<project>/blocks/<name>.py`` and opens it for editing. Three steps to make
+it yours:
 
-Quick reference
----------------
+    1. Rename ``MyBlock`` and edit ``name`` / ``description``.
+    2. Declare your input/output ports and parameters.
+    3. Fill in ``run()`` with your logic.
 
-Ports — typed connection points on the block, declared as class attributes::
+Everything you need is in the sections below. Read the part you care about and
+skip the rest.
 
-    input_ports  = [InputPort(name="input",  accepted_types=[DataFrame])]
-    output_ports = [OutputPort(name="output", accepted_types=[DataFrame])]
+====================================================================
+1. WHAT IS A BLOCK -- and which base class to inherit
+====================================================================
 
-  ``accepted_types`` restricts what may connect: any ``DataObject`` subclass
-  (``DataFrame``, ``Array``, ``Series``, ``Text``, ``Artifact`` ...). An empty
-  list ``[]`` accepts anything. Optional keywords: ``description=`` (shown in
-  the UI), ``required=False`` (make an input optional), ``default=``.
+A block is one step in a workflow: it takes typed inputs, does some work, and
+returns typed outputs. Users wire blocks together on the canvas.
 
-Parameters — ``config_schema`` is a JSON Schema that renders the GUI
-parameter panel. Read values inside ``run()`` with ``config.get(name, default)``::
+Most custom blocks subclass ``Block`` (this template). Other base classes
+exist for special jobs:
+
+    Block         General work. You write run() yourself, and you see the
+                  data in batches (Collections). <- this template.
+    ProcessBlock  One item in, one item out. You write only
+                  process_item(self, item, config) and the base class loops
+                  over the batch for you. Use it when every item is
+                  transformed independently and the number of items does not
+                  change (no filtering, no merging, no splitting).
+    IOBlock       Load or save files. You write load() or save().
+    AppBlock      Hand work to an external GUI application.
+    CodeBlock     Run a project-local Python / R / Julia script.
+
+When unsure, stay on ``Block``: it can do anything the others can.
+
+====================================================================
+2. DATA TYPES -- what flows between blocks
+====================================================================
+
+Every value is a "DataObject". Call ``item.to_memory()`` to read the real
+value. What you get back depends on the type:
+
+    Type        item.to_memory() returns    construct one with
+    ---------   -------------------------   ----------------------------------
+    Array       numpy ndarray               Array(axes=["y", "x"], data=arr)
+    DataFrame   pyarrow.Table  (*)          DataFrame(data=table)
+    Series      pyarrow.Table               Series(data=table)
+    Text        str                         Text(content="hello")
+    Artifact    bytes                       Artifact(file_path=Path(...))
+
+    (*) DataFrame/Series give you an Arrow table. For a pandas frame:
+        df = item.to_memory().to_pandas()
+        ...and build one back with:
+        DataFrame(data=pyarrow.Table.from_pandas(df))
+
+Domain packages add more types (e.g. Image, Spectrum) -- see section 7.
+
+====================================================================
+3. COLLECTIONS -- data arrives in batches
+====================================================================
+
+Batch processing is the norm for scientific data, so every port carries a
+``Collection``: an ordered group of same-type items. A single value is a
+Collection of length 1; "no data" is an empty Collection. You decide how to
+loop over it.
+
+Read items directly::
+
+    for item in inputs["input"]:     # each item is one DataObject
+        data = item.to_memory()      # the real value (see the table above)
+
+Helper methods on ``self`` so you do not manage storage by hand::
+
+    self.map_items(fn, coll)       apply fn to each item -> Collection
+                                   (low memory: one item at a time)
+    self.parallel_map(fn, coll)    same, but in parallel (uses more memory)
+    self.pack(items, item_type=T)  build a Collection from a list of items
+    self.unpack(coll)              -> a plain list of items
+    self.unpack_single(coll)       -> the single item (errors if not exactly 1)
+
+====================================================================
+4. PORTS & PARAMETERS
+====================================================================
+
+Ports are typed connection points, declared as class attributes::
+
+    input_ports  = [InputPort(name="input",  accepted_types=[Array])]
+    output_ports = [OutputPort(name="output", accepted_types=[Array])]
+
+``accepted_types`` controls what may connect. Always name a concrete type
+(Array, DataFrame, Series, Text, Artifact, or a package type like Image) so
+the canvas can type-check connections and choose a preview. ``[]`` means
+"accept anything" -- avoid it unless you truly mean it. Optional keywords:
+``description=`` (shown in the UI), ``required=False`` (optional input),
+``default=``.
+
+Parameters are a JSON Schema in ``config_schema``; it renders the GUI
+parameter panel. Read values inside run() with ``config.get(name, default)``::
 
     config_schema = {"type": "object", "properties": {
-        "threshold": {"type": "number", "default": 0.5},
-        "method":    {"type": "string", "enum": ["otsu", "li"], "default": "otsu"},
+        "gain":   {"type": "number", "default": 1.0},
+        "method": {"type": "string", "enum": ["a", "b"], "default": "a"},
     }}
     # inside run():
-    threshold = config.get("threshold", 0.5)
+    gain = config.get("gain", 1.0)
 
-run() — signature ``run(self, inputs, config) -> dict[str, Collection]``::
+====================================================================
+5. WRITING run()
+====================================================================
+
+Signature::
+
+    def run(self, inputs: dict[str, Collection],
+            config: BlockConfig) -> dict[str, Collection]:
 
     * ``inputs[port_name]`` is the ``Collection`` arriving on that input port.
-    * Iterate a Collection to get its ``DataObject`` items; read the native
-      value with ``item.to_memory()`` — an Arrow table for ``DataFrame`` (call
-      ``.to_pandas()`` for a pandas frame), a numpy array for ``Array``, etc.
-    * Return a dict keyed by your OUTPUT port names. Each value is a
-      ``Collection`` of DataObjects of the declared type; build one with
-      ``Collection([obj, ...], item_type=DataFrame)``.
+    * Return a dict keyed by your OUTPUT port names; each value is a
+      ``Collection`` of the declared type.
 
-Minimal example — keep only the numeric columns of each input table::
+====================================================================
+6. Minimal examples (batch processing)
+====================================================================
 
+Array -- scale every image in the batch by a ``gain`` parameter::
+
+    from scistudio.core.types.array import Array
+
+    def run(self, inputs, config):
+        gain = config.get("gain", 1.0)
+
+        def scale(item):
+            arr = item.to_memory()                  # numpy ndarray
+            return Array(axes=list(item.axes), data=arr * gain)
+
+        return {"output": self.map_items(scale, inputs["input"])}
+
+DataFrame -- keep only the numeric columns of every table in the batch::
+
+    import pyarrow as pa
     from scistudio.core.types.dataframe import DataFrame
 
     def run(self, inputs, config):
-        results = []
-        for item in inputs["input"]:
-            table = item.to_memory().to_pandas()   # Arrow table -> pandas DataFrame
-            numeric = table.select_dtypes(include="number")
-            results.append(DataFrame(data=numeric))
-        return {"output": Collection(results, item_type=DataFrame)}
+        def numeric_only(item):
+            df = item.to_memory().to_pandas()       # pyarrow.Table -> pandas
+            numeric = df.select_dtypes(include="number")
+            return DataFrame(data=pa.Table.from_pandas(numeric))
+
+        return {"output": self.map_items(numeric_only, inputs["input"])}
+
+====================================================================
+7. PACKAGE-SPECIFIC TYPES & HELPERS
+====================================================================
+
+Installed domain packages (imaging, lcms, spectroscopy, ...) add their own
+types (e.g. Image) and helper functions on top of the core types above. To
+find what a package gives you, read THAT package's own documentation.
+
+Do not import a package's private, underscore-prefixed modules (for example
+``_support``): they are internal and may change without notice. A public,
+browsable list of installed packages and the types/helpers they export is
+being built; until it ships, the package's own docs are the source of truth.
 """
 
 from __future__ import annotations
@@ -60,6 +172,7 @@ from scistudio.blocks.base import (
     InputPort,
     OutputPort,
 )
+from scistudio.core.types.array import Array
 from scistudio.core.types.collection import Collection
 
 
@@ -70,29 +183,35 @@ class MyBlock(Block):
     name: ClassVar[str] = "My Block"
     description: ClassVar[str] = "Describe what this block does."
 
-    # Typed ports. Edit ``accepted_types`` to constrain connections to any
-    # ``DataObject`` subclass; an empty list ``[]`` accepts anything.
+    # Typed ports. Change ``accepted_types`` to the concrete type you handle
+    # (Array, DataFrame, Series, Text, Artifact, or a package type like Image).
+    # Prefer a concrete type over ``[]`` so connections are type-checked.
     input_ports: ClassVar[list[InputPort]] = [
-        InputPort(name="input", accepted_types=[], description="Input data"),
+        InputPort(name="input", accepted_types=[Array], description="Input data"),
     ]
     output_ports: ClassVar[list[OutputPort]] = [
-        OutputPort(name="output", accepted_types=[], description="Output data"),
+        OutputPort(name="output", accepted_types=[Array], description="Output data"),
     ]
 
-    # JSON Schema for the parameters panel rendered in the GUI.
+    # Parameters for the GUI panel (JSON Schema). Read them with config.get().
     config_schema: ClassVar[dict[str, Any]] = {
         "type": "object",
         "properties": {
-            # "threshold": {"type": "number", "default": 0.5},
+            "gain": {"type": "number", "default": 1.0},
         },
     }
 
     def run(self, inputs: dict[str, Collection], config: BlockConfig) -> dict[str, Collection]:
         # >>> EDIT THIS <<<
-        # Read parameters with ``config.get("name", default)`` and input
-        # Collections from ``inputs["<input_port_name>"]``. Do your work, then
-        # return a dict keyed by your output port names, each value a Collection.
-        #
-        # The default below passes the input straight through unchanged.
-        # Replace it with your own logic (see "Minimal example" above).
-        return {"output": inputs["input"]}
+        # Batch example: scale every input Array by the ``gain`` parameter.
+        # ``map_items`` runs your function on each item in the Collection and
+        # packs the results back into a Collection, one item in memory at a
+        # time. See section 6 of the header for a DataFrame version, and
+        # section 3 for the other Collection helpers.
+        gain = config.get("gain", 1.0)
+
+        def scale(item: Array) -> Array:
+            arr = item.to_memory()  # numpy ndarray (see the type table above)
+            return Array(axes=list(item.axes), data=arr * gain)
+
+        return {"output": self.map_items(scale, inputs["input"])}

--- a/src/scistudio/blocks/_templates/block_base_template.py
+++ b/src/scistudio/blocks/_templates/block_base_template.py
@@ -172,8 +172,17 @@ from scistudio.blocks.base import (
     InputPort,
     OutputPort,
 )
+
+# All built-in data types are imported here so you can use any of them in your
+# ports and in run() without adding an import line. The trailing "unused
+# import" notes just silence the linter for the types you have not used yet --
+# delete the note once you start using one.
 from scistudio.core.types.array import Array
+from scistudio.core.types.artifact import Artifact  # noqa: F401
 from scistudio.core.types.collection import Collection
+from scistudio.core.types.dataframe import DataFrame  # noqa: F401
+from scistudio.core.types.series import Series  # noqa: F401
+from scistudio.core.types.text import Text  # noqa: F401
 
 
 class MyBlock(Block):

--- a/tests/api/test_blocks_template.py
+++ b/tests/api/test_blocks_template.py
@@ -91,3 +91,85 @@ def test_template_documents_real_run_contract(client: TestClient) -> None:
     assert "item.to_memory()" in content
     # A worked, paste-over example is part of the user-friendly rewrite.
     assert "Minimal example" in content
+
+
+# #1816 — the template is the only thing our non-programmer authors actually
+# read, so the teaching content lives in the template itself. These tests pin
+# the sections the rewrite promised so they cannot silently disappear.
+
+
+def _template(client: TestClient) -> str:
+    return client.get("/api/blocks/template?kind=basic").json()["content"]
+
+
+def test_template_teaches_block_family(client: TestClient) -> None:
+    """Section 1 — authors must learn which base classes exist and when to use them."""
+    content = _template(client)
+    # The default base plus the realistic alternatives a human might subclass.
+    for base in ("ProcessBlock", "IOBlock", "AppBlock", "CodeBlock"):
+        assert base in content, f"template should mention the {base} base class"
+
+
+def test_template_teaches_type_to_memory_returns(client: TestClient) -> None:
+    """Section 2 — the type table must surface the differing to_memory() returns.
+
+    The #1 newbie trap is that Array.to_memory() is a numpy array while
+    DataFrame.to_memory() is an Arrow table. Both must be named explicitly.
+    """
+    content = _template(client)
+    for type_name in ("Array", "DataFrame", "Series", "Text", "Artifact"):
+        assert type_name in content, f"template should list the {type_name} type"
+    assert "numpy" in content
+    assert "pyarrow" in content or "Arrow" in content
+    assert "to_pandas()" in content, "template must show how to get a pandas frame"
+
+
+def test_template_teaches_collection_helpers(client: TestClient) -> None:
+    """Section 3 — Collection is exposed directly, so its helpers must be taught."""
+    content = _template(client)
+    for helper in ("map_items", "parallel_map", "pack", "unpack"):
+        assert helper in content, f"template should mention the {helper} helper"
+
+
+def test_template_has_array_and_dataframe_examples(client: TestClient) -> None:
+    """Section 6 — owner directive: two batch examples, one Array and one DataFrame."""
+    content = _template(client)
+    assert "from scistudio.core.types.array import Array" in content
+    assert "from scistudio.core.types.dataframe import DataFrame" in content
+    # Both examples drive the point that batch processing is the default.
+    assert content.count("self.map_items(") >= 2
+
+
+def test_template_ports_use_concrete_type_not_empty(client: TestClient) -> None:
+    """The default ports must declare a concrete type, never ``accepted_types=[]``.
+
+    The old template used ``[]``, which contradicts the block contract that
+    requires concrete types for connection checks and preview routing.
+    """
+    content = _template(client)
+    assert "accepted_types=[]" not in content
+    assert "accepted_types=[Array]" in content
+
+
+def test_template_points_authors_at_package_docs(client: TestClient) -> None:
+    """Section 7 — authors must be told where domain (package) types come from."""
+    content = _template(client)
+    assert "package" in content
+    # Warn against the private internals AI code is seen reaching into (#1817).
+    assert "_support" in content
+
+
+def test_template_myblock_validates_via_harness(client: TestClient) -> None:
+    """The served template must define a block that passes the contract harness.
+
+    Executing the template content also guarantees the worked ``run()`` body is
+    importable and syntactically sound, not just the file as a whole.
+    """
+    from scistudio.testing import BlockTestHarness
+
+    content = _template(client)
+    namespace: dict[str, object] = {}
+    exec(compile(content, "block_base_template.py", "exec"), namespace)
+    my_block = namespace["MyBlock"]
+    errors = BlockTestHarness(my_block).validate_block()
+    assert not errors, errors

--- a/tests/api/test_blocks_template.py
+++ b/tests/api/test_blocks_template.py
@@ -173,3 +173,22 @@ def test_template_myblock_validates_via_harness(client: TestClient) -> None:
     my_block = namespace["MyBlock"]
     errors = BlockTestHarness(my_block).validate_block()
     assert not errors, errors
+
+
+def test_template_preimports_every_advertised_type(client: TestClient) -> None:
+    """Switching a port to any advertised type must not NameError (#1818 review).
+
+    Section 4 tells authors to change ``accepted_types`` to DataFrame / Series /
+    Text / Artifact. The old template only imported ``Array`` in the executable
+    body, so a non-programmer's copied module raised ``NameError`` at registry
+    import the moment they followed that instruction. Every base type named in
+    the guidance must be importable in the served module.
+    """
+    content = _template(client)
+    namespace: dict[str, object] = {}
+    exec(compile(content, "block_base_template.py", "exec"), namespace)
+    for type_name in ("Array", "DataFrame", "Series", "Text", "Artifact"):
+        assert type_name in namespace, (
+            f"{type_name} is advertised in the template but not imported in the "
+            "executable body — switching a port to it would NameError on import"
+        )


### PR DESCRIPTION
## What

Rewrites the GUI **"New custom block"** starter template so the teaching
content lives in the template itself. Our target authors (bench scientists who
don't code fluently and mostly read the template, not the docs) previously got
too little: one type example, `accepted_types=[]` ports that contradict the
block contract, and no guidance on the block family, data types, Collections,
or where domain-package types come from.

The new template ([`block_base_template.py`](../../src/scistudio/blocks/_templates/block_base_template.py))
is organised into skimmable sections:

1. **Block family** — when to subclass `Block` vs `ProcessBlock` / `IOBlock` / `AppBlock` / `CodeBlock`.
2. **Data types** — `Array` / `DataFrame` / `Series` / `Text` / `Artifact`, what `to_memory()` returns for each (numpy ndarray vs Arrow table vs str vs bytes), and how to construct one.
3. **Collections** — exposed directly (batch processing is fundamental for scientific data); items, and the `map_items` / `parallel_map` / `pack` / `unpack` helpers.
4. **Ports & parameters** — concrete `accepted_types`, `config_schema`, `config.get(...)`.
5. **Writing `run()`** — the real `dict[str, Collection]` contract.
6. **Two worked batch examples** — one `Array`, one `DataFrame`.
7. **Package-specific types/helpers** — points authors at the package's own docs and warns against importing private `_support`-style internals.

Default ports now declare a concrete type (`Array`) instead of `accepted_types=[]`.

## Why

The starter template is the primary surface non-programmer authors actually
read. Owner directive: ship the teaching content in the template; expose
Collection directly; provide both an `Array` and a `DataFrame` example.

## Tests

`tests/api/test_blocks_template.py` gains assertions for the block-family
section, the type table (numpy/pyarrow/`to_pandas`), the Collection helpers,
the two examples, concrete ports, the package-docs pointer, and a test that
`exec`s the served template and validates `MyBlock` via `BlockTestHarness`
(also guaranteeing the worked `run()` body is importable and runs).

## Notes

- The template file is under the protected `src/scistudio/blocks/**` path;
  owner authorized `admin-approved:core-change` (template string only, no
  runtime logic).
- A public, browsable package authoring API (so the template can point at a
  live list instead of "read the package docs") is tracked separately in #1817.

Gate record: .workflow/records/1816-guided-1816-custom-block-template.json

Closes #1816
