### PR TITLE
guided(#1858): protect project data/ from direct agent edits; palette + setup UX

### DIFF
--- a/.workflow/records/1857-guided-1858-agent-data-protection.json
+++ b/.workflow/records/1857-guided-1858-agent-data-protection.json
@@ -190,9 +190,9 @@
   ],
   "check_na": [],
   "commit": {
-    "sha": "69cbd910adae9a1515968ce38bf15fc8a0ee399e",
+    "sha": "573476bacc4b46221c8612e2d629872e437cc20d",
     "shas": [
-      "69cbd910adae9a1515968ce38bf15fc8a0ee399e"
+      "573476bacc4b46221c8612e2d629872e437cc20d"
     ],
     "trailers": []
   },
@@ -482,6 +482,252 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-06-29T00:49:11.305499Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T00:49:11.314002Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T00:49:11.322456Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T00:49:11.330873Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T00:49:11.339003Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T00:49:11.348222Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T00:49:11.357082Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T00:49:11.367339Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T00:49:11.375936Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T00:49:11.388650Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T00:49:16.342551Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T00:49:16.351156Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T00:49:16.359608Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T00:49:16.368630Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T00:49:16.376992Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T00:49:16.385497Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T00:49:16.393742Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T00:49:16.402060Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T00:49:16.410276Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T00:49:16.422283Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T00:49:25.273754Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T00:49:25.282357Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T00:49:25.290709Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T00:49:25.299262Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T00:49:25.307561Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T00:49:25.316115Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T00:49:25.324247Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T00:49:25.333192Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T00:49:25.341665Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T00:49:25.353965Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -506,7 +752,7 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "origin/main",
+    "base": "764f94733a4f8528a7a44e58cc5fd041c3658b8e",
     "base_sha": "764f9473",
     "changed_files": [
       ".workflow/records/1857-guided-1858-agent-data-protection.json",
@@ -523,9 +769,9 @@
       "tests/agent_provisioning/test_hooks.py",
       "tests/agent_provisioning/test_orchestrate.py"
     ],
-    "diff_fingerprint": "sha256:4f7ba06719ee3f97d30fe3d8354c1ddad4d93c15373bbcdd673914ef92443fba",
+    "diff_fingerprint": "sha256:58493855eb491f16442f71907d99a98c66d8ff4f7dd8ae183f6d94e1e46cff1a",
     "head": "HEAD",
-    "head_sha": "69cbd910",
+    "head_sha": "573476ba",
     "surfaces": {
       "docs": 1,
       "frontend": 4,
@@ -548,7 +794,7 @@
       1858,
       1859
     ],
-    "number": null,
+    "number": 1861,
     "url": null
   },
   "reconcile_events": [
@@ -575,6 +821,30 @@
     {
       "at": "2026-06-29T00:48:26.392179Z",
       "diff_fingerprint": "sha256:4f7ba06719ee3f97d30fe3d8354c1ddad4d93c15373bbcdd673914ef92443fba",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-29T00:49:11.388681Z",
+      "diff_fingerprint": "sha256:58493855eb491f16442f71907d99a98c66d8ff4f7dd8ae183f6d94e1e46cff1a",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-29T00:49:16.422324Z",
+      "diff_fingerprint": "sha256:58493855eb491f16442f71907d99a98c66d8ff4f7dd8ae183f6d94e1e46cff1a",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-29T00:49:25.354005Z",
+      "diff_fingerprint": "sha256:58493855eb491f16442f71907d99a98c66d8ff4f7dd8ae183f6d94e1e46cff1a",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 2,

--- a/.workflow/records/1857-guided-1858-agent-data-protection.json
+++ b/.workflow/records/1857-guided-1858-agent-data-protection.json
@@ -1,0 +1,738 @@
+{
+  "branch": "guided/1858-agent-data-protection",
+  "check_events": [
+    {
+      "at": "2026-06-29T00:37:59.386628Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:10a6959b1c117546f44f442d779fa2c1e71fc3292c91f2d4d881e78c062df010",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-29T00:38:05.145773Z",
+      "command": "(cd frontend && npm run check:ci)",
+      "covered_surface": "frontend",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:630e11153f6b19fe99d2979eba0bc116eb75949c549a6059b4f1e9f208b49e67",
+      "name": "frontend",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/frontend.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-29T00:38:09.279055Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:4aff3615e8ab3b5a4de94b2875e971a6f8c46195825cf891d11f3742cb0aba9b",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-29T00:38:09.777238Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:98aa889e422dadbd23d8c21bc2aabf3f018297997405ee56528476c00e2b8ee6",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-29T00:38:09.818759Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:bce8f43c166013bd9210552dc52455dcaf7660e9aadb55489d38a851d9418364",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-29T00:40:03.039275Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:b66269ad014d80b24fb7d159b002aa3487f05776ea0017deb2e33232fae5ca4f",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-29T00:42:02.598712Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:b8290c47eacf0f6c1ad508660c8a3aec61492bcf867c1591810b081356b57d5a",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-29T00:42:09.321605Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:02061c9db0121e4af5cbef7492894b1f2dd421ec121c27c510d1960cff2047de",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    },
+    {
+      "at": "2026-06-29T00:44:39.789312Z",
+      "command": "(cd frontend && npm run check:ci)",
+      "covered_surface": "frontend",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e391601083f02636aafec1093e98807583fecec3f12f2efba65abe8984375e9d",
+      "name": "frontend",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/frontend.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-29T00:44:43.415569Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:911faff1c0df995fb49a9d06ba7688f46ccfdf9c8c2102d76fe4d47b2372d4eb",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-29T00:46:01.396915Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:b66269ad014d80b24fb7d159b002aa3487f05776ea0017deb2e33232fae5ca4f",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-29T00:47:59.301632Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:0117a1a818aec1f1edb6642660a0f56bfd1ed451fbc347041e69940c01e867a4",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    }
+  ],
+  "check_na": [],
+  "commit": {
+    "sha": "69cbd910adae9a1515968ce38bf15fc8a0ee399e",
+    "shas": [
+      "69cbd910adae9a1515968ce38bf15fc8a0ee399e"
+    ],
+    "trailers": []
+  },
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "frontend/src/components/BlockPalette.tsx",
+      "frontend/src/components/BlockPalette.test.tsx"
+    ]
+  },
+  "directive_events": [
+    {
+      "at": "2026-06-29T00:16:51.897883Z",
+      "owner_directive": "Add a PreToolUse hook for the internal agent that intercepts direct modification of project data/ and all subfolders. Block file-tool edits (Edit/Write/MultiEdit) under data/; block obvious destructive Bash targeting data/ (rm/mv/cp/redirect); reads allowed; deletes outside data/ (e.g. workflow) allowed; workflow runtime artifact writes unaffected.",
+      "reason": "Owner directive: add a guard so the in-app agent cannot directly modify project data/."
+    },
+    {
+      "at": "2026-06-29T00:16:52.036852Z",
+      "owner_directive": "On project open, check structure and auto-update old projects with things they are missing (new docs, new hooks). Additively merge missing canonical hook entries into existing .claude/settings.json (never overwrite user-modified files, never delete), bump provision version, keep generic for future docs. Reuse the deferred ADR-040 Phase-3 upgrade flow (stale TODO #1011, now closed).",
+      "reason": "Owner directive: opening a project should top up old projects with newly-added canonical assets."
+    },
+    {
+      "at": "2026-06-29T00:17:02.090637Z",
+      "owner_directive": "On the AI chat setup screen, when Codex provider is selected, show a short note that Codex will ask to trust this project's hooks on first launch and the user should accept it, otherwise SciStudio's protection hooks will not run. Do NOT auto-write trust into the user's global Codex config file.",
+      "reason": "Owner directive: instead of auto-writing global Codex trust (out of scope), add a UI note."
+    },
+    {
+      "at": "2026-06-29T00:32:32.395557Z",
+      "owner_directive": "Confirm all hooks take effect for both Codex and Claude Code; if any hook is not effective for a provider, wire it up. Add a parity guard.",
+      "reason": "Owner directive: verify every provisioned hook is wired for BOTH Codex and Claude Code; connect any that are not."
+    }
+  ],
+  "docs_events": [
+    {
+      "at": "2026-06-29T00:35:10.938902Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/adr/ADR-040.md",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": false,
+  "guard_events": [
+    {
+      "at": "2026-06-29T00:42:09.494175Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T00:42:09.504063Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T00:42:09.514208Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T00:42:09.524454Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T00:42:09.533648Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T00:42:09.543577Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T00:42:09.553326Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T00:42:09.564638Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T00:42:09.573687Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T00:42:09.586625Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T00:47:59.340451Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T00:47:59.350009Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T00:47:59.359840Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T00:47:59.369747Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T00:47:59.379253Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T00:47:59.388357Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T00:47:59.398118Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T00:47:59.408859Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T00:47:59.419224Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T00:47:59.432263Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T00:48:26.308550Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T00:48:26.317011Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T00:48:26.326131Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T00:48:26.335278Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T00:48:26.344069Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T00:48:26.353194Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T00:48:26.362006Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T00:48:26.371238Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T00:48:26.379859Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T00:48:26.392149Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1857,
+      "url": null
+    },
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1858,
+      "url": null
+    },
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1859,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": {
+    "base": "origin/main",
+    "base_sha": "764f9473",
+    "changed_files": [
+      ".workflow/records/1857-guided-1858-agent-data-protection.json",
+      "docs/adr/ADR-040.md",
+      "frontend/src/components/AIChat/SetupScreen.tsx",
+      "frontend/src/components/AIChat/__tests__/SetupScreen.test.tsx",
+      "frontend/src/components/BlockPalette.test.tsx",
+      "frontend/src/components/BlockPalette.tsx",
+      "src/scistudio/agent_provisioning/_orchestrate.py",
+      "src/scistudio/agent_provisioning/codex_config.py",
+      "src/scistudio/agent_provisioning/hooks.py",
+      "src/scistudio/agent_provisioning/templates/hook_protect_data_dir.py",
+      "tests/agent_provisioning/test_codex_config.py",
+      "tests/agent_provisioning/test_hooks.py",
+      "tests/agent_provisioning/test_orchestrate.py"
+    ],
+    "diff_fingerprint": "sha256:4f7ba06719ee3f97d30fe3d8354c1ddad4d93c15373bbcdd673914ef92443fba",
+    "head": "HEAD",
+    "head_sha": "69cbd910",
+    "surfaces": {
+      "docs": 1,
+      "frontend": 4,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 8,
+      "packaging": 0,
+      "protected_core": 0,
+      "sentrux": 12,
+      "test": 5,
+      "workflow_ci": 0
+    }
+  },
+  "owner_directive": "Fix palette block grid to auto-adapt column count to palette width (default 2, expand to 3 when wide, drop to 1 only when too narrow for two 72px swatches).",
+  "persona": "live_implementer",
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [
+      1857,
+      1858,
+      1859
+    ],
+    "number": null,
+    "url": null
+  },
+  "reconcile_events": [
+    {
+      "at": "2026-06-29T00:42:09.586658Z",
+      "diff_fingerprint": "sha256:19341cfd6ffc7f74a8bcbc5f5ef5ce3765949385ee6aa7c4ea9e2c8472979f3a",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.frontend",
+        "checks.python_tests",
+        "tests.changed_test_required"
+      ]
+    },
+    {
+      "at": "2026-06-29T00:47:59.432300Z",
+      "diff_fingerprint": "sha256:9215533f17b50132089255edc2cc8a0ca4a6749602f455249bf3807870ca1a6d",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-29T00:48:26.392179Z",
+      "diff_fingerprint": "sha256:4f7ba06719ee3f97d30fe3d8354c1ddad4d93c15373bbcdd673914ef92443fba",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    }
+  ],
+  "record_id": "1857-guided-1858-agent-data-protection",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [
+      "format_check",
+      "frontend",
+      "full_audit",
+      "import_contracts",
+      "lint_format",
+      "python_tests",
+      "semantic_dup",
+      "type_check"
+    ],
+    "docs": [
+      "docs_required_or_na"
+    ],
+    "guards": [
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": [
+      "changed_test_required"
+    ]
+  },
+  "runtime": "claude-code",
+  "schema_version": 2,
+  "scope_events": [
+    {
+      "action": "add-include",
+      "at": "2026-06-29T00:16:51.898054Z",
+      "pattern": "src/scistudio/agent_provisioning/templates/hook_protect_data_dir.py",
+      "reason": "Owner directive: add a guard so the in-app agent cannot directly modify project data/."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-29T00:16:51.898065Z",
+      "pattern": "src/scistudio/agent_provisioning/hooks.py",
+      "reason": "Owner directive: add a guard so the in-app agent cannot directly modify project data/."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-29T00:16:51.898067Z",
+      "pattern": "src/scistudio/agent_provisioning/codex_config.py",
+      "reason": "Owner directive: add a guard so the in-app agent cannot directly modify project data/."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-29T00:16:51.898068Z",
+      "pattern": "tests/agent_provisioning/test_hooks.py",
+      "reason": "Owner directive: add a guard so the in-app agent cannot directly modify project data/."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-29T00:16:51.898069Z",
+      "pattern": "tests/agent_provisioning/test_codex_config.py",
+      "reason": "Owner directive: add a guard so the in-app agent cannot directly modify project data/."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-29T00:16:52.037035Z",
+      "pattern": "src/scistudio/agent_provisioning/_orchestrate.py",
+      "reason": "Owner directive: opening a project should top up old projects with newly-added canonical assets."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-29T00:16:52.037040Z",
+      "pattern": "tests/agent_provisioning/test_orchestrate.py",
+      "reason": "Owner directive: opening a project should top up old projects with newly-added canonical assets."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-29T00:16:52.037042Z",
+      "pattern": "docs/adr/ADR-040.md",
+      "reason": "Owner directive: opening a project should top up old projects with newly-added canonical assets."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-29T00:17:02.090765Z",
+      "pattern": "frontend/src/components/AIChat/SetupScreen.tsx",
+      "reason": "Owner directive: instead of auto-writing global Codex trust (out of scope), add a UI note."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-29T00:17:02.090770Z",
+      "pattern": "frontend/src/components/AIChat/SetupScreen.parts/ProviderPicker.tsx",
+      "reason": "Owner directive: instead of auto-writing global Codex trust (out of scope), add a UI note."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-29T00:17:02.090771Z",
+      "pattern": "frontend/src/components/AIChat/__tests__/SetupScreen.test.tsx",
+      "reason": "Owner directive: instead of auto-writing global Codex trust (out of scope), add a UI note."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-29T00:32:32.395678Z",
+      "pattern": "tests/agent_provisioning/test_codex_config.py",
+      "reason": "Owner directive: verify every provisioned hook is wired for BOTH Codex and Claude Code; connect any that are not."
+    }
+  ],
+  "session_id": "9c77c001-25e9-40f0-a316-b6e47c67d5c5",
+  "strictness_tier": 2,
+  "task_kind": "guided",
+  "test_events": [
+    {
+      "at": "2026-06-29T00:43:46.291072Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/agent_provisioning/test_hooks.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-29T00:43:46.291236Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/agent_provisioning/test_codex_config.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-29T00:43:46.291239Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/agent_provisioning/test_orchestrate.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-29T00:43:46.291240Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/components/BlockPalette.test.tsx",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-29T00:43:46.291241Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/components/AIChat/__tests__/SetupScreen.test.tsx",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/docs/adr/ADR-040.md
+++ b/docs/adr/ADR-040.md
@@ -1109,3 +1109,66 @@ pushed at every turn (agent already has `get_workflow`); per-tab or
 per-session isolation; user-edit history.
 
 **Tracking**: #1488.
+
+## Addendum 6 (2026-06-28) — `data/` protection hook + on-open top-up of existing projects
+
+**Status**: accepted (extends §3.6 hooks and §3.8 lifecycle top-up).
+
+**What changed**:
+
+1. **One new PreToolUse hook — `hook_protect_data_dir.py`** (provisioned to
+   `<project>/.claude/hooks/protect_data_dir.py`). It stops the in-app agent
+   from *directly* hand-editing the user's scientific data. The §3.6 hook count
+   goes from six to **seven** (4 PreToolUse + 3 PostToolUse).
+   - Blocks `Edit | Write | MultiEdit | apply_patch` whose target file resolves
+     under `<project>/data/**` (exit 2). Path resolution prefers
+     `CLAUDE_PROJECT_DIR` / `SCISTUDIO_PROJECT_DIR` / hook `cwd`, falling back to
+     a `/data/` segment match.
+   - Blocks **obvious** destructive `Bash` targeting `data/` (`rm`/`rmdir`/
+     `truncate`/`mv` of a `data/` operand, `cp`/`ln`/`rsync` *into* `data/`, and
+     `>`/`>>` redirects into `data/`). This is a best-effort textual check, not a
+     shell parser; the file-tool matchers are the reliable layer (same
+     defense-in-depth caveat as `enforce_list_blocks_before_block_write.py`).
+   - **Allowed**: reading anything under `data/`; editing or deleting files
+     *outside* `data/` (the agent may still `rm` an unrelated workflow); and the
+     workflow runtime writing artifacts into `data/` — that happens in the
+     backend, not through the agent's Edit/Write/Bash tools, so it never reaches
+     the hook.
+   - Registered for **both** providers: `.claude/settings.json` matcher
+     `Edit|Write|MultiEdit|Bash` (the script branches on `tool_name`) and
+     `.codex/config.toml` matcher `^(Edit|Write|MultiEdit|apply_patch|Bash)$`.
+     A new cross-provider parity test asserts every provisioned hook script is
+     wired for both Claude Code and Codex so future hooks cannot silently miss a
+     provider.
+
+2. **On-open additive top-up for existing projects** (§3.8 / §9 OQ-1 Phase-3,
+   the half that was the stale `TODO(#1011)`; that umbrella issue is closed).
+   `write_hooks` now, when a project already has `.claude/settings.json`,
+   additively merges in any **missing** canonical hook entry (keyed on script
+   filename) without modifying or removing user-authored entries or
+   already-present canonical entries. This is what lets a project created before
+   this addendum pick up `protect_data_dir.py` on its next open. The mechanism is
+   generic: a future canonical hook flows into old projects the same way, and
+   genuinely new standalone canonical files (docs, etc.) are still written by the
+   existing `force=False` "write-if-absent" path.
+
+3. **Provision version bump** `0.1.0` → **`0.2.0`**
+   (`SCISTUDIO_PROVISION_VERSION`), written to
+   `<project>/.claude/.scistudio-provision-version` on every run.
+
+**Why**: Users worried the agent could silently rewrite their data. The data
+directory is now guarded the same way `workflows/*.yaml` already is, and the
+guard reaches existing projects automatically on open instead of only new ones.
+
+**Out of scope**:
+- Content-aware refresh of canonical files that **already exist** (re-writing
+  only files unmodified from a previous canonical version) — needs per-file
+  canonical hashing to avoid clobbering user edits. Tracked in **#1860**.
+- Extending `protect_workflow_yaml.py` to the `Bash` matcher (the data guard
+  covers Bash; workflow-yaml Bash coverage is unchanged here).
+- Auto-writing Codex workspace trust into the user's global Codex config — the
+  setup screen instead surfaces a note prompting the user to accept the trust
+  prompt (#1859).
+
+**Tracking**: #1858 (data hook + top-up), #1859 (Codex trust note), #1860
+(content-aware refresh follow-up).

--- a/frontend/src/components/AIChat/SetupScreen.tsx
+++ b/frontend/src/components/AIChat/SetupScreen.tsx
@@ -145,6 +145,23 @@ export function SetupScreen({ tabId, onLaunch, onCancel }: SetupScreenProps) {
           onChange={setProvider}
         />
 
+        {/* #1859: Codex asks the user to trust this project's hooks on first
+            launch. Non-technical users may not know what hooks are; if they
+            decline, SciStudio's safety hooks (e.g. the data/ guard) never run.
+            We surface a short note rather than silently editing global config. */}
+        {provider === "codex" ? (
+          <div
+            className="rounded-2xl border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800"
+            data-testid="setup-codex-trust-note"
+          >
+            <strong className="font-medium">Heads up:</strong> the first time Codex launches in this
+            project it will ask whether to trust its hooks. Please choose{" "}
+            <strong className="font-medium">trust / yes</strong> — SciStudio installs safety hooks
+            (such as protecting your <span className="font-mono">data/</span> folder from accidental
+            edits) that only take effect if you accept.
+          </div>
+        ) : null}
+
         <PermissionModePicker
           tabId={tabId}
           permissionMode={permissionMode}

--- a/frontend/src/components/AIChat/__tests__/SetupScreen.test.tsx
+++ b/frontend/src/components/AIChat/__tests__/SetupScreen.test.tsx
@@ -156,4 +156,28 @@ describe("SetupScreen", () => {
     act(() => fireEvent.click(screen.getByTestId("setup-cancel")));
     expect(onCancel).toHaveBeenCalled();
   });
+
+  it("shows the Codex trust-hooks note only when Codex is selected (#1859)", async () => {
+    mockStatusOnce({
+      providers: [
+        { name: "claude-code", available: true, version: "2.1.0", logged_in: true },
+        { name: "codex", available: true, version: "0.118.0", logged_in: true },
+      ],
+    });
+    render(<SetupScreen tabId="t1" onLaunch={vi.fn()} onCancel={vi.fn()} />);
+    await screen.findByTestId("setup-launch");
+
+    // No provider chosen yet → no note.
+    expect(screen.queryByTestId("setup-codex-trust-note")).not.toBeInTheDocument();
+
+    // Claude Code selected → still no Codex note.
+    act(() => fireEvent.click(screen.getByTestId("setup-provider-claude-code")));
+    expect(screen.queryByTestId("setup-codex-trust-note")).not.toBeInTheDocument();
+
+    // Codex selected → note appears and mentions trusting hooks + the data/ guard.
+    act(() => fireEvent.click(screen.getByTestId("setup-provider-codex")));
+    const note = screen.getByTestId("setup-codex-trust-note");
+    expect(note.textContent).toMatch(/trust/i);
+    expect(note.textContent).toMatch(/data\//);
+  });
 });

--- a/frontend/src/components/BlockPalette.test.tsx
+++ b/frontend/src/components/BlockPalette.test.tsx
@@ -1,7 +1,7 @@
 import { act, cleanup, fireEvent, render, screen, within } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { BlockPalette } from "./BlockPalette";
+import { BlockPalette, paletteColumns } from "./BlockPalette";
 import type { BlockSummary } from "../types/api";
 
 afterEach(() => {
@@ -188,5 +188,39 @@ describe("BlockPalette — grid redesign (#1797)", () => {
     expect(screen.queryByTestId("palette-category-chips")).not.toBeInTheDocument();
     // The block is still reachable by its title attribute.
     expect(screen.getByTitle("Cellpose Segment")).toBeInTheDocument();
+  });
+
+  it("renders the tile grid via a width-driven column count, not a fixed 2-col class (#1857)", () => {
+    render(<BlockPalette {...defaultProps} blocks={[cellpose]} />);
+    const grid = screen.getByTestId("palette-block-tile").parentElement!;
+    // No hardcoded Tailwind 2-column class anymore.
+    expect(grid.className).not.toContain("grid-cols-2");
+    expect(grid.className).toContain("grid");
+    // Column count is driven by an inline grid-template-columns. jsdom has no
+    // layout / ResizeObserver, so the component keeps the default 2 columns.
+    expect(grid.style.gridTemplateColumns).toBe("repeat(2, minmax(0, 1fr))");
+  });
+});
+
+describe("paletteColumns — width → column count (#1857)", () => {
+  it("keeps the default 2 columns before the grid has been measured", () => {
+    expect(paletteColumns(0)).toBe(2);
+    expect(paletteColumns(-50)).toBe(2);
+  });
+
+  it("falls back to 1 column only when too narrow for two 80px tiles", () => {
+    expect(paletteColumns(100)).toBe(1);
+    expect(paletteColumns(163)).toBe(1); // just under 2*80 + gap
+    expect(paletteColumns(164)).toBe(2); // exactly two tiles + gap fit
+  });
+
+  it("prefers 2 columns at a typical default panel width", () => {
+    expect(paletteColumns(184)).toBe(2);
+  });
+
+  it("expands to 3 columns when the panel is dragged wide, capped at 3", () => {
+    expect(paletteColumns(247)).toBe(2); // just under 3 tiles
+    expect(paletteColumns(248)).toBe(3); // three tiles + gaps fit
+    expect(paletteColumns(1000)).toBe(3); // never exceeds the 3-column cap
   });
 });

--- a/frontend/src/components/BlockPalette.tsx
+++ b/frontend/src/components/BlockPalette.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { useReloadFlash } from "../hooks/useReloadFlash";
 import type { BlockSummary } from "../types/api";
@@ -24,9 +24,32 @@ const POPOVER_OPEN_DELAY_MS = 150;
 /** Rough popover height used to keep it inside the viewport. */
 const POPOVER_MAX_HEIGHT = 240;
 
+// #1857: the tile grid auto-adapts its column count to the (resizable) palette
+// width instead of a hardcoded 2 columns. A tile's intrinsic minimum width is
+// the 72px category swatch plus the tile's own padding, so TILE_MIN_PX leaves a
+// little breathing room above that. We prefer 2 columns (the default-panel
+// look), expand to at most 3 when the panel is dragged wide, and only fall back
+// to 1 when the panel is too narrow to fit two swatches side by side.
+const TILE_MIN_PX = 80;
+const GRID_GAP_PX = 4; // Tailwind gap-1 = 0.25rem.
+const MIN_COLUMNS = 1;
+const MAX_COLUMNS = 3;
+const DEFAULT_COLUMNS = 2;
+
+/** Column count that fits `width` px, clamped to [MIN_COLUMNS, MAX_COLUMNS]. */
+export function paletteColumns(width: number): number {
+  if (width <= 0) {
+    // Pre-measurement (first paint / jsdom): keep the default 2-column look.
+    return DEFAULT_COLUMNS;
+  }
+  const fit = Math.floor((width + GRID_GAP_PX) / (TILE_MIN_PX + GRID_GAP_PX));
+  return Math.max(MIN_COLUMNS, Math.min(MAX_COLUMNS, fit));
+}
+
 interface SectionViewProps {
   section: PaletteSection;
   forceOpen: boolean;
+  columns: number;
   onDragStart: (event: React.DragEvent, block: BlockSummary) => void;
   onAddBlock: (block: BlockSummary) => void;
   onEnter: (block: BlockSummary, rect: DOMRect) => void;
@@ -36,6 +59,7 @@ interface SectionViewProps {
 function SectionView({
   section,
   forceOpen,
+  columns,
   onDragStart,
   onAddBlock,
   onEnter,
@@ -63,7 +87,10 @@ function SectionView({
         </button>
       )}
       {open ? (
-        <div className="grid grid-cols-2 gap-1">
+        <div
+          className="grid gap-1"
+          style={{ gridTemplateColumns: `repeat(${columns}, minmax(0, 1fr))` }}
+        >
           {section.blocks.map((block) => (
             <BlockTile
               block={block}
@@ -99,6 +126,23 @@ export function BlockPalette({
   const [hovered, setHovered] = useState<{ block: BlockSummary; anchor: PopoverAnchor } | null>(
     null,
   );
+
+  // #1857: measure the scrollable grid area so the tile grid can pick a column
+  // count that fits the resizable palette. clientWidth excludes the scrollbar,
+  // so it reflects the space tiles actually get.
+  const gridScrollRef = useRef<HTMLDivElement | null>(null);
+  const [gridWidth, setGridWidth] = useState(0);
+  useEffect(() => {
+    const node = gridScrollRef.current;
+    if (!node || typeof ResizeObserver === "undefined") {
+      return;
+    }
+    const observer = new ResizeObserver(() => setGridWidth(node.clientWidth));
+    observer.observe(node);
+    setGridWidth(node.clientWidth);
+    return () => observer.disconnect();
+  }, []);
+  const columns = paletteColumns(gridWidth);
 
   const handleReload = () => {
     triggerFlash();
@@ -215,9 +259,13 @@ export function BlockPalette({
 
         <CategoryChips active={activeCategories} onToggle={toggleCategory} />
 
-        <div className="mt-4 min-h-0 flex-1 space-y-4 overflow-y-auto pb-6 scrollbar-thin">
+        <div
+          className="mt-4 min-h-0 flex-1 space-y-4 overflow-y-auto pb-6 scrollbar-thin"
+          ref={gridScrollRef}
+        >
           {sections.map((section) => (
             <SectionView
+              columns={columns}
               forceOpen={forceOpen}
               key={section.id}
               onAddBlock={onAddBlock}

--- a/src/scistudio/agent_provisioning/_orchestrate.py
+++ b/src/scistudio/agent_provisioning/_orchestrate.py
@@ -8,8 +8,10 @@ The orchestrator coordinates per-project provisioning:
   - .codex/config.toml (§3.7)            → ``codex_config.py``
 
 A version-marker file at ``<project>/.claude/.scistudio-provision-version``
-governs upgrade behavior on later SciStudio releases (§9 OQ-1; design
-deferred to Phase 3, see #1011).
+records the provisioning version. On every open the top-up writes any
+*missing* canonical assets and additively registers any newly-added canonical
+hook in an existing ``.claude/settings.json`` (ADR-040 Addendum 6, #1858), so
+old projects pick up new hooks/docs without overwriting user edits.
 
 Per ADR §7, failures are NOT fatal — they log at WARNING and return a
 ``ProvisionResult`` summarizing what succeeded. Callers continue with
@@ -30,12 +32,15 @@ from scistudio.agent_provisioning.skills import write_skills
 
 logger = logging.getLogger(__name__)
 
-# I40c Phase 2a sets this to "0.1.0" — the first real cut.
-# TODO(#1011): version-marker UPGRADE flow (detect stale version + re-write
-#   only changed canonical files) is Phase 3 design.
-#   Out of scope per ADR-040 §3.8 / §9 OQ-1.
-#   Followup: https://github.com/zjzcpj/SciStudio/issues/1011.
-SCISTUDIO_PROVISION_VERSION = "0.1.0"
+# 0.2.0 (ADR-040 Addendum 6, #1858): adds the data/ protection hook and the
+# additive on-open top-up (missing canonical assets + missing settings hook
+# entries are filled in for existing projects).
+# TODO(#1860): content-aware refresh of canonical files that ALREADY exist
+#   (re-write only files unmodified from a previous canonical version) is still
+#   deferred — it needs per-file canonical hashing to avoid clobbering user
+#   edits. Out of scope per ADR-040 Addendum 6.
+#   Followup: https://github.com/jiazhenz026/SciStudio/issues/1860.
+SCISTUDIO_PROVISION_VERSION = "0.2.0"
 
 _MARKER_REL_PATH = ".claude/.scistudio-provision-version"
 
@@ -90,6 +95,7 @@ def install_project_agent_assets(
                 ".claude/settings.json",
                 ".claude/hooks/deny_scistudio_cli.py",
                 ".claude/hooks/protect_workflow_yaml.py",
+                ".claude/hooks/protect_data_dir.py",
                 ".claude/hooks/enforce_list_blocks_before_block_write.py",
                 ".claude/hooks/remind_poll_status.py",
                 ".claude/hooks/mark_list_blocks_called.py",

--- a/src/scistudio/agent_provisioning/codex_config.py
+++ b/src/scistudio/agent_provisioning/codex_config.py
@@ -55,6 +55,11 @@ _PRE_HOOKS: tuple[tuple[str, str, str], ...] = (
         "Protecting workflows/*.yaml from direct edits",
     ),
     (
+        "^(Edit|Write|MultiEdit|apply_patch|Bash)$",
+        "protect_data_dir.py",
+        "Protecting project data/ from direct agent edits",
+    ),
+    (
         "^(Edit|Write|MultiEdit|apply_patch|Bash|mcp__scistudio__scaffold_block)$",
         "enforce_list_blocks_before_block_write.py",
         "Enforcing #875 block-reuse rule",

--- a/src/scistudio/agent_provisioning/hooks.py
+++ b/src/scistudio/agent_provisioning/hooks.py
@@ -1,15 +1,16 @@
 """Write project-scoped hook config + scripts (ADR-040 §3.6).
 
-Provisions ``<project>/.claude/settings.json`` and the 6 hook scripts at
+Provisions ``<project>/.claude/settings.json`` and the 7 hook scripts at
 ``<project>/.claude/hooks/`` for Claude Code's hook system.
 
 Per ADR §3.6 (matcher list expanded with ``MultiEdit`` per Codex P1
 review on PR #1047 — Claude Code treats ``MultiEdit`` as a distinct
 tool name; omitting it leaves a bypass path):
 
-  PreToolUse (3):
+  PreToolUse (4):
     - hook_deny_scistudio_cli.py                      (matcher: Bash)
     - hook_protect_workflow_yaml.py                 (matcher: Edit|Write|MultiEdit)
+    - hook_protect_data_dir.py                       (matcher: Edit|Write|MultiEdit|Bash)
     - hook_enforce_list_blocks_before_block_write.py
         (matcher: Edit|Write|MultiEdit|Bash|mcp__scistudio__scaffold_block)
 
@@ -46,6 +47,7 @@ _SETTINGS_REL = ".claude/settings.json"
 _HOOK_FILES: tuple[tuple[str, str], ...] = (
     ("hook_deny_scistudio_cli.py", "deny_scistudio_cli.py"),
     ("hook_protect_workflow_yaml.py", "protect_workflow_yaml.py"),
+    ("hook_protect_data_dir.py", "protect_data_dir.py"),
     (
         "hook_enforce_list_blocks_before_block_write.py",
         "enforce_list_blocks_before_block_write.py",
@@ -87,6 +89,9 @@ def _build_settings_json(hooks_dir_rel: str) -> dict:
     pre = [
         ("Bash", "deny_scistudio_cli.py"),
         ("Edit|Write|MultiEdit", "protect_workflow_yaml.py"),
+        # #1858: one matcher covers file tools + Bash; the script branches on
+        # tool_name (file-tool target check vs. best-effort Bash check).
+        ("Edit|Write|MultiEdit|Bash", "protect_data_dir.py"),
         (
             "Edit|Write|MultiEdit|Bash|mcp__scistudio__scaffold_block",
             "enforce_list_blocks_before_block_write.py",
@@ -161,12 +166,73 @@ def _upgrade_legacy_settings_commands(settings: dict, hooks_dir_rel: str) -> boo
     return changed
 
 
+def _entry_command_strings(entry: object) -> list[str]:
+    """Return all ``command`` strings declared by a settings hook entry."""
+    if not isinstance(entry, dict):
+        return []
+    handlers = entry.get("hooks")
+    if not isinstance(handlers, list):
+        return []
+    out: list[str] = []
+    for handler in handlers:
+        if isinstance(handler, dict) and isinstance(handler.get("command"), str):
+            out.append(handler["command"])
+    return out
+
+
+def _entry_script_name(entry: object, script_names: set[str]) -> str | None:
+    """The canonical hook script a settings entry invokes, if any."""
+    for command in _entry_command_strings(entry):
+        for script in script_names:
+            if script in command:
+                return script
+    return None
+
+
+def _merge_missing_canonical_hooks(settings: dict) -> bool:
+    """Additively register canonical hook entries missing from ``settings``.
+
+    ADR-040 Addendum 6 top-up (#1858): when a newer SciStudio version adds a
+    canonical hook, existing projects already have a ``settings.json`` and so
+    the plain "write only if absent" path never registers the new matcher.
+    This merge appends any canonical hook entry whose script is not referenced
+    in the corresponding event group.
+
+    Strictly additive: user-authored entries and any already-present canonical
+    entry (including a user-edited matcher/command for it) are left untouched.
+    Returns True if the settings dict was modified.
+    """
+    canonical = _build_settings_json(_HOOKS_DIR_REL)["hooks"]
+    hooks = settings.get("hooks")
+    if not isinstance(hooks, dict):
+        if "hooks" in settings:
+            return False  # malformed user config — do not touch
+        hooks = {}
+        settings["hooks"] = hooks
+    script_names = {dest for _template, dest in _HOOK_FILES}
+    changed = False
+    for event, entries in canonical.items():
+        group = hooks.get(event)
+        if not isinstance(group, list):
+            hooks[event] = json.loads(json.dumps(entries))
+            changed = True
+            continue
+        present = {name for entry in group if (name := _entry_script_name(entry, script_names)) is not None}
+        for entry in entries:
+            script = _entry_script_name(entry, script_names)
+            if script is not None and script not in present:
+                group.append(json.loads(json.dumps(entry)))
+                present.add(script)
+                changed = True
+    return changed
+
+
 def write_hooks(
     project_dir: Path,
     *,
     force: bool = False,
 ) -> list[str]:
-    """Write ``<project>/.claude/settings.json`` + 6 hook scripts.
+    """Write ``<project>/.claude/settings.json`` + 7 hook scripts.
 
     Returns list of project-relative paths actually written.
     """
@@ -189,9 +255,15 @@ def write_hooks(
             existing = json.loads(settings_path.read_text(encoding="utf-8"))
         except (json.JSONDecodeError, OSError):
             existing = None
-        if isinstance(existing, dict) and _upgrade_legacy_settings_commands(existing, _HOOKS_DIR_REL):
-            settings_path.write_text(json.dumps(existing, indent=2) + "\n", encoding="utf-8")
-            written.append(_SETTINGS_REL)
+        if isinstance(existing, dict):
+            # Order matters: upgrade legacy command strings first, then top up
+            # any canonical hooks this SciStudio version adds (#1858). Use a
+            # non-short-circuiting OR so both run.
+            upgraded = _upgrade_legacy_settings_commands(existing, _HOOKS_DIR_REL)
+            merged = _merge_missing_canonical_hooks(existing)
+            if upgraded or merged:
+                settings_path.write_text(json.dumps(existing, indent=2) + "\n", encoding="utf-8")
+                written.append(_SETTINGS_REL)
 
     for template_name, dest_name in _HOOK_FILES:
         dest = hooks_dir / dest_name

--- a/src/scistudio/agent_provisioning/templates/hook_protect_data_dir.py
+++ b/src/scistudio/agent_provisioning/templates/hook_protect_data_dir.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python
+"""hook_protect_data_dir.py — PreToolUse guard (ADR-040 §3.6 + Addendum 6).
+
+Blocks the in-app agent (Claude Code / Codex) from DIRECTLY modifying files
+under the project's ``data/`` tree. The intent is to stop the agent from
+"hand-editing" the user's scientific data; it is NOT a sandbox.
+
+Allowed (NOT blocked):
+  - Reading anything under ``data/`` (Read/cat/head/ls ...).
+  - Editing or deleting files OUTSIDE ``data/`` (e.g. ``workflows/``,
+    ``blocks/``) — the agent may still ``rm`` an unrelated workflow.
+  - The workflow runtime writing artifacts into ``data/`` — that happens in
+    the backend, not through the agent's Edit/Write/Bash tools, so it never
+    reaches this hook.
+
+Blocked (exit 2):
+  - ``Edit`` / ``Write`` / ``MultiEdit`` / ``apply_patch`` whose target file
+    resolves under ``<project>/data/`` (reliable).
+  - ``Bash`` commands that obviously write to or delete something under
+    ``data/`` (``rm``/``mv``/redirect into ``data/`` ...). This is a
+    best-effort textual check, not a shell parser; the file-tool matchers
+    above are the reliable layer.
+
+stdin: Claude Code / Codex hook JSON (``tool_name``, ``tool_input``, ``cwd``).
+exit 2 + stderr blocks the call; exit 0 allows it.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+
+_MESSAGE = (
+    "The project's data/ directory is protected: the agent must not directly "
+    "edit or delete files under data/. Produce or change data by running "
+    "workflow blocks (mcp__scistudio__run_workflow), not by hand-editing files. "
+    "Reading data/ and editing files outside data/ is fine."
+)
+
+# A ``data/`` path token: at a boundary (start / whitespace / quote / '=' / '(')
+# with an optional ``./``, OR any ``/data/`` segment in an absolute path.
+_DATA_TOKEN = re.compile(r"(?:(?:^|[\s='\"(])(?:\./)?|/)data/")
+# A redirection (``>`` / ``>>``) whose target path lands under ``data/``.
+_REDIR_INTO_DATA = re.compile(r">>?\s*['\"]?(?:[^\s|;&>'\"]*/)?data/")
+
+# Verbs that always alter their data/ operand (delete / overwrite / move).
+_ALWAYS_DESTRUCTIVE = {"rm", "rmdir", "shred", "truncate", "dd", "tee", "install", "mv"}
+# Verbs where only the destination (last operand) writing into data/ matters.
+_DEST_SENSITIVE = {"cp", "ln", "rsync"}
+# Leading words to skip when finding the real command verb.
+_PREFIX_WORDS = {"sudo", "env", "command", "nohup", "time", "exec", "builtin"}
+
+
+def _read_payload() -> dict:
+    try:
+        raw = sys.stdin.read()
+    except OSError:
+        return {}
+    if not raw.strip():
+        return {}
+    try:
+        data = json.loads(raw)
+        return data if isinstance(data, dict) else {}
+    except json.JSONDecodeError:
+        return {}
+
+
+def _project_root(payload: dict) -> str | None:
+    for key in ("CLAUDE_PROJECT_DIR", "SCISTUDIO_PROJECT_DIR"):
+        value = os.environ.get(key)
+        if value:
+            return os.path.normpath(value).replace("\\", "/")
+    cwd = payload.get("cwd")
+    if isinstance(cwd, str) and cwd:
+        return os.path.normpath(cwd).replace("\\", "/")
+    return None
+
+
+def _under_data(path_str: str, root: str | None) -> bool:
+    """True if ``path_str`` resolves to a file under ``<project>/data/``."""
+    if not path_str:
+        return False
+    norm = path_str.replace("\\", "/")
+    if root and not os.path.isabs(norm):
+        joined = os.path.normpath(os.path.join(root, norm)).replace("\\", "/")
+    else:
+        joined = os.path.normpath(norm).replace("\\", "/")
+    if root:
+        try:
+            rel = os.path.relpath(joined, root).replace("\\", "/")
+        except ValueError:
+            rel = None
+        if rel is not None and rel != ".." and not rel.startswith("../"):
+            return rel == "data" or rel.startswith("data/")
+    # No known root (or path on another drive): fall back to a segment match.
+    return bool(re.search(r"(?:^|/)data/", joined)) or joined == "data"
+
+
+def _command_segments(command: str) -> list[str]:
+    return [seg.strip() for seg in re.split(r"[;&|\n]+", command) if seg.strip()]
+
+
+def _segment_verb(segment: str) -> str:
+    toks = segment.split()
+    i = 0
+    while i < len(toks) and ("=" in toks[i] or toks[i] in _PREFIX_WORDS):
+        i += 1
+    if i >= len(toks):
+        return ""
+    return os.path.basename(toks[i].strip("\"'"))
+
+
+def _bash_hits_data(command: str) -> bool:
+    for seg in _command_segments(command):
+        if not _DATA_TOKEN.search(seg):
+            continue
+        if _REDIR_INTO_DATA.search(seg):
+            return True
+        verb = _segment_verb(seg)
+        if verb in _ALWAYS_DESTRUCTIVE:
+            return True
+        if verb in _DEST_SENSITIVE:
+            toks = [t for t in seg.split() if not t.startswith("-")]
+            if toks and _DATA_TOKEN.search(" " + toks[-1]):
+                return True
+    return False
+
+
+def main() -> int:
+    payload = _read_payload()
+    tool_name = str(payload.get("tool_name") or "")
+    tool_input = payload.get("tool_input") or {}
+    if not isinstance(tool_input, dict):
+        return 0
+    root = _project_root(payload)
+
+    if tool_name == "Bash":
+        command = str(tool_input.get("command") or "")
+        if command and _bash_hits_data(command):
+            print(_MESSAGE, file=sys.stderr)
+            return 2
+        return 0
+
+    # File-editing tools. Edit/Write/MultiEdit expose ``file_path`` directly.
+    file_path = str(tool_input.get("file_path") or tool_input.get("path") or "")
+    if file_path and _under_data(file_path, root):
+        print(_MESSAGE, file=sys.stderr)
+        return 2
+
+    # Codex ``apply_patch`` carries its targets inside the patch text rather
+    # than a single ``file_path``. Any data/ path in an apply_patch is a write
+    # or delete (it is an edit tool), so block when one appears.
+    if not file_path:
+        blob = " ".join(str(v) for v in tool_input.values())
+        if blob and _DATA_TOKEN.search(blob):
+            print(_MESSAGE, file=sys.stderr)
+            return 2
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/agent_provisioning/test_codex_config.py
+++ b/tests/agent_provisioning/test_codex_config.py
@@ -6,7 +6,47 @@ import sys
 import tomllib
 from pathlib import Path
 
+from scistudio.agent_provisioning import codex_config as _cc
 from scistudio.agent_provisioning.codex_config import write_codex_config
+from scistudio.agent_provisioning.hooks import _HOOK_FILES, _build_settings_json
+
+
+def test_every_provisioned_hook_is_wired_for_both_providers() -> None:
+    """#1858 parity guard: every provisioned hook script is registered for BOTH
+    Claude Code (``.claude/settings.json``) and Codex (``.codex/config.toml``).
+
+    Locks the two provider configs and the provisioned script set together so a
+    future hook added to one provider can't silently miss the other.
+    """
+    provisioned = {dest for _template, dest in _HOOK_FILES}
+
+    settings = _build_settings_json(".claude/hooks")
+    claude_wired: set[str] = set()
+    for entries in settings["hooks"].values():
+        for entry in entries:
+            for handler in entry["hooks"]:
+                for name in provisioned:
+                    if name in handler["command"]:
+                        claude_wired.add(name)
+
+    codex_wired = {s for _m, s, _msg in _cc._PRE_HOOKS} | {s for _m, s, _msg in _cc._POST_HOOKS}
+
+    assert provisioned == claude_wired, f"Claude missing: {provisioned - claude_wired}"
+    assert provisioned == codex_wired, f"Codex missing: {provisioned - codex_wired}"
+
+
+def test_data_dir_guard_matcher_covers_file_tools_and_bash_for_both_providers() -> None:
+    """The data/ guard must fire for file edits AND Bash on both providers."""
+    settings = _build_settings_json(".claude/hooks")
+    claude_matcher = next(
+        e["matcher"] for e in settings["hooks"]["PreToolUse"] if "protect_data_dir.py" in e["hooks"][0]["command"]
+    )
+    for tool in ("Edit", "Write", "MultiEdit", "Bash"):
+        assert tool in claude_matcher
+
+    codex_matcher = next(m for m, s, _ in _cc._PRE_HOOKS if s == "protect_data_dir.py")
+    for tool in ("Edit", "Write", "MultiEdit", "apply_patch", "Bash"):
+        assert tool in codex_matcher
 
 
 def test_writes_codex_config_toml(tmp_project_dir: Path) -> None:
@@ -45,7 +85,7 @@ def test_codex_config_mcp_block_matches_install_render(tmp_project_dir: Path) ->
 def test_codex_config_emits_hooks(tmp_project_dir: Path) -> None:
     """ADR-040/042: Codex gets the same hook surface as Claude.
 
-    Asserts ``features.hooks = true``, 3 PreToolUse + 3 PostToolUse
+    Asserts ``features.hooks = true``, 4 PreToolUse + 3 PostToolUse
     matcher groups, and each hook command line references a script
     under ``.claude/hooks/`` (the cross-provider canonical home).
     """
@@ -59,12 +99,13 @@ def test_codex_config_emits_hooks(tmp_project_dir: Path) -> None:
 
     pre = data.get("hooks", {}).get("PreToolUse", [])
     post = data.get("hooks", {}).get("PostToolUse", [])
-    assert len(pre) == 3, f"expected 3 PreToolUse hooks, got {len(pre)}"
+    assert len(pre) == 4, f"expected 4 PreToolUse hooks, got {len(pre)}"
     assert len(post) == 3, f"expected 3 PostToolUse hooks, got {len(post)}"
 
     expected_pre_scripts = {
         "deny_scistudio_cli.py",
         "protect_workflow_yaml.py",
+        "protect_data_dir.py",
         "enforce_list_blocks_before_block_write.py",
     }
     expected_post_scripts = {

--- a/tests/agent_provisioning/test_hooks.py
+++ b/tests/agent_provisioning/test_hooks.py
@@ -13,11 +13,16 @@ from pathlib import Path
 
 import pytest
 
-from scistudio.agent_provisioning.hooks import write_hooks
+from scistudio.agent_provisioning.hooks import (
+    _build_settings_json,
+    _merge_missing_canonical_hooks,
+    write_hooks,
+)
 
 _HOOK_NAMES = (
     "deny_scistudio_cli.py",
     "protect_workflow_yaml.py",
+    "protect_data_dir.py",
     "enforce_list_blocks_before_block_write.py",
     "remind_poll_status.py",
     "mark_list_blocks_called.py",
@@ -35,8 +40,13 @@ def test_write_hooks_creates_settings_json(tmp_project_dir: Path) -> None:
     assert "hooks" in data
     pre = data["hooks"]["PreToolUse"]
     post = data["hooks"]["PostToolUse"]
-    assert len(pre) == 3
+    assert len(pre) == 4  # +protect_data_dir.py (#1858)
     assert len(post) == 3
+
+    # #1858: the data/ guard is registered for both file tools and Bash.
+    data_dir_entries = [e for e in pre if "protect_data_dir.py" in e["hooks"][0]["command"]]
+    assert len(data_dir_entries) == 1
+    assert data_dir_entries[0]["matcher"] == "Edit|Write|MultiEdit|Bash"
 
     # Every entry references a python interpreter and a hook script path.
     for entry in pre + post:
@@ -76,17 +86,74 @@ def test_write_hooks_excludes_worktree_write_guard(tmp_project_dir: Path) -> Non
     assert not any("worktree_write_guard" in command for command in commands)
 
 
-def test_write_hooks_idempotent_preserves_user_edits(tmp_project_dir: Path) -> None:
-    """force=False does not overwrite user-customized settings.json."""
-    write_hooks(tmp_project_dir, force=False)
-
-    custom = {"hooks": {"PreToolUse": [], "PostToolUse": [], "_custom": "user-added"}}
-    (tmp_project_dir / ".claude" / "settings.json").write_text(json.dumps(custom), encoding="utf-8")
+def test_write_hooks_idempotent_when_all_canonical_present(tmp_project_dir: Path) -> None:
+    """force=False does not rewrite settings.json when nothing is missing."""
+    settings = _build_settings_json(".claude/hooks")
+    settings["hooks"]["_custom"] = "user-added"
+    settings_path = tmp_project_dir / ".claude" / "settings.json"
+    settings_path.parent.mkdir(parents=True, exist_ok=True)
+    settings_path.write_text(json.dumps(settings), encoding="utf-8")
 
     written = write_hooks(tmp_project_dir, force=False)
     assert ".claude/settings.json" not in written
-    data = json.loads((tmp_project_dir / ".claude" / "settings.json").read_text(encoding="utf-8"))
-    assert data.get("hooks", {}).get("_custom") == "user-added"
+    data = json.loads(settings_path.read_text(encoding="utf-8"))
+    assert data["hooks"]["_custom"] == "user-added"
+
+
+def test_write_hooks_tops_up_missing_canonical_hook(tmp_project_dir: Path) -> None:
+    """#1858: an existing settings.json missing the data/ guard gets it added.
+
+    Simulates an old project provisioned before ``protect_data_dir.py`` existed:
+    its settings.json already exists, so the plain write-if-absent path would
+    never register the new hook. The additive top-up must add it on next open,
+    while preserving the user's own entries.
+    """
+    settings = _build_settings_json(".claude/hooks")
+    # Drop the data/ guard to mimic a pre-#1858 project, and add a user hook.
+    settings["hooks"]["PreToolUse"] = [
+        e for e in settings["hooks"]["PreToolUse"] if "protect_data_dir.py" not in e["hooks"][0]["command"]
+    ]
+    settings["hooks"]["PreToolUse"].append(
+        {"matcher": "Bash", "hooks": [{"type": "command", "command": "my-own-hook.sh"}]}
+    )
+    settings_path = tmp_project_dir / ".claude" / "settings.json"
+    settings_path.parent.mkdir(parents=True, exist_ok=True)
+    settings_path.write_text(json.dumps(settings), encoding="utf-8")
+
+    written = write_hooks(tmp_project_dir, force=False)
+
+    assert ".claude/settings.json" in written
+    data = json.loads(settings_path.read_text(encoding="utf-8"))
+    commands = [h["command"] for e in data["hooks"]["PreToolUse"] for h in e["hooks"]]
+    # New canonical hook registered...
+    assert any("protect_data_dir.py" in c for c in commands)
+    # ...the script file is present...
+    assert (tmp_project_dir / ".claude" / "hooks" / "protect_data_dir.py").is_file()
+    # ...and the user's own hook is left intact.
+    assert "my-own-hook.sh" in commands
+
+
+def test_merge_missing_canonical_hooks_is_additive_only() -> None:
+    """The merge adds missing canonical entries and never duplicates present ones."""
+    settings = _build_settings_json(".claude/hooks")
+    # Everything already present → no change.
+    assert _merge_missing_canonical_hooks(settings) is False
+
+    # Remove one canonical entry → exactly that one is re-added, idempotently.
+    settings["hooks"]["PreToolUse"] = [
+        e for e in settings["hooks"]["PreToolUse"] if "protect_data_dir.py" not in e["hooks"][0]["command"]
+    ]
+    assert _merge_missing_canonical_hooks(settings) is True
+    assert _merge_missing_canonical_hooks(settings) is False
+    cmds = [h["command"] for e in settings["hooks"]["PreToolUse"] for h in e["hooks"]]
+    assert sum("protect_data_dir.py" in c for c in cmds) == 1
+
+
+def test_merge_missing_canonical_hooks_leaves_malformed_hooks_untouched() -> None:
+    """A non-dict ``hooks`` value is user data we must not clobber."""
+    settings = {"hooks": "not-a-dict"}
+    assert _merge_missing_canonical_hooks(settings) is False
+    assert settings == {"hooks": "not-a-dict"}
 
 
 def test_write_hooks_upgrades_legacy_python_commands(tmp_project_dir: Path) -> None:
@@ -197,6 +264,99 @@ def test_hook_protect_workflow_yaml_passes_other_paths(tmp_project_dir: Path) ->
     for fp in ("README.md", "data/raw/file.csv", "workflows.yaml.bak"):
         proc = _run_hook(script, {"tool_input": {"file_path": fp}})
         assert proc.returncode == 0, f"expected pass for {fp}"
+
+
+# ---------------------------------------------------------------------------
+# #1858 — protect_data_dir.py
+# ---------------------------------------------------------------------------
+
+
+def _data_hook(tmp_project_dir: Path) -> Path:
+    write_hooks(tmp_project_dir, force=False)
+    return tmp_project_dir / ".claude" / "hooks" / "protect_data_dir.py"
+
+
+def _env_for(tmp_project_dir: Path) -> dict[str, str]:
+    import os
+
+    env = os.environ.copy()
+    env["CLAUDE_PROJECT_DIR"] = str(tmp_project_dir)
+    env.pop("SCISTUDIO_PROJECT_DIR", None)
+    return env
+
+
+def test_data_hook_blocks_file_edits_under_data(tmp_project_dir: Path) -> None:
+    script = _data_hook(tmp_project_dir)
+    env = _env_for(tmp_project_dir)
+    for tool in ("Edit", "Write", "MultiEdit"):
+        for fp in (
+            "data/raw/file.csv",
+            "data/zarr/array",
+            str(tmp_project_dir / "data" / "artifacts" / "out.png"),
+            "./data/exchange/x.json",
+        ):
+            proc = _run_hook(script, {"tool_name": tool, "tool_input": {"file_path": fp}}, env=env)
+            assert proc.returncode == 2, f"expected block for {tool} {fp}"
+
+
+def test_data_hook_allows_file_edits_outside_data(tmp_project_dir: Path) -> None:
+    script = _data_hook(tmp_project_dir)
+    env = _env_for(tmp_project_dir)
+    for fp in (
+        "blocks/my_block.py",
+        "workflows/main.yaml",
+        "README.md",
+        "database.py",  # not the data/ dir
+        "metadata/notes.txt",
+        str(tmp_project_dir / "blocks" / "x.py"),
+    ):
+        proc = _run_hook(script, {"tool_name": "Write", "tool_input": {"file_path": fp}}, env=env)
+        assert proc.returncode == 0, f"expected pass for {fp}"
+
+
+def test_data_hook_blocks_obvious_bash_writes_and_deletes(tmp_project_dir: Path) -> None:
+    script = _data_hook(tmp_project_dir)
+    env = _env_for(tmp_project_dir)
+    for cmd in (
+        "rm -rf data/raw",
+        "rm data/zarr/array",
+        "echo hi > data/raw/out.txt",
+        "cat foo >> data/exchange/log",
+        "mv data/raw/a.csv /tmp/a.csv",  # moving OUT of data deletes the source
+        "cp report.csv data/artifacts/report.csv",  # writing INTO data
+        "truncate -s 0 data/raw/big.bin",
+    ):
+        proc = _run_hook(script, {"tool_name": "Bash", "tool_input": {"command": cmd}}, env=env)
+        assert proc.returncode == 2, f"expected block for: {cmd}"
+
+
+def test_data_hook_allows_reads_and_non_data_bash(tmp_project_dir: Path) -> None:
+    script = _data_hook(tmp_project_dir)
+    env = _env_for(tmp_project_dir)
+    for cmd in (
+        "cat data/raw/file.csv",  # reading data is fine
+        "ls -la data/",
+        "head -n 5 data/raw/file.csv",
+        "rm -rf workflows/old.yaml",  # deleting non-data is allowed
+        "mv blocks/a.py blocks/b.py",
+        "echo hello > notes.txt",
+    ):
+        proc = _run_hook(script, {"tool_name": "Bash", "tool_input": {"command": cmd}}, env=env)
+        assert proc.returncode == 0, f"expected pass for: {cmd}"
+
+
+def test_data_hook_blocks_apply_patch_touching_data(tmp_project_dir: Path) -> None:
+    script = _data_hook(tmp_project_dir)
+    env = _env_for(tmp_project_dir)
+    patch = "*** Begin Patch\n*** Update File: data/raw/file.csv\n+changed\n*** End Patch\n"
+    proc = _run_hook(script, {"tool_name": "apply_patch", "tool_input": {"input": patch}}, env=env)
+    assert proc.returncode == 2
+
+
+def test_data_hook_empty_stdin_passes(tmp_project_dir: Path) -> None:
+    script = _data_hook(tmp_project_dir)
+    proc = subprocess.run([sys.executable, str(script)], input="", capture_output=True, text=True, timeout=15)
+    assert proc.returncode == 0
 
 
 def test_hook_enforce_list_blocks_blocks_without_marker(tmp_project_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/agent_provisioning/test_orchestrate.py
+++ b/tests/agent_provisioning/test_orchestrate.py
@@ -25,6 +25,7 @@ def test_install_project_agent_assets_fresh_project(tmp_project_dir: Path) -> No
         ".claude/settings.json",
         ".claude/hooks/deny_scistudio_cli.py",
         ".claude/hooks/protect_workflow_yaml.py",
+        ".claude/hooks/protect_data_dir.py",
         ".claude/hooks/enforce_list_blocks_before_block_write.py",
         ".claude/hooks/remind_poll_status.py",
         ".claude/hooks/mark_list_blocks_called.py",


### PR DESCRIPTION
## Summary

Three owner-directed UX items from one guided session, all small and reviewable:

1. **Palette column auto-fit (#1857)** — the left Block Palette grid was hardcoded
   to 2 columns, so resizing the palette either crammed tiles (narrow) or left
   them sparse (wide). It now adapts the column count to the measured grid width:
   default **2**, up to **3** when dragged wide, and **1** only when too narrow to
   fit two 72px swatches. Pure measurement via a small `ResizeObserver` (same
   pattern as `AIChat/TerminalView.tsx`); `paletteColumns()` is unit-tested.

2. **`data/` protection hook (#1858)** — users were worried the in-app agent could
   directly rewrite their data. A new provisioned PreToolUse hook
   `protect_data_dir.py` blocks `Edit/Write/MultiEdit/apply_patch` and obvious
   destructive `Bash` targeting `<project>/data/**`, for **both Claude Code and
   Codex**. Reading `data/` and editing/deleting files outside `data/` stay
   allowed, and the workflow runtime writing artifacts into `data/` is unaffected
   (it never goes through the agent's edit tools).

3. **On-open top-up for existing projects (#1858)** — opening a project now
   additively merges any missing canonical hook entries into an existing
   `.claude/settings.json` (never clobbering user edits, never deleting) and bumps
   `SCISTUDIO_PROVISION_VERSION` 0.1.0 → 0.2.0, so old projects pick up the new
   hook automatically. A cross-provider parity guard test asserts every
   provisioned hook is wired for both providers.

4. **Codex trust-hooks note (#1859)** — the AI chat setup screen now shows a
   Codex-only note prompting the user to accept Codex's "trust hooks" prompt, so
   the safety hooks actually run. (We deliberately do **not** auto-write trust into
   the user's global Codex config.)

ADR-040 Addendum 6 records the hook + top-up contract.

## Tests
- Frontend: `paletteColumns` breakpoints + grid uses `gridTemplateColumns`;
  Codex-only setup note appears only when Codex is selected.
- Backend: `protect_data_dir.py` block/allow behavior (file tools + Bash +
  apply_patch), additive settings merge, top-up of an old project, cross-provider
  hook parity.

## Out of scope
- Content-aware refresh of canonical files that already exist — tracked in #1860.

Gate record: .workflow/records/1857-guided-1858-agent-data-protection.json

Closes #1857
Closes #1858
Closes #1859
