### PR TITLE
feat(#1828): add scistudio.stability public-API decorators (ADR-052 §5)

### DIFF
--- a/.workflow/records/1828-guided-1828-scistudio-stability.json
+++ b/.workflow/records/1828-guided-1828-scistudio-stability.json
@@ -337,9 +337,9 @@
   ],
   "check_na": [],
   "commit": {
-    "sha": "e6007d01d4567a5b5d6e4134fd8db02b41a3ef51",
+    "sha": "ce56dae3681cb1d3f64eab1cda28af3dda960f7c",
     "shas": [
-      "e6007d01d4567a5b5d6e4134fd8db02b41a3ef51"
+      "ce56dae3681cb1d3f64eab1cda28af3dda960f7c"
     ],
     "trailers": []
   },
@@ -979,6 +979,88 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:46:04.946114Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:46:04.954849Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:46:04.963810Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:46:04.973605Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:46:04.982811Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:46:04.991989Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:46:05.001394Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:46:05.010298Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:46:05.018978Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:46:05.030916Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -1003,9 +1085,9 @@
       "tests/stability/__init__.py",
       "tests/stability/test_stability.py"
     ],
-    "diff_fingerprint": "sha256:4f1028a8a6f314b7c4b52877865c1a014d532e1cbb6d7e95545bed75e7e23d74",
+    "diff_fingerprint": "sha256:61d0999d09ae99e34d6026ea70890adaf0f40672f3c860d7efa2c74d71552f14",
     "head": "HEAD",
-    "head_sha": "a80bba91",
+    "head_sha": "ce56dae3",
     "surfaces": {
       "docs": 2,
       "frontend": 0,
@@ -1085,6 +1167,14 @@
       "at": "2026-06-28T01:45:38.062108Z",
       "diff_fingerprint": "sha256:4f1028a8a6f314b7c4b52877865c1a014d532e1cbb6d7e95545bed75e7e23d74",
       "mode": "local",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-28T01:46:05.030948Z",
+      "diff_fingerprint": "sha256:61d0999d09ae99e34d6026ea70890adaf0f40672f3c860d7efa2c74d71552f14",
+      "mode": "pre-pr",
       "result": "pass",
       "tier": 2,
       "unsatisfied": []

--- a/.workflow/records/1828-guided-1828-scistudio-stability.json
+++ b/.workflow/records/1828-guided-1828-scistudio-stability.json
@@ -337,9 +337,9 @@
   ],
   "check_na": [],
   "commit": {
-    "sha": "ce56dae3681cb1d3f64eab1cda28af3dda960f7c",
+    "sha": "9cd409417ca24a282ab64d49f8293eda8b3c4853",
     "shas": [
-      "ce56dae3681cb1d3f64eab1cda28af3dda960f7c"
+      "9cd409417ca24a282ab64d49f8293eda8b3c4853"
     ],
     "trailers": []
   },
@@ -1061,6 +1061,88 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:46:30.221071Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:46:30.229581Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:46:30.238318Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:46:30.246962Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:46:30.256781Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:46:30.266514Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:46:30.275398Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:46:30.284131Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:46:30.293250Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:46:30.306171Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -1073,7 +1155,7 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "origin/main",
+    "base": "ec4f752b293dd20a007ea1ed1b077a42eac333e0",
     "base_sha": "ec4f752b",
     "changed_files": [
       ".workflow/records/1828-guided-1828-scistudio-stability.json",
@@ -1085,9 +1167,9 @@
       "tests/stability/__init__.py",
       "tests/stability/test_stability.py"
     ],
-    "diff_fingerprint": "sha256:61d0999d09ae99e34d6026ea70890adaf0f40672f3c860d7efa2c74d71552f14",
+    "diff_fingerprint": "sha256:89b65ee863fc1045f30d72e5f8cf0f2e28f8dffcda3b160223bd11f18d2e15f2",
     "head": "HEAD",
-    "head_sha": "ce56dae3",
+    "head_sha": "9cd40941",
     "surfaces": {
       "docs": 2,
       "frontend": 0,
@@ -1174,6 +1256,14 @@
     {
       "at": "2026-06-28T01:46:05.030948Z",
       "diff_fingerprint": "sha256:61d0999d09ae99e34d6026ea70890adaf0f40672f3c860d7efa2c74d71552f14",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-28T01:46:30.306202Z",
+      "diff_fingerprint": "sha256:89b65ee863fc1045f30d72e5f8cf0f2e28f8dffcda3b160223bd11f18d2e15f2",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 2,

--- a/.workflow/records/1828-guided-1828-scistudio-stability.json
+++ b/.workflow/records/1828-guided-1828-scistudio-stability.json
@@ -1,0 +1,1168 @@
+{
+  "branch": "guided/1828-scistudio-stability",
+  "check_events": [
+    {
+      "at": "2026-06-28T01:02:51.073677Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:419623234ce11c434814d504304e77411037f74e256a51627b782cc2a74c7e5d",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-28T01:02:54.837756Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:939581e35b982bf35431a761496da8c493374e5b308549a910209348624ef3f5",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-28T01:02:55.322531Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:8ccc9d5d69fd4dcbb4af9b96489b624a692d4afd4c4d7b246a8c4b213200d3e7",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-28T01:02:55.361943Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:50df31d530eb1ad6e7c30b28705949b920a418807846256fb677c264b17f4245",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-28T01:04:40.858606Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:37269d7391161f08ea1d5d3f6e81b359f2ab362564a6abb6eb38c275da7c0737",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-28T01:06:32.863495Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:86e7824444363a7ac0273bad51128ae5d3a50a9d6f3aa6bd02ee40f2c20bbcea",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-28T01:06:38.837178Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:8875197bb775573bc3844b7de427dbf236bb817a307e3bf429f037dbef913899",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    },
+    {
+      "at": "2026-06-28T01:21:52.266807Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:91957ea673d5ef5481a23ef744550b27ac76fc6ca87d2a9e5be6869c0d8136fd",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-28T01:21:55.499511Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:b4a006f887b09c32c1cee921161467641adeb363d488f27d4e903b8c90698f6e",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-28T01:21:55.606679Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:f70e938cd625e2434a1987b2e99840f5f8c4467add99bab6a5967600a94ee400",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-28T01:21:55.625755Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:31c2d3fc50e93e07d267270fb979150090d233257c8f200946490a558451318f",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-28T01:23:05.637301Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:2e839c7cb8377eaf199198bceec50195db08bb9897654120a99eae99a0285875",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-28T01:24:59.240423Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:4610dadb7cb5970c413b1ef55f827c3d88e51369a5b1741b6c4437acb3f469ea",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-28T01:24:59.648637Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:7992687d3a5e97d2433ece341efe8216c27411694efe99bb463418f74e9642be",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    },
+    {
+      "at": "2026-06-28T01:42:29.720625Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:d28f0bd4da9a2fc77d7cc55fc2161fdfdb7d2adf2b23c9e941e276ea028ed849",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-28T01:42:33.245660Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:2e2ce00eeb753086348380c980766ec12a7f9064286c97b69e966653fd01fd08",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-28T01:42:33.369460Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:2b4b9e39eac12f753857385aa4ce010e1e13f53c949c31fbe4a9ca63f5f8dbfc",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-28T01:42:33.388134Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:c059e0bbeccd164457aced408b1678506c4ad39e941f82208ff77a0652759f2a",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-28T01:43:42.842640Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:b15b8561f52f39940d4a7e3a38cdc2c7875278944e9f11fbe611d4c17de26eff",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-28T01:45:37.030303Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:7beea85fddbdfa93f8aeadd8265484a28b1ed54c85f08a843275f8f4a02ac633",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-28T01:45:37.931363Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:3ad654d128a00ae20918e0c99eecd2297ce3627952713e20d5707afa07925c99",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    }
+  ],
+  "check_na": [],
+  "commit": {
+    "sha": "e6007d01d4567a5b5d6e4134fd8db02b41a3ef51",
+    "shas": [
+      "e6007d01d4567a5b5d6e4134fd8db02b41a3ef51"
+    ],
+    "trailers": []
+  },
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "src/scistudio/stability/**",
+      "tests/stability/**",
+      "CHANGELOG.md"
+    ]
+  },
+  "directive_events": [
+    {
+      "at": "2026-06-28T00:57:55.063993Z",
+      "owner_directive": "Foundational scistudio.stability module: stable/provisional/internal decorators (each with Since) + StabilityInfo + get_stability introspection; runtime no-ops. Tests in tests/stability/. CHANGELOG Added entry. Design already fixed by ADR-052 \u00a75, so no ADR/spec change.",
+      "reason": "plan"
+    },
+    {
+      "at": "2026-06-28T01:18:03.206314Z",
+      "owner_directive": "Also add CHANGELOG entries for already-merged PRs #1815, #1818, #1822 (backfill missed entries).",
+      "reason": "Owner directed backfilling missed CHANGELOG entries for already-merged PRs"
+    },
+    {
+      "at": "2026-06-28T01:18:04.419524Z",
+      "owner_directive": "Authorized editing ADR-052 (agent_editable:false): move scistudio.stability + .stable/.provisional/.internal from planned_governs to governs (audit-required). Keep the test at tests/stability/test_stability.py; update ADR-052 and spec-052 planned stability-test references to that path (not the reverse). Register the new top-level 'stability' package in the architecture placement allowlist.",
+      "reason": "Landing the new top-level module triggers required governance/placement updates; owner authorized the ADR-052 edit and chose to keep the test location, updating planned-test references in the docs to match"
+    },
+    {
+      "at": "2026-06-28T01:41:54.559906Z",
+      "owner_directive": "P2 fix: get_stability must unwrap property.fget (and fset/fdel) before reading the marker, so #1817 can decorate public properties (e.g. DataObject.framework, Collection.item_type) with the normal @property/@stable order without the shared validator/docs reporting them as undecorated.",
+      "reason": "Owner-reported P2: get_stability returned None for decorated properties"
+    },
+    {
+      "at": "2026-06-28T01:41:55.770216Z",
+      "owner_directive": "Resolve the CHANGELOG merge conflict introduced when #1812 merged to main.",
+      "reason": "Rebased onto origin/main; resolved CHANGELOG [Unreleased] conflict with #1812 by merging into single Added/Changed/Fixed sections"
+    }
+  ],
+  "docs_events": [
+    {
+      "at": "2026-06-28T00:57:55.064240Z",
+      "class": null,
+      "kind": "path",
+      "path": "CHANGELOG.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-28T01:18:04.419647Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/adr/ADR-052.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-28T01:18:04.419649Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/specs/adr-052-public-api-surface.md",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": false,
+  "guard_events": [
+    {
+      "at": "2026-06-28T01:06:38.873735Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:06:38.883065Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:06:38.892313Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:06:38.901666Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:06:38.910779Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:06:38.919673Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:06:38.928373Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:06:38.938174Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:06:38.947015Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:06:38.956772Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:24:59.686023Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:24:59.695507Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:24:59.705023Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:24:59.714162Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:24:59.722974Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:24:59.731791Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:24:59.740355Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:24:59.750018Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:24:59.758630Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:24:59.768899Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:26:29.325568Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:26:29.333894Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:26:29.342507Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:26:29.351807Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:26:29.360347Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:26:29.368580Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:26:29.376818Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:26:29.385305Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:26:29.393464Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:26:29.403639Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:27:52.050165Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:27:52.059335Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:27:52.067948Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:27:52.076346Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:27:52.084808Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:27:52.093583Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:27:52.102554Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:27:52.111307Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:27:52.119488Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:27:52.129795Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:28:00.034509Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:28:00.044911Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:28:00.055119Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:28:00.064680Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:28:00.073389Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:28:00.083301Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:28:00.095497Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:28:00.106299Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:28:00.119938Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:28:00.134562Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:28:13.229751Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:28:13.239486Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:28:13.249627Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:28:13.259386Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:28:13.269031Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:28:13.278491Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:28:13.287430Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:28:13.297249Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:28:13.306582Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:28:13.318148Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:45:37.974697Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:45:37.985542Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:45:37.995053Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:45:38.004796Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:45:38.013785Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:45:38.023130Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:45:38.032029Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:45:38.041190Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:45:38.050195Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T01:45:38.062080Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1828,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": {
+    "base": "origin/main",
+    "base_sha": "ec4f752b",
+    "changed_files": [
+      ".workflow/records/1828-guided-1828-scistudio-stability.json",
+      "CHANGELOG.md",
+      "docs/adr/ADR-052.md",
+      "docs/specs/adr-052-public-api-surface.md",
+      "src/scistudio/stability/__init__.py",
+      "tests/architecture/test_placement.py",
+      "tests/stability/__init__.py",
+      "tests/stability/test_stability.py"
+    ],
+    "diff_fingerprint": "sha256:4f1028a8a6f314b7c4b52877865c1a014d532e1cbb6d7e95545bed75e7e23d74",
+    "head": "HEAD",
+    "head_sha": "a80bba91",
+    "surfaces": {
+      "docs": 2,
+      "frontend": 0,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 1,
+      "packaging": 0,
+      "protected_core": 0,
+      "sentrux": 6,
+      "test": 3,
+      "workflow_ci": 0
+    }
+  },
+  "owner_directive": "Implement scistudio.stability (ADR-052 \u00a75 stability decorators + Since + introspection) in core to unblock the package template contract (#1826). Foundational module only; do not decorate core's own surface (#1817); touch nothing else.",
+  "persona": "live_implementer",
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [
+      1828
+    ],
+    "number": 1831,
+    "url": null
+  },
+  "reconcile_events": [
+    {
+      "at": "2026-06-28T01:06:38.956794Z",
+      "diff_fingerprint": "sha256:80ab34f38eedba3a0385d184e87c66dd1d0b28eb7e4a1d033f9ca834225293d5",
+      "mode": "local",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.full_audit",
+        "checks.python_tests"
+      ]
+    },
+    {
+      "at": "2026-06-28T01:24:59.768930Z",
+      "diff_fingerprint": "sha256:29d97e0bcc5152fc5c069af8b6ce45227f22e9dbc4d968e218acfe5f7200a982",
+      "mode": "local",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-28T01:26:29.403668Z",
+      "diff_fingerprint": "sha256:908980e2c05a764bd9096b0beb94ad0c88f4dfa4b3e2223a37e78b24e86d6ea0",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-28T01:27:52.129821Z",
+      "diff_fingerprint": "sha256:181745eafd1ad39afc6d5eee9d8ea2cac7852d43971c184e8950181598d67443",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-28T01:28:00.134593Z",
+      "diff_fingerprint": "sha256:181745eafd1ad39afc6d5eee9d8ea2cac7852d43971c184e8950181598d67443",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-28T01:28:13.318182Z",
+      "diff_fingerprint": "sha256:181745eafd1ad39afc6d5eee9d8ea2cac7852d43971c184e8950181598d67443",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-28T01:45:38.062108Z",
+      "diff_fingerprint": "sha256:4f1028a8a6f314b7c4b52877865c1a014d532e1cbb6d7e95545bed75e7e23d74",
+      "mode": "local",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    }
+  ],
+  "record_id": "1828-guided-1828-scistudio-stability",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [
+      "format_check",
+      "full_audit",
+      "import_contracts",
+      "lint_format",
+      "python_tests",
+      "semantic_dup",
+      "type_check"
+    ],
+    "docs": [
+      "docs_required_or_na"
+    ],
+    "guards": [
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": [
+      "changed_test_required"
+    ]
+  },
+  "runtime": "claude",
+  "schema_version": 2,
+  "scope_events": [
+    {
+      "action": "add-include",
+      "at": "2026-06-28T01:18:04.419635Z",
+      "pattern": "docs/adr/ADR-052.md",
+      "reason": "Landing the new top-level module triggers required governance/placement updates; owner authorized the ADR-052 edit and chose to keep the test location, updating planned-test references in the docs to match"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-28T01:18:04.419640Z",
+      "pattern": "docs/specs/adr-052-public-api-surface.md",
+      "reason": "Landing the new top-level module triggers required governance/placement updates; owner authorized the ADR-052 edit and chose to keep the test location, updating planned-test references in the docs to match"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-28T01:18:04.419641Z",
+      "pattern": "tests/architecture/test_placement.py",
+      "reason": "Landing the new top-level module triggers required governance/placement updates; owner authorized the ADR-052 edit and chose to keep the test location, updating planned-test references in the docs to match"
+    }
+  ],
+  "session_id": "c6b1473a-3852-42b1-b5ec-88be47c9f0cb",
+  "strictness_tier": 2,
+  "task_kind": "guided",
+  "test_events": [
+    {
+      "at": "2026-06-28T00:57:55.064256Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/stability/test_stability.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-28T01:41:54.560132Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/stability/test_stability.py",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- [#1828] `scistudio.stability` — the ADR-052 §5 public-API stability decorators (`stable` / `provisional` / `internal`, each carrying `Since`) plus `StabilityInfo` and `get_stability()` introspection. The decorators are runtime no-ops that stamp tier/version metadata on a public symbol; `get_stability()` is the single read path shared by the contract validator, the API-surface freeze test, and the generated reference (ADR-052 §7, §15). Foundational mechanism only: decorating core's own public surface, the generated reference, and the freeze test are tracked under #1817; the package template consumes it under #1826. (@claude, 2026-06-27, branch: guided/1828-scistudio-stability)
+- [#1815] Native Excel (`.xlsx`) read/write for core **DataFrame** and **Series** (#1810): an `xlsx` format capability on LoadData/SaveData via the pandas + openpyxl bridge. `.xlsx` is collection-valued — a workbook loads as one DataObject per sheet. Adds `openpyxl>=3.1` and raises the numpy floor `>=1.25` → `>=2.1` (#1809). (@claude, 2026-06-27, branch: feature/1810-dataframe-xlsx-io)
+
 ### Changed
 
+- [#1818] Richer GUI **"New custom block"** starter template for non-programmer authors (#1816): the teaching content now lives in the template itself — block family, data types, Collections, and where domain-package types come from — replacing the previous minimal example whose `accepted_types=[]` ports contradicted the block contract. (`src/scistudio/blocks/_templates/block_base_template.py`) (@claude, 2026-06-27, branch: guided/1816-custom-block-template)
 - [#1812] Canonical display-name convention: user-facing item names are now resolved by a single backend authority (`scistudio.core.meta._display_name.resolve_display_name`) instead of two divergent fallback chains (the interactive-panel `interactive_item_label` and the frontend `deriveDisplayName`). The resolver reads one precedence — `user["display_name"]` (the optional producer override, e.g. the xlsx loader's `"<file> — <sheet>"`) → `name` → `meta.source_file` → `file_path` → `framework.source` (path-only) — over both a live `DataObject` and the serialized wire metadata. `register_output_payload` now stamps a resolved `display_name` onto each item descriptor (additive; omitted when nothing resolves) and the frontend reads that field, keeping its metadata chain only as a compatibility fallback. New origins are added in the backend resolver alone; packages may optionally set `user["display_name"]` for their own types (documented in `docs/specs/adr-052-public-api-surface.md` §8.2/§13). Touches protected `src/scistudio/blocks/base/interactive.py` + `src/scistudio/core/meta/**` — owner-authorized (`admin-approved:core-change`). Tests: `tests/core/test_display_name.py`, `tests/api/test_data.py`, `frontend/src/components/DataPreview.parts/refEntries.test.ts`. (@claude, 2026-06-27, branch: guided/1812-display-name-convention)
+
+### Fixed
+
+- [#1822] Transport every single-value port as a length-one Collection (#1811): the engine's `_normalize_outputs` now wraps `is_collection=False` outputs in a length-one Collection (`engine/runners/worker.py`), closing the ADR-020 §3 engine/spec drift where single-value ports still transported a bare `DataObject`. (@claude, 2026-06-27, branch: guided/1811-single-value-collection-fix)
 
 ## [0.3.1] - 2026-06-27
 

--- a/docs/adr/ADR-052.md
+++ b/docs/adr/ADR-052.md
@@ -23,6 +23,7 @@ governs:
     - scistudio.blocks.app
     - scistudio.blocks.code
     - scistudio.previewers.models
+    - scistudio.stability
   contracts:
     - scistudio.blocks.base.block.Block
     - scistudio.blocks.base.config.BlockConfig
@@ -37,6 +38,9 @@ governs:
     - scistudio.core.types.dataframe.DataFrame
     - scistudio.core.types.collection.Collection
     - scistudio.previewers.models.PreviewerSpec
+    - scistudio.stability.stable
+    - scistudio.stability.provisional
+    - scistudio.stability.internal
   entry_points:
     - scistudio.blocks
     - scistudio.types
@@ -46,12 +50,8 @@ governs:
   excludes:
     - docs/user/reference/**
 planned_governs:
-  modules:
-    - scistudio.stability
+  modules: []
   contracts:
-    - scistudio.stability.stable
-    - scistudio.stability.provisional
-    - scistudio.stability.internal
     - scistudio.core.types.Array.to_numpy
     - scistudio.core.types.DataFrame.to_pandas
     - scistudio.core.types.DataFrame.to_numpy
@@ -64,7 +64,7 @@ planned_governs:
   excludes: []
 tests:
   - tests/api/test_public_surface.py
-  - tests/api/test_stability_decorators.py
+  - tests/stability/test_stability.py
   - tests/api/test_ergonomic_accessors.py
 agent_editable: false
 assisted_by:
@@ -519,7 +519,7 @@ The expected tooling impact this ADR commits to:
 
 - A `scistudio.stability` module with `stable`/`provisional`/`internal`
   decorators, unit-tested for no-op runtime behavior and correct metadata
-  attachment (`tests/api/test_stability_decorators.py`).
+  attachment (`tests/stability/test_stability.py`).
 - Explicit `__all__` declarations on the core public roots in Section 3, with a
   test that asserts the declared public surface and that no `internal` symbol
   leaks into it (`tests/api/test_public_surface.py`).

--- a/docs/specs/adr-052-public-api-surface.md
+++ b/docs/specs/adr-052-public-api-surface.md
@@ -42,7 +42,7 @@ planned_governs:
   excludes: []
 tests:
   - tests/api/test_public_surface.py
-  - tests/api/test_stability_decorators.py
+  - tests/stability/test_stability.py
   - tests/api/test_ergonomic_accessors.py
 acceptance_source: adr
 language_source: en

--- a/src/scistudio/stability/__init__.py
+++ b/src/scistudio/stability/__init__.py
@@ -1,0 +1,151 @@
+"""Public-API stability decorators for SciStudio (ADR-052 §5).
+
+Every public symbol in core and in a package carries two facts an author needs
+and cannot infer from the code: how much they may rely on it (its *tier*), and
+when it first became public (its ``Since`` version). ADR-052 §5 records both
+**on the symbol** via a small set of decorators, rather than in a separate
+hand-maintained table that would drift the moment a symbol changed.
+
+The three tiers:
+
+* ``stable`` — supported. Will not change incompatibly within a major version;
+  removal or a breaking change requires deprecation first.
+* ``provisional`` — usable but still settling. May change in a minor release,
+  with a changelog note.
+* ``internal`` — no promise. May change or vanish in any release. Excluded from
+  the generated reference; the tier exists so a symbol that must stay importable
+  for compatibility can still be labelled honestly.
+
+The decorators are **no-ops at runtime**: each attaches a :class:`StabilityInfo`
+to the symbol and returns it unchanged, so they add no runtime cost and change
+no behaviour. :func:`get_stability` reads the metadata back — the single read
+path shared by the contract validator, the API-surface freeze test, and the
+``griffe`` reference generator (ADR-052 §7, §15), so all three agree.
+
+``Since`` records the version a symbol first became public on *its own* surface:
+core's version line for core symbols (baseline ``0.3.1``), the package's version
+line for package symbols (ADR-052 §4.3, §13.1).
+
+This module is **decorators only** — not a re-export façade (ADR-052 §5). It is
+the foundational mechanism; decorating core's own public surface, generating the
+reference, and the surface freeze test are tracked separately under #1817.
+
+Usage::
+
+    from scistudio.stability import provisional, stable
+
+    @stable(since="0.3.1")
+    class Series(DataObject):
+        ...
+
+    @provisional(since="0.3.1")
+    def new_helper(...):
+        ...
+
+For a classmethod, apply ``@classmethod`` *outermost* so the marker lands on the
+underlying function::
+
+    class Spectrum(Series):
+        @classmethod
+        @stable(since="0.1.0")
+        def from_arrays(cls, ...):
+            ...
+
+:func:`get_stability` transparently unwraps classmethods, staticmethods, bound
+methods, and properties (reading the marker off ``fget`` / ``fset`` / ``fdel``),
+so the marker is found regardless of how the symbol is reached.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Literal, TypeVar
+
+__all__ = [
+    "StabilityInfo",
+    "Tier",
+    "get_stability",
+    "internal",
+    "provisional",
+    "stable",
+]
+
+#: The stability tiers an author may rely on, in descending order of promise.
+Tier = Literal["stable", "provisional", "internal"]
+
+#: Attribute under which :class:`StabilityInfo` is stashed on a decorated symbol.
+#: Namespaced to avoid colliding with author attributes; always read it through
+#: :func:`get_stability`, never directly.
+_STABILITY_ATTR = "__scistudio_stability__"
+
+_T = TypeVar("_T")
+
+
+@dataclass(frozen=True)
+class StabilityInfo:
+    """The stability facts attached to one public symbol (ADR-052 §5).
+
+    ``tier`` is the reliance promise; ``since`` is the version the symbol first
+    became public on its surface (``None`` only for ``internal`` symbols, which
+    carry no promise and need no version).
+    """
+
+    tier: Tier
+    since: str | None = None
+
+
+def _marker(info: StabilityInfo) -> Callable[[_T], _T]:
+    """Build a decorator that stamps ``info`` onto a symbol and returns it."""
+
+    def decorate(symbol: _T) -> _T:
+        # classmethod/staticmethod wrappers reject attribute assignment, so when
+        # the marker is applied outside one, stamp the function it wraps instead;
+        # get_stability unwraps the same way on read.
+        target: object = symbol.__func__ if isinstance(symbol, (classmethod, staticmethod)) else symbol
+        # A few objects (builtins, some C/slotted types) can't carry the marker;
+        # the validator then reads "undecorated", the honest result for a symbol
+        # that cannot be marked.
+        with contextlib.suppress(AttributeError, TypeError):
+            setattr(target, _STABILITY_ATTR, info)
+        return symbol
+
+    return decorate
+
+
+def stable(*, since: str) -> Callable[[_T], _T]:
+    """Mark a public symbol ``stable`` as of ``since`` (ADR-052 §5)."""
+    return _marker(StabilityInfo(tier="stable", since=since))
+
+
+def provisional(*, since: str) -> Callable[[_T], _T]:
+    """Mark a public symbol ``provisional`` as of ``since`` (ADR-052 §5)."""
+    return _marker(StabilityInfo(tier="provisional", since=since))
+
+
+def internal(*, since: str | None = None) -> Callable[[_T], _T]:
+    """Mark a symbol ``internal`` — importable but carrying no promise (ADR-052 §5)."""
+    return _marker(StabilityInfo(tier="internal", since=since))
+
+
+def get_stability(symbol: object) -> StabilityInfo | None:
+    """Return the :class:`StabilityInfo` stamped on ``symbol``, or ``None``.
+
+    Transparently unwraps ``classmethod`` / ``staticmethod`` / bound-method
+    access and ``property`` objects so a symbol marked on its underlying
+    function (or accessor) is found regardless of how it is reached. A property
+    is read from its getter first, then its setter, then its deleter — matching
+    the normal ``@property`` / ``@stable`` order, where the marker lands on
+    ``fget``. This is the single read path for the contract validator, the
+    API-surface freeze test, and the generated reference (ADR-052 §7, §15).
+    """
+    if isinstance(symbol, property):
+        for accessor in (symbol.fget, symbol.fset, symbol.fdel):
+            info = getattr(accessor, _STABILITY_ATTR, None)
+            if isinstance(info, StabilityInfo):
+                return info
+        return None
+    target = getattr(symbol, "__func__", symbol)
+    info = getattr(target, _STABILITY_ATTR, None)
+    return info if isinstance(info, StabilityInfo) else None

--- a/tests/architecture/test_placement.py
+++ b/tests/architecture/test_placement.py
@@ -151,6 +151,7 @@ def test_no_py_files_outside_known_packages() -> None:
         "agent_provisioning",  # ADR-040 §3.5-3.8: prod-env agent provisioning module
         "previewers",  # ADR-048: extensible type previewer subsystem (scistudio.previewers)
         "desktop",  # ADR-037: desktop distribution path/resource helpers
+        "stability",  # ADR-052 §5: public-API stability decorators (scistudio.stability)
     }
     stray: list[str] = []
     for filepath in SRC_ROOT.rglob("*.py"):

--- a/tests/stability/test_stability.py
+++ b/tests/stability/test_stability.py
@@ -1,0 +1,142 @@
+"""Tests for :mod:`scistudio.stability` (ADR-052 §5 stability decorators)."""
+
+from __future__ import annotations
+
+from scistudio import stability
+from scistudio.stability import (
+    StabilityInfo,
+    get_stability,
+    internal,
+    provisional,
+    stable,
+)
+
+
+def test_stable_stamps_tier_and_since() -> None:
+    @stable(since="0.3.1")
+    def f() -> int:
+        return 1
+
+    assert get_stability(f) == StabilityInfo(tier="stable", since="0.3.1")
+    # no-op at runtime: the symbol is returned unchanged and still works.
+    assert f() == 1
+
+
+def test_provisional_and_internal_tiers() -> None:
+    @provisional(since="0.3.1")
+    def g() -> None: ...
+
+    @internal()
+    def h() -> None: ...
+
+    assert get_stability(g) == StabilityInfo(tier="provisional", since="0.3.1")
+    assert get_stability(h) == StabilityInfo(tier="internal", since=None)
+
+
+def test_internal_accepts_explicit_since() -> None:
+    @internal(since="0.3.1")
+    def f() -> None: ...
+
+    assert get_stability(f) == StabilityInfo(tier="internal", since="0.3.1")
+
+
+def test_decorates_class() -> None:
+    @stable(since="0.3.1")
+    class C:
+        pass
+
+    assert get_stability(C) == StabilityInfo(tier="stable", since="0.3.1")
+    assert isinstance(C(), C)  # still instantiable, unchanged
+
+
+def test_classmethod_marker_readable() -> None:
+    # Recommended order: @classmethod outermost, marker on the raw function.
+    class C:
+        @classmethod
+        @stable(since="0.1.0")
+        def make(cls) -> str:
+            return "ok"
+
+    assert get_stability(C.make) == StabilityInfo(tier="stable", since="0.1.0")
+    assert C.make() == "ok"
+
+
+def test_marker_outside_classmethod_also_works() -> None:
+    # Reverse order: marker receives the classmethod object and unwraps it.
+    class C:
+        @stable(since="0.1.0")
+        @classmethod
+        def make(cls) -> str:
+            return "ok"
+
+    assert get_stability(C.make) == StabilityInfo(tier="stable", since="0.1.0")
+    assert C.make() == "ok"
+
+
+def test_staticmethod_marker_readable() -> None:
+    class C:
+        @staticmethod
+        @provisional(since="0.1.0")
+        def helper() -> int:
+            return 2
+
+    assert get_stability(C.helper) == StabilityInfo(tier="provisional", since="0.1.0")
+    assert C.helper() == 2
+
+
+def test_property_marker_readable() -> None:
+    # Normal order: @property outermost, marker on the getter (fget). This is
+    # how #1817 will decorate public properties like DataObject.framework.
+    class C:
+        @property
+        @stable(since="0.3.1")
+        def framework(self) -> str:
+            return "core"
+
+    assert get_stability(C.framework) == StabilityInfo(tier="stable", since="0.3.1")
+    assert C().framework == "core"  # property still works
+
+
+def test_property_setter_marker_readable() -> None:
+    # Marker on the setter only — get_stability falls back fget -> fset -> fdel.
+    class C:
+        _v = 0
+
+        @property
+        def x(self) -> int:
+            return self._v
+
+        @x.setter
+        @stable(since="0.3.1")
+        def x(self, value: int) -> None:
+            self._v = value
+
+    assert get_stability(C.x) == StabilityInfo(tier="stable", since="0.3.1")
+    obj = C()
+    obj.x = 7
+    assert obj.x == 7  # setter still works
+
+
+def test_decorator_returns_same_object_identity() -> None:
+    def f() -> None: ...
+
+    assert stable(since="0.3.1")(f) is f
+
+
+def test_get_stability_none_for_undecorated() -> None:
+    def plain() -> None: ...
+
+    assert get_stability(plain) is None
+    assert get_stability(object()) is None
+    assert get_stability(42) is None
+
+
+def test_public_exports() -> None:
+    assert set(stability.__all__) == {
+        "StabilityInfo",
+        "Tier",
+        "get_stability",
+        "internal",
+        "provisional",
+        "stable",
+    }


### PR DESCRIPTION
## What

Add the foundational `scistudio.stability` module (ADR-052 §5): the
`stable` / `provisional` / `internal` decorators (each carrying `Since`),
`StabilityInfo`, and `get_stability()` introspection. The decorators are
runtime no-ops that stamp tier/version metadata on a public symbol;
`get_stability()` is the single read path shared by the contract validator,
the API-surface freeze test, and the generated reference (ADR-052 §7, §15).

This is the **foundational mechanism only** — it does not decorate core's own
public surface (#1817) and adds no re-export façade (ADR-052 §5). It unblocks
the package template's self-enforcing developer-facing contract (#1826), which
imports these decorators instead of vendoring a parallel mechanism.

## Why now

`scistudio.stability` is the shared dependency both core's full public-API
formalization (#1817) and the package template (#1826) build on. Landing just
the module unblocks the package work without the larger #1817 pass.

## Changes

- **New module** `src/scistudio/stability/__init__.py` + `tests/stability/test_stability.py`.
- **ADR-052 / spec governance:** now that the symbols resolve, moves
  `scistudio.stability` + `.stable` / `.provisional` / `.internal` from
  `planned_governs` to `governs` (owner-authorized edit to an
  `agent_editable: false` ADR), and re-points the planned stability-test path
  in ADR-052 and the spec to `tests/stability/test_stability.py` (kept out of
  `tests/api/` — it is not an api-surface test).
- **Placement:** registers the new top-level `stability` package in the
  architecture placement allowlist.
- **CHANGELOG backfill** (owner-directed) for already-merged PRs #1815, #1818,
  #1822.

## Tests

- `tests/stability/test_stability.py` — 10 tests: tier/`Since` stamping for
  functions, classes, classmethods (both decoration orders), and staticmethods;
  runtime no-op (identity preserved); `get_stability()` returns `None` for
  undecorated objects; `__all__` surface.

Gate record: .workflow/records/1828-guided-1828-scistudio-stability.json

Closes #1828
