### PR TITLE
guided(#1847): alpha UX batch — block icons/colors, all-lucide ui_icon, preview/interactive reskin

### DIFF
--- a/.workflow/records/1847-guided-1847-alpha-ux-batch.json
+++ b/.workflow/records/1847-guided-1847-alpha-ux-batch.json
@@ -1,0 +1,1981 @@
+{
+  "branch": "guided/1847-alpha-ux-batch",
+  "check_events": [
+    {
+      "at": "2026-06-28T20:57:41.685186Z",
+      "command": "pytest tests/architecture/ -v --no-cov",
+      "covered_surface": "architecture",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:df7f4a626bad5237c77214347b1d05744d5110ca9ef9b116a7f85e7bd7b1db1c",
+      "name": "architecture_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/architecture_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-28T20:57:42.411819Z",
+      "command": "python scripts/deferral_scan.py --check docs/audit/baselines/deferral-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e8e116415226c6f3a00af450f5ca399e3b434e37a15b72b06f41c0df5ecf5b3b",
+      "name": "deferral_discipline",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/deferral_discipline.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-28T20:57:42.814400Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:1d11ca9e795c27c5ae5bb3829671aee3fc819472b5a89b1c85592528987a9908",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-28T20:57:48.375713Z",
+      "command": "(cd frontend && npm run check:ci)",
+      "covered_surface": "frontend",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:e06c767be8db1b670c1d02d36021b4ddb2ce5151e349708a7606e3fc223c1fba",
+      "name": "frontend",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/frontend.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-28T20:57:51.931127Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:b4da7ae3b9b99dc26ed0b63bfd82a2f869bb7f83fb5e60619840082679637721",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-28T20:57:52.423936Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:c0b23e2613ec480a754bcb054e3623ce11a638e02b392e8c4dfd9ce0e32a5936",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-28T20:57:52.463787Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:3b1bae31f14ca8ef5ff9bb03fea07e7079a63f701540b99b4ecdfd7738a409d8",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-28T21:00:05.798387Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:343f5b698bbae80eba425dc298c2830d45a6b1625ffbff195656a2e38cddd235",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-28T21:03:37.051412Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:77a2d35a5f975197044413df7fa66db3b69b3b8614fe85781524738a3eff3827",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-28T21:03:45.310065Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:508265d5ca426806ef5dbd2f4532dc2ee43955c0b06be51987d770d55181a7e8",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    },
+    {
+      "at": "2026-06-28T21:06:00.302196Z",
+      "command": "(cd frontend && npm run check:ci)",
+      "covered_surface": "frontend",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:e06c767be8db1b670c1d02d36021b4ddb2ce5151e349708a7606e3fc223c1fba",
+      "name": "frontend",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/frontend.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-28T21:07:40.526539Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:343f5b698bbae80eba425dc298c2830d45a6b1625ffbff195656a2e38cddd235",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-28T21:08:39.804948Z",
+      "command": "python scripts/deferral_scan.py --check docs/audit/baselines/deferral-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:bf506507137e02906e41b18a31ec362c4de22619f42f61db585006abf954fd61",
+      "name": "deferral_discipline",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/deferral_discipline.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-28T21:09:40.891915Z",
+      "command": "(cd frontend && npm run check:ci)",
+      "covered_surface": "frontend",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:6f755129069a7fc01dfc6b6a15c4a0558fb28c8428f1f1c459d6ea5ec2a881b1",
+      "name": "frontend",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/frontend.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-28T21:09:44.705313Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:abc32ebba233998bb57bd30886a15f9bc26942df10ee6aff23a7ebefa8087bb4",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-28T21:11:37.568697Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:baa3ff8eda478fd96ac7940fddf590b75448c45cdeb8569b2b16913095e7d1f1",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    }
+  ],
+  "check_na": [],
+  "commit": {
+    "sha": "14ecbbaba0deda7e76369f102270af47ece27ab0",
+    "shas": [
+      "14ecbbaba0deda7e76369f102270af47ece27ab0"
+    ],
+    "trailers": []
+  },
+  "declared_scope": {
+    "exclude": [],
+    "include": []
+  },
+  "directive_events": [
+    {
+      "at": "2026-06-28T19:58:33.247454Z",
+      "owner_directive": "Restyle data_router, merge_collection, pair_editor (macaron palette, more personalized Lucide icons via ui_color/ui_icon #1839); also give save block its own color+icon so it stops looking identical to load",
+      "reason": "owner directed per-block color/icon restyle of four builtin blocks; owner authorized core-change for src/scistudio/blocks/**"
+    },
+    {
+      "at": "2026-06-28T20:00:17.404828Z",
+      "owner_directive": "icons should be more personalized; add fitting Lucide glyphs to the curated set so save no longer looks like load",
+      "reason": "personalized icons require expanding the frontend curated Lucide set (Save/Split/Merge/ArrowLeftRight); save currently falls back to io default = identical to load"
+    },
+    {
+      "at": "2026-06-28T20:14:16.381096Z",
+      "owner_directive": "Go with all-lucide-icons (option B intent). Don't update #1839 docs yet (docstrings being rewritten). load=folder-up, save=folder-down. Rotate data_router and merge_collection icons 90deg. Change pair_editor color (too similar to subworkflow).",
+      "reason": "owner: support ALL lucide icons (delivered via namespace resolution, not lazy DynamicIcon \u2014 vendored lucide 1.7.0 empty exports blocks the dynamic subpath; bundle-size moot for desktop); load->folder-up, save->folder-down; rotate router/merge glyphs 90deg via ui_icon name:deg suffix; recolor pair_editor (was too close to subworkflow pink)"
+    },
+    {
+      "at": "2026-06-28T20:33:26.000650Z",
+      "owner_directive": "Do #1841 steps 1+2 this session (brand-token CSS-var layer + core/interactive panel reskin); record the cross-boundary theming contract as a follow-up issue instead of implementing it now",
+      "reason": "owner approved #1841 workstreams 1+2 (promote brand tokens to CSS vars + reskin core preview/interactive panels onto brand tokens & shared ui/Button); workstream 3 (cross-boundary --ss-* contract) deferred to new issue #1849"
+    }
+  ],
+  "docs_events": [
+    {
+      "at": "2026-06-28T21:04:24.465142Z",
+      "class": "implementation",
+      "kind": "na",
+      "path": null,
+      "rationale": "Visual reskin + per-block ui_color/ui_icon cosmetic hints; ui_icon all-lucide is a provisional (#1839) display-hint widening with safe fallback and no contract/schema change \u2014 authoring docs deferred per owner pending the in-flight docstring rewrite; cross-boundary --ss-* theming contract documentation tracked in #1849.",
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": false,
+  "guard_events": [
+    {
+      "at": "2026-06-28T21:03:45.367009Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/io/loaders/load_data.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/io/loaders/load_data.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/io/savers/save_data.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/io/savers/save_data.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/process/builtins/data_router.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/process/builtins/data_router.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/process/builtins/merge_collection.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/process/builtins/merge_collection.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/process/builtins/pair_editor.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/process/builtins/pair_editor.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:03:45.378284Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {
+            "governed_files": [
+              "frontend/src/App.parts/InteractiveModals.parts/DynamicPanel.tsx",
+              "frontend/src/components/BlockPalette.parts/BlockDetailPopover.tsx",
+              "frontend/src/components/BlockPalette.parts/BlockTile.tsx",
+              "frontend/src/components/DataPreview.parts/PlotViewer.tsx",
+              "frontend/src/components/DataPreview.parts/TableViewer.tsx",
+              "frontend/src/components/DataPreview.parts/coreViewers.tsx",
+              "frontend/src/components/DataRouterModal.parts/InputPanels.tsx",
+              "frontend/src/components/DataRouterModal.parts/ItemCard.tsx",
+              "frontend/src/components/DataRouterModal.parts/OutputPanels.tsx",
+              "frontend/src/components/DataRouterModal.tsx",
+              "frontend/src/components/PairEditorModal.tsx",
+              "frontend/src/components/interactiveModals.designSystem.test.tsx",
+              "frontend/src/components/nodes/BlockNode.parts/categoryVisuals.test.ts",
+              "frontend/src/components/nodes/BlockNode.parts/categoryVisuals.ts",
+              "frontend/src/index.css",
+              "frontend/tailwind.config.ts",
+              "src/scistudio/blocks/io/loaders/load_data.py",
+              "src/scistudio/blocks/io/savers/save_data.py",
+              "src/scistudio/blocks/process/builtins/data_router.py",
+              "src/scistudio/blocks/process/builtins/merge_collection.py",
+              "src/scistudio/blocks/process/builtins/pair_editor.py"
+            ]
+          },
+          "expected": null,
+          "file": "",
+          "finding_class": "docs_landing",
+          "git_evidence": null,
+          "id": "docs_landing.missing-landing",
+          "line": null,
+          "message": "governed change requires docs/changelog/checklist landing evidence or an explicit N/A rationale",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "docs_landing.missing-landing",
+          "severity": "error",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "docs_landing",
+      "status": "fail"
+    },
+    {
+      "at": "2026-06-28T21:03:45.389141Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:03:45.399578Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:03:45.410550Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:03:45.421309Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:03:45.431753Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:03:45.442232Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:03:45.453042Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:03:45.467789Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:07:40.579091Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/io/loaders/load_data.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/io/loaders/load_data.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/io/savers/save_data.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/io/savers/save_data.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/process/builtins/data_router.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/process/builtins/data_router.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/process/builtins/merge_collection.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/process/builtins/merge_collection.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/process/builtins/pair_editor.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/process/builtins/pair_editor.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:07:40.589057Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:07:40.598439Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:07:40.608878Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:07:40.619170Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:07:40.628747Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:07:40.637712Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:07:40.647100Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:07:40.657776Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:07:40.672796Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:11:37.608426Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/io/loaders/load_data.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/io/loaders/load_data.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/io/savers/save_data.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/io/savers/save_data.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/process/builtins/data_router.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/process/builtins/data_router.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/process/builtins/merge_collection.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/process/builtins/merge_collection.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/process/builtins/pair_editor.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/process/builtins/pair_editor.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:11:37.618316Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:11:37.628224Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:11:37.638762Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:11:37.648954Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:11:37.658756Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:11:37.668413Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:11:37.678187Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:11:37.687936Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:11:37.701642Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:12:00.012862Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/io/loaders/load_data.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/io/loaders/load_data.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/io/savers/save_data.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/io/savers/save_data.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/process/builtins/data_router.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/process/builtins/data_router.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/process/builtins/merge_collection.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/process/builtins/merge_collection.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/process/builtins/pair_editor.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/process/builtins/pair_editor.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:12:00.022027Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:12:00.030520Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:12:00.039954Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:12:00.049566Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:12:00.059331Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:12:00.068880Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:12:00.077818Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:12:00.086966Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:12:00.099360Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:13:14.295274Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/io/loaders/load_data.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/io/loaders/load_data.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/io/savers/save_data.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/io/savers/save_data.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/process/builtins/data_router.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/process/builtins/data_router.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/process/builtins/merge_collection.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/process/builtins/merge_collection.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/process/builtins/pair_editor.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/process/builtins/pair_editor.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:13:14.305436Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:13:14.315420Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:13:14.325455Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:13:14.335015Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:13:14.343691Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:13:14.352113Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:13:14.360730Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:13:14.368938Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:13:14.382856Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:13:47.081953Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/io/loaders/load_data.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/io/loaders/load_data.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/io/savers/save_data.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/io/savers/save_data.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/process/builtins/data_router.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/process/builtins/data_router.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/process/builtins/merge_collection.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/process/builtins/merge_collection.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/process/builtins/pair_editor.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/process/builtins/pair_editor.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:13:47.091403Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:13:47.100979Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:13:47.111220Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:13:47.120589Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:13:47.130160Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:13:47.139876Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:13:47.148989Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:13:47.158477Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:13:47.173388Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:14:03.565671Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/io/loaders/load_data.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/io/loaders/load_data.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/io/savers/save_data.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/io/savers/save_data.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/process/builtins/data_router.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/process/builtins/data_router.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/process/builtins/merge_collection.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/process/builtins/merge_collection.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/process/builtins/pair_editor.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/process/builtins/pair_editor.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:14:03.574759Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:14:03.583838Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:14:03.593014Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:14:03.602671Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:14:03.612240Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:14:03.621119Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:14:03.630123Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:14:03.639101Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:14:03.653704Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1847,
+      "url": null
+    },
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1841,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": {
+    "base": "origin/main",
+    "base_sha": "faa9fa38",
+    "changed_files": [
+      ".workflow/records/1847-guided-1847-alpha-ux-batch.json",
+      "frontend/src/App.parts/InteractiveModals.parts/DynamicPanel.tsx",
+      "frontend/src/components/BlockPalette.parts/BlockDetailPopover.tsx",
+      "frontend/src/components/BlockPalette.parts/BlockTile.tsx",
+      "frontend/src/components/DataPreview.parts/PlotViewer.tsx",
+      "frontend/src/components/DataPreview.parts/TableViewer.tsx",
+      "frontend/src/components/DataPreview.parts/coreViewers.tsx",
+      "frontend/src/components/DataRouterModal.parts/InputPanels.tsx",
+      "frontend/src/components/DataRouterModal.parts/ItemCard.tsx",
+      "frontend/src/components/DataRouterModal.parts/OutputPanels.tsx",
+      "frontend/src/components/DataRouterModal.tsx",
+      "frontend/src/components/PairEditorModal.tsx",
+      "frontend/src/components/interactiveModals.designSystem.test.tsx",
+      "frontend/src/components/nodes/BlockNode.parts/categoryVisuals.test.ts",
+      "frontend/src/components/nodes/BlockNode.parts/categoryVisuals.ts",
+      "frontend/src/index.css",
+      "frontend/tailwind.config.ts",
+      "src/scistudio/blocks/io/loaders/load_data.py",
+      "src/scistudio/blocks/io/savers/save_data.py",
+      "src/scistudio/blocks/process/builtins/data_router.py",
+      "src/scistudio/blocks/process/builtins/merge_collection.py",
+      "src/scistudio/blocks/process/builtins/pair_editor.py"
+    ],
+    "diff_fingerprint": "sha256:34b080ee2d30e69235e7880a9628003b2d58cd3bc8c2acd7be77815cf76a9a5d",
+    "head": "HEAD",
+    "head_sha": "7768734a",
+    "surfaces": {
+      "docs": 0,
+      "frontend": 16,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 21,
+      "packaging": 0,
+      "protected_core": 5,
+      "sentrux": 21,
+      "test": 2,
+      "workflow_ci": 0
+    }
+  },
+  "owner_directive": "Owner-guided live UX enhancement batch; owner tests the desktop app and directs each UX change live",
+  "persona": "live_implementer",
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [
+      1847,
+      1841
+    ],
+    "number": null,
+    "url": null
+  },
+  "reconcile_events": [
+    {
+      "at": "2026-06-28T21:03:45.467836Z",
+      "diff_fingerprint": "sha256:39d3227862e94269f46db584f35211b82be08281f8f7f58ef2ce405bfdc84186",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.frontend",
+        "checks.python_tests",
+        "docs.docs_required_or_na",
+        "guard.docs_landing"
+      ]
+    },
+    {
+      "at": "2026-06-28T21:07:40.672831Z",
+      "diff_fingerprint": "sha256:39d3227862e94269f46db584f35211b82be08281f8f7f58ef2ce405bfdc84186",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.frontend"
+      ]
+    },
+    {
+      "at": "2026-06-28T21:11:37.701684Z",
+      "diff_fingerprint": "sha256:d591674e83912c5fb0be1d05903b9d976fd8efe420b1170d6ea63f260bf7d614",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-28T21:12:00.099402Z",
+      "diff_fingerprint": "sha256:d591674e83912c5fb0be1d05903b9d976fd8efe420b1170d6ea63f260bf7d614",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-28T21:13:14.382896Z",
+      "diff_fingerprint": "sha256:34b080ee2d30e69235e7880a9628003b2d58cd3bc8c2acd7be77815cf76a9a5d",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-28T21:13:47.173420Z",
+      "diff_fingerprint": "sha256:34b080ee2d30e69235e7880a9628003b2d58cd3bc8c2acd7be77815cf76a9a5d",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-28T21:14:03.653738Z",
+      "diff_fingerprint": "sha256:34b080ee2d30e69235e7880a9628003b2d58cd3bc8c2acd7be77815cf76a9a5d",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    }
+  ],
+  "record_id": "1847-guided-1847-alpha-ux-batch",
+  "requested_admin_labels": [
+    {
+      "actor_permission": null,
+      "applied_at": null,
+      "applied_by": null,
+      "name": "admin-approved:core-change"
+    }
+  ],
+  "required_obligations": {
+    "admin_labels": [
+      "admin-approved:core-change"
+    ],
+    "checks": [
+      "architecture_tests",
+      "deferral_discipline",
+      "format_check",
+      "frontend",
+      "full_audit",
+      "import_contracts",
+      "lint_format",
+      "python_tests",
+      "semantic_dup",
+      "type_check"
+    ],
+    "docs": [
+      "docs_required_or_na"
+    ],
+    "guards": [
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": [
+      "changed_test_required"
+    ]
+  },
+  "runtime": "claude-code",
+  "schema_version": 2,
+  "scope_events": [
+    {
+      "action": "add-include",
+      "at": "2026-06-28T19:58:33.247681Z",
+      "pattern": "src/scistudio/blocks/process/builtins/data_router.py",
+      "reason": "owner directed per-block color/icon restyle of four builtin blocks; owner authorized core-change for src/scistudio/blocks/**"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-28T19:58:33.247693Z",
+      "pattern": "src/scistudio/blocks/process/builtins/merge_collection.py",
+      "reason": "owner directed per-block color/icon restyle of four builtin blocks; owner authorized core-change for src/scistudio/blocks/**"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-28T19:58:33.247697Z",
+      "pattern": "src/scistudio/blocks/process/builtins/pair_editor.py",
+      "reason": "owner directed per-block color/icon restyle of four builtin blocks; owner authorized core-change for src/scistudio/blocks/**"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-28T19:58:33.247699Z",
+      "pattern": "src/scistudio/blocks/io/savers/save_data.py",
+      "reason": "owner directed per-block color/icon restyle of four builtin blocks; owner authorized core-change for src/scistudio/blocks/**"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-28T20:00:17.404985Z",
+      "pattern": "frontend/src/components/nodes/BlockNode.parts/categoryVisuals.ts",
+      "reason": "personalized icons require expanding the frontend curated Lucide set (Save/Split/Merge/ArrowLeftRight); save currently falls back to io default = identical to load"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-28T20:05:21.430427Z",
+      "pattern": "frontend/src/components/BlockPalette.parts/BlockTile.tsx",
+      "reason": "palette tile + detail popover ignored per-block ui_color/ui_icon (passed only base_category to getCategoryVisual), so personalized icons were invisible in the palette where authors pick blocks"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-28T20:05:21.430614Z",
+      "pattern": "frontend/src/components/BlockPalette.parts/BlockDetailPopover.tsx",
+      "reason": "palette tile + detail popover ignored per-block ui_color/ui_icon (passed only base_category to getCategoryVisual), so personalized icons were invisible in the palette where authors pick blocks"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-28T20:14:16.381306Z",
+      "pattern": "src/scistudio/blocks/io/loaders/load_data.py",
+      "reason": "owner: support ALL lucide icons (delivered via namespace resolution, not lazy DynamicIcon \u2014 vendored lucide 1.7.0 empty exports blocks the dynamic subpath; bundle-size moot for desktop); load->folder-up, save->folder-down; rotate router/merge glyphs 90deg via ui_icon name:deg suffix; recolor pair_editor (was too close to subworkflow pink)"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-28T20:14:16.381313Z",
+      "pattern": "frontend/src/components/nodes/BlockNode.parts/categoryVisuals.test.ts",
+      "reason": "owner: support ALL lucide icons (delivered via namespace resolution, not lazy DynamicIcon \u2014 vendored lucide 1.7.0 empty exports blocks the dynamic subpath; bundle-size moot for desktop); load->folder-up, save->folder-down; rotate router/merge glyphs 90deg via ui_icon name:deg suffix; recolor pair_editor (was too close to subworkflow pink)"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-28T20:33:26.000873Z",
+      "pattern": "frontend/src/index.css",
+      "reason": "owner approved #1841 workstreams 1+2 (promote brand tokens to CSS vars + reskin core preview/interactive panels onto brand tokens & shared ui/Button); workstream 3 (cross-boundary --ss-* contract) deferred to new issue #1849"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-28T20:33:26.000877Z",
+      "pattern": "frontend/tailwind.config.ts",
+      "reason": "owner approved #1841 workstreams 1+2 (promote brand tokens to CSS vars + reskin core preview/interactive panels onto brand tokens & shared ui/Button); workstream 3 (cross-boundary --ss-* contract) deferred to new issue #1849"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-28T20:33:26.000878Z",
+      "pattern": "frontend/src/components/DataPreview.parts/coreViewers.tsx",
+      "reason": "owner approved #1841 workstreams 1+2 (promote brand tokens to CSS vars + reskin core preview/interactive panels onto brand tokens & shared ui/Button); workstream 3 (cross-boundary --ss-* contract) deferred to new issue #1849"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-28T20:33:26.000879Z",
+      "pattern": "frontend/src/components/DataPreview.parts/TableViewer.tsx",
+      "reason": "owner approved #1841 workstreams 1+2 (promote brand tokens to CSS vars + reskin core preview/interactive panels onto brand tokens & shared ui/Button); workstream 3 (cross-boundary --ss-* contract) deferred to new issue #1849"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-28T20:33:26.000880Z",
+      "pattern": "frontend/src/components/DataPreview.parts/PlotViewer.tsx",
+      "reason": "owner approved #1841 workstreams 1+2 (promote brand tokens to CSS vars + reskin core preview/interactive panels onto brand tokens & shared ui/Button); workstream 3 (cross-boundary --ss-* contract) deferred to new issue #1849"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-28T20:33:26.000881Z",
+      "pattern": "frontend/src/components/DataRouterModal.tsx",
+      "reason": "owner approved #1841 workstreams 1+2 (promote brand tokens to CSS vars + reskin core preview/interactive panels onto brand tokens & shared ui/Button); workstream 3 (cross-boundary --ss-* contract) deferred to new issue #1849"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-28T20:33:26.000882Z",
+      "pattern": "frontend/src/components/PairEditorModal.tsx",
+      "reason": "owner approved #1841 workstreams 1+2 (promote brand tokens to CSS vars + reskin core preview/interactive panels onto brand tokens & shared ui/Button); workstream 3 (cross-boundary --ss-* contract) deferred to new issue #1849"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-28T20:33:26.000883Z",
+      "pattern": "frontend/src/App.parts/InteractiveModals.parts/DynamicPanel.tsx",
+      "reason": "owner approved #1841 workstreams 1+2 (promote brand tokens to CSS vars + reskin core preview/interactive panels onto brand tokens & shared ui/Button); workstream 3 (cross-boundary --ss-* contract) deferred to new issue #1849"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-28T20:43:18.317978Z",
+      "pattern": "frontend/src/components/DataRouterModal.parts/InputPanels.tsx",
+      "reason": "DataRouter modal's visible drag panels/cards live in DataRouterModal.parts/*; reskinning the modal shell without them would leave the cold stone/blue look on the most visible surface \u2014 same #1841 directive"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-28T20:43:18.318125Z",
+      "pattern": "frontend/src/components/DataRouterModal.parts/OutputPanels.tsx",
+      "reason": "DataRouter modal's visible drag panels/cards live in DataRouterModal.parts/*; reskinning the modal shell without them would leave the cold stone/blue look on the most visible surface \u2014 same #1841 directive"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-28T20:43:18.318127Z",
+      "pattern": "frontend/src/components/DataRouterModal.parts/ItemCard.tsx",
+      "reason": "DataRouter modal's visible drag panels/cards live in DataRouterModal.parts/*; reskinning the modal shell without them would leave the cold stone/blue look on the most visible surface \u2014 same #1841 directive"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-28T20:48:32.532835Z",
+      "pattern": "frontend/src/components/interactiveModals.designSystem.test.tsx",
+      "reason": "add reskin regression test (interactive modals adopt shared Button + brand tokens, no cold blue)"
+    }
+  ],
+  "session_id": "eb15c1c7-1c30-4a54-92dc-df723684e9d1",
+  "strictness_tier": 1,
+  "task_kind": "guided",
+  "test_events": [
+    {
+      "at": "2026-06-28T20:48:32.532996Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/components/interactiveModals.designSystem.test.tsx",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/.workflow/records/1847-guided-1847-alpha-ux-batch.json
+++ b/.workflow/records/1847-guided-1847-alpha-ux-batch.json
@@ -250,9 +250,9 @@
   ],
   "check_na": [],
   "commit": {
-    "sha": "14ecbbaba0deda7e76369f102270af47ece27ab0",
+    "sha": "dcd0480ca8688daa3e62a5ef9be49450a551c7d8",
     "shas": [
-      "14ecbbaba0deda7e76369f102270af47ece27ab0"
+      "dcd0480ca8688daa3e62a5ef9be49450a551c7d8"
     ],
     "trailers": []
   },
@@ -1655,6 +1655,194 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:15:05.885278Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/io/loaders/load_data.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/io/loaders/load_data.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/io/savers/save_data.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/io/savers/save_data.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/process/builtins/data_router.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/process/builtins/data_router.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/process/builtins/merge_collection.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/process/builtins/merge_collection.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/process/builtins/pair_editor.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/process/builtins/pair_editor.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:15:05.893678Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:15:05.902220Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:15:05.910608Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:15:05.919002Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:15:05.927383Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:15:05.935608Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:15:05.944517Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:15:05.953503Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:15:05.969430Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -1673,7 +1861,7 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "origin/main",
+    "base": "faa9fa3803c4580f954a5a12985c138fb27b4709",
     "base_sha": "faa9fa38",
     "changed_files": [
       ".workflow/records/1847-guided-1847-alpha-ux-batch.json",
@@ -1699,9 +1887,9 @@
       "src/scistudio/blocks/process/builtins/merge_collection.py",
       "src/scistudio/blocks/process/builtins/pair_editor.py"
     ],
-    "diff_fingerprint": "sha256:34b080ee2d30e69235e7880a9628003b2d58cd3bc8c2acd7be77815cf76a9a5d",
+    "diff_fingerprint": "sha256:74486f775c75a34de93ab9dc3f28d9ee695787596437bc271fa73ffd848d4eec",
     "head": "HEAD",
-    "head_sha": "7768734a",
+    "head_sha": "dcd0480c",
     "surfaces": {
       "docs": 0,
       "frontend": 16,
@@ -1723,7 +1911,7 @@
       1847,
       1841
     ],
-    "number": null,
+    "number": 1851,
     "url": null
   },
   "reconcile_events": [
@@ -1785,6 +1973,14 @@
     {
       "at": "2026-06-28T21:14:03.653738Z",
       "diff_fingerprint": "sha256:34b080ee2d30e69235e7880a9628003b2d58cd3bc8c2acd7be77815cf76a9a5d",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-28T21:15:05.969464Z",
+      "diff_fingerprint": "sha256:74486f775c75a34de93ab9dc3f28d9ee695787596437bc271fa73ffd848d4eec",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 1,

--- a/frontend/src/App.parts/InteractiveModals.parts/DynamicPanel.tsx
+++ b/frontend/src/App.parts/InteractiveModals.parts/DynamicPanel.tsx
@@ -19,6 +19,7 @@
 
 import { useEffect, useMemo, useRef, useState } from "react";
 
+import { Button } from "../../components/ui/button";
 import type { PanelManifestDescriptor } from "../../store/types";
 import {
   PANEL_HOST_API_VERSION,
@@ -124,7 +125,7 @@ export function DynamicPanel({
       data-testid="dynamic-panel"
       data-block-id={blockId}
     >
-      <div className="flex max-h-[85vh] w-[900px] flex-col overflow-hidden rounded-xl border border-stone-200 bg-white shadow-xl">
+      <div className="flex max-h-[85vh] w-[900px] flex-col overflow-hidden rounded-xl border border-ink/10 bg-white shadow-panel">
         {/* Mount point for the package panel module. Always present in the DOM so
             the mount effect has a stable container; hidden when we show the
             error surface instead. */}
@@ -136,19 +137,20 @@ export function DynamicPanel({
 
         {failure ? (
           <div className="p-5" role="alert" data-testid="dynamic-panel-error">
-            <div className="text-sm font-semibold text-red-700">
+            <div className="text-sm font-semibold text-destructive">
               Couldn’t load this interactive panel
             </div>
-            <div className="mt-1 break-words text-xs text-stone-600">{failure.message}</div>
+            <div className="mt-1 break-words text-xs text-ink/70">{failure.message}</div>
             <div className="mt-4 flex justify-end">
-              <button
+              <Button
                 type="button"
-                className="rounded border border-stone-200 px-4 py-1.5 text-xs text-stone-600 hover:bg-stone-50"
+                variant="outline"
+                size="sm"
                 onClick={onCancel}
                 data-testid="dynamic-panel-cancel"
               >
                 Cancel
-              </button>
+              </Button>
             </div>
           </div>
         ) : null}

--- a/frontend/src/components/BlockPalette.parts/BlockDetailPopover.tsx
+++ b/frontend/src/components/BlockPalette.parts/BlockDetailPopover.tsx
@@ -20,7 +20,8 @@ export interface BlockDetailPopoverProps {
 }
 
 export function BlockDetailPopover({ block, anchor }: BlockDetailPopoverProps) {
-  const visual = getCategoryVisual(block.base_category);
+  // #1839/#1847: honour the block's own ui_color/ui_icon (match its canvas node).
+  const visual = getCategoryVisual(block.base_category, block.ui_color, block.ui_icon);
   const Icon = visual.Icon;
   const inputs = portSignature(block.input_ports);
   const outputs = portSignature(block.output_ports);

--- a/frontend/src/components/BlockPalette.parts/BlockTile.tsx
+++ b/frontend/src/components/BlockPalette.parts/BlockTile.tsx
@@ -16,7 +16,9 @@ export interface BlockTileProps {
 }
 
 export function BlockTile({ block, onDragStart, onAddBlock, onEnter, onLeave }: BlockTileProps) {
-  const visual = getCategoryVisual(block.base_category);
+  // #1839/#1847: honour the block's own ui_color/ui_icon so the palette tile
+  // matches its canvas node (the palette is where authors pick by glyph).
+  const visual = getCategoryVisual(block.base_category, block.ui_color, block.ui_icon);
   const Icon = visual.Icon;
 
   return (

--- a/frontend/src/components/DataPreview.parts/PlotViewer.tsx
+++ b/frontend/src/components/DataPreview.parts/PlotViewer.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 
+import { Button } from "../ui/button";
 import type { PreviewEnvelope, PreviewResource } from "../../types/api";
 
 function asString(value: unknown, fallback = ""): string {
@@ -113,7 +114,7 @@ export function PlotViewer({
   return (
     <div data-testid="core-plot-viewer" className="space-y-2">
       <PlotDiagnosticsBanner diagnostics={envelope.diagnostics} />
-      <div className="rounded-[1rem] border border-stone-200 bg-white p-3">
+      <div className="rounded-[1rem] border border-ink/10 bg-white p-3">
         <div className={PLOT_PREVIEW_SURFACE_CLASS} data-testid="plot-preview-surface">
           {/* Zoom layer: scale from the top-left so the whole figure stays
               reachable via the surface's scrollbars when zoomed in. At 100%
@@ -151,57 +152,65 @@ export function PlotViewer({
                 className="block w-full"
               />
             ) : (
-              <p className="text-xs text-stone-500">No renderable plot artifact.</p>
+              <p className="text-xs text-ink/60">No renderable plot artifact.</p>
             )}
           </div>
         </div>
       </div>
-      <div className="flex items-center gap-2 text-xs text-stone-600">
-        <span className="uppercase tracking-wider text-stone-400">{format || mime}</span>
+      <div className="flex items-center gap-2 text-xs text-ink/70">
+        <span className="uppercase tracking-wider text-ink/45">{format || mime}</span>
         {hasRenderable ? (
           <div className="flex items-center gap-1" data-testid="plot-zoom-controls">
-            <button
+            <Button
               type="button"
+              variant="outline"
+              size="sm"
               aria-label="Zoom out"
               data-testid="plot-zoom-out"
               onClick={() => applyZoom(zoom - 0.25)}
-              className="rounded border border-stone-300 bg-white px-2 leading-none hover:bg-stone-50"
+              className="h-7 px-2"
             >
               −
-            </button>
+            </Button>
             <span className="w-12 text-center tabular-nums" data-testid="plot-zoom-level">
               {Math.round(zoom * 100)}%
             </span>
-            <button
+            <Button
               type="button"
+              variant="outline"
+              size="sm"
               aria-label="Zoom in"
               data-testid="plot-zoom-in"
               onClick={() => applyZoom(zoom + 0.25)}
-              className="rounded border border-stone-300 bg-white px-2 leading-none hover:bg-stone-50"
+              className="h-7 px-2"
             >
               +
-            </button>
-            <button
+            </Button>
+            <Button
               type="button"
+              variant="outline"
+              size="sm"
               aria-label="Reset zoom"
               data-testid="plot-zoom-reset"
               onClick={() => setZoom(1)}
-              className="rounded border border-stone-300 bg-white px-2 leading-none hover:bg-stone-50"
+              className="h-7 px-2"
             >
               Reset
-            </button>
+            </Button>
           </div>
         ) : null}
-        <button
+        <Button
           type="button"
+          variant="outline"
+          size="sm"
           data-testid="plot-export-button"
           aria-label={`Save plot as ${format || "file"}`}
           disabled={!exportResource}
           onClick={() => (exportResource && onExport ? onExport(exportResource) : undefined)}
-          className="ml-auto rounded border border-stone-300 bg-white px-3 py-0.5 disabled:opacity-50"
+          className="ml-auto h-7"
         >
           Save
-        </button>
+        </Button>
       </div>
       <PlotMetadataBadges envelope={envelope} />
     </div>

--- a/frontend/src/components/DataPreview.parts/TableViewer.tsx
+++ b/frontend/src/components/DataPreview.parts/TableViewer.tsx
@@ -66,10 +66,10 @@ function paginationButtonStyle(disabled: boolean): React.CSSProperties {
     width: 22,
     height: 20,
     padding: 0,
-    border: "1px solid #d6d3d1",
+    border: "1px solid rgb(var(--ss-ink) / 0.15)",
     borderRadius: 4,
-    background: disabled ? "#f5f5f4" : "#fff",
-    color: disabled ? "#a8a29e" : "#475569",
+    background: disabled ? "rgb(var(--ss-ink) / 0.04)" : "#fff",
+    color: disabled ? "rgb(var(--ss-ink) / 0.4)" : "rgb(var(--ss-ink) / 0.6)",
     cursor: disabled ? "not-allowed" : "pointer",
     fontSize: 10,
     lineHeight: 1,
@@ -149,10 +149,10 @@ function TableHeader({
               style={{
                 whiteSpace: "nowrap",
                 padding: "6px 10px",
-                borderBottom: "1px solid #cbd5e1",
+                borderBottom: "1px solid rgb(var(--ss-ink) / 0.15)",
                 fontWeight: 600,
                 fontSize: 11,
-                color: isSorted ? "#1c1917" : "#475569",
+                color: isSorted ? "rgb(var(--ss-ink))" : "rgb(var(--ss-ink) / 0.6)",
                 background: "#fff",
                 position: "sticky",
                 top: 0,
@@ -163,7 +163,7 @@ function TableHeader({
               title={isSorted ? `Sorted ${sortDir}; click to change` : "Click to sort"}
             >
               {column}
-              <span style={{ fontSize: 9, color: "#a8a29e" }}>{indicator}</span>
+              <span style={{ fontSize: 9, color: "rgb(var(--ss-ink) / 0.4)" }}>{indicator}</span>
             </th>
           );
         })}
@@ -176,7 +176,7 @@ function TableBody({ columns, rows }: { columns: string[]; rows: Array<Record<st
   return (
     <tbody>
       {rows.map((row, index) => (
-        <tr key={index} style={{ borderBottom: "1px solid #f1f5f9" }}>
+        <tr key={index} style={{ borderBottom: "1px solid rgb(var(--ss-ink) / 0.06)" }}>
           {columns.map((column) => (
             <td
               key={column}
@@ -184,8 +184,8 @@ function TableBody({ columns, rows }: { columns: string[]; rows: Array<Record<st
                 whiteSpace: "nowrap",
                 padding: "3px 10px",
                 fontSize: 10,
-                color: "#334155",
-                borderBottom: "1px solid #f1f5f9",
+                color: "rgb(var(--ss-ink) / 0.8)",
+                borderBottom: "1px solid rgb(var(--ss-ink) / 0.06)",
               }}
             >
               {formatCell(row[column])}
@@ -251,7 +251,7 @@ function PaginationControls({
             width: 44,
             padding: "1px 4px",
             fontSize: 10,
-            border: "1px solid #d6d3d1",
+            border: "1px solid rgb(var(--ss-ink) / 0.15)",
             borderRadius: 4,
             textAlign: "center",
           }}
@@ -335,7 +335,7 @@ export function TableViewer({ initial, onPatchQuery }: TableViewerProps) {
         style={{
           overflow: "auto",
           borderRadius: "0.8rem",
-          border: "1px solid #e7e5e4",
+          border: "1px solid rgb(var(--ss-ink) / 0.1)",
           background: "#fff",
           maxHeight: "360px",
           opacity: loading ? 0.6 : 1,
@@ -367,7 +367,7 @@ export function TableViewer({ initial, onPatchQuery }: TableViewerProps) {
           gap: 6,
           padding: "6px 4px 0",
           fontSize: 10,
-          color: "#78716c",
+          color: "rgb(var(--ss-ink) / 0.55)",
         }}
       >
         <span>

--- a/frontend/src/components/DataPreview.parts/coreViewers.tsx
+++ b/frontend/src/components/DataPreview.parts/coreViewers.tsx
@@ -229,7 +229,7 @@ export function ArrayViewer({
   return (
     <div data-testid="core-array-viewer" className="space-y-2">
       <div
-        className="flex flex-wrap items-center gap-2 rounded-[1rem] border border-stone-200 bg-white px-3 py-2 text-xs text-stone-600"
+        className="flex flex-wrap items-center gap-2 rounded-[1rem] border border-ink/10 bg-white px-3 py-2 text-xs text-ink/70"
         data-testid="array-info"
       >
         <span className="font-medium text-ink">Array</span>
@@ -240,7 +240,7 @@ export function ArrayViewer({
 
       {isScalar ? (
         <div
-          className="rounded-[1rem] border border-stone-200 bg-white p-4 text-sm"
+          className="rounded-[1rem] border border-ink/10 bg-white p-4 text-sm"
           data-testid="array-scalar"
         >
           {String(scalarValue(matrix) ?? "")}
@@ -262,7 +262,7 @@ export function ArrayViewer({
             return (
               <div
                 key={ax.axis}
-                className="flex items-center gap-2 text-xs text-stone-600"
+                className="flex items-center gap-2 text-xs text-ink/70"
                 data-testid={`array-slice-row-${ax.axis}`}
               >
                 <span className="w-24 truncate">
@@ -286,7 +286,7 @@ export function ArrayViewer({
                   max={ax.size - 1}
                   value={value}
                   onChange={(e) => change(ax.axis, clampIndex(Number(e.target.value), ax.size))}
-                  className="w-16 rounded border border-stone-300 bg-white px-1 py-0.5 text-right"
+                  className="w-16 rounded border border-ink/15 bg-white px-1 py-0.5 text-right"
                 />
                 <span className="w-12 text-right">
                   {value + 1}/{ax.size}
@@ -392,11 +392,13 @@ export function heatmapColor(value: Cell, vmin: number, vmax: number): string {
 
 /** Pick readable text color for a heatmap cell given its intensity. */
 function cellTextColor(value: Cell, vmin: number, vmax: number): string {
-  if (value === null || !Number.isFinite(value)) return "#94a3b8";
+  // Warm-neutral contrast tones over the heatmap (brand ink / warm white),
+  // matching the rest of the app rather than cool slate.
+  if (value === null || !Number.isFinite(value)) return "rgb(var(--ss-ink) / 0.4)";
   const mag =
     vmin < 0 && vmax > 0 ? Math.max(Math.abs(vmin), Math.abs(vmax)) || 1 : vmax - vmin || 1;
   const intensity = vmin < 0 && vmax > 0 ? Math.abs(value) / mag : (value - vmin) / mag;
-  return intensity > 0.6 ? "#f8fafc" : "#0f172a";
+  return intensity > 0.6 ? "#fffdf8" : "rgb(var(--ss-ink))";
 }
 
 /** Format a numeric cell compactly but readably. ``null`` = non-finite cell. */
@@ -443,16 +445,13 @@ export function ArrayHeatmapTable({
   const cols = matrix[0]?.length ?? 0;
   return (
     <div data-testid="array-2d-heatmap" className="space-y-1">
-      <div className="max-h-80 overflow-auto rounded-[0.8rem] border border-stone-200 bg-white">
+      <div className="max-h-80 overflow-auto rounded-[0.8rem] border border-ink/10 bg-white">
         <table className="border-collapse text-[10px] tabular-nums">
           <thead>
             <tr>
-              <th className="sticky left-0 top-0 z-10 bg-stone-100 px-1 py-0.5 text-stone-400" />
+              <th className="sticky left-0 top-0 z-10 bg-ink/10 px-1 py-0.5 text-ink/45" />
               {Array.from({ length: cols }, (_, c) => (
-                <th
-                  key={c}
-                  className="sticky top-0 bg-stone-100 px-1 py-0.5 font-normal text-stone-400"
-                >
+                <th key={c} className="sticky top-0 bg-ink/10 px-1 py-0.5 font-normal text-ink/45">
                   {c}
                 </th>
               ))}
@@ -461,7 +460,7 @@ export function ArrayHeatmapTable({
           <tbody>
             {matrix.map((row, r) => (
               <tr key={r}>
-                <th className="sticky left-0 z-10 bg-stone-100 px-1 py-0.5 font-normal text-stone-400">
+                <th className="sticky left-0 z-10 bg-ink/10 px-1 py-0.5 font-normal text-ink/45">
                   {r}
                 </th>
                 {row.map((value, c) => (
@@ -483,7 +482,7 @@ export function ArrayHeatmapTable({
           </tbody>
         </table>
       </div>
-      <div className="text-[10px] text-stone-400" data-testid="array-grid-info">
+      <div className="text-[10px] text-ink/45" data-testid="array-grid-info">
         {shape.length ? `${shape.join(" × ")} | ` : ""}
         displaying {rows} × {cols}
       </div>
@@ -499,7 +498,7 @@ export function ArrayLegend({ vmin, vmax }: { vmin: number; vmax: number }) {
   });
   const mid = vmin < 0 && vmax > 0 ? 0 : (vmin + vmax) / 2;
   return (
-    <div className="flex items-center gap-2 text-[10px] text-stone-500" data-testid="array-legend">
+    <div className="flex items-center gap-2 text-[10px] text-ink/60" data-testid="array-legend">
       <span data-testid="array-legend-min">{formatCell(vmin)}</span>
       <div
         className="h-2 flex-1 rounded"
@@ -528,7 +527,7 @@ export function SeriesViewer({ envelope }: { envelope: PreviewEnvelope }) {
           type="button"
           onClick={() => setMode("chart")}
           aria-pressed={mode === "chart"}
-          className={`rounded-full px-3 py-0.5 ${mode === "chart" ? "bg-ink text-white" : "bg-white text-stone-600"}`}
+          className={`rounded-full px-3 py-0.5 ${mode === "chart" ? "bg-ink text-white" : "bg-white text-ink/70"}`}
         >
           Chart
         </button>
@@ -536,7 +535,7 @@ export function SeriesViewer({ envelope }: { envelope: PreviewEnvelope }) {
           type="button"
           onClick={() => setMode("table")}
           aria-pressed={mode === "table"}
-          className={`rounded-full px-3 py-0.5 ${mode === "table" ? "bg-ink text-white" : "bg-white text-stone-600"}`}
+          className={`rounded-full px-3 py-0.5 ${mode === "table" ? "bg-ink text-white" : "bg-white text-ink/70"}`}
         >
           Table
         </button>
@@ -564,21 +563,21 @@ export function SeriesViewer({ envelope }: { envelope: PreviewEnvelope }) {
         />
       ) : (
         <div
-          className="max-h-72 overflow-auto rounded-[1rem] border border-stone-200 bg-white"
+          className="max-h-72 overflow-auto rounded-[1rem] border border-ink/10 bg-white"
           data-testid="series-table"
         >
           <table className="min-w-full text-left text-xs">
             <thead>
               <tr>
-                <th className="border-b border-stone-200 px-3 py-1">index</th>
-                <th className="border-b border-stone-200 px-3 py-1">value</th>
+                <th className="border-b border-ink/10 px-3 py-1">index</th>
+                <th className="border-b border-ink/10 px-3 py-1">value</th>
               </tr>
             </thead>
             <tbody>
               {tableRows.map((r, i) => (
                 <tr key={i}>
-                  <td className="border-b border-stone-100 px-3 py-1">{String(r.index ?? "")}</td>
-                  <td className="border-b border-stone-100 px-3 py-1">{String(r.value ?? "")}</td>
+                  <td className="border-b border-ink/5 px-3 py-1">{String(r.index ?? "")}</td>
+                  <td className="border-b border-ink/5 px-3 py-1">{String(r.value ?? "")}</td>
                 </tr>
               ))}
             </tbody>
@@ -601,7 +600,7 @@ export function TextViewer({ envelope }: { envelope: PreviewEnvelope }) {
   const handoff = asRecord(payload.editor_handoff);
   return (
     <div data-testid="core-text-viewer" className="space-y-2">
-      <pre className="max-h-80 overflow-auto rounded-[1rem] border border-stone-200 bg-white p-4 text-sm">
+      <pre className="max-h-80 overflow-auto rounded-[1rem] border border-ink/10 bg-white p-4 text-sm">
         {content}
       </pre>
       {truncated ? (
@@ -635,7 +634,7 @@ export function ArtifactViewer({ envelope }: { envelope: PreviewEnvelope }) {
   return (
     <div
       data-testid="core-artifact-viewer"
-      className="space-y-2 rounded-[1rem] border border-stone-200 bg-white p-4 text-sm text-stone-600"
+      className="space-y-2 rounded-[1rem] border border-ink/10 bg-white p-4 text-sm text-ink/70"
     >
       <p className="font-medium text-ink">Artifact</p>
       <p className="break-all text-xs">{path}</p>
@@ -665,7 +664,7 @@ export function CompositeViewer({
   const slotResources = envelope.resources.filter((r) => r.resource_id.startsWith("slot:"));
   return (
     <div data-testid="core-composite-viewer" className="space-y-2">
-      <p className="text-xs uppercase tracking-wider text-stone-500">
+      <p className="text-xs uppercase tracking-wider text-ink/60">
         {Object.keys(slots).length} slot{Object.keys(slots).length === 1 ? "" : "s"}
       </p>
       {Object.entries(slots).map(([name, typeName]) => {
@@ -676,14 +675,14 @@ export function CompositeViewer({
             type="button"
             data-testid={`composite-slot-${name}`}
             onClick={() => (resource && onOpenResource ? onOpenResource(resource) : undefined)}
-            className="flex w-full items-center justify-between rounded-2xl border border-stone-200 bg-white px-4 py-3 text-left hover:bg-stone-50"
+            className="flex w-full items-center justify-between rounded-2xl border border-ink/10 bg-white px-4 py-3 text-left hover:bg-ink/5"
           >
             <span>
-              <span className="text-xs uppercase tracking-wider text-stone-500">{name}</span>
+              <span className="text-xs uppercase tracking-wider text-ink/60">{name}</span>
               <span className="mt-1 block text-sm text-ink">{String(typeName)}</span>
             </span>
             {resource && onOpenResource ? (
-              <span className="text-xs text-stone-400">Preview →</span>
+              <span className="text-xs text-ink/45">Preview →</span>
             ) : null}
           </button>
         );
@@ -711,10 +710,7 @@ export function CollectionViewer({
   const itemResources = envelope.resources.filter((r) => r.resource_id.startsWith("item:"));
   return (
     <div data-testid="core-collection-viewer" className="space-y-2">
-      <p
-        className="text-xs uppercase tracking-wider text-stone-500"
-        data-testid="collection-summary"
-      >
+      <p className="text-xs uppercase tracking-wider text-ink/60" data-testid="collection-summary">
         {count} {itemType} (showing {items.length})
       </p>
       <div className="grid grid-cols-2 gap-2">
@@ -728,12 +724,12 @@ export function CollectionViewer({
               type="button"
               data-testid={`collection-item-${idx}`}
               onClick={() => (resource && onOpenResource ? onOpenResource(resource) : undefined)}
-              className="rounded-2xl border border-stone-200 bg-white px-3 py-2 text-left text-xs hover:bg-stone-50"
+              className="rounded-2xl border border-ink/10 bg-white px-3 py-2 text-left text-xs hover:bg-ink/5"
             >
               <span className="block truncate text-ink" title={ref}>
                 {displayName}
               </span>
-              <span className="text-stone-400">{asString(item.type_name, itemType)}</span>
+              <span className="text-ink/45">{asString(item.type_name, itemType)}</span>
             </button>
           );
         })}
@@ -752,13 +748,15 @@ export function ErrorViewer({ envelope }: { envelope: PreviewEnvelope }) {
   return (
     <div
       data-testid="core-error-viewer"
-      className="space-y-1 rounded-[1rem] border border-red-300 bg-red-50 p-4 text-sm text-red-800"
+      className="space-y-1 rounded-[1rem] border border-destructive/30 bg-destructive/10 p-4 text-sm text-destructive"
       role="alert"
     >
       <p className="font-medium">Preview failed</p>
       {error ? (
         <>
-          <p className="text-xs uppercase tracking-wider text-red-500">{String(error.code)}</p>
+          <p className="text-xs uppercase tracking-wider text-destructive/70">
+            {String(error.code)}
+          </p>
           <p className="text-xs">{error.message}</p>
         </>
       ) : (

--- a/frontend/src/components/DataRouterModal.parts/InputPanels.tsx
+++ b/frontend/src/components/DataRouterModal.parts/InputPanels.tsx
@@ -23,15 +23,15 @@ export function InputPanels({
 }: InputPanelsProps) {
   return (
     <div className="flex flex-1 flex-col gap-3" onDrop={onDropOnInput} onDragOver={onDragOver}>
-      <div className="text-xs font-medium uppercase tracking-wide text-stone-400">Inputs</div>
+      <div className="text-xs font-medium uppercase tracking-wide text-ink/45">Inputs</div>
       {inputPorts.map((portName) => {
         const portItems = itemsPerPort[portName] ?? [];
         const unassignedPortItems = portItems.filter((item) => !assignedRefs.has(item.ref));
         return (
-          <div key={portName} className="rounded-lg border border-stone-200 bg-stone-50 p-3">
-            <div className="mb-2 text-xs font-medium text-stone-600">
+          <div key={portName} className="rounded-lg border border-ink/10 bg-ink/5 p-3">
+            <div className="mb-2 text-xs font-medium text-ink/70">
               {portName}{" "}
-              <span className="text-stone-400">
+              <span className="text-ink/45">
                 ({unassignedPortItems.length}/{portItems.length})
               </span>
             </div>
@@ -40,7 +40,7 @@ export function InputPanels({
                 <ItemCard key={item.ref} item={item} draggable onDragStart={onDragStart} />
               ))}
               {unassignedPortItems.length === 0 && (
-                <span className="text-[10px] italic text-stone-400">All items assigned</span>
+                <span className="text-[10px] italic text-ink/45">All items assigned</span>
               )}
             </div>
           </div>

--- a/frontend/src/components/DataRouterModal.parts/ItemCard.tsx
+++ b/frontend/src/components/DataRouterModal.parts/ItemCard.tsx
@@ -15,7 +15,7 @@ export function ItemCard({ item, draggable, onDragStart, colorIndex }: ItemCardP
   const colorClass =
     colorIndex !== undefined
       ? ROW_COLORS[colorIndex % ROW_COLORS.length]
-      : "bg-white border-stone-200";
+      : "bg-white border-ink/10";
   return (
     <div
       className={`flex items-center gap-2 rounded border px-2 py-1.5 text-xs ${colorClass} ${draggable ? "cursor-grab" : "cursor-default opacity-50"}`}
@@ -23,7 +23,7 @@ export function ItemCard({ item, draggable, onDragStart, colorIndex }: ItemCardP
       onDragStart={(e) => onDragStart?.(e, item.ref)}
     >
       <span className="truncate font-medium text-ink">{item.name}</span>
-      <span className="shrink-0 text-[10px] text-stone-400">{item.type}</span>
+      <span className="shrink-0 text-[10px] text-ink/45">{item.type}</span>
     </div>
   );
 }

--- a/frontend/src/components/DataRouterModal.parts/OutputPanels.tsx
+++ b/frontend/src/components/DataRouterModal.parts/OutputPanels.tsx
@@ -23,18 +23,18 @@ export function OutputPanels({
 }: OutputPanelsProps) {
   return (
     <div className="flex flex-1 flex-col gap-3">
-      <div className="text-xs font-medium uppercase tracking-wide text-stone-400">Outputs</div>
+      <div className="text-xs font-medium uppercase tracking-wide text-ink/45">Outputs</div>
       {outputPorts.map((portName, portIndex) => {
         const portRefs = assignments[portName] ?? [];
         return (
           <div
             key={portName}
-            className="min-h-[60px] rounded-lg border-2 border-dashed border-stone-200 bg-stone-50 p-3 transition-colors hover:border-blue-300"
+            className="min-h-[60px] rounded-lg border-2 border-dashed border-ink/10 bg-ink/5 p-3 transition-colors hover:border-ember/50"
             onDrop={(e) => onDropOnOutput(e, portName)}
             onDragOver={onDragOver}
           >
-            <div className="mb-2 text-xs font-medium text-stone-600">
-              {portName} <span className="text-stone-400">({portRefs.length})</span>
+            <div className="mb-2 text-xs font-medium text-ink/70">
+              {portName} <span className="text-ink/45">({portRefs.length})</span>
             </div>
             <div className="flex flex-wrap gap-1.5">
               {portRefs.map((ref) => {
@@ -51,7 +51,7 @@ export function OutputPanels({
                 );
               })}
               {portRefs.length === 0 && (
-                <span className="text-[10px] italic text-stone-400">Drop items here</span>
+                <span className="text-[10px] italic text-ink/45">Drop items here</span>
               )}
             </div>
           </div>

--- a/frontend/src/components/DataRouterModal.tsx
+++ b/frontend/src/components/DataRouterModal.tsx
@@ -9,6 +9,7 @@
 
 import { useCallback, useState } from "react";
 
+import { Button } from "./ui/button";
 import { InputPanels } from "./DataRouterModal.parts/InputPanels";
 import { OutputPanels } from "./DataRouterModal.parts/OutputPanels";
 import type { ItemDescriptor } from "./DataRouterModal.parts/types";
@@ -105,13 +106,13 @@ export function DataRouterModal({
       data-testid="data-router-modal"
     >
       <div
-        className="flex max-h-[85vh] w-[900px] flex-col rounded-xl border border-stone-200 bg-white shadow-xl"
+        className="flex max-h-[85vh] w-[900px] flex-col rounded-xl border border-ink/10 bg-white shadow-panel"
         onClick={(e) => e.stopPropagation()}
       >
         {/* Header */}
-        <div className="border-b border-stone-100 px-5 py-3">
+        <div className="border-b border-ink/5 px-5 py-3">
           <div className="text-sm font-semibold text-ink">Data Router</div>
-          <div className="mt-0.5 text-xs text-stone-500">
+          <div className="mt-0.5 text-xs text-ink/60">
             Drag items from input panels to output panels. All items must be assigned.
           </div>
         </div>
@@ -128,7 +129,7 @@ export function DataRouterModal({
           />
 
           {/* Arrow divider */}
-          <div className="flex items-center text-stone-300">
+          <div className="flex items-center text-ink/30">
             <svg
               width="24"
               height="24"
@@ -152,10 +153,10 @@ export function DataRouterModal({
         </div>
 
         {/* Footer */}
-        <div className="flex items-center justify-between border-t border-stone-100 px-5 py-3">
-          <div className="text-xs text-stone-500">
+        <div className="flex items-center justify-between border-t border-ink/5 px-5 py-3">
+          <div className="text-xs text-ink/60">
             {allAssigned ? (
-              <span className="text-green-600">All items assigned</span>
+              <span className="text-pine">All items assigned</span>
             ) : (
               <span className="text-amber-600">
                 {unassignedItems.length} item(s) not yet assigned
@@ -163,21 +164,12 @@ export function DataRouterModal({
             )}
           </div>
           <div className="flex items-center gap-2">
-            <button
-              type="button"
-              className="rounded border border-stone-200 px-4 py-1.5 text-xs text-stone-600 hover:bg-stone-50"
-              onClick={onCancel}
-            >
+            <Button type="button" variant="outline" size="sm" onClick={onCancel}>
               Cancel
-            </button>
-            <button
-              type="button"
-              className="rounded bg-blue-500 px-4 py-1.5 text-xs text-white hover:bg-blue-600 disabled:opacity-40"
-              disabled={!allAssigned}
-              onClick={handleConfirm}
-            >
+            </Button>
+            <Button type="button" size="sm" disabled={!allAssigned} onClick={handleConfirm}>
               Confirm
-            </button>
+            </Button>
           </div>
         </div>
       </div>

--- a/frontend/src/components/PairEditorModal.tsx
+++ b/frontend/src/components/PairEditorModal.tsx
@@ -10,6 +10,8 @@
 
 import { useState, useCallback, useRef } from "react";
 
+import { Button } from "./ui/button";
+
 interface ItemDescriptor {
   index: number;
   name: string;
@@ -126,13 +128,13 @@ export function PairEditorModal({
       onClick={onCancel}
     >
       <div
-        className="flex max-h-[85vh] w-[900px] flex-col rounded-xl border border-stone-200 bg-white shadow-xl"
+        className="flex max-h-[85vh] w-[900px] flex-col rounded-xl border border-ink/10 bg-white shadow-panel"
         onClick={(e) => e.stopPropagation()}
       >
         {/* Header */}
-        <div className="border-b border-stone-100 px-5 py-3">
+        <div className="border-b border-ink/5 px-5 py-3">
           <div className="text-sm font-semibold text-ink">Pair Editor</div>
-          <div className="mt-0.5 text-xs text-stone-500">
+          <div className="mt-0.5 text-xs text-ink/60">
             Reorder items within each panel so that same-row items are correctly paired. Items in
             the same row (same color) are paired by index.
           </div>
@@ -143,9 +145,9 @@ export function PairEditorModal({
           {/* Row number header */}
           <div className={`grid gap-3 ${gridCols}`}>
             {ports.map((portName) => (
-              <div key={portName} className="text-xs font-medium text-stone-600">
+              <div key={portName} className="text-xs font-medium text-ink/70">
                 {portName}
-                <span className="ml-1 text-stone-400">({collectionLength})</span>
+                <span className="ml-1 text-ink/45">({collectionLength})</span>
               </div>
             ))}
           </div>
@@ -174,7 +176,7 @@ export function PairEditorModal({
                       <span className="min-w-0 flex-1 truncate font-medium text-ink">
                         {item.name}
                       </span>
-                      <span className="shrink-0 text-[10px] text-stone-400">{item.type}</span>
+                      <span className="shrink-0 text-[10px] text-ink/45">{item.type}</span>
                     </div>
                   );
                 })}
@@ -184,21 +186,13 @@ export function PairEditorModal({
         </div>
 
         {/* Footer */}
-        <div className="flex items-center justify-end gap-2 border-t border-stone-100 px-5 py-3">
-          <button
-            type="button"
-            className="rounded border border-stone-200 px-4 py-1.5 text-xs text-stone-600 hover:bg-stone-50"
-            onClick={onCancel}
-          >
+        <div className="flex items-center justify-end gap-2 border-t border-ink/5 px-5 py-3">
+          <Button type="button" variant="outline" size="sm" onClick={onCancel}>
             Cancel
-          </button>
-          <button
-            type="button"
-            className="rounded bg-blue-500 px-4 py-1.5 text-xs text-white hover:bg-blue-600"
-            onClick={handleConfirm}
-          >
+          </Button>
+          <Button type="button" size="sm" onClick={handleConfirm}>
             Confirm
-          </button>
+          </Button>
         </div>
       </div>
     </div>

--- a/frontend/src/components/interactiveModals.designSystem.test.tsx
+++ b/frontend/src/components/interactiveModals.designSystem.test.tsx
@@ -1,0 +1,65 @@
+// #1841 / #1847 — regression guard for the interactive-panel reskin: the
+// DataRouter / PairEditor modals must adopt the shared design system (the
+// `ui/Button` primitive + brand tokens) instead of the old hand-rolled cold
+// `bg-blue-500` action buttons + `border-stone-*` chrome.
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, within } from "@testing-library/react";
+
+afterEach(cleanup);
+
+import { DataRouterModal } from "./DataRouterModal";
+import { PairEditorModal } from "./PairEditorModal";
+
+describe("interactive modals adopt the shared design system (#1841)", () => {
+  it("DataRouterModal renders Confirm/Cancel as shared ui/Button (brand, not cold blue)", () => {
+    const { container } = render(
+      <DataRouterModal
+        blockId="blk-1"
+        inputPorts={["in_1"]}
+        outputPorts={["out_1"]}
+        // No items → everything is trivially assigned, so Confirm is enabled.
+        itemsPerPort={{ in_1: [] }}
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    const confirm = within(container).getByRole("button", { name: "Confirm" });
+    const cancel = within(container).getByRole("button", { name: "Cancel" });
+
+    // Shared Button primitive: default variant => brand primary; outline => input border.
+    expect(confirm.className).toContain("bg-primary");
+    expect(cancel.className).toContain("border-input");
+
+    // The old cold action-button blue must be gone (categorical bg-blue-50
+    // pairing tints are unaffected — we only guard the 500/600 action shade).
+    expect(container.innerHTML).not.toMatch(/bg-blue-(500|600)/);
+    // Chrome migrated off the generic stone neutrals onto the ink brand token.
+    expect(container.innerHTML).not.toMatch(/border-stone-\d/);
+  });
+
+  it("PairEditorModal renders Confirm/Cancel as shared ui/Button (brand, not cold blue)", () => {
+    const { container } = render(
+      <PairEditorModal
+        blockId="blk-2"
+        ports={["a", "b"]}
+        itemsPerPort={{
+          a: [{ index: 0, name: "x", type: "Array" }],
+          b: [{ index: 0, name: "y", type: "Array" }],
+        }}
+        collectionLength={1}
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    const confirm = within(container).getByRole("button", { name: "Confirm" });
+    const cancel = within(container).getByRole("button", { name: "Cancel" });
+
+    expect(confirm.className).toContain("bg-primary");
+    expect(cancel.className).toContain("border-input");
+    expect(container.innerHTML).not.toMatch(/bg-blue-(500|600)/);
+    expect(container.innerHTML).not.toMatch(/border-stone-\d/);
+  });
+});

--- a/frontend/src/components/nodes/BlockNode.parts/categoryVisuals.test.ts
+++ b/frontend/src/components/nodes/BlockNode.parts/categoryVisuals.test.ts
@@ -2,7 +2,7 @@
 // with safe fallback to the base-category default.
 
 import { describe, expect, it } from "vitest";
-import { FunctionSquare, Microscope } from "lucide-react";
+import { FolderDown, FunctionSquare, Microscope, Split } from "lucide-react";
 
 import { categoryVisuals, getCategoryVisual, resolveIconByName } from "./categoryVisuals";
 
@@ -23,6 +23,39 @@ describe("resolveIconByName (#1839)", () => {
     expect(resolveIconByName("")).toBeUndefined();
     expect(resolveIconByName(null)).toBeUndefined();
     expect(resolveIconByName(undefined)).toBeUndefined();
+  });
+});
+
+describe("resolveIconByName — full lucide set + kebab + rotation suffix (#1847)", () => {
+  it("resolves ANY lucide name, not just the old curated subset", () => {
+    // FolderDown was never in the curated set; it must resolve now.
+    expect(resolveIconByName("FolderDown")).toBe(FolderDown);
+  });
+
+  it("resolves kebab-case names", () => {
+    expect(resolveIconByName("folder-down")).toBe(FolderDown);
+    expect(resolveIconByName("arrow-left-right")).toBeDefined();
+  });
+
+  it("strips a trailing :<deg> rotation suffix before lookup", () => {
+    expect(resolveIconByName("split:90")).toBe(Split);
+    expect(resolveIconByName("folder-down:270")).toBe(FolderDown);
+  });
+});
+
+describe("getCategoryVisual — icon rotation (#1847)", () => {
+  it("returns the raw icon (reference-equal) when no rotation is requested", () => {
+    expect(getCategoryVisual("process", null, "Split").Icon).toBe(Split);
+  });
+
+  it("wraps the icon (not reference-equal) when a rotation is requested", () => {
+    const v = getCategoryVisual("process", null, "split:90");
+    expect(v.Icon).not.toBe(Split);
+    expect(v.Icon).toBeDefined();
+  });
+
+  it("falls back to the category icon for an unknown name even with a suffix", () => {
+    expect(getCategoryVisual("process", null, "totally-unknown:90").Icon).toBe(FunctionSquare);
   });
 });
 

--- a/frontend/src/components/nodes/BlockNode.parts/categoryVisuals.ts
+++ b/frontend/src/components/nodes/BlockNode.parts/categoryVisuals.ts
@@ -18,8 +18,15 @@
 // below) silently falls back to the category icon — never an error, never a
 // missing glyph. Custom SVG/asset glyphs are deferred (issue #1839 option b).
 
+import { createElement, forwardRef, type ComponentProps, type CSSProperties } from "react";
+// #1847: a block's `ui_icon` may now name ANY lucide glyph (PascalCase or
+// kebab-case), not just a curated subset. For this desktop app the full
+// namespace import is acceptable (offline bundle, no per-load download) and it
+// sidesteps the vendored lucide build's empty `exports` map, which blocks the
+// lazy `lucide-react/dynamic` subpath. Names resolve via `resolveIconByName`.
+import * as LucideIcons from "lucide-react";
 import {
-  // Base-category icons.
+  // Base-category default icons (the 6 core block kinds), resolved statically.
   AppWindow,
   Code2,
   FolderInput,
@@ -27,35 +34,11 @@ import {
   Package,
   Puzzle,
   Sparkles,
-  // Curated extras a block author may name via `ui_icon` (#1839). Kept to a
-  // bounded, already-bundled set rather than importing all of lucide-react.
-  Activity,
-  Atom,
-  Binary,
-  Box,
-  Brain,
-  Calculator,
-  Cpu,
-  Database,
-  Dna,
-  Filter,
-  FlaskConical,
-  Gauge,
-  Image,
-  LineChart,
-  Microscope,
-  ScatterChart,
-  Sigma,
-  Table,
-  TestTube,
-  Waves,
-  Workflow,
-  Zap,
   type LucideIcon,
 } from "lucide-react";
 
 export interface CategoryVisual {
-  /** lucide line icon rendered in the node body. */
+  /** Icon rendered in the node body (a lucide glyph, optionally rotated). */
   Icon: LucideIcon;
   /** Soft macaron body background fill. */
   bg: string;
@@ -101,54 +84,58 @@ export const categoryVisuals: Record<string, CategoryVisual> = {
   custom: CUSTOM,
 };
 
-// Curated, name-addressable Lucide set a block may select via `ui_icon` (#1839).
-// Includes the base-category icons plus common science/data glyphs. Names are
-// the PascalCase Lucide export names a block author writes (e.g. "Microscope").
-const CURATED_ICONS: Record<string, LucideIcon> = {
-  AppWindow,
-  Code2,
-  FolderInput,
-  FunctionSquare,
-  Package,
-  Puzzle,
-  Sparkles,
-  Activity,
-  Atom,
-  Binary,
-  Box,
-  Brain,
-  Calculator,
-  Cpu,
-  Database,
-  Dna,
-  Filter,
-  FlaskConical,
-  Gauge,
-  Image,
-  LineChart,
-  Microscope,
-  ScatterChart,
-  Sigma,
-  Table,
-  TestTube,
-  Waves,
-  Workflow,
-  Zap,
-};
-
-// Lowercased index for tolerant lookup (so "microscope" resolves "Microscope").
-const CURATED_ICONS_LOWER: Record<string, LucideIcon> = Object.fromEntries(
-  Object.entries(CURATED_ICONS).map(([name, Icon]) => [name.toLowerCase(), Icon]),
-);
+/** PascalCase a kebab/snake/space name: "folder-down" -> "FolderDown". */
+function toPascalCase(name: string): string {
+  return name
+    .split(/[-_\s]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join("");
+}
 
 /**
- * Resolve a Lucide icon NAME (#1839) to a component from the curated set.
- * Returns `undefined` for an empty or unknown name so callers fall back to the
- * category icon (never an error, never a missing glyph).
+ * Resolve a Lucide icon NAME to a component from the FULL lucide set (#1847,
+ * widening #1839's curated set). Accepts PascalCase ("FolderDown") or
+ * kebab-case ("folder-down"), and tolerates a trailing ":<deg>" rotation suffix
+ * (stripped here; applied by {@link getCategoryVisual}). Returns `undefined`
+ * for an empty or unknown name so callers fall back to the category icon —
+ * never an error, never a missing glyph.
  */
 export function resolveIconByName(name: string | null | undefined): LucideIcon | undefined {
   if (!name) return undefined;
-  return CURATED_ICONS[name] ?? CURATED_ICONS_LOWER[name.toLowerCase()];
+  const bare = name.split(":")[0]?.trim();
+  if (!bare) return undefined;
+  const pascal = /[-_\s]/.test(bare)
+    ? toPascalCase(bare)
+    : bare.charAt(0).toUpperCase() + bare.slice(1);
+  const icon = (LucideIcons as Record<string, unknown>)[pascal];
+  // Lucide icon exports are forwardRef objects; guard against non-icon exports
+  // (e.g. `createLucideIcon`, `icons`) and unknown names.
+  return typeof icon === "object" && icon !== null ? (icon as LucideIcon) : undefined;
+}
+
+/** Parse the optional ":<deg>" rotation suffix on a ui_icon spec (#1847). */
+function parseIconRotation(spec: string | null | undefined): number {
+  if (!spec) return 0;
+  const parts = spec.split(":");
+  if (parts.length < 2) return 0;
+  const deg = Number.parseInt(parts[1], 10);
+  return Number.isFinite(deg) ? ((deg % 360) + 360) % 360 : 0;
+}
+
+/** Wrap an icon so it renders with a baked-in CSS rotation transform (#1847). */
+function withRotation(Base: LucideIcon, deg: number): LucideIcon {
+  if (!deg) return Base;
+  const Rotated = forwardRef<SVGSVGElement, Omit<ComponentProps<LucideIcon>, "ref">>(
+    function RotatedIcon({ style, ...rest }, ref) {
+      return createElement(Base, {
+        ...rest,
+        ref,
+        style: { transform: `rotate(${deg}deg)`, ...(style as CSSProperties) },
+      });
+    },
+  );
+  return Rotated as LucideIcon;
 }
 
 const HEX_RE = /^#(?:[0-9a-f]{3}|[0-9a-f]{6})$/i;
@@ -182,8 +169,9 @@ function darken(rgb: [number, number, number], factor: number): string {
  *   - `uiColor` (valid CSS hex) becomes the body fill, with `fg` (accent) and
  *     `border` derived as deeper shades — mirroring the category palette
  *     relationship. An invalid hex is ignored (category colors kept).
- *   - `uiIcon` (a curated Lucide name) becomes the node icon; an unknown name
- *     keeps the category icon.
+ *   - `uiIcon` (any Lucide name, PascalCase or kebab-case, with an optional
+ *     ":<deg>" rotation suffix — e.g. "folder-down" or "split:90") becomes the
+ *     node icon; an unknown name keeps the category icon (#1847).
  * With neither override the category default is returned unchanged.
  */
 export function getCategoryVisual(
@@ -194,7 +182,8 @@ export function getCategoryVisual(
   const base = (category && categoryVisuals[category]) || CUSTOM;
   if (!uiColor && !uiIcon) return base;
 
-  const overrideIcon = resolveIconByName(uiIcon);
+  const resolved = resolveIconByName(uiIcon);
+  const overrideIcon = resolved ? withRotation(resolved, parseIconRotation(uiIcon)) : undefined;
   const rgb = uiColor ? parseHex(uiColor) : null;
 
   return {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -26,14 +26,30 @@
     --input: 20 6% 83%;
     --ring: 20 8% 10%;
     --radius: 0.5rem;
+
+    /*
+     * #1847 / #1841: brand color tokens as space-separated RGB channels, so
+     * Tailwind can apply opacity modifiers (e.g. `border-ember/55`) via
+     * `rgb(var(--ss-x) / <alpha-value>)` while preserving the exact hex value
+     * at full opacity. Single source of truth for the brand palette; the
+     * Tailwind `canvas/ink/ember/pine/sea/sand` utilities resolve to these.
+     * These also seed the cross-boundary `--ss-*` theming contract (#1849).
+     */
+    --ss-canvas: 245 241 232; /* #f5f1e8 */
+    --ss-ink: 28 33 27; /* #1c211b */
+    --ss-ember: 240 106 68; /* #f06a44 */
+    --ss-pine: 46 93 80; /* #2e5d50 */
+    --ss-sea: 45 120 145; /* #2d7891 */
+    --ss-sand: 221 196 157; /* #ddc49d */
   }
 }
 
 :root {
-  color: #1c211b;
+  color: rgb(var(--ss-ink));
   background:
-    radial-gradient(circle at top right, rgba(45, 120, 145, 0.12), transparent 30%),
-    radial-gradient(circle at bottom left, rgba(240, 106, 68, 0.18), transparent 28%), #f5f1e8;
+    radial-gradient(circle at top right, rgb(var(--ss-sea) / 0.12), transparent 30%),
+    radial-gradient(circle at bottom left, rgb(var(--ss-ember) / 0.18), transparent 28%),
+    rgb(var(--ss-canvas));
   font-family: "IBM Plex Sans", "Segoe UI", sans-serif;
 }
 
@@ -91,7 +107,7 @@ select {
 
 .toolbar-button:hover:not(:disabled) {
   transform: translateY(-1px);
-  border-color: rgba(240, 106, 68, 0.55);
+  border-color: rgb(var(--ss-ember) / 0.55);
 }
 
 .toolbar-button:disabled {
@@ -100,7 +116,7 @@ select {
 }
 
 .toolbar-button-dark {
-  background: #1c211b;
+  background: rgb(var(--ss-ink));
   color: #fffdf8;
 }
 

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -11,12 +11,17 @@ export default {
         body: ["IBM Plex Sans", "Segoe UI", "sans-serif"],
       },
       colors: {
-        canvas: "#f5f1e8",
-        ink: "#1c211b",
-        ember: "#f06a44",
-        pine: "#2e5d50",
-        sea: "#2d7891",
-        sand: "#ddc49d",
+        // #1847 / #1841: brand tokens resolve to the `--ss-*` CSS custom
+        // properties (RGB channels in index.css) so opacity modifiers work and
+        // the palette has a single source of truth. Full-opacity values are the
+        // exact original hexes (canvas #f5f1e8, ink #1c211b, ember #f06a44,
+        // pine #2e5d50, sea #2d7891, sand #ddc49d).
+        canvas: "rgb(var(--ss-canvas) / <alpha-value>)",
+        ink: "rgb(var(--ss-ink) / <alpha-value>)",
+        ember: "rgb(var(--ss-ember) / <alpha-value>)",
+        pine: "rgb(var(--ss-pine) / <alpha-value>)",
+        sea: "rgb(var(--ss-sea) / <alpha-value>)",
+        sand: "rgb(var(--ss-sand) / <alpha-value>)",
         border: "hsl(var(--border))",
         input: "hsl(var(--input))",
         ring: "hsl(var(--ring))",

--- a/src/scistudio/blocks/io/loaders/load_data.py
+++ b/src/scistudio/blocks/io/loaders/load_data.py
@@ -117,6 +117,10 @@ class LoadData(IOBlock):
     )
     subcategory: ClassVar[str] = "io"
 
+    # #1847: a folder-up glyph (data coming *in* from disk). Keeps the io
+    # category default colour; pairs visually with SaveData's folder-down.
+    ui_icon: ClassVar[str] = "folder-up"
+
     # ADR-043 / spec ``adr-043-package-migration`` FR-001 / FR-003:
     # explicit per-(type, format) capability records. Replaces the
     # legacy ``supported_extensions`` ClassVar which has been removed.

--- a/src/scistudio/blocks/io/savers/save_data.py
+++ b/src/scistudio/blocks/io/savers/save_data.py
@@ -363,6 +363,12 @@ class SaveData(IOBlock):
     )
     subcategory: ClassVar[str] = "io"
 
+    # #1847: distinct color + a folder-down glyph (data going *to* disk) so the
+    # output block reads differently from LoadData (io-blue folder-up). The two
+    # form an up/down pair on the io category.
+    ui_color: ClassVar[str] = "#b9e3a0"
+    ui_icon: ClassVar[str] = "folder-down"
+
     # ADR-043 / spec ``adr-043-package-migration`` FR-002 / FR-003:
     # explicit per-(type, format) capability records. Replaces the
     # legacy ``supported_extensions`` ClassVar which has been removed.

--- a/src/scistudio/blocks/process/builtins/data_router.py
+++ b/src/scistudio/blocks/process/builtins/data_router.py
@@ -52,6 +52,13 @@ class DataRouter(InteractiveMixin, ProcessBlock):
     algorithm: ClassVar[str] = "data_router"
     subcategory: ClassVar[str] = "routing"
 
+    # #1839 / #1847: macaron periwinkle + a split glyph for the N->M routing
+    # block. The ":90" suffix rotates the glyph 90deg to read left->right, in
+    # line with the canvas data-flow direction (rotation parsed by the frontend
+    # ui_icon resolver in categoryVisuals.ts).
+    ui_color: ClassVar[str] = "#aec5eb"
+    ui_icon: ClassVar[str] = "split:90"
+
     execution_mode: ClassVar[ExecutionMode] = ExecutionMode.INTERACTIVE
 
     # ADR-051: the block-owned window. Resolved by the frontend panel host from

--- a/src/scistudio/blocks/process/builtins/merge_collection.py
+++ b/src/scistudio/blocks/process/builtins/merge_collection.py
@@ -29,6 +29,12 @@ class MergeCollection(ProcessBlock):
     description: ClassVar[str] = "Concatenate multiple same-typed Collections into one"
     subcategory: ClassVar[str] = "routing"
 
+    # #1839 / #1847: macaron mint + a merge glyph for the N->1 concatenation
+    # block. ":90" rotates the glyph 90deg to read left->right with the canvas
+    # data-flow direction (rotation parsed by the frontend ui_icon resolver).
+    ui_color: ClassVar[str] = "#a8e0d3"
+    ui_icon: ClassVar[str] = "merge:90"
+
     # Variadic input side (ADR-029): the concrete ports live in
     # ``config["input_ports"]``; the class-level list is the default 2-port seed.
     variadic_inputs: ClassVar[bool] = True

--- a/src/scistudio/blocks/process/builtins/pair_editor.py
+++ b/src/scistudio/blocks/process/builtins/pair_editor.py
@@ -54,6 +54,12 @@ class PairEditor(InteractiveMixin, ProcessBlock):
     algorithm: ClassVar[str] = "pair_editor"
     subcategory: ClassVar[str] = "routing"
 
+    # #1839 / #1847: macaron apricot + a left-right swap glyph for the
+    # pairing/reorder block. (Recoloured off the earlier rose, which read too
+    # close to the subworkflow category pink.)
+    ui_color: ClassVar[str] = "#f6cba0"
+    ui_icon: ClassVar[str] = "arrow-left-right"
+
     execution_mode: ClassVar[ExecutionMode] = ExecutionMode.INTERACTIVE
 
     # ADR-051: the block-owned window, resolved from the built-in panel registry.


### PR DESCRIPTION
## Alpha UX batch (owner-guided live session)

Owner-directed `guided` session. Three coherent UX workstreams:

### 1. Per-block color + icon polish (#1839 surface)
- `data_router` / `merge_collection` / `pair_editor`: macaron `ui_color` + personalized glyphs (`split:90` / `merge:90` / `arrow-left-right`); pair recoloured off the subworkflow-pink clash.
- `save_data` → `folder-down`, `load_data` → `folder-up` (distinct up/down pair; Save no longer mirrors Load).

### 2. `ui_icon` now resolves the full Lucide set
- `categoryVisuals.ts`: a block's `ui_icon` may name **any** Lucide glyph (PascalCase `FolderDown` or kebab `folder-down`), with an optional `:<deg>` rotation suffix, resolved via namespace lookup (was a ~30-icon curated set). Unknown names still fall back safely to the category default.
- `#1839` authoring docs intentionally untouched (docstrings are being rewritten separately).

### 3. Preview + interactive-panel design-system reskin (#1841 workstreams ① + ②)
- **① Brand-token layer**: brand colours promoted to `--ss-*` CSS custom properties (RGB channels) in `index.css`; Tailwind `canvas/ink/ember/pine/sea/sand` resolve to `rgb(var(--ss-*) / <alpha-value>)`. Exact original hexes, opacity modifiers preserved, single source of truth.
- **② Reskin**: core previewers (`coreViewers`, `TableViewer`, `PlotViewer`) and interactive panels (`DataRouterModal` + parts, `PairEditorModal`, `DynamicPanel` error UI) migrated off cold `stone/blue/slate` + raw hex onto brand tokens and the shared `ui/Button`. Categorical pairing palettes, heatmap colormaps, and amber warning semantics are intentionally preserved.
- **③ cross-boundary `--ss-*` contract deferred** → tracked in #1849.

### Tests
- `categoryVisuals.test.ts`: full-set + kebab + rotation resolution.
- `interactiveModals.designSystem.test.tsx`: new regression guard — modals adopt the shared Button + brand tokens, no cold `bg-blue-500`/`border-stone`.
- Frontend `tsc` clean; affected vitest suites pass.

Gate record: .workflow/records/1847-guided-1847-alpha-ux-batch.json

Closes #1847
Closes #1841
