### PR TITLE
fix(#1837,#1836,#1838,#1840): alpha UX/bug batch

### DIFF
--- a/.workflow/records/1837-guided-1837-alpha-ux-bug-batch.json
+++ b/.workflow/records/1837-guided-1837-alpha-ux-bug-batch.json
@@ -241,9 +241,9 @@
   ],
   "check_na": [],
   "commit": {
-    "sha": "9073cc2571bdea1aff0c485a31fdf8565101f75d",
+    "sha": "7bc0181a7d2a16631ca04f2b707693ee25c87781",
     "shas": [
-      "9073cc2571bdea1aff0c485a31fdf8565101f75d"
+      "7bc0181a7d2a16631ca04f2b707693ee25c87781"
     ],
     "trailers": []
   },
@@ -528,6 +528,334 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-06-28T18:58:40.857263Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T18:58:40.866904Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T18:58:40.876797Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T18:58:40.885956Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T18:58:40.894372Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T18:58:40.903318Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T18:58:40.911722Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T18:58:40.920638Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T18:58:40.929422Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T18:58:40.942343Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T18:58:56.037414Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T18:58:56.046525Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T18:58:56.056252Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T18:58:56.066229Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T18:58:56.075424Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T18:58:56.085195Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T18:58:56.094614Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T18:58:56.104360Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T18:58:56.114055Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T18:58:56.127275Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T18:59:14.094238Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T18:59:14.103314Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T18:59:14.111913Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T18:59:14.120512Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T18:59:14.129134Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T18:59:14.137798Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T18:59:14.147096Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T18:59:14.156872Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T18:59:14.165529Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T18:59:14.177480Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T18:59:31.859941Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T18:59:31.868462Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T18:59:31.876971Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T18:59:31.885294Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T18:59:31.893540Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T18:59:31.901743Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T18:59:31.910699Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T18:59:31.920167Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T18:59:31.929645Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T18:59:31.941661Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -558,7 +886,7 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "origin/main",
+    "base": "1ace1783efd357c704325f3215867a3b0844f472",
     "base_sha": "1ace1783",
     "changed_files": [
       ".workflow/records/1837-guided-1837-alpha-ux-bug-batch.json",
@@ -578,9 +906,9 @@
       "tests/api/test_workflow_id_conflict.py",
       "tests/desktop/test_terminal_post_rc.py"
     ],
-    "diff_fingerprint": "sha256:bf18a7f38c6ecba31db26e7f634e2a49a2c24b53b983ff7bb0ed2a97533cc92a",
+    "diff_fingerprint": "sha256:0cc7ffd424eec83206b99b83303d2ffc7e7937bea6e814fb0206546110565bc3",
     "head": "HEAD",
-    "head_sha": "9073cc25",
+    "head_sha": "7bc0181a",
     "surfaces": {
       "docs": 1,
       "frontend": 4,
@@ -604,7 +932,7 @@
       1838,
       1840
     ],
-    "number": null,
+    "number": 1844,
     "url": null
   },
   "reconcile_events": [
@@ -631,6 +959,38 @@
     {
       "at": "2026-06-28T18:58:05.695804Z",
       "diff_fingerprint": "sha256:bf18a7f38c6ecba31db26e7f634e2a49a2c24b53b983ff7bb0ed2a97533cc92a",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-28T18:58:40.942374Z",
+      "diff_fingerprint": "sha256:0cc7ffd424eec83206b99b83303d2ffc7e7937bea6e814fb0206546110565bc3",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-28T18:58:56.127319Z",
+      "diff_fingerprint": "sha256:0cc7ffd424eec83206b99b83303d2ffc7e7937bea6e814fb0206546110565bc3",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-28T18:59:14.177509Z",
+      "diff_fingerprint": "sha256:0cc7ffd424eec83206b99b83303d2ffc7e7937bea6e814fb0206546110565bc3",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-28T18:59:31.941703Z",
+      "diff_fingerprint": "sha256:0cc7ffd424eec83206b99b83303d2ffc7e7937bea6e814fb0206546110565bc3",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 2,

--- a/.workflow/records/1837-guided-1837-alpha-ux-bug-batch.json
+++ b/.workflow/records/1837-guided-1837-alpha-ux-bug-batch.json
@@ -1,0 +1,776 @@
+{
+  "branch": "guided/1837-alpha-ux-bug-batch",
+  "check_events": [
+    {
+      "at": "2026-06-28T18:46:08.920543Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:29ca274ecf5d808d902144163d70514aeb731baa08d785da7eb5152b22dabd36",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-28T18:46:58.805616Z",
+      "command": "(cd frontend && npm run check:ci)",
+      "covered_surface": "frontend",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:47305fed846549fa509fcb27bfdba23e961140fa8efcfe37e6ec81058512386f",
+      "name": "frontend",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/frontend.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-28T18:47:03.977842Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:09259ea276fe546f3529dc709876bca50f86b2cc506d150b7976bb3a0400732a",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-28T18:47:04.522593Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:20bf050c5233524b7bd4c79d1722e6ab298d0a33a850a822f9d5203ab9476420",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-28T18:47:04.605324Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:8c7423540e566904339a852897aa25d9d0d0d7b33361455cc5485972b0a60d15",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-28T18:48:55.530594Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:7902eaaef37bc4feadcf924d4498a99520a2a2cd9d85107ae1afd5652d9b5c22",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-28T18:50:50.033799Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cb1c9992c03c56690effa070c21330661b00e5f60bbfdb694c5a8cdd952e33b4",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-28T18:50:56.655462Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:f81bb195d38547b6afe52f9a120fee7d399481db8932f95dcb567c629b01ac49",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    },
+    {
+      "at": "2026-06-28T18:52:05.458113Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:6c443548727b8a9f1e481f8b9dcf84c332f3ad999aae6771f1b2dc5ad38bb255",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-28T18:52:09.260341Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:36527be0148291865661ca8c390f5bd8d8159efe25e07592d2c84b4a6aac8976",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-28T18:52:09.373847Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:77e220e0881371f025a59208c76c5507886568ad61de683ade05f6b2b7f84965",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-28T18:52:09.388861Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:649c9935085cf30a41dfd87441addb7d4639cd6dc389a915fe76a1ade94a4636",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-28T18:54:08.872102Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e446e2b4e5b4129ba84dbc865a3dcf6aeff21cb1e0ad2b5aad31ff1187095b3f",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-28T18:57:28.967802Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:196757a21e1e4a326dc9d934b25472e16cc36d454f40b3db1c9d488e1498157e",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-28T18:57:29.563522Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:fb3517fd773f9a44fdc490a7eb54dc2a298a67b095d902ae1bac6b28573c0027",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    }
+  ],
+  "check_na": [],
+  "commit": {
+    "sha": "9073cc2571bdea1aff0c485a31fdf8565101f75d",
+    "shas": [
+      "9073cc2571bdea1aff0c485a31fdf8565101f75d"
+    ],
+    "trailers": []
+  },
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "src/scistudio/previewers/fallbacks.py",
+      "src/scistudio/api/runtime/_workflows.py",
+      "src/scistudio/api/routes/workflows.py",
+      "src/scistudio/ai/agent/terminal.py",
+      "src/scistudio/desktop/paths.py",
+      "frontend/src/components/DataPreview.parts/PortInfoPanel.tsx",
+      "tests/**"
+    ]
+  },
+  "directive_events": [
+    {
+      "at": "2026-06-28T18:43:18.131459Z",
+      "owner_directive": "\u90fd\u662f\u5c0f\u4fee\uff0c\u4e00\u4e2aPR\u76f4\u63a5\u5168\u90e8\u63d0\u4ea4\u30021836\u7528\u65b9\u68482\uff0c\u5e94\u8be5\u5f3a\u5236workflow id\u552f\u4e00\u3002",
+      "reason": "Owner redirected: ship all four fixes in ONE combined PR (not four separate PRs); #1836 use option 2 (enforce unique workflow id per project on import/save) rather than option 1."
+    },
+    {
+      "at": "2026-06-28T18:44:24.081985Z",
+      "owner_directive": "Four fixes in one PR: #1837 previewer minimal params; #1836 unique workflow id (option 2); #1838 terminal post-rc bundled-python shim; #1840 port core base-type annotation.",
+      "reason": "plan"
+    }
+  ],
+  "docs_events": [
+    {
+      "at": "2026-06-28T18:44:24.082180Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/specs/port-description-metadata.md",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": false,
+  "guard_events": [
+    {
+      "at": "2026-06-28T18:50:56.703427Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T18:50:56.713170Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T18:50:56.723326Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T18:50:56.732722Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T18:50:56.742336Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T18:50:56.751478Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T18:50:56.760566Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T18:50:56.769807Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T18:50:56.778665Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T18:50:56.790145Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T18:57:29.636141Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T18:57:29.660463Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T18:57:29.680867Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T18:57:29.706258Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T18:57:29.728179Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T18:57:29.746418Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T18:57:29.765809Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T18:57:29.787338Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T18:57:29.808664Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T18:57:29.829917Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T18:58:05.609687Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T18:58:05.619835Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T18:58:05.628850Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T18:58:05.637902Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T18:58:05.646268Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T18:58:05.655112Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T18:58:05.665459Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T18:58:05.675112Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T18:58:05.684122Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T18:58:05.695757Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1837,
+      "url": null
+    },
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1836,
+      "url": null
+    },
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1838,
+      "url": null
+    },
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1840,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": {
+    "base": "origin/main",
+    "base_sha": "1ace1783",
+    "changed_files": [
+      ".workflow/records/1837-guided-1837-alpha-ux-bug-batch.json",
+      "docs/specs/port-description-metadata.md",
+      "frontend/src/components/DataPreview.parts/PortInfoPanel.test.tsx",
+      "frontend/src/components/DataPreview.parts/PortInfoPanel.tsx",
+      "frontend/src/config/__tests__/typeColorMap.test.ts",
+      "frontend/src/config/typeColorMap.ts",
+      "src/scistudio/ai/agent/terminal.py",
+      "src/scistudio/api/routes/workflows.py",
+      "src/scistudio/api/runtime/__init__.py",
+      "src/scistudio/api/runtime/_workflows.py",
+      "src/scistudio/desktop/paths.py",
+      "src/scistudio/previewers/fallbacks.py",
+      "src/scistudio/previewers/session.py",
+      "tests/api/test_previewers.py",
+      "tests/api/test_workflow_id_conflict.py",
+      "tests/desktop/test_terminal_post_rc.py"
+    ],
+    "diff_fingerprint": "sha256:bf18a7f38c6ecba31db26e7f634e2a49a2c24b53b983ff7bb0ed2a97533cc92a",
+    "head": "HEAD",
+    "head_sha": "9073cc25",
+    "surfaces": {
+      "docs": 1,
+      "frontend": 4,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 11,
+      "packaging": 0,
+      "protected_core": 0,
+      "sentrux": 15,
+      "test": 5,
+      "workflow_ci": 0
+    }
+  },
+  "owner_directive": "Batch-fix four small alpha issues in ONE PR (owner-directed): #1837 collection previewer 422 (minimal params), #1836 enforce unique workflow id per project on import/save (option 2), #1838 embedded terminal defaults to bundled python not conda base, #1840 annotate port type with core base type. Owner explicitly authorized a single combined PR.",
+  "persona": "live_implementer",
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [
+      1837,
+      1836,
+      1838,
+      1840
+    ],
+    "number": null,
+    "url": null
+  },
+  "reconcile_events": [
+    {
+      "at": "2026-06-28T18:50:56.790189Z",
+      "diff_fingerprint": "sha256:bcb6e548e561cc8912704cf3a5bf631472860bf1763ddb9896e51bf0a5be8fd6",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.format_check",
+        "checks.lint_format",
+        "scope.out-of-scope"
+      ]
+    },
+    {
+      "at": "2026-06-28T18:57:29.829959Z",
+      "diff_fingerprint": "sha256:bf18a7f38c6ecba31db26e7f634e2a49a2c24b53b983ff7bb0ed2a97533cc92a",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-28T18:58:05.695804Z",
+      "diff_fingerprint": "sha256:bf18a7f38c6ecba31db26e7f634e2a49a2c24b53b983ff7bb0ed2a97533cc92a",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    }
+  ],
+  "record_id": "1837-guided-1837-alpha-ux-bug-batch",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [
+      "format_check",
+      "frontend",
+      "full_audit",
+      "import_contracts",
+      "lint_format",
+      "python_tests",
+      "semantic_dup",
+      "type_check"
+    ],
+    "docs": [
+      "docs_required_or_na"
+    ],
+    "guards": [
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": [
+      "changed_test_required"
+    ]
+  },
+  "runtime": "claude-code",
+  "schema_version": 2,
+  "scope_events": [
+    {
+      "action": "add-include",
+      "at": "2026-06-28T18:43:18.131614Z",
+      "pattern": "src/scistudio/previewers/session.py",
+      "reason": "Owner redirected: ship all four fixes in ONE combined PR (not four separate PRs); #1836 use option 2 (enforce unique workflow id per project on import/save) rather than option 1."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-28T18:43:18.131621Z",
+      "pattern": "src/scistudio/api/runtime/__init__.py",
+      "reason": "Owner redirected: ship all four fixes in ONE combined PR (not four separate PRs); #1836 use option 2 (enforce unique workflow id per project on import/save) rather than option 1."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-28T18:43:18.131623Z",
+      "pattern": "frontend/src/config/typeColorMap.ts",
+      "reason": "Owner redirected: ship all four fixes in ONE combined PR (not four separate PRs); #1836 use option 2 (enforce unique workflow id per project on import/save) rather than option 1."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-28T18:43:18.131625Z",
+      "pattern": "frontend/src/config/__tests__/typeColorMap.test.ts",
+      "reason": "Owner redirected: ship all four fixes in ONE combined PR (not four separate PRs); #1836 use option 2 (enforce unique workflow id per project on import/save) rather than option 1."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-28T18:43:18.131626Z",
+      "pattern": "frontend/src/components/DataPreview.parts/PortInfoPanel.test.tsx",
+      "reason": "Owner redirected: ship all four fixes in ONE combined PR (not four separate PRs); #1836 use option 2 (enforce unique workflow id per project on import/save) rather than option 1."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-28T18:43:18.131628Z",
+      "pattern": "tests/api/test_workflow_id_conflict.py",
+      "reason": "Owner redirected: ship all four fixes in ONE combined PR (not four separate PRs); #1836 use option 2 (enforce unique workflow id per project on import/save) rather than option 1."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-28T18:43:18.131629Z",
+      "pattern": "tests/desktop/test_terminal_post_rc.py",
+      "reason": "Owner redirected: ship all four fixes in ONE combined PR (not four separate PRs); #1836 use option 2 (enforce unique workflow id per project on import/save) rather than option 1."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-28T18:43:18.131630Z",
+      "pattern": "tests/api/test_previewers.py",
+      "reason": "Owner redirected: ship all four fixes in ONE combined PR (not four separate PRs); #1836 use option 2 (enforce unique workflow id per project on import/save) rather than option 1."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-28T18:51:41.696522Z",
+      "pattern": "docs/specs/port-description-metadata.md",
+      "reason": "Documentation: #1840 core base-type annotation documented in the port-description spec (UI render rules it governs)."
+    }
+  ],
+  "session_id": "cca1481c-6a89-4fb3-8d97-63977bccce56",
+  "strictness_tier": 2,
+  "task_kind": "guided",
+  "test_events": [
+    {
+      "at": "2026-06-28T18:44:24.082205Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/api/test_previewers.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-28T18:44:24.082216Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/api/test_workflow_id_conflict.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-28T18:44:24.082220Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/desktop/test_terminal_post_rc.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-28T18:44:24.082223Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/config/__tests__/typeColorMap.test.ts",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-28T18:44:24.082226Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/components/DataPreview.parts/PortInfoPanel.test.tsx",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/docs/specs/port-description-metadata.md
+++ b/docs/specs/port-description-metadata.md
@@ -103,6 +103,36 @@ Field semantics:
 - **Em-dash separator** — render ` — ` only when `descriptive_text`
   is non-empty.
 
+### 3.1 Core Base-Type Annotation (#1840)
+
+For a specialized type whose previewer hides its underlying structure
+(e.g. `SRSImage`, `SpectralDataset`), the row appends the **fundamental
+core base type** after the type name so users can tell what the type
+fundamentally is:
+
+```
+[icon] SRSImage (Array) [— descriptive_text]
+[icon] SpectralDataset (DataFrame)
+```
+
+The core base is the highest ancestor in the inheritance chain whose
+immediate base is the universal `DataObject` root — for
+`SRSImage → Image → Array → DataObject` it is `Array` (not the immediate
+parent `Image`, not the generic root `DataObject`). It is resolved
+**frontend-side** by walking `BlockSchemaResponse.type_hierarchy` (a
+`name → base_type` map), so no backend or schema change is required.
+
+The annotation is **omitted** when:
+
+- the type already IS a core base (no redundant `Array (Array)`),
+- the type is `DataObject` itself,
+- the chain cannot be resolved (unknown type) — degrade to no annotation,
+- a cycle is detected (defensive).
+
+Helper: `resolveCoreBaseType(typeName, typeHierarchy)` in
+`frontend/src/config/typeColorMap.ts`. The annotation is applied to the
+primary type name (consistent with the existing color logic).
+
 ## 4. Ordering And Trigger
 
 - **Ordering**: declared order. The order in which `input_ports` /

--- a/frontend/src/components/DataPreview.parts/PortInfoPanel.test.tsx
+++ b/frontend/src/components/DataPreview.parts/PortInfoPanel.test.tsx
@@ -125,4 +125,44 @@ describe("PortInfoPanel", () => {
     );
     expect(container.firstChild).toBeNull();
   });
+
+  // #1840: a specialized type is annotated with its fundamental core base.
+  it("annotates a specialized port type with its core base type", () => {
+    const SPECIALIZED_HIERARCHY = [
+      { name: "DataObject", base_type: "", description: "" },
+      { name: "Array", base_type: "DataObject", description: "" },
+      { name: "Image", base_type: "Array", description: "" },
+      { name: "SRSImage", base_type: "Image", description: "" },
+    ];
+    const srs = port("img", "", ["SRSImage"]);
+    render(
+      <PortInfoPanel
+        inputPorts={[srs]}
+        outputPorts={[]}
+        schema={schema({ input_ports: [srs], type_hierarchy: SPECIALIZED_HIERARCHY })}
+      />,
+    );
+
+    expect(screen.getByText("SRSImage")).toBeInTheDocument();
+    expect(screen.getByText("(Array)")).toBeInTheDocument();
+  });
+
+  it("omits the core-base annotation for a port that already accepts a core base", () => {
+    const SPECIALIZED_HIERARCHY = [
+      { name: "DataObject", base_type: "", description: "" },
+      { name: "Array", base_type: "DataObject", description: "" },
+    ];
+    const arr = port("data", "", ["Array"]);
+    render(
+      <PortInfoPanel
+        inputPorts={[arr]}
+        outputPorts={[]}
+        schema={schema({ input_ports: [arr], type_hierarchy: SPECIALIZED_HIERARCHY })}
+      />,
+    );
+
+    expect(screen.getByText("Array")).toBeInTheDocument();
+    // No redundant "(Array)" annotation.
+    expect(screen.queryByText("(Array)")).toBeNull();
+  });
 });

--- a/frontend/src/components/DataPreview.parts/PortInfoPanel.tsx
+++ b/frontend/src/components/DataPreview.parts/PortInfoPanel.tsx
@@ -17,7 +17,7 @@
 // names and the effective per-instance port list so it can pick the
 // right row format without a new wire field.
 
-import { primaryTypeName, resolveTypeColor } from "../../config/typeColorMap";
+import { primaryTypeName, resolveCoreBaseType, resolveTypeColor } from "../../config/typeColorMap";
 import type { BlockPortResponse, BlockSchemaResponse } from "../../types/api";
 
 interface PortInfoPanelProps {
@@ -48,6 +48,10 @@ function describePort(port: BlockPortResponse, declaredNames: Set<string>): stri
 function PortRow({ port, typeHierarchy, declaredNames }: RowProps) {
   const color = resolveTypeColor(port.accepted_types, typeHierarchy);
   const typeName = primaryTypeName(port.accepted_types) || "Any";
+  // #1840: annotate a specialized type with its fundamental core base
+  // (e.g. `SRSImage (Array)`) so users can tell what a specialized type is at
+  // bottom. Omitted for core-base / DataObject / unresolved types.
+  const coreBase = resolveCoreBaseType(typeName, typeHierarchy);
   const text = describePort(port, declaredNames);
   return (
     <li className="flex items-baseline gap-2 py-1 text-xs text-stone-700">
@@ -56,7 +60,10 @@ function PortRow({ port, typeHierarchy, declaredNames }: RowProps) {
         className="mt-1 inline-block h-2 w-2 flex-shrink-0 rounded-full"
         style={{ backgroundColor: color }}
       />
-      <span className="font-medium text-stone-800">{typeName}</span>
+      <span className="font-medium text-stone-800">
+        {typeName}
+        {coreBase != null && <span className="font-normal text-stone-400"> ({coreBase})</span>}
+      </span>
       {text != null && (
         <>
           <span className="text-stone-400">—</span>

--- a/frontend/src/config/__tests__/typeColorMap.test.ts
+++ b/frontend/src/config/__tests__/typeColorMap.test.ts
@@ -4,11 +4,13 @@ import {
   hashTypeName,
   isAnyType,
   primaryTypeName,
+  resolveCoreBaseType,
   resolveRingColor,
   resolveTypeColor,
   subtypeRingColorMap,
   typeColorMap,
 } from "../typeColorMap";
+import type { TypeHierarchyEntry } from "../../types/api";
 
 // Regression test for #1487: DataObject was rendered with #e5e7eb
 // (gray-200) which is unreadable on the white canvas. The fallback used
@@ -98,5 +100,52 @@ describe("hashTypeName", () => {
 
   it("is non-negative", () => {
     expect(hashTypeName("Foo")).toBeGreaterThanOrEqual(0);
+  });
+});
+
+// #1840: annotate a specialized type with its fundamental core base — the
+// highest ancestor above the universal DataObject root.
+describe("resolveCoreBaseType", () => {
+  const HIERARCHY: TypeHierarchyEntry[] = [
+    { name: "DataObject", base_type: "", description: "" },
+    { name: "Array", base_type: "DataObject", description: "" },
+    { name: "Image", base_type: "Array", description: "" },
+    { name: "SRSImage", base_type: "Image", description: "" },
+    { name: "DataFrame", base_type: "DataObject", description: "" },
+    { name: "SpectralDataset", base_type: "DataFrame", description: "" },
+  ];
+
+  it("walks a multi-level chain to the core base (SRSImage → Array)", () => {
+    expect(resolveCoreBaseType("SRSImage", HIERARCHY)).toBe("Array");
+  });
+
+  it("resolves a one-level chain (SpectralDataset → DataFrame)", () => {
+    expect(resolveCoreBaseType("SpectralDataset", HIERARCHY)).toBe("DataFrame");
+  });
+
+  it("resolves an intermediate type to its core base (Image → Array)", () => {
+    expect(resolveCoreBaseType("Image", HIERARCHY)).toBe("Array");
+  });
+
+  it("returns null when the type already IS a core base (no Array (Array))", () => {
+    expect(resolveCoreBaseType("Array", HIERARCHY)).toBeNull();
+    expect(resolveCoreBaseType("DataFrame", HIERARCHY)).toBeNull();
+  });
+
+  it("returns null for DataObject itself", () => {
+    expect(resolveCoreBaseType("DataObject", HIERARCHY)).toBeNull();
+  });
+
+  it("returns null for an unknown type or missing hierarchy", () => {
+    expect(resolveCoreBaseType("Mystery", HIERARCHY)).toBeNull();
+    expect(resolveCoreBaseType("SRSImage", undefined)).toBeNull();
+  });
+
+  it("returns null and does not hang on a cycle", () => {
+    const cyclic: TypeHierarchyEntry[] = [
+      { name: "A", base_type: "B", description: "" },
+      { name: "B", base_type: "A", description: "" },
+    ];
+    expect(resolveCoreBaseType("A", cyclic)).toBeNull();
   });
 });

--- a/frontend/src/config/typeColorMap.ts
+++ b/frontend/src/config/typeColorMap.ts
@@ -158,3 +158,44 @@ export function primaryTypeName(typeNames: string[]): string {
   if (typeNames.length === 0) return "Any";
   return typeNames[0];
 }
+
+/**
+ * Resolve a type's *fundamental core base* — the highest ancestor in its
+ * inheritance chain whose immediate base is the universal `DataObject` root
+ * (#1840). For `SRSImage → Image → Array → DataObject` this is `Array`, not
+ * the immediate parent `Image` and not the generic root `DataObject`.
+ *
+ * Returns `null` (omit the annotation) when:
+ *   - the type already IS a core base (its immediate base is `DataObject`),
+ *     so there is no redundant `Array (Array)`;
+ *   - the type is `DataObject` itself;
+ *   - the chain can't be resolved (unknown type, or a root that does not
+ *     descend from `DataObject`);
+ *   - a cycle is detected (defensive).
+ *
+ * Walks frontend-side from the existing `type_hierarchy` (a `name → base_type`
+ * map), so no backend change is needed.
+ */
+export function resolveCoreBaseType(
+  typeName: string,
+  typeHierarchy?: TypeHierarchyEntry[],
+): string | null {
+  if (!typeName || typeName === "DataObject" || !typeHierarchy) return null;
+  const baseOf = new Map<string, string>();
+  for (const entry of typeHierarchy) baseOf.set(entry.name, entry.base_type ?? "");
+
+  let current = typeName;
+  const seen = new Set<string>([current]);
+  while (baseOf.has(current)) {
+    const parent = baseOf.get(current) as string;
+    if (parent === "DataObject") {
+      // `current` is the highest ancestor above DataObject — the core base.
+      // Omit when it equals the displayed type (no redundant `Array (Array)`).
+      return current === typeName ? null : current;
+    }
+    if (parent === "" || seen.has(parent)) return null; // root-not-via-DataObject / cycle
+    seen.add(parent);
+    current = parent;
+  }
+  return null; // chain left the known hierarchy → unresolved
+}

--- a/src/scistudio/ai/agent/terminal.py
+++ b/src/scistudio/ai/agent/terminal.py
@@ -668,14 +668,21 @@ def spawn_user_terminal(
 ) -> PtyProcess:
     """Spawn a desktop user shell with SciStudio's user dependency env."""
     del dangerous
-    from scistudio.desktop.paths import user_python_terminal_env
+    from scistudio.desktop.paths import user_python_terminal_env, user_terminal_post_rc_invocation
 
     env = user_python_terminal_env(sys.executable)
     if extra_env:
         env.update(extra_env)
 
+    # #1838: run the shell against a post-rc shim so the bundled Python bin is
+    # re-prepended AFTER the user's dotfiles (conda init) run; otherwise a
+    # `(base)` conda env shadows our wrappers and `pip install` lands in conda
+    # base with no effect on the app.
+    argv = list(_spawn_argv or _user_shell_argv())
+    argv, env = user_terminal_post_rc_invocation(argv, env)
+
     return PtyProcess(
-        list(_spawn_argv or _user_shell_argv()),
+        argv,
         cwd=project_dir,
         cols=cols,
         rows=rows,

--- a/src/scistudio/api/routes/workflows.py
+++ b/src/scistudio/api/routes/workflows.py
@@ -17,6 +17,7 @@ from scistudio.api.deps import get_runtime
 from scistudio.api.routes import workflow_watcher
 from scistudio.api.runtime import WORKFLOW_ENTITY_CLASS, ApiRuntime, WorkflowRun
 from scistudio.api.runtime._runs import WorkflowAlreadyRunningError
+from scistudio.api.runtime._workflows import WorkflowIdConflictError
 from scistudio.api.schemas import (
     CancelPropagationResponse,
     ExecuteFromRequest,
@@ -252,6 +253,14 @@ async def import_workflow(file: UploadFile, runtime: RuntimeDep) -> VersionedWor
         finally:
             tmp_path.unlink(missing_ok=True)
 
+        # #1836: reject an import that would create a duplicate-id collision.
+        conflict = runtime.find_workflow_id_conflict(definition.id)
+        if conflict is not None:
+            raise HTTPException(
+                status_code=409,
+                detail=str(WorkflowIdConflictError(definition.id, conflict)),
+            )
+
         out_path = runtime.workflow_path(definition.id)
         existed = out_path.exists()
         save_yaml(definition, out_path)
@@ -304,10 +313,19 @@ async def import_workflow_from_path(body: dict, runtime: RuntimeDep) -> Versione
         from scistudio.workflow.serializer import load_yaml, save_yaml
 
         definition = load_yaml(path)
+        # #1836: reject an import that would create a duplicate-id collision.
+        conflict = runtime.find_workflow_id_conflict(definition.id)
+        if conflict is not None:
+            raise HTTPException(
+                status_code=409,
+                detail=str(WorkflowIdConflictError(definition.id, conflict)),
+            )
         out_path = runtime.workflow_path(definition.id)
         existed = out_path.exists()
         save_yaml(definition, out_path)
         _mark_self_write(out_path)
+    except HTTPException:
+        raise
     except Exception as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
@@ -338,6 +356,9 @@ async def create_workflow(body: WorkflowCreate, runtime: RuntimeDep, request: Re
     try:
         existed = runtime.workflow_path(body.id).exists()
         definition = runtime.save_workflow(body.model_dump())
+    except WorkflowIdConflictError as exc:
+        # #1836: duplicate workflow id within the project → 409 Conflict
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
     except ValueError as exc:
         # Cycle detection and other validation errors → 422
         raise HTTPException(status_code=422, detail=str(exc)) from exc

--- a/src/scistudio/api/runtime/__init__.py
+++ b/src/scistudio/api/runtime/__init__.py
@@ -714,6 +714,7 @@ class ApiRuntime:
 
     # Workflow I/O + upload (_workflows)
     workflow_path = _workflows.workflow_path
+    find_workflow_id_conflict = _workflows.find_workflow_id_conflict
     save_workflow = _workflows.save_workflow
     mark_workflow_self_write = _workflows.mark_workflow_self_write
     load_workflow = _workflows.load_workflow

--- a/src/scistudio/api/runtime/_workflows.py
+++ b/src/scistudio/api/runtime/_workflows.py
@@ -12,6 +12,8 @@ import tempfile
 from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING, Any
 
+import yaml
+
 from scistudio.core.storage.ref import StorageReference
 from scistudio.workflow.definition import EdgeDef, NodeDef, WorkflowDefinition
 from scistudio.workflow.serializer import absolutify_paths, load_yaml, relativify_paths, save_yaml
@@ -22,9 +24,85 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+class WorkflowIdConflictError(ValueError):
+    """A different project workflow file already declares this workflow id.
+
+    #1836: a project must hold at most one file per workflow id — the
+    canonical ``workflows/{id}.yaml``. A second file with a different
+    filename but the same internal ``id`` breaks the per-project unique-id
+    invariant: target/workflow discovery walks every ``workflows/*.yaml`` and
+    surfaces phantom plot targets (whose nodes are not on the open canvas),
+    and "which workflow is open" is tracked by id, not path. We reject the
+    save/import that would create or perpetuate the collision instead of
+    silently merging.
+    """
+
+    def __init__(self, workflow_id: str, existing_path: Path) -> None:
+        self.workflow_id = workflow_id
+        self.existing_path = existing_path
+        super().__init__(
+            f"Workflow id {workflow_id!r} is already declared by "
+            f"{existing_path.name!r} in this project. Workflow ids must be "
+            "unique per project; rename or remove the conflicting file."
+        )
+
+
+def _read_declared_workflow_id(path: Path) -> str | None:
+    """Best-effort read of a workflow file's declared ``id`` (#1836).
+
+    Lenient on purpose: a malformed or unreadable sibling must not block
+    saving a well-formed workflow, so parse failures degrade to ``None``.
+    """
+    try:
+        with path.open("r", encoding="utf-8") as fh:
+            data = yaml.safe_load(fh)
+    except (OSError, yaml.YAMLError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    # Workflow YAML wraps its body under a top-level ``workflow:`` envelope
+    # (see ``serializer.dump_yaml_str``); tolerate a flat shape too.
+    body = data.get("workflow")
+    if not isinstance(body, dict):
+        body = data
+    wid = body.get("id")
+    return str(wid) if wid is not None else None
+
+
 def workflow_path(self: ApiRuntime, workflow_id: str) -> Path:
     project = self.require_active_project()
     return Path(project.path) / "workflows" / f"{workflow_id}.yaml"
+
+
+def find_workflow_id_conflict(self: ApiRuntime, workflow_id: str) -> Path | None:
+    """Return an existing project workflow file that declares *workflow_id*
+    at a non-canonical path, else ``None`` (#1836).
+
+    The canonical home for a workflow is ``workflows/{id}.yaml``; that file
+    (if present) is never a conflict with itself. Any *other* ``workflows/
+    *.yaml`` whose internal ``id`` equals *workflow_id* is a duplicate-id
+    collision and is returned so the caller can reject the save/import.
+    """
+    project = self.active_project
+    if project is None:
+        return None
+    workflows_dir = Path(project.path) / "workflows"
+    if not workflows_dir.is_dir():
+        return None
+    try:
+        canonical = self.workflow_path(workflow_id).resolve()
+    except Exception:
+        canonical = workflows_dir / f"{workflow_id}.yaml"
+    for path in sorted(workflows_dir.glob("*.yaml")):
+        try:
+            resolved = path.resolve()
+        except OSError:
+            continue
+        if resolved == canonical:
+            continue
+        if _read_declared_workflow_id(path) == workflow_id:
+            return path
+    return None
 
 
 def save_workflow(self: ApiRuntime, payload: dict[str, Any]) -> WorkflowDefinition:
@@ -69,6 +147,11 @@ def save_workflow(self: ApiRuntime, payload: dict[str, Any]) -> WorkflowDefiniti
         logger.warning("Workflow validation warnings: %s", "; ".join(str(w) for w in warnings))
     if hard_errors:
         raise ValueError("Workflow validation failed: " + "; ".join(str(e) for e in hard_errors))
+
+    # #1836: enforce per-project unique workflow id at save time.
+    conflict = find_workflow_id_conflict(self, definition.id)
+    if conflict is not None:
+        raise WorkflowIdConflictError(definition.id, conflict)
 
     path = self.workflow_path(definition.id)
     save_yaml(definition, path)

--- a/src/scistudio/desktop/paths.py
+++ b/src/scistudio/desktop/paths.py
@@ -367,7 +367,103 @@ def user_python_terminal_env(python_executable: str | Path | None = None) -> dic
         "PIP_REQUIRE_VIRTUALENV": "false",
         "SCISTUDIO_USER_PYTHON_SITE": str(paths["site"]),
         "SCISTUDIO_PYTHON": str(paths["python"]),
+        # Wrapper bin dir, exposed so the post-rc terminal shim can re-prepend
+        # it after the user's dotfiles run (#1838).
+        "SCISTUDIO_USER_PYTHON_BIN": str(paths["bin"]),
     }
+
+
+def user_terminal_post_rc_invocation(shell_argv: list[str], env: dict[str, str]) -> tuple[list[str], dict[str, str]]:
+    """Wrap an interactive user shell so the bundled Python bin wins *after*
+    the user's dotfiles run (#1838).
+
+    The env-only ``PATH`` prepend in :func:`user_python_terminal_env` is
+    defeated by rc files: a conda ``init`` block in ``~/.zshrc`` /
+    ``~/.bash_profile`` re-prepends the conda base env to the FRONT of
+    ``PATH``, shadowing our wrappers, so ``pip install X`` in the terminal
+    lands in conda base and never reaches the app's interpreter.
+
+    This launches the shell against a post-rc shim that first sources the
+    user's own configuration (preserving their aliases/env) and then
+    re-prepends the bundled bin, so it is the last writer of ``PATH``:
+
+    - ``zsh``: a generated ``ZDOTDIR`` whose dotfiles source the user's and
+      re-prepend in ``.zshrc``.
+    - ``bash``: a generated ``--rcfile`` that sources ``~/.bashrc`` and
+      re-prepends.
+
+    Returns the (possibly rewritten) ``argv`` and ``env``. Shells we do not
+    shim (``sh`` and others), Windows, or a missing bundled bin all fall
+    back to the inputs unchanged.
+    """
+    if sys.platform == "win32" or not shell_argv:
+        return shell_argv, env
+    bin_dir = env.get("SCISTUDIO_USER_PYTHON_BIN")
+    python = env.get("SCISTUDIO_PYTHON")
+    if not bin_dir or not python:
+        return shell_argv, env
+
+    prepend_dirs = [bin_dir, str(Path(python).parent)]
+    prepend_expr = ":".join(shlex.quote(d) for d in prepend_dirs)
+    shim_root = Path(bin_dir).parent / "shellrc"
+    shell_name = Path(shell_argv[0]).name
+
+    if shell_name == "zsh":
+        zdotdir = _write_zsh_post_rc_shim(shim_root, prepend_expr)
+        new_env = dict(env)
+        # Where the user's real zsh dotfiles live, so the shim can source them.
+        new_env["SCISTUDIO_USER_ZDOTDIR"] = env.get("ZDOTDIR") or os.environ.get("ZDOTDIR") or os.path.expanduser("~")
+        new_env["ZDOTDIR"] = str(zdotdir)
+        return shell_argv, new_env
+
+    if shell_name == "bash":
+        rcfile = _write_bash_post_rc_shim(shim_root, prepend_expr)
+        argv = [shell_argv[0], "--rcfile", str(rcfile), "-i", *shell_argv[1:]]
+        return argv, env
+
+    return shell_argv, env
+
+
+def _write_zsh_post_rc_shim(shim_root: Path, prepend_expr: str) -> Path:
+    """Write a generated ZDOTDIR whose dotfiles source the user's then
+    re-prepend the bundled bin in ``.zshrc`` (#1838). Returns the dir."""
+    zdotdir = shim_root / "zsh"
+    zdotdir.mkdir(parents=True, exist_ok=True)
+    # Each zsh startup file sources the user's counterpart so aliases/env/
+    # completions are preserved. Only ``.zshrc`` re-prepends PATH, and it is
+    # the last interactive startup file before the prompt, so it wins over a
+    # conda init that ran inside the user's own ``.zshrc``/``.zprofile``.
+    for name in (".zshenv", ".zprofile", ".zlogin"):
+        (zdotdir / name).write_text(
+            f'[ -f "${{SCISTUDIO_USER_ZDOTDIR}}/{name}" ] && source "${{SCISTUDIO_USER_ZDOTDIR}}/{name}"\n',
+            encoding="utf-8",
+        )
+    (zdotdir / ".zshrc").write_text(
+        '[ -f "${SCISTUDIO_USER_ZDOTDIR}/.zshrc" ] && '
+        'source "${SCISTUDIO_USER_ZDOTDIR}/.zshrc"\n'
+        "# SciStudio #1838: re-prepend the bundled Python bin AFTER the user's\n"
+        "# dotfiles (conda init re-prepends base) so python/pip resolve to the\n"
+        "# app's bundled interpreter.\n"
+        f'export PATH={prepend_expr}:"$PATH"\n',
+        encoding="utf-8",
+    )
+    return zdotdir
+
+
+def _write_bash_post_rc_shim(shim_root: Path, prepend_expr: str) -> Path:
+    """Write a generated bash ``--rcfile`` that sources ``~/.bashrc`` then
+    re-prepends the bundled bin (#1838). Returns the file path."""
+    shim_root.mkdir(parents=True, exist_ok=True)
+    rcfile = shim_root / "bash_rcfile"
+    rcfile.write_text(
+        "# SciStudio #1838: source the user's interactive bash config, then\n"
+        "# re-prepend the bundled Python bin so python/pip resolve to the app's\n"
+        "# bundled interpreter even when conda init re-prepends base.\n"
+        '[ -f "$HOME/.bashrc" ] && source "$HOME/.bashrc"\n'
+        f'export PATH={prepend_expr}:"$PATH"\n',
+        encoding="utf-8",
+    )
+    return rcfile
 
 
 def _write_command_wrapper(

--- a/src/scistudio/previewers/fallbacks.py
+++ b/src/scistudio/previewers/fallbacks.py
@@ -386,6 +386,29 @@ def composite_previewer(request: PreviewRequest) -> PreviewEnvelope:
 # ---------------------------------------------------------------------------
 
 
+def _collection_item_params(index: int, item: object) -> dict[str, object]:
+    """Minimal child-resolve params for a collection item (#1837).
+
+    Embed only the fields the resolver actually consumes — the item's
+    ``ref`` and ``type_name`` — instead of round-tripping the whole item
+    descriptor. The full descriptor scales with table width / metadata
+    richness; sending it back as ``PreviewResource.params`` trips the API
+    resource-param node-count guard (``_RESOURCE_PARAMS_MAX_ITEMS`` in
+    ``api/routes/data.py``) and fails wide/rich collection items with HTTP
+    422. The rich descriptor still rides the COLLECTION envelope ``payload``,
+    so nothing is lost. Resolver: ``PreviewSession._child_target_from_resource``.
+    """
+    params: dict[str, object] = {"index": index}
+    if isinstance(item, dict):
+        ref = str(item.get("data_ref") or item.get("ref") or "")
+        type_name = str(item.get("type_name") or "")
+        if ref:
+            params["ref"] = ref
+        if type_name:
+            params["type_name"] = type_name
+    return params
+
+
 def collection_previewer(request: PreviewRequest) -> PreviewEnvelope:
     """Collection fallback: count + item types + bounded sampled refs (FR-009)."""
     q = request.query
@@ -403,7 +426,7 @@ def collection_previewer(request: PreviewRequest) -> PreviewEnvelope:
             resource_id=f"item:{idx}",
             kind="child",
             description="child preview for a collection item",
-            params={"index": idx, "item": item},
+            params=_collection_item_params(idx, item),
         )
         for idx, item in enumerate(sample.items)
     )

--- a/src/scistudio/previewers/session.py
+++ b/src/scistudio/previewers/session.py
@@ -430,13 +430,20 @@ class PreviewSessionManager:
         from scistudio.previewers.models import TargetKind
 
         if resource_id.startswith("item:"):
-            item = params.get("item")
-            if not isinstance(item, dict):
-                return None
-            ref = str(item.get("data_ref") or item.get("ref") or "")
-            type_name = str(item.get("type_name") or parent.collection_item_type or "")
+            # #1837: prefer the minimal flat params emitted by
+            # ``_collection_item_params`` (``ref`` + ``type_name``). Fall back
+            # to the legacy full ``item`` descriptor for any resource params
+            # captured before that change.
+            ref = str(params.get("ref") or "")
+            type_name = str(params.get("type_name") or "")
+            if not ref:
+                item = params.get("item")
+                if isinstance(item, dict):
+                    ref = str(item.get("data_ref") or item.get("ref") or "")
+                    type_name = type_name or str(item.get("type_name") or "")
             if not ref:
                 return None
+            type_name = type_name or str(parent.collection_item_type or "")
             return PreviewTarget(
                 kind=TargetKind.DATA_REF,
                 ref=ref,

--- a/tests/api/test_previewers.py
+++ b/tests/api/test_previewers.py
@@ -553,6 +553,70 @@ def test_collection_resource_uses_descriptor_params(
     assert child["target"]["recorded_type"] == "DataFrame"
 
 
+def test_collection_wide_item_child_resource_opens(
+    client: TestClient,
+    opened_project: Path,
+) -> None:
+    """#1837: a wide/rich collection item must still open its child preview.
+
+    The collection fallback previously round-tripped the entire item
+    descriptor through ``PreviewResource.params``; for a wide table (many
+    columns / rich metadata) that exceeded the API resource-param node-count
+    guard (256 entries) and the child GET failed with HTTP 422
+    ("resource params contain too many entries"). The params now embed only
+    ``ref`` + ``type_name``, so they stay small and constant-size regardless
+    of table width.
+    """
+    wide_item = {
+        "data_ref": "wide-child",
+        "type_name": "DataFrame",
+        # Descriptor content that scales with table width — well over the
+        # 256-entry guard that used to fail the child round-trip.
+        "columns": [f"col_{i}" for i in range(300)],
+        "dtypes": {f"col_{i}": "float64" for i in range(300)},
+    }
+    resp = client.post(
+        "/api/previews/sessions",
+        json={
+            "target": {
+                "kind": "collection_ref",
+                "ref": "coll-wide",
+                "recorded_type": "DataFrame",
+                "type_chain": ["DataObject", "DataFrame"],
+                "collection_item_type": "DataFrame",
+            },
+            "query": {
+                "_collection_items": [wide_item],
+                "_collection_count": 1,
+                "_collection_item_type": "DataFrame",
+            },
+        },
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    sid = body["session_id"]
+    resource = body["resources"][0]
+
+    # Params must be the minimal flat form, not the full wide descriptor.
+    assert resource["params"] == {
+        "index": 0,
+        "ref": "wide-child",
+        "type_name": "DataFrame",
+    }
+    assert "item" not in resource["params"]
+
+    res = client.get(
+        f"/api/previews/sessions/{sid}/resources/{resource['resource_id']}",
+        params={"params": json.dumps(resource["params"])},
+    )
+
+    # Pre-fix this returned 422 "resource params contain too many entries".
+    assert res.status_code == 200
+    child = res.json()["data"]
+    assert child["target"]["ref"] == "wide-child"
+    assert child["target"]["recorded_type"] == "DataFrame"
+
+
 def test_collection_image_child_resource_uses_catalog_storage(
     client: TestClient,
     runtime: ApiRuntime,

--- a/tests/api/test_workflow_id_conflict.py
+++ b/tests/api/test_workflow_id_conflict.py
@@ -1,0 +1,83 @@
+"""Per-project unique workflow id enforcement (#1836).
+
+Two workflow files in one project that share the same internal ``id`` break
+the unique-id invariant: target/workflow discovery walks every
+``workflows/*.yaml`` and surfaces phantom plot targets whose nodes are not on
+the open canvas. Saving/importing a workflow now rejects a write that would
+create or perpetuate such a collision (409 Conflict) instead of silently
+merging.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from scistudio.api.runtime import ApiRuntime
+from tests.api.helpers import build_linear_workflow
+
+
+def _plant_duplicate_sibling(opened_project: Path, *, canonical_id: str) -> Path:
+    """Copy the canonical workflow file to a second, differently-named file
+    that keeps the same internal id — the duplicate-id collision."""
+    canonical = opened_project / "workflows" / f"{canonical_id}.yaml"
+    assert canonical.exists()
+    sibling = opened_project / "workflows" / f"{canonical_id}-copy.yaml"
+    shutil.copyfile(canonical, sibling)
+    return sibling
+
+
+def test_find_workflow_id_conflict_detects_sibling(
+    client: TestClient, runtime: ApiRuntime, opened_project: Path
+) -> None:
+    payload = build_linear_workflow(opened_project, workflow_id="flow-x")
+    assert client.post("/api/workflows/", json=payload).status_code == 200
+
+    # No collision yet: only the canonical file declares the id.
+    assert runtime.find_workflow_id_conflict("flow-x") is None
+    # A genuinely unique id never collides.
+    assert runtime.find_workflow_id_conflict("never-used") is None
+
+    sibling = _plant_duplicate_sibling(opened_project, canonical_id="flow-x")
+    conflict = runtime.find_workflow_id_conflict("flow-x")
+    assert conflict is not None
+    assert conflict.resolve() == sibling.resolve()
+
+
+def test_create_workflow_rejects_duplicate_id(client: TestClient, opened_project: Path) -> None:
+    payload = build_linear_workflow(opened_project, workflow_id="flow-x")
+    assert client.post("/api/workflows/", json=payload).status_code == 200
+    _plant_duplicate_sibling(opened_project, canonical_id="flow-x")
+
+    # Re-saving the id now that a duplicate sibling exists must 409, not merge.
+    resp = client.post("/api/workflows/", json=payload)
+    assert resp.status_code == 409
+    assert "unique per project" in resp.json()["detail"]
+
+
+def test_import_path_rejects_duplicate_id(client: TestClient, opened_project: Path, tmp_path: Path) -> None:
+    payload = build_linear_workflow(opened_project, workflow_id="flow-x")
+    assert client.post("/api/workflows/", json=payload).status_code == 200
+
+    # A valid external file that declares the same id as an existing sibling.
+    external = tmp_path / "external-flow-x.yaml"
+    shutil.copyfile(opened_project / "workflows" / "flow-x.yaml", external)
+    _plant_duplicate_sibling(opened_project, canonical_id="flow-x")
+
+    resp = client.post("/api/workflows/import-path", json={"path": str(external)})
+    assert resp.status_code == 409
+    assert "unique per project" in resp.json()["detail"]
+
+
+def test_import_path_without_conflict_still_succeeds(client: TestClient, opened_project: Path, tmp_path: Path) -> None:
+    """Re-importing an id to its canonical home is not a conflict."""
+    payload = build_linear_workflow(opened_project, workflow_id="flow-y")
+    assert client.post("/api/workflows/", json=payload).status_code == 200
+
+    external = tmp_path / "external-flow-y.yaml"
+    shutil.copyfile(opened_project / "workflows" / "flow-y.yaml", external)
+
+    resp = client.post("/api/workflows/import-path", json={"path": str(external)})
+    assert resp.status_code == 200

--- a/tests/desktop/test_terminal_post_rc.py
+++ b/tests/desktop/test_terminal_post_rc.py
@@ -1,0 +1,83 @@
+"""Post-rc terminal shim: bundled Python bin must win after dotfiles (#1838).
+
+The embedded user terminal previously opened in whatever the user's shell rc
+files activated (conda ``base`` for a typical conda user), shadowing the app's
+bundled interpreter so ``pip install X`` had no effect on the app. The shim
+sources the user's own config first, then re-prepends the bundled bin so it is
+the last writer of ``PATH``.
+"""
+
+from __future__ import annotations
+
+import shlex
+from pathlib import Path
+
+from scistudio.desktop import paths as desktop_paths
+
+
+def _env(tmp_path: Path) -> tuple[dict[str, str], Path, Path]:
+    bin_dir = tmp_path / "env" / "bin"
+    python = tmp_path / "env" / "py" / "python"
+    env = {
+        "SCISTUDIO_USER_PYTHON_BIN": str(bin_dir),
+        "SCISTUDIO_PYTHON": str(python),
+        "ZDOTDIR": "/user/zdot",
+    }
+    return env, bin_dir, python
+
+
+def test_zsh_invocation_writes_zdotdir_that_reprepends_after_user_rc(tmp_path: Path) -> None:
+    env, bin_dir, python = _env(tmp_path)
+
+    argv, new_env = desktop_paths.user_terminal_post_rc_invocation(["/bin/zsh"], env)
+
+    # The shell binary itself is unchanged; the redirection is via ZDOTDIR.
+    assert argv == ["/bin/zsh"]
+    zdotdir = Path(new_env["ZDOTDIR"])
+    assert zdotdir.is_dir()
+    # The user's real dotfiles location is preserved for the shim to source.
+    assert new_env["SCISTUDIO_USER_ZDOTDIR"] == "/user/zdot"
+
+    zshrc = (zdotdir / ".zshrc").read_text(encoding="utf-8")
+    # Sources the user's own .zshrc first (preserve aliases/env)...
+    assert 'source "${SCISTUDIO_USER_ZDOTDIR}/.zshrc"' in zshrc
+    # ...then re-prepends the bundled bin + the interpreter dir, last.
+    expected = f'export PATH={shlex.quote(str(bin_dir))}:{shlex.quote(str(python.parent))}:"$PATH"'
+    assert expected in zshrc
+    # The re-prepend line comes after the user-source line.
+    assert zshrc.index("export PATH=") > zshrc.index("source ")
+
+    # Other startup files exist and chain to the user's counterparts.
+    assert 'source "${SCISTUDIO_USER_ZDOTDIR}/.zshenv"' in (zdotdir / ".zshenv").read_text("utf-8")
+
+
+def test_bash_invocation_uses_rcfile_that_reprepends(tmp_path: Path) -> None:
+    env, bin_dir, python = _env(tmp_path)
+
+    argv, new_env = desktop_paths.user_terminal_post_rc_invocation(["/bin/bash"], env)
+
+    # bash reaches the shim via --rcfile, not env rewriting, so env is unchanged.
+    assert new_env == env
+    assert argv[0] == "/bin/bash"
+    assert "--rcfile" in argv
+    assert "-i" in argv
+    rcfile = Path(argv[argv.index("--rcfile") + 1])
+    body = rcfile.read_text(encoding="utf-8")
+    assert 'source "$HOME/.bashrc"' in body
+    expected = f'export PATH={shlex.quote(str(bin_dir))}:{shlex.quote(str(python.parent))}:"$PATH"'
+    assert expected in body
+    assert body.index("export PATH=") > body.index("source ")
+
+
+def test_unshimmed_shell_is_unchanged(tmp_path: Path) -> None:
+    env, _, _ = _env(tmp_path)
+    argv, new_env = desktop_paths.user_terminal_post_rc_invocation(["/bin/sh"], env)
+    assert argv == ["/bin/sh"]
+    assert new_env == env
+    assert "ZDOTDIR" not in {k for k in new_env if k == "SCISTUDIO_USER_ZDOTDIR"}
+
+
+def test_missing_bundled_bin_falls_back_unchanged(tmp_path: Path) -> None:
+    argv, new_env = desktop_paths.user_terminal_post_rc_invocation(["/bin/zsh"], {})
+    assert argv == ["/bin/zsh"]
+    assert new_env == {}


### PR DESCRIPTION
Owner-directed `guided` session bundling four small alpha UX/bug fixes into one PR.

## Fixes

### #1837 (P1) — collection item preview "too many entries" 422
`collection_previewer` round-tripped the entire collection item descriptor
through `PreviewResource.params`; for wide/rich items that exceeded the API
resource-param node-count guard (256) and the child preview failed with HTTP
422. The params now embed only the minimal flat fields the resolver consumes
(`index`/`ref`/`type_name`), so they stay small regardless of table width. The
resolver reads the flat form with a legacy `item`-dict fallback. The rich
descriptor still rides the COLLECTION envelope `payload`.

### #1836 — duplicate workflow id phantom plot targets
Two project workflow files sharing the same internal `id` broke the
per-project unique-id invariant (target discovery walks every
`workflows/*.yaml`, surfacing phantom plot targets that don't highlight).
Save/import now rejects a write that would create or perpetuate the collision
with **409 Conflict** (option 2) instead of silently merging, via a new
`ApiRuntime.find_workflow_id_conflict` + `WorkflowIdConflictError` wired into
create / import / import-path.

### #1838 — embedded terminal defaults to conda base, not bundled Python
The env-only PATH prepend was shadowed by the user's rc files (conda `init`
re-prepends base). The terminal now launches the shell against a post-rc shim
(zsh `ZDOTDIR` / bash `--rcfile`) that sources the user's own dotfiles first,
then re-prepends the bundled Python bin so it is the last writer of `PATH` —
`pip install X` reaches the app's interpreter.

### #1840 — annotate port type with its fundamental core base type
The port-info panel now appends the core base type after a specialized type
name (e.g. `SRSImage (Array)`), resolved frontend-side from the existing
`type_hierarchy` via `resolveCoreBaseType`. No backend change.

## Tests
- `tests/api/test_previewers.py::test_collection_wide_item_child_resource_opens`
- `tests/api/test_workflow_id_conflict.py` (4 cases)
- `tests/desktop/test_terminal_post_rc.py` (4 cases)
- `frontend` typeColorMap + PortInfoPanel unit tests

## Docs
- `docs/specs/port-description-metadata.md` §3.1 documents the core base-type annotation.

Gate record: .workflow/records/1837-guided-1837-alpha-ux-bug-batch.json

Closes #1837
Closes #1836
Closes #1838
Closes #1840
