### PR TITLE
feat(#1870): add AppBlock pre-launch hook for config-driven external tools

### DIFF
--- a/.workflow/records/1870-jiazhenz026-feature-1870-appblock-prelaunch-hook.json
+++ b/.workflow/records/1870-jiazhenz026-feature-1870-appblock-prelaunch-hook.json
@@ -271,9 +271,9 @@
   ],
   "check_na": [],
   "commit": {
-    "sha": "cbcd62ecbcf5c5354188764c7b44bcb519d42c5c",
+    "sha": "ad56ddb24e015737f25fd43697f4f5ddec4cbf67",
     "shas": [
-      "cbcd62ecbcf5c5354188764c7b44bcb519d42c5c"
+      "ad56ddb24e015737f25fd43697f4f5ddec4cbf67"
     ],
     "trailers": []
   },
@@ -630,6 +630,318 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-06-29T20:56:07.457486Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/app/app_block.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/app/app_block.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T20:56:07.465969Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T20:56:07.474381Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T20:56:07.482742Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T20:56:07.490949Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T20:56:07.499197Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T20:56:07.507454Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T20:56:07.515667Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T20:56:07.523946Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T20:56:07.534654Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T20:56:14.819345Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/app/app_block.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/app/app_block.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T20:56:14.827811Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T20:56:14.836579Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T20:56:14.845264Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T20:56:14.853704Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T20:56:14.862074Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T20:56:14.870324Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T20:56:14.879189Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T20:56:14.887535Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T20:56:14.898336Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T20:56:25.499856Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/app/app_block.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/app/app_block.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T20:56:25.509765Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T20:56:25.519863Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T20:56:25.529957Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T20:56:25.539666Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T20:56:25.549730Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T20:56:25.558969Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T20:56:25.568143Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T20:56:25.576609Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T20:56:25.588638Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -642,7 +954,7 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "origin/main",
+    "base": "a7ebbfa3d9a824770a51d45cfa40d01c7dbe9cc0",
     "base_sha": "a7ebbfa3",
     "changed_files": [
       ".workflow/records/1870-jiazhenz026-feature-1870-appblock-prelaunch-hook.json",
@@ -650,9 +962,9 @@
       "src/scistudio/blocks/app/app_block.py",
       "tests/blocks/test_app_block.py"
     ],
-    "diff_fingerprint": "sha256:294bed56bf08c82f7bc8b161b9b2a210db65cc17eb3ad1c07a02adf1486fecdd",
+    "diff_fingerprint": "sha256:cbbbd3127c4f3fc8797a1555af317b8138d7391cff3f14dc46d4db62c0af303e",
     "head": "HEAD",
-    "head_sha": "cbcd62ec",
+    "head_sha": "ad56ddb2",
     "surfaces": {
       "docs": 1,
       "frontend": 0,
@@ -673,8 +985,8 @@
     "closes": [
       1870
     ],
-    "number": null,
-    "url": null
+    "number": 1871,
+    "url": "https://github.com/jiazhenz026/SciStudio/pull/1871"
   },
   "reconcile_events": [
     {
@@ -699,6 +1011,30 @@
     {
       "at": "2026-06-29T20:55:20.903572Z",
       "diff_fingerprint": "sha256:294bed56bf08c82f7bc8b161b9b2a210db65cc17eb3ad1c07a02adf1486fecdd",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-29T20:56:07.534683Z",
+      "diff_fingerprint": "sha256:cbbbd3127c4f3fc8797a1555af317b8138d7391cff3f14dc46d4db62c0af303e",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-29T20:56:14.898385Z",
+      "diff_fingerprint": "sha256:cbbbd3127c4f3fc8797a1555af317b8138d7391cff3f14dc46d4db62c0af303e",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-29T20:56:25.588677Z",
+      "diff_fingerprint": "sha256:cbbbd3127c4f3fc8797a1555af317b8138d7391cff3f14dc46d4db62c0af303e",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 1,

--- a/.workflow/records/1870-jiazhenz026-feature-1870-appblock-prelaunch-hook.json
+++ b/.workflow/records/1870-jiazhenz026-feature-1870-appblock-prelaunch-hook.json
@@ -1,8 +1,282 @@
 {
   "branch": "jiazhenz026/feature/1870-appblock-prelaunch-hook",
-  "check_events": [],
+  "check_events": [
+    {
+      "at": "2026-06-29T20:46:39.901887Z",
+      "command": "pytest tests/architecture/ -v --no-cov",
+      "covered_surface": "architecture",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:af2849440b5d976f2e7b8f2bec73681cfdb515a1040d02ac5337952c96ef7566",
+      "name": "architecture_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/architecture_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-29T20:46:40.690551Z",
+      "command": "python scripts/deferral_scan.py --check docs/audit/baselines/deferral-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:f6e365507ca5e1aefeb6bbfa4a1b55de7285ece61bf598889be8023a1d8a145d",
+      "name": "deferral_discipline",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/deferral_discipline.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-29T20:46:41.029359Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:05338b83593145889ddc958fcbe0579aba42d4616c2c337c04c49ac43e457d69",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-29T20:46:44.922057Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:58ed7c2e1d4dac26c2d4a76efacc0237189b01d9e4d9b8003b004f8dcc08384d",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-29T20:46:45.408412Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:c67591c613bf61ba1f3cdc0bd6290e6219cfc5a4e911eb8a5ee9aa6e34524c12",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-29T20:46:45.454138Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:79d4d6b9c214b23f43a8c213ba1ca00654bf76c88c69f7e9288945db8b5ff748",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-29T20:48:39.180438Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:9825544864c1a7a5dfd255791060a3ad96409dbf9f2c6bbffa77c1edcd57cbb2",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-29T20:50:38.305030Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:5d0b5837b63f1627bf18f932c04620a307aac59291608b0e18bad779ea975c82",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-29T20:50:45.129898Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:ee5ffad439c8e4186691ed8bf42691d910ce1fe77dcab6b8f760dbb382c5a875",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    },
+    {
+      "at": "2026-06-29T20:51:42.044920Z",
+      "command": "python scripts/deferral_scan.py --check docs/audit/baselines/deferral-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:026fd77bc2313db0a466998d18823470386806fc90d6d0c551c13c0d9d6a6b21",
+      "name": "deferral_discipline",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/deferral_discipline.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-29T20:51:42.093241Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:c32203f20c18feeb5b0103c03c16f286135d51b8db5bd516b5fafac3275ba36a",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-29T20:51:45.798819Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:0e54536f4a386c254d96b64d68e9a176d5f831b74c328d3a63464c2e934c67ee",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-29T20:51:45.908232Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:955a6fd71e8a0dbf2c501bf6687e0246e47c06aa42f6382d7066b9c31f5b35c0",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-29T20:51:45.929890Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:922a69262c34b2401129335b7baaed7d45ce408af4fbd11e02a69dc25c7c772d",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-29T20:52:55.922271Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:c5c161a4f11d4ff5c4446616133373eaecf15f1505208c36a8911d9f7d60f86f",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-29T20:54:45.701287Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:ceccda8039c5bd087b425e7f7ab99c7b2f176749bda233efcff02ecfdec3fde7",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-29T20:54:46.135807Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:2194a30c5e35d406ea6647d7f25bad15fff62473864b476ba85343e1b041e2cd",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    }
+  ],
   "check_na": [],
-  "commit": null,
+  "commit": {
+    "sha": "cbcd62ecbcf5c5354188764c7b44bcb519d42c5c",
+    "shas": [
+      "cbcd62ecbcf5c5354188764c7b44bcb519d42c5c"
+    ],
+    "trailers": []
+  },
   "declared_scope": {
     "exclude": [],
     "include": [
@@ -44,7 +318,320 @@
     }
   ],
   "governance_touch": false,
-  "guard_events": [],
+  "guard_events": [
+    {
+      "at": "2026-06-29T20:50:45.164679Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/app/app_block.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/app/app_block.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T20:50:45.174332Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T20:50:45.185301Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T20:50:45.195468Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T20:50:45.205482Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T20:50:45.214798Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T20:50:45.223852Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T20:50:45.233799Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T20:50:45.243972Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T20:50:45.254791Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T20:54:46.166526Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/app/app_block.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/app/app_block.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T20:54:46.175702Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T20:54:46.185433Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T20:54:46.194851Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T20:54:46.204238Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T20:54:46.213423Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T20:54:46.222279Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T20:54:46.231509Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T20:54:46.240553Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T20:54:46.250957Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T20:55:20.820712Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/app/app_block.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/app/app_block.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T20:55:20.830529Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T20:55:20.839389Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T20:55:20.848024Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T20:55:20.856561Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T20:55:20.867001Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T20:55:20.876242Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T20:55:20.885119Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T20:55:20.894060Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T20:55:20.903539Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
   "issues": [
     {
       "close_in_pr": true,
@@ -54,11 +641,70 @@
     }
   ],
   "observed_admin_labels": [],
-  "observed_diff": null,
+  "observed_diff": {
+    "base": "origin/main",
+    "base_sha": "a7ebbfa3",
+    "changed_files": [
+      ".workflow/records/1870-jiazhenz026-feature-1870-appblock-prelaunch-hook.json",
+      "docs/adr/ADR-006.md",
+      "src/scistudio/blocks/app/app_block.py",
+      "tests/blocks/test_app_block.py"
+    ],
+    "diff_fingerprint": "sha256:294bed56bf08c82f7bc8b161b9b2a210db65cc17eb3ad1c07a02adf1486fecdd",
+    "head": "HEAD",
+    "head_sha": "cbcd62ec",
+    "surfaces": {
+      "docs": 1,
+      "frontend": 0,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 1,
+      "packaging": 0,
+      "protected_core": 1,
+      "sentrux": 3,
+      "test": 1,
+      "workflow_ci": 0
+    }
+  },
   "owner_directive": "Add a subclass-overridable pre-launch hook (prepare_launch) on core AppBlock so config-driven external tools can generate a config/params file from the already-materialised inputs and launch with a custom argv. Generic core capability, no tool-specific naming. Owner authorized this protected-core change (admin-approved:core-change).",
   "persona": "implementer",
-  "pull_request": null,
-  "reconcile_events": [],
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [
+      1870
+    ],
+    "number": null,
+    "url": null
+  },
+  "reconcile_events": [
+    {
+      "at": "2026-06-29T20:50:45.254827Z",
+      "diff_fingerprint": "sha256:362b8e4214db9617d4a2ac0cddcc31ca04abba63715ad5a8157ebe49b71d0fa2",
+      "mode": "local",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.format_check",
+        "checks.python_tests"
+      ]
+    },
+    {
+      "at": "2026-06-29T20:54:46.251000Z",
+      "diff_fingerprint": "sha256:294bed56bf08c82f7bc8b161b9b2a210db65cc17eb3ad1c07a02adf1486fecdd",
+      "mode": "local",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-29T20:55:20.903572Z",
+      "diff_fingerprint": "sha256:294bed56bf08c82f7bc8b161b9b2a210db65cc17eb3ad1c07a02adf1486fecdd",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    }
+  ],
   "record_id": "1870-jiazhenz026-feature-1870-appblock-prelaunch-hook",
   "requested_admin_labels": [
     {
@@ -69,11 +715,38 @@
     }
   ],
   "required_obligations": {
-    "admin_labels": [],
-    "checks": [],
-    "docs": [],
-    "guards": [],
-    "tests": []
+    "admin_labels": [
+      "admin-approved:core-change"
+    ],
+    "checks": [
+      "architecture_tests",
+      "deferral_discipline",
+      "format_check",
+      "full_audit",
+      "import_contracts",
+      "lint_format",
+      "python_tests",
+      "semantic_dup",
+      "type_check"
+    ],
+    "docs": [
+      "docs_required_or_na"
+    ],
+    "guards": [
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": [
+      "changed_test_required"
+    ]
   },
   "runtime": "claude-code",
   "schema_version": 2,
@@ -98,7 +771,7 @@
     }
   ],
   "session_id": "ed81899b-04a1-4b9e-bf01-db45f6455333",
-  "strictness_tier": null,
+  "strictness_tier": 1,
   "task_kind": "feature",
   "test_events": [
     {

--- a/.workflow/records/1870-jiazhenz026-feature-1870-appblock-prelaunch-hook.json
+++ b/.workflow/records/1870-jiazhenz026-feature-1870-appblock-prelaunch-hook.json
@@ -1,0 +1,113 @@
+{
+  "branch": "jiazhenz026/feature/1870-appblock-prelaunch-hook",
+  "check_events": [],
+  "check_na": [],
+  "commit": null,
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "src/scistudio/blocks/app/app_block.py",
+      "tests/blocks/test_app_block.py"
+    ]
+  },
+  "directive_events": [
+    {
+      "at": "2026-06-29T20:41:26.396698Z",
+      "owner_directive": "Add AppBlock.prepare_launch(exchange_dir, output_dir, config) -> list[str] | None subclass hook (default None = unchanged behavior). Move output_dir computation+mkdir above launch; thread argv_override = prepare_launch(...) into bridge.launch. Document contract extension + backward-compat in ADR-006 addendum. Security: argv_override is block-authored and launched with shell=False, same as the existing exchange_dir trailing arg, so no extra metacharacter validation is needed; the executable itself stays validated by validate_app_command.",
+      "reason": "plan"
+    }
+  ],
+  "docs_events": [
+    {
+      "at": "2026-06-29T20:41:26.396843Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/adr/ADR-006.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-29T20:41:26.396866Z",
+      "class": "dev-guide",
+      "kind": "na",
+      "path": null,
+      "rationale": "docs/package-development/blocks.md only names AppBlock as a base class and has no AppBlock launch-flow section to amend; the hook is documented in the AppBlock docstring (generated API reference) and the ADR-006 addendum.",
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-29T20:41:26.396871Z",
+      "class": "changelog",
+      "kind": "na",
+      "path": null,
+      "rationale": "no changelog file is maintained for provisional core block-authoring hooks in this repo.",
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": false,
+  "guard_events": [],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1870,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": null,
+  "owner_directive": "Add a subclass-overridable pre-launch hook (prepare_launch) on core AppBlock so config-driven external tools can generate a config/params file from the already-materialised inputs and launch with a custom argv. Generic core capability, no tool-specific naming. Owner authorized this protected-core change (admin-approved:core-change).",
+  "persona": "implementer",
+  "pull_request": null,
+  "reconcile_events": [],
+  "record_id": "1870-jiazhenz026-feature-1870-appblock-prelaunch-hook",
+  "requested_admin_labels": [
+    {
+      "actor_permission": null,
+      "applied_at": null,
+      "applied_by": null,
+      "name": "admin-approved:core-change"
+    }
+  ],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [],
+    "docs": [],
+    "guards": [],
+    "tests": []
+  },
+  "runtime": "claude-code",
+  "schema_version": 2,
+  "scope_events": [
+    {
+      "action": "add-include",
+      "at": "2026-06-29T20:41:26.396824Z",
+      "pattern": "src/scistudio/blocks/app/app_block.py",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-29T20:41:26.396832Z",
+      "pattern": "tests/blocks/test_app_block.py",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-29T20:41:26.396834Z",
+      "pattern": "docs/adr/ADR-006.md",
+      "reason": "plan"
+    }
+  ],
+  "session_id": "ed81899b-04a1-4b9e-bf01-db45f6455333",
+  "strictness_tier": null,
+  "task_kind": "feature",
+  "test_events": [
+    {
+      "at": "2026-06-29T20:41:26.396875Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/blocks/test_app_block.py",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/docs/adr/ADR-006.md
+++ b/docs/adr/ADR-006.md
@@ -84,3 +84,71 @@ class FileExchangeBridge:
 Stable per-app APIs were rejected as unavailable for many tools. Screen
 scraping was rejected as fragile. Ignoring external tools was rejected because
 SciStudio must wrap existing lab software rather than replace it.
+
+## Addendum 1: Pre-Launch Hook For Config-Driven Tools (2026-06-29)
+
+This addendum extends the `AppBlock` contract; it does not revise the accepted
+decision above. Tracked by issue #1870.
+
+The original `AppBlock.run` pipeline is fixed: prepare inputs into the exchange
+directory, launch `<app_command...> <exchange_dir>`, watch the output directory,
+then bin the results. That pipeline assumes the external program (or a wrapper
+script) reads the exchange directory — and `manifest.json` — itself to discover
+its inputs.
+
+Many config-driven command-line tools do not work that way. They expect a
+generated config/parameter file (XML/JSON/parameter file) that enumerates each
+materialised input by absolute path together with the output directory and run
+parameters, and they are launched with a non-default command line (for example
+`tool --config config.xml`) rather than receiving a directory as a positional
+argument. Before this addendum `run` exposed no "inputs are staged but the
+process has not launched" extension point, so these tools could not be wrapped
+cleanly. This shape is common across configuration-driven CLIs (mass
+spectrometry, imaging, genomics); the hook is intentionally generic and names no
+specific tool. Concrete tool subclasses live in domain plugin packages, not in
+core.
+
+### Contract extension
+
+A new subclass-overridable hook is added to `AppBlock`:
+
+- `AppBlock.prepare_launch(exchange_dir, output_dir, config) -> list[str] | None`
+  (`@provisional`, `since = 0.3.2`).
+
+It is called once per run, after inputs are materialised into `exchange_dir`
+and `output_dir` has been created, but before the external process is launched.
+A subclass may (a) read the staged inputs under `exchange_dir` to write the
+config/parameter file the tool needs (pointing the tool's outputs at
+`output_dir`), and (b) return the argv used to launch the tool. The return value
+is threaded into `FileExchangeBridge.launch` as its existing `argv_override`
+argument. Returning `None` keeps the default behavior of passing `exchange_dir`
+as the sole trailing argument.
+
+`run` now resolves and creates `output_dir` before launch (previously it was
+computed in the watcher step) so the hook receives the same directory the
+watcher polls; the watcher step reuses that directory rather than recomputing
+it.
+
+### Backward compatibility
+
+The base `prepare_launch` is a no-op returning `None`. When it returns `None`,
+`run` behaves exactly as before: `FileExchangeBridge.launch` receives
+`argv_override=None` and appends `exchange_dir` as the sole trailing argument.
+Existing `AppBlock` subclasses and configurations are unaffected.
+
+### Security
+
+The executable (`app_command`) is still resolved and injection-checked by
+`validate_app_command`. The argv returned by `prepare_launch` is authored by the
+block, not by untrusted user input, and the process is started with
+`shell=False`, so each argv element is one literal token with no shell
+interpretation — identical to the existing default `[str(exchange_dir)]`
+trailing argument. The override therefore needs no separate shell-metacharacter
+validation. Subclasses must not build an argv element by concatenating an
+untrusted string with shell intent; with `shell=False` there is no shell to
+interpret it, but keeping each token literal preserves the boundary.
+
+This addendum amends the `AppBlock` authoring surface only. It does not change
+the governed module/contract list: `AppBlock` and `FileExchangeBridge` remain
+the governed contracts at class granularity, and `prepare_launch` is a method on
+the already-governed `AppBlock` class.

--- a/src/scistudio/blocks/app/app_block.py
+++ b/src/scistudio/blocks/app/app_block.py
@@ -78,6 +78,13 @@ class AppBlock(Block):
     program) rather than stuck. Once result files appear and stop changing, the
     block finishes on its own.
 
+    Config-driven tools: some command-line tools do not read the exchange
+    directory themselves — they expect a generated config/parameter file listing
+    each input by path and a non-default command line (for example
+    ``tool --config config.xml``). Override :meth:`prepare_launch` to generate
+    that file from the staged inputs and return the launch arguments; the
+    default implementation is a no-op and keeps the standard behavior.
+
     Ports and config:
         - Reads an optional input port named ``data`` by default; you can add or
           rename input and output ports in the port editor. Each output port may
@@ -392,6 +399,77 @@ class AppBlock(Block):
             result[port.name] = Collection(items, item_type=item_type)
         return result
 
+    @provisional(since="0.3.2")
+    def prepare_launch(
+        self,
+        exchange_dir: Path,
+        output_dir: Path,
+        config: BlockConfig,
+    ) -> list[str] | None:
+        """Customise the launch of the external tool after inputs are staged.
+
+        This hook is called once per run, after :meth:`run` has materialised the
+        block's inputs into *exchange_dir* (``inputs/<port>/item_XXXX.<ext>`` and
+        a ``manifest.json``) and created *output_dir*, but **before** the
+        external process is started. The default implementation is a no-op that
+        returns ``None``, so the base block and every existing subclass keep the
+        original behavior unchanged.
+
+        Override this for tools that do not read the exchange directory
+        themselves. A *config-driven* command-line tool typically wants a
+        generated config/parameter file that enumerates each staged input by
+        absolute path plus the output directory, and is launched with a
+        non-default command line (for example ``tool --config config.xml``)
+        rather than receiving a directory as a positional argument. A subclass
+        can do both here:
+
+        1. read the already-staged inputs under *exchange_dir* (via
+           ``manifest.json`` or by walking the ``inputs/`` tree) and write the
+           tool's config/parameter file (point its outputs at *output_dir* so
+           the watcher sees them);
+        2. return the argv to launch the tool with.
+
+        The returned list is passed to the bridge as ``argv_override`` and
+        becomes the trailing arguments after the validated executable (the
+        executable itself is still resolved and injection-checked by
+        :func:`validate_app_command`). Returning ``None`` keeps the default
+        behavior of passing *exchange_dir* as the sole trailing argument.
+
+        Security: the returned argv is authored by the block, not by untrusted
+        user input, and the process is started with ``shell=False`` (each list
+        element is one literal ``argv`` token with no shell interpretation),
+        exactly like the default ``[str(exchange_dir)]`` trailing argument. It
+        therefore needs no separate shell-metacharacter validation; do not build
+        it by concatenating an untrusted string into one element.
+
+        Args:
+            exchange_dir: The exchange directory holding the staged inputs and
+                ``manifest.json`` for this run.
+            output_dir: The directory the watcher will poll for result files;
+                point the tool's outputs here.
+            config: The node configuration for this run.
+
+        Returns:
+            The argv (trailing arguments) to launch the tool with, or ``None``
+            to use the default behavior.
+
+        Example:
+            A minimal config-driven pseudo-tool launched as
+            ``mytool --config <file>``::
+
+                class MyToolBlock(AppBlock):
+                    app_command = "mytool"
+
+                    def prepare_launch(self, exchange_dir, output_dir, config):
+                        inputs = sorted((exchange_dir / "inputs").rglob("*"))
+                        config_path = exchange_dir / "config.txt"
+                        lines = [f"out_dir={output_dir}"]
+                        lines += [f"input={p}" for p in inputs if p.is_file()]
+                        config_path.write_text("\\n".join(lines), encoding="utf-8")
+                        return ["--config", str(config_path)]
+        """
+        return None
+
     @provisional(since="0.3.1")
     def run(self, inputs: dict[str, Collection], config: BlockConfig) -> dict[str, Collection]:
         """Serialise inputs, launch the external app, and collect its outputs.
@@ -402,6 +480,12 @@ class AppBlock(Block):
         loads those files back into output Collections. The external process is
         always waited on (and terminated or killed if it overruns), and any
         exchange folder created just for this run is removed, even on error.
+
+        Between staging the inputs and launching the process, :meth:`prepare_launch`
+        is called so subclasses wrapping config-driven tools can generate a
+        config file and supply a custom launch command line; by default it is a
+        no-op and the executable is launched with the exchange folder as its
+        sole trailing argument.
 
         If output ports were declared in the port editor, result files are
         sorted into those ports by file extension; otherwise every result file
@@ -475,22 +559,33 @@ class AppBlock(Block):
 
         proc: subprocess.Popen[bytes] | None = None
         try:
-            # Step 2: Launch external app (waits for external interaction).
-            # PAUSED visibility for in-flight AppBlocks is tracked in #56
-            # (subprocess→engine status channel); the engine-owned scheduler
-            # (ADR-018 §8.1) is the authoritative state machine.
-            proc = bridge.launch(command, exchange_dir)
-
-            # Step 3: Watch for outputs with process monitoring.
+            # Resolve the output directory *before* launch so the pre-launch
+            # hook and the watcher observe the same directory. ADR-030 D3:
+            # use the user-selected output_dir when configured.
             # ADR-052 §7.1 (option b): FileWatcher accepts a plain
             # ``subprocess.Popen`` as its ``process_handle`` (alive while
             # ``poll()`` is None), so no adapter wrapper is needed.
-            # ADR-030 D3: use user-selected output_dir if configured.
             from scistudio.blocks.app.watcher import FileWatcher, ProcessExitedWithoutOutputError
 
             custom_output_dir = config.get("output_dir")
             output_dir = Path(custom_output_dir) if custom_output_dir else exchange_dir / "outputs"
             output_dir.mkdir(parents=True, exist_ok=True)
+
+            # ADR-006 Addendum 1 (#1870): pre-launch hook. Inputs are now staged
+            # under ``exchange_dir`` and ``output_dir`` exists, but the external
+            # process has not started. Subclasses may read the staged inputs to
+            # generate the config/parameter file a config-driven tool needs and
+            # return the argv used to launch it. ``None`` keeps the default
+            # behavior (``exchange_dir`` as the sole trailing argument).
+            argv_override = self.prepare_launch(exchange_dir, output_dir, config)
+
+            # Step 2: Launch external app (waits for external interaction).
+            # PAUSED visibility for in-flight AppBlocks is tracked in #56
+            # (subprocess→engine status channel); the engine-owned scheduler
+            # (ADR-018 §8.1) is the authoritative state machine.
+            proc = bridge.launch(command, exchange_dir, argv_override=argv_override)
+
+            # Step 3: Watch for outputs with process monitoring.
             stability_period = float(config.get("stability_period", 2.0))
             done_marker = config.get("done_marker")
             watcher = FileWatcher(

--- a/tests/blocks/test_app_block.py
+++ b/tests/blocks/test_app_block.py
@@ -1181,3 +1181,148 @@ class TestAppBlockVestigialStateRemoval:
 
                 with pytest.raises(BlockCancelledByAppError, match="gone"):
                     block.run(inputs={}, config=config)
+
+
+# ---------------------------------------------------------------------------
+# Issue #1870: AppBlock.prepare_launch pre-launch hook (ADR-006 Addendum 1)
+# ---------------------------------------------------------------------------
+
+
+class TestAppBlockPrepareLaunch:
+    """#1870: subclass-overridable pre-launch hook customises the launch argv."""
+
+    @staticmethod
+    def _run_with_mocks(block: Any, config: Any, tmp_path: Path) -> tuple[Any, Any]:
+        """Run ``block`` with the bridge + watcher mocked.
+
+        Returns ``(mock_bridge, mock_watcher_cls)`` so callers can assert how
+        ``bridge.launch`` and ``FileWatcher`` were invoked.
+        """
+        from unittest.mock import MagicMock, patch
+
+        with (
+            patch("scistudio.blocks.app.app_block.FileExchangeBridge") as mock_bridge_cls,
+            patch("scistudio.blocks.app.app_block.validate_app_command", return_value=["echo", "hello"]),
+            patch(
+                "scistudio.blocks.app.app_block.tempfile.mkdtemp",
+                return_value=str(tmp_path / "exchange"),
+            ),
+        ):
+            mock_bridge = MagicMock()
+            mock_bridge_cls.return_value = mock_bridge
+            mock_proc = MagicMock()
+            mock_proc.poll.return_value = None
+            mock_proc.pid = 1
+            mock_proc.wait.return_value = 0
+            mock_bridge.launch.return_value = mock_proc
+
+            with patch("scistudio.blocks.app.watcher.FileWatcher") as mock_watcher_cls:
+                mock_watcher = MagicMock()
+                mock_watcher_cls.return_value = mock_watcher
+                fake_output = tmp_path / "result.csv"
+                fake_output.write_text("a,b\n1,2\n", encoding="utf-8")
+                mock_watcher.wait_for_output.return_value = [fake_output]
+                mock_bridge.collect.return_value = {}
+
+                block.run(inputs={}, config=config)
+
+        return mock_bridge, mock_watcher_cls
+
+    def test_default_hook_returns_none_and_launch_unchanged(self, tmp_path: Path) -> None:
+        """The base hook returns None and launch receives argv_override=None.
+
+        Regression guard: the default code path must be identical to the
+        pre-#1870 behavior, where launch only ever appended the exchange dir.
+        """
+        from scistudio.blocks.app.app_block import AppBlock
+        from scistudio.blocks.base.config import BlockConfig
+
+        block = AppBlock()
+        # The hook itself is a no-op for the base class.
+        assert block.prepare_launch(tmp_path, tmp_path, BlockConfig(params={})) is None
+
+        config = BlockConfig(params={"app_command": "echo hello"})
+        mock_bridge, _ = self._run_with_mocks(block, config, tmp_path)
+
+        launch_call = mock_bridge.launch.call_args
+        assert launch_call.kwargs.get("argv_override") is None
+
+    def test_subclass_override_argv_is_threaded_to_launch(self, tmp_path: Path) -> None:
+        """A subclass-supplied argv is passed through to bridge.launch."""
+        from typing import ClassVar
+
+        from scistudio.blocks.app.app_block import AppBlock
+        from scistudio.blocks.base.config import BlockConfig
+
+        custom_argv = ["--config", "/generated/config.xml"]
+
+        class _ConfigDrivenBlock(AppBlock):
+            app_command: ClassVar[str] = "echo hello"
+
+            def prepare_launch(self, exchange_dir: Path, output_dir: Path, config: Any) -> list[str] | None:
+                return custom_argv
+
+        block = _ConfigDrivenBlock()
+        config = BlockConfig(params={"app_command": "echo hello"})
+        mock_bridge, _ = self._run_with_mocks(block, config, tmp_path)
+
+        launch_call = mock_bridge.launch.call_args
+        assert launch_call.kwargs.get("argv_override") == custom_argv
+
+    def test_hook_receives_existing_output_dir_shared_with_watcher(self, tmp_path: Path) -> None:
+        """output_dir exists when the hook runs and is the dir the watcher polls."""
+        from typing import Any as _Any
+        from typing import ClassVar
+
+        from scistudio.blocks.app.app_block import AppBlock
+        from scistudio.blocks.base.config import BlockConfig
+
+        seen: dict[str, _Any] = {}
+
+        class _CapturingBlock(AppBlock):
+            app_command: ClassVar[str] = "echo hello"
+
+            def prepare_launch(self, exchange_dir: Path, output_dir: Path, config: _Any) -> list[str] | None:
+                # The output dir must already exist when the hook is invoked so
+                # a subclass can point a tool's outputs at it.
+                seen["output_dir"] = output_dir
+                seen["existed_at_hook"] = output_dir.exists()
+                seen["exchange_existed"] = exchange_dir.exists()
+                return None
+
+        block = _CapturingBlock()
+        config = BlockConfig(params={"app_command": "echo hello"})
+        _, mock_watcher_cls = self._run_with_mocks(block, config, tmp_path)
+
+        assert seen["existed_at_hook"] is True
+        assert seen["exchange_existed"] is True
+        # The watcher must poll the exact directory the hook was handed (no
+        # second, divergent computation in the watcher step).
+        watcher_directory = mock_watcher_cls.call_args.kwargs["directory"]
+        assert watcher_directory == seen["output_dir"]
+
+    def test_hook_receives_configured_output_dir(self, tmp_path: Path) -> None:
+        """A configured output_dir is the one passed to the hook and watcher."""
+        from typing import Any as _Any
+        from typing import ClassVar
+
+        from scistudio.blocks.app.app_block import AppBlock
+        from scistudio.blocks.base.config import BlockConfig
+
+        configured_out = tmp_path / "chosen_outputs"
+        seen: dict[str, _Any] = {}
+
+        class _CapturingBlock(AppBlock):
+            app_command: ClassVar[str] = "echo hello"
+
+            def prepare_launch(self, exchange_dir: Path, output_dir: Path, config: _Any) -> list[str] | None:
+                seen["output_dir"] = output_dir
+                return None
+
+        block = _CapturingBlock()
+        config = BlockConfig(params={"app_command": "echo hello", "output_dir": str(configured_out)})
+        _, mock_watcher_cls = self._run_with_mocks(block, config, tmp_path)
+
+        assert seen["output_dir"] == configured_out
+        assert configured_out.exists()
+        assert mock_watcher_cls.call_args.kwargs["directory"] == configured_out


### PR DESCRIPTION
## Summary

Adds a subclass-overridable **pre-launch hook** to the core `AppBlock` so
config-driven external tools can be wrapped cleanly.

`AppBlock.prepare_launch(exchange_dir, output_dir, config) -> list[str] | None`
(`@provisional`, `since="0.3.2"`) is called after inputs are materialised into
the exchange directory and `output_dir` is created, but before the external
process launches. Subclasses can read the staged inputs to generate the
config/parameter file a config-driven CLI needs (XML/JSON/parameter file listing
each input by absolute path + the output directory) and return a custom launch
argv. The return value is threaded into `FileExchangeBridge.launch` via its
existing `argv_override` argument.

The hook is generic — no tool-specific naming. Concrete tool subclasses live in
domain plugin packages, not in core.

## Changes

- `src/scistudio/blocks/app/app_block.py`
  - Add `prepare_launch` hook (default no-op returning `None`).
  - `run()` resolves and creates `output_dir` **before** launch (previously in
    the watcher step) so the hook and watcher share one directory; the watcher
    step reuses it.
  - Thread `argv_override = self.prepare_launch(...)` into `bridge.launch(...)`.
  - Update class/`run` docstrings.
- `tests/blocks/test_app_block.py` — new `TestAppBlockPrepareLaunch`: default-None
  regression path, custom-argv threading, output_dir exists at hook time and is
  shared with the watcher, configured-output_dir path.
- `docs/adr/ADR-006.md` — Addendum 1 records the contract extension, backward
  compatibility, and the `argv_override`/`shell=False` security conclusion.

## Backward compatibility

The base hook returns `None`, so the default code path is byte-for-byte
identical: `bridge.launch` receives `argv_override=None` and appends
`exchange_dir` as the sole trailing argument. Existing `AppBlock` subclasses and
configurations are unaffected; existing tests pass unchanged.

## Security

The executable stays validated by `validate_app_command`. The block-authored
argv is launched with `shell=False` (each element a literal token, no shell
interpretation), identical to the existing `[str(exchange_dir)]` trailing
argument, so it needs no separate shell-metacharacter validation.

## Governance

This change touches a protected core path (`src/scistudio/blocks/**`) and
requires the `admin-approved:core-change` label (owner-authorized).

Gate record: .workflow/records/1870-jiazhenz026-feature-1870-appblock-prelaunch-hook.json

Closes #1870
