### PR TITLE
release(#1853): bump base version to 0.3.2 (standardized public API + alpha token activator)

### DIFF
--- a/.workflow/records/1853-guided-1853-release-0-3-2.json
+++ b/.workflow/records/1853-guided-1853-release-0-3-2.json
@@ -1,8 +1,246 @@
 {
   "branch": "guided/1853-release-0.3.2",
-  "check_events": [],
+  "check_events": [
+    {
+      "at": "2026-06-28T22:10:54.683044Z",
+      "command": "pytest tests/architecture/ -v --no-cov",
+      "covered_surface": "architecture",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:90a593c58e0d05f1d9f63654c9621415d5711e16bd9ea4dfbb4bcdcb608d4747",
+      "name": "architecture_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/architecture_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-28T22:10:55.373409Z",
+      "command": "python scripts/deferral_scan.py --check docs/audit/baselines/deferral-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:9e61ff8b224c087248a8fcbe16744b76e200684148b19e267f020ca958226a6d",
+      "name": "deferral_discipline",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/deferral_discipline.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-28T22:10:55.415625Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:7718e2534306bd11542d156034cf850d8cbbe6c2514d11b48a8026eb691ea8c4",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-28T22:11:31.962949Z",
+      "command": "(cd frontend && npm run check:ci)",
+      "covered_surface": "frontend",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:1fdb4f0f06201c76ac1610cb951f8f2031cebf877e80ee241c4665d8f8633f52",
+      "name": "frontend",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/frontend.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-28T22:11:36.124511Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e1db5ceb9ebc51895cc8b2b36614706b871b41dcbdb13dbabaaa73390f43d53b",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-28T22:11:36.218906Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:00490f2545fbd60511c989777fa4fd57f36849f5dc1fe5d021fda509d4b1f1be",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-28T22:11:36.255451Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:c9c03bc1ad579dd5fc7497fe164adb0ab31cfe9b9106168f8db758fcc9694512",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-28T22:12:55.946616Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:e86c45035ba5510b4205a595ed85731f637d1416ad93459920dc9f9abb018db6",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-28T22:14:48.657499Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:edbe72e4c5eec65983a2690ff4991d2e336f3c714fc29e1ec32ef0d40518c064",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-28T22:14:54.704537Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:0a0853f1f690d11689675e58785138b860c16dc15d92c8c9b25c4839c294ee76",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    },
+    {
+      "at": "2026-06-28T22:14:56.642072Z",
+      "command": "python -m build --wheel",
+      "covered_surface": "packaging",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:a12d793651af1cf45528766322239417eb96046ec002af6490963921807745ec",
+      "name": "wheel_release_smoke",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/wheel_release_smoke.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-28T22:16:49.709041Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:e86c45035ba5510b4205a595ed85731f637d1416ad93459920dc9f9abb018db6",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-28T22:19:59.535787Z",
+      "command": "python scripts/deferral_scan.py --check docs/audit/baselines/deferral-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e0c7cef35db3524f9a8b9af7e2e41d30002c74113d0ebb0e0f5be3f7da7d1238",
+      "name": "deferral_discipline",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/deferral_discipline.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-28T22:20:02.851540Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:7c5fac28f6c4a3ca32b94f6384402ed0afadb6b0041d75575b58d7411c2936ad",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-28T22:21:06.646342Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e86c45035ba5510b4205a595ed85731f637d1416ad93459920dc9f9abb018db6",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    }
+  ],
   "check_na": [],
-  "commit": null,
+  "commit": {
+    "sha": "b2188836d4ad2215428e91c8d89fa790355ad3dd",
+    "shas": [
+      "b2188836d4ad2215428e91c8d89fa790355ad3dd"
+    ],
+    "trailers": []
+  },
   "declared_scope": {
     "exclude": [],
     "include": [
@@ -20,6 +258,11 @@
       "at": "2026-06-28T22:08:30.933879Z",
       "owner_directive": "bump _version.py \u5230 0.3.2 + version.py sync \u540c\u6b65 manifests(\u63d0\u4ea4 build0000)+ CHANGELOG 0.3.2 \u53d1\u884c\u516c\u544a",
       "reason": "plan"
+    },
+    {
+      "at": "2026-06-28T22:15:35.797714Z",
+      "owner_directive": "bump \u5230 0.3.2 \u5e76 sync manifests(\u542b pyproject \u7248\u672c\u884c)",
+      "reason": "version.py sync \u6539\u5199 pyproject.toml \u7684 version \u884c(0.3.1a0->0.3.2a0);\u4ec5\u7248\u672c\u53f7,\u975e\u4f9d\u8d56/\u6784\u5efa\u914d\u7f6e\u53d8\u66f4;owner \u6307\u793a\u7684 0.3.2 \u53d1\u5e03"
     }
   ],
   "docs_events": [
@@ -32,8 +275,523 @@
       "verified_in_diff": null
     }
   ],
-  "governance_touch": false,
-  "guard_events": [],
+  "governance_touch": true,
+  "guard_events": [
+    {
+      "at": "2026-06-28T22:14:56.668774Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:14:56.677793Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:14:56.686780Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:14:56.695667Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:14:56.705310Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "pyproject.toml",
+          "finding_class": "governance",
+          "git_evidence": null,
+          "id": "governance.mod_guard.unauthorized-change",
+          "line": null,
+          "message": "governance-critical file changed without authorization; declare governance_touch in the ledger and obtain owner review",
+          "path": "pyproject.toml",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "governance.mod_guard.unauthorized-change",
+          "severity": "error",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "mod_guard",
+      "status": "fail"
+    },
+    {
+      "at": "2026-06-28T22:14:56.714268Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:14:56.723332Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:14:56.732909Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:14:56.741655Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:14:56.750893Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:16:49.738449Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:16:49.748115Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:16:49.757605Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:16:49.767555Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:16:49.777387Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:16:49.787881Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:16:49.797531Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:16:49.807664Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:16:49.817087Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:16:49.827287Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:21:06.675278Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:21:06.685265Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:21:06.696094Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:21:06.705815Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:21:06.715833Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:21:06.725879Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:21:06.735675Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:21:06.745746Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:21:06.755555Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:21:06.766324Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:21:33.646499Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:21:33.655532Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:21:33.664046Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:21:33.672680Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:21:33.681006Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:21:33.689671Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:21:33.699034Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:21:33.708110Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:21:33.717265Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:21:33.727298Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:21:46.570027Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:21:46.578996Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:21:46.588388Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:21:46.597857Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:21:46.606347Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:21:46.615008Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:21:46.623204Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:21:46.631888Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:21:46.640323Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:21:46.648982Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:21:57.743778Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:21:57.752890Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:21:57.761520Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:21:57.771041Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:21:57.780087Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:21:57.789537Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:21:57.799099Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:21:57.809558Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:21:57.819324Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:21:57.828670Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
   "issues": [
     {
       "close_in_pr": true,
@@ -43,25 +801,149 @@
     }
   ],
   "observed_admin_labels": [],
-  "observed_diff": null,
+  "observed_diff": {
+    "base": "9731cd4a23e4eb19c93dd61426612b88da809b94",
+    "base_sha": "9731cd4a",
+    "changed_files": [
+      ".workflow/records/1853-guided-1853-release-0-3-2.json",
+      "CHANGELOG.md",
+      "README.md",
+      "desktop/package-lock.json",
+      "desktop/package.json",
+      "frontend/package-lock.json",
+      "frontend/package.json",
+      "pyproject.toml",
+      "src/scistudio/_version.py"
+    ],
+    "diff_fingerprint": "sha256:6e38f26ae5624c9a76fe2d453f3cc4bba52b006b348077a86ca6f3831e7ae6b1",
+    "head": "HEAD",
+    "head_sha": "b2188836",
+    "surfaces": {
+      "docs": 0,
+      "frontend": 2,
+      "governance": 1,
+      "governed_docs": 0,
+      "implementation": 4,
+      "packaging": 1,
+      "protected_core": 0,
+      "sentrux": 3,
+      "test": 0,
+      "workflow_ci": 0
+    }
+  },
   "owner_directive": "\u7248\u672c bump \u5230 0.3.2;\u53d1\u884c\u516c\u544a:\u6807\u51c6\u5316\u516c\u5171 API + \u52a0\u5165 alpha \u6d4b\u8bd5 token \u6fc0\u6d3b\u5668\u3002\u4e3a\u53d1\u5e03\u5e26 gate \u7684\u5b98\u65b9 dmg \u505a\u51c6\u5907\u3002",
   "persona": "live_implementer",
-  "pull_request": null,
-  "reconcile_events": [],
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [
+      1853
+    ],
+    "number": 1854,
+    "url": "https://github.com/jiazhenz026/SciStudio/pull/1854"
+  },
+  "reconcile_events": [
+    {
+      "at": "2026-06-28T22:14:56.750928Z",
+      "diff_fingerprint": "sha256:046ab20537cf89330474a10f59831640360af57d40050fceb83f87917f45d270",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.python_tests",
+        "guard.mod_guard"
+      ]
+    },
+    {
+      "at": "2026-06-28T22:16:49.827319Z",
+      "diff_fingerprint": "sha256:046ab20537cf89330474a10f59831640360af57d40050fceb83f87917f45d270",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.python_tests"
+      ]
+    },
+    {
+      "at": "2026-06-28T22:21:06.766365Z",
+      "diff_fingerprint": "sha256:6e38f26ae5624c9a76fe2d453f3cc4bba52b006b348077a86ca6f3831e7ae6b1",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-28T22:21:33.727326Z",
+      "diff_fingerprint": "sha256:6e38f26ae5624c9a76fe2d453f3cc4bba52b006b348077a86ca6f3831e7ae6b1",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-28T22:21:46.649023Z",
+      "diff_fingerprint": "sha256:6e38f26ae5624c9a76fe2d453f3cc4bba52b006b348077a86ca6f3831e7ae6b1",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-28T22:21:57.828706Z",
+      "diff_fingerprint": "sha256:6e38f26ae5624c9a76fe2d453f3cc4bba52b006b348077a86ca6f3831e7ae6b1",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    }
+  ],
   "record_id": "1853-guided-1853-release-0-3-2",
   "requested_admin_labels": [],
   "required_obligations": {
     "admin_labels": [],
-    "checks": [],
-    "docs": [],
-    "guards": [],
-    "tests": []
+    "checks": [
+      "architecture_tests",
+      "deferral_discipline",
+      "format_check",
+      "frontend",
+      "full_audit",
+      "import_contracts",
+      "lint_format",
+      "python_tests",
+      "semantic_dup",
+      "type_check",
+      "wheel_release_smoke"
+    ],
+    "docs": [
+      "docs_required_or_na"
+    ],
+    "guards": [
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": [
+      "changed_test_required"
+    ]
   },
   "runtime": "claude-code",
   "schema_version": 2,
-  "scope_events": [],
+  "scope_events": [
+    {
+      "action": "add-include",
+      "at": "2026-06-28T22:18:46.457637Z",
+      "pattern": "README.md",
+      "reason": "README \u7248\u672c\u72b6\u6001\u884c\u9700\u4e0e pyproject \u540c\u6b65(test_version_alignment);\u968f 0.3.2 bump \u66f4\u65b0"
+    }
+  ],
   "session_id": "45d8686c-92c5-45ea-b380-c348978bec9d",
-  "strictness_tier": null,
+  "strictness_tier": 1,
   "task_kind": "guided",
   "test_events": [
     {

--- a/.workflow/records/1853-guided-1853-release-0-3-2.json
+++ b/.workflow/records/1853-guided-1853-release-0-3-2.json
@@ -1,0 +1,76 @@
+{
+  "branch": "guided/1853-release-0.3.2",
+  "check_events": [],
+  "check_na": [],
+  "commit": null,
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "src/scistudio/_version.py",
+      "pyproject.toml",
+      "desktop/package.json",
+      "frontend/package.json",
+      "desktop/package-lock.json",
+      "frontend/package-lock.json",
+      "CHANGELOG.md"
+    ]
+  },
+  "directive_events": [
+    {
+      "at": "2026-06-28T22:08:30.933879Z",
+      "owner_directive": "bump _version.py \u5230 0.3.2 + version.py sync \u540c\u6b65 manifests(\u63d0\u4ea4 build0000)+ CHANGELOG 0.3.2 \u53d1\u884c\u516c\u544a",
+      "reason": "plan"
+    }
+  ],
+  "docs_events": [
+    {
+      "at": "2026-06-28T22:08:30.933998Z",
+      "class": null,
+      "kind": "path",
+      "path": "CHANGELOG.md",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": false,
+  "guard_events": [],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1853,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": null,
+  "owner_directive": "\u7248\u672c bump \u5230 0.3.2;\u53d1\u884c\u516c\u544a:\u6807\u51c6\u5316\u516c\u5171 API + \u52a0\u5165 alpha \u6d4b\u8bd5 token \u6fc0\u6d3b\u5668\u3002\u4e3a\u53d1\u5e03\u5e26 gate \u7684\u5b98\u65b9 dmg \u505a\u51c6\u5907\u3002",
+  "persona": "live_implementer",
+  "pull_request": null,
+  "reconcile_events": [],
+  "record_id": "1853-guided-1853-release-0-3-2",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [],
+    "docs": [],
+    "guards": [],
+    "tests": []
+  },
+  "runtime": "claude-code",
+  "schema_version": 2,
+  "scope_events": [],
+  "session_id": "45d8686c-92c5-45ea-b380-c348978bec9d",
+  "strictness_tier": null,
+  "task_kind": "guided",
+  "test_events": [
+    {
+      "at": "2026-06-28T22:08:30.934009Z",
+      "class": "implementation",
+      "kind": "na",
+      "path": null,
+      "rationale": "version-data bump (BASE_VERSION 0.3.1->0.3.2) with no logic change; covered by existing tests/test_version.py (13 pass)",
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.3.2] - 2026-06-28
+
+Standardized the public API surface (ADR-052) and added the alpha testing token
+activator. This is the first release carrying the activation gate: a packaged
+build will not open without a developer-issued, per-machine token, so the
+installer can be distributed for download without being runnable by
+unauthorized recipients. Going forward each release publishes the OTA patch and
+the full (gated) dmg together on the alpha release.
+
 ### Added
 
+- [#1848] Alpha activation gate — the desktop app now requires a per-machine
+  activation token to launch. Offline and zero-server: Ed25519-signed tokens
+  bound to a stable machine fingerprint, verified against a public key shipped
+  in the build (the developer holds the private key); a forwarded copy fails on
+  a different machine. Packaged builds always enforce the gate (no env bypass)
+  and trust only the shipped key. Ships developer token-issuer tooling
+  (`scripts/alpha-token.js` CLI, a local GUI, a double-click launcher, and a
+  no-Electron `.app` builder) plus a CSV issuance ledger. Alpha-only; removed in
+  beta (`docs/alpha-activation-gate.md`). (@claude, 2026-06-28, branch: guided/1848-alpha-activation-gate)
 - [#1828] `scistudio.stability` — the ADR-052 §5 public-API stability decorators (`stable` / `provisional` / `internal`, each carrying `Since`) plus `StabilityInfo` and `get_stability()` introspection. The decorators are runtime no-ops that stamp tier/version metadata on a public symbol; `get_stability()` is the single read path shared by the contract validator, the API-surface freeze test, and the generated reference (ADR-052 §7, §15). Foundational mechanism only: decorating core's own public surface, the generated reference, and the freeze test are tracked under #1817; the package template consumes it under #1826. (@claude, 2026-06-27, branch: guided/1828-scistudio-stability)
 - [#1815] Native Excel (`.xlsx`) read/write for core **DataFrame** and **Series** (#1810): an `xlsx` format capability on LoadData/SaveData via the pandas + openpyxl bridge. `.xlsx` is collection-valued — a workbook loads as one DataObject per sheet. Adds `openpyxl>=3.1` and raises the numpy floor `>=1.25` → `>=2.1` (#1809). (@claude, 2026-06-27, branch: feature/1810-dataframe-xlsx-io)
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ SciStudio is a **modality-agnostic, building-block workflow framework** where:
 - Multiple data modalities coexist in a **single workflow graph**, enabling true cross-modal fusion analysis.
 - The framework is **AI-native**: AI can generate blocks, synthesize workflows, and optimize parameters at runtime.
 
-> **Status**: SciStudio is in **pre-alpha** (v0.3.1a0). The core runtime, block system, execution engine, API layer, and frontend workflow editor are implemented and under active development. See [Current Status](#current-status) for details.
+> **Status**: SciStudio is in **pre-alpha** (v0.3.2a0). The core runtime, block system, execution engine, API layer, and frontend workflow editor are implemented and under active development. See [Current Status](#current-status) for details.
 
 ---
 
@@ -427,7 +427,7 @@ Significant design decisions are documented as ADRs in [`docs/adr/`](docs/adr/).
 
 ## Current Status
 
-SciStudio is in **pre-alpha** (v0.3.1a0). The following is implemented and under active development:
+SciStudio is in **pre-alpha** (v0.3.2a0). The following is implemented and under active development:
 
 **Implemented:**
 - Core data type hierarchy with six base types and domain-specific subtypes

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scistudio-desktop",
-  "version": "0.3.1-alpha-build0000",
+  "version": "0.3.2-alpha-build0000",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scistudio-desktop",
-      "version": "0.3.1-alpha-build0000",
+      "version": "0.3.2-alpha-build0000",
       "devDependencies": {
         "electron": "42.2.0",
         "electron-builder": "26.8.1"

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scistudio-desktop",
-  "version": "0.3.1-alpha-build0000",
+  "version": "0.3.2-alpha-build0000",
   "private": true,
   "description": "SciStudio ADR-037 desktop MVP shell",
   "author": "SciStudio",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scistudio-frontend",
-  "version": "0.3.1-alpha-build0000",
+  "version": "0.3.2-alpha-build0000",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scistudio-frontend",
-      "version": "0.3.1-alpha-build0000",
+      "version": "0.3.2-alpha-build0000",
       "dependencies": {
         "@monaco-editor/react": "^4.6.0",
         "@radix-ui/react-dropdown-menu": "^2.1.16",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scistudio-frontend",
-  "version": "0.3.1-alpha-build0000",
+  "version": "0.3.2-alpha-build0000",
   "private": true,
   "type": "module",
   "scripts": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "scistudio"
-version = "0.3.1a0"
+version = "0.3.2a0"
 description = "AI-native, inclusive workflow runtime for multimodal scientific data"
 readme = "README.md"
 license = {text = "MIT"}
@@ -453,7 +453,7 @@ ancestors = ["scistudio.ai.agent.mcp.tools_inspection"]
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "0.3.1a0"
+version = "0.3.2a0"
 tag_format = "v$version"
 
 # Issue #1340 / ADR-042 code-quality stack: vulture runs as an informational

--- a/src/scistudio/_version.py
+++ b/src/scistudio/_version.py
@@ -15,7 +15,7 @@ Keep this module import-cheap and dependency-free: it is imported very early
 from __future__ import annotations
 
 #: Base semantic version ``a.b.c`` (no channel/build suffix).
-BASE_VERSION = "0.3.1"
+BASE_VERSION = "0.3.2"
 
 #: Release channel. One of ``"alpha"``, ``"beta"``, ``"stable"``.
 CHANNEL = "alpha"


### PR DESCRIPTION
## Summary

Bumps the SSOT base version `0.3.1` → `0.3.2` (alpha) and records the 0.3.2
release notes. 0.3.2 is the first release carrying the alpha activation gate
(#1848): a packaged build will not open without a developer-issued, per-machine
token, so the installer can be distributed for download without being runnable
by unauthorized recipients.

## Changes

- `src/scistudio/_version.py`: `BASE_VERSION = "0.3.2"` (the single source of truth).
- `scripts/version.py sync`: pyproject (`0.3.2a0`), both `package.json` and both
  lockfiles to `0.3.2-alpha-build0000`. Committed manifests stay at build `0000`;
  the real build number is injected at installer build time.
- `CHANGELOG.md`: new `## [0.3.2]` section — standardized public API surface
  (ADR-052, #1828/#1817) and the alpha testing token activator (#1848).
- `README.md`: status line version `v0.3.1a0` → `v0.3.2a0` (version-alignment test).

## Notes

- `governance_touch` declared for the `pyproject.toml` version-line edit (owner
  directed the bump). No dependency or build-config change.
- Local gate ran the full Tier-1 CI mirror with a clean `HOME` (reconciliation
  passed). The only local failures without a clean `HOME` are the known
  user-plugin-leakage previewer tests, which pass under CI conditions.

Closes #1853
