### PR TITLE
guided(#1812): canonical display-name resolver + descriptor field

### DIFF
--- a/.workflow/records/1812-display-name-convention.json
+++ b/.workflow/records/1812-display-name-convention.json
@@ -235,9 +235,9 @@
   ],
   "check_na": [],
   "commit": {
-    "sha": "db60aee0d5cadcc04cd61f8e1b3ab52cb7ea387b",
+    "sha": "8f82293a961a064497d3f5ac75315b87d73a6806",
     "shas": [
-      "db60aee0d5cadcc04cd61f8e1b3ab52cb7ea387b"
+      "8f82293a961a064497d3f5ac75315b87d73a6806"
     ],
     "trailers": []
   },
@@ -901,6 +901,131 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-06-28T00:45:19.608533Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/base/interactive.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/base/interactive.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/core/meta/_display_name.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/core/meta/_display_name.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T00:45:19.616845Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T00:45:19.625477Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T00:45:19.634517Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T00:45:19.643040Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T00:45:19.651709Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T00:45:19.659964Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T00:45:19.668149Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T00:45:19.676253Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T00:45:19.689024Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -913,7 +1038,7 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "origin/main",
+    "base": "1965e8708d83d9bfafe102afc1c0f485d628b8f4",
     "base_sha": "1965e870",
     "changed_files": [
       ".workflow/records/1812-display-name-convention.json",
@@ -927,9 +1052,9 @@
       "tests/api/test_data.py",
       "tests/core/test_display_name.py"
     ],
-    "diff_fingerprint": "sha256:3cc3820fd9beb27fea91f28e15e2c04a3e5ad060dfc452a5cabd386714273614",
+    "diff_fingerprint": "sha256:971c353559db08ef39638af6e567545c98cda538c53dd0e92fe55fb6b398cb25",
     "head": "HEAD",
-    "head_sha": "0d3d1244",
+    "head_sha": "8f82293a",
     "surfaces": {
       "docs": 1,
       "frontend": 2,
@@ -950,7 +1075,7 @@
     "closes": [
       1812
     ],
-    "number": null,
+    "number": 1827,
     "url": null
   },
   "reconcile_events": [
@@ -992,6 +1117,14 @@
     {
       "at": "2026-06-28T00:44:31.434838Z",
       "diff_fingerprint": "sha256:3cc3820fd9beb27fea91f28e15e2c04a3e5ad060dfc452a5cabd386714273614",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-28T00:45:19.689054Z",
+      "diff_fingerprint": "sha256:971c353559db08ef39638af6e567545c98cda538c53dd0e92fe55fb6b398cb25",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 1,

--- a/.workflow/records/1812-display-name-convention.json
+++ b/.workflow/records/1812-display-name-convention.json
@@ -1,0 +1,720 @@
+{
+  "branch": "guided/1812-display-name-convention",
+  "check_events": [
+    {
+      "at": "2026-06-28T00:33:52.364356Z",
+      "command": "pytest tests/architecture/ -v --no-cov",
+      "covered_surface": "architecture",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:dddf6569ecf6a3da2d51db88fdf5e5d97b7807da746248b0306de7fa503e478e",
+      "name": "architecture_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/architecture_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-28T00:33:53.062192Z",
+      "command": "python scripts/deferral_scan.py --check docs/audit/baselines/deferral-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:69b525f4b9f1f775b36c41ea76408307e4ee947e75e8fd2629148e201b3b938d",
+      "name": "deferral_discipline",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/deferral_discipline.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-28T00:33:53.411094Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:0d7117a1ee8e90fae4c36fd9f6f0c472cb2243d1f7e1948dd5e72e2b57e6722f",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-28T00:33:58.290240Z",
+      "command": "(cd frontend && npm run check:ci)",
+      "covered_surface": "frontend",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:f191d2240730fa9058e2fc5b1fb5ecec02c7009939d8be5d8653f9f05167af82",
+      "name": "frontend",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/frontend.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-28T00:34:01.713314Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:46893aa4ea29cbeed692cfbe27982b88d5ea8010b336e7e7400ab509e39b20f8",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-28T00:34:02.215608Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e057da19666c0262555d8190f0424e94e4cf1ccbbc0875f3017a6a3128a78b19",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-28T00:34:02.251453Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:a9ad6a398621215a5a39e53ae8852b69ab519e8d1ea209864744681073516daa",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-28T00:35:41.990329Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:94262d903699a4b6184de71c5e724202e2c4962277da44a6ead90857bbcc1c79",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-28T00:37:33.694703Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:13404c13a5a4b3b83b4276dbd198f27c51985aa97d8d1640c136c8206b3b61f5",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-28T00:37:40.364863Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:676b8ec1bf8916a8377d6ef8fb641f205fe09aaa79cabb689a75a29b32595e30",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    },
+    {
+      "at": "2026-06-28T00:39:16.142073Z",
+      "command": "python scripts/deferral_scan.py --check docs/audit/baselines/deferral-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:362217befd63c1c2dc5c18a425ab1c8188fc05f5274656faed986aa7b79c0849",
+      "name": "deferral_discipline",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/deferral_discipline.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-28T00:39:53.242086Z",
+      "command": "(cd frontend && npm run check:ci)",
+      "covered_surface": "frontend",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:678f51857124da2db32dc14bee288f20c8d0b03d37d2759a88113b0d6925cd15",
+      "name": "frontend",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/frontend.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-28T00:39:57.129574Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:912174f31184b040bce8b94c95013e013dc003d598e4a9991d4f23b3b7fb437c",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-28T00:41:11.893798Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:94262d903699a4b6184de71c5e724202e2c4962277da44a6ead90857bbcc1c79",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-28T00:43:05.705406Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:f521c856b7fa818f81bf27c97f5bad0e53af6617f48414510bfcf6e2f803f1bc",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    }
+  ],
+  "check_na": [],
+  "commit": null,
+  "declared_scope": {
+    "exclude": [],
+    "include": []
+  },
+  "directive_events": [
+    {
+      "at": "2026-06-28T00:19:34.354457Z",
+      "owner_directive": "Resolver lives in src/scistudio/core/meta as an INTERNAL dict-based resolve_display_name(metadata) (not in __all__, no \u00a73.10 public-surface row). It is the single precedence authority for BOTH interactive labels and previewer/frontend display names. API register_output_payload stamps a resolved display_name onto each item descriptor; frontend deriveDisplayName slims to read it; interactive_item_label delegates to the same resolver. Owner authorized admin-approved:core-change for src/scistudio/core/meta/** and src/scistudio/blocks/base/interactive.py.",
+      "reason": "Owner finalized design + authorized protected-core change"
+    },
+    {
+      "at": "2026-06-28T00:32:48.282281Z",
+      "owner_directive": "Implemented: core resolver + interactive delegation + API stamping + frontend read + spec/changelog + tests.",
+      "reason": "plan"
+    }
+  ],
+  "docs_events": [
+    {
+      "at": "2026-06-28T00:32:48.282486Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/specs/adr-052-public-api-surface.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-28T00:32:48.282691Z",
+      "class": null,
+      "kind": "path",
+      "path": "CHANGELOG.md",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": false,
+  "guard_events": [
+    {
+      "at": "2026-06-28T00:37:40.404360Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/base/interactive.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/base/interactive.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/core/meta/_display_name.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/core/meta/_display_name.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T00:37:40.415401Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T00:37:40.425269Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T00:37:40.434997Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T00:37:40.445125Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T00:37:40.455320Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T00:37:40.465521Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T00:37:40.475565Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T00:37:40.485126Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T00:37:40.497428Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T00:43:05.751549Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/base/interactive.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/base/interactive.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/core/meta/_display_name.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/core/meta/_display_name.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T00:43:05.760592Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T00:43:05.769782Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T00:43:05.778648Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T00:43:05.787420Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T00:43:05.796234Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T00:43:05.805319Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T00:43:05.814186Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T00:43:05.823977Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T00:43:05.836997Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1812,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": {
+    "base": "origin/main",
+    "base_sha": "1965e870",
+    "changed_files": [
+      ".workflow/records/1812-display-name-convention.json",
+      "CHANGELOG.md",
+      "docs/specs/adr-052-public-api-surface.md",
+      "frontend/src/components/DataPreview.parts/refEntries.test.ts",
+      "frontend/src/components/DataPreview.parts/refEntries.ts",
+      "src/scistudio/api/runtime/_data.py",
+      "src/scistudio/blocks/base/interactive.py",
+      "src/scistudio/core/meta/_display_name.py",
+      "tests/api/test_data.py",
+      "tests/core/test_display_name.py"
+    ],
+    "diff_fingerprint": "sha256:42a1cdac3bc683c0dd475499f056a17ce820d3384be03e2437229656636ceb92",
+    "head": "HEAD",
+    "head_sha": "79a1a18a",
+    "surfaces": {
+      "docs": 1,
+      "frontend": 2,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 5,
+      "packaging": 0,
+      "protected_core": 2,
+      "sentrux": 8,
+      "test": 3,
+      "workflow_ci": 0
+    }
+  },
+  "owner_directive": "Land #1812: converge on a single canonical display-name convention. Decided with owner: (B) formalize optional user['display_name'] producer override (no typed framework field, no core schema change); core resolve_display_name() fallback resolver; interactive_item_label + API item serialization both call it; API emits a resolved display_name field per item descriptor (additive to dict[str,Any]); frontend deriveDisplayName slims to read backend display_name; document optional convention in spec adr-052-public-api-surface.md \u00a713 + descriptor field note near \u00a78.2 (additive, no frozen contract row changes); precedence: user['display_name'] > .name > meta.source_file > framework.source > file_path > item_N.",
+  "persona": "live_implementer",
+  "pull_request": null,
+  "reconcile_events": [
+    {
+      "at": "2026-06-28T00:37:40.497464Z",
+      "diff_fingerprint": "sha256:7e2a2f0a350e2aace535a78f3259233b59bc6df894fbf0ca1f9ebd5cbe76247a",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.frontend",
+        "checks.python_tests"
+      ]
+    },
+    {
+      "at": "2026-06-28T00:43:05.837035Z",
+      "diff_fingerprint": "sha256:42a1cdac3bc683c0dd475499f056a17ce820d3384be03e2437229656636ceb92",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    }
+  ],
+  "record_id": "1812-display-name-convention",
+  "requested_admin_labels": [
+    {
+      "actor_permission": null,
+      "applied_at": null,
+      "applied_by": null,
+      "name": "admin-approved:core-change"
+    }
+  ],
+  "required_obligations": {
+    "admin_labels": [
+      "admin-approved:core-change"
+    ],
+    "checks": [
+      "architecture_tests",
+      "deferral_discipline",
+      "format_check",
+      "frontend",
+      "full_audit",
+      "import_contracts",
+      "lint_format",
+      "python_tests",
+      "semantic_dup",
+      "type_check"
+    ],
+    "docs": [
+      "docs_required_or_na"
+    ],
+    "guards": [
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": [
+      "changed_test_required"
+    ]
+  },
+  "runtime": "claude-code",
+  "schema_version": 2,
+  "scope_events": [
+    {
+      "action": "add-include",
+      "at": "2026-06-28T00:19:34.354582Z",
+      "pattern": "src/scistudio/core/meta/**",
+      "reason": "Owner finalized design + authorized protected-core change"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-28T00:19:34.354591Z",
+      "pattern": "src/scistudio/blocks/base/interactive.py",
+      "reason": "Owner finalized design + authorized protected-core change"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-28T00:19:34.354593Z",
+      "pattern": "src/scistudio/api/runtime/_data.py",
+      "reason": "Owner finalized design + authorized protected-core change"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-28T00:19:34.354595Z",
+      "pattern": "frontend/src/components/DataPreview.parts/refEntries.ts",
+      "reason": "Owner finalized design + authorized protected-core change"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-28T00:19:34.354596Z",
+      "pattern": "docs/specs/adr-052-public-api-surface.md",
+      "reason": "Owner finalized design + authorized protected-core change"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-28T00:32:48.282391Z",
+      "pattern": "tests/core/test_display_name.py",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-28T00:32:48.282397Z",
+      "pattern": "tests/api/test_data.py",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-28T00:32:48.282398Z",
+      "pattern": "frontend/src/components/DataPreview.parts/refEntries.test.ts",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-28T00:32:48.282399Z",
+      "pattern": "CHANGELOG.md",
+      "reason": "plan"
+    }
+  ],
+  "session_id": "be727a45-0a99-485c-9716-6a11be8e6305",
+  "strictness_tier": 1,
+  "task_kind": "guided",
+  "test_events": [
+    {
+      "at": "2026-06-28T00:32:48.282695Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/core/test_display_name.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-28T00:32:48.282699Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/api/test_data.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-28T00:32:48.282700Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/components/DataPreview.parts/refEntries.test.ts",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/.workflow/records/1812-display-name-convention.json
+++ b/.workflow/records/1812-display-name-convention.json
@@ -234,7 +234,13 @@
     }
   ],
   "check_na": [],
-  "commit": null,
+  "commit": {
+    "sha": "db60aee0d5cadcc04cd61f8e1b3ab52cb7ea387b",
+    "shas": [
+      "db60aee0d5cadcc04cd61f8e1b3ab52cb7ea387b"
+    ],
+    "trailers": []
+  },
   "declared_scope": {
     "exclude": [],
     "include": []
@@ -520,6 +526,381 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-06-28T00:43:24.644176Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/base/interactive.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/base/interactive.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/core/meta/_display_name.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/core/meta/_display_name.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T00:43:24.654220Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T00:43:24.664410Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T00:43:24.699114Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T00:43:24.738024Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T00:43:24.759166Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T00:43:24.778491Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T00:43:24.802420Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T00:43:24.825436Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T00:43:24.852739Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T00:44:12.635210Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/base/interactive.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/base/interactive.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/core/meta/_display_name.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/core/meta/_display_name.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T00:44:12.644155Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T00:44:12.652679Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T00:44:12.661904Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T00:44:12.671665Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T00:44:12.680608Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T00:44:12.689471Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T00:44:12.698447Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T00:44:12.708144Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T00:44:12.720468Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T00:44:31.335704Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/base/interactive.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/base/interactive.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/core/meta/_display_name.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/core/meta/_display_name.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T00:44:31.346300Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T00:44:31.356910Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T00:44:31.367589Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T00:44:31.378390Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T00:44:31.389104Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T00:44:31.399940Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T00:44:31.410169Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T00:44:31.420753Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T00:44:31.434790Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -546,9 +927,9 @@
       "tests/api/test_data.py",
       "tests/core/test_display_name.py"
     ],
-    "diff_fingerprint": "sha256:42a1cdac3bc683c0dd475499f056a17ce820d3384be03e2437229656636ceb92",
+    "diff_fingerprint": "sha256:3cc3820fd9beb27fea91f28e15e2c04a3e5ad060dfc452a5cabd386714273614",
     "head": "HEAD",
-    "head_sha": "79a1a18a",
+    "head_sha": "0d3d1244",
     "surfaces": {
       "docs": 1,
       "frontend": 2,
@@ -564,7 +945,14 @@
   },
   "owner_directive": "Land #1812: converge on a single canonical display-name convention. Decided with owner: (B) formalize optional user['display_name'] producer override (no typed framework field, no core schema change); core resolve_display_name() fallback resolver; interactive_item_label + API item serialization both call it; API emits a resolved display_name field per item descriptor (additive to dict[str,Any]); frontend deriveDisplayName slims to read backend display_name; document optional convention in spec adr-052-public-api-surface.md \u00a713 + descriptor field note near \u00a78.2 (additive, no frozen contract row changes); precedence: user['display_name'] > .name > meta.source_file > framework.source > file_path > item_N.",
   "persona": "live_implementer",
-  "pull_request": null,
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [
+      1812
+    ],
+    "number": null,
+    "url": null
+  },
   "reconcile_events": [
     {
       "at": "2026-06-28T00:37:40.497464Z",
@@ -580,6 +968,30 @@
     {
       "at": "2026-06-28T00:43:05.837035Z",
       "diff_fingerprint": "sha256:42a1cdac3bc683c0dd475499f056a17ce820d3384be03e2437229656636ceb92",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-28T00:43:24.852806Z",
+      "diff_fingerprint": "sha256:f0ee37c170e2ce2695ef21206b2c6ad6bf29d1fdd32fb6010fda0e31a87c1b6a",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-28T00:44:12.720514Z",
+      "diff_fingerprint": "sha256:3cc3820fd9beb27fea91f28e15e2c04a3e5ad060dfc452a5cabd386714273614",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-28T00:44:31.434838Z",
+      "diff_fingerprint": "sha256:3cc3820fd9beb27fea91f28e15e2c04a3e5ad060dfc452a5cabd386714273614",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 1,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- [#1812] Canonical display-name convention: user-facing item names are now resolved by a single backend authority (`scistudio.core.meta._display_name.resolve_display_name`) instead of two divergent fallback chains (the interactive-panel `interactive_item_label` and the frontend `deriveDisplayName`). The resolver reads one precedence — `user["display_name"]` (the optional producer override, e.g. the xlsx loader's `"<file> — <sheet>"`) → `name` → `meta.source_file` → `file_path` → `framework.source` (path-only) — over both a live `DataObject` and the serialized wire metadata. `register_output_payload` now stamps a resolved `display_name` onto each item descriptor (additive; omitted when nothing resolves) and the frontend reads that field, keeping its metadata chain only as a compatibility fallback. New origins are added in the backend resolver alone; packages may optionally set `user["display_name"]` for their own types (documented in `docs/specs/adr-052-public-api-surface.md` §8.2/§13). Touches protected `src/scistudio/blocks/base/interactive.py` + `src/scistudio/core/meta/**` — owner-authorized (`admin-approved:core-change`). Tests: `tests/core/test_display_name.py`, `tests/api/test_data.py`, `frontend/src/components/DataPreview.parts/refEntries.test.ts`. (@claude, 2026-06-27, branch: guided/1812-display-name-convention)
+
 ## [0.3.1] - 2026-06-27
 
 Patch release; the first internally-distributed 0.3.x build (0.3.0 was never

--- a/docs/specs/adr-052-public-api-surface.md
+++ b/docs/specs/adr-052-public-api-surface.md
@@ -1008,6 +1008,17 @@ result dataclasses are **read-only outputs** authors receive, not types they bui
 | ✅ | `DEFAULT_MAX_TILE` | constant | Internal | — | — | as above |
 | ✅ | `DEFAULT_MAX_DIM` | constant | Internal | — | — | as above |
 
+**Item display name (#1812).** Each item descriptor handed to the frontend (built
+by `register_output_payload`, surfaced through `collection_sample`) carries an
+optional `display_name` string alongside `{data_ref, type_name, metadata}`. It is
+the single user-facing name resolved by the internal core authority
+`scistudio.core.meta._display_name.resolve_display_name` from the item's
+`user["display_name"]` → `meta.source_file` → `file_path` → `framework.source`
+chain. The field is **additive** to the descriptor dict (not a typed public
+symbol, no `CollectionSample` field change) and is **omitted** when nothing
+resolves, so the frontend keeps its own truncated-ref fallback. The resolver is
+internal plumbing — deliberately not in `core.meta.__all__` (§3.10).
+
 ### 8.3 `fallbacks.py`
 
 Not an author root. Holds core's own fallback viewers; one helper escaped here and
@@ -1233,6 +1244,19 @@ Prohibitions (lint / freeze-test enforced, not skeletons): **no** `to_pandas` /
 `to_numpy` shadowing; **no** underscore-named author-facing helper
 (`_support`-style modules are internal only); block / previewer classes are not
 part of the reuse surface.
+
+**Canonical item display name (#1812).** A package MAY set `user["display_name"]`
+on an item to declare its human-facing label — e.g. a loader emitting multiple
+items from one workbook composes `"<file> — <sheet>"` so same-file/different-sheet
+items do not collide. This is an **optional value convention inside the
+already-public `user` slot**, not a new member of the contract table above and not
+a typed field, so it adds no obligation and no surface to freeze. The single core
+authority `scistudio.core.meta._display_name.resolve_display_name` reads it with
+highest precedence and otherwise applies a deterministic default
+(`meta.source_file` / `framework.source` basename); every consumer (interactive
+panels, previewer item descriptors, the frontend) then reads the resolved name
+uniformly. A package never special-cases display names per consumer — it either
+sets the override once at production or relies on the core default.
 
 ### 13.2 Per-package reuse-surface inventories
 
@@ -1509,3 +1533,4 @@ even after the tables are complete.
 | 2026-06-27 | §13 rewritten to the **developer-facing reuse API only** (owner correction: the core-facing registration contract — entry points / `PackageInfo` / OTA — is **not** ADR-052 and is not mentioned here at all). The reuse contract **standardizes types + constructors + accessors**: types public at top level subclassing a core `DataObject`; **domain constructors MUST be classmethods on the type** (`Type.from_<domain>`), not free functions (`build_spectrum` → `Spectrum.from_arrays`); no `to_pandas`/`to_numpy` shadowing; `__all__` + decorators + discovery. §13.3: the template makes it self-enforcing — **MUST → `NotImplementedError` skeleton, SHOULD → empty file**, plus generated-reference build + freeze-test **parity with core** (§7/§15) against the package's own version line. §13.2 per-package inventories stay deferred. | Owner 2026-06-27. |
 | 2026-06-27 | §13 refined: (a) §13.1 expressed as a **per-member contract table** (St/Member/Kind/Rule/Template/Tier/Notes) like the core sections — not prose — enumerating the standardized type + constructor + accessor surface with each item's MUST/SHOULD rule and its template treatment (skeleton `NotImplementedError` / empty file / inherited / declared). (b) §13.2 **genericized — no package names** (owner: many domain packages are being rewritten or retired, so the roster is volatile); each package carries its own §13.1 table in its own repo. §13.1's constructor example de-named too. | Owner 2026-06-27 ("define an actual contract as a table, not prose"; "§13.2 must not name packages — many are abandoned"). |
 | 2026-06-27 | Filed **#1826** (build `scistudio-package-template` to self-enforce the §13.1 developer-facing contract: MUST→`NotImplementedError` skeletons + SHOULD→empty files, developer-facing contract validation, and generated-reference + freeze-test parity with core). §13.3 repointed from "issue TBD" → #1826. | Owner 2026-06-27 ("open the issue"). |
+| 2026-06-27 | **#1812 canonical display-name convention landed.** Chose **(B)** `user["display_name"]` as the optional producer override (not a typed `framework`/`meta` field), so **no §3.10 `FrameworkMeta` row and no §13.1 contract-table row change** — it is a value convention inside the already-public `user` slot. One core authority `core.meta._display_name.resolve_display_name` (Internal, not in `core.meta.__all__`) resolves both the interactive label path and the previewer/API path; `register_output_payload` stamps a resolved `display_name` onto item descriptors (additive, §8.2 note) and the frontend reads it instead of re-deriving. §13 + §8.2 notes added. | Owner 2026-06-27 (B + resolver in `core.meta` + `admin-approved:core-change` for `core.meta`/`blocks.base.interactive`). |

--- a/frontend/src/components/DataPreview.parts/refEntries.test.ts
+++ b/frontend/src/components/DataPreview.parts/refEntries.test.ts
@@ -52,6 +52,37 @@ describe("extractRefEntries", () => {
     ]);
   });
 
+  it("prefers the backend-stamped top-level display_name over everything (#1812)", () => {
+    // The backend is the single precedence authority; when it stamps
+    // display_name on the descriptor the frontend trusts it and does not
+    // re-derive from metadata (here the metadata would disagree).
+    const result = extractRefEntries({
+      data_ref: "data-sheet2",
+      display_name: "exp.xlsx — beta",
+      metadata: {
+        framework: { source: "/data/exp.xlsx" },
+        meta: { source_file: "/data/wrong.csv" },
+      },
+    });
+    expect(result).toEqual([
+      expect.objectContaining({ ref: "data-sheet2", displayName: "exp.xlsx — beta" }),
+    ]);
+  });
+
+  it("carries the stamped display_name through collection items (#1812)", () => {
+    // Collection items are normalized before reaching the grid viewer; the
+    // stamped name must survive so the grid reads the same label as the pills.
+    const result = extractRefEntries({
+      images: {
+        kind: "collection",
+        item_type: "DataFrame",
+        items: [{ data_ref: "data-1", type_name: "DataFrame", display_name: "exp.xlsx — alpha" }],
+      },
+    });
+    const items = result[0].initialQuery?._collection_items as Record<string, unknown>[];
+    expect(items[0].display_name).toBe("exp.xlsx — alpha");
+  });
+
   it("falls back to metadata.meta.source_file when framework absent", () => {
     const result = extractRefEntries({
       data_ref: "data-xyz",

--- a/frontend/src/components/DataPreview.parts/refEntries.ts
+++ b/frontend/src/components/DataPreview.parts/refEntries.ts
@@ -28,10 +28,18 @@ function basename(p: string): string {
 }
 
 export function deriveDisplayName(ref: string, dataItem: Record<string, unknown>): string {
+  // 0. Backend-resolved canonical display name (#1812). The backend is now the
+  // single precedence authority (`resolve_display_name`) and stamps the result
+  // onto each item descriptor, so trust it when present. The metadata chain
+  // below is a compatibility fallback for any descriptor that predates the
+  // stamp or is built outside `register_output_payload`; new origins are added
+  // in the backend resolver only, never here.
+  const stamped = dataItem.display_name;
+  if (typeof stamped === "string" && stamped) return stamped;
   const md = dataItem.metadata;
   if (md && typeof md === "object") {
     const mdRec = md as Record<string, unknown>;
-    // 0. Generic user-set display name (#1810 interim, #1812 convention). The
+    // 0b. Generic user-set display name (#1810 interim, #1812 convention). The
     // producer composes a user-facing label — e.g. "<file> — <sheet>" for an
     // .xlsx sheet — so same-file/different-sheet items don't collide. Preferred
     // over file-based heuristics because it is an explicit presentation choice.
@@ -85,6 +93,10 @@ function normalizeCollectionItem(item: unknown): Record<string, unknown> | null 
   const out: Record<string, unknown> = { data_ref: ref };
   if (typeof record.type_name === "string") out.type_name = record.type_name;
   if (record.metadata && typeof record.metadata === "object") out.metadata = record.metadata;
+  // Carry the backend-stamped canonical name (#1812) so the collection grid
+  // reads the same resolved label as the pills instead of re-deriving.
+  if (typeof record.display_name === "string" && record.display_name)
+    out.display_name = record.display_name;
   return out;
 }
 

--- a/src/scistudio/api/runtime/_data.py
+++ b/src/scistudio/api/runtime/_data.py
@@ -25,6 +25,7 @@ from uuid import uuid4
 
 import pyarrow.parquet as pq
 
+from scistudio.core.meta._display_name import resolve_display_name
 from scistudio.core.storage.ref import StorageReference
 from scistudio.previewers import (
     PreviewService,
@@ -152,11 +153,19 @@ def register_output_payload(self: ApiRuntime, payload: Any) -> Any:
         if tc and isinstance(tc, list) and tc:
             explicit_type_name = str(tc[-1])
         record = self.register_data_ref(ref, type_name=explicit_type_name, metadata=self.describe_ref(ref))
-        return {
+        descriptor: dict[str, Any] = {
             "data_ref": record.id,
             "type_name": record.type_name,
             "metadata": record.metadata,
         }
+        # Stamp the canonical user-facing name resolved by the single backend
+        # authority (#1812) so the frontend reads one field instead of
+        # re-deriving. Omitted when nothing resolves; the frontend then keeps
+        # its own truncated-ref fallback.
+        display_name = resolve_display_name(record.metadata, fallback="")
+        if display_name:
+            descriptor["display_name"] = display_name
+        return descriptor
     if isinstance(payload, dict) and payload.get("_collection") is True:
         raw_items = payload.get("items", [])
         # #1811 Option 2: a length-one Collection is the canonical

--- a/src/scistudio/blocks/base/interactive.py
+++ b/src/scistudio/blocks/base/interactive.py
@@ -38,6 +38,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, ClassVar, Protocol, runtime_checkable
 
+from scistudio.core.meta._display_name import resolve_display_name
 from scistudio.core.storage.ref import StorageReference
 
 if TYPE_CHECKING:
@@ -233,48 +234,12 @@ def interactive_item_label(item: Any, index: int) -> str:
 
     Interactive panels (DataRouter, PairEditor) list a block's input items for
     the user to route or reorder. A generic ``item_<index>`` is meaningless when
-    the user is matching items by which file they came from, so prefer an
-    identifying name in this order:
-
-    1. an explicit ``name`` attribute, if the object carries one;
-    2. the generic ``user['display_name']`` presentation hook (#1810 interim,
-       #1812 convention) — e.g. ``"<file> — <sheet>"`` for an .xlsx sheet so
-       same-file/different-sheet items do not collide;
-    3. the originating file's basename from typed domain metadata
-       (``item.meta.source_file`` — populated by the loaders for spectra,
-       images, etc.);
-    4. an :class:`~scistudio.core.types.artifact.Artifact`-style ``file_path``
-       basename;
-    5. ``item_<index>`` as the last resort.
-
-    The lookups are all duck-typed so the helper stays type-agnostic across the
-    DataObject hierarchy and any plugin-provided type.
+    the user is matching items by which file they came from, so this delegates
+    to :func:`scistudio.core.meta._display_name.resolve_display_name` — the
+    single canonical precedence authority shared with the previewer/API path
+    (#1812) — and supplies ``item_<index>`` as the last-resort fallback.
     """
-    name = getattr(item, "name", None)
-    if isinstance(name, str) and name:
-        return name
-
-    user = getattr(item, "user", None)
-    display_name = user.get("display_name") if isinstance(user, dict) else None
-    if isinstance(display_name, str) and display_name:
-        return display_name
-
-    meta = getattr(item, "meta", None)
-    source_file = getattr(meta, "source_file", None) if meta is not None else None
-    if isinstance(source_file, str) and source_file:
-        # Basename, tolerant of either path separator (the value is a
-        # user-supplied path captured at load time).
-        basename = source_file.replace("\\", "/").rstrip("/").rsplit("/", 1)[-1]
-        if basename:
-            return basename
-
-    file_path = getattr(item, "file_path", None)
-    if file_path is not None:
-        fp_name = getattr(file_path, "name", None)
-        if isinstance(fp_name, str) and fp_name:
-            return fp_name
-
-    return f"item_{index}"
+    return resolve_display_name(item, fallback=f"item_{index}")
 
 
 def interactive_input_signature(inputs: dict[str, Any]) -> dict[str, list[str]]:

--- a/src/scistudio/core/meta/_display_name.py
+++ b/src/scistudio/core/meta/_display_name.py
@@ -1,0 +1,140 @@
+"""resolve_display_name — the single canonical user-facing-name resolver (#1812).
+
+User-facing item names used to be computed by two divergent fallback chains: a
+backend one for interactive panels (``interactive_item_label``) and a frontend
+one for preview pills (``deriveDisplayName``). Each new origin (xlsx sheets, OME
+``source_file``, …) needed a new special case in both places, and they could
+disagree.
+
+This module is the **single precedence authority** for that name. Both
+consumers delegate here:
+
+- ``scistudio.blocks.base.interactive.interactive_item_label`` calls it on the
+  live ``DataObject`` to label an interactive panel row.
+- ``scistudio.api.runtime`` calls it on the serialized wire ``metadata`` dict to
+  stamp a resolved ``display_name`` onto each item descriptor; the frontend then
+  reads that one field instead of re-deriving.
+
+Living in ``scistudio.core.meta`` keeps the import direction clean: both
+``blocks`` and ``api`` depend on ``core``, never the reverse. This is an
+**internal** helper — it is deliberately not exported from
+``scistudio.core.meta.__all__`` (it is framework presentation plumbing, not a
+package-author-facing symbol per ADR-052 §3.10).
+
+The resolver is **input-shape agnostic**: it reads its fields through a
+duck-typed accessor, so the same function handles both a live ``DataObject``
+(Pydantic ``meta``/``framework`` attributes) and the serialized wire ``metadata``
+dict (nested ``meta``/``framework``/``user`` mappings). See
+``scistudio.core.types.serialization`` for the wire shape.
+
+Precedence (highest first):
+
+1. ``user["display_name"]`` — an explicit presentation override declared once by
+   the producing block (e.g. the xlsx loader composes ``"<file> — <sheet>"`` so
+   same-file/different-sheet items do not collide). This is the canonical
+   override channel a producer reaches for when the structural default is wrong.
+2. ``name`` — an explicit object name, if the object carries one (defensive; no
+   core ``DataObject`` declares ``name`` today, but a plugin type might).
+3. ``meta.source_file`` — the originating filename from typed domain metadata,
+   reduced to its basename (loaders for spectra, images, etc. populate this).
+4. ``file_path`` — an :class:`~scistudio.core.types.artifact.Artifact`-style file
+   path, reduced to its basename.
+5. ``framework.source`` — the framework provenance origin, used only when it
+   looks like a path (contains a separator); package-name provenance such as
+   ``"scistudio-blocks-spectroscopy"`` is not a filename and is skipped.
+6. the caller-supplied ``fallback`` (``"item_<index>"`` for an interactive row,
+   ``""`` for a wire descriptor so the field is simply omitted when nothing
+   resolves and the frontend keeps its own truncated-ref fallback).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+
+def _get(source: Any, key: str) -> Any:
+    """Read ``key`` from either a Mapping (wire dict) or an attribute holder.
+
+    The resolver runs over two input shapes: the serialized wire ``metadata``
+    dict (``source["meta"]``) and a live ``DataObject`` (``source.meta``). A
+    single duck-typed accessor lets one precedence definition serve both.
+    """
+    if source is None:
+        return None
+    if isinstance(source, Mapping):
+        return source.get(key)
+    return getattr(source, key, None)
+
+
+def _basename(value: str) -> str:
+    """Basename of a path string, tolerant of either separator.
+
+    The value is a user-supplied path captured at load time, so it may use
+    either ``/`` or ``\\`` regardless of the host OS.
+    """
+    return value.replace("\\", "/").rstrip("/").rsplit("/", 1)[-1]
+
+
+def resolve_display_name(source: Any, *, fallback: str) -> str:
+    """Resolve the canonical user-facing display name for one data item.
+
+    ``source`` is either a live :class:`~scistudio.core.types.base.DataObject`
+    or its serialized wire ``metadata`` mapping. See the module docstring for
+    the precedence chain.
+
+    Args:
+        source: A ``DataObject`` instance, a wire ``metadata`` mapping, or
+            ``None``.
+        fallback: The value returned when no signal resolves. Interactive rows
+            pass ``"item_<index>"``; wire descriptors pass ``""`` and omit the
+            field when the result is empty.
+
+    Returns:
+        The resolved display name, or ``fallback`` if nothing matched.
+    """
+    # 1. Explicit presentation override (the canonical producer channel).
+    display_name = _get(_get(source, "user"), "display_name")
+    if isinstance(display_name, str) and display_name:
+        return display_name
+
+    # 2. Explicit object name (defensive; no core type declares one today).
+    name = _get(source, "name")
+    if isinstance(name, str) and name:
+        return name
+
+    # 3. Typed domain source filename → basename.
+    meta = _get(source, "meta")
+    source_file = _get(meta, "source_file")
+    if not (isinstance(source_file, str) and source_file):
+        # Wire dicts may also carry source_file at the metadata root.
+        source_file = _get(source, "source_file")
+    if isinstance(source_file, str) and source_file:
+        base = _basename(source_file)
+        if base:
+            return base
+
+    # 4. Artifact-style file path → basename. Live objects expose a ``Path``
+    # (use its ``.name``); wire dicts expose a string (basename it).
+    file_path = _get(meta, "file_path")
+    if file_path is None:
+        file_path = _get(source, "file_path")
+    if file_path is not None:
+        path_name = getattr(file_path, "name", None)
+        if isinstance(path_name, str) and path_name:
+            return path_name
+        if isinstance(file_path, str) and file_path:
+            base = _basename(file_path)
+            if base:
+                return base
+
+    # 5. Framework provenance, only when it looks like a path (not a package
+    # name such as "scistudio-blocks-spectroscopy").
+    framework_source = _get(_get(source, "framework"), "source")
+    if isinstance(framework_source, str) and ("/" in framework_source or "\\" in framework_source):
+        base = _basename(framework_source)
+        if base:
+            return base
+
+    # 6. Caller-supplied fallback.
+    return fallback

--- a/tests/api/test_data.py
+++ b/tests/api/test_data.py
@@ -304,3 +304,61 @@ def test_register_output_payload_preserves_plugin_type_name(
     record = runtime.get_data_record(data_ref)
     assert record.type_name == "Image"
     assert record.type_chain == ["DataObject", "Array", "Image"]
+
+
+def test_register_output_payload_stamps_display_name_from_user_hook(
+    runtime: ApiRuntime,
+    opened_project: Path,
+) -> None:
+    """#1812: the descriptor carries a backend-resolved ``display_name``.
+
+    ``user['display_name']`` (the producer override, e.g. the xlsx loader's
+    ``"<file> — <sheet>"``) is resolved by the single backend authority and
+    stamped onto the item descriptor so the frontend reads one field.
+    """
+    wire_payload = {
+        "backend": "arrow",
+        "path": str(opened_project / "data" / "arrow" / "sheet2.arrow"),
+        "format": "arrow",
+        "metadata": {
+            "type_chain": ["DataObject", "DataFrame"],
+            "user": {"sheet_name": "beta", "display_name": "exp.xlsx — beta"},
+        },
+    }
+    result = runtime.register_output_payload(wire_payload)
+    assert result["display_name"] == "exp.xlsx — beta"
+
+
+def test_register_output_payload_stamps_display_name_from_source_file(
+    runtime: ApiRuntime,
+    opened_project: Path,
+) -> None:
+    """#1812: with no explicit override, the resolver falls back to the
+    typed ``meta.source_file`` basename."""
+    wire_payload = {
+        "backend": "zarr",
+        "path": str(opened_project / "data" / "zarr" / "beads.zarr"),
+        "format": "zarr",
+        "metadata": {
+            "type_chain": ["DataObject", "Array", "Image"],
+            "meta": {"source_file": "/uploads/beads.tif"},
+        },
+    }
+    result = runtime.register_output_payload(wire_payload)
+    assert result["display_name"] == "beads.tif"
+
+
+def test_register_output_payload_omits_display_name_when_unresolved(
+    runtime: ApiRuntime,
+    opened_project: Path,
+) -> None:
+    """#1812: the field is omitted (not empty) when nothing resolves, so the
+    frontend keeps its own truncated-ref fallback."""
+    wire_payload = {
+        "backend": "zarr",
+        "path": str(opened_project / "data" / "zarr" / "anon.zarr"),
+        "format": "zarr",
+        "metadata": {"type_chain": ["DataObject", "Array", "Image"]},
+    }
+    result = runtime.register_output_payload(wire_payload)
+    assert "display_name" not in result

--- a/tests/core/test_display_name.py
+++ b/tests/core/test_display_name.py
@@ -1,0 +1,130 @@
+"""Tests for ``resolve_display_name`` — the single canonical name resolver (#1812).
+
+The resolver is the one precedence authority shared by the interactive-panel
+label path (``interactive_item_label`` on a live ``DataObject``) and the
+previewer/API path (the serialized wire ``metadata`` dict stamped onto each
+item descriptor). These tests pin the precedence order and the dual input-shape
+contract (live object vs wire mapping).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scistudio.core.meta._display_name import resolve_display_name
+
+
+class _Meta:
+    """Attribute-style stand-in for a Pydantic ``meta`` slot."""
+
+    def __init__(self, *, source_file=None, file_path=None):
+        self.source_file = source_file
+        self.file_path = file_path
+
+
+class _Framework:
+    def __init__(self, *, source=""):
+        self.source = source
+
+
+class _Obj:
+    """Minimal duck-typed live ``DataObject`` stand-in."""
+
+    def __init__(self, *, name=None, user=None, meta=None, framework=None, file_path=None):
+        self.name = name
+        self.user = user if user is not None else {}
+        self.meta = meta
+        self.framework = framework
+        self.file_path = file_path
+
+
+# -- Precedence (wire-dict input) ------------------------------------------
+
+
+def test_user_display_name_wins_over_everything():
+    md = {
+        "user": {"display_name": "exp.xlsx — beta"},
+        "meta": {"source_file": "/data/exp.xlsx"},
+        "framework": {"source": "/data/exp.xlsx"},
+    }
+    assert resolve_display_name(md, fallback="item_0") == "exp.xlsx — beta"
+
+
+def test_name_used_when_no_display_name():
+    assert resolve_display_name({"name": "My Object"}, fallback="x") == "My Object"
+
+
+def test_meta_source_file_basename():
+    assert resolve_display_name({"meta": {"source_file": "/data/beads.tif"}}, fallback="x") == "beads.tif"
+
+
+def test_meta_source_file_windows_separator():
+    assert resolve_display_name({"meta": {"source_file": "C:\\runs\\a.csv"}}, fallback="x") == "a.csv"
+
+
+def test_root_level_source_file_wire_variant():
+    assert resolve_display_name({"source_file": "/a/root.csv"}, fallback="x") == "root.csv"
+
+
+def test_file_path_basename():
+    assert resolve_display_name({"file_path": "/x/y/photo.png"}, fallback="x") == "photo.png"
+
+
+def test_framework_source_basename_when_path():
+    assert resolve_display_name({"framework": {"source": "/p/img.ome.tiff"}}, fallback="x") == "img.ome.tiff"
+
+
+def test_framework_source_ignored_when_package_name():
+    # Package-name provenance is not a filename — fall through to the fallback.
+    md = {"framework": {"source": "scistudio-blocks-spectroscopy"}}
+    assert resolve_display_name(md, fallback="item_7") == "item_7"
+
+
+def test_source_file_beats_framework_source():
+    md = {"meta": {"source_file": "/data/real.tif"}, "framework": {"source": "/prov/other.tif"}}
+    assert resolve_display_name(md, fallback="x") == "real.tif"
+
+
+def test_empty_metadata_returns_fallback():
+    assert resolve_display_name({}, fallback="item_3") == "item_3"
+
+
+def test_none_source_returns_fallback():
+    assert resolve_display_name(None, fallback="item_9") == "item_9"
+
+
+# -- Dual input shape: the same precedence over a live object --------------
+
+
+def test_live_object_display_name():
+    obj = _Obj(user={"display_name": "A — s1"})
+    assert resolve_display_name(obj, fallback="item_0") == "A — s1"
+
+
+def test_live_object_meta_source_file():
+    obj = _Obj(meta=_Meta(source_file="/data/spectrum.dx"))
+    assert resolve_display_name(obj, fallback="item_0") == "spectrum.dx"
+
+
+def test_live_object_artifact_path_uses_name():
+    # An Artifact-style ``file_path`` is a ``Path``; its ``.name`` is the basename.
+    obj = _Obj(framework=_Framework(source=""), file_path=Path("/x/y/photo.png"))
+    assert resolve_display_name(obj, fallback="z") == "photo.png"
+
+
+def test_live_object_framework_source():
+    obj = _Obj(framework=_Framework(source="/data/run.mzML"))
+    assert resolve_display_name(obj, fallback="item_0") == "run.mzML"
+
+
+def test_live_object_empty_returns_fallback():
+    obj = _Obj()
+    assert resolve_display_name(obj, fallback="item_5") == "item_5"
+
+
+@pytest.mark.parametrize("blank", ["", None])
+def test_blank_display_name_falls_through(blank):
+    md = {"user": {"display_name": blank}, "meta": {"source_file": "/d/f.tif"}}
+    assert resolve_display_name(md, fallback="x") == "f.tif"


### PR DESCRIPTION
## What

Converge the two divergent user-facing display-name fallback chains (backend
`interactive_item_label` + frontend `deriveDisplayName`) onto a single backend
authority, `scistudio.core.meta._display_name.resolve_display_name` (#1812).

- **core (new, internal):** `resolve_display_name(source)` — duck-typed over both
  a live `DataObject` and the serialized wire metadata dict; one precedence:
  `user["display_name"]` → `name` → `meta.source_file` → `file_path` →
  `framework.source` (path-only). Not in `core.meta.__all__`.
- **interactive (protected core):** `interactive_item_label` delegates to it.
- **api:** `register_output_payload` stamps a resolved `display_name` onto each
  item descriptor (additive; omitted when nothing resolves).
- **frontend:** `deriveDisplayName` reads the stamped field first, keeps its
  metadata chain only as a compatibility fallback; collection items carry it through.
- **docs:** ADR-052 spec §8.2 (descriptor field) + §13 (optional package
  `user["display_name"]` convention) + Decision Log; CHANGELOG.

## Design

Chose **`user["display_name"]`** (an optional producer override) over a typed
`framework`/`meta` field. Result: **no `FrameworkMeta` schema change and no
ADR-052 §3.10 / §13.1 frozen-contract-row change** — it is a value convention
inside the already-public `user` slot, and the descriptor `display_name` is a
purely additive wire field. Owner-authorized `admin-approved:core-change` for
`src/scistudio/core/meta/**` + `src/scistudio/blocks/base/interactive.py`.

## Tests

`tests/core/test_display_name.py` (resolver precedence + dual input shape),
`tests/api/test_data.py` (descriptor stamping),
`frontend/.../refEntries.test.ts` (stamped read + collection carry-through).
Tier 1 gate green (clean HOME).

Gate record: .workflow/records/1812-display-name-convention.json

Closes #1812
