### PR TITLE
fix(#1811): transport every single-value port as a length-one Collection

### DIFF
--- a/.workflow/records/1811-guided-1811-single-value-collection-xfail.json
+++ b/.workflow/records/1811-guided-1811-single-value-collection-xfail.json
@@ -1,0 +1,482 @@
+{
+  "branch": "guided/1811-single-value-collection-xfail",
+  "check_events": [
+    {
+      "at": "2026-06-27T13:16:48.580484Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:98493140540f590e7d1841edb101511c210d74ee79e486ec11b90f9103ee8642",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-27T13:16:54.735737Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:b5414b137fd3767e343d60a65e9143b27c236e720cdd7fe2ca0c4da795ceef34",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-27T13:16:54.801515Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:14308490a9e0c3c2b3aef65b4177fe540a874e3a668998cc82f8c7bbb70922c4",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-27T13:21:52.021466Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:5af20fdd000bc1fd03bd63b0ebaee7e1b04102d1668501741d073f12901010f2",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-27T13:23:57.228514Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:022644cfdd272a4b940b70b7824d7c3b2ea3a82efd77529d634c98197024d3bb",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    }
+  ],
+  "check_na": [],
+  "commit": null,
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "tests/engine/test_single_value_collection_contract.py"
+    ]
+  },
+  "directive_events": [
+    {
+      "at": "2026-06-27T12:56:32.823756Z",
+      "owner_directive": "Design xfail tests for the bare single-value DataObject path before discussing the root-cause fix.",
+      "reason": "plan"
+    },
+    {
+      "at": "2026-06-27T13:02:59.103352Z",
+      "owner_directive": "\u96c6\u6210xfail\u4e5f\u8865\u4e00\u4e0b",
+      "reason": "Owner directed adding a scheduler in-process integration xfail covering the second _normalize_outputs call site (_dispatch.py:325)."
+    }
+  ],
+  "docs_events": [
+    {
+      "at": "2026-06-27T12:56:32.823922Z",
+      "class": "spec",
+      "kind": "na",
+      "path": null,
+      "rationale": "no runtime/contract behavior changes yet; xfail tests document the ADR-020 \u00a73 gap in-place. Docs/ADR follow with the option (a) fix.",
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": false,
+  "guard_events": [
+    {
+      "at": "2026-06-27T13:23:57.271652Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:23:57.282321Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:23:57.293120Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:23:57.304013Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:23:57.314206Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:23:57.324114Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:23:57.333523Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:23:57.345274Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:23:57.356213Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:23:57.368666Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:24:51.647264Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:24:51.656035Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:24:51.664516Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:24:51.673603Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:24:51.682320Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:24:51.691016Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:24:51.699440Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:24:51.708053Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:24:51.716309Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:24:51.727169Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:25:03.815901Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:25:03.824349Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:25:03.833553Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:25:03.843375Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:25:03.852551Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:25:03.861376Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:25:03.869835Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:25:03.878558Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:25:03.886857Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:25:03.896382Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1813,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": {
+    "base": "origin/main",
+    "base_sha": "d7c3314b",
+    "changed_files": [
+      ".workflow/records/1811-guided-1811-single-value-collection-xfail.json",
+      "tests/engine/test_single_value_collection_contract.py"
+    ],
+    "diff_fingerprint": "sha256:e0a1ad87c4325116f388495c73ff3241c1dcd7d594e245a71e4087b18bd2f14d",
+    "head": "HEAD",
+    "head_sha": "c38e0d9a",
+    "surfaces": {
+      "docs": 0,
+      "frontend": 0,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 0,
+      "packaging": 0,
+      "protected_core": 0,
+      "sentrux": 1,
+      "test": 1,
+      "workflow_ci": 0
+    }
+  },
+  "owner_directive": "Design xfail tests pinning the residual bare single-value DataObject transport drift (ADR-020 \u00a73 says single value = length-one Collection); root-cause fix discussed separately afterward.",
+  "persona": "live_implementer",
+  "pull_request": null,
+  "reconcile_events": [
+    {
+      "at": "2026-06-27T13:23:57.368699Z",
+      "diff_fingerprint": "sha256:e0a1ad87c4325116f388495c73ff3241c1dcd7d594e245a71e4087b18bd2f14d",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.lint_format",
+        "checks.python_tests"
+      ]
+    },
+    {
+      "at": "2026-06-27T13:24:51.727196Z",
+      "diff_fingerprint": "sha256:e0a1ad87c4325116f388495c73ff3241c1dcd7d594e245a71e4087b18bd2f14d",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.lint_format",
+        "checks.python_tests"
+      ]
+    },
+    {
+      "at": "2026-06-27T13:25:03.896405Z",
+      "diff_fingerprint": "sha256:e0a1ad87c4325116f388495c73ff3241c1dcd7d594e245a71e4087b18bd2f14d",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.lint_format",
+        "checks.python_tests"
+      ]
+    }
+  ],
+  "record_id": "1811-guided-1811-single-value-collection-xfail",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [
+      "format_check",
+      "full_audit",
+      "lint_format",
+      "python_tests",
+      "semantic_dup"
+    ],
+    "docs": [],
+    "guards": [
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": []
+  },
+  "runtime": "claude-code",
+  "schema_version": 2,
+  "scope_events": [
+    {
+      "action": "add-include",
+      "at": "2026-06-27T12:56:32.823899Z",
+      "pattern": "tests/engine/test_single_value_collection_contract.py",
+      "reason": "plan"
+    }
+  ],
+  "session_id": "a0251190-d45b-451b-b60d-ddfaf96601a5",
+  "strictness_tier": 2,
+  "task_kind": "guided",
+  "test_events": [
+    {
+      "at": "2026-06-27T12:56:32.823940Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/engine/test_single_value_collection_contract.py",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/.workflow/records/1811-guided-1811-single-value-collection-xfail.json
+++ b/.workflow/records/1811-guided-1811-single-value-collection-xfail.json
@@ -82,7 +82,13 @@
     }
   ],
   "check_na": [],
-  "commit": null,
+  "commit": {
+    "sha": "e21be3f63be5f520a185d0f2c1a5eb4fa2fc8509",
+    "shas": [
+      "e21be3f63be5f520a185d0f2c1a5eb4fa2fc8509"
+    ],
+    "trailers": []
+  },
   "declared_scope": {
     "exclude": [],
     "include": [
@@ -358,6 +364,88 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:29:43.869693Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:29:43.878823Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:29:43.888030Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:29:43.897284Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:29:43.906416Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:29:43.915748Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:29:43.925305Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:29:43.935344Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:29:43.943826Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T13:29:43.954062Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -370,15 +458,15 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "origin/main",
+    "base": "d7c3314bef0fee826620b5a675f156f60053c045",
     "base_sha": "d7c3314b",
     "changed_files": [
       ".workflow/records/1811-guided-1811-single-value-collection-xfail.json",
       "tests/engine/test_single_value_collection_contract.py"
     ],
-    "diff_fingerprint": "sha256:e0a1ad87c4325116f388495c73ff3241c1dcd7d594e245a71e4087b18bd2f14d",
+    "diff_fingerprint": "sha256:173cbf2355e9de542f673c831c2ac3e0fdb8b3be72030325f6f14e9371497ac5",
     "head": "HEAD",
-    "head_sha": "c38e0d9a",
+    "head_sha": "e21be3f6",
     "surfaces": {
       "docs": 0,
       "frontend": 0,
@@ -394,7 +482,12 @@
   },
   "owner_directive": "Design xfail tests pinning the residual bare single-value DataObject transport drift (ADR-020 \u00a73 says single value = length-one Collection); root-cause fix discussed separately afterward.",
   "persona": "live_implementer",
-  "pull_request": null,
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [],
+    "number": 1814,
+    "url": null
+  },
   "reconcile_events": [
     {
       "at": "2026-06-27T13:23:57.368699Z",
@@ -427,6 +520,20 @@
       "unsatisfied": [
         "checks.lint_format",
         "checks.python_tests"
+      ]
+    },
+    {
+      "at": "2026-06-27T13:29:43.954086Z",
+      "diff_fingerprint": "sha256:173cbf2355e9de542f673c831c2ac3e0fdb8b3be72030325f6f14e9371497ac5",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.format_check",
+        "checks.full_audit",
+        "checks.lint_format",
+        "checks.python_tests",
+        "checks.semantic_dup"
       ]
     }
   ],

--- a/.workflow/records/1811-single-value-collection-fix.json
+++ b/.workflow/records/1811-single-value-collection-fix.json
@@ -175,9 +175,9 @@
   ],
   "check_na": [],
   "commit": {
-    "sha": "b27392089407fe1eeb15a426882e580315f00c5c",
+    "sha": "1d84cd961f4ecdd98a33c01c891b65ea1e3cd89c",
     "shas": [
-      "b27392089407fe1eeb15a426882e580315f00c5c"
+      "1d84cd961f4ecdd98a33c01c891b65ea1e3cd89c"
     ],
     "trailers": []
   },
@@ -969,6 +969,152 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-06-27T21:18:54.030257Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/ai/ai_block.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/ai/ai_block.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "error",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/process/process_block.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/process/process_block.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "error",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/engine/runners/worker.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/engine/runners/worker.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "error",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "fail"
+    },
+    {
+      "at": "2026-06-27T21:18:54.047908Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T21:18:54.064303Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T21:18:54.083664Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T21:18:54.102642Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T21:18:54.127054Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T21:18:54.153077Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T21:18:54.180491Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T21:18:54.197502Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T21:18:54.214663Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -981,7 +1127,7 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "main",
+    "base": "d7c3314bef0fee826620b5a675f156f60053c045",
     "base_sha": "d7c3314b",
     "changed_files": [
       ".workflow/records/1811-guided-1811-single-value-collection-xfail.json",
@@ -997,9 +1143,9 @@
       "tests/engine/test_single_value_collection_consumers.py",
       "tests/engine/test_single_value_collection_contract.py"
     ],
-    "diff_fingerprint": "sha256:e71a435b44a8be2ac379a7c9b352d6a6bd630cf53a28d19458006940b7f2a24c",
+    "diff_fingerprint": "sha256:3696f70ec1331bf1da19f17ddd5adc579f2d286b1e69e5f688d2bf4d06a5f3b0",
     "head": "HEAD",
-    "head_sha": "b2739208",
+    "head_sha": "1d84cd96",
     "surfaces": {
       "docs": 0,
       "frontend": 0,
@@ -1020,8 +1166,8 @@
     "closes": [
       1811
     ],
-    "number": null,
-    "url": null
+    "number": 1822,
+    "url": "https://github.com/jiazhenz026/SciStudio/pull/1822"
   },
   "reconcile_events": [
     {
@@ -1074,6 +1220,17 @@
     {
       "at": "2026-06-27T15:45:47.990624Z",
       "diff_fingerprint": "sha256:e71a435b44a8be2ac379a7c9b352d6a6bd630cf53a28d19458006940b7f2a24c",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.python_tests",
+        "guard.core_change_guard"
+      ]
+    },
+    {
+      "at": "2026-06-27T21:18:54.214724Z",
+      "diff_fingerprint": "sha256:3696f70ec1331bf1da19f17ddd5adc579f2d286b1e69e5f688d2bf4d06a5f3b0",
       "mode": "pre-pr",
       "result": "fail",
       "tier": 1,

--- a/.workflow/records/1811-single-value-collection-fix.json
+++ b/.workflow/records/1811-single-value-collection-fix.json
@@ -1,8 +1,186 @@
 {
   "branch": "guided/1811-single-value-collection-fix",
-  "check_events": [],
+  "check_events": [
+    {
+      "at": "2026-06-27T15:24:20.008970Z",
+      "command": "pytest tests/architecture/ -v --no-cov",
+      "covered_surface": "architecture",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:9c23861c509ce6a9f406a6e4a3e57e7a784edc0e037c884cb3ce16acabcead83",
+      "name": "architecture_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/architecture_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-27T15:24:20.753635Z",
+      "command": "python scripts/deferral_scan.py --check docs/audit/baselines/deferral-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:9488a8905fb83c117a31bbabfb000f7e628da59deaf117bdd3503e11efa282f9",
+      "name": "deferral_discipline",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/deferral_discipline.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-27T15:24:21.114722Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:791a99aeee43e25bab7629ff189a96a3e9ac9e238a7834998c8fb4bb8b690c04",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-27T15:24:24.845002Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:bb8aca92a6a5f119d29c48358898168e7aa734a6df779155d171c59f1b2e49e7",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-27T15:24:25.362428Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:2e87d09365883fd9cfdea39e88fc9bc279419848a094264ea95eced1b852985c",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-27T15:24:25.403344Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:a4b3a94ffc539d2ee82eaf573665b3c84f2dc43602eba0375fdee962450af354",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-27T15:28:45.391503Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:ed74f6bc8320553884574e02c8eca8733c3bb205be7747e873f592f8a29ff64a",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-27T15:34:35.920370Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:51d8e7bdbf7af9a6af2a15dad7f75441eaeafbe0b4e7bceab34981265ea6bbf4",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-27T15:34:45.770142Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:95a997b2c7a4e2fa5ddeb74368344fb392cc6204cc796e6e78cd4b0215c1d329",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    },
+    {
+      "at": "2026-06-27T15:39:51.959849Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:ed74f6bc8320553884574e02c8eca8733c3bb205be7747e873f592f8a29ff64a",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-27T15:45:16.240594Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:ed74f6bc8320553884574e02c8eca8733c3bb205be7747e873f592f8a29ff64a",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    }
+  ],
   "check_na": [],
-  "commit": null,
+  "commit": {
+    "sha": "b27392089407fe1eeb15a426882e580315f00c5c",
+    "shas": [
+      "b27392089407fe1eeb15a426882e580315f00c5c"
+    ],
+    "trailers": []
+  },
   "declared_scope": {
     "exclude": [],
     "include": []
@@ -19,9 +197,780 @@
       "reason": "Owner narrowed scope to AIBlock.result only; record consumer-migration paths touched (api/runtime, ai/agent/mcp, process_block, ai_block) not in original include."
     }
   ],
-  "docs_events": [],
+  "docs_events": [
+    {
+      "at": "2026-06-27T15:35:35.935399Z",
+      "class": "implementation",
+      "kind": "na",
+      "path": null,
+      "rationale": "collection-guide.md already documents that is_collection is a UI hint and 'all port values are Collections regardless'; this fix aligns the runtime to that existing documented contract (no behavioral contract change, a conformance fix to ADR-020 \u00a73). No doc/ADR update needed.",
+      "verified_in_diff": null
+    }
+  ],
   "governance_touch": false,
-  "guard_events": [],
+  "guard_events": [
+    {
+      "at": "2026-06-27T15:34:45.838412Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/ai/ai_block.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/ai/ai_block.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "error",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/process/process_block.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/process/process_block.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "error",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/engine/runners/worker.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/engine/runners/worker.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "error",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "fail"
+    },
+    {
+      "at": "2026-06-27T15:34:45.859018Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {
+            "governed_files": [
+              "src/scistudio/ai/agent/mcp/tools_inspection/read.py",
+              "src/scistudio/ai/agent/mcp/tools_plot/targets.py",
+              "src/scistudio/api/runtime/_data.py",
+              "src/scistudio/blocks/ai/ai_block.py",
+              "src/scistudio/blocks/process/process_block.py",
+              "src/scistudio/engine/runners/worker.py"
+            ]
+          },
+          "expected": null,
+          "file": "",
+          "finding_class": "docs_landing",
+          "git_evidence": null,
+          "id": "docs_landing.missing-landing",
+          "line": null,
+          "message": "governed change requires docs/changelog/checklist landing evidence or an explicit N/A rationale",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "docs_landing.missing-landing",
+          "severity": "error",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "docs_landing",
+      "status": "fail"
+    },
+    {
+      "at": "2026-06-27T15:34:45.879679Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:34:45.894885Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:34:45.912006Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:34:45.928158Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:34:45.946161Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:34:45.968581Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:34:45.987242Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:34:46.010857Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:35:55.220508Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/ai/ai_block.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/ai/ai_block.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "error",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/process/process_block.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/process/process_block.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "error",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/engine/runners/worker.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/engine/runners/worker.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "error",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "fail"
+    },
+    {
+      "at": "2026-06-27T15:35:55.245301Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:35:55.275083Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:35:55.300860Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:35:55.313562Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:35:55.329193Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:35:55.347486Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:35:55.371152Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:35:55.387324Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:35:55.415183Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:39:52.001307Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/ai/ai_block.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/ai/ai_block.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "error",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/process/process_block.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/process/process_block.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "error",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/engine/runners/worker.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/engine/runners/worker.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "error",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "fail"
+    },
+    {
+      "at": "2026-06-27T15:39:52.011385Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:39:52.021694Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:39:52.031401Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:39:52.041060Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:39:52.051679Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:39:52.061261Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:39:52.070673Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:39:52.080293Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:39:52.093543Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:45:16.289014Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/ai/ai_block.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/ai/ai_block.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "error",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/process/process_block.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/process/process_block.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "error",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/engine/runners/worker.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/engine/runners/worker.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "error",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "fail"
+    },
+    {
+      "at": "2026-06-27T15:45:16.298489Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:45:16.308373Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:45:16.317827Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:45:16.328041Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:45:16.337706Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:45:16.346997Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:45:16.356282Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:45:16.365553Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:45:16.378371Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:45:47.902557Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/ai/ai_block.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/ai/ai_block.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "error",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/process/process_block.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/process/process_block.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "error",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/engine/runners/worker.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/engine/runners/worker.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "error",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "fail"
+    },
+    {
+      "at": "2026-06-27T15:45:47.912994Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:45:47.922901Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:45:47.933495Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:45:47.943037Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:45:47.951984Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:45:47.960857Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:45:47.969656Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:45:47.978701Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-27T15:45:47.990569Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
   "issues": [
     {
       "close_in_pr": true,
@@ -31,19 +980,144 @@
     }
   ],
   "observed_admin_labels": [],
-  "observed_diff": null,
+  "observed_diff": {
+    "base": "main",
+    "base_sha": "d7c3314b",
+    "changed_files": [
+      ".workflow/records/1811-guided-1811-single-value-collection-xfail.json",
+      ".workflow/records/1811-single-value-collection-fix.json",
+      "src/scistudio/ai/agent/mcp/tools_inspection/read.py",
+      "src/scistudio/ai/agent/mcp/tools_plot/targets.py",
+      "src/scistudio/api/runtime/_data.py",
+      "src/scistudio/blocks/ai/ai_block.py",
+      "src/scistudio/blocks/process/process_block.py",
+      "src/scistudio/engine/runners/worker.py",
+      "tests/ai/test_mcp_tools_inspection.py",
+      "tests/engine/test_collection_wrap.py",
+      "tests/engine/test_single_value_collection_consumers.py",
+      "tests/engine/test_single_value_collection_contract.py"
+    ],
+    "diff_fingerprint": "sha256:e71a435b44a8be2ac379a7c9b352d6a6bd630cf53a28d19458006940b7f2a24c",
+    "head": "HEAD",
+    "head_sha": "b2739208",
+    "surfaces": {
+      "docs": 0,
+      "frontend": 0,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 6,
+      "packaging": 0,
+      "protected_core": 3,
+      "sentrux": 10,
+      "test": 4,
+      "workflow_ci": 0
+    }
+  },
   "owner_directive": "Root-fix #1811: make every block-boundary port transport a length-one Collection (ADR-020 \u00a73). Engine: remove is_collection=False early-return in _normalize_outputs, wrap unconditionally + validate Collection. Set core ports is_collection=True (incl AIBlock.result). Test-first ratchet: pin single-value wire readers (preview/plot/serialize) green today, mark broken-after-fix with strict-xfail = migration list, migrate + remove markers. Flip Phase-1 xfails. Core only; packages owner-managed.",
   "persona": "live_implementer",
-  "pull_request": null,
-  "reconcile_events": [],
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [
+      1811
+    ],
+    "number": null,
+    "url": null
+  },
+  "reconcile_events": [
+    {
+      "at": "2026-06-27T15:34:46.010946Z",
+      "diff_fingerprint": "sha256:e71a435b44a8be2ac379a7c9b352d6a6bd630cf53a28d19458006940b7f2a24c",
+      "mode": "local",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.python_tests",
+        "docs.docs_required_or_na",
+        "guard.core_change_guard",
+        "guard.docs_landing",
+        "tests.changed_test_required"
+      ]
+    },
+    {
+      "at": "2026-06-27T15:35:55.415258Z",
+      "diff_fingerprint": "sha256:e71a435b44a8be2ac379a7c9b352d6a6bd630cf53a28d19458006940b7f2a24c",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.python_tests",
+        "guard.core_change_guard"
+      ]
+    },
+    {
+      "at": "2026-06-27T15:39:52.093592Z",
+      "diff_fingerprint": "sha256:e71a435b44a8be2ac379a7c9b352d6a6bd630cf53a28d19458006940b7f2a24c",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.python_tests",
+        "guard.core_change_guard"
+      ]
+    },
+    {
+      "at": "2026-06-27T15:45:16.378423Z",
+      "diff_fingerprint": "sha256:e71a435b44a8be2ac379a7c9b352d6a6bd630cf53a28d19458006940b7f2a24c",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.python_tests",
+        "guard.core_change_guard"
+      ]
+    },
+    {
+      "at": "2026-06-27T15:45:47.990624Z",
+      "diff_fingerprint": "sha256:e71a435b44a8be2ac379a7c9b352d6a6bd630cf53a28d19458006940b7f2a24c",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.python_tests",
+        "guard.core_change_guard"
+      ]
+    }
+  ],
   "record_id": "1811-single-value-collection-fix",
   "requested_admin_labels": [],
   "required_obligations": {
-    "admin_labels": [],
-    "checks": [],
-    "docs": [],
-    "guards": [],
-    "tests": []
+    "admin_labels": [
+      "admin-approved:core-change"
+    ],
+    "checks": [
+      "architecture_tests",
+      "deferral_discipline",
+      "format_check",
+      "full_audit",
+      "import_contracts",
+      "lint_format",
+      "python_tests",
+      "semantic_dup",
+      "type_check"
+    ],
+    "docs": [
+      "docs_required_or_na"
+    ],
+    "guards": [
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": [
+      "changed_test_required"
+    ]
   },
   "runtime": "claude",
   "schema_version": 2,
@@ -110,7 +1184,40 @@
     }
   ],
   "session_id": "e389d8da-5dc3-4b8b-b886-b0a61974db31",
-  "strictness_tier": null,
+  "strictness_tier": 1,
   "task_kind": "guided",
-  "test_events": []
+  "test_events": [
+    {
+      "at": "2026-06-27T15:35:35.935825Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/engine/test_single_value_collection_contract.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-27T15:35:35.935832Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/engine/test_single_value_collection_consumers.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-27T15:35:35.935834Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/engine/test_collection_wrap.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-27T15:35:35.935836Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/ai/test_mcp_tools_inspection.py",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
 }

--- a/.workflow/records/1811-single-value-collection-fix.json
+++ b/.workflow/records/1811-single-value-collection-fix.json
@@ -1,0 +1,116 @@
+{
+  "branch": "guided/1811-single-value-collection-fix",
+  "check_events": [],
+  "check_na": [],
+  "commit": null,
+  "declared_scope": {
+    "exclude": [],
+    "include": []
+  },
+  "directive_events": [
+    {
+      "at": "2026-06-27T14:15:39.905002Z",
+      "owner_directive": "Phase 2 plan: (1) write ratchet tests pinning single-value wire readers (preview target build, plot targets, serialize round-trip) \u2014 green today; (2) engine fix in worker._normalize_outputs (drop is_collection=False early-return, wrap unconditionally) + dispatch call sites + Collection validation; (3) run ratchet, strict-xfail the broken readers; (4) migrate readers, remove markers; (5) set core ports is_collection=True incl AIBlock.result, flip Phase-1 xfails, update test_collection_wrap, drop dead bare fallbacks.",
+      "reason": "plan"
+    },
+    {
+      "at": "2026-06-27T15:19:59.491272Z",
+      "owner_directive": "Scope narrowed (owner): keep PR focused \u2014 only AIBlock.result flipped to is_collection=True (it can emit a batch); the broader 'all core ports declare is_collection=True' sweep deferred to a separate follow-up (flag is inert post-fix: previewer routes on value kind, transport via _normalize_outputs). Codec primitives serialise_outputs/reconstruct_inputs left unchanged \u2014 _normalize_outputs is the single enforcement point; legacy bare wire handled by blocks' existing bare-input fallback.",
+      "reason": "Owner narrowed scope to AIBlock.result only; record consumer-migration paths touched (api/runtime, ai/agent/mcp, process_block, ai_block) not in original include."
+    }
+  ],
+  "docs_events": [],
+  "governance_touch": false,
+  "guard_events": [],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1811,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": null,
+  "owner_directive": "Root-fix #1811: make every block-boundary port transport a length-one Collection (ADR-020 \u00a73). Engine: remove is_collection=False early-return in _normalize_outputs, wrap unconditionally + validate Collection. Set core ports is_collection=True (incl AIBlock.result). Test-first ratchet: pin single-value wire readers (preview/plot/serialize) green today, mark broken-after-fix with strict-xfail = migration list, migrate + remove markers. Flip Phase-1 xfails. Core only; packages owner-managed.",
+  "persona": "live_implementer",
+  "pull_request": null,
+  "reconcile_events": [],
+  "record_id": "1811-single-value-collection-fix",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [],
+    "docs": [],
+    "guards": [],
+    "tests": []
+  },
+  "runtime": "claude",
+  "schema_version": 2,
+  "scope_events": [
+    {
+      "action": "add-include",
+      "at": "2026-06-27T14:15:39.905158Z",
+      "pattern": "src/scistudio/engine/runners/worker.py",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-27T14:15:39.905171Z",
+      "pattern": "src/scistudio/engine/scheduler/_dispatch.py",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-27T14:15:39.905175Z",
+      "pattern": "src/scistudio/blocks/",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-27T14:15:39.905176Z",
+      "pattern": "tests/engine/",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-27T15:19:59.491411Z",
+      "pattern": "src/scistudio/api/runtime/_data.py",
+      "reason": "Owner narrowed scope to AIBlock.result only; record consumer-migration paths touched (api/runtime, ai/agent/mcp, process_block, ai_block) not in original include."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-27T15:19:59.491416Z",
+      "pattern": "src/scistudio/ai/agent/mcp/tools_plot/targets.py",
+      "reason": "Owner narrowed scope to AIBlock.result only; record consumer-migration paths touched (api/runtime, ai/agent/mcp, process_block, ai_block) not in original include."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-27T15:19:59.491417Z",
+      "pattern": "src/scistudio/ai/agent/mcp/tools_inspection/read.py",
+      "reason": "Owner narrowed scope to AIBlock.result only; record consumer-migration paths touched (api/runtime, ai/agent/mcp, process_block, ai_block) not in original include."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-27T15:19:59.491419Z",
+      "pattern": "src/scistudio/blocks/process/process_block.py",
+      "reason": "Owner narrowed scope to AIBlock.result only; record consumer-migration paths touched (api/runtime, ai/agent/mcp, process_block, ai_block) not in original include."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-27T15:19:59.491420Z",
+      "pattern": "src/scistudio/blocks/ai/ai_block.py",
+      "reason": "Owner narrowed scope to AIBlock.result only; record consumer-migration paths touched (api/runtime, ai/agent/mcp, process_block, ai_block) not in original include."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-27T15:19:59.491421Z",
+      "pattern": "tests/ai/test_mcp_tools_inspection.py",
+      "reason": "Owner narrowed scope to AIBlock.result only; record consumer-migration paths touched (api/runtime, ai/agent/mcp, process_block, ai_block) not in original include."
+    }
+  ],
+  "session_id": "e389d8da-5dc3-4b8b-b886-b0a61974db31",
+  "strictness_tier": null,
+  "task_kind": "guided",
+  "test_events": []
+}

--- a/src/scistudio/ai/agent/mcp/tools_inspection/read.py
+++ b/src/scistudio/ai/agent/mcp/tools_inspection/read.py
@@ -78,15 +78,27 @@ async def get_block_output(
         value = block_payload[port]
     else:
         raise KeyError(f"Block '{block_id}' has no output port '{port}' in run '{run_id}'")
+    # #1811 Option 2: a length-one Collection is the canonical single-value
+    # shape (ADR-020 §3). Surface the inner item's type and ref so inspection
+    # matches the single-item preview instead of losing the type to the
+    # collection envelope (which carries no top-level ``metadata``).
+    effective = value
+    if (
+        isinstance(value, dict)
+        and value.get("_collection")
+        and isinstance(value.get("items"), list)
+        and len(value["items"]) == 1
+    ):
+        effective = value["items"][0]
     type_chain: list[str] = []
-    if isinstance(value, dict):
-        meta = value.get("metadata") or {}
+    if isinstance(effective, dict):
+        meta = effective.get("metadata") or {}
         if isinstance(meta, dict):
             chain = meta.get("type_chain")
             if isinstance(chain, list):
                 type_chain = [str(x) for x in chain]
     return GetBlockOutputResult(
-        ref=value if isinstance(value, dict) else {"value": value},
+        ref=effective if isinstance(effective, dict) else {"value": effective},
         type=TypeChainInfo(
             type_chain=type_chain,
             type_name=type_chain[-1] if type_chain else "",

--- a/src/scistudio/ai/agent/mcp/tools_plot/targets.py
+++ b/src/scistudio/ai/agent/mcp/tools_plot/targets.py
@@ -122,12 +122,17 @@ def _latest_output_for(ctx: Any, node_id: str, output_port: str) -> tuple[str | 
 
 def _looks_like_collection(value: Any) -> bool:
     if isinstance(value, dict):
+        if value.get("_collection"):
+            # #1811 Option 2: a length-one Collection represents a single
+            # value (ADR-020 §3); only >1 items is a real collection target.
+            items = value.get("items")
+            return not (isinstance(items, list) and len(items) == 1)
         meta = value.get("metadata")
         if isinstance(meta, dict):
             chain = meta.get("type_chain")
             if isinstance(chain, list) and any("Collection" in str(x) for x in chain):
                 return True
-        if value.get("_collection") or value.get("collection_item_type"):
+        if value.get("collection_item_type"):
             return True
     return isinstance(value, (list, tuple))
 

--- a/src/scistudio/api/runtime/_data.py
+++ b/src/scistudio/api/runtime/_data.py
@@ -158,7 +158,15 @@ def register_output_payload(self: ApiRuntime, payload: Any) -> Any:
             "metadata": record.metadata,
         }
     if isinstance(payload, dict) and payload.get("_collection") is True:
-        items = [self.register_output_payload(item) for item in payload.get("items", [])]
+        raw_items = payload.get("items", [])
+        # #1811 Option 2: a length-one Collection is the canonical
+        # representation of a single value (ADR-020 §3). Register it as a
+        # single ``data_ref`` so the frontend opens the single-item viewer
+        # rather than rerouting to a collection/grid previewer. Genuine
+        # multi-item collections keep the ``kind="collection"`` payload.
+        if isinstance(raw_items, list) and len(raw_items) == 1:
+            return self.register_output_payload(raw_items[0])
+        items = [self.register_output_payload(item) for item in raw_items]
         return {
             "kind": "collection",
             "count": len(items),

--- a/src/scistudio/blocks/ai/ai_block.py
+++ b/src/scistudio/blocks/ai/ai_block.py
@@ -161,9 +161,12 @@ class AIBlock(Block):
     output_ports: ClassVar[list[OutputPort]] = [
         OutputPort(
             name="result",
+            # #1811: the agent can emit one or many files; every port transports
+            # a Collection (ADR-020 §3), so declare it honestly as a collection
+            # rather than the historical single-value default.
             accepted_types=[DataObject],
-            is_collection=False,
-            description="Output port; the agent writes a file at the configured expected_path.",
+            is_collection=True,
+            description="Output port; the agent writes one or more files at the configured expected_path.",
         ),
     ]
 

--- a/src/scistudio/blocks/process/process_block.py
+++ b/src/scistudio/blocks/process/process_block.py
@@ -171,10 +171,14 @@ class ProcessBlock(Block):
                 out_collection = Collection(results) if results else Collection([], item_type=primary.item_type)
                 return {output_name: out_collection}
 
-            # Fallback for non-Collection inputs (backward compatibility).
+            # Fallback for a bare (non-Collection) primary input: treat it as a
+            # single item and still emit a length-one Collection so the output
+            # honours the ADR-020 §3 transport contract (#1811) even when a bare
+            # value reaches the block directly (e.g. a legacy wire payload).
             result = self.process_item(primary, config, state) if takes_state else self.process_item(primary, config)
+            result = self._auto_flush(result)
             output_name = effective_output_ports[0].name if effective_output_ports else "output"
-            return {output_name: result}
+            return {output_name: Collection([result])}
         finally:
             # ADR-027 D7: teardown always runs, even on exception.
             self.teardown(state)

--- a/src/scistudio/engine/runners/worker.py
+++ b/src/scistudio/engine/runners/worker.py
@@ -173,6 +173,14 @@ def reconstruct_inputs(payload: dict[str, Any]) -> dict[str, Any]:
             result[key] = Collection(items, item_type=item_type)
         elif isinstance(value, dict) and "backend" in value and "path" in value:
             # Single typed DataObject — delegate to _reconstruct_one.
+            # #1811: in the live flow this branch is not reached for block
+            # outputs — every port output is wrapped into a Collection at the
+            # engine boundary (_normalize_outputs) and serialised as a
+            # ``_collection`` envelope, which the branch above decodes. This
+            # bare branch faithfully decodes any legacy bare-wire payload
+            # (e.g. an old checkpoint); such a value is delivered as a bare
+            # DataObject and handled by the consuming block's existing
+            # bare-input fallback.
             result[key] = _reconstruct_one(value)
         else:
             # Scalar / list / dict / None — pass through for non-DataObject
@@ -192,36 +200,39 @@ def _normalize_outputs(
     boundary is represented as a :class:`Collection`. A single item is a
     length-one Collection; a multi-file or multi-object input is a longer
     Collection. The engine, not the block, is responsible for honouring
-    that contract — block authors who follow the docs and return a bare
-    :class:`DataObject` on a port with ``is_collection=True`` would
-    otherwise silently produce a wire-format mismatch at the downstream
-    port (#1330).
+    that contract.
+
+    #1811: this wrap is **unconditional** — it applies to every declared
+    output port, not just ``is_collection=True`` ports. ``is_collection``
+    is a UI hint only and does not change runtime transport
+    (collection-guide.md). The earlier ``is_collection=True``-gated wrap
+    (#1330) left single-value ports transporting a bare DataObject, which
+    violated the contract and produced wire-format drift at the downstream
+    port; gating is removed so the wire format is uniform.
 
     For each ``(port_name, value)`` pair:
 
     1. Look up the matching :class:`OutputPort` by name. If the port name
        is not declared (e.g. sentinels like ``__scistudio_env__``), leave
        the value unchanged.
-    2. If ``port.is_collection=True`` and ``value`` is a bare
-       :class:`DataObject` (not already a :class:`Collection`), wrap it as
+    2. If ``value`` is a bare :class:`DataObject` (not already a
+       :class:`Collection`), wrap it as
        ``Collection([value], item_type=type(value))``. The ``type(value)``
        strategy matches the precedent in
        :mod:`scistudio.blocks.ai.ai_block` (``ai_block.py:532``) and is
        stable under Add6's ``port_accepts_type`` check.
-    3. If ``port.is_collection=True`` and ``value`` is a bare ``list`` of
-       :class:`DataObject` items (every element is a DataObject and the
-       list is non-empty), pack it as
+    3. If ``value`` is a bare ``list`` of :class:`DataObject` items (every
+       element is a DataObject and the list is non-empty), pack it as
        ``Collection(value, item_type=type(value[0]))``. Catches the
        ADR-020 §3 "multi-file → longer Collection" case where a block
        returned a native list without packing — without this, the bare
        list would either fall through unwrapped or be wrapped as a single
        1-item Collection containing the list (which violates Collection's
        homogeneity invariant).
-    4. For all other shapes (already-wrapped Collection, non-Collection
-       port, scalar/dict/None, wire-format dict from a serialised payload,
-       mixed-type lists, empty lists), leave the value untouched and let
-       the existing serialisation / validation layer surface a clear
-       error.
+    4. For all other shapes (already-wrapped Collection, scalar/dict/None,
+       wire-format dict from a serialised payload, mixed-type lists, empty
+       lists), leave the value untouched and let the existing
+       serialisation / validation layer surface a clear error.
 
     The helper is idempotent: calling it twice on the same dict yields
     the same result. It is safe to invoke on both raw-Python outputs
@@ -254,8 +265,12 @@ def _normalize_outputs(
             # Unknown port name (e.g. ``__scistudio_env__`` sentinel) —
             # leave it alone.
             continue
-        if not getattr(port, "is_collection", False):
-            continue
+        # #1811: ADR-020 §3 makes the Collection transport contract
+        # unconditional — EVERY declared port carries a Collection, not just
+        # ``is_collection=True`` ports. The ``is_collection`` flag is a UI
+        # hint only (collection-guide.md) and must not gate the wrap. A bare
+        # single value on any port is wrapped into a length-one Collection
+        # here, so the wire format is uniform regardless of the flag.
         if isinstance(value, Collection):
             continue
         if isinstance(value, list) and value and all(isinstance(item, DataObject) for item in value):
@@ -566,12 +581,13 @@ def main() -> None:
             print(json.dumps(envelope))
             return
 
-        # #1330: enforce ADR-020 §3 transport contract — wrap bare
-        # DataObject values on ``is_collection=True`` ports into length-one
-        # Collections at the engine boundary. Idempotent and a no-op for
-        # blocks that already self-wrap (six concrete blocks in
-        # blocks/process|code|app|ai). Skipped when ``run`` returned a
-        # non-dict (handled below by the ``_result`` fallback).
+        # #1330/#1811: enforce ADR-020 §3 transport contract — wrap bare
+        # DataObject values on EVERY declared output port into length-one
+        # Collections at the engine boundary (unconditional as of #1811;
+        # the ``is_collection`` flag no longer gates the wrap). Idempotent
+        # and a no-op for blocks that already self-wrap. Skipped when
+        # ``run`` returned a non-dict (handled below by the ``_result``
+        # fallback).
         if isinstance(outputs, dict):
             try:
                 effective_output_ports = block.get_effective_output_ports()

--- a/tests/ai/test_mcp_tools_inspection.py
+++ b/tests/ai/test_mcp_tools_inspection.py
@@ -89,6 +89,50 @@ def test_get_block_output_happy(ctx: _StubRuntime) -> None:
     assert result.type.type_name == "Array"
 
 
+def test_get_block_output_single_value_keeps_type(ctx: _StubRuntime, tmp_path: Path) -> None:
+    """#1811: a single-value output must keep its type after the engine wraps
+    it into a length-one Collection.
+
+    Builds the recorded output through the real engine output codec
+    (``_normalize_outputs`` -> ``serialise_outputs``) so the stored shape is
+    whatever the engine actually produces. Green today (bare wire ->
+    ``type_name == "Array"``). When the engine wraps single values the value
+    becomes ``{_collection: True, items: [...], item_type: "Array"}`` with no
+    top-level ``metadata`` — ``get_block_output`` would return ``type_name ==
+    ""`` — until the Option-2 migration teaches it to read the single item's
+    type from a length-one collection envelope.
+    """
+    import numpy as np
+    import zarr
+
+    from scistudio.blocks.base.ports import OutputPort
+    from scistudio.core.storage.ref import StorageReference
+    from scistudio.core.types.array import Array
+    from scistudio.engine.runners.worker import _normalize_outputs, serialise_outputs
+
+    zarr_path = str(tmp_path / "single.zarr")
+    zarr.save(zarr_path, np.zeros((4, 4), dtype="uint8"))
+    arr = Array(
+        axes=["y", "x"],
+        shape=(4, 4),
+        dtype="uint8",
+        storage_ref=StorageReference(backend="zarr", path=zarr_path),
+    )
+    outputs: dict[str, Any] = {"out": arr}
+    _normalize_outputs(outputs, [OutputPort(name="out", accepted_types=[Array], is_collection=False)])
+    wire = serialise_outputs(outputs, str(tmp_path))["out"]
+
+    class _Sched:
+        _block_outputs: ClassVar[dict[str, Any]] = {"b1": {"out": wire}}
+
+    class _Run:
+        scheduler = _Sched()
+
+    ctx.workflow_runs["r1"] = _Run()
+    result = _run(tools_inspection.get_block_output(run_id="r1", block_id="b1", port="out"))
+    assert result.type.type_name == "Array"
+
+
 # --- inspect_data ----------------------------------------------------------
 
 

--- a/tests/engine/test_collection_wrap.py
+++ b/tests/engine/test_collection_wrap.py
@@ -141,16 +141,18 @@ class TestEngineDoesNotDoubleWrap:
         assert len(outputs["out"]) == 2
 
 
-class TestEngineLeavesNonCollectionPortAlone:
-    """Bare DataObject on an ``is_collection=False`` port is NOT wrapped."""
+class TestEngineWrapsBareOnNonCollectionPort:
+    """#1811: a bare DataObject on an ``is_collection=False`` port IS wrapped.
 
-    def test_engine_leaves_bare_alone_on_non_collection_port(self) -> None:
+    This reverses the original #1330 behaviour (single-value ports kept the
+    bare wire format). ADR-020 §3 makes the Collection-as-transport contract
+    unconditional; ``is_collection`` is a UI hint only (collection-guide.md)
+    and no longer gates the wrap.
+    """
+
+    def test_engine_wraps_bare_on_non_collection_port(self) -> None:
         """Block returns ``{"out": bare_array}`` for an ``is_collection=False``
-        port; post-normalize value is the same bare object (no wrap).
-
-        ADR-020 §3 only mandates Collection-as-transport on Collection
-        ports. Scalar / single-item ports keep their bare-DataObject
-        wire format.
+        port; post-normalize value is a length-one Collection.
         """
         bare = _make_array()
         ports = [
@@ -160,8 +162,10 @@ class TestEngineLeavesNonCollectionPortAlone:
 
         _normalize_outputs(outputs, ports)
 
-        assert outputs["out"] is bare
-        assert not isinstance(outputs["out"], Collection)
+        wrapped = outputs["out"]
+        assert isinstance(wrapped, Collection)
+        assert len(wrapped) == 1
+        assert wrapped[0] is bare
 
 
 class TestEngineNormalizeEdgeCases:

--- a/tests/engine/test_single_value_collection_consumers.py
+++ b/tests/engine/test_single_value_collection_consumers.py
@@ -1,0 +1,107 @@
+"""Green-today consumer coverage for the #1811 single-value→Collection fix.
+
+#1811 makes the engine wrap every single-value block output into a
+length-one :class:`Collection` (ADR-020 §3: "a single item is represented
+as a length-one Collection"). The wire shape of a single value therefore
+changes from a bare ``{backend, path, format, metadata}`` reference to a
+``{_collection: True, items: [...], item_type: ...}`` envelope.
+
+Three downstream consumers read the single-value **wire** shape and had no
+existing coverage of the length-one-Collection path, so a silent behaviour
+change could slip through (the exact gap this work targets):
+
+- ``ApiRuntime.register_output_payload`` (preview registration): a single
+  value must register as a ``data_ref`` (frontend single-item viewer), not
+  a ``kind="collection"`` payload that the frontend reroutes to a grid
+  previewer.
+- ``tools_plot.targets._looks_like_collection`` (plot target hint): a
+  single value must report ``is_collection=False``.
+
+The third consumer, ``tools_inspection.get_block_output``, is covered next
+to its FastMCP context fixture in
+``tests/ai/test_mcp_tools_inspection.py``.
+
+Each test builds the wire payload through the **real** engine output codec
+(:func:`_normalize_outputs` -> :func:`serialise_outputs`) so it tracks the
+fix automatically: it passes on today's bare-wire path and fails the moment
+the engine wraps single values. The Option-2 migration — treat a length-one
+Collection as a single value in these single-item-oriented consumers — then
+restores each to green. This is the "green today, red after the engine
+flip, green after migration" ratchet that bounds the fix's blast radius.
+
+References: ADR-020 §3; #1811.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import zarr
+
+from scistudio.blocks.base.ports import OutputPort
+from scistudio.core.storage.ref import StorageReference
+from scistudio.core.types.array import Array
+from scistudio.engine.runners.worker import _normalize_outputs, serialise_outputs
+
+
+def _single_value_wire(tmp_path) -> dict:
+    """Return the engine wire payload for a single value on an is_collection=False port.
+
+    Drives the real output codec so the returned shape is whatever the
+    engine actually produces: a bare reference today, a length-one
+    ``_collection`` envelope once #1811 lands.
+    """
+    zarr_path = str(tmp_path / "single.zarr")
+    zarr.save(zarr_path, np.zeros((4, 4), dtype="uint8"))
+    arr = Array(
+        axes=["y", "x"],
+        shape=(4, 4),
+        dtype="uint8",
+        storage_ref=StorageReference(backend="zarr", path=zarr_path),
+    )
+    ports = [OutputPort(name="out", accepted_types=[Array], is_collection=False)]
+    outputs: dict = {"out": arr}
+    _normalize_outputs(outputs, ports)
+    return serialise_outputs(outputs, str(tmp_path))["out"]
+
+
+class TestPreviewRegistrationSingleValue:
+    """``register_output_payload`` must keep a single value a single-item ref."""
+
+    def test_single_value_registers_as_data_ref_not_collection(self, tmp_path, monkeypatch) -> None:
+        """A single block output should register as a ``data_ref`` so the
+        frontend opens the single-item viewer — not a ``kind="collection"``
+        payload that reroutes to a collection/grid previewer.
+
+        Green today (bare wire -> ``data_ref``). When the engine wraps single
+        values it becomes a length-one ``_collection`` and
+        ``register_output_payload`` would emit ``kind="collection"`` — the
+        Option-2 migration unwraps length-one collections back to a single
+        ``data_ref``.
+        """
+        from scistudio.api import runtime as runtime_module
+
+        # Self-contained ApiRuntime: redirect the registry dir into tmp_path
+        # exactly like tests/api/conftest.py, so no real ~/.scistudio is touched.
+        monkeypatch.setattr(runtime_module.Path, "home", classmethod(lambda cls: tmp_path))
+        rt = runtime_module.ApiRuntime()
+
+        result = rt.register_output_payload(_single_value_wire(tmp_path))
+
+        assert isinstance(result, dict)
+        assert "data_ref" in result, f"single value should register as a data_ref; got {result!r}"
+        assert result.get("kind") != "collection"
+        assert result.get("type_name") == "Array"
+
+
+class TestPlotTargetSingleValue:
+    """``_looks_like_collection`` must report a single value as non-collection."""
+
+    def test_single_value_is_not_a_collection_target(self, tmp_path) -> None:
+        """A single block output should yield ``is_collection=False`` for the
+        plot target hint. Green today (bare wire); after the engine wraps the
+        value the length-one ``_collection`` must still report ``False`` under
+        Option 2 (a length-one Collection is semantically a single value).
+        """
+        from scistudio.ai.agent.mcp.tools_plot.targets import _looks_like_collection
+
+        assert _looks_like_collection(_single_value_wire(tmp_path)) is False

--- a/tests/engine/test_single_value_collection_contract.py
+++ b/tests/engine/test_single_value_collection_contract.py
@@ -1,4 +1,4 @@
-"""xfail baseline for the residual single-value transport drift (#1811).
+"""Single-value transport contract — every port crosses as a Collection (#1811).
 
 ADR-020 §3 states the runtime transport contract:
 
@@ -7,59 +7,36 @@ ADR-020 §3 states the runtime transport contract:
     multi-file/multi-object input is a longer Collection.
 
 #1330 (closed) enforced this **only** on ports already declared
-``is_collection=True`` — :func:`_normalize_outputs` wraps a bare
-DataObject into a length-one Collection on those ports. It did *not* make
-single-value ports (``is_collection=False``) always-Collection. As a
-result the engine still:
+``is_collection=True``. #1811 makes the wrap **unconditional**: the
+``is_collection`` flag is a UI hint only (collection-guide.md) and no
+longer gates transport, so single-value (``is_collection=False``) ports
+also cross the boundary as length-one Collections.
 
-- serialises a single DataObject as a bare ``{backend, path, metadata}``
-  reference (no ``_collection`` envelope) on ``is_collection=False`` ports
-  (:func:`serialise_outputs`);
-- reconstructs that wire shape as a **bare** DataObject downstream
-  (:func:`reconstruct_inputs`); and
-- re-emits a bare value from :meth:`ProcessBlock.run` when the primary
-  input was itself bare (the non-Collection fallback branch).
+Enforcement point
+-----------------
+:func:`_normalize_outputs` is the single engine boundary that guarantees
+the contract: it wraps every bare ``DataObject`` (or bare
+``list[DataObject]``) on every declared output port into a Collection,
+before serialisation and before the value lands in
+``DAGScheduler._block_outputs``. Because normalize always runs first, the
+downstream wire codec (:func:`serialise_outputs` /
+:func:`reconstruct_inputs`) only ever sees an already-wrapped Collection in
+the live flow and faithfully transports it as a ``_collection`` envelope —
+the primitives are not single-value-aware and do not need to be.
+:meth:`ProcessBlock.run` additionally wraps its own output so a block that
+is handed a bare primary still emits a Collection.
 
-Per ADR-020 §3 every one of these single values should be a length-one
-Collection. The tests below pin that **target** behaviour. They are
-marked ``xfail(strict=True)`` because the residual drift means they fail
-today; when the #1811 root-cause fix lands (option (a): treat every
-DataObject port as a Collection), each will start passing and the strict
-marker forces us to delete it — a self-cleaning regression ratchet.
+This file pins that contract at each boundary a single value passes:
 
-These tests are intentionally distinct from
-``tests/engine/test_collection_wrap.py`` (the #1330 suite), whose
-``TestEngineLeavesNonCollectionPortAlone`` pins the *current* drift as
-intended #1330 behaviour. When #1811 lands, that #1330 test must be
-revisited in the same change; this file documents why.
+- output produce — :func:`_normalize_outputs` (the enforcement point);
+- wire round-trip — a normalised single value serialises to a
+  ``_collection`` envelope and reconstructs to a length-one Collection;
+- in-memory consume + re-emit — :meth:`ProcessBlock.run`;
+- the scheduler in-process boundary (``_dispatch.py``).
 
-Completeness
-------------
-These boundaries are not a sample — they are the **closed set** of places a
-bare single value can enter or leave a block boundary. A bare DataObject can
-only exist where the transport codec produces or consumes one, and that codec
-is a small, greppable API:
-
-- In-memory raw objects enter ``DAGScheduler._block_outputs`` via exactly five
-  writers (``_dispatch.py`` 249/327/588, ``scheduler/__init__.py`` 452/461).
-  327/588 pass through ``_normalize_outputs`` first; 249 and 452/461 are
-  wire-format paths (worker terminal outputs and checkpoint restore) that carry
-  whatever the wire codec produced.
-- Wire-format single values are produced **only** by ``_serialise_one`` and
-  consumed **only** by ``_reconstruct_one``. At a port boundary the single-value
-  branches are ``worker.serialise_outputs`` (worker.py:383) and
-  ``worker.reconstruct_inputs`` (worker.py:176); every other caller is either
-  Collection-item recursion, CompositeData slot recursion, a deprecated
-  checkpoint deserialiser, or a metadata/preview side-channel.
-
-So the root-cause surface reduces to three engine locations — ``_normalize_outputs``
-(output produce), ``serialise_outputs`` (wire produce), ``reconstruct_inputs``
-(wire consume) — plus the ``ProcessBlock.run`` non-Collection fallback (in-memory
-consume + re-emit). The tests below pin all four. Checkpoint restore and worker
-terminal outputs inherit the same codec and are fixed transitively when it is;
-they are noted here so a future reviewer knows they were considered, not missed.
-A new leak would require adding a new call site to one of those three functions,
-which a grep-based guard can catch.
+These tests were the ``xfail(strict=True)`` baseline that pinned the
+residual drift before the fix (the Phase-1 ratchet, PR #1814); the strict
+markers were removed when the #1811 fix landed and flipped them green.
 
 References: ADR-020 §3, §5, §7.1; #1330 (closed); #1811.
 """
@@ -69,8 +46,6 @@ from __future__ import annotations
 import asyncio
 from typing import Any, ClassVar
 from unittest.mock import AsyncMock, MagicMock
-
-import pytest
 
 from scistudio.blocks.base.block import Block
 from scistudio.blocks.base.config import BlockConfig
@@ -89,12 +64,6 @@ from scistudio.engine.runners.worker import (
 from scistudio.engine.scheduler import DAGScheduler
 from scistudio.workflow.definition import NodeDef, WorkflowDefinition
 
-_XFAIL_REASON = (
-    "#1811: ADR-020 §3 requires single values on is_collection=False ports to "
-    "transport as length-one Collections; the engine still uses the bare "
-    "DataObject path. Remove this xfail when the option (a) fix lands."
-)
-
 
 def _ref(path: str = "/tmp/test.zarr", backend: str = "zarr") -> StorageReference:
     """Minimal StorageReference so serialise_outputs skips auto-flush."""
@@ -106,25 +75,26 @@ def _make_array() -> Array:
     return Array(axes=["y", "x"], shape=(4, 4), dtype="uint8")
 
 
+def _single_value_port() -> OutputPort:
+    return OutputPort(name="out", accepted_types=[Array], is_collection=False)
+
+
 # ---------------------------------------------------------------------------
 # Output boundary: _normalize_outputs on single-value (is_collection=False)
 # ---------------------------------------------------------------------------
 
 
 class TestNormalizeSingleValuePort:
-    """``_normalize_outputs`` should treat every DataObject port as Collection."""
+    """``_normalize_outputs`` treats every DataObject port as Collection."""
 
-    @pytest.mark.xfail(reason=_XFAIL_REASON, strict=True)
     def test_normalize_wraps_bare_dataobject_on_single_value_port(self) -> None:
-        """Bare DataObject on an ``is_collection=False`` port should become a
-        length-one Collection. Today ``_normalize_outputs`` early-returns for
-        non-Collection ports ([worker.py:257]) and leaves the bare object.
+        """Bare DataObject on an ``is_collection=False`` port becomes a
+        length-one Collection (the #1811 unconditional wrap).
         """
         bare = _make_array()
-        ports = [OutputPort(name="out", accepted_types=[Array], is_collection=False)]
         outputs: dict = {"out": bare}
 
-        _normalize_outputs(outputs, ports)
+        _normalize_outputs(outputs, [_single_value_port()])
 
         wrapped = outputs["out"]
         assert isinstance(wrapped, Collection)
@@ -132,17 +102,15 @@ class TestNormalizeSingleValuePort:
         assert wrapped[0] is bare
         assert wrapped.item_type is Array
 
-    @pytest.mark.xfail(reason=_XFAIL_REASON, strict=True)
     def test_normalize_packs_bare_list_on_single_value_port(self) -> None:
-        """A bare ``list[DataObject]`` on an ``is_collection=False`` port should
-        pack into a Collection (ADR-020 §3 "multi-object input is a longer
-        Collection"). Today the non-Collection port is skipped entirely.
+        """A bare ``list[DataObject]`` on an ``is_collection=False`` port packs
+        into a Collection (ADR-020 §3 "multi-object input is a longer
+        Collection").
         """
         a, b = _make_array(), _make_array()
-        ports = [OutputPort(name="out", accepted_types=[Array], is_collection=False)]
         outputs: dict = {"out": [a, b]}
 
-        _normalize_outputs(outputs, ports)
+        _normalize_outputs(outputs, [_single_value_port()])
 
         packed = outputs["out"]
         assert isinstance(packed, Collection)
@@ -153,18 +121,17 @@ class TestNormalizeSingleValuePort:
 
 
 # ---------------------------------------------------------------------------
-# Wire format: serialise_outputs / reconstruct_inputs for single values
+# Wire round-trip: a normalised single value crosses as a _collection envelope
 # ---------------------------------------------------------------------------
 
 
 class TestSingleValueWireFormat:
-    """A single DataObject should cross the wire as a ``_collection`` envelope."""
+    """A normalised single value crosses the wire as a ``_collection`` envelope."""
 
-    @pytest.mark.xfail(reason=_XFAIL_REASON, strict=True)
-    def test_serialise_single_dataobject_emits_collection_envelope(self, tmp_path) -> None:
-        """``serialise_outputs`` of a single DataObject should produce a
-        ``{"_collection": True, "items": [...], "item_type": ...}`` payload,
-        not a bare ``{backend, path, metadata}`` reference ([worker.py:383]).
+    def test_normalized_single_value_serialises_as_collection_envelope(self, tmp_path) -> None:
+        """After the engine boundary wraps a single value, ``serialise_outputs``
+        emits a ``{"_collection": True, "items": [...], "item_type": ...}``
+        payload — not a bare ``{backend, path, metadata}`` reference.
         """
         import numpy as np
         import zarr
@@ -173,44 +140,18 @@ class TestSingleValueWireFormat:
         zarr.save(zarr_path, np.zeros((4, 4), dtype="uint8"))
         arr = Array(axes=["y", "x"], shape=(4, 4), dtype="uint8", storage_ref=_ref(zarr_path))
 
-        wire = serialise_outputs({"out": arr}, str(tmp_path))
-        payload = wire["out"]
+        outputs: dict = {"out": arr}
+        _normalize_outputs(outputs, [_single_value_port()])
+        payload = serialise_outputs(outputs, str(tmp_path))["out"]
 
         assert payload.get("_collection") is True
         assert payload["item_type"] == "Array"
         assert len(payload["items"]) == 1
 
-    @pytest.mark.xfail(reason=_XFAIL_REASON, strict=True)
-    def test_reconstruct_bare_wire_dict_yields_length_one_collection(self, tmp_path) -> None:
-        """A bare ``{backend, path, metadata}`` wire dict should reconstruct as a
-        length-one Collection, not a bare DataObject ([worker.py:174-176]).
-
-        Builds the bare wire shape via the existing single-value serialiser so
-        the metadata is realistic, then asserts the target reconstruct result.
-        """
-        import numpy as np
-        import zarr
-
-        zarr_path = str(tmp_path / "bare.zarr")
-        zarr.save(zarr_path, np.zeros((4, 4), dtype="uint8"))
-        arr = Array(axes=["y", "x"], shape=(4, 4), dtype="uint8", storage_ref=_ref(zarr_path))
-
-        bare_wire = serialise_outputs({"out": arr}, str(tmp_path))["out"]
-        # Guard the test's own premise: today this is a bare reference, the
-        # exact shape #1811 is about. (If this key appears, the fix landed and
-        # this xfail test plus its premise must be revisited.)
-        assert "backend" in bare_wire and "_collection" not in bare_wire
-
-        rebuilt = reconstruct_inputs({"inputs": {"out": bare_wire}})["out"]
-
-        assert isinstance(rebuilt, Collection)
-        assert len(rebuilt) == 1
-        assert isinstance(rebuilt[0], Array)
-
-    @pytest.mark.xfail(reason=_XFAIL_REASON, strict=True)
     def test_single_value_round_trip_is_length_one_collection(self, tmp_path) -> None:
-        """End-to-end ``serialise_outputs`` -> ``reconstruct_inputs`` of a single
-        value should hand the downstream block a length-one Collection.
+        """End-to-end ``_normalize_outputs`` -> ``serialise_outputs`` ->
+        ``reconstruct_inputs`` of a single value hands the downstream block a
+        length-one Collection.
         """
         import numpy as np
         import zarr
@@ -219,7 +160,9 @@ class TestSingleValueWireFormat:
         zarr.save(zarr_path, np.zeros((8, 8), dtype="float32"))
         original = Array(axes=["y", "x"], shape=(8, 8), dtype="float32", storage_ref=_ref(zarr_path))
 
-        wire = serialise_outputs({"out": original}, str(tmp_path))
+        outputs: dict = {"out": original}
+        _normalize_outputs(outputs, [_single_value_port()])
+        wire = serialise_outputs(outputs, str(tmp_path))
         rebuilt = reconstruct_inputs({"inputs": wire})["out"]
 
         assert isinstance(rebuilt, Collection)
@@ -228,20 +171,17 @@ class TestSingleValueWireFormat:
 
 
 # ---------------------------------------------------------------------------
-# Consumer boundary: ProcessBlock.run must not re-emit bare on bare input
+# Consumer boundary: ProcessBlock.run emits a Collection on bare input
 # ---------------------------------------------------------------------------
 
 
 class TestProcessBlockSingleValueOutput:
-    """The non-Collection fallback in :meth:`ProcessBlock.run` propagates drift."""
+    """:meth:`ProcessBlock.run` wraps even a bare primary input."""
 
-    @pytest.mark.xfail(reason=_XFAIL_REASON, strict=True)
     def test_process_block_emits_collection_for_bare_input(self) -> None:
         """When the primary input is a bare DataObject, ``ProcessBlock.run``
-        should still emit a Collection on its output port. Today the
-        non-Collection fallback ([process_block.py:174-177]) calls
-        ``process_item`` once and returns the bare result, so the drift
-        propagates transitively down the graph.
+        still emits a Collection on its output port, so the contract holds even
+        for a legacy bare value reaching the block directly.
         """
         from scistudio.blocks.process.process_block import ProcessBlock
 
@@ -263,18 +203,17 @@ class TestProcessBlockSingleValueOutput:
 
 
 # ---------------------------------------------------------------------------
-# Integration: scheduler in-process boundary (_dispatch.py:325)
+# Integration: scheduler in-process boundary (_dispatch.py)
 # ---------------------------------------------------------------------------
 
 
 class _BareSingleValueBlock(Block):
     """Non-interactive block returning a bare Array on an is_collection=False port.
 
-    Mirrors the in-process drift: a runner returning a raw Python
+    Mirrors the in-process path: a runner returning a raw Python
     :class:`DataObject` (not a wire dict) on a single-value port. The
-    engine's in-process ``_normalize_outputs`` call ([_dispatch.py:325])
-    skips non-Collection ports today, so the bare Array lands in
-    ``_block_outputs`` unwrapped.
+    engine's in-process ``_normalize_outputs`` call must wrap it before it
+    lands in ``_block_outputs``.
     """
 
     name: ClassVar[str] = "BareSingleValue"
@@ -296,7 +235,7 @@ def _make_single_value_scheduler() -> tuple[DAGScheduler, EventBus]:
 
     The mock runner returns the block's bare, un-normalised output so the
     in-process finalize ``_normalize_outputs`` call is the only thing that
-    could honour ADR-020 §3 before the value lands in ``_block_outputs``.
+    can honour ADR-020 §3 before the value lands in ``_block_outputs``.
     """
     wf = WorkflowDefinition(
         id="wf-1811-single-value",
@@ -332,14 +271,11 @@ def _make_single_value_scheduler() -> tuple[DAGScheduler, EventBus]:
 
 
 class TestSchedulerInProcessSingleValueBoundary:
-    """The second ``_normalize_outputs`` call site must wrap single values too."""
+    """The in-process ``_normalize_outputs`` call site wraps single values too."""
 
-    @pytest.mark.xfail(reason=_XFAIL_REASON, strict=True)
     def test_in_process_dispatch_wraps_bare_single_value(self) -> None:
         """A bare Array produced in-process on an ``is_collection=False`` port
-        should land in ``_block_outputs`` as a length-one Collection. Today the
-        in-process boundary ([_dispatch.py:325]) skips non-Collection ports, so
-        the bare value propagates to downstream blocks unwrapped.
+        lands in ``_block_outputs`` as a length-one Collection.
         """
         scheduler, _event_bus = _make_single_value_scheduler()
 

--- a/tests/engine/test_single_value_collection_contract.py
+++ b/tests/engine/test_single_value_collection_contract.py
@@ -1,0 +1,354 @@
+"""xfail baseline for the residual single-value transport drift (#1811).
+
+ADR-020 §3 states the runtime transport contract:
+
+    All values crossing a block boundary are represented as Collection
+    objects. A single item is represented as a length-one Collection; a
+    multi-file/multi-object input is a longer Collection.
+
+#1330 (closed) enforced this **only** on ports already declared
+``is_collection=True`` — :func:`_normalize_outputs` wraps a bare
+DataObject into a length-one Collection on those ports. It did *not* make
+single-value ports (``is_collection=False``) always-Collection. As a
+result the engine still:
+
+- serialises a single DataObject as a bare ``{backend, path, metadata}``
+  reference (no ``_collection`` envelope) on ``is_collection=False`` ports
+  (:func:`serialise_outputs`);
+- reconstructs that wire shape as a **bare** DataObject downstream
+  (:func:`reconstruct_inputs`); and
+- re-emits a bare value from :meth:`ProcessBlock.run` when the primary
+  input was itself bare (the non-Collection fallback branch).
+
+Per ADR-020 §3 every one of these single values should be a length-one
+Collection. The tests below pin that **target** behaviour. They are
+marked ``xfail(strict=True)`` because the residual drift means they fail
+today; when the #1811 root-cause fix lands (option (a): treat every
+DataObject port as a Collection), each will start passing and the strict
+marker forces us to delete it — a self-cleaning regression ratchet.
+
+These tests are intentionally distinct from
+``tests/engine/test_collection_wrap.py`` (the #1330 suite), whose
+``TestEngineLeavesNonCollectionPortAlone`` pins the *current* drift as
+intended #1330 behaviour. When #1811 lands, that #1330 test must be
+revisited in the same change; this file documents why.
+
+Completeness
+------------
+These boundaries are not a sample — they are the **closed set** of places a
+bare single value can enter or leave a block boundary. A bare DataObject can
+only exist where the transport codec produces or consumes one, and that codec
+is a small, greppable API:
+
+- In-memory raw objects enter ``DAGScheduler._block_outputs`` via exactly five
+  writers (``_dispatch.py`` 249/327/588, ``scheduler/__init__.py`` 452/461).
+  327/588 pass through ``_normalize_outputs`` first; 249 and 452/461 are
+  wire-format paths (worker terminal outputs and checkpoint restore) that carry
+  whatever the wire codec produced.
+- Wire-format single values are produced **only** by ``_serialise_one`` and
+  consumed **only** by ``_reconstruct_one``. At a port boundary the single-value
+  branches are ``worker.serialise_outputs`` (worker.py:383) and
+  ``worker.reconstruct_inputs`` (worker.py:176); every other caller is either
+  Collection-item recursion, CompositeData slot recursion, a deprecated
+  checkpoint deserialiser, or a metadata/preview side-channel.
+
+So the root-cause surface reduces to three engine locations — ``_normalize_outputs``
+(output produce), ``serialise_outputs`` (wire produce), ``reconstruct_inputs``
+(wire consume) — plus the ``ProcessBlock.run`` non-Collection fallback (in-memory
+consume + re-emit). The tests below pin all four. Checkpoint restore and worker
+terminal outputs inherit the same codec and are fixed transitively when it is;
+they are noted here so a future reviewer knows they were considered, not missed.
+A new leak would require adding a new call site to one of those three functions,
+which a grep-based guard can catch.
+
+References: ADR-020 §3, §5, §7.1; #1330 (closed); #1811.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, ClassVar
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from scistudio.blocks.base.block import Block
+from scistudio.blocks.base.config import BlockConfig
+from scistudio.blocks.base.ports import InputPort, OutputPort
+from scistudio.blocks.base.state import BlockState
+from scistudio.core.storage.ref import StorageReference
+from scistudio.core.types.array import Array
+from scistudio.core.types.base import DataObject
+from scistudio.core.types.collection import Collection
+from scistudio.engine.events import EventBus
+from scistudio.engine.runners.worker import (
+    _normalize_outputs,
+    reconstruct_inputs,
+    serialise_outputs,
+)
+from scistudio.engine.scheduler import DAGScheduler
+from scistudio.workflow.definition import NodeDef, WorkflowDefinition
+
+_XFAIL_REASON = (
+    "#1811: ADR-020 §3 requires single values on is_collection=False ports to "
+    "transport as length-one Collections; the engine still uses the bare "
+    "DataObject path. Remove this xfail when the option (a) fix lands."
+)
+
+
+def _ref(path: str = "/tmp/test.zarr", backend: str = "zarr") -> StorageReference:
+    """Minimal StorageReference so serialise_outputs skips auto-flush."""
+    return StorageReference(backend=backend, path=path)
+
+
+def _make_array() -> Array:
+    """Bare :class:`Array` with deterministic axes/shape and no storage."""
+    return Array(axes=["y", "x"], shape=(4, 4), dtype="uint8")
+
+
+# ---------------------------------------------------------------------------
+# Output boundary: _normalize_outputs on single-value (is_collection=False)
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeSingleValuePort:
+    """``_normalize_outputs`` should treat every DataObject port as Collection."""
+
+    @pytest.mark.xfail(reason=_XFAIL_REASON, strict=True)
+    def test_normalize_wraps_bare_dataobject_on_single_value_port(self) -> None:
+        """Bare DataObject on an ``is_collection=False`` port should become a
+        length-one Collection. Today ``_normalize_outputs`` early-returns for
+        non-Collection ports ([worker.py:257]) and leaves the bare object.
+        """
+        bare = _make_array()
+        ports = [OutputPort(name="out", accepted_types=[Array], is_collection=False)]
+        outputs: dict = {"out": bare}
+
+        _normalize_outputs(outputs, ports)
+
+        wrapped = outputs["out"]
+        assert isinstance(wrapped, Collection)
+        assert len(wrapped) == 1
+        assert wrapped[0] is bare
+        assert wrapped.item_type is Array
+
+    @pytest.mark.xfail(reason=_XFAIL_REASON, strict=True)
+    def test_normalize_packs_bare_list_on_single_value_port(self) -> None:
+        """A bare ``list[DataObject]`` on an ``is_collection=False`` port should
+        pack into a Collection (ADR-020 §3 "multi-object input is a longer
+        Collection"). Today the non-Collection port is skipped entirely.
+        """
+        a, b = _make_array(), _make_array()
+        ports = [OutputPort(name="out", accepted_types=[Array], is_collection=False)]
+        outputs: dict = {"out": [a, b]}
+
+        _normalize_outputs(outputs, ports)
+
+        packed = outputs["out"]
+        assert isinstance(packed, Collection)
+        assert len(packed) == 2
+        assert packed[0] is a
+        assert packed[1] is b
+        assert packed.item_type is Array
+
+
+# ---------------------------------------------------------------------------
+# Wire format: serialise_outputs / reconstruct_inputs for single values
+# ---------------------------------------------------------------------------
+
+
+class TestSingleValueWireFormat:
+    """A single DataObject should cross the wire as a ``_collection`` envelope."""
+
+    @pytest.mark.xfail(reason=_XFAIL_REASON, strict=True)
+    def test_serialise_single_dataobject_emits_collection_envelope(self, tmp_path) -> None:
+        """``serialise_outputs`` of a single DataObject should produce a
+        ``{"_collection": True, "items": [...], "item_type": ...}`` payload,
+        not a bare ``{backend, path, metadata}`` reference ([worker.py:383]).
+        """
+        import numpy as np
+        import zarr
+
+        zarr_path = str(tmp_path / "single.zarr")
+        zarr.save(zarr_path, np.zeros((4, 4), dtype="uint8"))
+        arr = Array(axes=["y", "x"], shape=(4, 4), dtype="uint8", storage_ref=_ref(zarr_path))
+
+        wire = serialise_outputs({"out": arr}, str(tmp_path))
+        payload = wire["out"]
+
+        assert payload.get("_collection") is True
+        assert payload["item_type"] == "Array"
+        assert len(payload["items"]) == 1
+
+    @pytest.mark.xfail(reason=_XFAIL_REASON, strict=True)
+    def test_reconstruct_bare_wire_dict_yields_length_one_collection(self, tmp_path) -> None:
+        """A bare ``{backend, path, metadata}`` wire dict should reconstruct as a
+        length-one Collection, not a bare DataObject ([worker.py:174-176]).
+
+        Builds the bare wire shape via the existing single-value serialiser so
+        the metadata is realistic, then asserts the target reconstruct result.
+        """
+        import numpy as np
+        import zarr
+
+        zarr_path = str(tmp_path / "bare.zarr")
+        zarr.save(zarr_path, np.zeros((4, 4), dtype="uint8"))
+        arr = Array(axes=["y", "x"], shape=(4, 4), dtype="uint8", storage_ref=_ref(zarr_path))
+
+        bare_wire = serialise_outputs({"out": arr}, str(tmp_path))["out"]
+        # Guard the test's own premise: today this is a bare reference, the
+        # exact shape #1811 is about. (If this key appears, the fix landed and
+        # this xfail test plus its premise must be revisited.)
+        assert "backend" in bare_wire and "_collection" not in bare_wire
+
+        rebuilt = reconstruct_inputs({"inputs": {"out": bare_wire}})["out"]
+
+        assert isinstance(rebuilt, Collection)
+        assert len(rebuilt) == 1
+        assert isinstance(rebuilt[0], Array)
+
+    @pytest.mark.xfail(reason=_XFAIL_REASON, strict=True)
+    def test_single_value_round_trip_is_length_one_collection(self, tmp_path) -> None:
+        """End-to-end ``serialise_outputs`` -> ``reconstruct_inputs`` of a single
+        value should hand the downstream block a length-one Collection.
+        """
+        import numpy as np
+        import zarr
+
+        zarr_path = str(tmp_path / "rt_single.zarr")
+        zarr.save(zarr_path, np.zeros((8, 8), dtype="float32"))
+        original = Array(axes=["y", "x"], shape=(8, 8), dtype="float32", storage_ref=_ref(zarr_path))
+
+        wire = serialise_outputs({"out": original}, str(tmp_path))
+        rebuilt = reconstruct_inputs({"inputs": wire})["out"]
+
+        assert isinstance(rebuilt, Collection)
+        assert len(rebuilt) == 1
+        assert rebuilt[0].shape == original.shape
+
+
+# ---------------------------------------------------------------------------
+# Consumer boundary: ProcessBlock.run must not re-emit bare on bare input
+# ---------------------------------------------------------------------------
+
+
+class TestProcessBlockSingleValueOutput:
+    """The non-Collection fallback in :meth:`ProcessBlock.run` propagates drift."""
+
+    @pytest.mark.xfail(reason=_XFAIL_REASON, strict=True)
+    def test_process_block_emits_collection_for_bare_input(self) -> None:
+        """When the primary input is a bare DataObject, ``ProcessBlock.run``
+        should still emit a Collection on its output port. Today the
+        non-Collection fallback ([process_block.py:174-177]) calls
+        ``process_item`` once and returns the bare result, so the drift
+        propagates transitively down the graph.
+        """
+        from scistudio.blocks.process.process_block import ProcessBlock
+
+        class _Passthrough(ProcessBlock):
+            type_name = "_test.single_value_passthrough"
+            input_ports: ClassVar = [InputPort(name="data", accepted_types=[DataObject])]
+            output_ports: ClassVar = [OutputPort(name="out", accepted_types=[DataObject])]
+
+            def process_item(self, item, config, state=None):  # type: ignore[no-untyped-def]
+                return item
+
+        block = _Passthrough()
+        bare = _make_array()
+
+        result = block.run({"data": bare}, block.config)
+
+        assert isinstance(result["out"], Collection)
+        assert len(result["out"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# Integration: scheduler in-process boundary (_dispatch.py:325)
+# ---------------------------------------------------------------------------
+
+
+class _BareSingleValueBlock(Block):
+    """Non-interactive block returning a bare Array on an is_collection=False port.
+
+    Mirrors the in-process drift: a runner returning a raw Python
+    :class:`DataObject` (not a wire dict) on a single-value port. The
+    engine's in-process ``_normalize_outputs`` call ([_dispatch.py:325])
+    skips non-Collection ports today, so the bare Array lands in
+    ``_block_outputs`` unwrapped.
+    """
+
+    name: ClassVar[str] = "BareSingleValue"
+    output_ports: ClassVar[list[OutputPort]] = [
+        OutputPort(name="out", accepted_types=[Array], is_collection=False),
+    ]
+
+    def __init__(self, config: dict[str, Any] | None = None) -> None:
+        super().__init__(config)
+        # DAGScheduler._instantiate_block assigns ``.id`` after construction.
+        self.id = ""
+
+    def run(self, inputs: dict[str, Any], config: BlockConfig) -> dict[str, Any]:  # type: ignore[override]
+        return {"out": _make_array()}
+
+
+def _make_single_value_scheduler() -> tuple[DAGScheduler, EventBus]:
+    """Build a DAGScheduler whose registry returns ``_BareSingleValueBlock``.
+
+    The mock runner returns the block's bare, un-normalised output so the
+    in-process finalize ``_normalize_outputs`` call is the only thing that
+    could honour ADR-020 §3 before the value lands in ``_block_outputs``.
+    """
+    wf = WorkflowDefinition(
+        id="wf-1811-single-value",
+        nodes=[NodeDef(id="a", block_type="bare-single-value", config={})],
+        edges=[],
+    )
+    event_bus = EventBus()
+    resource_manager = MagicMock()
+    resource_manager.can_dispatch.return_value = True
+    process_registry = MagicMock()
+    process_registry.get_handle.return_value = None
+
+    runner = AsyncMock()
+
+    async def _compute(block: Block, inputs: dict[str, Any], config: dict[str, Any]) -> dict[str, Any]:
+        return block.run(inputs, BlockConfig(**config))
+
+    runner.run.side_effect = _compute
+
+    registry = MagicMock()
+    registry.instantiate.side_effect = lambda name, config=None: _BareSingleValueBlock(config or {})
+    registry.get_spec.return_value = None
+
+    scheduler = DAGScheduler(
+        workflow=wf,
+        event_bus=event_bus,
+        resource_manager=resource_manager,
+        process_registry=process_registry,
+        runner=runner,
+        registry=registry,
+    )
+    return scheduler, event_bus
+
+
+class TestSchedulerInProcessSingleValueBoundary:
+    """The second ``_normalize_outputs`` call site must wrap single values too."""
+
+    @pytest.mark.xfail(reason=_XFAIL_REASON, strict=True)
+    def test_in_process_dispatch_wraps_bare_single_value(self) -> None:
+        """A bare Array produced in-process on an ``is_collection=False`` port
+        should land in ``_block_outputs`` as a length-one Collection. Today the
+        in-process boundary ([_dispatch.py:325]) skips non-Collection ports, so
+        the bare value propagates to downstream blocks unwrapped.
+        """
+        scheduler, _event_bus = _make_single_value_scheduler()
+
+        asyncio.run(scheduler.execute())
+
+        assert scheduler._block_states["a"] == BlockState.DONE
+        stored = scheduler._block_outputs["a"]
+        assert isinstance(stored, dict)
+        wrapped = stored["out"]
+        assert isinstance(wrapped, Collection)
+        assert len(wrapped) == 1
+        assert isinstance(wrapped[0], Array)


### PR DESCRIPTION
## Summary

Closes #1811.

ADR-020 §3 requires every value crossing a block boundary to be a `Collection` (a single item = a length-one Collection). #1330 enforced this only on `is_collection=True` ports, so single-value (`is_collection=False`) ports still transported a **bare `DataObject`** — the engine/spec drift tracked by #1811. Per `collection-guide.md`, `is_collection` is a UI hint and must not gate transport.

This is the root-cause fix for the strict-xfail baseline landed in #1814.

## Root fix — one enforcement point

- **`engine/runners/worker.py`** — `_normalize_outputs` now wraps a bare `DataObject` (or bare `list[DataObject]`) on **every** declared output port, not just `is_collection=True` ports. The wire codec (`serialise_outputs` / `reconstruct_inputs`) is intentionally **unchanged**: because `_normalize_outputs` always runs first, the codec only ever transports an already-wrapped Collection in the live flow. Legacy bare wire (e.g. an old checkpoint) is decoded faithfully and handled by blocks' existing bare-input fallback.
- **`blocks/process/process_block.py`** — the bare-input fallback also emits a length-one Collection, so a block handed a bare primary stays compliant.

## Option 2 — length-one Collection = a single value at single-item-oriented consumers

Investigation found three downstream consumers that read the single-value **wire** shape with no existing coverage of the length-one-Collection path. Each now treats a length-one Collection as a single value, so single outputs keep their single-item behaviour:

| Consumer | Behaviour preserved |
|---|---|
| `api/runtime/_data.py` `register_output_payload` | a length-one collection registers as a single `data_ref` → single-item viewer, **not** a grid previewer |
| `ai/agent/mcp/tools_plot/targets._looks_like_collection` | a length-one collection reports `is_collection=False` |
| `ai/agent/mcp/tools_inspection/read.get_block_output` | reads the inner item's type/ref from the envelope (no type loss) |

The rest of the `_block_outputs` readers (checkpoint, IO savers, lineage, frontend) were already Collection-aware and covered.

## Ports

- `blocks/ai/ai_block.py` — `AIBlock.result` declared `is_collection=True` (the agent can emit one or many files).
- The broader "all core ports declare `is_collection=True`" sweep is **deferred** to a focused follow-up: the flag is inert post-fix (the previewer routes on the value's actual kind, transport on `_normalize_outputs`), so the sweep is cosmetic schema metadata and out of scope for this fix.

## Tests

- `tests/engine/test_single_value_collection_contract.py` — the Phase-1 strict-xfail baseline (PR #1814) flips green; strict markers removed; wire-format tests re-scoped to drive through the `_normalize_outputs` enforcement point.
- `tests/engine/test_single_value_collection_consumers.py` (new) + a `get_block_output` case — codec-driven coverage of the A/B/C consumers. Each was confirmed **green today → red after the engine flip → green after migration**, a ratchet proving it exercises the changed path (closes the coverage gap that motivated this work).
- `tests/engine/test_collection_wrap.py` — the #1330 "leaves non-collection port alone" test rewritten to assert the new unconditional wrap.

## Docs

`collection-guide.md` already states the flag is a UI hint and "all port values are Collections regardless"; this change aligns the runtime to that documented contract. No doc change required (N/A recorded in the gate ledger).

## Governance

Touches a protected-core path (`engine/runners/worker.py`); needs the `admin-approved:core-change` label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
