### PR TITLE
feat(#1855): alpha launch check-in to count active internal testers

### DIFF
--- a/.workflow/records/1855-guided-1855-alpha-checkin.json
+++ b/.workflow/records/1855-guided-1855-alpha-checkin.json
@@ -1,0 +1,52 @@
+{
+  "branch": "guided/1855-alpha-checkin",
+  "check_events": [],
+  "check_na": [],
+  "commit": null,
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "src/scistudio/telemetry/**",
+      "src/scistudio/api/app.py",
+      "desktop/main.js",
+      "desktop/resources/alpha-gate.html",
+      "docs/alpha-activation-gate.md",
+      ".gitignore",
+      "tests/**"
+    ]
+  },
+  "directive_events": [],
+  "docs_events": [],
+  "governance_touch": false,
+  "guard_events": [],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1855,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": null,
+  "owner_directive": "Add A-tier lightweight Slack webhook launch check-in in the Python backend to count active internal alpha testers (covers gate-bypass users too). Webhook URL gitignored to avoid spam. Privacy notice added on the activation gate screen. Code marked alpha-only/temporary with beta-removal checklist.",
+  "persona": "live_implementer",
+  "pull_request": null,
+  "reconcile_events": [],
+  "record_id": "1855-guided-1855-alpha-checkin",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [],
+    "docs": [],
+    "guards": [],
+    "tests": []
+  },
+  "runtime": "claude-code",
+  "schema_version": 2,
+  "scope_events": [],
+  "session_id": "9a1782ad-5af8-4fea-97a7-c42d5308aa56",
+  "strictness_tier": null,
+  "task_kind": "guided",
+  "test_events": []
+}

--- a/.workflow/records/1855-guided-1855-alpha-checkin.json
+++ b/.workflow/records/1855-guided-1855-alpha-checkin.json
@@ -1,6 +1,118 @@
 {
   "branch": "guided/1855-alpha-checkin",
-  "check_events": [],
+  "check_events": [
+    {
+      "at": "2026-06-28T22:38:17.187895Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:215a1c84c5ae22741df475f208010abe05561e34d577410ca3d17f707626e7d2",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-28T22:38:20.277380Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:7ae85b6c24334279e25b157c05d600d52620a2471dec65ece116fff35631b310",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-28T22:38:20.377334Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:1a7ce5b66b66777384d7a1f7fa3bf82df42e7effe3a66ce96f81196d3c9e5026",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-28T22:38:20.397899Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:2a23fca22ef066da6cd866c644bea74cfae72844943434d83f598a53114dbb48",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-28T22:39:35.091025Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:e20c4d1cdfdc689206b72495a2367fad461234e1ea9ee952489c90747c786eff",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-28T22:41:23.087023Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:7e3d292486728e55fd42ea4a98ff3f8fd2fa899713fd390003cdf94daa027203",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-28T22:41:29.547369Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:41bd051e4c0b2a10346a83846d8bbbc1bea835762a5d55b67a5d0755f6109697",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    }
+  ],
   "check_na": [],
   "commit": null,
   "declared_scope": {
@@ -16,9 +128,151 @@
     ]
   },
   "directive_events": [],
-  "docs_events": [],
+  "docs_events": [
+    {
+      "at": "2026-06-28T22:43:18.646139Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/alpha-activation-gate.md",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ],
   "governance_touch": false,
-  "guard_events": [],
+  "guard_events": [
+    {
+      "at": "2026-06-28T22:37:41.760689Z",
+      "findings": [
+        {
+          "message": "AI-authored edits must happen in a dedicated worktree, not the main working tree (/private/var/folders/mk/xk0dqvn934l5425gwb19rsqc0000gn/T/pytest-of-jiazhenz/pytest-875/popen-gw4/test_hook_payload_blocks_main_0/main). Create one with `git worktree add ../<name> <branch>` and run your edits there.",
+          "rule_id": "worktree.main-checkout-write"
+        }
+      ],
+      "guard": "worktree_write_guard",
+      "status": "fail"
+    },
+    {
+      "at": "2026-06-28T22:37:42.533514Z",
+      "findings": [
+        {
+          "message": "AI-authored edits must happen in a dedicated worktree, not the main working tree (/private/var/folders/mk/xk0dqvn934l5425gwb19rsqc0000gn/T/pytest-of-jiazhenz/pytest-875/popen-gw4/test_hook_payload_extracts_mul0/main). Create one with `git worktree add ../<name> <branch>` and run your edits there.",
+          "rule_id": "worktree.main-checkout-write"
+        }
+      ],
+      "guard": "worktree_write_guard",
+      "status": "fail"
+    },
+    {
+      "at": "2026-06-28T22:41:29.587429Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:41:29.598168Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {
+            "governed_files": [
+              "src/scistudio/api/app.py",
+              "src/scistudio/telemetry/__init__.py",
+              "src/scistudio/telemetry/checkin.py"
+            ]
+          },
+          "expected": null,
+          "file": "",
+          "finding_class": "docs_landing",
+          "git_evidence": null,
+          "id": "docs_landing.missing-landing",
+          "line": null,
+          "message": "governed change requires docs/changelog/checklist landing evidence or an explicit N/A rationale",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "docs_landing.missing-landing",
+          "severity": "error",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "docs_landing",
+      "status": "fail"
+    },
+    {
+      "at": "2026-06-28T22:41:29.607395Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:41:29.616444Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:41:29.625180Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:41:29.634167Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:41:29.642984Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:41:29.651792Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:41:29.660398Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:41:29.670358Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
   "issues": [
     {
       "close_in_pr": true,
@@ -28,25 +282,103 @@
     }
   ],
   "observed_admin_labels": [],
-  "observed_diff": null,
+  "observed_diff": {
+    "base": "origin/main",
+    "base_sha": "9731cd4a",
+    "changed_files": [
+      ".workflow/records/1855-guided-1855-alpha-checkin.json",
+      "desktop/main.js",
+      "desktop/resources/.gitignore",
+      "desktop/resources/alpha-gate.html",
+      "docs/alpha-activation-gate.md",
+      "src/scistudio/api/app.py",
+      "src/scistudio/telemetry/__init__.py",
+      "src/scistudio/telemetry/checkin.py",
+      "tests/telemetry/test_checkin.py"
+    ],
+    "diff_fingerprint": "sha256:bc1553f3ddee007ebaa0f9d370b400f7f691f43d93f12abc83f450c15464b0dc",
+    "head": "HEAD",
+    "head_sha": "6bd8e37a",
+    "surfaces": {
+      "docs": 1,
+      "frontend": 0,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 3,
+      "packaging": 0,
+      "protected_core": 0,
+      "sentrux": 4,
+      "test": 1,
+      "workflow_ci": 0
+    }
+  },
   "owner_directive": "Add A-tier lightweight Slack webhook launch check-in in the Python backend to count active internal alpha testers (covers gate-bypass users too). Webhook URL gitignored to avoid spam. Privacy notice added on the activation gate screen. Code marked alpha-only/temporary with beta-removal checklist.",
   "persona": "live_implementer",
   "pull_request": null,
-  "reconcile_events": [],
+  "reconcile_events": [
+    {
+      "at": "2026-06-28T22:41:29.670415Z",
+      "diff_fingerprint": "sha256:bc1553f3ddee007ebaa0f9d370b400f7f691f43d93f12abc83f450c15464b0dc",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.format_check",
+        "checks.lint_format",
+        "checks.python_tests",
+        "docs.docs_required_or_na",
+        "guard.docs_landing",
+        "scope.out-of-scope",
+        "tests.changed_test_required"
+      ]
+    }
+  ],
   "record_id": "1855-guided-1855-alpha-checkin",
   "requested_admin_labels": [],
   "required_obligations": {
     "admin_labels": [],
-    "checks": [],
-    "docs": [],
-    "guards": [],
-    "tests": []
+    "checks": [
+      "format_check",
+      "full_audit",
+      "import_contracts",
+      "lint_format",
+      "python_tests",
+      "semantic_dup",
+      "type_check"
+    ],
+    "docs": [
+      "docs_required_or_na"
+    ],
+    "guards": [
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": [
+      "changed_test_required"
+    ]
   },
   "runtime": "claude-code",
   "schema_version": 2,
   "scope_events": [],
   "session_id": "9a1782ad-5af8-4fea-97a7-c42d5308aa56",
-  "strictness_tier": null,
+  "strictness_tier": 2,
   "task_kind": "guided",
-  "test_events": []
+  "test_events": [
+    {
+      "at": "2026-06-28T22:43:18.646277Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/telemetry/test_checkin.py",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
 }

--- a/.workflow/records/1855-guided-1855-alpha-checkin.json
+++ b/.workflow/records/1855-guided-1855-alpha-checkin.json
@@ -333,10 +333,127 @@
       "tool_versions": {
         "mypy": "2.1.0"
       }
+    },
+    {
+      "at": "2026-06-28T22:51:45.073987Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:15a2b60a4e4ddf97abf0625de393cb43e99f9687f8261c7874dd2ddee8692d77",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-28T22:51:48.356472Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:008d5c08926dfb6d7b16b85b2d0dc4a4d2d0f106f7b9197017496eb90039aaa3",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-28T22:51:48.457612Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:31015a411eefe58debfc09c1f47118f444e9e65a18c28191cc0a6087345d80ac",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-28T22:51:48.476984Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:77a4a8170ca5b7e190396998483f4d2fe2fc397aba5ceaffa0bd88c2f98937ef",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-28T22:52:56.819616Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:8d3b01b2facdb11e94d53dd3e4f1a73b329eb749a6aff7ac97474ab026475ea3",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-28T22:54:57.549704Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cb1e0371160c07c076c417da2a448701adab47e30d949afe4ef7e59ac1f0133a",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-28T22:54:58.170792Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:2f9b89178c5516391a79c7614cfcc2271d579843aeefa75984cf612459746804",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
     }
   ],
   "check_na": [],
-  "commit": null,
+  "commit": {
+    "sha": "e7c7ecde6ac4e6c86b4c30836e94631e2f7d1662",
+    "shas": [
+      "e7c7ecde6ac4e6c86b4c30836e94631e2f7d1662"
+    ],
+    "trailers": []
+  },
   "declared_scope": {
     "exclude": [],
     "include": [
@@ -657,6 +774,170 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:54:58.214611Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:54:58.223613Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:54:58.232541Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:54:58.241591Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:54:58.250672Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:54:58.259852Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:54:58.268661Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:54:58.277631Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:54:58.286846Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:54:58.298515Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:55:15.554448Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:55:15.565491Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:55:15.576597Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:55:15.588045Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:55:15.598953Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:55:15.609699Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:55:15.620349Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:55:15.632247Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:55:15.643269Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:55:15.657064Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -683,9 +964,9 @@
       "tests/architecture/test_placement.py",
       "tests/telemetry/test_checkin.py"
     ],
-    "diff_fingerprint": "sha256:824ed901fa4ee52b09b23f1b0c08c8a3c1f5070958aaa5eb872f389a76e3632f",
+    "diff_fingerprint": "sha256:5c8fcc28518564864cc4eb39f0b899b5cf3893f24b9df8c0d34fef0021012ea5",
     "head": "HEAD",
-    "head_sha": "60c4b8e9",
+    "head_sha": "e7c7ecde",
     "surfaces": {
       "docs": 1,
       "frontend": 0,
@@ -701,7 +982,14 @@
   },
   "owner_directive": "Add A-tier lightweight Slack webhook launch check-in in the Python backend to count active internal alpha testers (covers gate-bypass users too). Webhook URL gitignored to avoid spam. Privacy notice added on the activation gate screen. Code marked alpha-only/temporary with beta-removal checklist.",
   "persona": "live_implementer",
-  "pull_request": null,
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [
+      1855
+    ],
+    "number": null,
+    "url": null
+  },
   "reconcile_events": [
     {
       "at": "2026-06-28T22:41:29.670415Z",
@@ -741,6 +1029,22 @@
         "checks.format_check",
         "scope.out-of-scope"
       ]
+    },
+    {
+      "at": "2026-06-28T22:54:58.298546Z",
+      "diff_fingerprint": "sha256:5c8fcc28518564864cc4eb39f0b899b5cf3893f24b9df8c0d34fef0021012ea5",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-28T22:55:15.657101Z",
+      "diff_fingerprint": "sha256:5c8fcc28518564864cc4eb39f0b899b5cf3893f24b9df8c0d34fef0021012ea5",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
     }
   ],
   "record_id": "1855-guided-1855-alpha-checkin",

--- a/.workflow/records/1855-guided-1855-alpha-checkin.json
+++ b/.workflow/records/1855-guided-1855-alpha-checkin.json
@@ -111,6 +111,228 @@
       "tool_versions": {
         "mypy": "2.1.0"
       }
+    },
+    {
+      "at": "2026-06-28T22:43:38.497499Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:79cf06c54fde8172ba52454c75e5107130df2bafaef644d685678b0500801c8b",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-28T22:43:41.804360Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e73679417699a2d96d93ca679b4344343173450d73f53edbb3252637100ef900",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-28T22:43:41.900799Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:402c385924bd8cfbd9fb90bd5515b2a2c6591bb917c623dc031e5c08574de77f",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-28T22:43:41.919068Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:913e0f43014a610c0aaf58584dd4af366c3e5d509046e7a2d6b028d0bfce5031",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-28T22:44:50.934609Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:84042517c7caeba5f7188180b79a1491fb6feaadc5272c071e93aa9ba341448c",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-28T22:46:59.964046Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:6887c707dea227a4021aaee826dbec100c7cdc7abe57140c60180dc21da42abc",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-28T22:47:00.568884Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:b59ec6506a06ba4a283ab97ffd2028029754ca90ce386307f396188404fb0d12",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    },
+    {
+      "at": "2026-06-28T22:48:02.190034Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:b812401e76c9b8e059efdd60743d3b2beba4c9fe85877379edd771c15190023a",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-28T22:48:06.050438Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:0f3751013070b62cf8a01c9abb279b31c92434a36d3fcc8a331c23666137c625",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-28T22:48:06.170034Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:c91af4f45b7856ab65287e345e4dde7a521d6ceb1f475e50e362d6aceaa37857",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-28T22:48:06.195706Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:a87a65d93805c0eda4eb822928d0d23245baa751f65af4c1ed45e381185f58d0",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-28T22:49:14.369759Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:2b250593b653c2c444dbd1acccba6a5b61782e1e1d5ba3e8f7baa7726e5122f8",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-28T22:51:06.927281Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:8df3989b9ac8cb5a035edc12a8a42daf0538621b91b740fb56e4bccb296fbc3c",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-28T22:51:07.518220Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:222bbffd24a16fcb6d9ca74becb59bb62acabebaefefb4679106e95b54d888be",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
     }
   ],
   "check_na": [],
@@ -271,6 +493,170 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:47:00.630296Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:47:00.639559Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:47:00.649252Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:47:00.658229Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:47:00.667146Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:47:00.676032Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:47:00.685539Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:47:00.697658Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:47:00.706684Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:47:00.717869Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:51:07.563609Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:51:07.574643Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:51:07.584944Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:51:07.595116Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:51:07.605762Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:51:07.617296Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:51:07.627274Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:51:07.640157Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:51:07.651060Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:51:07.663969Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -294,11 +680,12 @@
       "src/scistudio/api/app.py",
       "src/scistudio/telemetry/__init__.py",
       "src/scistudio/telemetry/checkin.py",
+      "tests/architecture/test_placement.py",
       "tests/telemetry/test_checkin.py"
     ],
-    "diff_fingerprint": "sha256:bc1553f3ddee007ebaa0f9d370b400f7f691f43d93f12abc83f450c15464b0dc",
+    "diff_fingerprint": "sha256:824ed901fa4ee52b09b23f1b0c08c8a3c1f5070958aaa5eb872f389a76e3632f",
     "head": "HEAD",
-    "head_sha": "6bd8e37a",
+    "head_sha": "60c4b8e9",
     "surfaces": {
       "docs": 1,
       "frontend": 0,
@@ -307,8 +694,8 @@
       "implementation": 3,
       "packaging": 0,
       "protected_core": 0,
-      "sentrux": 4,
-      "test": 1,
+      "sentrux": 5,
+      "test": 2,
       "workflow_ci": 0
     }
   },
@@ -330,6 +717,29 @@
         "guard.docs_landing",
         "scope.out-of-scope",
         "tests.changed_test_required"
+      ]
+    },
+    {
+      "at": "2026-06-28T22:47:00.717910Z",
+      "diff_fingerprint": "sha256:9d5a2b864d3043b3a448de0c4c85da09360f27d6fbd3f3da565f64c24e46b741",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.format_check",
+        "checks.lint_format",
+        "scope.out-of-scope"
+      ]
+    },
+    {
+      "at": "2026-06-28T22:51:07.664015Z",
+      "diff_fingerprint": "sha256:824ed901fa4ee52b09b23f1b0c08c8a3c1f5070958aaa5eb872f389a76e3632f",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.format_check",
+        "scope.out-of-scope"
       ]
     }
   ],
@@ -367,7 +777,14 @@
   },
   "runtime": "claude-code",
   "schema_version": 2,
-  "scope_events": [],
+  "scope_events": [
+    {
+      "action": "add-include",
+      "at": "2026-06-28T22:51:32.428050Z",
+      "pattern": "desktop/resources/.gitignore",
+      "reason": "gitignore the alpha-checkin webhook config lives under desktop/resources/.gitignore"
+    }
+  ],
   "session_id": "9a1782ad-5af8-4fea-97a7-c42d5308aa56",
   "strictness_tier": 2,
   "task_kind": "guided",

--- a/.workflow/records/1855-guided-1855-alpha-checkin.json
+++ b/.workflow/records/1855-guided-1855-alpha-checkin.json
@@ -448,9 +448,9 @@
   ],
   "check_na": [],
   "commit": {
-    "sha": "e7c7ecde6ac4e6c86b4c30836e94631e2f7d1662",
+    "sha": "658895e2d28f06ba72667ce5f09a25bbf1916c86",
     "shas": [
-      "e7c7ecde6ac4e6c86b4c30836e94631e2f7d1662"
+      "658895e2d28f06ba72667ce5f09a25bbf1916c86"
     ],
     "trailers": []
   },
@@ -938,6 +938,252 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:55:55.810510Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:55:55.821287Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:55:55.830785Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:55:55.839974Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:55:55.849169Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:55:55.858443Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:55:55.869257Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:55:55.880433Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:55:55.891490Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:55:55.903845Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:56:06.468174Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:56:06.479877Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:56:06.491506Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:56:06.502490Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:56:06.512949Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:56:06.524747Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:56:06.536253Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:56:06.547140Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:56:06.558391Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:56:06.572872Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:56:16.806623Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:56:16.818288Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:56:16.828716Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:56:16.839405Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:56:16.851405Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:56:16.862150Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:56:16.872487Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:56:16.883211Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:56:16.893421Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-28T22:56:16.906656Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -950,7 +1196,7 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "origin/main",
+    "base": "9731cd4a23e4eb19c93dd61426612b88da809b94",
     "base_sha": "9731cd4a",
     "changed_files": [
       ".workflow/records/1855-guided-1855-alpha-checkin.json",
@@ -964,9 +1210,9 @@
       "tests/architecture/test_placement.py",
       "tests/telemetry/test_checkin.py"
     ],
-    "diff_fingerprint": "sha256:5c8fcc28518564864cc4eb39f0b899b5cf3893f24b9df8c0d34fef0021012ea5",
+    "diff_fingerprint": "sha256:ab1ab5dd3d3e6d07aefd9356fbb1e32ef1f03a999cf8d95565539ab1756119f6",
     "head": "HEAD",
-    "head_sha": "e7c7ecde",
+    "head_sha": "658895e2",
     "surfaces": {
       "docs": 1,
       "frontend": 0,
@@ -987,7 +1233,7 @@
     "closes": [
       1855
     ],
-    "number": null,
+    "number": 1856,
     "url": null
   },
   "reconcile_events": [
@@ -1041,6 +1287,30 @@
     {
       "at": "2026-06-28T22:55:15.657101Z",
       "diff_fingerprint": "sha256:5c8fcc28518564864cc4eb39f0b899b5cf3893f24b9df8c0d34fef0021012ea5",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-28T22:55:55.903875Z",
+      "diff_fingerprint": "sha256:ab1ab5dd3d3e6d07aefd9356fbb1e32ef1f03a999cf8d95565539ab1756119f6",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-28T22:56:06.572908Z",
+      "diff_fingerprint": "sha256:ab1ab5dd3d3e6d07aefd9356fbb1e32ef1f03a999cf8d95565539ab1756119f6",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-28T22:56:16.906681Z",
+      "diff_fingerprint": "sha256:ab1ab5dd3d3e6d07aefd9356fbb1e32ef1f03a999cf8d95565539ab1756119f6",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 2,

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -648,6 +648,36 @@ function macLoginShellEnv() {
   return cachedMacLoginShellEnv;
 }
 
+// #1855: alpha-only launch check-in env. Reads the gitignored webhook URL from
+// resources/alpha-checkin.json and forwards it plus the already-computed machine
+// fingerprint (and the activated tester's name, if any) so the Python backend
+// check-in can report active machines. Best-effort: any failure yields no env
+// additions and never blocks runtime spawn. ALPHA-ONLY; removed in beta with the
+// #1848 gate (see docs/alpha-activation-gate.md).
+function alphaCheckinEnv() {
+  const out = {};
+  try {
+    const cfg = readJsonSafe(path.join(resourcesDir(), "alpha-checkin.json"));
+    const url = cfg && typeof cfg.url === "string" ? cfg.url.trim() : "";
+    if (!url) {
+      return out;
+    }
+    out.SCISTUDIO_ALPHA_CHECKIN_URL = url;
+    try {
+      out.SCISTUDIO_ALPHA_FP = activation.machineFingerprint();
+    } catch {
+      // Fingerprint is best-effort; the Python side recomputes it if absent.
+    }
+    const stored = readJsonSafe(activation.activationFilePath(app.getPath("userData")));
+    if (stored && typeof stored.name === "string" && stored.name) {
+      out.SCISTUDIO_ALPHA_NAME = stored.name;
+    }
+  } catch {
+    // Check-in wiring is purely a counting aid and must never affect launch.
+  }
+  return out;
+}
+
 function runtimeEnv() {
   const resources = resourcesDir();
   const stagedSrc = path.join(resources, "backend", "src");
@@ -690,7 +720,9 @@ function runtimeEnv() {
     SCISTUDIO_BUILD_NUMBER: String(effectiveBuild()),
     // #1741: route backend logs to the same directory as the desktop log so the
     // diagnostic bundle captures both the Electron and Python sides.
-    SCISTUDIO_LOG_DIR: desktopLogDir()
+    SCISTUDIO_LOG_DIR: desktopLogDir(),
+    // #1855: alpha-only check-in wiring (webhook URL + machine fingerprint).
+    ...alphaCheckinEnv()
   };
   delete env.ELECTRON_RUN_AS_NODE;
   return env;

--- a/desktop/resources/.gitignore
+++ b/desktop/resources/.gitignore
@@ -2,6 +2,10 @@ frontend/
 app/
 backend/
 
+# #1855: alpha check-in webhook URL — never commit (it would let anyone spam the
+# Slack channel). Stamped into the build locally; ALPHA-ONLY, removed in beta.
+alpha-checkin.json
+
 packages/*
 !packages/.gitkeep
 !packages/README.md

--- a/desktop/resources/alpha-gate.html
+++ b/desktop/resources/alpha-gate.html
@@ -67,6 +67,7 @@
       .status.error { color: var(--error); }
       .status.success { color: var(--success); }
       .link { background: none; border: none; color: var(--muted); padding: 6px 0; text-decoration: underline; cursor: pointer; font-weight: 400; font-size: 12px; }
+      p.note { margin: 16px 0 0; color: var(--muted); font-size: 12px; }
     </style>
   </head>
   <body>
@@ -95,6 +96,12 @@
     </div>
 
     <button id="quit" class="link" type="button">Quit</button>
+
+    <!-- #1855: alpha-only privacy notice. Removed in beta with the gate. -->
+    <p class="note">
+      During the alpha, SciStudio may collect usage and log information to help
+      with testing and development.
+    </p>
 
     <script>
       const api = window.scistudioAlphaGate;

--- a/docs/alpha-activation-gate.md
+++ b/docs/alpha-activation-gate.md
@@ -106,6 +106,49 @@ SCISTUDIO_ALPHA_PUBKEY="-----BEGIN PUBLIC KEY-----\n...\n-----END PUBLIC KEY----
                          # dev only: use a public key inline without a rebuild
 ```
 
+## Alpha tester check-in (#1855)
+
+The gate binds a token to a machine but, being offline/zero-server, cannot tell
+you how many machines are actually running the build (the issuance ledger only
+counts tokens you *minted*). A lightweight launch check-in fills that gap.
+
+How it works:
+
+- On every launch the **Python backend** (`scistudio.api.app` lifespan) fires a
+  best-effort, fire-and-forget POST to a Slack incoming webhook. It runs on a
+  daemon thread, never blocks startup, and swallows all errors.
+- It lives in the backend on purpose: a user who bypasses the Electron gate by
+  running the bundled backend directly still flows through `create_app`, so the
+  count includes them.
+- The payload is a single Slack `{"text": ...}` line:
+  `alpha_launch fp=<fingerprint> build=<n> <os>/<arch> name=<tester>`. The
+  fingerprint matches the gate's exactly, so you can de-duplicate by machine and
+  spot a shared token (one token id reporting from many fingerprints means the
+  per-machine binding was spoofed).
+
+Setup (per build, the URL is **never committed**):
+
+```bash
+# Create the gitignored config so the desktop app knows where to report.
+cat > desktop/resources/alpha-checkin.json <<'JSON'
+{ "url": "https://hooks.slack.com/services/XXX/YYY/ZZZ" }
+JSON
+```
+
+`desktop/main.js` reads that file and forwards the URL plus the already-computed
+fingerprint to the backend as `SCISTUDIO_ALPHA_CHECKIN_URL` /
+`SCISTUDIO_ALPHA_FP`. With no config file the check-in is a no-op (source
+checkouts and CI stay silent). The webhook URL is intentionally gitignored: in
+an open-source build it would otherwise let anyone spam the channel. If that
+happens, rotate the webhook.
+
+A short privacy notice on the activation screen tells testers that usage and log
+information may be collected during the alpha.
+
+> The check-in narrows casual bypass tracking, not determined bypass: a
+> professional can strip it from the open source. That is accepted — the goal is
+> a tester count, not DRM.
+
 ## Beta removal checklist
 
 The gate is intentionally isolated so it can be deleted in one pass:
@@ -125,4 +168,12 @@ The gate is intentionally isolated so it can be deleted in one pass:
       import if unused elsewhere.
 - [ ] In `desktop/package.json`: remove `activation.js` and `preload-gate.js`
       from `build.files`.
+- [ ] (#1855 check-in) Delete `src/scistudio/telemetry/` and
+      `tests/telemetry/test_checkin.py`; remove the `fire_and_forget()` block
+      from the `scistudio.api.app` lifespan; remove `alphaCheckinEnv()` and its
+      spread in `runtimeEnv()` from `desktop/main.js`; remove the privacy notice
+      from `desktop/resources/alpha-gate.html`; drop the `alpha-checkin.json`
+      entry from `desktop/resources/.gitignore`.
+- [ ] (Local only) remove `desktop/resources/alpha-checkin.json` from your
+      machine; the Slack webhook is never committed.
 - [ ] Delete this document.

--- a/src/scistudio/api/app.py
+++ b/src/scistudio/api/app.py
@@ -173,6 +173,17 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         logging.getLogger(__name__).error("MCP context failed to initialize", exc_info=True)
         app.state.mcp_server = None
 
+    # ---- #1855: alpha-only launch check-in (removed in beta with the #1848
+    # gate). Best-effort, fire-and-forget, opt-in via SCISTUDIO_ALPHA_CHECKIN_URL.
+    # Lives here so direct-backend launches (the common gate bypass) report too.
+    # Must never affect startup. See docs/alpha-activation-gate.md.
+    try:
+        from scistudio.telemetry.checkin import fire_and_forget
+
+        fire_and_forget()
+    except Exception:
+        pass
+
     try:
         yield
     finally:

--- a/src/scistudio/telemetry/__init__.py
+++ b/src/scistudio/telemetry/__init__.py
@@ -1,0 +1,10 @@
+"""Alpha-only telemetry helpers (#1855).
+
+ALPHA-ONLY. This whole package exists to count active internal alpha testers
+for the #1848 activation gate and is removed in beta together with the gate.
+See the beta-removal checklist in docs/alpha-activation-gate.md.
+"""
+
+from scistudio.telemetry.checkin import fire_and_forget, machine_fingerprint
+
+__all__ = ["fire_and_forget", "machine_fingerprint"]

--- a/src/scistudio/telemetry/checkin.py
+++ b/src/scistudio/telemetry/checkin.py
@@ -94,9 +94,7 @@ def _post(url: str, text: str) -> None:
     try:
         data = json.dumps({"text": text}).encode("utf-8")
         # ``url`` is an operator-configured https webhook, not user input.
-        req = urllib.request.Request(
-            url, data=data, headers={"Content-Type": "application/json"}
-        )
+        req = urllib.request.Request(url, data=data, headers={"Content-Type": "application/json"})
         urllib.request.urlopen(req, timeout=_TIMEOUT_S).read()
     except Exception:
         # Offline / firewalled / bad URL: a check-in is best-effort, never fatal.

--- a/src/scistudio/telemetry/checkin.py
+++ b/src/scistudio/telemetry/checkin.py
@@ -1,0 +1,127 @@
+"""Alpha launch check-in: best-effort, fire-and-forget tester counting (#1855).
+
+ALPHA-ONLY; removed in beta with the #1848 activation gate (see the beta-removal
+checklist in docs/alpha-activation-gate.md).
+
+Why this exists
+---------------
+The #1848 activation gate binds a per-machine token but is offline/zero-server,
+so it yields no count of how many machines actually run the build, and a
+security review confirmed it is bypassable (run the bundled backend directly,
+patch the unsigned asar, spoof the fingerprint). Because SciStudio is fully
+open source that is accepted; the real goal is a count of internal testers, not
+unbreakable DRM. This check-in lives in the Python backend on purpose: every way
+of starting the product -- Electron, a source checkout, or a direct
+``python -m scistudio.cli.main`` (the most common gate bypass) -- flows through
+``create_app``'s lifespan, so all of them report.
+
+Design constraints (match the codebase's "never crash startup" posture)
+-----------------------------------------------------------------------
+- Never blocks the event loop: the POST runs on a daemon thread we never join.
+- Never raises: every error is swallowed.
+- No new dependency: stdlib ``urllib`` only.
+- Opt-in: a no-op unless ``SCISTUDIO_ALPHA_CHECKIN_URL`` is set, so source
+  checkouts and CI stay silent. The desktop app injects the URL from a
+  gitignored config (see desktop/main.js); the URL is never committed.
+
+The endpoint is a Slack incoming webhook, which accepts only ``{"text": ...}``;
+the fingerprint and build are folded into a single human-readable line so the
+channel can be eyeballed or exported and de-duplicated by fingerprint.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import platform
+import socket
+import subprocess
+import threading
+import urllib.request
+
+# Must match desktop/activation.js machineFingerprint() byte-for-byte so a
+# check-in can be cross-referenced against the issued-token ledger, which is
+# keyed by the same fingerprint. See desktop/activation.js:36-68.
+_FP_PREFIX = "scistudio-alpha-v1:"  # parity constant, not a version marker (#1848)
+_TIMEOUT_S = 2
+
+
+def _raw_machine_id() -> str:
+    """Stable per-machine id mirroring desktop/activation.js rawMachineId()."""
+    try:
+        if platform.system() == "Darwin":
+            out = subprocess.run(
+                ["ioreg", "-rd1", "-c", "IOPlatformExpertDevice"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+                check=False,
+            ).stdout
+            for line in out.splitlines():
+                if '"IOPlatformUUID"' in line:
+                    rhs = line.split("=", 1)[-1].strip()
+                    if rhs.startswith('"') and rhs.endswith('"') and len(rhs) > 2:
+                        return f"mac:{rhs[1:-1]}"
+        elif platform.system() == "Windows":
+            out = subprocess.run(
+                ["reg", "query", r"HKLM\SOFTWARE\Microsoft\Cryptography", "/v", "MachineGuid"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+                check=False,
+            ).stdout
+            for tok in out.split():
+                if tok.count("-") >= 4 and len(tok) >= 32:
+                    return f"win:{tok}"
+    except Exception:
+        # Fall through to the hostname-based fallback below.
+        pass
+    return f"host:{socket.gethostname()}"
+
+
+def machine_fingerprint() -> str:
+    """sha256 hex of the prefixed raw machine id (matches the gate's value)."""
+    return hashlib.sha256((_FP_PREFIX + _raw_machine_id()).encode("utf-8")).hexdigest()
+
+
+def _slack_text(fp: str, build: str, plat: str, name: str | None) -> str:
+    who = f" name={name}" if name else ""
+    return f"alpha_launch fp={fp} build={build} {plat}{who}"
+
+
+def _post(url: str, text: str) -> None:
+    try:
+        data = json.dumps({"text": text}).encode("utf-8")
+        req = urllib.request.Request(  # noqa: S310 -- operator-configured https webhook
+            url, data=data, headers={"Content-Type": "application/json"}
+        )
+        urllib.request.urlopen(req, timeout=_TIMEOUT_S).read()  # noqa: S310
+    except Exception:
+        # Offline / firewalled / bad URL: a check-in is best-effort, never fatal.
+        pass
+
+
+def fire_and_forget() -> bool:
+    """Dispatch a best-effort launch check-in. Returns immediately.
+
+    Returns ``True`` when a POST was dispatched on a background daemon thread,
+    ``False`` when no endpoint is configured (the opt-in no-op). The network
+    call never blocks the caller and never raises.
+    """
+    url = (os.environ.get("SCISTUDIO_ALPHA_CHECKIN_URL") or "").strip()
+    if not url:
+        return False
+
+    # Reuse the fingerprint Electron already computed when present (saves the
+    # ioreg call); fall back to computing it so direct-backend launches still
+    # report.
+    fp = (os.environ.get("SCISTUDIO_ALPHA_FP") or "").strip() or machine_fingerprint()
+    text = _slack_text(
+        fp=fp,
+        build=os.environ.get("SCISTUDIO_BUILD_NUMBER") or "unknown",
+        plat=f"{platform.system()}/{platform.machine()}",
+        name=(os.environ.get("SCISTUDIO_ALPHA_NAME") or "").strip() or None,
+    )
+    threading.Thread(target=_post, args=(url, text), daemon=True).start()
+    return True

--- a/src/scistudio/telemetry/checkin.py
+++ b/src/scistudio/telemetry/checkin.py
@@ -93,10 +93,11 @@ def _slack_text(fp: str, build: str, plat: str, name: str | None) -> str:
 def _post(url: str, text: str) -> None:
     try:
         data = json.dumps({"text": text}).encode("utf-8")
-        req = urllib.request.Request(  # noqa: S310 -- operator-configured https webhook
+        # ``url`` is an operator-configured https webhook, not user input.
+        req = urllib.request.Request(
             url, data=data, headers={"Content-Type": "application/json"}
         )
-        urllib.request.urlopen(req, timeout=_TIMEOUT_S).read()  # noqa: S310
+        urllib.request.urlopen(req, timeout=_TIMEOUT_S).read()
     except Exception:
         # Offline / firewalled / bad URL: a check-in is best-effort, never fatal.
         pass

--- a/tests/architecture/test_placement.py
+++ b/tests/architecture/test_placement.py
@@ -153,6 +153,7 @@ def test_no_py_files_outside_known_packages() -> None:
         "plot",  # #1824 / ADR-052 §9: first-class plot render(collection) engine (scistudio.plot)
         "desktop",  # ADR-037: desktop distribution path/resource helpers
         "stability",  # ADR-052 §5: public-API stability decorators (scistudio.stability)
+        "telemetry",  # #1855: alpha-only tester check-in (removed in beta with the gate)
     }
     stray: list[str] = []
     for filepath in SRC_ROOT.rglob("*.py"):

--- a/tests/telemetry/test_checkin.py
+++ b/tests/telemetry/test_checkin.py
@@ -1,0 +1,117 @@
+"""Tests for the alpha-only launch check-in (#1855).
+
+ALPHA-ONLY; deleted in beta with the rest of the #1848 gate.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import http.server
+import json
+import socketserver
+import threading
+import time
+
+import pytest
+
+from scistudio.telemetry import checkin
+
+
+def test_no_url_is_a_no_op(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Opt-in: with no endpoint configured the check-in does nothing."""
+    monkeypatch.delenv("SCISTUDIO_ALPHA_CHECKIN_URL", raising=False)
+    assert checkin.fire_and_forget() is False
+
+
+def test_fingerprint_matches_gate_formula() -> None:
+    """The fingerprint must equal desktop/activation.js machineFingerprint().
+
+    Same construction: sha256("scistudio-alpha-v1:" + raw machine id). We can't
+    know the raw id here, but we can prove the digest is the prefixed-raw-id
+    hash and is a stable 64-char hex string.
+    """
+    fp = checkin.machine_fingerprint()
+    assert len(fp) == 64
+    assert all(c in "0123456789abcdef" for c in fp)
+    expected = hashlib.sha256(
+        (checkin._FP_PREFIX + checkin._raw_machine_id()).encode("utf-8")
+    ).hexdigest()
+    assert fp == expected
+
+
+def test_slack_text_is_single_line_with_fields() -> None:
+    line = checkin._slack_text(fp="abc123", build="7", plat="Darwin/arm64", name="Tester")
+    assert "\n" not in line
+    assert "fp=abc123" in line
+    assert "build=7" in line
+    assert "Darwin/arm64" in line
+    assert "name=Tester" in line
+
+
+def test_slack_text_omits_name_when_absent() -> None:
+    line = checkin._slack_text(fp="abc", build="1", plat="Linux/x86_64", name=None)
+    assert "name=" not in line
+
+
+def test_dispatch_posts_slack_payload(monkeypatch: pytest.MonkeyPatch) -> None:
+    """End-to-end: a configured URL receives a Slack {"text": ...} body."""
+    received: list[dict] = []
+
+    class Collector(http.server.BaseHTTPRequestHandler):
+        def do_POST(self) -> None:  # noqa: N802
+            n = int(self.headers.get("Content-Length", 0))
+            received.append(json.loads(self.rfile.read(n) or b"{}"))
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(b"ok")
+
+        def log_message(self, *_: object) -> None:  # silence
+            pass
+
+    with socketserver.TCPServer(("127.0.0.1", 0), Collector) as httpd:
+        port = httpd.server_address[1]
+        threading.Thread(target=httpd.serve_forever, daemon=True).start()
+
+        monkeypatch.setenv("SCISTUDIO_ALPHA_CHECKIN_URL", f"http://127.0.0.1:{port}/")
+        monkeypatch.setenv("SCISTUDIO_ALPHA_FP", "deadbeef")
+        monkeypatch.setenv("SCISTUDIO_BUILD_NUMBER", "42")
+        monkeypatch.setenv("SCISTUDIO_ALPHA_NAME", "unit-test")
+
+        assert checkin.fire_and_forget() is True
+        deadline = time.time() + 5
+        while not received and time.time() < deadline:
+            time.sleep(0.02)
+        httpd.shutdown()
+
+    assert received, "collector never received the check-in"
+    payload = received[0]
+    assert set(payload.keys()) == {"text"}  # Slack incoming-webhook shape
+    assert "fp=deadbeef" in payload["text"]
+    assert "build=42" in payload["text"]
+    assert "name=unit-test" in payload["text"]
+
+
+def test_uses_forwarded_fingerprint_without_recompute(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When Electron forwards SCISTUDIO_ALPHA_FP, the check-in uses it verbatim."""
+    sent: list[str] = []
+    monkeypatch.setattr(checkin, "_post", lambda url, text: sent.append(text))
+    monkeypatch.setattr(
+        checkin, "machine_fingerprint", lambda: pytest.fail("should not recompute")
+    )
+    monkeypatch.setenv("SCISTUDIO_ALPHA_CHECKIN_URL", "http://example.invalid/")
+    monkeypatch.setenv("SCISTUDIO_ALPHA_FP", "forwarded-fp")
+    # Give the daemon thread a moment; _post is monkeypatched so it's instant.
+    assert checkin.fire_and_forget() is True
+    deadline = time.time() + 2
+    while not sent and time.time() < deadline:
+        time.sleep(0.01)
+    assert sent and "fp=forwarded-fp" in sent[0]
+
+
+def test_bad_url_never_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A dead endpoint must not raise or block beyond the short timeout."""
+    monkeypatch.setenv("SCISTUDIO_ALPHA_CHECKIN_URL", "http://127.0.0.1:1/")
+    monkeypatch.setenv("SCISTUDIO_ALPHA_FP", "x")
+    start = time.perf_counter()
+    assert checkin.fire_and_forget() is True  # returns immediately (background thread)
+    assert (time.perf_counter() - start) < 0.5

--- a/tests/telemetry/test_checkin.py
+++ b/tests/telemetry/test_checkin.py
@@ -58,7 +58,7 @@ def test_dispatch_posts_slack_payload(monkeypatch: pytest.MonkeyPatch) -> None:
     received: list[dict] = []
 
     class Collector(http.server.BaseHTTPRequestHandler):
-        def do_POST(self) -> None:  # noqa: N802
+        def do_POST(self) -> None:
             n = int(self.headers.get("Content-Length", 0))
             received.append(json.loads(self.rfile.read(n) or b"{}"))
             self.send_response(200)

--- a/tests/telemetry/test_checkin.py
+++ b/tests/telemetry/test_checkin.py
@@ -33,9 +33,7 @@ def test_fingerprint_matches_gate_formula() -> None:
     fp = checkin.machine_fingerprint()
     assert len(fp) == 64
     assert all(c in "0123456789abcdef" for c in fp)
-    expected = hashlib.sha256(
-        (checkin._FP_PREFIX + checkin._raw_machine_id()).encode("utf-8")
-    ).hexdigest()
+    expected = hashlib.sha256((checkin._FP_PREFIX + checkin._raw_machine_id()).encode("utf-8")).hexdigest()
     assert fp == expected
 
 
@@ -95,9 +93,7 @@ def test_uses_forwarded_fingerprint_without_recompute(monkeypatch: pytest.Monkey
     """When Electron forwards SCISTUDIO_ALPHA_FP, the check-in uses it verbatim."""
     sent: list[str] = []
     monkeypatch.setattr(checkin, "_post", lambda url, text: sent.append(text))
-    monkeypatch.setattr(
-        checkin, "machine_fingerprint", lambda: pytest.fail("should not recompute")
-    )
+    monkeypatch.setattr(checkin, "machine_fingerprint", lambda: pytest.fail("should not recompute"))
     monkeypatch.setenv("SCISTUDIO_ALPHA_CHECKIN_URL", "http://example.invalid/")
     monkeypatch.setenv("SCISTUDIO_ALPHA_FP", "forwarded-fp")
     # Give the daemon thread a moment; _post is monkeypatched so it's instant.


### PR DESCRIPTION
## Summary

Adds a lightweight, **alpha-only** launch check-in so the offline #1848
activation gate can produce a real **active-machine count** of internal testers.
The gate binds a per-machine token but, being zero-server, only the issuance
ledger exists — and it counts tokens *minted*, not installs. A security review
also confirmed the gate is bypassable (run the bundled backend directly, patch
the unsigned asar, spoof the machine fingerprint); since SciStudio is fully open
source that is accepted. The goal here is **counting testers and keeping casual
users honest**, not DRM.

## What it does

- **`scistudio/telemetry/checkin.py`** — stdlib-only, fire-and-forget POST on a
  daemon thread we never join; never raises; opt-in via
  `SCISTUDIO_ALPHA_CHECKIN_URL`. The machine fingerprint matches
  `desktop/activation.js` byte-for-byte, so check-ins de-duplicate by machine
  and reveal a shared/spoofed token (one token id from many fingerprints).
- **`scistudio.api.app` lifespan** — fires the check-in at startup, fully
  guarded so it can never affect boot. It lives in the **backend** on purpose:
  users who bypass the Electron launcher by running the bundled backend directly
  still flow through `create_app`, so they are counted too.
- **`desktop/main.js`** — reads the webhook URL from a **gitignored**
  `desktop/resources/alpha-checkin.json` and forwards it plus the
  already-computed fingerprint (and activated tester name) to the backend env.
- **`desktop/resources/alpha-gate.html`** — a short privacy notice on the
  activation screen.
- **`desktop/resources/.gitignore`** — the webhook URL is never committed (an
  open-source build would otherwise let anyone spam the channel; rotate if
  abused).
- **Docs** — `docs/alpha-activation-gate.md` gains a check-in section and an
  extended beta-removal checklist so this deletes in one pass with the gate.

## Tests

`tests/telemetry/test_checkin.py`: opt-in no-op, Slack `{"text": ...}` payload
shape, forwarded-fingerprint reuse, non-blocking return, never-raises on a dead
endpoint. The Slack webhook was also validated end to end (HTTP 200 `ok`).

## Scope / accepted

ALPHA-ONLY; removed in beta with the #1848 gate. Real anti-tamper (code
signing/notarization) and a server-side dedup dashboard are intentionally out of
scope for the open-source alpha.

Closes #1855

🤖 Generated with [Claude Code](https://claude.com/claude-code)
