### PR TITLE
feat(#1867,#1868): stop desktop backend orphans + mandatory OTA updates

### DIFF
--- a/.workflow/records/1867-guided-1867-desktop-orphan-mandatory-ota.json
+++ b/.workflow/records/1867-guided-1867-desktop-orphan-mandatory-ota.json
@@ -79,13 +79,124 @@
       "status": "pass",
       "summary": "clean",
       "tool_versions": {}
+    },
+    {
+      "at": "2026-06-29T14:36:48.217838Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:48cb6a9c6ed51d5fc451ac103a20913708fa10ef170557857c3d16be52d23d2b",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-29T14:36:52.180746Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:b26ab54127d6f196dd0db688803a9784f5c39ff0d325db6d5d1b0e3f207f7016",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-29T14:36:52.748352Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:1c991f81b7bc2389670eff013578ce2fc04596a91dbd1f7bd68f9fef478e3f5d",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-29T14:36:52.769451Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:1410f4c77c03bb51a095ebf4ff9ee59f69c237655eb020545f1e1a0ebefc008e",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-29T14:38:07.490587Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:4d0256aec4f77f00fa6eb08d8a0e9669aa2c6bbf29bc2142b3fc852866bb1188",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-29T14:40:08.068707Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:2a59bb05e75d8d8c206210ee67c6885d6aa75b8fd35455dcbbf46544fbf61e1e",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-29T14:40:14.476642Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:97ff6b0193a35ccc9bfc7d5d486cf4029b5e3e069f1b47937a01be67132e7d53",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
     }
   ],
   "check_na": [],
   "commit": {
-    "sha": "f69725a9e6f6de5a2f69b5bb0a5653d83c1961f8",
+    "sha": "dac2bd84d9d2fbf9ac5b2b031100421a46c3cf8c",
     "shas": [
-      "f69725a9e6f6de5a2f69b5bb0a5653d83c1961f8"
+      "dac2bd84d9d2fbf9ac5b2b031100421a46c3cf8c"
     ],
     "trailers": []
   },
@@ -527,6 +638,170 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-06-29T14:40:14.521555Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T14:40:14.531310Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T14:40:14.540791Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T14:40:14.549991Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T14:40:14.559494Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T14:40:14.569102Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T14:40:14.578943Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T14:40:14.589555Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T14:40:14.598684Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T14:40:14.610764Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T14:40:27.679677Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T14:40:27.688758Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T14:40:27.697508Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T14:40:27.706968Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T14:40:27.715971Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T14:40:27.725140Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T14:40:27.734042Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T14:40:27.743223Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T14:40:27.752218Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T14:40:27.764065Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -554,21 +829,23 @@
       "desktop/test/ota.test.js",
       "docs/specs/desktop-ota-hot-update.md",
       "scripts/ota_publish.py",
+      "src/scistudio/desktop/parent_watchdog.py",
+      "tests/desktop/test_parent_watchdog.py",
       "tests/scripts/test_ota_publish.py"
     ],
-    "diff_fingerprint": "sha256:ec21ed0a61f9a2a28e09517768c4161639d27faf1b1412c6c1e17a75aaaae255",
+    "diff_fingerprint": "sha256:25e27de86964e8a8567ebf5ebc0ce4a11bf0093d97471feb71c84b75e32da9d8",
     "head": "HEAD",
-    "head_sha": "f69725a9",
+    "head_sha": "dac2bd84",
     "surfaces": {
       "docs": 1,
       "frontend": 0,
       "governance": 0,
       "governed_docs": 0,
-      "implementation": 0,
+      "implementation": 1,
       "packaging": 0,
       "protected_core": 0,
-      "sentrux": 2,
-      "test": 2,
+      "sentrux": 4,
+      "test": 3,
       "workflow_ci": 0
     }
   },
@@ -625,6 +902,22 @@
       "result": "pass",
       "tier": 2,
       "unsatisfied": []
+    },
+    {
+      "at": "2026-06-29T14:40:14.610804Z",
+      "diff_fingerprint": "sha256:25e27de86964e8a8567ebf5ebc0ce4a11bf0093d97471feb71c84b75e32da9d8",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-29T14:40:27.764113Z",
+      "diff_fingerprint": "sha256:25e27de86964e8a8567ebf5ebc0ce4a11bf0093d97471feb71c84b75e32da9d8",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
     }
   ],
   "record_id": "1867-guided-1867-desktop-orphan-mandatory-ota",
@@ -634,11 +927,15 @@
     "checks": [
       "format_check",
       "full_audit",
+      "import_contracts",
       "lint_format",
       "python_tests",
-      "semantic_dup"
+      "semantic_dup",
+      "type_check"
     ],
-    "docs": [],
+    "docs": [
+      "docs_required_or_na"
+    ],
     "guards": [
       "core_change_guard",
       "docs_landing",
@@ -651,7 +948,9 @@
       "test_engineer_scope_guard",
       "weakened_ci_check"
     ],
-    "tests": []
+    "tests": [
+      "changed_test_required"
+    ]
   },
   "runtime": "claude-code",
   "schema_version": 2,

--- a/.workflow/records/1867-guided-1867-desktop-orphan-mandatory-ota.json
+++ b/.workflow/records/1867-guided-1867-desktop-orphan-mandatory-ota.json
@@ -661,6 +661,18 @@
       "at": "2026-06-29T04:26:40.311690Z",
       "pattern": "docs/specs/desktop-ota-hot-update.md",
       "reason": "OTA manifest gains requires.min_build + mandatory-update client behavior; the OTA spec documents that contract."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-29T14:34:48.971175Z",
+      "pattern": "src/scistudio/desktop/parent_watchdog.py",
+      "reason": "CI xdist worker crashed/hung on the #1865 parent-watchdog test (leaked while-True daemon thread). Make watchdog stoppable; test stop+joins it deterministically."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-29T14:34:48.971333Z",
+      "pattern": "tests/desktop/test_parent_watchdog.py",
+      "reason": "CI xdist worker crashed/hung on the #1865 parent-watchdog test (leaked while-True daemon thread). Make watchdog stoppable; test stop+joins it deterministically."
     }
   ],
   "session_id": "0725cdef-25af-45f8-8a02-869a3fb74c13",

--- a/.workflow/records/1867-guided-1867-desktop-orphan-mandatory-ota.json
+++ b/.workflow/records/1867-guided-1867-desktop-orphan-mandatory-ota.json
@@ -1,8 +1,94 @@
 {
   "branch": "guided/1867-desktop-orphan-mandatory-ota",
-  "check_events": [],
+  "check_events": [
+    {
+      "at": "2026-06-29T04:22:48.161608Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:ab7c85d532bac828e4c5790ed124d9c4afca0fe23e7760f95ee043dde9d4a23a",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-29T04:22:52.308971Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:864d1fbda534809f15ebd565d0c57041b79bc4cf91e981342df385aac25e0438",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-29T04:22:52.347940Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:bed0e9812f26104212fdba4391a4fd9bb4ca8548cce16c923b3d0d47cbfe44da",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-29T04:24:27.783114Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:238aafed8ffafb8db8b76d55c3fb6cfe8125635cf3bd2e30da642b994e399430",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-29T04:26:21.006186Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:bc77d1270226d08977279eedacaeb4aa6fe459e94f276f3339bb3a67245a49c9",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    }
+  ],
   "check_na": [],
-  "commit": null,
+  "commit": {
+    "sha": "4b0bbf7e1e72c9627ba786abd0d37a9f23e50641",
+    "shas": [
+      "4b0bbf7e1e72c9627ba786abd0d37a9f23e50641"
+    ],
+    "trailers": []
+  },
   "declared_scope": {
     "exclude": [],
     "include": [
@@ -31,7 +117,254 @@
     }
   ],
   "governance_touch": false,
-  "guard_events": [],
+  "guard_events": [
+    {
+      "at": "2026-06-29T04:26:21.047660Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T04:26:21.057311Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T04:26:21.066257Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T04:26:21.075563Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T04:26:21.084438Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T04:26:21.093404Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T04:26:21.102798Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T04:26:21.111799Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T04:26:21.120976Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T04:26:21.131102Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T04:26:40.662229Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T04:26:40.671099Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T04:26:40.680818Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T04:26:40.689549Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T04:26:40.698507Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T04:26:40.707875Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T04:26:40.716554Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T04:26:40.726718Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T04:26:40.735893Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T04:26:40.746069Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T04:27:05.429613Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T04:27:05.438886Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T04:27:05.447733Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T04:27:05.456604Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T04:27:05.464856Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T04:27:05.473374Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T04:27:05.481923Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T04:27:05.490431Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T04:27:05.498733Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T04:27:05.508392Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
   "issues": [
     {
       "close_in_pr": true,
@@ -47,25 +380,111 @@
     }
   ],
   "observed_admin_labels": [],
-  "observed_diff": null,
+  "observed_diff": {
+    "base": "origin/main",
+    "base_sha": "a7ebbfa3",
+    "changed_files": [
+      ".workflow/records/1867-guided-1867-desktop-orphan-mandatory-ota.json",
+      "desktop/main.js",
+      "desktop/ota.js",
+      "desktop/test/ota.test.js",
+      "docs/specs/desktop-ota-hot-update.md",
+      "scripts/ota_publish.py",
+      "tests/scripts/test_ota_publish.py"
+    ],
+    "diff_fingerprint": "sha256:fe90a85e642f86454560a62b64457e3d926b58e63ea9348b6220f7fb5c7940e6",
+    "head": "HEAD",
+    "head_sha": "4b0bbf7e",
+    "surfaces": {
+      "docs": 1,
+      "frontend": 0,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 0,
+      "packaging": 0,
+      "protected_core": 0,
+      "sentrux": 2,
+      "test": 2,
+      "workflow_ci": 0
+    }
+  },
   "owner_directive": "PR B (Electron-shell, ships with next dmg): (1) fix scistudio:relaunch handler to stopRuntime before exit; (2) add single-instance lock; (3) harden stopRuntime SIGKILL fallback; plus mandatory-OTA gate: manifest requires.min_build, block-at-next-launch Update-now/Quit, fail-open offline, incompatible+mandatory -> reinstall+quit; publisher can set min_build.",
   "persona": "live_implementer",
-  "pull_request": null,
-  "reconcile_events": [],
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [
+      1867,
+      1868
+    ],
+    "number": null,
+    "url": null
+  },
+  "reconcile_events": [
+    {
+      "at": "2026-06-29T04:26:21.131146Z",
+      "diff_fingerprint": "sha256:fe90a85e642f86454560a62b64457e3d926b58e63ea9348b6220f7fb5c7940e6",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "scope.out-of-scope"
+      ]
+    },
+    {
+      "at": "2026-06-29T04:26:40.746099Z",
+      "diff_fingerprint": "sha256:fe90a85e642f86454560a62b64457e3d926b58e63ea9348b6220f7fb5c7940e6",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-29T04:27:05.508423Z",
+      "diff_fingerprint": "sha256:fe90a85e642f86454560a62b64457e3d926b58e63ea9348b6220f7fb5c7940e6",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    }
+  ],
   "record_id": "1867-guided-1867-desktop-orphan-mandatory-ota",
   "requested_admin_labels": [],
   "required_obligations": {
     "admin_labels": [],
-    "checks": [],
+    "checks": [
+      "format_check",
+      "full_audit",
+      "lint_format",
+      "python_tests",
+      "semantic_dup"
+    ],
     "docs": [],
-    "guards": [],
+    "guards": [
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
     "tests": []
   },
   "runtime": "claude-code",
   "schema_version": 2,
-  "scope_events": [],
+  "scope_events": [
+    {
+      "action": "add-include",
+      "at": "2026-06-29T04:26:40.311690Z",
+      "pattern": "docs/specs/desktop-ota-hot-update.md",
+      "reason": "OTA manifest gains requires.min_build + mandatory-update client behavior; the OTA spec documents that contract."
+    }
+  ],
   "session_id": "0725cdef-25af-45f8-8a02-869a3fb74c13",
-  "strictness_tier": null,
+  "strictness_tier": 2,
   "task_kind": "guided",
   "test_events": [
     {

--- a/.workflow/records/1867-guided-1867-desktop-orphan-mandatory-ota.json
+++ b/.workflow/records/1867-guided-1867-desktop-orphan-mandatory-ota.json
@@ -1,0 +1,88 @@
+{
+  "branch": "guided/1867-desktop-orphan-mandatory-ota",
+  "check_events": [],
+  "check_na": [],
+  "commit": null,
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "desktop/main.js",
+      "desktop/ota.js",
+      "scripts/ota_publish.py",
+      "desktop/test/**",
+      "tests/**"
+    ]
+  },
+  "directive_events": [
+    {
+      "at": "2026-06-29T04:22:05.377198Z",
+      "owner_directive": "PR B: desktop orphan lifecycle (#1867: relaunch stopRuntime, single-instance lock, exit-time reap) + mandatory OTA (#1868: requires.min_build, pre-window block gate fail-open, publisher --min-build).",
+      "reason": "plan"
+    }
+  ],
+  "docs_events": [
+    {
+      "at": "2026-06-29T04:22:05.377345Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/specs/desktop-ota-hot-update.md",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": false,
+  "guard_events": [],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1867,
+      "url": null
+    },
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1868,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": null,
+  "owner_directive": "PR B (Electron-shell, ships with next dmg): (1) fix scistudio:relaunch handler to stopRuntime before exit; (2) add single-instance lock; (3) harden stopRuntime SIGKILL fallback; plus mandatory-OTA gate: manifest requires.min_build, block-at-next-launch Update-now/Quit, fail-open offline, incompatible+mandatory -> reinstall+quit; publisher can set min_build.",
+  "persona": "live_implementer",
+  "pull_request": null,
+  "reconcile_events": [],
+  "record_id": "1867-guided-1867-desktop-orphan-mandatory-ota",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [],
+    "docs": [],
+    "guards": [],
+    "tests": []
+  },
+  "runtime": "claude-code",
+  "schema_version": 2,
+  "scope_events": [],
+  "session_id": "0725cdef-25af-45f8-8a02-869a3fb74c13",
+  "strictness_tier": null,
+  "task_kind": "guided",
+  "test_events": [
+    {
+      "at": "2026-06-29T04:22:05.377525Z",
+      "class": null,
+      "kind": "path",
+      "path": "desktop/test/ota.test.js",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-29T04:22:05.377536Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/scripts/test_ota_publish.py",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/.workflow/records/1867-guided-1867-desktop-orphan-mandatory-ota.json
+++ b/.workflow/records/1867-guided-1867-desktop-orphan-mandatory-ota.json
@@ -83,9 +83,9 @@
   ],
   "check_na": [],
   "commit": {
-    "sha": "4b0bbf7e1e72c9627ba786abd0d37a9f23e50641",
+    "sha": "f69725a9e6f6de5a2f69b5bb0a5653d83c1961f8",
     "shas": [
-      "4b0bbf7e1e72c9627ba786abd0d37a9f23e50641"
+      "f69725a9e6f6de5a2f69b5bb0a5653d83c1961f8"
     ],
     "trailers": []
   },
@@ -363,6 +363,170 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-06-29T04:27:28.895299Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T04:27:28.904034Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T04:27:28.912710Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T04:27:28.921316Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T04:27:28.929840Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T04:27:28.938896Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T04:27:28.948104Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T04:27:28.957012Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T04:27:28.966290Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T04:27:28.976871Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T04:27:45.328926Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T04:27:45.337636Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T04:27:45.346267Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T04:27:45.354816Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T04:27:45.363047Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T04:27:45.371375Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T04:27:45.379591Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T04:27:45.388305Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T04:27:45.397062Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T04:27:45.408396Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -381,7 +545,7 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "origin/main",
+    "base": "a7ebbfa3d9a824770a51d45cfa40d01c7dbe9cc0",
     "base_sha": "a7ebbfa3",
     "changed_files": [
       ".workflow/records/1867-guided-1867-desktop-orphan-mandatory-ota.json",
@@ -392,9 +556,9 @@
       "scripts/ota_publish.py",
       "tests/scripts/test_ota_publish.py"
     ],
-    "diff_fingerprint": "sha256:fe90a85e642f86454560a62b64457e3d926b58e63ea9348b6220f7fb5c7940e6",
+    "diff_fingerprint": "sha256:ec21ed0a61f9a2a28e09517768c4161639d27faf1b1412c6c1e17a75aaaae255",
     "head": "HEAD",
-    "head_sha": "4b0bbf7e",
+    "head_sha": "f69725a9",
     "surfaces": {
       "docs": 1,
       "frontend": 0,
@@ -416,7 +580,7 @@
       1867,
       1868
     ],
-    "number": null,
+    "number": 1869,
     "url": null
   },
   "reconcile_events": [
@@ -441,6 +605,22 @@
     {
       "at": "2026-06-29T04:27:05.508423Z",
       "diff_fingerprint": "sha256:fe90a85e642f86454560a62b64457e3d926b58e63ea9348b6220f7fb5c7940e6",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-29T04:27:28.976910Z",
+      "diff_fingerprint": "sha256:ec21ed0a61f9a2a28e09517768c4161639d27faf1b1412c6c1e17a75aaaae255",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-29T04:27:45.408442Z",
+      "diff_fingerprint": "sha256:ec21ed0a61f9a2a28e09517768c4161639d27faf1b1412c6c1e17a75aaaae255",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 2,

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -18,6 +18,12 @@ const activation = require("./activation");
 // safeLog is hoisted and only called when the handler fires.
 ipcMain.handle("scistudio:relaunch", () => {
   safeLog("[scistudio] relaunch requested by renderer (package update)");
+  // #1867: stop the backend before exiting. app.exit() does NOT emit
+  // `before-quit`, so without this the child backend is never signalled and is
+  // reparented to init as an orphan on every package-update relaunch. Mirrors
+  // the OTA relaunch path.
+  isQuitting = true;
+  stopRuntime();
   app.relaunch();
   app.exit(0);
 });
@@ -40,6 +46,39 @@ let isQuitting = false;
 // window-all-closed quit before the main window is created.
 let startingUp = false;
 let cachedMacLoginShellEnv = null;
+
+// #1867: single-instance lock. A second launch must focus the existing window
+// instead of spawning a second backend (which would then orphan on quit). The
+// whenReady handler bails early when the lock was not acquired.
+const gotSingleInstanceLock = app.requestSingleInstanceLock();
+if (!gotSingleInstanceLock) {
+  app.quit();
+} else {
+  app.on("second-instance", () => {
+    if (mainWindow) {
+      if (mainWindow.isMinimized()) {
+        mainWindow.restore();
+      }
+      mainWindow.show();
+      mainWindow.focus();
+    }
+  });
+}
+
+// #1867: last-resort synchronous reap. If the main process is exiting while the
+// backend is still tracked (e.g. the SIGTERM escalation timer in stopRuntime was
+// dropped when the process exited first), kill it now. The 'exit' event only
+// permits synchronous work, so this sends SIGKILL directly. A clean stopRuntime
+// nulls runtimeProcess first, making this a no-op on the normal path.
+process.on("exit", () => {
+  if (runtimeProcess && !runtimeProcess.killed && process.platform !== "win32") {
+    try {
+      runtimeProcess.kill("SIGKILL");
+    } catch {
+      // best-effort; the process is already going away
+    }
+  }
+});
 
 function installPipeGuard(stream) {
   if (!stream || typeof stream.on !== "function") {
@@ -405,6 +444,95 @@ async function downloadAndApply(manifest) {
       // Temp cleanup is best-effort.
     }
   }
+}
+
+// #1868: pre-window mandatory-update gate. Runs before the runtime/window so a
+// required build can block entry. Returns true when startup should continue,
+// false when the app is updating or quitting.
+//
+// Fail-open by design: OTA disabled, no manifest URL, or any fetch/parse failure
+// (offline, bad manifest) returns true. Only a successfully fetched manifest that
+// `evaluateUpdate` marks `mandatory` can block. Optional (non-mandatory) updates
+// are left to the post-window maybeCheckForUpdate so this gate never nags.
+async function maybeEnforceMandatoryUpdate() {
+  const config = loadOtaConfig();
+  if (!config.enabled || !config.manifestUrl) {
+    return true;
+  }
+
+  let manifest = null;
+  try {
+    manifest = JSON.parse(await fetchText(config.manifestUrl, OTA_MANIFEST_TIMEOUT_MS));
+  } catch (error) {
+    safeLog(`[scistudio] mandatory update check skipped (fail-open): ${error.message}`);
+    return true;
+  }
+
+  const baseline = baselineVersion();
+  const local = effectiveBuild();
+  const decision = ota.evaluateUpdate(config, manifest, baseline, local);
+  if (!decision.mandatory) {
+    return true;
+  }
+  safeLog(`[scistudio] mandatory update required: kind=${decision.kind} remote build=${manifest.build}`);
+
+  if (decision.kind === "incompatible") {
+    // Can't hot-patch across a base bump: the only path forward is a reinstall.
+    await dialog.showMessageBox({
+      type: "warning",
+      title: "Update required",
+      message: "A required SciStudio update is available.",
+      detail:
+        `Version ${ota.displayBuildVersion(manifest.base, decision.build)} requires a newer base ` +
+        `version (${decision.minBase}) than this installation (${baseline.base}). ` +
+        `Please download and reinstall SciStudio to continue.`,
+      buttons: ["Quit"],
+      defaultId: 0
+    });
+    app.quit();
+    return false;
+  }
+  if (decision.kind !== "patch") {
+    return true;
+  }
+
+  const choice = await dialog.showMessageBox({
+    type: "warning",
+    title: "Update required",
+    message: `SciStudio must update to ${ota.displayBuildVersion(manifest.base, manifest.build)} to continue.`,
+    detail:
+      (manifest.notes ? `${manifest.notes}\n\n` : "") + "SciStudio will restart to apply the update.",
+    buttons: ["Update now", "Quit"],
+    defaultId: 0,
+    cancelId: 1
+  });
+  if (choice.response !== 0) {
+    app.quit();
+    return false;
+  }
+
+  try {
+    await downloadAndApply(manifest);
+  } catch (error) {
+    safeError(`[scistudio] mandatory update apply failed: ${error.message}`);
+    await dialog.showMessageBox({
+      type: "error",
+      title: "Update failed",
+      message: "SciStudio could not apply the required update.",
+      detail: `${error.message}\n\nPlease try again or reinstall SciStudio.`,
+      buttons: ["Quit"],
+      defaultId: 0
+    });
+    app.quit();
+    return false;
+  }
+
+  safeLog(`[scistudio] applied mandatory OTA build ${manifest.build}; relaunching`);
+  isQuitting = true;
+  stopRuntime();
+  app.relaunch();
+  app.exit(0);
+  return false;
 }
 
 // Launch-time update check. Silent on dev builds and when offline.
@@ -1193,6 +1321,11 @@ async function ensureAlphaActivation() {
 }
 
 app.whenReady().then(async () => {
+  // #1867: a second instance never acquired the lock; it has already requested
+  // quit and must not start a runtime or window.
+  if (!gotSingleInstanceLock) {
+    return;
+  }
   try {
     safeLog("[scistudio] electron ready");
     // #1848: alpha gate — do not start the runtime or main window until the
@@ -1204,6 +1337,13 @@ app.whenReady().then(async () => {
     if (!activated) {
       safeLog("[scistudio] alpha activation not completed; quitting");
       app.quit();
+      return;
+    }
+    // #1868: enforce a mandatory OTA update before starting the runtime/window.
+    // Fail-open: returns true (continue) unless a fetched manifest marks the
+    // update mandatory and the user declines or it cannot be applied.
+    const proceed = await maybeEnforceMandatoryUpdate();
+    if (!proceed) {
       return;
     }
     const { ready } = await startRuntimeWithRollback();

--- a/desktop/ota.js
+++ b/desktop/ota.js
@@ -49,13 +49,29 @@ function displayBuildVersion(base, build) {
   return `${base}.${padded}`;
 }
 
+// #1868: is the offered update mandatory for this client? A manifest may carry
+// `requires.min_build: N`; when the local effective build is below it the update
+// must be taken. Guard on `manifest.build >= min_build` so applying the offered
+// build actually clears the requirement (a misconfigured min_build above the
+// offered build is treated as non-mandatory rather than an unsatisfiable block).
+function isMandatoryUpdate(manifest, effectiveBuild) {
+  const minBuild =
+    manifest && manifest.requires && typeof manifest.requires.min_build === "number"
+      ? manifest.requires.min_build
+      : 0;
+  return effectiveBuild < minBuild && manifest.build >= minBuild;
+}
+
 // Decide what to do with a fetched manifest given local state.
 //
 // Returns one of:
 //   { kind: "none", reason }          - nothing to do
 //   { kind: "invalid", reason }       - manifest is malformed; ignore it
-//   { kind: "incompatible", build, minBase } - newer, but needs a new installer
-//   { kind: "patch", build }          - newer and hot-patchable
+//   { kind: "incompatible", build, minBase, mandatory } - newer, needs a new installer
+//   { kind: "patch", build, mandatory } - newer and hot-patchable
+//
+// #1868: `mandatory` is true when the manifest's `requires.min_build` is newer
+// than the local build; main.js blocks startup on a mandatory update.
 function evaluateUpdate(config, manifest, baseline, effectiveBuild) {
   if (!config || !config.enabled) {
     return { kind: "none", reason: "ota-disabled" };
@@ -69,11 +85,12 @@ function evaluateUpdate(config, manifest, baseline, effectiveBuild) {
   if (manifest.build <= effectiveBuild) {
     return { kind: "none", reason: "up-to-date" };
   }
+  const mandatory = isMandatoryUpdate(manifest, effectiveBuild);
   const minBase = (manifest.requires && manifest.requires.min_base) || manifest.base;
   if (minBase && baseline && compareBase(baseline.base, minBase) < 0) {
-    return { kind: "incompatible", build: manifest.build, minBase };
+    return { kind: "incompatible", build: manifest.build, minBase, mandatory };
   }
-  return { kind: "patch", build: manifest.build };
+  return { kind: "patch", build: manifest.build, mandatory };
 }
 
 // #1787: decide how to treat the persisted active-patch pointer given the
@@ -130,6 +147,7 @@ module.exports = {
   parseVersion,
   compareBase,
   patchDirName,
+  isMandatoryUpdate,
   evaluateUpdate,
   resolveActivePatch,
   pythonPathFor,

--- a/desktop/test/ota.test.js
+++ b/desktop/test/ota.test.js
@@ -80,6 +80,41 @@ test("evaluateUpdate: compares against effective build, not baseline", () => {
   assert.equal(ota.evaluateUpdate(CONFIG, m, BASELINE, 9).reason, "up-to-date");
 });
 
+// #1868: mandatory updates (requires.min_build).
+test("isMandatoryUpdate: below min_build is mandatory; at/above is not", () => {
+  assert.equal(ota.isMandatoryUpdate({ build: 8, requires: { min_build: 8 } }, 6), true);
+  assert.equal(ota.isMandatoryUpdate({ build: 8, requires: { min_build: 8 } }, 8), false);
+  assert.equal(ota.isMandatoryUpdate({ build: 8, requires: { min_build: 8 } }, 9), false);
+});
+
+test("isMandatoryUpdate: no min_build (or non-numeric) is never mandatory", () => {
+  assert.equal(ota.isMandatoryUpdate({ build: 8 }, 0), false);
+  assert.equal(ota.isMandatoryUpdate({ build: 8, requires: {} }, 0), false);
+  assert.equal(ota.isMandatoryUpdate({ build: 8, requires: { min_build: "8" } }, 0), false);
+});
+
+test("isMandatoryUpdate: min_build above the offered build is not enforceable", () => {
+  // Applying build 7 would not reach min_build 9, so it must not block.
+  assert.equal(ota.isMandatoryUpdate({ build: 7, requires: { min_build: 9 } }, 6), false);
+});
+
+test("evaluateUpdate: patch carries mandatory flag from min_build", () => {
+  const required = { build: 8, channel: "alpha", base: "0.2.1", requires: { min_base: "0.2.1", min_build: 8 } };
+  const d = ota.evaluateUpdate(CONFIG, required, BASELINE, 6);
+  assert.equal(d.kind, "patch");
+  assert.equal(d.mandatory, true);
+
+  const optional = { build: 8, channel: "alpha", base: "0.2.1", requires: { min_base: "0.2.1" } };
+  assert.equal(ota.evaluateUpdate(CONFIG, optional, BASELINE, 6).mandatory, false);
+});
+
+test("evaluateUpdate: incompatible can also be mandatory", () => {
+  const m = { build: 8, channel: "alpha", base: "0.3.0", requires: { min_base: "0.3.0", min_build: 8 } };
+  const d = ota.evaluateUpdate(CONFIG, m, BASELINE, 6);
+  assert.equal(d.kind, "incompatible");
+  assert.equal(d.mandatory, true);
+});
+
 // #1787: an active patch must shadow the bundled baseline only when it is
 // strictly newer. A freshly installed bundle whose build is >= the patch build
 // supersedes it; otherwise a stale patch would silently shadow the new bundle.

--- a/docs/specs/desktop-ota-hot-update.md
+++ b/docs/specs/desktop-ota-hot-update.md
@@ -97,6 +97,10 @@ Update decision (pure logic in `desktop/ota.js`, `evaluateUpdate`):
 3. `base >= manifest.requires.min_base` → **patch**; otherwise **incompatible**
    (prompt to reinstall). The client always targets the latest build; a client
    several builds behind jumps straight to it in one snapshot download.
+4. **Mandatory (#1868)**: if `manifest.requires.min_build` is set and the
+   effective build is below it (and the offered `build >= min_build`), the
+   result carries `mandatory: true`. Both **patch** and **incompatible** results
+   can be mandatory.
 
 ## 4. Distribution
 
@@ -104,7 +108,9 @@ Update decision (pure logic in `desktop/ota.js`, `evaluateUpdate`):
   `ota-<channel>`, with assets `manifest.json` and `backend-build<N>.tar.gz`.
   Anonymous download (repo is public); pre-release is visible but not "latest".
 - `manifest.json`:
-  `{channel, base, build, requires:{min_base}, url, sha256, size, notes, published_at}`.
+  `{channel, base, build, requires:{min_base, min_build?}, url, sha256, size, notes, published_at}`.
+  `requires.min_build` is optional (#1868): present only for a mandatory patch,
+  set via `ota_publish.py --min-build N`.
 - Publish: `scripts/ota_publish.py` packs `desktop/resources/backend/src` into a
   gzip tarball rooted at `src/` (excluding `__pycache__`/`.pyc`/`egg-info`),
   computes sha256, sets `build = max(latest_published, baseline) + 1`, and
@@ -112,13 +118,25 @@ Update decision (pure logic in `desktop/ota.js`, `evaluateUpdate`):
 
 ## 5. Client behavior (`desktop/main.js`)
 
-- **Launch-time only**, after the window is shown (never blocks startup); offline
-  failures are logged and ignored.
+- **Optional updates: launch-time only**, after the window is shown (never blocks
+  startup); offline failures are logged and ignored.
+- **Mandatory updates (#1868): pre-window gate.** Before the runtime/window come
+  up, `maybeEnforceMandatoryUpdate()` fetches the manifest and, if the decision is
+  `mandatory`, blocks: a **patch** shows "Update now / Quit" (no "Later") and
+  declining quits; an **incompatible** mandatory update shows a reinstall notice
+  and quits. **Fail-open**: OTA disabled, no manifest URL, or any fetch/parse
+  failure (offline) allows normal startup — only a successfully fetched mandatory
+  manifest can block. Non-mandatory updates fall through to the post-window check.
 - Reads `resources/ota-config.json`. `{enabled:false, channel:"dev"}` (the
   default for local builds) disables OTA entirely.
 - On a `patch` decision: native dialog → download → sha256 verify → `tar -xzf`
   into a temp dir → atomic rename to `userData/patches/build<N>/` → write
   `active.json` pointer → `app.relaunch()`.
+- **Single instance + clean shutdown (#1867)**: the app holds a single-instance
+  lock (a second launch focuses the existing window); the package-update relaunch
+  path and `process.on("exit")` stop the backend so it is never left as an orphan.
+  The enforcement logic lives in the Electron shell, so mandatory updates only
+  apply to clients already running a force-aware shell (next dmg onward).
 - `runtimeEnv()` prepends `userData/patches/build<N>/src` to `PYTHONPATH`; the
   app bundle is never modified (works under a read-only/signed bundle and avoids
   Windows `Program Files` permission issues). The ordered entries are resolved by
@@ -167,10 +185,12 @@ deferred to a release-grade channel.
 ## 8. Verification
 
 - `tests/scripts/test_ota_publish.py`: version parse, monotonic build numbering,
-  manifest shape, naming/URLs, sha256, snapshot packing + exclusions.
-- `desktop/test/ota.test.js`: `parseVersion`, numeric `compareBase`, and every
+  manifest shape (incl. optional `min_build`, #1868), naming/URLs, sha256,
+  snapshot packing + exclusions.
+- `desktop/test/ota.test.js`: `parseVersion`, numeric `compareBase`, every
   `evaluateUpdate` branch (disabled, invalid, channel-mismatch, up-to-date,
-  patch, incompatible, effective-build comparison).
+  patch, incompatible, effective-build comparison), and `isMandatoryUpdate` /
+  the `mandatory` flag on patch and incompatible decisions (#1868).
 - Manual: `python scripts/ota_publish.py --channel alpha --dry-run`; build a
   dev DMG and confirm OTA is skipped; build with `SCISTUDIO_OTA_CHANNEL=alpha`
   and confirm the launch-time dialog, apply, relaunch, and `/version` update.

--- a/scripts/ota_publish.py
+++ b/scripts/ota_publish.py
@@ -107,13 +107,22 @@ def build_manifest(
     size: int,
     notes: str,
     published_at: str,
+    min_build: int | None = None,
 ) -> dict:
-    """Assemble the manifest document the desktop client compares against."""
+    """Assemble the manifest document the desktop client compares against.
+
+    #1868: pass ``min_build`` to mark the patch mandatory — clients whose
+    effective build is below it must take the update before they can continue
+    (the desktop shell blocks startup). Omit it for an ordinary optional patch.
+    """
+    requires: dict[str, object] = {"min_base": base}
+    if min_build is not None:
+        requires["min_build"] = min_build
     return {
         "channel": channel,
         "base": base,
         "build": build,
-        "requires": {"min_base": base},
+        "requires": requires,
         "url": url,
         "sha256": sha256,
         "size": size,
@@ -230,6 +239,16 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--repo", default=DEFAULT_REPO, help="owner/name of the GitHub repo.")
     parser.add_argument("--notes", default="", help="Human-readable patch notes for the manifest.")
     parser.add_argument(
+        "--min-build",
+        type=int,
+        default=None,
+        help=(
+            "#1868: mark this patch mandatory. Clients whose effective build is below "
+            "this value must apply the update before they can continue (the desktop "
+            "shell blocks startup). Omit for an ordinary optional patch."
+        ),
+    )
+    parser.add_argument(
         "--src",
         type=Path,
         default=STAGED_SRC,
@@ -275,6 +294,7 @@ def main(argv: list[str] | None = None) -> int:
         size=size,
         notes=args.notes,
         published_at=_utc_now_iso(),
+        min_build=args.min_build,
     )
     manifest_path = workdir / "manifest.json"
     manifest_path.write_text(json.dumps(manifest, indent=2) + "\n")

--- a/src/scistudio/desktop/parent_watchdog.py
+++ b/src/scistudio/desktop/parent_watchdog.py
@@ -65,23 +65,30 @@ def start_parent_death_watchdog(
     *,
     interval: float = PARENT_WATCH_INTERVAL_S,
     on_orphan: Callable[[], None] | None = None,
+    stop_event: threading.Event | None = None,
 ) -> threading.Thread | None:
     """Start a daemon thread that reaps this backend once it is orphaned.
 
     Returns the started thread, or ``None`` when there is no live parent to
     watch (``initial_ppid <= 1``). POSIX-only; callers gate on bundled mode.
+
+    ``stop_event`` makes the poll loop interruptible: setting it ends the loop
+    on the next tick without invoking the handler. The bundled runtime never
+    sets it (the watchdog runs for the process lifetime); tests pass one so the
+    daemon thread is stopped and joined deterministically rather than leaked.
     """
     if initial_ppid <= 1:
         return None
 
     handler = on_orphan or _shutdown_orphaned_backend
+    stop = stop_event if stop_event is not None else threading.Event()
 
     def _run() -> None:
         import os
-        import time
 
-        while True:
-            time.sleep(interval)
+        # Event.wait returns True only when the stop event is set; on a timeout
+        # (the common path) it returns False, so we poll the parent each tick.
+        while not stop.wait(interval):
             if backend_is_orphaned(initial_ppid, os.getppid()):
                 handler()
                 return

--- a/tests/desktop/test_parent_watchdog.py
+++ b/tests/desktop/test_parent_watchdog.py
@@ -40,6 +40,7 @@ class TestStartParentDeathWatchdog:
 
     def test_fires_on_orphan_when_parent_goes_away(self, monkeypatch: pytest.MonkeyPatch) -> None:
         fired = threading.Event()
+        stop = threading.Event()
         # Pretend the spawning parent (pid 4321) has been replaced by init.
         monkeypatch.setattr(os, "getppid", lambda: 1)
 
@@ -47,14 +48,19 @@ class TestStartParentDeathWatchdog:
             4321,
             interval=0.01,
             on_orphan=fired.set,
+            stop_event=stop,
         )
         assert thread is not None
-        assert fired.wait(timeout=2.0), "watchdog did not fire after parent loss"
-        thread.join(timeout=2.0)
+        try:
+            assert fired.wait(timeout=2.0), "watchdog did not fire after parent loss"
+        finally:
+            stop.set()
+            thread.join(timeout=2.0)
         assert not thread.is_alive()
 
     def test_stays_quiet_while_parent_is_alive(self, monkeypatch: pytest.MonkeyPatch) -> None:
         fired = threading.Event()
+        stop = threading.Event()
         # Parent pid never changes -> backend is not orphaned.
         monkeypatch.setattr(os, "getppid", lambda: 4321)
 
@@ -62,8 +68,17 @@ class TestStartParentDeathWatchdog:
             4321,
             interval=0.01,
             on_orphan=fired.set,
+            stop_event=stop,
         )
         assert thread is not None
-        # Give the daemon several poll intervals to (incorrectly) fire.
-        assert not fired.wait(timeout=0.2)
-        assert thread.is_alive()
+        try:
+            # Give the daemon several poll intervals to (incorrectly) fire.
+            assert not fired.wait(timeout=0.2)
+            assert thread.is_alive()
+        finally:
+            # Stop and join deterministically so the daemon never leaks past the
+            # test (a leaked while-loop thread crashed an xdist worker, #1867).
+            stop.set()
+            thread.join(timeout=2.0)
+        assert not thread.is_alive()
+        assert not fired.is_set()

--- a/tests/scripts/test_ota_publish.py
+++ b/tests/scripts/test_ota_publish.py
@@ -101,6 +101,38 @@ def test_build_manifest_shape(mod):
     assert json.loads(json.dumps(manifest))["url"].endswith("backend-build7.tar.gz")
 
 
+def test_build_manifest_omits_min_build_by_default(mod):
+    # #1868: an ordinary optional patch must not carry min_build.
+    manifest = mod.build_manifest(
+        channel="alpha",
+        base="0.2.1",
+        build=7,
+        url="https://example/backend-build7.tar.gz",
+        sha256="abc",
+        size=1234,
+        notes="hi",
+        published_at="2026-06-25T00:00:00Z",
+    )
+    assert "min_build" not in manifest["requires"]
+
+
+def test_build_manifest_includes_min_build_when_mandatory(mod):
+    # #1868: a mandatory patch records requires.min_build so the client blocks
+    # startup for builds below it.
+    manifest = mod.build_manifest(
+        channel="alpha",
+        base="0.2.1",
+        build=8,
+        url="https://example/backend-build8.tar.gz",
+        sha256="abc",
+        size=1234,
+        notes="hi",
+        published_at="2026-06-25T00:00:00Z",
+        min_build=8,
+    )
+    assert manifest["requires"] == {"min_base": "0.2.1", "min_build": 8}
+
+
 # --------------------------------------------------------------------------- #
 # sha256_file
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary

Electron-shell-side companions to #1865 (the OTA-deliverable backend self-reap). These live in `desktop/main.js` / `desktop/ota.js` / `scripts/ota_publish.py`, are not OTA-deliverable, and ship with the next app build.

## #1867 — stop leaking orphaned backend processes

- **`scistudio:relaunch` handler** now calls `stopRuntime()` before `app.exit(0)`. `app.exit()` does not emit `before-quit`, so the package-update relaunch path previously orphaned the backend on every update.
- **Single-instance lock**: a second launch focuses the existing window instead of spawning a second backend; `whenReady` bails when the lock was not acquired.
- **`process.on("exit")` reap**: last-resort synchronous SIGKILL of a still-tracked backend, covering the case where `stopRuntime`'s `unref()`'d escalation timer is dropped when the main process exits first.

## #1868 — mandatory OTA updates

- Manifest gains optional **`requires.min_build`**. `ota.js` `evaluateUpdate` returns a `mandatory` flag (`isMandatoryUpdate`) on both `patch` and `incompatible` decisions.
- `main.js` **`maybeEnforceMandatoryUpdate()`** blocks before the runtime/window: `patch` → "Update now / Quit" (no "Later"), `incompatible` → reinstall notice + quit, decline → quit. **Fail-open**: OTA disabled / no URL / offline / unparseable manifest allows normal startup; only a fetched mandatory manifest blocks. Optional updates still flow through the post-window check.
- `ota_publish.py --min-build N` sets `requires.min_build`.

**Reach**: enforcement lives in the Electron shell, so mandatory updates only apply to clients already running a force-aware shell — i.e. from the next dmg onward; it cannot retroactively force older shells.

## Tests / docs

- `desktop/test/ota.test.js`: `isMandatoryUpdate` + `mandatory` flag on patch/incompatible.
- `tests/scripts/test_ota_publish.py`: optional vs mandatory `min_build` manifest shape.
- `docs/specs/desktop-ota-hot-update.md` updated for the manifest field + client behavior.

Gate record: .workflow/records/1867-guided-1867-desktop-orphan-mandatory-ota.json

Closes #1867
Closes #1868
