### PR TITLE
fix(#1865): self-reap bundled backend when Electron parent dies

### DIFF
--- a/.workflow/records/1865-guided-1865-backend-orphan-self-reap.json
+++ b/.workflow/records/1865-guided-1865-backend-orphan-self-reap.json
@@ -1,0 +1,97 @@
+{
+  "branch": "guided/1865-backend-orphan-self-reap",
+  "check_events": [],
+  "check_na": [],
+  "commit": null,
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "src/scistudio/cli/main.py",
+      "tests/**"
+    ]
+  },
+  "directive_events": [
+    {
+      "at": "2026-06-29T03:42:40.067648Z",
+      "owner_directive": "\u4e3a\u5565\u8981\u653e\u5230cli\u91cc \u2014 move the backstop out of cli/main.py into scistudio/desktop/parent_watchdog.py; cli/main.py just imports and calls it.",
+      "reason": "Owner: parent-death backstop should not live in the cli arg-parsing module; move it to a dedicated desktop bundled-runtime lifecycle module, cli only wires it."
+    },
+    {
+      "at": "2026-06-29T03:46:17.043239Z",
+      "owner_directive": "PR A: OTA-deliverable parent-death backstop in scistudio/desktop/parent_watchdog.py; cli/main.py wires it in bundled+posix gui mode.",
+      "reason": "plan"
+    }
+  ],
+  "docs_events": [
+    {
+      "at": "2026-06-29T03:46:17.043380Z",
+      "class": "user_guide",
+      "kind": "na",
+      "path": null,
+      "rationale": "internal bundled-runtime process-lifecycle hardening; no public API/UI/schema/contract change. Desktop spawn-lifecycle docs belong with the Electron-side PR.",
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-29T03:46:17.043397Z",
+      "class": "changelog",
+      "kind": "na",
+      "path": null,
+      "rationale": "alpha pre-release; orphan-backend fix is internal reliability, no user-facing changelog maintained at this stage.",
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": false,
+  "guard_events": [],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1865,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": null,
+  "owner_directive": "Fix bundled backend orphan accumulation. PR A (this one): add an OTA-deliverable parent-death backstop in src/scistudio/cli/main.py so the bundled backend self-terminates when its Electron parent dies by any means. Desktop-side spawn-lifecycle fixes are a separate PR.",
+  "persona": "live_implementer",
+  "pull_request": null,
+  "reconcile_events": [],
+  "record_id": "1865-guided-1865-backend-orphan-self-reap",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [],
+    "docs": [],
+    "guards": [],
+    "tests": []
+  },
+  "runtime": "claude-code",
+  "schema_version": 2,
+  "scope_events": [
+    {
+      "action": "add-include",
+      "at": "2026-06-29T03:42:40.067783Z",
+      "pattern": "src/scistudio/desktop/parent_watchdog.py",
+      "reason": "Owner: parent-death backstop should not live in the cli arg-parsing module; move it to a dedicated desktop bundled-runtime lifecycle module, cli only wires it."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-29T03:42:40.067791Z",
+      "pattern": "tests/desktop/**",
+      "reason": "Owner: parent-death backstop should not live in the cli arg-parsing module; move it to a dedicated desktop bundled-runtime lifecycle module, cli only wires it."
+    }
+  ],
+  "session_id": "787b467e-d83b-4f3e-a1fb-40dc4551c342",
+  "strictness_tier": null,
+  "task_kind": "guided",
+  "test_events": [
+    {
+      "at": "2026-06-29T03:46:17.043401Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/desktop/test_parent_watchdog.py",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/.workflow/records/1865-guided-1865-backend-orphan-self-reap.json
+++ b/.workflow/records/1865-guided-1865-backend-orphan-self-reap.json
@@ -130,9 +130,9 @@
   ],
   "check_na": [],
   "commit": {
-    "sha": "808200053823c309a68fabd451acdf7332d3600d",
+    "sha": "1c4f4efa447271a2d03a057bd69cc4219f4da00d",
     "shas": [
-      "808200053823c309a68fabd451acdf7332d3600d"
+      "1c4f4efa447271a2d03a057bd69cc4219f4da00d"
     ],
     "trailers": []
   },
@@ -420,6 +420,252 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-06-29T03:54:55.954960Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T03:54:55.964110Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T03:54:55.972650Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T03:54:55.981740Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T03:54:55.990682Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T03:54:55.999682Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T03:54:56.008817Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T03:54:56.019109Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T03:54:56.028727Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T03:54:56.039417Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T03:55:02.112653Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T03:55:02.121680Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T03:55:02.130265Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T03:55:02.138831Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T03:55:02.147170Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T03:55:02.155851Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T03:55:02.164267Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T03:55:02.173866Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T03:55:02.183630Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T03:55:02.194286Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T03:55:13.515146Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T03:55:13.524063Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T03:55:13.532417Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T03:55:13.540659Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T03:55:13.548861Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T03:55:13.557116Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T03:55:13.565896Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T03:55:13.574870Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T03:55:13.583297Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T03:55:13.593139Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -432,7 +678,7 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "origin/main",
+    "base": "cd31d6fffde72fe06168ac7834f61197c20dff04",
     "base_sha": "cd31d6ff",
     "changed_files": [
       ".workflow/records/1865-guided-1865-backend-orphan-self-reap.json",
@@ -440,9 +686,9 @@
       "src/scistudio/desktop/parent_watchdog.py",
       "tests/desktop/test_parent_watchdog.py"
     ],
-    "diff_fingerprint": "sha256:15984313b97916328ee023e50a51acb12e2c19189285e48e04a4fed36e40461b",
+    "diff_fingerprint": "sha256:0c37c934fc27f63d9324fc7a6173a346ee63718573c49b2cecd5ee6475e7bff9",
     "head": "HEAD",
-    "head_sha": "80820005",
+    "head_sha": "1c4f4efa",
     "surfaces": {
       "docs": 0,
       "frontend": 0,
@@ -463,7 +709,7 @@
     "closes": [
       1865
     ],
-    "number": null,
+    "number": 1866,
     "url": null
   },
   "reconcile_events": [
@@ -488,6 +734,30 @@
     {
       "at": "2026-06-29T03:53:52.939254Z",
       "diff_fingerprint": "sha256:15984313b97916328ee023e50a51acb12e2c19189285e48e04a4fed36e40461b",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-29T03:54:56.039444Z",
+      "diff_fingerprint": "sha256:0c37c934fc27f63d9324fc7a6173a346ee63718573c49b2cecd5ee6475e7bff9",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-29T03:55:02.194314Z",
+      "diff_fingerprint": "sha256:0c37c934fc27f63d9324fc7a6173a346ee63718573c49b2cecd5ee6475e7bff9",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-29T03:55:13.593166Z",
+      "diff_fingerprint": "sha256:0c37c934fc27f63d9324fc7a6173a346ee63718573c49b2cecd5ee6475e7bff9",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 2,

--- a/.workflow/records/1865-guided-1865-backend-orphan-self-reap.json
+++ b/.workflow/records/1865-guided-1865-backend-orphan-self-reap.json
@@ -1,8 +1,141 @@
 {
   "branch": "guided/1865-backend-orphan-self-reap",
-  "check_events": [],
+  "check_events": [
+    {
+      "at": "2026-06-29T03:47:18.854905Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:ad37e3d9f3feee1d5675fa95b3253e7daa5be28ab17aa0767872a497b9a8a660",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-29T03:47:22.890997Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:1e3b112cd8a222a5ba2dc72bc2dcd0a5a1e20f51f3776c56bbb1ff12dcb803ce",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-29T03:47:23.393924Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:a36643bc09c435ba406ad47da2d5bc3ba5d5e8354c295ef7d83b37b7e43d2f1a",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-29T03:47:23.432935Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:71357c6dcd15eb7709b48a38ef9c0200cefd7ad622abc3f06f42a52a641da966",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-29T03:49:16.666350Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:2037f96a8ad211dfa03eb904dbc5cf85c8c2c8abef593cde30ee5313bb0a8e80",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-29T03:51:09.597496Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:d0bf8cd5c8a7c0db8d43f29dd586c17d09cd495c754520acf208a6f8fe92805c",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-29T03:51:14.870677Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:1bf583ca972d0469f517527fe0c528e5a9030aea07d5722fbea148e491b5f0ca",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    },
+    {
+      "at": "2026-06-29T03:53:26.844916Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:2037f96a8ad211dfa03eb904dbc5cf85c8c2c8abef593cde30ee5313bb0a8e80",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    }
+  ],
   "check_na": [],
-  "commit": null,
+  "commit": {
+    "sha": "808200053823c309a68fabd451acdf7332d3600d",
+    "shas": [
+      "808200053823c309a68fabd451acdf7332d3600d"
+    ],
+    "trailers": []
+  },
   "declared_scope": {
     "exclude": [],
     "include": [
@@ -41,7 +174,254 @@
     }
   ],
   "governance_touch": false,
-  "guard_events": [],
+  "guard_events": [
+    {
+      "at": "2026-06-29T03:51:14.903434Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T03:51:14.912583Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T03:51:14.921551Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T03:51:14.930456Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T03:51:14.939425Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T03:51:14.949067Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T03:51:14.958441Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T03:51:14.968613Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T03:51:14.977619Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T03:51:14.987649Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T03:53:26.871850Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T03:53:26.880810Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T03:53:26.889736Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T03:53:26.899267Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T03:53:26.908641Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T03:53:26.917834Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T03:53:26.926638Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T03:53:26.936629Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T03:53:26.946311Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T03:53:26.957039Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T03:53:52.858221Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T03:53:52.867397Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T03:53:52.876853Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T03:53:52.886099Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T03:53:52.894746Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T03:53:52.903450Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T03:53:52.912002Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T03:53:52.920640Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T03:53:52.929229Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T03:53:52.939220Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
   "issues": [
     {
       "close_in_pr": true,
@@ -51,19 +431,100 @@
     }
   ],
   "observed_admin_labels": [],
-  "observed_diff": null,
+  "observed_diff": {
+    "base": "origin/main",
+    "base_sha": "cd31d6ff",
+    "changed_files": [
+      ".workflow/records/1865-guided-1865-backend-orphan-self-reap.json",
+      "src/scistudio/cli/main.py",
+      "src/scistudio/desktop/parent_watchdog.py",
+      "tests/desktop/test_parent_watchdog.py"
+    ],
+    "diff_fingerprint": "sha256:15984313b97916328ee023e50a51acb12e2c19189285e48e04a4fed36e40461b",
+    "head": "HEAD",
+    "head_sha": "80820005",
+    "surfaces": {
+      "docs": 0,
+      "frontend": 0,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 2,
+      "packaging": 0,
+      "protected_core": 0,
+      "sentrux": 3,
+      "test": 1,
+      "workflow_ci": 0
+    }
+  },
   "owner_directive": "Fix bundled backend orphan accumulation. PR A (this one): add an OTA-deliverable parent-death backstop in src/scistudio/cli/main.py so the bundled backend self-terminates when its Electron parent dies by any means. Desktop-side spawn-lifecycle fixes are a separate PR.",
   "persona": "live_implementer",
-  "pull_request": null,
-  "reconcile_events": [],
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [
+      1865
+    ],
+    "number": null,
+    "url": null
+  },
+  "reconcile_events": [
+    {
+      "at": "2026-06-29T03:51:14.987688Z",
+      "diff_fingerprint": "sha256:15984313b97916328ee023e50a51acb12e2c19189285e48e04a4fed36e40461b",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.python_tests"
+      ]
+    },
+    {
+      "at": "2026-06-29T03:53:26.957090Z",
+      "diff_fingerprint": "sha256:15984313b97916328ee023e50a51acb12e2c19189285e48e04a4fed36e40461b",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-29T03:53:52.939254Z",
+      "diff_fingerprint": "sha256:15984313b97916328ee023e50a51acb12e2c19189285e48e04a4fed36e40461b",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    }
+  ],
   "record_id": "1865-guided-1865-backend-orphan-self-reap",
   "requested_admin_labels": [],
   "required_obligations": {
     "admin_labels": [],
-    "checks": [],
-    "docs": [],
-    "guards": [],
-    "tests": []
+    "checks": [
+      "format_check",
+      "full_audit",
+      "import_contracts",
+      "lint_format",
+      "python_tests",
+      "semantic_dup",
+      "type_check"
+    ],
+    "docs": [
+      "docs_required_or_na"
+    ],
+    "guards": [
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": [
+      "changed_test_required"
+    ]
   },
   "runtime": "claude-code",
   "schema_version": 2,
@@ -82,7 +543,7 @@
     }
   ],
   "session_id": "787b467e-d83b-4f3e-a1fb-40dc4551c342",
-  "strictness_tier": null,
+  "strictness_tier": 2,
   "task_kind": "guided",
   "test_events": [
     {

--- a/src/scistudio/cli/main.py
+++ b/src/scistudio/cli/main.py
@@ -450,6 +450,13 @@ def gui(
     os.environ.setdefault("SCISTUDIO_ENGINE_API_URL", f"http://127.0.0.1:{bound_port}")
     if not no_browser and not bundled:
         threading.Timer(1.5, webbrowser.open, args=[url]).start()
+    # #1865: in bundled desktop mode, self-reap if the Electron parent dies
+    # without signalling us (force-quit / crash / app.exit relaunch) so the
+    # backend does not linger as an orphan. POSIX-only: relies on reparent-to-init.
+    if bundled and os.name == "posix":
+        from scistudio.desktop.parent_watchdog import start_parent_death_watchdog
+
+        start_parent_death_watchdog(os.getppid())
     # #1741: log_config=None lets uvicorn loggers propagate to our root handlers.
     uvicorn.run(
         "scistudio.api.app:create_app",

--- a/src/scistudio/desktop/parent_watchdog.py
+++ b/src/scistudio/desktop/parent_watchdog.py
@@ -1,0 +1,91 @@
+"""Parent-death backstop for the bundled desktop backend (#1865).
+
+The desktop Electron process spawns the backend (``scistudio gui --bundled``) as
+a child. When Electron exits *without* sending SIGTERM — force-quit, crash, or
+the ``app.exit()`` relaunch paths — POSIX reparents the backend to init (PID 1)
+and it would otherwise run forever as an orphan, accumulating one stray process
+per launch. The frontend can then reconnect to a stale orphan that never scanned
+the active project's blocks, so freshly authored drop-in blocks fail to appear.
+
+The watchdog here notices the spawning parent has gone and shuts the backend
+down. It lives in the backend source tree, so the OTA hot-patch carries it to
+existing installs without a reinstall. The Electron-side spawn-lifecycle fixes
+(relaunch handler, single-instance lock) are tracked separately and need a new
+app build.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from collections.abc import Callable
+
+logger = logging.getLogger(__name__)
+
+# How often the watchdog re-checks the parent PID, and how long to wait for a
+# graceful uvicorn shutdown before hard-exiting an orphaned backend.
+PARENT_WATCH_INTERVAL_S = 2.0
+ORPHAN_SHUTDOWN_GRACE_S = 3.0
+
+
+def backend_is_orphaned(initial_ppid: int, current_ppid: int) -> bool:
+    """Return ``True`` when the process that launched this backend has exited.
+
+    On POSIX an orphaned child is reparented to init (PID 1), so either a change
+    away from the original parent PID or a current parent of PID 1 means the
+    spawning parent is gone.
+
+    ``initial_ppid <= 1`` means the backend was already orphaned (or the parent
+    was unknown) at startup; there is then no live parent to track, so this
+    returns ``False`` and the watchdog stays inert rather than self-terminating.
+    """
+    if initial_ppid <= 1:
+        return False
+    return current_ppid != initial_ppid or current_ppid == 1
+
+
+def _shutdown_orphaned_backend() -> None:
+    """Gracefully stop, then hard-exit, an orphaned bundled backend."""
+    import contextlib
+    import os
+    import signal
+    import time
+
+    logger.warning("Parent process exited; shutting down orphaned bundled backend (#1865).")
+    # Prefer a graceful uvicorn shutdown so lifespan teardown still runs.
+    with contextlib.suppress(Exception):  # best-effort graceful path
+        os.kill(os.getpid(), signal.SIGTERM)
+    time.sleep(ORPHAN_SHUTDOWN_GRACE_S)
+    # Hard fallback if graceful shutdown did not exit the process in time.
+    os._exit(0)
+
+
+def start_parent_death_watchdog(
+    initial_ppid: int,
+    *,
+    interval: float = PARENT_WATCH_INTERVAL_S,
+    on_orphan: Callable[[], None] | None = None,
+) -> threading.Thread | None:
+    """Start a daemon thread that reaps this backend once it is orphaned.
+
+    Returns the started thread, or ``None`` when there is no live parent to
+    watch (``initial_ppid <= 1``). POSIX-only; callers gate on bundled mode.
+    """
+    if initial_ppid <= 1:
+        return None
+
+    handler = on_orphan or _shutdown_orphaned_backend
+
+    def _run() -> None:
+        import os
+        import time
+
+        while True:
+            time.sleep(interval)
+            if backend_is_orphaned(initial_ppid, os.getppid()):
+                handler()
+                return
+
+    thread = threading.Thread(target=_run, name="scistudio-parent-watchdog", daemon=True)
+    thread.start()
+    return thread

--- a/tests/desktop/test_parent_watchdog.py
+++ b/tests/desktop/test_parent_watchdog.py
@@ -1,0 +1,69 @@
+"""Tests for the bundled-backend parent-death backstop (#1865).
+
+The desktop Electron process spawns the backend as a child. When Electron exits
+without sending SIGTERM (force-quit / crash / ``app.exit()`` relaunch paths) the
+backend is reparented to init and would otherwise run forever as an orphan. The
+watchdog reaps the backend once it detects it has been orphaned.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+
+import pytest
+
+from scistudio.desktop import parent_watchdog
+
+
+class TestBackendIsOrphaned:
+    def test_unchanged_live_parent_is_not_orphaned(self) -> None:
+        assert parent_watchdog.backend_is_orphaned(4321, 4321) is False
+
+    def test_reparented_to_init_is_orphaned(self) -> None:
+        assert parent_watchdog.backend_is_orphaned(4321, 1) is True
+
+    def test_parent_pid_changed_is_orphaned(self) -> None:
+        # Parent died and a new (different) parent was assigned.
+        assert parent_watchdog.backend_is_orphaned(4321, 9999) is True
+
+    @pytest.mark.parametrize("initial", [0, 1, -1])
+    def test_already_orphaned_or_unknown_at_start_stays_inert(self, initial: int) -> None:
+        # No live parent to track at startup -> never self-terminate.
+        assert parent_watchdog.backend_is_orphaned(initial, 1) is False
+        assert parent_watchdog.backend_is_orphaned(initial, 12345) is False
+
+
+class TestStartParentDeathWatchdog:
+    def test_returns_none_when_no_live_parent_to_watch(self) -> None:
+        assert parent_watchdog.start_parent_death_watchdog(1) is None
+
+    def test_fires_on_orphan_when_parent_goes_away(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        fired = threading.Event()
+        # Pretend the spawning parent (pid 4321) has been replaced by init.
+        monkeypatch.setattr(os, "getppid", lambda: 1)
+
+        thread = parent_watchdog.start_parent_death_watchdog(
+            4321,
+            interval=0.01,
+            on_orphan=fired.set,
+        )
+        assert thread is not None
+        assert fired.wait(timeout=2.0), "watchdog did not fire after parent loss"
+        thread.join(timeout=2.0)
+        assert not thread.is_alive()
+
+    def test_stays_quiet_while_parent_is_alive(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        fired = threading.Event()
+        # Parent pid never changes -> backend is not orphaned.
+        monkeypatch.setattr(os, "getppid", lambda: 4321)
+
+        thread = parent_watchdog.start_parent_death_watchdog(
+            4321,
+            interval=0.01,
+            on_orphan=fired.set,
+        )
+        assert thread is not None
+        # Give the daemon several poll intervals to (incorrectly) fire.
+        assert not fired.wait(timeout=0.2)
+        assert thread.is_alive()


### PR DESCRIPTION
## Summary

The desktop Electron process spawns the Python backend (`scistudio gui --bundled`) as a child. When Electron exits **without** sending SIGTERM — force-quit, crash, or the `app.exit()` relaunch paths — POSIX reparents the backend to init (PID 1) and it runs forever as an orphan, accumulating one stray process per launch. The frontend can then reconnect to a stale orphan that never scanned the active project's `blocks/` dir, so freshly authored drop-in blocks fail to appear in the palette.

## Change

- New `scistudio/desktop/parent_watchdog.py`: a POSIX-only daemon-thread watchdog that polls the parent PID and shuts the backend down (graceful SIGTERM, then hard-exit fallback) once orphaned.
- `cli/main.py` `gui` starts it in bundled + POSIX mode only; dev/non-bundled runs are unaffected.

Because it lives in the backend source tree, it ships via the **OTA hot-patch** and stops orphan accumulation on existing installs **without a reinstall**, regardless of how Electron dies.

## Scope boundary

The Electron-side spawn-lifecycle bugs (the `scistudio:relaunch` handler skipping `stopRuntime()` via `app.exit(0)`, and the missing single-instance lock) live in `desktop/main.js`, are **not** OTA-deliverable, and are tracked separately for the next app build.

## Tests

`tests/desktop/test_parent_watchdog.py` — orphan-detection truth table + watchdog fires on parent loss / stays quiet while parent is alive.

Gate record: .workflow/records/1865-guided-1865-backend-orphan-self-reap.json

Closes #1865
