### PR TITLE
feat(#1848): alpha activation gate — per-machine token required to open the app

### DIFF
--- a/.workflow/records/1848-guided-1848-alpha-activation-gate.json
+++ b/.workflow/records/1848-guided-1848-alpha-activation-gate.json
@@ -1,0 +1,90 @@
+{
+  "branch": "guided/1848-alpha-activation-gate",
+  "check_events": [],
+  "check_na": [],
+  "commit": null,
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "desktop/**",
+      "scripts/**"
+    ]
+  },
+  "directive_events": [
+    {
+      "at": "2026-06-28T20:37:17.288355Z",
+      "owner_directive": "\u5b9e\u73b0\u79bb\u7ebf\u7b7e\u540d\u6fc0\u6d3b\u95f8\u95e8:desktop activation \u6a21\u5757 + \u6fc0\u6d3b\u7a97\u53e3 GUI + \u5f00\u53d1\u8005\u7b7e\u53d1 CLI + \u6d4b\u8bd5 + \u6587\u6863\u3002Mac/Windows \u673a\u5668\u6307\u7eb9\u3002",
+      "reason": "plan"
+    }
+  ],
+  "docs_events": [
+    {
+      "at": "2026-06-28T20:37:17.288551Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/alpha-activation-gate.md",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": false,
+  "guard_events": [],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1848,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": null,
+  "owner_directive": "\u9632\u6b62 alpha tester \u672a\u7ecf\u5141\u8bb8\u4f20\u64ad\u6784\u5efa:\u79bb\u7ebf\u96f6\u670d\u52a1\u5668\u3001\u6bcf\u673a\u4e00\u7801\u7684\u6fc0\u6d3b\u95f8\u95e8\u2014\u2014\u6ca1\u6709\u5408\u6cd5 token \u5c31\u6253\u4e0d\u5f00 app\u3002GUI:\u63d0\u793a\u6587\u5b57+\u673a\u5668\u6307\u7eb9(\u5e26\u590d\u5236)+token\u8f93\u5165\u6846+\u6fc0\u6d3b\u6309\u94ae\u3002Mac+Windows \u90fd\u652f\u6301\u3002alpha \u4e34\u65f6\u6a21\u5757,beta \u6574\u4f53\u5220\u9664\u3002",
+  "persona": "live_implementer",
+  "pull_request": null,
+  "reconcile_events": [],
+  "record_id": "1848-guided-1848-alpha-activation-gate",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [],
+    "docs": [],
+    "guards": [],
+    "tests": []
+  },
+  "runtime": "claude-code",
+  "schema_version": 2,
+  "scope_events": [
+    {
+      "action": "add-include",
+      "at": "2026-06-28T20:37:17.288531Z",
+      "pattern": "desktop/**",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-28T20:37:17.288535Z",
+      "pattern": "scripts/**",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-28T20:37:17.288537Z",
+      "pattern": "docs/alpha-activation-gate.md",
+      "reason": "plan"
+    }
+  ],
+  "session_id": "945f4a8a-9e47-4c21-b82c-e4c9b522eb61",
+  "strictness_tier": null,
+  "task_kind": "guided",
+  "test_events": [
+    {
+      "at": "2026-06-28T20:37:17.288557Z",
+      "class": null,
+      "kind": "path",
+      "path": "desktop/test/activation.test.js",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/.workflow/records/1848-guided-1848-alpha-activation-gate.json
+++ b/.workflow/records/1848-guided-1848-alpha-activation-gate.json
@@ -49,6 +49,55 @@
       "tool_versions": {
         "ruff": "0.15.15"
       }
+    },
+    {
+      "at": "2026-06-28T20:57:33.269792Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:2f90130b58ec88db28456f1a1d2851ff5128335717459a1d2ec775d47d0db7a5",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-28T20:57:37.314728Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:b4c3e87ba7df8d069c609c027139d84dc6f6500d1c0ec29a80c33628bfef32fa",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-28T20:57:37.329946Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:238553235c872df30b3358d990487404d34bc6f96817baecfcb2b5fd7fac580e",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
     }
   ],
   "check_na": [],
@@ -75,6 +124,11 @@
       "at": "2026-06-28T20:53:42.030244Z",
       "owner_directive": "\u7ed9 GUI \u52a0\u4e00\u4e2a\u628a\u6240\u6709\u7b7e\u53d1\u7684 token \u548c\u673a\u5668\u6307\u7eb9\u8bb0\u5230 CSV \u7684\u529f\u80fd,\u65b9\u4fbf\u77e5\u9053\u53d1\u4e86\u591a\u5c11\u4e2a token",
       "reason": "owner \u8981\u6c42\u53d1\u653e\u53f0\u8d26:GUI/CLI \u6bcf\u6b21\u7b7e\u53d1 token \u90fd\u8bb0\u5f55\u5230\u672c\u5730 CSV(\u65f6\u95f4/\u540d\u5b57/\u673a\u5668\u6307\u7eb9/token),\u4fbf\u4e8e\u7edf\u8ba1\u53d1\u4e86\u591a\u5c11"
+    },
+    {
+      "at": "2026-06-28T21:03:44.144101Z",
+      "owner_directive": "\u7b7e\u53d1\u5de5\u5177\u4e0d\u9700\u8981\u72ec\u7acb dmg,\u505a\u4e2a\u8f7b\u91cf\u53cc\u51fb\u542f\u52a8\u5668\u5c31\u884c(B)",
+      "reason": "owner \u9009 B:\u4e0d\u505a\u72ec\u7acb Electron \u5305,\u6539\u4e3a\u6781\u5c0f\u7684\u53cc\u51fb\u542f\u52a8\u5668(.command)\u8fd0\u884c\u73b0\u6709 GUI \u811a\u672c"
     }
   ],
   "docs_events": [
@@ -148,6 +202,66 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-06-28T20:57:37.355984Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T20:57:37.367726Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T20:57:37.377946Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T20:57:37.388516Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T20:57:37.399160Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T20:57:37.410016Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T20:57:37.420041Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T20:57:37.430721Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T20:57:37.440858Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T20:57:37.454678Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -169,13 +283,16 @@
       "desktop/package.json",
       "desktop/preload-gate.js",
       "desktop/resources/alpha-gate.html",
+      "desktop/resources/alpha-public-key.pem",
       "desktop/test/activation.test.js",
+      "desktop/test/alpha-token.test.js",
       "docs/alpha-activation-gate.md",
+      "scripts/alpha-token-gui.js",
       "scripts/alpha-token.js"
     ],
-    "diff_fingerprint": "sha256:96d05dd1f226133ebfb1466e71edfd7490fdc88fbd9caf578ab1b7be284e9418",
+    "diff_fingerprint": "sha256:e90a79645f0f01ce8e7ec4c853d41c1abeecbd889200182ffe7730bbdc155024",
     "head": "HEAD",
-    "head_sha": "afac326f",
+    "head_sha": "945cd229",
     "surfaces": {
       "docs": 1,
       "frontend": 0,
@@ -185,7 +302,7 @@
       "packaging": 0,
       "protected_core": 0,
       "sentrux": 0,
-      "test": 1,
+      "test": 2,
       "workflow_ci": 0
     }
   },
@@ -196,6 +313,14 @@
     {
       "at": "2026-06-28T20:38:27.043625Z",
       "diff_fingerprint": "sha256:96d05dd1f226133ebfb1466e71edfd7490fdc88fbd9caf578ab1b7be284e9418",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-28T20:57:37.454711Z",
+      "diff_fingerprint": "sha256:e90a79645f0f01ce8e7ec4c853d41c1abeecbd889200182ffe7730bbdc155024",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 2,
@@ -258,6 +383,12 @@
       "at": "2026-06-28T20:53:42.030482Z",
       "pattern": "scripts/**",
       "reason": "owner \u8981\u6c42\u53d1\u653e\u53f0\u8d26:GUI/CLI \u6bcf\u6b21\u7b7e\u53d1 token \u90fd\u8bb0\u5f55\u5230\u672c\u5730 CSV(\u65f6\u95f4/\u540d\u5b57/\u673a\u5668\u6307\u7eb9/token),\u4fbf\u4e8e\u7edf\u8ba1\u53d1\u4e86\u591a\u5c11"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-28T21:03:44.144298Z",
+      "pattern": "scripts/**",
+      "reason": "owner \u9009 B:\u4e0d\u505a\u72ec\u7acb Electron \u5305,\u6539\u4e3a\u6781\u5c0f\u7684\u53cc\u51fb\u542f\u52a8\u5668(.command)\u8fd0\u884c\u73b0\u6709 GUI \u811a\u672c"
     }
   ],
   "session_id": "945f4a8a-9e47-4c21-b82c-e4c9b522eb61",

--- a/.workflow/records/1848-guided-1848-alpha-activation-gate.json
+++ b/.workflow/records/1848-guided-1848-alpha-activation-gate.json
@@ -1,6 +1,56 @@
 {
   "branch": "guided/1848-alpha-activation-gate",
-  "check_events": [],
+  "check_events": [
+    {
+      "at": "2026-06-28T20:38:23.139602Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:8cc1c48bc0218a7f6207cc84e1dc81f3818c9fc43441cc2bd34f0e62787bb4b9",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-28T20:38:26.890664Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:f5279c7c319a84c4c8bc7d62f4204b261b8936cd6f5ca8352d18ebb693cb594c",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-28T20:38:26.929263Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:49cef9f68c7f7c130aa16c0ce348ad16942517176fc26adb0c67941f4de5bba0",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    }
+  ],
   "check_na": [],
   "commit": null,
   "declared_scope": {
@@ -15,6 +65,16 @@
       "at": "2026-06-28T20:37:17.288355Z",
       "owner_directive": "\u5b9e\u73b0\u79bb\u7ebf\u7b7e\u540d\u6fc0\u6d3b\u95f8\u95e8:desktop activation \u6a21\u5757 + \u6fc0\u6d3b\u7a97\u53e3 GUI + \u5f00\u53d1\u8005\u7b7e\u53d1 CLI + \u6d4b\u8bd5 + \u6587\u6863\u3002Mac/Windows \u673a\u5668\u6307\u7eb9\u3002",
       "reason": "plan"
+    },
+    {
+      "at": "2026-06-28T20:45:06.961034Z",
+      "owner_directive": "\u7ed9\u79c1\u94a5\u7b7e\u53d1\u5de5\u5177\u505a\u4e00\u4e2a\u6781\u7b80 GUI \u65b9\u4fbf\u4f7f\u7528",
+      "reason": "owner \u8981\u6c42\u7ed9\u5f00\u53d1\u8005\u7b7e\u53d1\u5de5\u5177\u505a\u4e00\u4e2a\u6781\u7b80 GUI,\u65b9\u4fbf\u65e5\u5e38\u7b7e\u53d1 token"
+    },
+    {
+      "at": "2026-06-28T20:53:42.030244Z",
+      "owner_directive": "\u7ed9 GUI \u52a0\u4e00\u4e2a\u628a\u6240\u6709\u7b7e\u53d1\u7684 token \u548c\u673a\u5668\u6307\u7eb9\u8bb0\u5230 CSV \u7684\u529f\u80fd,\u65b9\u4fbf\u77e5\u9053\u53d1\u4e86\u591a\u5c11\u4e2a token",
+      "reason": "owner \u8981\u6c42\u53d1\u653e\u53f0\u8d26:GUI/CLI \u6bcf\u6b21\u7b7e\u53d1 token \u90fd\u8bb0\u5f55\u5230\u672c\u5730 CSV(\u65f6\u95f4/\u540d\u5b57/\u673a\u5668\u6307\u7eb9/token),\u4fbf\u4e8e\u7edf\u8ba1\u53d1\u4e86\u591a\u5c11"
     }
   ],
   "docs_events": [
@@ -28,7 +88,68 @@
     }
   ],
   "governance_touch": false,
-  "guard_events": [],
+  "guard_events": [
+    {
+      "at": "2026-06-28T20:38:26.955400Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T20:38:26.966371Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T20:38:26.976556Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T20:38:26.986104Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T20:38:26.995452Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T20:38:27.004677Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T20:38:27.013464Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T20:38:27.022939Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T20:38:27.032345Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T20:38:27.043590Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
   "issues": [
     {
       "close_in_pr": true,
@@ -38,18 +159,71 @@
     }
   ],
   "observed_admin_labels": [],
-  "observed_diff": null,
+  "observed_diff": {
+    "base": "origin/main",
+    "base_sha": "faa9fa38",
+    "changed_files": [
+      ".workflow/records/1848-guided-1848-alpha-activation-gate.json",
+      "desktop/activation.js",
+      "desktop/main.js",
+      "desktop/package.json",
+      "desktop/preload-gate.js",
+      "desktop/resources/alpha-gate.html",
+      "desktop/test/activation.test.js",
+      "docs/alpha-activation-gate.md",
+      "scripts/alpha-token.js"
+    ],
+    "diff_fingerprint": "sha256:96d05dd1f226133ebfb1466e71edfd7490fdc88fbd9caf578ab1b7be284e9418",
+    "head": "HEAD",
+    "head_sha": "afac326f",
+    "surfaces": {
+      "docs": 1,
+      "frontend": 0,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 0,
+      "packaging": 0,
+      "protected_core": 0,
+      "sentrux": 0,
+      "test": 1,
+      "workflow_ci": 0
+    }
+  },
   "owner_directive": "\u9632\u6b62 alpha tester \u672a\u7ecf\u5141\u8bb8\u4f20\u64ad\u6784\u5efa:\u79bb\u7ebf\u96f6\u670d\u52a1\u5668\u3001\u6bcf\u673a\u4e00\u7801\u7684\u6fc0\u6d3b\u95f8\u95e8\u2014\u2014\u6ca1\u6709\u5408\u6cd5 token \u5c31\u6253\u4e0d\u5f00 app\u3002GUI:\u63d0\u793a\u6587\u5b57+\u673a\u5668\u6307\u7eb9(\u5e26\u590d\u5236)+token\u8f93\u5165\u6846+\u6fc0\u6d3b\u6309\u94ae\u3002Mac+Windows \u90fd\u652f\u6301\u3002alpha \u4e34\u65f6\u6a21\u5757,beta \u6574\u4f53\u5220\u9664\u3002",
   "persona": "live_implementer",
   "pull_request": null,
-  "reconcile_events": [],
+  "reconcile_events": [
+    {
+      "at": "2026-06-28T20:38:27.043625Z",
+      "diff_fingerprint": "sha256:96d05dd1f226133ebfb1466e71edfd7490fdc88fbd9caf578ab1b7be284e9418",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    }
+  ],
   "record_id": "1848-guided-1848-alpha-activation-gate",
   "requested_admin_labels": [],
   "required_obligations": {
     "admin_labels": [],
-    "checks": [],
+    "checks": [
+      "format_check",
+      "full_audit",
+      "lint_format"
+    ],
     "docs": [],
-    "guards": [],
+    "guards": [
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
     "tests": []
   },
   "runtime": "claude-code",
@@ -72,10 +246,22 @@
       "at": "2026-06-28T20:37:17.288537Z",
       "pattern": "docs/alpha-activation-gate.md",
       "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-28T20:45:06.961148Z",
+      "pattern": "scripts/**",
+      "reason": "owner \u8981\u6c42\u7ed9\u5f00\u53d1\u8005\u7b7e\u53d1\u5de5\u5177\u505a\u4e00\u4e2a\u6781\u7b80 GUI,\u65b9\u4fbf\u65e5\u5e38\u7b7e\u53d1 token"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-28T20:53:42.030482Z",
+      "pattern": "scripts/**",
+      "reason": "owner \u8981\u6c42\u53d1\u653e\u53f0\u8d26:GUI/CLI \u6bcf\u6b21\u7b7e\u53d1 token \u90fd\u8bb0\u5f55\u5230\u672c\u5730 CSV(\u65f6\u95f4/\u540d\u5b57/\u673a\u5668\u6307\u7eb9/token),\u4fbf\u4e8e\u7edf\u8ba1\u53d1\u4e86\u591a\u5c11"
     }
   ],
   "session_id": "945f4a8a-9e47-4c21-b82c-e4c9b522eb61",
-  "strictness_tier": null,
+  "strictness_tier": 2,
   "task_kind": "guided",
   "test_events": [
     {

--- a/.workflow/records/1848-guided-1848-alpha-activation-gate.json
+++ b/.workflow/records/1848-guided-1848-alpha-activation-gate.json
@@ -147,13 +147,28 @@
       "tool_versions": {
         "ruff": "0.15.15"
       }
+    },
+    {
+      "at": "2026-06-28T21:45:08.847212Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:a50bccf2195d7cf04cc14eb9f57c9e6b1c36981eb0186d024c8ee90b8d289300",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
     }
   ],
   "check_na": [],
   "commit": {
-    "sha": "9fdefd1a358778a15c5467324f67ec72a521d019",
+    "sha": "06a19688be211d1a0119f0e237c521ecc221353b",
     "shas": [
-      "9fdefd1a358778a15c5467324f67ec72a521d019"
+      "06a19688be211d1a0119f0e237c521ecc221353b"
     ],
     "trailers": []
   },
@@ -562,6 +577,126 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:45:08.869529Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:45:08.878223Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:45:08.887335Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:45:08.895929Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:45:08.904274Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:45:08.912631Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:45:08.921182Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:45:08.930001Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:45:08.939143Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:45:08.953089Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:45:20.093304Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:45:20.103932Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:45:20.114051Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:45:20.124319Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:45:20.134284Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:45:20.144455Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:45:20.154271Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:45:20.164286Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:45:20.174267Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:45:20.188886Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -592,9 +727,9 @@
       "scripts/alpha-token.js",
       "scripts/build-issuer-app.sh"
     ],
-    "diff_fingerprint": "sha256:5f5f06bcc298bcf0ea6d9d5f31a189d123fa132fe1337fc915889bb380842d3c",
+    "diff_fingerprint": "sha256:261e215ccb206dd9e1bac378e905259df3c7bbfe28999946772ee554bb55146b",
     "head": "HEAD",
-    "head_sha": "9fdefd1a",
+    "head_sha": "06a19688",
     "surfaces": {
       "docs": 1,
       "frontend": 0,
@@ -662,6 +797,22 @@
     {
       "at": "2026-06-28T21:31:08.312735Z",
       "diff_fingerprint": "sha256:5f5f06bcc298bcf0ea6d9d5f31a189d123fa132fe1337fc915889bb380842d3c",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-28T21:45:08.953123Z",
+      "diff_fingerprint": "sha256:261e215ccb206dd9e1bac378e905259df3c7bbfe28999946772ee554bb55146b",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-28T21:45:20.188915Z",
+      "diff_fingerprint": "sha256:261e215ccb206dd9e1bac378e905259df3c7bbfe28999946772ee554bb55146b",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 2,

--- a/.workflow/records/1848-guided-1848-alpha-activation-gate.json
+++ b/.workflow/records/1848-guided-1848-alpha-activation-gate.json
@@ -98,10 +98,65 @@
       "tool_versions": {
         "ruff": "0.15.15"
       }
+    },
+    {
+      "at": "2026-06-28T21:30:14.484467Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:4f40eaffb45cfe5da73c4ab679a2e4c2a67a559b753117c50b2544307ec43afb",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-28T21:30:18.492828Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:a2005b3cc4d233f19d188e83088754f286696b109a12004d276331609cf34526",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-28T21:30:18.511804Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:9fb00109befc81c33e48c971f421dbd1f248ee5ab1c767e6fd6da8d4aa908f78",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
     }
   ],
   "check_na": [],
-  "commit": null,
+  "commit": {
+    "sha": "9fdefd1a358778a15c5467324f67ec72a521d019",
+    "shas": [
+      "9fdefd1a358778a15c5467324f67ec72a521d019"
+    ],
+    "trailers": []
+  },
   "declared_scope": {
     "exclude": [],
     "include": [
@@ -129,6 +184,11 @@
       "at": "2026-06-28T21:03:44.144101Z",
       "owner_directive": "\u7b7e\u53d1\u5de5\u5177\u4e0d\u9700\u8981\u72ec\u7acb dmg,\u505a\u4e2a\u8f7b\u91cf\u53cc\u51fb\u542f\u52a8\u5668\u5c31\u884c(B)",
       "reason": "owner \u9009 B:\u4e0d\u505a\u72ec\u7acb Electron \u5305,\u6539\u4e3a\u6781\u5c0f\u7684\u53cc\u51fb\u542f\u52a8\u5668(.command)\u8fd0\u884c\u73b0\u6709 GUI \u811a\u672c"
+    },
+    {
+      "at": "2026-06-28T21:22:04.965126Z",
+      "owner_directive": "\u7b7e\u53d1\u5668\u505a\u6210\u684c\u9762\u53cc\u51fb\u6253\u5f00\u7684 .app,\u4e0d\u7528 electron",
+      "reason": "owner \u60f3\u8981\u684c\u9762\u53ef\u53cc\u51fb\u7684 .app(\u975e electron)\u8fd0\u884c\u7b7e\u53d1\u5668:\u52a0\u4e00\u4e2a\u7ec4\u88c5\u811a\u672c\u751f\u6210\u81ea\u5305\u542b .app + GUI \u52a0 Quit/\u5df2\u8fd0\u884c\u68c0\u6d4b"
     }
   ],
   "docs_events": [
@@ -262,6 +322,246 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:30:18.536840Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:30:18.547520Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:30:18.557840Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:30:18.567988Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:30:18.578484Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:30:18.589302Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:30:18.599705Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:30:18.609898Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:30:18.619644Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:30:18.633899Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:30:26.864647Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:30:26.874323Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:30:26.883474Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:30:26.894420Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:30:26.903445Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:30:26.912478Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:30:26.921170Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:30:26.930401Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:30:26.939476Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:30:26.953650Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:30:58.238147Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:30:58.247843Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:30:58.257493Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:30:58.267266Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:30:58.276925Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:30:58.286415Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:30:58.296096Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:30:58.306049Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:30:58.316063Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:30:58.329802Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:31:08.230835Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:31:08.239584Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:31:08.248188Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:31:08.256927Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:31:08.265923Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:31:08.274643Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:31:08.283093Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:31:08.291860Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:31:08.300146Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T21:31:08.312702Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -274,7 +574,7 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "origin/main",
+    "base": "faa9fa3803c4580f954a5a12985c138fb27b4709",
     "base_sha": "faa9fa38",
     "changed_files": [
       ".workflow/records/1848-guided-1848-alpha-activation-gate.json",
@@ -288,11 +588,13 @@
       "desktop/test/alpha-token.test.js",
       "docs/alpha-activation-gate.md",
       "scripts/alpha-token-gui.js",
-      "scripts/alpha-token.js"
+      "scripts/alpha-token-issuer.command",
+      "scripts/alpha-token.js",
+      "scripts/build-issuer-app.sh"
     ],
-    "diff_fingerprint": "sha256:e90a79645f0f01ce8e7ec4c853d41c1abeecbd889200182ffe7730bbdc155024",
+    "diff_fingerprint": "sha256:5f5f06bcc298bcf0ea6d9d5f31a189d123fa132fe1337fc915889bb380842d3c",
     "head": "HEAD",
-    "head_sha": "945cd229",
+    "head_sha": "9fdefd1a",
     "surfaces": {
       "docs": 1,
       "frontend": 0,
@@ -308,7 +610,14 @@
   },
   "owner_directive": "\u9632\u6b62 alpha tester \u672a\u7ecf\u5141\u8bb8\u4f20\u64ad\u6784\u5efa:\u79bb\u7ebf\u96f6\u670d\u52a1\u5668\u3001\u6bcf\u673a\u4e00\u7801\u7684\u6fc0\u6d3b\u95f8\u95e8\u2014\u2014\u6ca1\u6709\u5408\u6cd5 token \u5c31\u6253\u4e0d\u5f00 app\u3002GUI:\u63d0\u793a\u6587\u5b57+\u673a\u5668\u6307\u7eb9(\u5e26\u590d\u5236)+token\u8f93\u5165\u6846+\u6fc0\u6d3b\u6309\u94ae\u3002Mac+Windows \u90fd\u652f\u6301\u3002alpha \u4e34\u65f6\u6a21\u5757,beta \u6574\u4f53\u5220\u9664\u3002",
   "persona": "live_implementer",
-  "pull_request": null,
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [
+      1848
+    ],
+    "number": 1852,
+    "url": "https://github.com/jiazhenz026/SciStudio/pull/1852"
+  },
   "reconcile_events": [
     {
       "at": "2026-06-28T20:38:27.043625Z",
@@ -321,6 +630,38 @@
     {
       "at": "2026-06-28T20:57:37.454711Z",
       "diff_fingerprint": "sha256:e90a79645f0f01ce8e7ec4c853d41c1abeecbd889200182ffe7730bbdc155024",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-28T21:30:18.633944Z",
+      "diff_fingerprint": "sha256:5f5f06bcc298bcf0ea6d9d5f31a189d123fa132fe1337fc915889bb380842d3c",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-28T21:30:26.953688Z",
+      "diff_fingerprint": "sha256:5f5f06bcc298bcf0ea6d9d5f31a189d123fa132fe1337fc915889bb380842d3c",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-28T21:30:58.329832Z",
+      "diff_fingerprint": "sha256:5f5f06bcc298bcf0ea6d9d5f31a189d123fa132fe1337fc915889bb380842d3c",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-28T21:31:08.312735Z",
+      "diff_fingerprint": "sha256:5f5f06bcc298bcf0ea6d9d5f31a189d123fa132fe1337fc915889bb380842d3c",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 2,
@@ -389,6 +730,12 @@
       "at": "2026-06-28T21:03:44.144298Z",
       "pattern": "scripts/**",
       "reason": "owner \u9009 B:\u4e0d\u505a\u72ec\u7acb Electron \u5305,\u6539\u4e3a\u6781\u5c0f\u7684\u53cc\u51fb\u542f\u52a8\u5668(.command)\u8fd0\u884c\u73b0\u6709 GUI \u811a\u672c"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-28T21:22:04.965319Z",
+      "pattern": "scripts/**",
+      "reason": "owner \u60f3\u8981\u684c\u9762\u53ef\u53cc\u51fb\u7684 .app(\u975e electron)\u8fd0\u884c\u7b7e\u53d1\u5668:\u52a0\u4e00\u4e2a\u7ec4\u88c5\u811a\u672c\u751f\u6210\u81ea\u5305\u542b .app + GUI \u52a0 Quit/\u5df2\u8fd0\u884c\u68c0\u6d4b"
     }
   ],
   "session_id": "945f4a8a-9e47-4c21-b82c-e4c9b522eb61",

--- a/desktop/activation.js
+++ b/desktop/activation.js
@@ -1,0 +1,211 @@
+// #1848: Alpha activation gate (offline, zero-server, per-machine token).
+//
+// Goal: stop alpha testers from redistributing the build to unauthorized
+// people. The installer/dmg itself never expires and may be reused; the gate is
+// a per-machine activation token. Without a valid token the app does not open.
+//
+// Trust model (Option C — offline signed token):
+//   - The developer holds an Ed25519 private signing key (outside the repo).
+//   - The matching public key ships in the build (resources/alpha-public-key.pem).
+//   - A token binds to one machine fingerprint and is signed with the private
+//     key. The app verifies the signature and that the bound fingerprint equals
+//     this machine's fingerprint. A forwarded copy fails on a different machine.
+//
+// This whole module is ALPHA-ONLY and is removed in beta. See issue #1848 for
+// the removal checklist.
+//
+// Token format (shared with scripts/alpha-token.js):
+//   token       = base64url(payloadJson) + "." + base64url(ed25519Signature)
+//   signed bytes = utf8 bytes of the base64url(payloadJson) string
+//   payloadJson = {"v":1,"fp":"<sha256-hex>","name":<string|null>,"iat":<unix>}
+
+const crypto = require("crypto");
+const { execFileSync } = require("child_process");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+// --------------------------------------------------------------------------- //
+// Machine fingerprint (stable, cross-platform: macOS + Windows).
+// --------------------------------------------------------------------------- //
+
+// Best-effort stable per-machine identifier. macOS uses the IOPlatformUUID;
+// Windows uses the registry MachineGuid. Both survive app reinstalls. Falls back
+// to the hostname when the platform probe is unavailable so the gate still has
+// *some* binding rather than crashing.
+function rawMachineId() {
+  try {
+    if (process.platform === "darwin") {
+      const out = execFileSync("ioreg", ["-rd1", "-c", "IOPlatformExpertDevice"], {
+        encoding: "utf8",
+        timeout: 5000
+      });
+      const match = out.match(/"IOPlatformUUID"\s*=\s*"([^"]+)"/);
+      if (match && match[1]) {
+        return `mac:${match[1]}`;
+      }
+    } else if (process.platform === "win32") {
+      const out = execFileSync(
+        "reg",
+        ["query", "HKLM\\SOFTWARE\\Microsoft\\Cryptography", "/v", "MachineGuid"],
+        { encoding: "utf8", timeout: 5000 }
+      );
+      const match = out.match(/MachineGuid\s+REG_SZ\s+([A-Za-z0-9-]+)/i);
+      if (match && match[1]) {
+        return `win:${match[1]}`;
+      }
+    }
+  } catch {
+    // Fall through to the hostname-based fallback below.
+  }
+  return `host:${os.hostname()}`;
+}
+
+// Public fingerprint: a sha256 hex digest the tester copies and sends to the
+// developer. Hashing hides the raw machine id and yields a fixed-width string.
+function machineFingerprint() {
+  return crypto.createHash("sha256").update(`scistudio-alpha-v1:${rawMachineId()}`).digest("hex");
+}
+
+// --------------------------------------------------------------------------- //
+// Token verification.
+// --------------------------------------------------------------------------- //
+
+// Verify a token against a machine fingerprint using the shipped public key.
+// Returns { ok, reason, payload }. `reason` is a short machine-readable tag the
+// gate UI maps to human text. Never throws.
+function verifyToken(token, fingerprint, publicKeyPem) {
+  if (!token || typeof token !== "string") {
+    return { ok: false, reason: "empty" };
+  }
+  if (!publicKeyPem) {
+    return { ok: false, reason: "not-configured" };
+  }
+  const parts = token.trim().split(".");
+  if (parts.length !== 2 || !parts[0] || !parts[1]) {
+    return { ok: false, reason: "malformed" };
+  }
+
+  let keyObject;
+  try {
+    keyObject = crypto.createPublicKey(publicKeyPem);
+  } catch {
+    return { ok: false, reason: "bad-key" };
+  }
+
+  const message = Buffer.from(parts[0], "utf8");
+  const signature = Buffer.from(parts[1], "base64url");
+
+  let signatureValid = false;
+  try {
+    // Ed25519: algorithm is null; the key carries the curve.
+    signatureValid = crypto.verify(null, message, keyObject, signature);
+  } catch {
+    return { ok: false, reason: "verify-error" };
+  }
+  if (!signatureValid) {
+    return { ok: false, reason: "bad-signature" };
+  }
+
+  let payload;
+  try {
+    payload = JSON.parse(Buffer.from(parts[0], "base64url").toString("utf8"));
+  } catch {
+    return { ok: false, reason: "malformed" };
+  }
+  if (!payload || typeof payload !== "object" || payload.fp !== fingerprint) {
+    return { ok: false, reason: "wrong-machine", payload };
+  }
+  return { ok: true, reason: "ok", payload };
+}
+
+// --------------------------------------------------------------------------- //
+// Public key + stored activation.
+// --------------------------------------------------------------------------- //
+
+// Resolve the shipped Ed25519 public key. An env override (SCISTUDIO_ALPHA_PUBKEY,
+// with literal "\n" allowed for one-line values) wins so a packaged build can be
+// tested without a rebuild. Returns the PEM string or null when not configured.
+function loadPublicKeyPem(resourcesDir) {
+  const inline = (process.env.SCISTUDIO_ALPHA_PUBKEY || "").trim();
+  if (inline) {
+    return inline.replace(/\\n/g, "\n");
+  }
+  try {
+    return fs.readFileSync(path.join(resourcesDir, "alpha-public-key.pem"), "utf8");
+  } catch {
+    return null;
+  }
+}
+
+function activationFilePath(userDataDir) {
+  return path.join(userDataDir, "alpha-activation.json");
+}
+
+function readStoredToken(userDataDir) {
+  try {
+    const data = JSON.parse(fs.readFileSync(activationFilePath(userDataDir), "utf8"));
+    return typeof data.token === "string" ? data.token : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeStoredToken(userDataDir, token, payload) {
+  const file = activationFilePath(userDataDir);
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  const tmp = `${file}.${process.pid}.tmp`;
+  fs.writeFileSync(
+    tmp,
+    JSON.stringify(
+      {
+        token,
+        name: (payload && payload.name) || null,
+        activated_at: new Date().toISOString()
+      },
+      null,
+      2
+    )
+  );
+  fs.renameSync(tmp, file);
+}
+
+// Is this machine already activated? Re-verifies the stored token every launch
+// so a token copied to another machine (different fingerprint) is rejected.
+function checkActivation({ userDataDir, fingerprint, publicKeyPem }) {
+  const token = readStoredToken(userDataDir);
+  if (!token) {
+    return { activated: false, reason: "no-token" };
+  }
+  const result = verifyToken(token, fingerprint, publicKeyPem);
+  return { activated: result.ok, reason: result.reason, payload: result.payload };
+}
+
+// --------------------------------------------------------------------------- //
+// Gate flag.
+// --------------------------------------------------------------------------- //
+
+// Whether the activation gate is active. SCISTUDIO_ALPHA_GATE forces it on/off;
+// otherwise it gates packaged builds (real dmg/installer) and is skipped in dev
+// so a source checkout is never locked out.
+function gateEnabled(isPackaged) {
+  const raw = (process.env.SCISTUDIO_ALPHA_GATE || "").trim().toLowerCase();
+  if (raw === "1" || raw === "true" || raw === "on") {
+    return true;
+  }
+  if (raw === "0" || raw === "false" || raw === "off") {
+    return false;
+  }
+  return Boolean(isPackaged);
+}
+
+module.exports = {
+  machineFingerprint,
+  verifyToken,
+  loadPublicKeyPem,
+  activationFilePath,
+  readStoredToken,
+  writeStoredToken,
+  checkActivation,
+  gateEnabled
+};

--- a/desktop/activation.js
+++ b/desktop/activation.js
@@ -123,13 +123,17 @@ function verifyToken(token, fingerprint, publicKeyPem) {
 // Public key + stored activation.
 // --------------------------------------------------------------------------- //
 
-// Resolve the shipped Ed25519 public key. An env override (SCISTUDIO_ALPHA_PUBKEY,
-// with literal "\n" allowed for one-line values) wins so a packaged build can be
-// tested without a rebuild. Returns the PEM string or null when not configured.
-function loadPublicKeyPem(resourcesDir) {
-  const inline = (process.env.SCISTUDIO_ALPHA_PUBKEY || "").trim();
-  if (inline) {
-    return inline.replace(/\\n/g, "\n");
+// Resolve the shipped Ed25519 public key. The SCISTUDIO_ALPHA_PUBKEY env override
+// (literal "\n" allowed for one-line values) is honored ONLY in dev/test builds:
+// in a packaged build a recipient could otherwise supply their own public key and
+// mint tokens for their own machine, defeating the per-machine model (#1848).
+// Returns the PEM string or null when not configured.
+function loadPublicKeyPem(resourcesDir, isPackaged) {
+  if (!isPackaged) {
+    const inline = (process.env.SCISTUDIO_ALPHA_PUBKEY || "").trim();
+    if (inline) {
+      return inline.replace(/\\n/g, "\n");
+    }
   }
   try {
     return fs.readFileSync(path.join(resourcesDir, "alpha-public-key.pem"), "utf8");
@@ -185,18 +189,17 @@ function checkActivation({ userDataDir, fingerprint, publicKeyPem }) {
 // Gate flag.
 // --------------------------------------------------------------------------- //
 
-// Whether the activation gate is active. SCISTUDIO_ALPHA_GATE forces it on/off;
-// otherwise it gates packaged builds (real dmg/installer) and is skipped in dev
-// so a source checkout is never locked out.
+// Whether the activation gate is active. Packaged builds (real dmg/installer)
+// ALWAYS require activation — there is deliberately no env bypass, or a
+// redistributed copy could be launched with SCISTUDIO_ALPHA_GATE=0 to skip the
+// gate entirely (#1848). In dev (non-packaged) the gate is off so a source
+// checkout is never locked out, but it can be opted in to exercise it locally.
 function gateEnabled(isPackaged) {
-  const raw = (process.env.SCISTUDIO_ALPHA_GATE || "").trim().toLowerCase();
-  if (raw === "1" || raw === "true" || raw === "on") {
+  if (isPackaged) {
     return true;
   }
-  if (raw === "0" || raw === "false" || raw === "off") {
-    return false;
-  }
-  return Boolean(isPackaged);
+  const raw = (process.env.SCISTUDIO_ALPHA_GATE || "").trim().toLowerCase();
+  return raw === "1" || raw === "true" || raw === "on";
 }
 
 module.exports = {

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -35,6 +35,10 @@ const OTA_MAX_REDIRECTS = 5;
 let mainWindow = null;
 let runtimeProcess = null;
 let isQuitting = false;
+// #1848: true from app-ready until the main window exists. The activation gate is
+// the only window during this span; closing it must NOT trigger the
+// window-all-closed quit before the main window is created.
+let startingUp = false;
 let cachedMacLoginShellEnv = null;
 
 function installPipeGuard(stream) {
@@ -1145,7 +1149,7 @@ async function ensureAlphaActivation() {
     return true;
   }
   const fingerprint = activation.machineFingerprint();
-  const publicKeyPem = activation.loadPublicKeyPem(resourcesDir());
+  const publicKeyPem = activation.loadPublicKeyPem(resourcesDir(), app.isPackaged);
   const userDataDir = app.getPath("userData");
   const status = activation.checkActivation({ userDataDir, fingerprint, publicKeyPem });
   if (status.activated) {
@@ -1160,7 +1164,10 @@ app.whenReady().then(async () => {
   try {
     safeLog("[scistudio] electron ready");
     // #1848: alpha gate — do not start the runtime or main window until the
-    // machine is activated. Quitting the gate quits the app.
+    // machine is activated. Quitting the gate quits the app. Guard the
+    // window-all-closed quit until the main window exists, so closing the gate
+    // window after a successful activation does not race startup into a quit.
+    startingUp = true;
     const activated = await ensureAlphaActivation();
     if (!activated) {
       safeLog("[scistudio] alpha activation not completed; quitting");
@@ -1177,6 +1184,7 @@ app.whenReady().then(async () => {
     const url = launchUrl(ready.url);
     safeLog(`[scistudio] creating window for ${url}`);
     createWindow(url);
+    startingUp = false;
     // #1775: check for an OTA update after the window is up so startup is never
     // blocked on the network. Fire-and-forget; failures are logged, not fatal.
     maybeCheckForUpdate().catch((error) => {
@@ -1200,6 +1208,12 @@ app.on("before-quit", () => {
 });
 
 app.on("window-all-closed", () => {
+  // #1848: while the activation gate is up (before the main window exists),
+  // closing it must not quit the app — startup is still bringing the runtime and
+  // main window online.
+  if (startingUp) {
+    return;
+  }
   app.quit();
 });
 

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -1,4 +1,4 @@
-const { app, BrowserWindow, dialog, ipcMain, session } = require("electron");
+const { app, BrowserWindow, dialog, ipcMain, session, clipboard } = require("electron");
 const { spawn, spawnSync } = require("child_process");
 const crypto = require("crypto");
 const fs = require("fs");
@@ -9,6 +9,8 @@ const path = require("path");
 const readline = require("readline");
 
 const ota = require("./ota");
+// #1848: alpha-only activation gate. Removed in beta (see issue #1848).
+const activation = require("./activation");
 
 // #1784: the in-app Package Manager stages a package update on disk (into the
 // scanned installed-packages dir) and then asks the main process to relaunch so
@@ -1049,9 +1051,122 @@ function stopRuntime() {
   }, 5000).unref();
 }
 
+// --------------------------------------------------------------------------- //
+// #1848: alpha activation gate. Block startup until a valid per-machine token is
+// present so a redistributed copy cannot be opened. ALPHA-ONLY; remove the gate
+// window, the IPC handlers, the ensureAlphaActivation() call, and the
+// ./activation + ./preload-gate + resources/alpha-gate.html files in beta.
+// --------------------------------------------------------------------------- //
+
+// Show the activation gate window and resolve true once the machine is
+// activated, or false if the user quits the gate. The IPC handlers are scoped to
+// the gate's lifetime and removed on close.
+function runActivationGate(ctx) {
+  return new Promise((resolve) => {
+    let settled = false;
+
+    const gateWindow = new BrowserWindow({
+      width: 640,
+      height: 600,
+      resizable: false,
+      fullscreenable: false,
+      maximizable: false,
+      title: "SciStudio — Alpha Activation",
+      icon: appIconPath(),
+      backgroundColor: "#f7f8fb",
+      webPreferences: {
+        contextIsolation: true,
+        nodeIntegration: false,
+        sandbox: true,
+        preload: path.join(__dirname, "preload-gate.js")
+      }
+    });
+
+    const cleanup = () => {
+      ipcMain.removeHandler("scistudio:alpha-gate-info");
+      ipcMain.removeHandler("scistudio:alpha-activate");
+      ipcMain.removeHandler("scistudio:alpha-copy");
+      ipcMain.removeHandler("scistudio:alpha-quit");
+    };
+
+    const finish = (ok) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanup();
+      if (!gateWindow.isDestroyed()) {
+        gateWindow.removeAllListeners("closed");
+        gateWindow.close();
+      }
+      resolve(ok);
+    };
+
+    ipcMain.handle("scistudio:alpha-gate-info", () => ({
+      fingerprint: ctx.fingerprint,
+      configured: Boolean(ctx.publicKeyPem)
+    }));
+
+    ipcMain.handle("scistudio:alpha-copy", (_event, text) => {
+      clipboard.writeText(String(text || ""));
+      return true;
+    });
+
+    ipcMain.handle("scistudio:alpha-quit", () => {
+      finish(false);
+      return true;
+    });
+
+    ipcMain.handle("scistudio:alpha-activate", (_event, token) => {
+      const result = activation.verifyToken(String(token || ""), ctx.fingerprint, ctx.publicKeyPem);
+      if (!result.ok) {
+        return { ok: false, reason: result.reason };
+      }
+      try {
+        activation.writeStoredToken(ctx.userDataDir, String(token).trim(), result.payload);
+      } catch (error) {
+        safeError(`[scistudio] failed to persist activation: ${error.message}`);
+      }
+      safeLog("[scistudio] alpha activation succeeded");
+      // Let the renderer paint the success message before tearing down.
+      setTimeout(() => finish(true), 500);
+      return { ok: true };
+    });
+
+    gateWindow.on("closed", () => finish(false));
+    gateWindow.loadFile(path.join(resourcesDir(), "alpha-gate.html"));
+  });
+}
+
+// Returns true when the app may proceed to launch. When the gate is enabled and
+// this machine is not yet activated, shows the gate window and waits.
+async function ensureAlphaActivation() {
+  if (!activation.gateEnabled(app.isPackaged)) {
+    return true;
+  }
+  const fingerprint = activation.machineFingerprint();
+  const publicKeyPem = activation.loadPublicKeyPem(resourcesDir());
+  const userDataDir = app.getPath("userData");
+  const status = activation.checkActivation({ userDataDir, fingerprint, publicKeyPem });
+  if (status.activated) {
+    safeLog("[scistudio] alpha activation: valid token for this machine");
+    return true;
+  }
+  safeLog(`[scistudio] alpha activation required (${status.reason}); showing gate`);
+  return runActivationGate({ fingerprint, publicKeyPem, userDataDir });
+}
+
 app.whenReady().then(async () => {
   try {
     safeLog("[scistudio] electron ready");
+    // #1848: alpha gate — do not start the runtime or main window until the
+    // machine is activated. Quitting the gate quits the app.
+    const activated = await ensureAlphaActivation();
+    if (!activated) {
+      safeLog("[scistudio] alpha activation not completed; quitting");
+      app.quit();
+      return;
+    }
     const { ready } = await startRuntimeWithRollback();
     safeLog(`[scistudio] waiting for HTTP readiness at ${ready.url}`);
     await waitForHttpReady(ready.url);

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -35,6 +35,8 @@
       "main.js",
       "ota.js",
       "preload.js",
+      "activation.js",
+      "preload-gate.js",
       "package.json",
       "assets/icon.png"
     ],

--- a/desktop/preload-gate.js
+++ b/desktop/preload-gate.js
@@ -1,0 +1,14 @@
+// #1848: preload for the alpha activation gate window (resources/alpha-gate.html).
+// Alpha-only; removed in beta together with the rest of the gate.
+const { contextBridge, ipcRenderer } = require("electron");
+
+contextBridge.exposeInMainWorld("scistudioAlphaGate", {
+  // Machine fingerprint + whether a public key is configured in this build.
+  getInfo: () => ipcRenderer.invoke("scistudio:alpha-gate-info"),
+  // Verify + persist a pasted token. Resolves { ok, reason }.
+  activate: (token) => ipcRenderer.invoke("scistudio:alpha-activate", token),
+  // Copy the fingerprint to the clipboard via the main process.
+  copy: (text) => ipcRenderer.invoke("scistudio:alpha-copy", text),
+  // Give up and quit the app.
+  quit: () => ipcRenderer.invoke("scistudio:alpha-quit")
+});

--- a/desktop/resources/alpha-gate.html
+++ b/desktop/resources/alpha-gate.html
@@ -1,0 +1,186 @@
+<!doctype html>
+<!-- #1848: alpha activation gate UI. Alpha-only; removed in beta. -->
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline';" />
+    <title>SciStudio — Alpha Activation</title>
+    <style>
+      :root {
+        --bg: #f7f8fb;
+        --fg: #1f2533;
+        --muted: #6b7280;
+        --border: #d7dbe3;
+        --accent: #2f6df6;
+        --accent-fg: #ffffff;
+        --error: #c0392b;
+        --success: #1e8e4e;
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        padding: 28px 32px;
+        font-family: -apple-system, "Segoe UI", system-ui, sans-serif;
+        background: var(--bg);
+        color: var(--fg);
+        font-size: 14px;
+        line-height: 1.5;
+        user-select: none;
+      }
+      h1 { font-size: 18px; margin: 0 0 6px; }
+      p.lead { margin: 0 0 18px; color: var(--muted); }
+      ol { margin: 0 0 18px; padding-left: 20px; color: var(--muted); }
+      ol li { margin-bottom: 4px; }
+      label { display: block; font-weight: 600; margin: 0 0 6px; }
+      .field { margin-bottom: 18px; }
+      .row { display: flex; gap: 8px; align-items: stretch; }
+      input[type="text"], textarea {
+        width: 100%;
+        font-family: ui-monospace, "SF Mono", "Consolas", monospace;
+        font-size: 12px;
+        padding: 9px 10px;
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        background: #fff;
+        color: var(--fg);
+        user-select: text;
+      }
+      input[type="text"][readonly] { background: #eef1f6; color: var(--muted); }
+      textarea { resize: vertical; min-height: 70px; }
+      button {
+        font-size: 14px;
+        font-weight: 600;
+        padding: 9px 16px;
+        border-radius: 8px;
+        border: 1px solid var(--border);
+        background: #fff;
+        color: var(--fg);
+        cursor: pointer;
+        white-space: nowrap;
+      }
+      button:hover { background: #f0f2f7; }
+      button.primary { background: var(--accent); color: var(--accent-fg); border-color: var(--accent); }
+      button.primary:hover { background: #2a61dc; }
+      button.primary:disabled { opacity: 0.5; cursor: default; }
+      .actions { display: flex; gap: 10px; align-items: center; margin-top: 6px; }
+      .status { min-height: 20px; font-size: 13px; }
+      .status.error { color: var(--error); }
+      .status.success { color: var(--success); }
+      .link { background: none; border: none; color: var(--muted); padding: 6px 0; text-decoration: underline; cursor: pointer; font-weight: 400; font-size: 12px; }
+    </style>
+  </head>
+  <body>
+    <h1>SciStudio Alpha — Activation Required</h1>
+    <p class="lead">
+      This is a private alpha build. It is licensed to you and must not be shared
+      or redistributed. To unlock it on this computer, request an activation token
+      from the developer.
+    </p>
+    <ol>
+      <li>Copy your machine fingerprint below.</li>
+      <li>Send it to the developer and ask for an activation token.</li>
+      <li>Paste the token you receive and click <strong>Activate</strong>.</li>
+    </ol>
+
+    <div class="field">
+      <label for="fingerprint">Your machine fingerprint</label>
+      <div class="row">
+        <input id="fingerprint" type="text" readonly value="…" />
+        <button id="copy" type="button">Copy</button>
+      </div>
+    </div>
+
+    <div class="field">
+      <label for="token">Activation token</label>
+      <textarea id="token" placeholder="Paste the token from the developer here"></textarea>
+    </div>
+
+    <div class="actions">
+      <button id="activate" class="primary" type="button">Activate</button>
+      <span id="status" class="status"></span>
+    </div>
+
+    <button id="quit" class="link" type="button">Quit</button>
+
+    <script>
+      const api = window.scistudioAlphaGate;
+      const fingerprintEl = document.getElementById("fingerprint");
+      const tokenEl = document.getElementById("token");
+      const statusEl = document.getElementById("status");
+      const activateEl = document.getElementById("activate");
+      const copyEl = document.getElementById("copy");
+      let fingerprint = "";
+
+      function setStatus(message, kind) {
+        statusEl.textContent = message || "";
+        statusEl.className = "status" + (kind ? " " + kind : "");
+      }
+
+      function reasonText(reason) {
+        switch (reason) {
+          case "wrong-machine":
+            return "This token was issued for a different machine.";
+          case "not-configured":
+            return "Activation is not configured in this build. Contact the developer.";
+          case "empty":
+            return "Paste the activation token first.";
+          case "bad-signature":
+          case "malformed":
+          case "bad-key":
+          case "verify-error":
+          default:
+            return "Invalid activation token. Check that you pasted it completely.";
+        }
+      }
+
+      async function init() {
+        try {
+          const info = await api.getInfo();
+          fingerprint = info.fingerprint || "";
+          fingerprintEl.value = fingerprint;
+          if (!info.configured) {
+            activateEl.disabled = true;
+            setStatus(reasonText("not-configured"), "error");
+          }
+        } catch (err) {
+          setStatus("Could not read machine fingerprint.", "error");
+        }
+      }
+
+      copyEl.addEventListener("click", async () => {
+        await api.copy(fingerprint);
+        const original = copyEl.textContent;
+        copyEl.textContent = "Copied";
+        setTimeout(() => {
+          copyEl.textContent = original;
+        }, 1200);
+      });
+
+      activateEl.addEventListener("click", async () => {
+        const token = tokenEl.value.trim();
+        if (!token) {
+          setStatus(reasonText("empty"), "error");
+          return;
+        }
+        activateEl.disabled = true;
+        setStatus("Verifying…", "");
+        try {
+          const result = await api.activate(token);
+          if (result && result.ok) {
+            setStatus("Activated. Launching SciStudio…", "success");
+          } else {
+            setStatus(reasonText(result && result.reason), "error");
+            activateEl.disabled = false;
+          }
+        } catch (err) {
+          setStatus("Activation failed. Please try again.", "error");
+          activateEl.disabled = false;
+        }
+      });
+
+      document.getElementById("quit").addEventListener("click", () => api.quit());
+
+      init();
+    </script>
+  </body>
+</html>

--- a/desktop/resources/alpha-gate.html
+++ b/desktop/resources/alpha-gate.html
@@ -72,12 +72,12 @@
   <body>
     <h1>Activate SciStudio</h1>
     <p class="lead">
-      Copy your machine fingerprint and send it to the developer to get an activation token.<br />
+      Copy your registration code and send it to the developer to get an activation token.<br />
       Paste the token below and click Activate.
     </p>
 
     <div class="field">
-      <label for="fingerprint">Your machine fingerprint</label>
+      <label for="fingerprint">Your registration code</label>
       <div class="row">
         <input id="fingerprint" type="text" readonly value="…" />
         <button id="copy" type="button">Copy</button>

--- a/desktop/resources/alpha-gate.html
+++ b/desktop/resources/alpha-gate.html
@@ -70,17 +70,11 @@
     </style>
   </head>
   <body>
-    <h1>SciStudio Alpha — Activation Required</h1>
+    <h1>Activate SciStudio</h1>
     <p class="lead">
-      This is a private alpha build. It is licensed to you and must not be shared
-      or redistributed. To unlock it on this computer, request an activation token
-      from the developer.
+      Copy your machine fingerprint and send it to the developer to get an activation token.<br />
+      Paste the token below and click Activate.
     </p>
-    <ol>
-      <li>Copy your machine fingerprint below.</li>
-      <li>Send it to the developer and ask for an activation token.</li>
-      <li>Paste the token you receive and click <strong>Activate</strong>.</li>
-    </ol>
 
     <div class="field">
       <label for="fingerprint">Your machine fingerprint</label>

--- a/desktop/resources/alpha-public-key.pem
+++ b/desktop/resources/alpha-public-key.pem
@@ -1,0 +1,3 @@
+-----BEGIN PUBLIC KEY-----
+MCowBQYDK2VwAyEAf8ptW9+06dSbbeIj3U6Q9wjPHm6+OveDaGllCjdM1K8=
+-----END PUBLIC KEY-----

--- a/desktop/test/activation.test.js
+++ b/desktop/test/activation.test.js
@@ -81,22 +81,50 @@ test("verifyToken: empty / malformed / unconfigured", () => {
   assert.equal(activation.verifyToken("a.b", "x", null).reason, "not-configured");
 });
 
-test("gateEnabled: env override beats packaged default", () => {
+test("gateEnabled: packaged always on (no env bypass); dev opt-in only", () => {
   const prev = process.env.SCISTUDIO_ALPHA_GATE;
   try {
     delete process.env.SCISTUDIO_ALPHA_GATE;
-    assert.equal(activation.gateEnabled(true), true);
-    assert.equal(activation.gateEnabled(false), false);
+    assert.equal(activation.gateEnabled(true), true); // packaged: on by default
+    assert.equal(activation.gateEnabled(false), false); // dev: off by default
+    // A packaged build must NOT be bypassable via the env var (#1848 P1).
     process.env.SCISTUDIO_ALPHA_GATE = "0";
-    assert.equal(activation.gateEnabled(true), false);
+    assert.equal(activation.gateEnabled(true), true);
+    process.env.SCISTUDIO_ALPHA_GATE = "off";
+    assert.equal(activation.gateEnabled(true), true);
+    // Dev opts in explicitly.
     process.env.SCISTUDIO_ALPHA_GATE = "1";
     assert.equal(activation.gateEnabled(false), true);
+    process.env.SCISTUDIO_ALPHA_GATE = "0";
+    assert.equal(activation.gateEnabled(false), false);
   } finally {
     if (prev === undefined) {
       delete process.env.SCISTUDIO_ALPHA_GATE;
     } else {
       process.env.SCISTUDIO_ALPHA_GATE = prev;
     }
+  }
+});
+
+test("loadPublicKeyPem: env override honored only in dev, never packaged", () => {
+  const prev = process.env.SCISTUDIO_ALPHA_PUBKEY;
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "scistudio-pub-"));
+  try {
+    process.env.SCISTUDIO_ALPHA_PUBKEY = "DEV-KEY";
+    // Dev: env override wins.
+    assert.equal(activation.loadPublicKeyPem(dir, false), "DEV-KEY");
+    // Packaged: env override ignored; no shipped file yet -> null (#1848 P1).
+    assert.equal(activation.loadPublicKeyPem(dir, true), null);
+    // Packaged: only the shipped file is trusted.
+    fs.writeFileSync(path.join(dir, "alpha-public-key.pem"), "FILE-KEY");
+    assert.equal(activation.loadPublicKeyPem(dir, true), "FILE-KEY");
+  } finally {
+    if (prev === undefined) {
+      delete process.env.SCISTUDIO_ALPHA_PUBKEY;
+    } else {
+      process.env.SCISTUDIO_ALPHA_PUBKEY = prev;
+    }
+    fs.rmSync(dir, { recursive: true, force: true });
   }
 });
 

--- a/desktop/test/activation.test.js
+++ b/desktop/test/activation.test.js
@@ -1,0 +1,120 @@
+"use strict";
+
+// Unit tests for the alpha activation gate's pure logic (desktop/activation.js,
+// issue #1848). Run with: npm --prefix desktop test (Node built-in test runner).
+//
+// Alpha-only; removed in beta together with the gate.
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const crypto = require("crypto");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const activation = require("../activation");
+
+// Mint a token the way scripts/alpha-token.js does, so the test exercises the
+// real verify path against an independently generated keypair.
+function makeKeypair() {
+  const { privateKey, publicKey } = crypto.generateKeyPairSync("ed25519");
+  return {
+    privatePem: privateKey.export({ type: "pkcs8", format: "pem" }),
+    publicPem: publicKey.export({ type: "spki", format: "pem" })
+  };
+}
+
+function signToken(privatePem, payload) {
+  const payloadB64 = Buffer.from(JSON.stringify(payload), "utf8").toString("base64url");
+  const sig = crypto.sign(null, Buffer.from(payloadB64, "utf8"), crypto.createPrivateKey(privatePem));
+  return `${payloadB64}.${sig.toString("base64url")}`;
+}
+
+test("machineFingerprint: stable 64-char hex digest", () => {
+  const fp = activation.machineFingerprint();
+  assert.match(fp, /^[0-9a-f]{64}$/);
+  assert.equal(fp, activation.machineFingerprint());
+});
+
+test("verifyToken: valid token for this machine", () => {
+  const { privatePem, publicPem } = makeKeypair();
+  const fp = "a".repeat(64);
+  const token = signToken(privatePem, { v: 1, fp, name: "tester", iat: 1 });
+  const result = activation.verifyToken(token, fp, publicPem);
+  assert.equal(result.ok, true);
+  assert.equal(result.payload.name, "tester");
+});
+
+test("verifyToken: rejects a token bound to a different machine", () => {
+  const { privatePem, publicPem } = makeKeypair();
+  const token = signToken(privatePem, { v: 1, fp: "a".repeat(64), name: null, iat: 1 });
+  const result = activation.verifyToken(token, "b".repeat(64), publicPem);
+  assert.equal(result.ok, false);
+  assert.equal(result.reason, "wrong-machine");
+});
+
+test("verifyToken: rejects a token signed by a different key", () => {
+  const signer = makeKeypair();
+  const other = makeKeypair();
+  const fp = "c".repeat(64);
+  const token = signToken(signer.privatePem, { v: 1, fp, name: null, iat: 1 });
+  const result = activation.verifyToken(token, fp, other.publicPem);
+  assert.equal(result.ok, false);
+  assert.equal(result.reason, "bad-signature");
+});
+
+test("verifyToken: rejects a tampered payload", () => {
+  const { privatePem, publicPem } = makeKeypair();
+  const fp = "d".repeat(64);
+  const token = signToken(privatePem, { v: 1, fp, name: null, iat: 1 });
+  const [, sig] = token.split(".");
+  const forged = Buffer.from(JSON.stringify({ v: 1, fp, name: "x", iat: 9 }), "utf8").toString("base64url");
+  const result = activation.verifyToken(`${forged}.${sig}`, fp, publicPem);
+  assert.equal(result.ok, false);
+  assert.equal(result.reason, "bad-signature");
+});
+
+test("verifyToken: empty / malformed / unconfigured", () => {
+  const { publicPem } = makeKeypair();
+  assert.equal(activation.verifyToken("", "x", publicPem).reason, "empty");
+  assert.equal(activation.verifyToken("nodot", "x", publicPem).reason, "malformed");
+  assert.equal(activation.verifyToken("a.b", "x", null).reason, "not-configured");
+});
+
+test("gateEnabled: env override beats packaged default", () => {
+  const prev = process.env.SCISTUDIO_ALPHA_GATE;
+  try {
+    delete process.env.SCISTUDIO_ALPHA_GATE;
+    assert.equal(activation.gateEnabled(true), true);
+    assert.equal(activation.gateEnabled(false), false);
+    process.env.SCISTUDIO_ALPHA_GATE = "0";
+    assert.equal(activation.gateEnabled(true), false);
+    process.env.SCISTUDIO_ALPHA_GATE = "1";
+    assert.equal(activation.gateEnabled(false), true);
+  } finally {
+    if (prev === undefined) {
+      delete process.env.SCISTUDIO_ALPHA_GATE;
+    } else {
+      process.env.SCISTUDIO_ALPHA_GATE = prev;
+    }
+  }
+});
+
+test("checkActivation + storage round-trip", () => {
+  const { privatePem, publicPem } = makeKeypair();
+  const fp = "e".repeat(64);
+  const token = signToken(privatePem, { v: 1, fp, name: "round-trip", iat: 1 });
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "scistudio-alpha-"));
+  try {
+    assert.equal(activation.checkActivation({ userDataDir: dir, fingerprint: fp, publicKeyPem: publicPem }).activated, false);
+    activation.writeStoredToken(dir, token, { name: "round-trip" });
+    const status = activation.checkActivation({ userDataDir: dir, fingerprint: fp, publicKeyPem: publicPem });
+    assert.equal(status.activated, true);
+    // A stored token does not activate a different machine.
+    const other = activation.checkActivation({ userDataDir: dir, fingerprint: "f".repeat(64), publicKeyPem: publicPem });
+    assert.equal(other.activated, false);
+    assert.equal(other.reason, "wrong-machine");
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/desktop/test/alpha-token.test.js
+++ b/desktop/test/alpha-token.test.js
@@ -1,0 +1,54 @@
+"use strict";
+
+// Unit tests for the developer-side token tooling (scripts/alpha-token.js,
+// issue #1848): mint/inspect round-trip and the CSV issuance ledger. Run with:
+// npm --prefix desktop test (Node built-in test runner). Alpha-only.
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const tokens = require("../../scripts/alpha-token");
+
+function tmpDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "scistudio-tok-"));
+}
+
+test("mintToken + inspectToken round-trip", () => {
+  const dir = tmpDir();
+  try {
+    const keyPath = path.join(dir, "priv.key");
+    const pubPath = path.join(dir, "pub.pem");
+    tokens.generateKeypair({ keyPath, pubPath });
+    const fp = "ab".repeat(32);
+    const token = tokens.mintToken({ fingerprint: fp, name: "alice", keyPath });
+    const result = tokens.inspectToken({ token, fingerprint: fp, pubPath });
+    assert.equal(result.valid, true);
+    assert.equal(result.payload.name, "alice");
+    // A different fingerprint is rejected.
+    assert.equal(tokens.inspectToken({ token, fingerprint: "cd".repeat(32), pubPath }).reason, "wrong-machine");
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("issuance ledger: append, read, count, CSV escaping", () => {
+  const dir = tmpDir();
+  const ledgerPath = path.join(dir, "issued.csv");
+  try {
+    assert.deepEqual(tokens.readIssuance({ ledgerPath }), []);
+    tokens.recordIssuance({ fingerprint: "f".repeat(64), name: "Bob", token: "tok-1", ledgerPath });
+    // A name containing a comma and a quote must survive the CSV round-trip.
+    tokens.recordIssuance({ fingerprint: "e".repeat(64), name: 'Eve, "the tester"', token: "tok-2", ledgerPath });
+    const rows = tokens.readIssuance({ ledgerPath });
+    assert.equal(rows.length, 2);
+    assert.equal(rows[0].name, "Bob");
+    assert.equal(rows[0].token, "tok-1");
+    assert.equal(rows[1].name, 'Eve, "the tester"');
+    assert.equal(rows[1].fingerprint, "e".repeat(64));
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/docs/alpha-activation-gate.md
+++ b/docs/alpha-activation-gate.md
@@ -68,6 +68,17 @@ closed (the window shows "Activation is not configured").
    To avoid the terminal, double-click `scripts/alpha-token-issuer.command` in
    Finder: it launches the same GUI (Ctrl+C in its Terminal window stops it).
 
+   For a desktop app you can double-click (no Electron, no terminal window),
+   build a self-contained `.app`:
+
+   ```bash
+   bash scripts/build-issuer-app.sh        # writes "Alpha Token Issuer.app" to ~/Desktop
+   ```
+
+   The app bundles the issuer scripts and reads the signing key from
+   `~/.scistudio/alpha-signing.key`; use the GUI's **Quit issuer** button to stop
+   it. It requires Node.js on the machine and is a build artifact (not committed).
+
    **CLI:**
 
    ```bash
@@ -97,8 +108,9 @@ The gate is intentionally isolated so it can be deleted in one pass:
 - [ ] Delete `desktop/activation.js`, `desktop/preload-gate.js`,
       `desktop/resources/alpha-gate.html`, `desktop/resources/alpha-public-key.pem`.
 - [ ] Delete `desktop/test/activation.test.js`.
-- [ ] Delete `scripts/alpha-token.js`, `scripts/alpha-token-gui.js`, and
-      `scripts/alpha-token-issuer.command`.
+- [ ] Delete `scripts/alpha-token.js`, `scripts/alpha-token-gui.js`,
+      `scripts/alpha-token-issuer.command`, and `scripts/build-issuer-app.sh`
+      (plus any "Alpha Token Issuer.app" you built).
 - [ ] (Local only) the issuance ledger `~/.scistudio/alpha-issued-tokens.csv` and
       the signing key `~/.scistudio/alpha-signing.key` are never committed; remove
       them from your machine when you retire the alpha.

--- a/docs/alpha-activation-gate.md
+++ b/docs/alpha-activation-gate.md
@@ -65,6 +65,9 @@ closed (the window shows "Activation is not configured").
    fingerprint, optionally a name, click **Sign token**, and copy the result. It
    also shows a running count of how many tokens you have issued.
 
+   To avoid the terminal, double-click `scripts/alpha-token-issuer.command` in
+   Finder: it launches the same GUI (Ctrl+C in its Terminal window stops it).
+
    **CLI:**
 
    ```bash
@@ -94,7 +97,8 @@ The gate is intentionally isolated so it can be deleted in one pass:
 - [ ] Delete `desktop/activation.js`, `desktop/preload-gate.js`,
       `desktop/resources/alpha-gate.html`, `desktop/resources/alpha-public-key.pem`.
 - [ ] Delete `desktop/test/activation.test.js`.
-- [ ] Delete `scripts/alpha-token.js` and `scripts/alpha-token-gui.js`.
+- [ ] Delete `scripts/alpha-token.js`, `scripts/alpha-token-gui.js`, and
+      `scripts/alpha-token-issuer.command`.
 - [ ] (Local only) the issuance ledger `~/.scistudio/alpha-issued-tokens.csv` and
       the signing key `~/.scistudio/alpha-signing.key` are never committed; remove
       them from your machine when you retire the alpha.

--- a/docs/alpha-activation-gate.md
+++ b/docs/alpha-activation-gate.md
@@ -1,0 +1,92 @@
+# Alpha Activation Gate (#1848)
+
+**Status:** Alpha-only, temporary. Remove entirely in beta (see the removal
+checklist below and issue #1848).
+
+## Purpose
+
+Stop alpha testers from redistributing the build to people who were not
+authorized. The dmg/installer itself never expires and may be reused or
+reinstalled freely. The gate is a **per-machine activation token**: without a
+valid token, the app does not open.
+
+## How it works (offline, zero-server)
+
+This is an offline signed-token scheme — there is no activation server.
+
+- The developer holds an **Ed25519 private signing key** (kept outside the repo,
+  in `~/.scistudio/alpha-signing.key`).
+- The matching **public key ships in the build** at
+  `desktop/resources/alpha-public-key.pem`.
+- A **token** binds to exactly one **machine fingerprint** (a sha256 of a stable
+  per-machine id: `IOPlatformUUID` on macOS, registry `MachineGuid` on Windows)
+  and is signed with the private key.
+- On launch the app verifies the token's signature with the embedded public key
+  **and** checks that the bound fingerprint equals this machine's fingerprint. A
+  token forwarded to a different machine fails the fingerprint check, so a
+  redistributed copy cannot be opened.
+
+Because verification is local, this stops casual redistribution (no token = no
+app; a tester's token only works on the tester's machine). It does not provide
+remote revocation — that would need a server and is deliberately out of scope
+for the alpha (see issue #1848).
+
+## One-time developer setup
+
+Generate the signing keypair once, then rebuild so the public key ships:
+
+```bash
+node scripts/alpha-token.js keygen
+# Private key -> ~/.scistudio/alpha-signing.key  (keep secret, never commit, back it up)
+# Public key  -> desktop/resources/alpha-public-key.pem  (commit it)
+```
+
+Commit `desktop/resources/alpha-public-key.pem` and build the alpha dmg/installer
+as usual. If the public key is missing from a packaged build, the gate fails
+closed (the window shows "Activation is not configured").
+
+> Losing the private key invalidates every issued token. Back it up.
+
+## Per-tester activation flow
+
+1. The tester installs and launches the app. The gate window shows their
+   **machine fingerprint** with a **Copy** button.
+2. The tester sends you that fingerprint.
+3. You mint a token bound to it:
+
+   ```bash
+   node scripts/alpha-token.js sign --fingerprint <fingerprint> --name "Tester Name"
+   ```
+
+   (Optionally check it: `node scripts/alpha-token.js verify --token <t> --fingerprint <fp>`.)
+4. You send the token back. The tester pastes it and clicks **Activate**.
+5. The app stores the token at `<userData>/alpha-activation.json` and launches.
+   Every subsequent launch re-verifies it silently. There is no expiry.
+
+## Developer / CI escape hatch
+
+The gate runs for **packaged builds** and is skipped in dev (running from a
+source checkout) so a checkout is never locked out. Override either way with:
+
+```bash
+SCISTUDIO_ALPHA_GATE=0   # force the gate off (e.g. a packaged build under test)
+SCISTUDIO_ALPHA_GATE=1   # force the gate on (e.g. exercise it in dev)
+SCISTUDIO_ALPHA_PUBKEY="-----BEGIN PUBLIC KEY-----\n...\n-----END PUBLIC KEY-----"
+                         # supply the public key inline without a rebuild
+```
+
+## Beta removal checklist
+
+The gate is intentionally isolated so it can be deleted in one pass:
+
+- [ ] Delete `desktop/activation.js`, `desktop/preload-gate.js`,
+      `desktop/resources/alpha-gate.html`, `desktop/resources/alpha-public-key.pem`.
+- [ ] Delete `desktop/test/activation.test.js`.
+- [ ] Delete `scripts/alpha-token.js`.
+- [ ] In `desktop/main.js`: remove the `./activation` require, the
+      `runActivationGate` / `ensureAlphaActivation` functions, the
+      `ensureAlphaActivation()` call in `app.whenReady`, and the `clipboard`
+      import if unused elsewhere.
+- [ ] In `desktop/package.json`: remove `activation.js` and `preload-gate.js`
+      from `build.files`.
+- [ ] Delete this document.

--- a/docs/alpha-activation-gate.md
+++ b/docs/alpha-activation-gate.md
@@ -89,16 +89,21 @@ closed (the window shows "Activation is not configured").
 5. The app stores the token at `<userData>/alpha-activation.json` and launches.
    Every subsequent launch re-verifies it silently. There is no expiry.
 
-## Developer / CI escape hatch
+## Developer escape hatch (dev builds only)
 
-The gate runs for **packaged builds** and is skipped in dev (running from a
-source checkout) so a checkout is never locked out. Override either way with:
+A **packaged build always requires activation** — there is no env switch to turn
+the gate off in a real dmg/installer, and the public key is read only from the
+shipped `alpha-public-key.pem`. Otherwise a redistributed copy could be bypassed
+with an env var (set `SCISTUDIO_ALPHA_GATE=0`, or point `SCISTUDIO_ALPHA_PUBKEY`
+at an attacker's key and self-mint a token).
+
+The env vars therefore apply **only in dev** (running from a source checkout),
+where the gate is off by default so a checkout is never locked out:
 
 ```bash
-SCISTUDIO_ALPHA_GATE=0   # force the gate off (e.g. a packaged build under test)
-SCISTUDIO_ALPHA_GATE=1   # force the gate on (e.g. exercise it in dev)
+SCISTUDIO_ALPHA_GATE=1   # dev only: exercise the gate from a source checkout
 SCISTUDIO_ALPHA_PUBKEY="-----BEGIN PUBLIC KEY-----\n...\n-----END PUBLIC KEY-----"
-                         # supply the public key inline without a rebuild
+                         # dev only: use a public key inline without a rebuild
 ```
 
 ## Beta removal checklist

--- a/docs/alpha-activation-gate.md
+++ b/docs/alpha-activation-gate.md
@@ -52,13 +52,25 @@ closed (the window shows "Activation is not configured").
 1. The tester installs and launches the app. The gate window shows their
    **machine fingerprint** with a **Copy** button.
 2. The tester sends you that fingerprint.
-3. You mint a token bound to it:
+3. You mint a token bound to it, either with the GUI or the CLI.
+
+   **GUI (recommended):**
+
+   ```bash
+   node scripts/alpha-token-gui.js
+   ```
+
+   This opens a small local page in your browser. It auto-uses the signing key
+   in `~/.scistudio/alpha-signing.key` (no key handling needed) — paste the
+   fingerprint, optionally a name, click **Sign token**, and copy the result. It
+   also shows a running count of how many tokens you have issued.
+
+   **CLI:**
 
    ```bash
    node scripts/alpha-token.js sign --fingerprint <fingerprint> --name "Tester Name"
+   # check it:  node scripts/alpha-token.js verify --token <t> --fingerprint <fp>
    ```
-
-   (Optionally check it: `node scripts/alpha-token.js verify --token <t> --fingerprint <fp>`.)
 4. You send the token back. The tester pastes it and clicks **Activate**.
 5. The app stores the token at `<userData>/alpha-activation.json` and launches.
    Every subsequent launch re-verifies it silently. There is no expiry.
@@ -82,7 +94,10 @@ The gate is intentionally isolated so it can be deleted in one pass:
 - [ ] Delete `desktop/activation.js`, `desktop/preload-gate.js`,
       `desktop/resources/alpha-gate.html`, `desktop/resources/alpha-public-key.pem`.
 - [ ] Delete `desktop/test/activation.test.js`.
-- [ ] Delete `scripts/alpha-token.js`.
+- [ ] Delete `scripts/alpha-token.js` and `scripts/alpha-token-gui.js`.
+- [ ] (Local only) the issuance ledger `~/.scistudio/alpha-issued-tokens.csv` and
+      the signing key `~/.scistudio/alpha-signing.key` are never committed; remove
+      them from your machine when you retire the alpha.
 - [ ] In `desktop/main.js`: remove the `./activation` require, the
       `runActivationGate` / `ensureAlphaActivation` functions, the
       `ensureAlphaActivation()` call in `app.whenReady`, and the `clipboard`

--- a/scripts/alpha-token-gui.js
+++ b/scripts/alpha-token-gui.js
@@ -77,6 +77,8 @@ const PAGE = `<!doctype html>
       <div id="issued" class="hint">…</div>
     </div>
 
+    <button id="quitBtn" class="secondary" type="button" style="margin-top:18px">Quit issuer</button>
+
     <script>
       const statusEl = document.getElementById("status");
       const keygenEl = document.getElementById("keygen");
@@ -88,9 +90,12 @@ const PAGE = `<!doctype html>
 
       async function refresh() {
         const s = await (await fetch("/api/status")).json();
+        // The issuer only needs the private key to sign. Never offer to
+        // regenerate when one already exists — that would overwrite the key and
+        // invalidate every token already issued.
         if (s.hasPrivate) {
-          setStatus("Signing key ready: " + s.keyPath + (s.hasPublic ? "" : "  (public key missing — generate or rebuild)"), s.hasPublic ? "ok" : "warn");
-          keygenEl.style.display = s.hasPublic ? "none" : "block";
+          setStatus("Signing key ready.", "ok");
+          keygenEl.style.display = "none";
           signBtn.disabled = false;
         } else {
           setStatus("No signing key found.", "warn");
@@ -143,6 +148,12 @@ const PAGE = `<!doctype html>
         try { await navigator.clipboard.writeText(tokenEl.value); } catch { tokenEl.select(); document.execCommand("copy"); }
         const btn = document.getElementById("copyBtn");
         const original = btn.textContent; btn.textContent = "Copied"; setTimeout(() => { btn.textContent = original; }, 1200);
+      });
+
+      document.getElementById("quitBtn").addEventListener("click", async () => {
+        await fetch("/api/quit", { method: "POST" }).catch(function () {});
+        document.body.innerHTML =
+          "<p style='font-family:-apple-system,sans-serif;padding:28px;color:#6b7280'>Issuer stopped. You can close this tab.</p>";
       });
 
       refresh();
@@ -205,6 +216,12 @@ const server = http.createServer(async (req, res) => {
       sendJson(res, 200, { token });
       return;
     }
+    if (req.method === "POST" && req.url === "/api/quit") {
+      sendJson(res, 200, { ok: true });
+      // Let the response flush, then stop the server (used by the .app Quit button).
+      setTimeout(() => process.exit(0), 100);
+      return;
+    }
     if (req.method === "GET" && req.url === "/api/issued") {
       const rows = tokens.readIssuance();
       const unique = new Set(rows.map((row) => row.fingerprint));
@@ -229,9 +246,21 @@ function openBrowser(url) {
   execFile(opener, [url], () => {});
 }
 
+// If an instance is already running on this port (e.g. the .app launched twice),
+// just open the browser to it instead of crashing.
+server.on("error", (error) => {
+  if (error && error.code === "EADDRINUSE") {
+    const url = `http://${HOST}:${PORT}/`;
+    process.stdout.write(`Issuer already running at ${url}; opening it.\n`);
+    openBrowser(url);
+    process.exit(0);
+  }
+  throw error;
+});
+
 server.listen(PORT, HOST, () => {
   const url = `http://${HOST}:${PORT}/`;
   process.stdout.write(`Alpha token issuer running at ${url}\n`);
-  process.stdout.write("Press Ctrl+C to stop.\n");
+  process.stdout.write("Press Ctrl+C (or the Quit button) to stop.\n");
   openBrowser(url);
 });

--- a/scripts/alpha-token-gui.js
+++ b/scripts/alpha-token-gui.js
@@ -1,0 +1,237 @@
+#!/usr/bin/env node
+// #1848: minimal local GUI for issuing alpha activation tokens.
+//
+// Run:  node scripts/alpha-token-gui.js
+// It starts a tiny local web app (127.0.0.1 only) and opens it in your browser.
+// Paste a tester's machine fingerprint, click Sign, copy the token. It reuses the
+// signing key in ~/.scistudio/alpha-signing.key via scripts/alpha-token.js.
+//
+// ALPHA-ONLY developer tool; delete in beta with the rest of the gate (#1848).
+
+const http = require("http");
+const { execFile } = require("child_process");
+
+const tokens = require("./alpha-token");
+
+const HOST = "127.0.0.1";
+const PORT = Number(process.env.SCISTUDIO_ALPHA_GUI_PORT || 7848);
+
+const PAGE = `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>SciStudio Alpha — Token Issuer</title>
+    <style>
+      * { box-sizing: border-box; }
+      body { font-family: -apple-system, "Segoe UI", system-ui, sans-serif; background: #f7f8fb; color: #1f2533; margin: 0; padding: 28px 32px; font-size: 14px; }
+      h1 { font-size: 18px; margin: 0 0 4px; }
+      p.sub { margin: 0 0 18px; color: #6b7280; }
+      .status { font-size: 13px; padding: 8px 12px; border-radius: 8px; margin-bottom: 18px; }
+      .status.ok { background: #e7f4ec; color: #1e8e4e; }
+      .status.warn { background: #fdecea; color: #c0392b; }
+      label { display: block; font-weight: 600; margin: 0 0 6px; }
+      .field { margin-bottom: 16px; }
+      input, textarea { width: 100%; font-size: 13px; padding: 9px 10px; border: 1px solid #d7dbe3; border-radius: 8px; background: #fff; font-family: ui-monospace, "SF Mono", Consolas, monospace; }
+      textarea { resize: vertical; min-height: 72px; }
+      button { font-size: 14px; font-weight: 600; padding: 9px 16px; border-radius: 8px; border: 1px solid #2f6df6; background: #2f6df6; color: #fff; cursor: pointer; }
+      button.secondary { background: #fff; color: #1f2533; border-color: #d7dbe3; }
+      button:disabled { opacity: 0.5; cursor: default; }
+      .row { display: flex; gap: 8px; align-items: flex-start; }
+      .result { margin-top: 18px; }
+      .hint { color: #6b7280; font-size: 12px; margin-top: 6px; }
+    </style>
+  </head>
+  <body>
+    <h1>Alpha Token Issuer</h1>
+    <p class="sub">Sign a per-machine activation token for an alpha tester (#1848).</p>
+
+    <div id="status" class="status">Checking signing key…</div>
+
+    <div id="keygen" style="display:none" class="field">
+      <button id="keygenBtn" class="secondary" type="button">Generate signing keys</button>
+      <div class="hint">No signing key found. This creates ~/.scistudio/alpha-signing.key and writes the public key into the build. Commit the public key and rebuild.</div>
+    </div>
+
+    <div class="field">
+      <label for="fp">Tester machine fingerprint</label>
+      <textarea id="fp" placeholder="Paste the fingerprint the tester copied from the activation window"></textarea>
+    </div>
+
+    <div class="field">
+      <label for="name">Tester name (optional)</label>
+      <input id="name" type="text" placeholder="e.g. Alice" />
+    </div>
+
+    <button id="signBtn" type="button">Sign token</button>
+
+    <div id="result" class="result" style="display:none">
+      <label for="token">Activation token — send this to the tester</label>
+      <div class="row">
+        <textarea id="token" readonly></textarea>
+        <button id="copyBtn" class="secondary" type="button">Copy</button>
+      </div>
+    </div>
+
+    <div class="result">
+      <label>Issued so far</label>
+      <div id="issued" class="hint">…</div>
+    </div>
+
+    <script>
+      const statusEl = document.getElementById("status");
+      const keygenEl = document.getElementById("keygen");
+      const signBtn = document.getElementById("signBtn");
+      const resultEl = document.getElementById("result");
+      const tokenEl = document.getElementById("token");
+
+      function setStatus(text, kind) { statusEl.textContent = text; statusEl.className = "status " + kind; }
+
+      async function refresh() {
+        const s = await (await fetch("/api/status")).json();
+        if (s.hasPrivate) {
+          setStatus("Signing key ready: " + s.keyPath + (s.hasPublic ? "" : "  (public key missing — generate or rebuild)"), s.hasPublic ? "ok" : "warn");
+          keygenEl.style.display = s.hasPublic ? "none" : "block";
+          signBtn.disabled = false;
+        } else {
+          setStatus("No signing key found.", "warn");
+          keygenEl.style.display = "block";
+          signBtn.disabled = true;
+        }
+      }
+
+      document.getElementById("keygenBtn").addEventListener("click", async () => {
+        setStatus("Generating keys…", "ok");
+        const res = await fetch("/api/keygen", { method: "POST" });
+        if (res.ok) { await refresh(); } else { setStatus("Key generation failed.", "warn"); }
+      });
+
+      signBtn.addEventListener("click", async () => {
+        const fingerprint = document.getElementById("fp").value.trim();
+        const name = document.getElementById("name").value.trim();
+        if (!fingerprint) { setStatus("Paste a fingerprint first.", "warn"); return; }
+        signBtn.disabled = true;
+        const res = await fetch("/api/sign", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ fingerprint, name })
+        });
+        signBtn.disabled = false;
+        const data = await res.json();
+        if (res.ok && data.token) {
+          tokenEl.value = data.token;
+          resultEl.style.display = "block";
+          setStatus("Token signed. Copy it and send it to the tester.", "ok");
+          refreshIssued();
+        } else {
+          setStatus("Signing failed: " + (data.error || "unknown error"), "warn");
+        }
+      });
+
+      async function refreshIssued() {
+        try {
+          const d = await (await fetch("/api/issued")).json();
+          const lines = (d.recent || []).map(function (r) {
+            return (r.issued_at || "").slice(0, 19).replace("T", " ") + "  " + (r.name || "-") + "  " + (r.fingerprint || "").slice(0, 12) + "…";
+          });
+          document.getElementById("issued").textContent =
+            d.count + " token(s), " + d.machines + " machine(s)" + (lines.length ? "\\n" + lines.join("\\n") : "");
+          document.getElementById("issued").style.whiteSpace = "pre-line";
+        } catch (e) { /* ignore */ }
+      }
+
+      document.getElementById("copyBtn").addEventListener("click", async () => {
+        try { await navigator.clipboard.writeText(tokenEl.value); } catch { tokenEl.select(); document.execCommand("copy"); }
+        const btn = document.getElementById("copyBtn");
+        const original = btn.textContent; btn.textContent = "Copied"; setTimeout(() => { btn.textContent = original; }, 1200);
+      });
+
+      refresh();
+      refreshIssued();
+    </script>
+  </body>
+</html>`;
+
+function readJsonBody(req) {
+  return new Promise((resolve) => {
+    let body = "";
+    req.on("data", (chunk) => {
+      body += chunk;
+      if (body.length > 1_000_000) {
+        req.destroy();
+      }
+    });
+    req.on("end", () => {
+      try {
+        resolve(body ? JSON.parse(body) : {});
+      } catch {
+        resolve({});
+      }
+    });
+  });
+}
+
+function sendJson(res, status, value) {
+  const payload = JSON.stringify(value);
+  res.writeHead(status, { "content-type": "application/json" });
+  res.end(payload);
+}
+
+const server = http.createServer(async (req, res) => {
+  try {
+    if (req.method === "GET" && req.url === "/") {
+      res.writeHead(200, { "content-type": "text/html; charset=utf-8" });
+      res.end(PAGE);
+      return;
+    }
+    if (req.method === "GET" && req.url === "/api/status") {
+      sendJson(res, 200, tokens.keyStatus());
+      return;
+    }
+    if (req.method === "POST" && req.url === "/api/keygen") {
+      const result = tokens.generateKeypair();
+      sendJson(res, 200, { ok: true, ...result });
+      return;
+    }
+    if (req.method === "POST" && req.url === "/api/sign") {
+      const body = await readJsonBody(req);
+      if (!body.fingerprint) {
+        sendJson(res, 400, { error: "fingerprint is required" });
+        return;
+      }
+      const name = body.name || null;
+      const token = tokens.mintToken({ fingerprint: body.fingerprint, name });
+      // #1848: record every issuance to the local CSV ledger.
+      tokens.recordIssuance({ fingerprint: String(body.fingerprint).trim(), name, token });
+      sendJson(res, 200, { token });
+      return;
+    }
+    if (req.method === "GET" && req.url === "/api/issued") {
+      const rows = tokens.readIssuance();
+      const unique = new Set(rows.map((row) => row.fingerprint));
+      sendJson(res, 200, {
+        count: rows.length,
+        machines: unique.size,
+        ledgerPath: tokens.defaultLedgerPath(),
+        recent: rows.slice(-8).reverse()
+      });
+      return;
+    }
+    res.writeHead(404);
+    res.end("not found");
+  } catch (error) {
+    sendJson(res, 500, { error: error.message });
+  }
+});
+
+function openBrowser(url) {
+  const opener =
+    process.platform === "darwin" ? "open" : process.platform === "win32" ? "explorer" : "xdg-open";
+  execFile(opener, [url], () => {});
+}
+
+server.listen(PORT, HOST, () => {
+  const url = `http://${HOST}:${PORT}/`;
+  process.stdout.write(`Alpha token issuer running at ${url}\n`);
+  process.stdout.write("Press Ctrl+C to stop.\n");
+  openBrowser(url);
+});

--- a/scripts/alpha-token-gui.js
+++ b/scripts/alpha-token-gui.js
@@ -53,8 +53,8 @@ const PAGE = `<!doctype html>
     </div>
 
     <div class="field">
-      <label for="fp">Tester machine fingerprint</label>
-      <textarea id="fp" placeholder="Paste the fingerprint the tester copied from the activation window"></textarea>
+      <label for="fp">Tester registration code</label>
+      <textarea id="fp" placeholder="Paste the registration code the tester copied from the activation window"></textarea>
     </div>
 
     <div class="field">

--- a/scripts/alpha-token-issuer.command
+++ b/scripts/alpha-token-issuer.command
@@ -1,0 +1,28 @@
+#!/bin/bash
+# #1848: double-click launcher for the alpha token issuer GUI.
+#
+# Double-click this file in Finder. It opens the token issuer in your browser so
+# you can paste a tester's machine fingerprint and sign a token. Press Ctrl+C in
+# the Terminal window it opens to stop the server.
+#
+# It resolves its own location, so the repo can live anywhere. ALPHA-ONLY;
+# delete in beta with the rest of the gate (see issue #1848).
+
+set -e
+
+# This file lives in scripts/, so the repo root is one level up.
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "error: 'node' was not found on your PATH." >&2
+  echo "Install Node.js, then double-click this launcher again." >&2
+  echo "Press Return to close." >&2
+  read -r _
+  exit 1
+fi
+
+echo "Starting the Alpha Token Issuer…"
+echo "(A browser tab will open. Press Ctrl+C here to stop.)"
+echo
+exec node scripts/alpha-token-gui.js

--- a/scripts/alpha-token.js
+++ b/scripts/alpha-token.js
@@ -1,20 +1,21 @@
 #!/usr/bin/env node
-// #1848: developer-side CLI for the alpha activation gate (offline, zero-server).
+// #1848: developer-side tooling for the alpha activation gate (offline, zero-server).
 //
 // The private signing key never lives in the repo. `keygen` writes it to
 // ~/.scistudio/alpha-signing.key and writes the matching public key into
 // desktop/resources/alpha-public-key.pem (safe to commit + ship). `sign` mints a
 // token bound to one machine fingerprint that the desktop app verifies offline.
 //
-// This whole tool is ALPHA-ONLY; delete it in beta together with the gate (see
-// issue #1848).
+// This module exposes its core functions for reuse (scripts/alpha-token-gui.js);
+// the CLI only runs when invoked directly. ALPHA-ONLY; delete in beta with the
+// rest of the gate (see issue #1848).
 //
 // Token format (shared with desktop/activation.js):
 //   token        = base64url(payloadJson) + "." + base64url(ed25519Signature)
 //   signed bytes = utf8 bytes of the base64url(payloadJson) string
 //   payloadJson  = {"v":1,"fp":"<sha256-hex>","name":<string|null>,"iat":<unix>}
 //
-// Usage:
+// CLI usage:
 //   node scripts/alpha-token.js keygen [--out <pubkey.pem>] [--key <private.key>]
 //   node scripts/alpha-token.js sign --fingerprint <fp> [--name <tester>] [--key <private.key>]
 //   node scripts/alpha-token.js verify --token <t> --fingerprint <fp> [--pubkey <pubkey.pem>]
@@ -36,6 +37,152 @@ function defaultPubPath() {
   return path.join(__dirname, "..", "desktop", "resources", "alpha-public-key.pem");
 }
 
+// --------------------------------------------------------------------------- //
+// Core functions (return values; no I/O to stdout). Reused by the GUI.
+// --------------------------------------------------------------------------- //
+
+function generateKeypair({ keyPath = defaultKeyPath(), pubPath = defaultPubPath() } = {}) {
+  const { privateKey, publicKey } = crypto.generateKeyPairSync("ed25519");
+  const privPem = privateKey.export({ type: "pkcs8", format: "pem" });
+  const pubPem = publicKey.export({ type: "spki", format: "pem" });
+
+  fs.mkdirSync(path.dirname(keyPath), { recursive: true });
+  fs.writeFileSync(keyPath, privPem, { mode: 0o600 });
+
+  fs.mkdirSync(path.dirname(pubPath), { recursive: true });
+  fs.writeFileSync(pubPath, pubPem);
+
+  return { keyPath, pubPath };
+}
+
+function mintToken({ fingerprint, name = null, keyPath = defaultKeyPath() }) {
+  if (!fingerprint) {
+    throw new Error("fingerprint is required");
+  }
+  const privPem = fs.readFileSync(keyPath, "utf8");
+  const keyObject = crypto.createPrivateKey(privPem);
+  const payload = {
+    v: 1,
+    fp: String(fingerprint).trim(),
+    name: name ? String(name) : null,
+    iat: Math.floor(Date.now() / 1000)
+  };
+  const payloadB64 = b64url(Buffer.from(JSON.stringify(payload), "utf8"));
+  const signature = crypto.sign(null, Buffer.from(payloadB64, "utf8"), keyObject);
+  return `${payloadB64}.${b64url(signature)}`;
+}
+
+function inspectToken({ token, fingerprint, pubPath = defaultPubPath() }) {
+  const pubPem = fs.readFileSync(pubPath, "utf8");
+  const parts = String(token).trim().split(".");
+  if (parts.length !== 2) {
+    return { valid: false, reason: "malformed" };
+  }
+  const keyObject = crypto.createPublicKey(pubPem);
+  const ok = crypto.verify(
+    null,
+    Buffer.from(parts[0], "utf8"),
+    keyObject,
+    Buffer.from(parts[1], "base64url")
+  );
+  if (!ok) {
+    return { valid: false, reason: "bad-signature" };
+  }
+  const payload = JSON.parse(Buffer.from(parts[0], "base64url").toString("utf8"));
+  if (fingerprint && payload.fp !== String(fingerprint).trim()) {
+    return { valid: false, reason: "wrong-machine", payload };
+  }
+  return { valid: true, reason: "ok", payload };
+}
+
+function keyStatus({ keyPath = defaultKeyPath(), pubPath = defaultPubPath() } = {}) {
+  return {
+    keyPath,
+    pubPath,
+    hasPrivate: fs.existsSync(keyPath),
+    hasPublic: fs.existsSync(pubPath)
+  };
+}
+
+// --------------------------------------------------------------------------- //
+// Issuance ledger (#1848): an append-only CSV of every token signed, so the
+// developer can see how many tokens were issued and to which machines. Lives
+// outside the repo (next to the signing key) and is never committed.
+// --------------------------------------------------------------------------- //
+
+const LEDGER_HEADER = "issued_at,name,fingerprint,token";
+
+function defaultLedgerPath() {
+  return path.join(os.homedir(), ".scistudio", "alpha-issued-tokens.csv");
+}
+
+function csvField(value) {
+  return `"${String(value == null ? "" : value).replace(/"/g, '""')}"`;
+}
+
+function parseCsvLine(line) {
+  const fields = [];
+  let current = "";
+  let inQuotes = false;
+  for (let i = 0; i < line.length; i += 1) {
+    const ch = line[i];
+    if (inQuotes) {
+      if (ch === '"' && line[i + 1] === '"') {
+        current += '"';
+        i += 1;
+      } else if (ch === '"') {
+        inQuotes = false;
+      } else {
+        current += ch;
+      }
+    } else if (ch === '"') {
+      inQuotes = true;
+    } else if (ch === ",") {
+      fields.push(current);
+      current = "";
+    } else {
+      current += ch;
+    }
+  }
+  fields.push(current);
+  return fields;
+}
+
+// Append one issuance to the CSV ledger (creating it with a header if needed).
+function recordIssuance({ fingerprint, name = null, token, ledgerPath = defaultLedgerPath() }) {
+  fs.mkdirSync(path.dirname(ledgerPath), { recursive: true });
+  if (!fs.existsSync(ledgerPath)) {
+    fs.writeFileSync(ledgerPath, `${LEDGER_HEADER}\n`);
+  }
+  const row = [
+    csvField(new Date().toISOString()),
+    csvField(name),
+    csvField(fingerprint),
+    csvField(token)
+  ].join(",");
+  fs.appendFileSync(ledgerPath, `${row}\n`);
+  return ledgerPath;
+}
+
+// Read the ledger back into rows. Returns [] when it does not exist yet.
+function readIssuance({ ledgerPath = defaultLedgerPath() } = {}) {
+  if (!fs.existsSync(ledgerPath)) {
+    return [];
+  }
+  const lines = fs.readFileSync(ledgerPath, "utf8").split("\n").filter((line) => line.length > 0);
+  if (lines.length <= 1) {
+    return [];
+  }
+  return lines.slice(1).map((line) => {
+    const [issued_at, name, fingerprint, token] = parseCsvLine(line);
+    return { issued_at, name, fingerprint, token };
+  });
+}
+
+// --------------------------------------------------------------------------- //
+// CLI.
+// --------------------------------------------------------------------------- //
+
 function parseArgs(argv) {
   const args = {};
   for (let i = 0; i < argv.length; i += 1) {
@@ -54,79 +201,59 @@ function parseArgs(argv) {
   return args;
 }
 
-function keygen(args) {
-  const { privateKey, publicKey } = crypto.generateKeyPairSync("ed25519");
-  const privPem = privateKey.export({ type: "pkcs8", format: "pem" });
-  const pubPem = publicKey.export({ type: "spki", format: "pem" });
-
-  const keyPath = args.key || defaultKeyPath();
-  fs.mkdirSync(path.dirname(keyPath), { recursive: true });
-  fs.writeFileSync(keyPath, privPem, { mode: 0o600 });
-
-  const pubPath = args.out || defaultPubPath();
-  fs.mkdirSync(path.dirname(pubPath), { recursive: true });
-  fs.writeFileSync(pubPath, pubPem);
-
-  process.stdout.write(`Private signing key: ${keyPath}\n`);
+function cliKeygen(args) {
+  const result = generateKeypair({
+    keyPath: args.key && args.key !== true ? args.key : undefined,
+    pubPath: args.out && args.out !== true ? args.out : undefined
+  });
+  process.stdout.write(`Private signing key: ${result.keyPath}\n`);
   process.stdout.write("  -> keep secret, never commit. Back it up; losing it invalidates every token.\n");
-  process.stdout.write(`Public key:          ${pubPath}\n`);
+  process.stdout.write(`Public key:          ${result.pubPath}\n`);
   process.stdout.write("  -> commit it and rebuild the app so the gate can verify tokens.\n");
 }
 
-function sign(args) {
+function cliSign(args) {
   if (!args.fingerprint || args.fingerprint === true) {
     throw new Error("sign requires --fingerprint <machine-fingerprint>");
   }
-  const keyPath = args.key || defaultKeyPath();
-  const privPem = fs.readFileSync(keyPath, "utf8");
-  const keyObject = crypto.createPrivateKey(privPem);
-
-  const payload = {
-    v: 1,
-    fp: String(args.fingerprint),
-    name: args.name && args.name !== true ? String(args.name) : null,
-    iat: Math.floor(Date.now() / 1000)
-  };
-  const payloadB64 = b64url(Buffer.from(JSON.stringify(payload), "utf8"));
-  const signature = crypto.sign(null, Buffer.from(payloadB64, "utf8"), keyObject);
-  const token = `${payloadB64}.${b64url(signature)}`;
+  const name = args.name && args.name !== true ? args.name : null;
+  const token = mintToken({
+    fingerprint: args.fingerprint,
+    name,
+    keyPath: args.key && args.key !== true ? args.key : undefined
+  });
+  recordIssuance({ fingerprint: String(args.fingerprint).trim(), name, token });
   process.stdout.write(`${token}\n`);
 }
 
-function verify(args) {
+function cliList() {
+  const rows = readIssuance();
+  const unique = new Set(rows.map((row) => row.fingerprint));
+  process.stdout.write(`Issued tokens: ${rows.length} (${unique.size} unique machines)\n`);
+  process.stdout.write(`Ledger: ${defaultLedgerPath()}\n`);
+  for (const row of rows) {
+    process.stdout.write(`  ${row.issued_at}  ${row.name || "-"}  ${row.fingerprint.slice(0, 12)}…\n`);
+  }
+}
+
+function cliVerify(args) {
   if (!args.token || args.token === true) {
     throw new Error("verify requires --token <token>");
   }
   if (!args.fingerprint || args.fingerprint === true) {
     throw new Error("verify requires --fingerprint <machine-fingerprint>");
   }
-  const pubPath = args.pubkey || defaultPubPath();
-  const pubPem = fs.readFileSync(pubPath, "utf8");
-  const parts = String(args.token).trim().split(".");
-  if (parts.length !== 2) {
-    process.stdout.write("INVALID (malformed)\n");
+  const result = inspectToken({
+    token: args.token,
+    fingerprint: args.fingerprint,
+    pubPath: args.pubkey && args.pubkey !== true ? args.pubkey : undefined
+  });
+  if (!result.valid) {
+    process.stdout.write(`INVALID (${result.reason})\n`);
     process.exitCode = 1;
     return;
   }
-  const keyObject = crypto.createPublicKey(pubPem);
-  const ok = crypto.verify(
-    null,
-    Buffer.from(parts[0], "utf8"),
-    keyObject,
-    Buffer.from(parts[1], "base64url")
-  );
-  if (!ok) {
-    process.stdout.write("INVALID (bad signature)\n");
-    process.exitCode = 1;
-    return;
-  }
-  const payload = JSON.parse(Buffer.from(parts[0], "base64url").toString("utf8"));
-  if (payload.fp !== String(args.fingerprint)) {
-    process.stdout.write("INVALID (wrong machine)\n");
-    process.exitCode = 1;
-    return;
-  }
-  process.stdout.write(`VALID (name=${payload.name || "-"}, iat=${payload.iat})\n`);
+  process.stdout.write(`VALID (name=${result.payload.name || "-"}, iat=${result.payload.iat})\n`);
 }
 
 function usage() {
@@ -137,6 +264,9 @@ function usage() {
       "  node scripts/alpha-token.js keygen [--out <pubkey.pem>] [--key <private.key>]",
       "  node scripts/alpha-token.js sign --fingerprint <fp> [--name <tester>] [--key <private.key>]",
       "  node scripts/alpha-token.js verify --token <t> --fingerprint <fp> [--pubkey <pubkey.pem>]",
+      "  node scripts/alpha-token.js list",
+      "",
+      "Or run the GUI:  node scripts/alpha-token-gui.js",
       ""
     ].join("\n")
   );
@@ -148,13 +278,16 @@ function main() {
   try {
     switch (command) {
       case "keygen":
-        keygen(args);
+        cliKeygen(args);
         break;
       case "sign":
-        sign(args);
+        cliSign(args);
         break;
       case "verify":
-        verify(args);
+        cliVerify(args);
+        break;
+      case "list":
+        cliList();
         break;
       default:
         usage();
@@ -166,4 +299,18 @@ function main() {
   }
 }
 
-main();
+if (require.main === module) {
+  main();
+}
+
+module.exports = {
+  defaultKeyPath,
+  defaultPubPath,
+  defaultLedgerPath,
+  generateKeypair,
+  mintToken,
+  inspectToken,
+  keyStatus,
+  recordIssuance,
+  readIssuance
+};

--- a/scripts/alpha-token.js
+++ b/scripts/alpha-token.js
@@ -1,0 +1,169 @@
+#!/usr/bin/env node
+// #1848: developer-side CLI for the alpha activation gate (offline, zero-server).
+//
+// The private signing key never lives in the repo. `keygen` writes it to
+// ~/.scistudio/alpha-signing.key and writes the matching public key into
+// desktop/resources/alpha-public-key.pem (safe to commit + ship). `sign` mints a
+// token bound to one machine fingerprint that the desktop app verifies offline.
+//
+// This whole tool is ALPHA-ONLY; delete it in beta together with the gate (see
+// issue #1848).
+//
+// Token format (shared with desktop/activation.js):
+//   token        = base64url(payloadJson) + "." + base64url(ed25519Signature)
+//   signed bytes = utf8 bytes of the base64url(payloadJson) string
+//   payloadJson  = {"v":1,"fp":"<sha256-hex>","name":<string|null>,"iat":<unix>}
+//
+// Usage:
+//   node scripts/alpha-token.js keygen [--out <pubkey.pem>] [--key <private.key>]
+//   node scripts/alpha-token.js sign --fingerprint <fp> [--name <tester>] [--key <private.key>]
+//   node scripts/alpha-token.js verify --token <t> --fingerprint <fp> [--pubkey <pubkey.pem>]
+
+const crypto = require("crypto");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+function b64url(buf) {
+  return Buffer.from(buf).toString("base64url");
+}
+
+function defaultKeyPath() {
+  return path.join(os.homedir(), ".scistudio", "alpha-signing.key");
+}
+
+function defaultPubPath() {
+  return path.join(__dirname, "..", "desktop", "resources", "alpha-public-key.pem");
+}
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i];
+    if (token.startsWith("--")) {
+      const key = token.slice(2);
+      const next = argv[i + 1];
+      if (next === undefined || next.startsWith("--")) {
+        args[key] = true;
+      } else {
+        args[key] = next;
+        i += 1;
+      }
+    }
+  }
+  return args;
+}
+
+function keygen(args) {
+  const { privateKey, publicKey } = crypto.generateKeyPairSync("ed25519");
+  const privPem = privateKey.export({ type: "pkcs8", format: "pem" });
+  const pubPem = publicKey.export({ type: "spki", format: "pem" });
+
+  const keyPath = args.key || defaultKeyPath();
+  fs.mkdirSync(path.dirname(keyPath), { recursive: true });
+  fs.writeFileSync(keyPath, privPem, { mode: 0o600 });
+
+  const pubPath = args.out || defaultPubPath();
+  fs.mkdirSync(path.dirname(pubPath), { recursive: true });
+  fs.writeFileSync(pubPath, pubPem);
+
+  process.stdout.write(`Private signing key: ${keyPath}\n`);
+  process.stdout.write("  -> keep secret, never commit. Back it up; losing it invalidates every token.\n");
+  process.stdout.write(`Public key:          ${pubPath}\n`);
+  process.stdout.write("  -> commit it and rebuild the app so the gate can verify tokens.\n");
+}
+
+function sign(args) {
+  if (!args.fingerprint || args.fingerprint === true) {
+    throw new Error("sign requires --fingerprint <machine-fingerprint>");
+  }
+  const keyPath = args.key || defaultKeyPath();
+  const privPem = fs.readFileSync(keyPath, "utf8");
+  const keyObject = crypto.createPrivateKey(privPem);
+
+  const payload = {
+    v: 1,
+    fp: String(args.fingerprint),
+    name: args.name && args.name !== true ? String(args.name) : null,
+    iat: Math.floor(Date.now() / 1000)
+  };
+  const payloadB64 = b64url(Buffer.from(JSON.stringify(payload), "utf8"));
+  const signature = crypto.sign(null, Buffer.from(payloadB64, "utf8"), keyObject);
+  const token = `${payloadB64}.${b64url(signature)}`;
+  process.stdout.write(`${token}\n`);
+}
+
+function verify(args) {
+  if (!args.token || args.token === true) {
+    throw new Error("verify requires --token <token>");
+  }
+  if (!args.fingerprint || args.fingerprint === true) {
+    throw new Error("verify requires --fingerprint <machine-fingerprint>");
+  }
+  const pubPath = args.pubkey || defaultPubPath();
+  const pubPem = fs.readFileSync(pubPath, "utf8");
+  const parts = String(args.token).trim().split(".");
+  if (parts.length !== 2) {
+    process.stdout.write("INVALID (malformed)\n");
+    process.exitCode = 1;
+    return;
+  }
+  const keyObject = crypto.createPublicKey(pubPem);
+  const ok = crypto.verify(
+    null,
+    Buffer.from(parts[0], "utf8"),
+    keyObject,
+    Buffer.from(parts[1], "base64url")
+  );
+  if (!ok) {
+    process.stdout.write("INVALID (bad signature)\n");
+    process.exitCode = 1;
+    return;
+  }
+  const payload = JSON.parse(Buffer.from(parts[0], "base64url").toString("utf8"));
+  if (payload.fp !== String(args.fingerprint)) {
+    process.stdout.write("INVALID (wrong machine)\n");
+    process.exitCode = 1;
+    return;
+  }
+  process.stdout.write(`VALID (name=${payload.name || "-"}, iat=${payload.iat})\n`);
+}
+
+function usage() {
+  process.stdout.write(
+    [
+      "Alpha activation token tool (#1848)",
+      "",
+      "  node scripts/alpha-token.js keygen [--out <pubkey.pem>] [--key <private.key>]",
+      "  node scripts/alpha-token.js sign --fingerprint <fp> [--name <tester>] [--key <private.key>]",
+      "  node scripts/alpha-token.js verify --token <t> --fingerprint <fp> [--pubkey <pubkey.pem>]",
+      ""
+    ].join("\n")
+  );
+}
+
+function main() {
+  const [command, ...rest] = process.argv.slice(2);
+  const args = parseArgs(rest);
+  try {
+    switch (command) {
+      case "keygen":
+        keygen(args);
+        break;
+      case "sign":
+        sign(args);
+        break;
+      case "verify":
+        verify(args);
+        break;
+      default:
+        usage();
+        process.exitCode = command ? 1 : 0;
+    }
+  } catch (error) {
+    process.stderr.write(`error: ${error.message}\n`);
+    process.exitCode = 1;
+  }
+}
+
+main();

--- a/scripts/build-issuer-app.sh
+++ b/scripts/build-issuer-app.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# #1848: assemble a tiny no-Electron macOS .app that launches the alpha token
+# issuer GUI. Double-click the resulting app to open the issuer in your browser;
+# it runs the bundled Node scripts and reads the signing key from
+# ~/.scistudio/alpha-signing.key. Use the GUI's "Quit issuer" button to stop it.
+#
+# Usage:  bash scripts/build-issuer-app.sh [dest-dir]   (default dest: ~/Desktop)
+#
+# The .app is a build artifact (not committed). Requires Node.js on the machine
+# that runs it. ALPHA-ONLY; delete in beta with the rest of the gate (#1848).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "$0")" && pwd)"
+DEST_DIR="${1:-$HOME/Desktop}"
+APP="$DEST_DIR/Alpha Token Issuer.app"
+
+rm -rf "$APP"
+mkdir -p "$APP/Contents/MacOS" "$APP/Contents/Resources"
+
+# Self-contained: bundle the issuer scripts so the app works wherever it lives.
+cp "$SCRIPT_DIR/alpha-token.js" "$APP/Contents/Resources/alpha-token.js"
+cp "$SCRIPT_DIR/alpha-token-gui.js" "$APP/Contents/Resources/alpha-token-gui.js"
+
+cat > "$APP/Contents/Info.plist" <<'PLIST'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleName</key><string>Alpha Token Issuer</string>
+  <key>CFBundleDisplayName</key><string>Alpha Token Issuer</string>
+  <key>CFBundleIdentifier</key><string>org.scistudio.alpha-token-issuer</string>
+  <key>CFBundleVersion</key><string>1.0</string>
+  <key>CFBundleShortVersionString</key><string>1.0</string>
+  <key>CFBundlePackageType</key><string>APPL</string>
+  <key>CFBundleExecutable</key><string>run</string>
+  <key>LSUIElement</key><true/>
+  <key>LSMinimumSystemVersion</key><string>10.13</string>
+</dict>
+</plist>
+PLIST
+
+cat > "$APP/Contents/MacOS/run" <<'RUN'
+#!/bin/bash
+# Launched by LaunchServices with a minimal PATH; add common Node locations.
+HERE="$(cd "$(dirname "$0")" && pwd)"
+RES="$(cd "$HERE/../Resources" && pwd)"
+export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"
+if ! command -v node >/dev/null 2>&1; then
+  osascript -e 'display alert "Node.js not found" message "Install Node.js, then reopen Alpha Token Issuer."' >/dev/null 2>&1
+  exit 1
+fi
+exec node "$RES/alpha-token-gui.js"
+RUN
+chmod +x "$APP/Contents/MacOS/run"
+
+echo "Built: $APP"
+echo "Double-click it (or move it anywhere, e.g. /Applications) to launch the issuer."


### PR DESCRIPTION
## Summary

Adds an **alpha activation gate**: the desktop app will not open without a valid
per-machine activation token. The installer/dmg itself never expires and may be
reused — the gate is the token. This stops alpha testers from redistributing the
build to unauthorized people: a token binds to one machine, so a forwarded copy
fails on a different machine.

Offline and zero-server (fits the existing GitHub-static distribution): Ed25519
signed tokens, the developer holds the private key, the public key ships in the
build. ALPHA-ONLY and isolated behind `app.isPackaged` / `SCISTUDIO_ALPHA_GATE`;
removed in beta per the checklist in the doc.

## What's included

- **Gate** (`desktop/activation.js`, `desktop/preload-gate.js`,
  `desktop/resources/alpha-gate.html`, wiring in `desktop/main.js`): on launch,
  block until the machine is activated. The window shows a "registration code"
  (a sha256 of a stable per-machine id — macOS `IOPlatformUUID` / Windows
  `MachineGuid`) with a copy button, plus a token field + Activate.
- **Developer tooling** (`scripts/alpha-token.js`): `keygen` / `sign` / `verify`
  / `list`, plus an append-only CSV issuance ledger (`~/.scistudio/`).
- **Issuer GUI** (`scripts/alpha-token-gui.js`) with a double-click launcher
  (`scripts/alpha-token-issuer.command`) and a no-Electron `.app` builder
  (`scripts/build-issuer-app.sh`).
- **Tests** (`desktop/test/activation.test.js`, `desktop/test/alpha-token.test.js`):
  signature/binding/storage + mint/inspect + CSV ledger. All 34 desktop tests pass.
- **Docs** (`docs/alpha-activation-gate.md`): flow, developer setup, and the beta
  removal checklist.

## Verification

- Built the macOS arm64 dmg; confirmed the gate code + resources ship inside the
  app bundle.
- Owner completed the activation click-through (gate blocks unactivated, opens
  after a valid token; re-launch opens directly).
- Issuer `.app` verified: serves, signs, records to the ledger, quits cleanly.

## Notes

- The private signing key lives only at `~/.scistudio/alpha-signing.key` (never
  committed). The shipped public key is `desktop/resources/alpha-public-key.pem`.
- Online revocation and a per-tester UI watermark are deliberately out of scope
  for the alpha.

Closes #1848
