### PR TITLE
refactor(#1823): typed PreviewRequest.storage + relocate sanitize_svg

### DIFF
--- a/.workflow/records/1823-guided-1823-previewer-storage-leak.json
+++ b/.workflow/records/1823-guided-1823-previewer-storage-leak.json
@@ -225,7 +225,13 @@
     }
   ],
   "check_na": [],
-  "commit": null,
+  "commit": {
+    "sha": "e603803b046753afcde1e1e7b621c14c5404a99f",
+    "shas": [
+      "e603803b046753afcde1e1e7b621c14c5404a99f"
+    ],
+    "trailers": []
+  },
   "declared_scope": {
     "exclude": [],
     "include": [
@@ -462,6 +468,88 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:00:05.381060Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:00:05.389433Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:00:05.398197Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:00:05.406979Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:00:05.415784Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:00:05.424751Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:00:05.433293Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:00:05.441848Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:00:05.449918Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:00:05.460399Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -486,9 +574,9 @@
       "tests/previewers/test_fallback_array.py",
       "tests/previewers/test_preview_security.py"
     ],
-    "diff_fingerprint": "sha256:2db90573c2f9791bb646a18bc71cc57ebe8a2c9389092a774e64c52d760eeba8",
+    "diff_fingerprint": "sha256:479110c778522bfb5d07033de27e9a2d4e449ca3397fa9a3ed2d9c3aeeaf875a",
     "head": "HEAD",
-    "head_sha": "e3af9908",
+    "head_sha": "e603803b",
     "surfaces": {
       "docs": 1,
       "frontend": 0,
@@ -504,7 +592,14 @@
   },
   "owner_directive": "Refactor previewer authoring surface (#1823): close the storage leak via typed PreviewRequest.storage/record_metadata (Option A \u2014 consolidate the dict->typed rebuild into the session manager, keep _storage as runtime-internal carrier for cache-key + resource reads), relocate sanitize_svg out of fallbacks.py to a public helper home, and reconcile previewers __all__ (drop the 7 internal symbols; mark operational classes Internal). Imaging package rewrite is cross-repo and out of scope for this PR.",
   "persona": "live_implementer",
-  "pull_request": null,
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [
+      1823
+    ],
+    "number": null,
+    "url": null
+  },
   "reconcile_events": [
     {
       "at": "2026-06-28T00:54:18.173302Z",
@@ -522,6 +617,14 @@
     {
       "at": "2026-06-28T00:59:22.759429Z",
       "diff_fingerprint": "sha256:2db90573c2f9791bb646a18bc71cc57ebe8a2c9389092a774e64c52d760eeba8",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-28T01:00:05.460426Z",
+      "diff_fingerprint": "sha256:479110c778522bfb5d07033de27e9a2d4e449ca3397fa9a3ed2d9c3aeeaf875a",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 2,

--- a/.workflow/records/1823-guided-1823-previewer-storage-leak.json
+++ b/.workflow/records/1823-guided-1823-previewer-storage-leak.json
@@ -1,0 +1,594 @@
+{
+  "branch": "guided/1823-previewer-storage-leak",
+  "check_events": [
+    {
+      "at": "2026-06-28T00:50:35.729243Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:8bda43a20daf7c07fed666665f069d0fda08337894027ac233bb8b1e680cba80",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-28T00:50:39.499073Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:19baa1a69475470daddb4c29015cd5c155a2c3b68957bf4d20b223cb820d7529",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-28T00:50:39.993804Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:74545584a00c9605a5854a6dad90af8383d9cf87118dda62fda5184c7cdda2cb",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-28T00:50:40.029526Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:24934a7359dd42210f49e957fb6651c7b5127e58587cbcf198fe75dfc6160fb3",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-28T00:52:19.950300Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:166e7a9bd89d4728bcdfce5dc48b41093e4864b7ba95e9bacaf41fdb2ad1e92b",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-28T00:54:11.696758Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:7af75f901cda34d0d943747b1ee945a85f6d9fd8e899ff47a8a50740ea79d90e",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-28T00:54:18.051773Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:5c3e16ba3b7573d1cefcd33e6afb901b7f435febc2bb194a310cdb73d6a058c3",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    },
+    {
+      "at": "2026-06-28T00:56:15.941534Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cc6552a06643d156cd54fe4aaab941681bafe744f010e1c9284a886b3e76682f",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-28T00:56:19.669160Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:43f289e2d9b65e763a0c4b22242d7d99448e00c048d55c44b337397254d84bfb",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-28T00:56:19.773309Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cfa9dff16a4319b060668802e8862c004820bd37875cde4c28022c1f02560e6c",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-28T00:56:19.795292Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:29c0b7a5333b33c978169e503d3e1371aa6377d130ed7fd13cf7118ea048fc7c",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-28T00:57:31.119733Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:89ae8d4d063424d06633e5dafc25dd6c337e21925688eaa5cd19433cdcb55530",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-28T00:59:22.214183Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:06702441dc77a8ac54c216a606a1be835f4bfd49e149f2df0ec2d13ca8975750",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-28T00:59:22.633500Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:2b4491ebd354cc365ac6b73523fae2a9c72d37c83659a08c36e13a49d4a2489a",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    }
+  ],
+  "check_na": [],
+  "commit": null,
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "src/scistudio/previewers/**",
+      "docs/specs/adr-052-public-api-surface.md",
+      "tests/previewers/**",
+      "tests/api/test_previewers.py",
+      "tests/api/test_plot_preview_wiring.py"
+    ]
+  },
+  "directive_events": [
+    {
+      "at": "2026-06-28T00:37:38.606596Z",
+      "owner_directive": "Owner: \u5f00\u5e72 (proceed with Option A). Build the typed request.storage fix + sanitize_svg relocation now.",
+      "reason": "Refine scope after re-reading ADR-052 spec: the models.__all__ / operational-class reconciliation is explicitly assigned to #1817 (spec \u00a78, \u00a78.1), and #1823's Done-when does not require it. Narrow this PR to the previewer-specific design fix: typed PreviewRequest.storage/record_metadata (Option A), sanitize_svg relocation to a public helpers home, and ADR-052 \u00a78/\u00a78.5 doc updates. Imaging rewrite stays cross-repo/out-of-scope."
+    },
+    {
+      "at": "2026-06-28T00:39:12.896117Z",
+      "owner_directive": "After the core storage-ref fix lands and the main-repo PR is pushed, normalize the scistudio-blocks-spectroscopy package's previewer behavior to the ADR-052 \u00a78 public API so the package becomes an exemplary reference for future development. Do this in the spectroscopy repo after the main PR is pushed.",
+      "reason": "Owner added a sequenced follow-up directive during the live session; recorded for audit trail. The work itself is cross-repo (scistudio-blocks-spectroscopy) and governed by package PR governance, not this gate ledger; it is gated to start only after this core PR is pushed."
+    },
+    {
+      "at": "2026-06-28T00:54:55.685592Z",
+      "owner_directive": "Implemented Option A: typed request.storage + sanitize_svg relocation + spec docs.",
+      "reason": "plan"
+    },
+    {
+      "at": "2026-06-28T00:55:42.366435Z",
+      "owner_directive": "\u539fissue\u5199\u9519\u4e86:imaging\u5e94\u4e3aSpectroscopy(\u6309\u65b0API\u89c4\u8303+\u65b0\u63a5\u7ebf\u91cd\u5199,\u5373\u6700\u540e\u90a3\u4e2a\u4efb\u52a1)\u3002\u76f4\u63a5\u5173\u4e86#1823\u5c31\u884c\u3002",
+      "reason": "Owner clarified an error in the issue text and chose closure plan A. #1823 Done-when item 3 ('fix imaging') was a typo for 'rewrite scistudio-blocks-spectroscopy to the new API + wiring' \u2014 that is the cross-repo follow-up already recorded as a directive and gated to start after this PR is pushed. imaging is being refactored separately and is unrelated to #1823. Owner: close #1823 directly with this PR."
+    }
+  ],
+  "docs_events": [
+    {
+      "at": "2026-06-28T00:54:55.685731Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/specs/adr-052-public-api-surface.md",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": false,
+  "guard_events": [
+    {
+      "at": "2026-06-28T00:54:18.089619Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T00:54:18.099080Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {
+            "governed_files": [
+              "src/scistudio/previewers/fallbacks.py",
+              "src/scistudio/previewers/helpers.py",
+              "src/scistudio/previewers/models.py",
+              "src/scistudio/previewers/session.py"
+            ]
+          },
+          "expected": null,
+          "file": "",
+          "finding_class": "docs_landing",
+          "git_evidence": null,
+          "id": "docs_landing.missing-landing",
+          "line": null,
+          "message": "governed change requires docs/changelog/checklist landing evidence or an explicit N/A rationale",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "docs_landing.missing-landing",
+          "severity": "error",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "docs_landing",
+      "status": "fail"
+    },
+    {
+      "at": "2026-06-28T00:54:18.107605Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T00:54:18.115972Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T00:54:18.124587Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T00:54:18.134411Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T00:54:18.144341Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T00:54:18.154163Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T00:54:18.163003Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T00:54:18.173257Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T00:59:22.672910Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T00:59:22.682231Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T00:59:22.691452Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T00:59:22.701628Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T00:59:22.711033Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T00:59:22.719980Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T00:59:22.729212Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T00:59:22.739494Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T00:59:22.748387Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T00:59:22.759390Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1823,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": {
+    "base": "origin/main",
+    "base_sha": "1965e870",
+    "changed_files": [
+      ".workflow/records/1823-guided-1823-previewer-storage-leak.json",
+      "docs/specs/adr-052-public-api-surface.md",
+      "src/scistudio/previewers/fallbacks.py",
+      "src/scistudio/previewers/helpers.py",
+      "src/scistudio/previewers/models.py",
+      "src/scistudio/previewers/session.py",
+      "tests/previewers/test_fallback_array.py",
+      "tests/previewers/test_preview_security.py"
+    ],
+    "diff_fingerprint": "sha256:2db90573c2f9791bb646a18bc71cc57ebe8a2c9389092a774e64c52d760eeba8",
+    "head": "HEAD",
+    "head_sha": "e3af9908",
+    "surfaces": {
+      "docs": 1,
+      "frontend": 0,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 4,
+      "packaging": 0,
+      "protected_core": 0,
+      "sentrux": 7,
+      "test": 2,
+      "workflow_ci": 0
+    }
+  },
+  "owner_directive": "Refactor previewer authoring surface (#1823): close the storage leak via typed PreviewRequest.storage/record_metadata (Option A \u2014 consolidate the dict->typed rebuild into the session manager, keep _storage as runtime-internal carrier for cache-key + resource reads), relocate sanitize_svg out of fallbacks.py to a public helper home, and reconcile previewers __all__ (drop the 7 internal symbols; mark operational classes Internal). Imaging package rewrite is cross-repo and out of scope for this PR.",
+  "persona": "live_implementer",
+  "pull_request": null,
+  "reconcile_events": [
+    {
+      "at": "2026-06-28T00:54:18.173302Z",
+      "diff_fingerprint": "sha256:c19f11db573320725a9e16cb0a0859a0c8e77df5e91ee154fea303982d51c33f",
+      "mode": "local",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.format_check",
+        "docs.docs_required_or_na",
+        "guard.docs_landing",
+        "tests.changed_test_required"
+      ]
+    },
+    {
+      "at": "2026-06-28T00:59:22.759429Z",
+      "diff_fingerprint": "sha256:2db90573c2f9791bb646a18bc71cc57ebe8a2c9389092a774e64c52d760eeba8",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    }
+  ],
+  "record_id": "1823-guided-1823-previewer-storage-leak",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [
+      "format_check",
+      "full_audit",
+      "import_contracts",
+      "lint_format",
+      "python_tests",
+      "semantic_dup",
+      "type_check"
+    ],
+    "docs": [
+      "docs_required_or_na"
+    ],
+    "guards": [
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": [
+      "changed_test_required"
+    ]
+  },
+  "runtime": "claude-code",
+  "schema_version": 2,
+  "scope_events": [
+    {
+      "action": "add-include",
+      "at": "2026-06-28T00:37:38.606750Z",
+      "pattern": "src/scistudio/previewers/helpers.py",
+      "reason": "Refine scope after re-reading ADR-052 spec: the models.__all__ / operational-class reconciliation is explicitly assigned to #1817 (spec \u00a78, \u00a78.1), and #1823's Done-when does not require it. Narrow this PR to the previewer-specific design fix: typed PreviewRequest.storage/record_metadata (Option A), sanitize_svg relocation to a public helpers home, and ADR-052 \u00a78/\u00a78.5 doc updates. Imaging rewrite stays cross-repo/out-of-scope."
+    }
+  ],
+  "session_id": "a0ea890c-6a5a-4ba9-80e1-4798bbf509e1",
+  "strictness_tier": 2,
+  "task_kind": "guided",
+  "test_events": [
+    {
+      "at": "2026-06-28T00:54:55.685740Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/previewers/test_fallback_array.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-28T00:54:55.685746Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/previewers/test_preview_security.py",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/.workflow/records/1823-guided-1823-previewer-storage-leak.json
+++ b/.workflow/records/1823-guided-1823-previewer-storage-leak.json
@@ -226,9 +226,9 @@
   ],
   "check_na": [],
   "commit": {
-    "sha": "e603803b046753afcde1e1e7b621c14c5404a99f",
+    "sha": "ee357766327b2f4cba2183fd32cdf880627c99e5",
     "shas": [
-      "e603803b046753afcde1e1e7b621c14c5404a99f"
+      "ee357766327b2f4cba2183fd32cdf880627c99e5"
     ],
     "trailers": []
   },
@@ -550,6 +550,252 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:00:38.572712Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:00:38.581138Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:00:38.589486Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:00:38.597946Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:00:38.607115Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:00:38.616330Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:00:38.624503Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:00:38.633814Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:00:38.642317Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:00:38.655773Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:00:44.909131Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:00:44.918718Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:00:44.928273Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:00:44.938034Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:00:44.947038Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:00:44.955609Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:00:44.964043Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:00:44.972367Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:00:44.980533Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:00:44.991274Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:00:56.115967Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:00:56.125137Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:00:56.133626Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:00:56.142025Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:00:56.150324Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:00:56.158512Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:00:56.166570Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:00:56.175841Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:00:56.185115Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:00:56.196187Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -562,7 +808,7 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "origin/main",
+    "base": "1965e8708d83d9bfafe102afc1c0f485d628b8f4",
     "base_sha": "1965e870",
     "changed_files": [
       ".workflow/records/1823-guided-1823-previewer-storage-leak.json",
@@ -574,9 +820,9 @@
       "tests/previewers/test_fallback_array.py",
       "tests/previewers/test_preview_security.py"
     ],
-    "diff_fingerprint": "sha256:479110c778522bfb5d07033de27e9a2d4e449ca3397fa9a3ed2d9c3aeeaf875a",
+    "diff_fingerprint": "sha256:346e4076ac1c2651b380796121e459fb46a775b46f93b40fbe3ffe6962b8560c",
     "head": "HEAD",
-    "head_sha": "e603803b",
+    "head_sha": "ee357766",
     "surfaces": {
       "docs": 1,
       "frontend": 0,
@@ -597,7 +843,7 @@
     "closes": [
       1823
     ],
-    "number": null,
+    "number": 1829,
     "url": null
   },
   "reconcile_events": [
@@ -625,6 +871,30 @@
     {
       "at": "2026-06-28T01:00:05.460426Z",
       "diff_fingerprint": "sha256:479110c778522bfb5d07033de27e9a2d4e449ca3397fa9a3ed2d9c3aeeaf875a",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-28T01:00:38.655808Z",
+      "diff_fingerprint": "sha256:346e4076ac1c2651b380796121e459fb46a775b46f93b40fbe3ffe6962b8560c",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-28T01:00:44.991312Z",
+      "diff_fingerprint": "sha256:346e4076ac1c2651b380796121e459fb46a775b46f93b40fbe3ffe6962b8560c",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-28T01:00:56.196213Z",
+      "diff_fingerprint": "sha256:346e4076ac1c2651b380796121e459fb46a775b46f93b40fbe3ffe6962b8560c",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 2,

--- a/docs/specs/adr-052-public-api-surface.md
+++ b/docs/specs/adr-052-public-api-surface.md
@@ -894,11 +894,13 @@ importers — owner chose removal over deprecation); leading-underscore names st
   error-info / provider-protocol types.
 - `scistudio.previewers.data_access` — the injected `PreviewDataAccess` reader and
   its bounded-read result dataclasses.
-- One helper, `sanitize_svg`, currently lives in `scistudio.previewers.fallbacks`
-  (otherwise a core-internal module). It is author-facing (a package SVG/plot
-  previewer reuses it) and is **mis-homed**: relocate it to a public helper home
-  in #1823 so the author surface is `models` + `data_access` + that helper, with
-  no author import from `fallbacks`.
+- `scistudio.previewers.helpers` — the public helper home. It exposes the one
+  author-facing helper, `sanitize_svg` (a package SVG/plot previewer reuses it).
+  It was relocated here from the core-internal `scistudio.previewers.fallbacks`
+  module in #1823 (shipped), so the author surface is `models` + `data_access` +
+  `helpers`, with no author import from `fallbacks`. `fallbacks` keeps a
+  back-compat re-export (out of `__all__`) for out-of-tree packages mid-migration;
+  #1817 drops it once spectroscopy imports from `helpers`.
 
 The operational classes (`PreviewerRegistry`, `PreviewRouter`,
 `PreviewSessionManager`, `PreviewService`, `build_preview_service`,
@@ -924,9 +926,12 @@ module; its own array loader bypassing `PreviewDataAccess`; uses the legacy
 
 File checklist:
 
-- [x] `models.py` (650) — author type surface (§8.1)
+- [x] `models.py` (650) — author type surface (§8.1); `PreviewRequest.storage` /
+  `record_metadata` typed fields shipped (#1823, §8.5)
 - [x] `data_access.py` (804) — `PreviewDataAccess` + result types (§8.2)
-- [x] `fallbacks.py` (629) — `sanitize_svg` public; 8 core providers + `core_previewer_specs` internal (§8.3)
+- [x] `helpers.py` — public author helper home; `sanitize_svg` (relocated #1823, §8.3)
+- [x] `fallbacks.py` — 8 core providers + `core_previewer_specs` internal; `sanitize_svg`
+  back-compat re-export only (out of `__all__`) (§8.3)
 - [x] `__init__.py` (164), `registry.py` (282), `router.py` (234), `session.py` (617), `project.py` (120), `assets.py` (161) — operational layer, Internal (§8.4)
 - [x] `_raster.py` (101), `_table_cache.py` (127) — underscore-private internals
 
@@ -944,7 +949,7 @@ symbols. Both public packages import from here; usage is cited per row.
 | ✅ | `PreviewErrorCode` | class (StrEnum) | Public | provisional | 0.3.1 | author embeds the code in `PreviewErrorInfo`; the canonical error vocabulary |
 | ✅ | `PreviewerSpec` | class | Public | provisional | 0.3.1 | author returns these from `get_previewers` |
 | ✅ | `FrontendManifest` | class | Public | provisional | 0.3.1 | same-origin UI descriptor the author ships |
-| ✅ | `PreviewRequest` | class | Public | provisional | 0.3.1 | provider input (carries `target`/`spec`/`query`/`data_access`/`limits`); #1823 adds typed `storage`/`record_metadata` fields — see §8.5 |
+| ✅ | `PreviewRequest` | class | Public | provisional | 0.3.1 | provider input (carries `target`/`spec`/`query`/`data_access`/`limits`); typed `storage`/`record_metadata` fields shipped #1823 — see §8.5 |
 | ✅ | `PreviewTarget` | class | Public | provisional | 0.3.1 | read off the request; shape: `kind`/`ref`/`recorded_type`/`type_chain`/`collection_item_type`/`is_collection` |
 | ✅ | `PreviewSource` | class | Public | provisional | 0.3.1 | optional display identity on `target.source` (no runtime truth) |
 | ✅ | `PreviewLimits` | class | Public | provisional | 0.3.1 | session budgets surfaced on `request.limits` |
@@ -1008,14 +1013,16 @@ result dataclasses are **read-only outputs** authors receive, not types they bui
 | ✅ | `DEFAULT_MAX_TILE` | constant | Internal | — | — | as above |
 | ✅ | `DEFAULT_MAX_DIM` | constant | Internal | — | — | as above |
 
-### 8.3 `fallbacks.py`
+### 8.3 `fallbacks.py` + `helpers.py`
 
-Not an author root. Holds core's own fallback viewers; one helper escaped here and
-is author-facing.
+`fallbacks.py` is not an author root — it holds core's own fallback viewers. The
+one author-facing helper that had escaped here, `sanitize_svg`, was relocated to
+the public `scistudio.previewers.helpers` home in #1823.
 
 | St | Symbol | Kind | Disposition | Tier | Since | Notes |
 |----|--------|------|-------------|------|-------|-------|
-| ✅ | `sanitize_svg` | function | Reach-through (relocate) | provisional | 0.3.1 | spectroscopy imports it for SVG/plot previewers; relocate out of `fallbacks` to a public helper home in #1823 |
+| ✅ | `sanitize_svg` (`helpers.py`) | function | Public | provisional | 0.3.1 | the public helper home (#1823); spectroscopy imports it for SVG/plot previewers |
+| ➖ | `sanitize_svg` (`fallbacks.py`, re-export) | function | Internal | — | — | back-compat re-export of `helpers.sanitize_svg`, out of `__all__`; #1817 drops it once spectroscopy migrates |
 | ➖ | `dataframe_previewer` / `array_previewer` / `series_previewer` / `text_previewer` / `artifact_previewer` / `composite_previewer` / `collection_previewer` / `plot_previewer` / `base_fallback_previewer` | function | Internal | — | — | core's own fallback viewers; authors may read as reference impls, do not import |
 | ➖ | `core_previewer_specs` | function | Internal | — | — | builds the core spec list at registry load |
 
@@ -1038,8 +1045,8 @@ Neither public package imports any of these; core owns the machinery (ADR-048).
 Providers must read payloads **without catalog access** (FR-009), so the runtime
 resolves the storage reference and hands it to the provider. That need is
 legitimate and not package-specific — core's own fallback viewers (`fallbacks.py`),
-spectroscopy, and imaging all rely on it. The *mechanism*, however, leaks a core
-type into author code and is to be closed in #1823.
+spectroscopy, and imaging all rely on it. The *mechanism*, however, leaked a core
+type into author code; it is closed in #1823 (below).
 
 **Today (verified data flow):** `ApiRuntime.enrich_preview_query`
 (`api/runtime/_data.py`) already holds a typed `StorageReference` (`record.ref`)
@@ -1049,19 +1056,27 @@ but **downgrades it to a JSON dict** under `request.query["_storage"]` (plus
 `scistudio.core.storage.ref.StorageReference` and rebuilds it from that dict
 before calling `PreviewDataAccess`.
 
-**Target (#1823):** add typed fields `storage: StorageReference | None` and
-`record_metadata: dict` to `PreviewRequest` — an in-process object that already
-carries the live `PreviewDataAccess` and is never serialized — populated by the
-`PreviewSessionManager`. Providers then read `request.storage` and forward it to
-`data_access.*`; they **no longer import `StorageReference` or touch `_storage`**.
-The `_storage` / `_record_metadata` query keys demote to a **runtime-internal
-serialization detail** (session persistence / resume), not an author contract.
+**Shipped (#1823, Option A):** `PreviewRequest` gained typed fields
+`storage: StorageReference | None` and `record_metadata: dict` — an in-process
+object that already carries the live `PreviewDataAccess` and is never serialized.
+The `PreviewSessionManager` populates both on every request it builds (it
+resolves the typed ref once, replacing the per-provider rebuild). Providers read
+`request.storage` and forward it to `data_access.*`; they **no longer import
+`StorageReference` or touch `_storage`** (core's own `fallbacks.py` reads
+`request.storage` and keeps the `_storage` rebuild only as a defensive fallback
+for requests built outside the session manager). The `_storage` /
+`_record_metadata` query keys are **retained as a runtime-internal carrier** — the
+session cache-key folds in `_storage.metadata.data_version` for cache
+invalidation, and the bounded resource reads (tile/export) rebuild the ref from
+it — not an author contract. Closing the dict carrier entirely (Option B) was
+considered and declined: it buys no author-facing gain and would touch the
+cache-key and resource-read paths before the API freeze.
 
 | St | Surface element | Disposition | Tier | Since | Notes |
 |----|-----------------|-------------|------|-------|-------|
-| ✅ | `PreviewRequest.storage` (typed field, adds in #1823) | Public | provisional | — | the sanctioned way a provider obtains its `StorageReference`; replaces the `_storage` rebuild |
-| ✅ | `PreviewRequest.record_metadata` (typed field, adds in #1823) | Public | provisional | — | replaces the `_record_metadata` query read |
-| ✅ | `request.query["_storage"]` / `["_record_metadata"]` | Internal | — | — | runtime serialization form for session persistence; not an author contract (was an implicit one) |
+| ✅ | `PreviewRequest.storage` (typed field, shipped #1823) | Public | provisional | 0.3.1 | the sanctioned way a provider obtains its `StorageReference`; replaces the `_storage` rebuild |
+| ✅ | `PreviewRequest.record_metadata` (typed field, shipped #1823) | Public | provisional | 0.3.1 | replaces the `_record_metadata` query read |
+| ✅ | `request.query["_storage"]` / `["_record_metadata"]` | Internal | — | — | runtime-internal carrier (cache-key `data_version` + bounded resource reads); not an author contract (was an implicit one) |
 | ➖ | `StorageReference` (`scistudio.core.storage.ref`) | Public (via `core.types` re-export, §3) | — | — | appears in `PreviewDataAccess` signatures + the new `request.storage` field; previewer authors only pass it through, never import or construct it. Canonical inventory tracked under the core.storage governed-modules gap (§17), unchanged by this section |
 
 ## 9. Plot `render(collection)` Contract
@@ -1509,3 +1524,4 @@ even after the tables are complete.
 | 2026-06-27 | §13 rewritten to the **developer-facing reuse API only** (owner correction: the core-facing registration contract — entry points / `PackageInfo` / OTA — is **not** ADR-052 and is not mentioned here at all). The reuse contract **standardizes types + constructors + accessors**: types public at top level subclassing a core `DataObject`; **domain constructors MUST be classmethods on the type** (`Type.from_<domain>`), not free functions (`build_spectrum` → `Spectrum.from_arrays`); no `to_pandas`/`to_numpy` shadowing; `__all__` + decorators + discovery. §13.3: the template makes it self-enforcing — **MUST → `NotImplementedError` skeleton, SHOULD → empty file**, plus generated-reference build + freeze-test **parity with core** (§7/§15) against the package's own version line. §13.2 per-package inventories stay deferred. | Owner 2026-06-27. |
 | 2026-06-27 | §13 refined: (a) §13.1 expressed as a **per-member contract table** (St/Member/Kind/Rule/Template/Tier/Notes) like the core sections — not prose — enumerating the standardized type + constructor + accessor surface with each item's MUST/SHOULD rule and its template treatment (skeleton `NotImplementedError` / empty file / inherited / declared). (b) §13.2 **genericized — no package names** (owner: many domain packages are being rewritten or retired, so the roster is volatile); each package carries its own §13.1 table in its own repo. §13.1's constructor example de-named too. | Owner 2026-06-27 ("define an actual contract as a table, not prose"; "§13.2 must not name packages — many are abandoned"). |
 | 2026-06-27 | Filed **#1826** (build `scistudio-package-template` to self-enforce the §13.1 developer-facing contract: MUST→`NotImplementedError` skeletons + SHOULD→empty files, developer-facing contract validation, and generated-reference + freeze-test parity with core). §13.3 repointed from "issue TBD" → #1826. | Owner 2026-06-27 ("open the issue"). |
+| 2026-06-27 | **#1823 implemented (storage closure):** within the owner-approved typed-field approach, the owner picked the **consolidate-the-rebuild** variant over fully deleting the dict carrier. The `PreviewSessionManager` resolves the typed `StorageReference` once and sets `request.storage` / `record_metadata`; providers read those (core `fallbacks.py` keeps a defensive `_storage` rebuild only for requests built outside the manager). The `_storage` / `_record_metadata` query keys are **retained as a runtime-internal carrier** — the session cache-key folds in `_storage.metadata.data_version` and the bounded resource reads (tile/export) rebuild the ref from it. Fully removing the carrier was declined: no author-facing gain, and it would disturb the cache-key + resource-read paths before the API freeze. `sanitize_svg` relocated to the public `scistudio.previewers.helpers` home (`fallbacks` keeps a back-compat re-export, out of `__all__`, dropped by #1817). `models.__all__` reconciliation stays with #1817 per §8/§8.1. §8/§8.3/§8.5 updated to the shipped state. | Owner 2026-06-27 ("方案 A — consolidate, keep the internal carrier"). |

--- a/src/scistudio/previewers/fallbacks.py
+++ b/src/scistudio/previewers/fallbacks.py
@@ -26,9 +26,9 @@ core catch-all tiers.
 from __future__ import annotations
 
 import logging
-import re
 
 from scistudio.core.storage.ref import StorageReference
+from scistudio.previewers.helpers import sanitize_svg
 from scistudio.previewers.models import (
     EnvelopeKind,
     OwnerKind,
@@ -39,25 +39,17 @@ from scistudio.previewers.models import (
     PreviewResource,
 )
 
+# Back-compat re-export: ``sanitize_svg`` moved to the public
+# ``scistudio.previewers.helpers`` home in #1823 (ADR-052 §8). It is re-exported
+# here (and intentionally kept out of ``__all__``) so an out-of-tree package that
+# still imports ``from scistudio.previewers.fallbacks import sanitize_svg`` does
+# not hard-break before it migrates.
+# TODO(#1817): drop this re-export once scistudio-blocks-spectroscopy imports
+#   sanitize_svg from scistudio.previewers.helpers.
+#   Followup: https://github.com/jiazhenz026/SciStudio/issues/1817
+
 logger = logging.getLogger(__name__)
 
-# SVG sanitization: strip <script> blocks and event handler / external-resource
-# attributes (FR-019, defense-in-depth). NOTE: the authoritative security
-# boundary is the frontend's `<iframe sandbox="" srcDoc=...>` (no allow-scripts /
-# allow-same-origin) — this best-effort regex pass is a second layer, not the
-# sole guarantee, since regex HTML filtering cannot be fully robust. The closing
-# tag is matched as `</script[^>]*>` (handles malformed closers like
-# `</script\t\nbar>`) and an unterminated `<script>` is stripped to end-of-text.
-_SVG_SCRIPT_RE = re.compile(r"<script\b[^>]*>[\s\S]*?(?:</script[^>]*>|\Z)", re.IGNORECASE)
-_SVG_EVENT_ATTR_RE = re.compile(r"\son\w+\s*=\s*(\"[^\"]*\"|'[^']*'|[^\s>]+)", re.IGNORECASE)
-# Strip remote (http/https/protocol-relative) and active-scheme
-# (javascript:/vbscript:) href / xlink:href values; data: URIs (embedded
-# images) are left intact and are inert under the iframe sandbox.
-_SVG_EXTERNAL_HREF_RE = re.compile(
-    r"\s(?:xlink:href|href)\s*=\s*"
-    r"(\"\s*(?:https?:|//|javascript:|vbscript:)[^\"]*\"|'\s*(?:https?:|//|javascript:|vbscript:)[^']*')",
-    re.IGNORECASE,
-)
 _PLOT_MIME = {
     ".png": "image/png",
     ".jpg": "image/jpeg",
@@ -68,13 +60,16 @@ _PLOT_MIME = {
 
 
 def _ref_for(request: PreviewRequest) -> StorageReference:
-    """Build a StorageReference for the target from the runtime-provided ref dict.
+    """Return the runtime-resolved StorageReference for the target (FR-009, ADR-052 §8.5).
 
-    The session manager places the resolved ``StorageReference`` and recorded
-    metadata on ``request.query`` under ``_storage`` so providers do not need
-    catalog access. ``_storage`` is a dict with ``backend``/``path``/``format``/
-    ``metadata`` keys.
+    The sanctioned path is :attr:`PreviewRequest.storage`, which the
+    :class:`~scistudio.previewers.session.PreviewSessionManager` populates so
+    providers need no catalog access — this is what a package previewer reads.
+    The legacy ``query["_storage"]`` rebuild is kept only as a defensive
+    fallback for a request constructed outside the session manager.
     """
+    if request.storage is not None:
+        return request.storage
     storage = request.query.get("_storage") or {}
     return StorageReference(
         backend=str(storage.get("backend", "filesystem")),
@@ -85,6 +80,14 @@ def _ref_for(request: PreviewRequest) -> StorageReference:
 
 
 def _record_metadata(request: PreviewRequest) -> dict[str, object]:
+    """Return the recorded data-record metadata (ADR-052 §8.5).
+
+    Prefers the typed :attr:`PreviewRequest.record_metadata`; falls back to the
+    legacy ``query["_record_metadata"]`` for requests built outside the session
+    manager.
+    """
+    if request.record_metadata:
+        return request.record_metadata
     md = request.query.get("_record_metadata")
     return md if isinstance(md, dict) else {}
 
@@ -483,18 +486,6 @@ def plot_previewer(request: PreviewRequest) -> PreviewEnvelope:
     )
 
 
-def sanitize_svg(svg_text: str) -> tuple[str, bool]:
-    """Strip <script>, on* handlers, and remote href/xlink:href from SVG (FR-019).
-
-    Returns ``(sanitized_text, removed_anything)``.
-    """
-    sanitized = _SVG_SCRIPT_RE.sub("", svg_text)
-    sanitized, n_events = _SVG_EVENT_ATTR_RE.subn("", sanitized)
-    sanitized, n_hrefs = _SVG_EXTERNAL_HREF_RE.subn("", sanitized)
-    removed = sanitized != svg_text or n_events > 0 or n_hrefs > 0
-    return sanitized, removed
-
-
 # ---------------------------------------------------------------------------
 # Universal base fallback (tier-8 catch-all)
 # ---------------------------------------------------------------------------
@@ -623,7 +614,6 @@ __all__ = [
     "core_previewer_specs",
     "dataframe_previewer",
     "plot_previewer",
-    "sanitize_svg",
     "series_previewer",
     "text_previewer",
 ]

--- a/src/scistudio/previewers/helpers.py
+++ b/src/scistudio/previewers/helpers.py
@@ -1,0 +1,51 @@
+"""Public author-facing previewer helpers (ADR-052 §8).
+
+This is the canonical home for the small, reusable helpers a package-owned
+previewer may import, alongside the two canonical author roots
+``scistudio.previewers.models`` and ``scistudio.previewers.data_access``.
+
+Today it exposes a single helper:
+
+* :func:`sanitize_svg` — defense-in-depth SVG sanitization (FR-019) that a
+  package SVG/plot previewer reuses before returning SVG text. Previously this
+  lived in the core-internal ``scistudio.previewers.fallbacks`` module; it was
+  relocated here in #1823 so authors never import from ``fallbacks``.
+
+NOTE: the authoritative security boundary for rendered SVG is the frontend's
+``<iframe sandbox="" srcDoc=...>`` (no ``allow-scripts`` / ``allow-same-origin``).
+This best-effort regex pass is a second layer, not the sole guarantee, since
+regex-based HTML filtering cannot be made fully robust.
+"""
+
+from __future__ import annotations
+
+import re
+
+__all__ = ["sanitize_svg"]
+
+# SVG sanitization: strip <script> blocks and event handler / external-resource
+# attributes (FR-019, defense-in-depth). The closing tag is matched as
+# ``</script[^>]*>`` (handles malformed closers like ``</script\t\nbar>``) and an
+# unterminated ``<script>`` is stripped to end-of-text.
+_SVG_SCRIPT_RE = re.compile(r"<script\b[^>]*>[\s\S]*?(?:</script[^>]*>|\Z)", re.IGNORECASE)
+_SVG_EVENT_ATTR_RE = re.compile(r"\son\w+\s*=\s*(\"[^\"]*\"|'[^']*'|[^\s>]+)", re.IGNORECASE)
+# Strip remote (http/https/protocol-relative) and active-scheme
+# (javascript:/vbscript:) href / xlink:href values; data: URIs (embedded
+# images) are left intact and are inert under the iframe sandbox.
+_SVG_EXTERNAL_HREF_RE = re.compile(
+    r"\s(?:xlink:href|href)\s*=\s*"
+    r"(\"\s*(?:https?:|//|javascript:|vbscript:)[^\"]*\"|'\s*(?:https?:|//|javascript:|vbscript:)[^']*')",
+    re.IGNORECASE,
+)
+
+
+def sanitize_svg(svg_text: str) -> tuple[str, bool]:
+    """Strip <script>, on* handlers, and remote href/xlink:href from SVG (FR-019).
+
+    Returns ``(sanitized_text, removed_anything)``.
+    """
+    sanitized = _SVG_SCRIPT_RE.sub("", svg_text)
+    sanitized, n_events = _SVG_EVENT_ATTR_RE.subn("", sanitized)
+    sanitized, n_hrefs = _SVG_EXTERNAL_HREF_RE.subn("", sanitized)
+    removed = sanitized != svg_text or n_events > 0 or n_hrefs > 0
+    return sanitized, removed

--- a/src/scistudio/previewers/models.py
+++ b/src/scistudio/previewers/models.py
@@ -38,6 +38,7 @@ from enum import StrEnum
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 if TYPE_CHECKING:
+    from scistudio.core.storage.ref import StorageReference
     from scistudio.previewers.data_access import PreviewDataAccess
 
 
@@ -505,6 +506,21 @@ class PreviewRequest:
             provider must use for all reads (FR-009/FR-010).
         limits: The session budgets.
         session_id: Owning session id, or ``None`` for one-shot previews.
+        storage: The runtime-resolved :class:`StorageReference` for the
+            target's payload (FR-009), populated by the
+            :class:`PreviewSessionManager`. This is the **sanctioned** way a
+            provider obtains its storage ref: read ``request.storage`` and
+            forward it to ``request.data_access`` methods — providers never
+            import :class:`StorageReference` or rebuild it from the query.
+            ``None`` only when a request is constructed outside the session
+            manager without supplying it.
+        record_metadata: The recorded data-record metadata (ADR-052 §8.5),
+            populated by the session manager. Replaces the legacy
+            ``query["_record_metadata"]`` read for provider code.
+
+    The ``query["_storage"]`` / ``query["_record_metadata"]`` keys remain as a
+    runtime-internal serialization detail (session cache-key versioning and
+    resource reads); they are **not** an author contract (ADR-052 §8.5).
     """
 
     target: PreviewTarget
@@ -513,6 +529,8 @@ class PreviewRequest:
     data_access: PreviewDataAccess
     limits: PreviewLimits
     session_id: str | None = None
+    storage: StorageReference | None = None
+    record_metadata: dict[str, Any] = field(default_factory=dict)
 
 
 # A backend preview provider is any callable mapping a request to an

--- a/src/scistudio/previewers/session.py
+++ b/src/scistudio/previewers/session.py
@@ -224,6 +224,8 @@ class PreviewSessionManager:
                 data_access=access,
                 limits=session.limits,
                 session_id=session.session_id,
+                storage=_storage_ref_from_query(merged, session.target.ref),
+                record_metadata=_record_metadata_from_query(merged),
             )
             try:
                 return resource_provider(request, resource_id, _public_resource_params(params or {}))
@@ -310,6 +312,8 @@ class PreviewSessionManager:
             data_access=self._data_access_factory(limits),
             limits=limits,
             session_id=session_id,
+            storage=_storage_ref_from_query(query, target.ref),
+            record_metadata=_record_metadata_from_query(query),
         )
         try:
             envelope = provider(request)
@@ -453,7 +457,7 @@ class PreviewSessionManager:
         return None
 
     def _export_plot_resource(self, session: PreviewSession, params: dict[str, Any]) -> dict[str, Any]:
-        from scistudio.previewers.fallbacks import sanitize_svg
+        from scistudio.previewers.helpers import sanitize_svg
         from scistudio.previewers.models import TargetKind
 
         if session.target.kind is not TargetKind.PLOT_ARTIFACT and session.previewer_id != "core.plot.basic":
@@ -559,6 +563,12 @@ def _storage_ref_from_query(query: dict[str, Any], fallback_ref: str) -> Any:
         format=storage.get("format"),
         metadata=storage.get("metadata"),
     )
+
+
+def _record_metadata_from_query(query: dict[str, Any]) -> dict[str, Any]:
+    """Extract the recorded data-record metadata carried on the query (ADR-052 §8.5)."""
+    md = query.get("_record_metadata")
+    return dict(md) if isinstance(md, dict) else {}
 
 
 def _public_resource_params(params: dict[str, Any]) -> dict[str, Any]:

--- a/tests/previewers/test_fallback_array.py
+++ b/tests/previewers/test_fallback_array.py
@@ -38,7 +38,7 @@ class _StubAccess(PreviewDataAccess):
         slice_index: int = 0,
         axis_indices: dict[int, int] | None = None,
     ) -> ArrayPlane:
-        self.calls.append({"slice_index": slice_index, "axis_indices": dict(axis_indices or {})})
+        self.calls.append({"ref": ref, "slice_index": slice_index, "axis_indices": dict(axis_indices or {})})
         return ArrayPlane(
             shape=[4, 6, 3, 3],
             axes=["t", "z", "y", "x"],
@@ -58,7 +58,7 @@ class _StubAccess(PreviewDataAccess):
         )
 
 
-def _request(query: dict[str, Any]) -> PreviewRequest:
+def _request(query: dict[str, Any], *, storage: Any | None = None) -> PreviewRequest:
     target = PreviewTarget(
         kind=TargetKind.DATA_REF,
         ref="r",
@@ -78,6 +78,7 @@ def _request(query: dict[str, Any]) -> PreviewRequest:
         query=query,
         data_access=_StubAccess(),
         limits=PreviewLimits(),
+        storage=storage,
     )
 
 
@@ -101,6 +102,23 @@ def test_array_previewer_emits_numeric_heatmap_payload() -> None:
     assert payload["thumbnail"] == payload["matrix"]
     # Raster src remains available for package-viewer fallback paths.
     assert isinstance(payload["src"], str)
+
+
+def test_array_previewer_forwards_typed_request_storage() -> None:
+    # #1823 / ADR-052 §8.5: the provider reads the runtime-resolved
+    # StorageReference off ``request.storage`` and forwards it to data_access —
+    # no ``_storage`` query rebuild, no StorageReference import in author code.
+    from scistudio.core.storage.ref import StorageReference
+
+    ref = StorageReference(backend="zarr", path="typed/x", format="zarr")
+    request = _request({}, storage=ref)
+    env = array_previewer(request)
+
+    access = request.data_access
+    assert isinstance(access, _StubAccess)
+    # The exact typed object on request.storage reached data_access.array_plane.
+    assert access.calls[0]["ref"] is ref
+    assert env.kind is EnvelopeKind.ARRAY
 
 
 def test_array_previewer_reads_axis_indices_from_query() -> None:

--- a/tests/previewers/test_preview_security.py
+++ b/tests/previewers/test_preview_security.py
@@ -14,7 +14,21 @@ import numpy as np
 
 from scistudio.core.storage.ref import StorageReference
 from scistudio.previewers.data_access import PreviewDataAccess
-from scistudio.previewers.fallbacks import sanitize_svg
+from scistudio.previewers.helpers import sanitize_svg
+
+
+def test_sanitize_svg_back_compat_reexport_from_fallbacks() -> None:
+    """#1823: sanitize_svg relocated to the public helpers home (ADR-052 §8).
+
+    The legacy ``scistudio.previewers.fallbacks`` import path is kept as a
+    back-compat re-export (out of ``__all__``) so out-of-tree packages do not
+    hard-break before migrating; it must resolve to the same function.
+    """
+    from scistudio.previewers import fallbacks, helpers
+
+    assert fallbacks.sanitize_svg is helpers.sanitize_svg
+    assert "sanitize_svg" not in fallbacks.__all__
+    assert "sanitize_svg" in helpers.__all__
 
 
 def test_sanitize_svg_strips_well_formed_script() -> None:


### PR DESCRIPTION
## Summary

Close the previewer **storage leak** on the author surface and **regularize the
canonical author roots** ahead of the public API contract (ADR-052 §8 / §8.5),
with no behavior change.

### Storage leak — Option A (consolidate the rebuild)
- Add typed `PreviewRequest.storage: StorageReference | None` and
  `record_metadata: dict` fields (the request is an in-process object that
  already carries the live `PreviewDataAccess` and is never serialized).
- `PreviewSessionManager` resolves the `StorageReference` once and sets both
  fields on every request it builds — replacing the per-provider rebuild.
- Core fallback providers read `request.storage` / `request.record_metadata`;
  the legacy `query["_storage"]` rebuild is kept only as a defensive fallback for
  requests built outside the session manager.
- The `_storage` / `_record_metadata` query keys stay as a **runtime-internal
  carrier** (session cache-key `data_version` + bounded tile/export resource
  reads), no longer an author contract.

Package previewers can now obtain their storage ref from `request.storage` and
stop importing `scistudio.core.storage.ref` / reading `_storage`.

### Roots
- Relocate `sanitize_svg` from the core-internal `previewers/fallbacks.py` to the
  public `scistudio.previewers.helpers` home. `fallbacks` keeps a back-compat
  re-export (out of `__all__`) so out-of-tree packages do not hard-break before
  migrating; #1817 drops it.

### Docs
- ADR-052 spec §8 / §8.3 / §8.5 + Decision Log updated to the shipped state.

### Scope notes
- The `models.__all__` / operational-class reconciliation stays with #1817 per
  the spec (§8, §8.1).
- #1823's third Done-when item is a cross-repo rewrite of
  `scistudio-blocks-spectroscopy` to the new API + wiring (the issue text said
  "imaging" in error); it lands in that package's own repo as a follow-up.

## Testing
- `tests/previewers/` (incl. new `request.storage` forwarding test + the
  `sanitize_svg` helpers-home / back-compat re-export assertions)
- `tests/architecture/test_layer_deps.py`, `tests/contracts/test_runtime_import_contract.py`
- `gate_record check` (Tier 2): format, lint, type, import-contracts, full audit,
  semantic-dup, python tests — all green (clean HOME to mirror CI).

Gate record: .workflow/records/1823-guided-1823-previewer-storage-leak.json

Closes #1823
