### PR TITLE
fix(#1872): reload active workflow on branch switch to clear stale config

### DIFF
--- a/.workflow/records/1872-guided-1872-branch-switch-stale-config.json
+++ b/.workflow/records/1872-guided-1872-branch-switch-stale-config.json
@@ -83,9 +83,9 @@
   ],
   "check_na": [],
   "commit": {
-    "sha": "e95146f646ca561f1b532cd83b89f34102a0c583",
+    "sha": "07f593bddf79e6308a40382250e6512043da4607",
     "shas": [
-      "e95146f646ca561f1b532cd83b89f34102a0c583"
+      "07f593bddf79e6308a40382250e6512043da4607"
     ],
     "trailers": []
   },
@@ -368,6 +368,170 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-06-29T21:27:38.767695Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T21:27:38.776249Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T21:27:38.784778Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T21:27:38.793202Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T21:27:38.801548Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T21:27:38.810033Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T21:27:38.818626Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T21:27:38.827315Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T21:27:38.835718Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T21:27:38.845874Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T21:27:49.391357Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T21:27:49.400205Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T21:27:49.408621Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T21:27:49.417792Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T21:27:49.426946Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T21:27:49.435395Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T21:27:49.443648Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T21:27:49.452147Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T21:27:49.460543Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T21:27:49.471030Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -380,16 +544,16 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "origin/main",
+    "base": "fb73515cb462170f4e6bf2d1c0a4fe94a0ba61f2",
     "base_sha": "fb73515c",
     "changed_files": [
       ".workflow/records/1872-guided-1872-branch-switch-stale-config.json",
       "frontend/src/store/__tests__/gitSlice.test.ts",
       "frontend/src/store/gitSlice.ts"
     ],
-    "diff_fingerprint": "sha256:f4b2117d4c298f328d0a4526d6ba30d439b4349ce6d7c5461b45a3eddf6e986e",
+    "diff_fingerprint": "sha256:84ee02a1bf92ff5f440db2130ab9f35fe96a6f6a1cb24528279e8a2fcf96933f",
     "head": "HEAD",
-    "head_sha": "e95146f6",
+    "head_sha": "07f593bd",
     "surfaces": {
       "docs": 0,
       "frontend": 2,
@@ -410,7 +574,7 @@
     "closes": [
       1872
     ],
-    "number": null,
+    "number": 1873,
     "url": null
   },
   "reconcile_events": [
@@ -433,6 +597,22 @@
     {
       "at": "2026-06-29T21:27:16.741718Z",
       "diff_fingerprint": "sha256:f4b2117d4c298f328d0a4526d6ba30d439b4349ce6d7c5461b45a3eddf6e986e",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-29T21:27:38.845908Z",
+      "diff_fingerprint": "sha256:84ee02a1bf92ff5f440db2130ab9f35fe96a6f6a1cb24528279e8a2fcf96933f",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-29T21:27:49.471078Z",
+      "diff_fingerprint": "sha256:84ee02a1bf92ff5f440db2130ab9f35fe96a6f6a1cb24528279e8a2fcf96933f",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 2,

--- a/.workflow/records/1872-guided-1872-branch-switch-stale-config.json
+++ b/.workflow/records/1872-guided-1872-branch-switch-stale-config.json
@@ -83,9 +83,9 @@
   ],
   "check_na": [],
   "commit": {
-    "sha": "2cbf8dbde349f73de8dcb5ef0d6abac299106afa",
+    "sha": "e95146f646ca561f1b532cd83b89f34102a0c583",
     "shas": [
-      "2cbf8dbde349f73de8dcb5ef0d6abac299106afa"
+      "e95146f646ca561f1b532cd83b89f34102a0c583"
     ],
     "trailers": []
   },
@@ -286,6 +286,88 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-06-29T21:27:16.654029Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T21:27:16.663811Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T21:27:16.673537Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T21:27:16.682929Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T21:27:16.692251Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T21:27:16.702125Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T21:27:16.711810Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T21:27:16.722243Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T21:27:16.731219Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T21:27:16.741684Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -305,9 +387,9 @@
       "frontend/src/store/__tests__/gitSlice.test.ts",
       "frontend/src/store/gitSlice.ts"
     ],
-    "diff_fingerprint": "sha256:348a3e3e3b3308a121f7578e43b508e7260fcc8e5bdccb0fa4c8c43d3b3e6330",
+    "diff_fingerprint": "sha256:f4b2117d4c298f328d0a4526d6ba30d439b4349ce6d7c5461b45a3eddf6e986e",
     "head": "HEAD",
-    "head_sha": "2cbf8dbd",
+    "head_sha": "e95146f6",
     "surfaces": {
       "docs": 0,
       "frontend": 2,
@@ -343,6 +425,14 @@
     {
       "at": "2026-06-29T21:26:39.804734Z",
       "diff_fingerprint": "sha256:348a3e3e3b3308a121f7578e43b508e7260fcc8e5bdccb0fa4c8c43d3b3e6330",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-29T21:27:16.741718Z",
+      "diff_fingerprint": "sha256:f4b2117d4c298f328d0a4526d6ba30d439b4349ce6d7c5461b45a3eddf6e986e",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 2,

--- a/.workflow/records/1872-guided-1872-branch-switch-stale-config.json
+++ b/.workflow/records/1872-guided-1872-branch-switch-stale-config.json
@@ -1,0 +1,411 @@
+{
+  "branch": "guided/1872-branch-switch-stale-config",
+  "check_events": [
+    {
+      "at": "2026-06-29T21:23:44.065670Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:bee0017f30f552d2df2de1173f9ac14b9aee5192ca5e5c1de574bb119512b275",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-29T21:24:22.029056Z",
+      "command": "(cd frontend && npm run check:ci)",
+      "covered_surface": "frontend",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:26c790672b5969892ec061518aea23a23522469b98ae29cf06e9745b30b3689a",
+      "name": "frontend",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/frontend.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-29T21:24:26.001305Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:4daad6f28a9e0a71f5e0fc8664b90c2ce3508b67ecdbaa14623ec3ae4ff53d28",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-29T21:24:26.072463Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e31351abfc33f0b3c0f28bc9f2f3d59ae3bc5d4925dc1159a7f931aa932441ed",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-29T21:26:23.047553Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:edfc3fbe0428e0a221c379a2312141a71689553c50233fc9fc0be71d09162160",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    }
+  ],
+  "check_na": [],
+  "commit": {
+    "sha": "2cbf8dbde349f73de8dcb5ef0d6abac299106afa",
+    "shas": [
+      "2cbf8dbde349f73de8dcb5ef0d6abac299106afa"
+    ],
+    "trailers": []
+  },
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "frontend/src/store/gitSlice.ts",
+      "frontend/src/store/__tests__/gitSlice.test.ts"
+    ]
+  },
+  "directive_events": [
+    {
+      "at": "2026-06-29T21:22:47.962487Z",
+      "owner_directive": "Fix stale block config after branch switch by reloading the active workflow from disk in gitSlice.switchBranch; mirror lineage-restore precedent. Active tab only.",
+      "reason": "plan"
+    }
+  ],
+  "docs_events": [
+    {
+      "at": "2026-06-29T21:22:47.962649Z",
+      "class": "adr",
+      "kind": "na",
+      "path": null,
+      "rationale": "Bugfix restores ADR-039 intended branch-switch behavior; no contract, schema, API, storage, or UI-semantics change.",
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-29T21:22:47.962667Z",
+      "class": "changelog",
+      "kind": "na",
+      "path": null,
+      "rationale": "Internal frontend store bugfix; no user-facing changelog surface in repo for FE store fixes.",
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": false,
+  "guard_events": [
+    {
+      "at": "2026-06-29T21:26:23.087004Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T21:26:23.096397Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T21:26:23.105241Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T21:26:23.114068Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T21:26:23.123752Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T21:26:23.133089Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T21:26:23.142341Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T21:26:23.151537Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T21:26:23.160772Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T21:26:23.170424Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T21:26:39.725308Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T21:26:39.734175Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T21:26:39.743039Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T21:26:39.751790Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T21:26:39.760658Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T21:26:39.769451Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T21:26:39.778092Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T21:26:39.786798Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T21:26:39.795280Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T21:26:39.804700Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1872,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": {
+    "base": "origin/main",
+    "base_sha": "fb73515c",
+    "changed_files": [
+      ".workflow/records/1872-guided-1872-branch-switch-stale-config.json",
+      "frontend/src/store/__tests__/gitSlice.test.ts",
+      "frontend/src/store/gitSlice.ts"
+    ],
+    "diff_fingerprint": "sha256:348a3e3e3b3308a121f7578e43b508e7260fcc8e5bdccb0fa4c8c43d3b3e6330",
+    "head": "HEAD",
+    "head_sha": "2cbf8dbd",
+    "surfaces": {
+      "docs": 0,
+      "frontend": 2,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 2,
+      "packaging": 0,
+      "protected_core": 0,
+      "sentrux": 2,
+      "test": 1,
+      "workflow_ci": 0
+    }
+  },
+  "owner_directive": "Fix: block config panel shows stale params after workflow branch switch. Single active tab only. No issue existed; created #1872. Submit PR at the end.",
+  "persona": "live_implementer",
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [
+      1872
+    ],
+    "number": null,
+    "url": null
+  },
+  "reconcile_events": [
+    {
+      "at": "2026-06-29T21:26:23.170465Z",
+      "diff_fingerprint": "sha256:348a3e3e3b3308a121f7578e43b508e7260fcc8e5bdccb0fa4c8c43d3b3e6330",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-29T21:26:39.804734Z",
+      "diff_fingerprint": "sha256:348a3e3e3b3308a121f7578e43b508e7260fcc8e5bdccb0fa4c8c43d3b3e6330",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    }
+  ],
+  "record_id": "1872-guided-1872-branch-switch-stale-config",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [
+      "format_check",
+      "frontend",
+      "full_audit",
+      "lint_format",
+      "semantic_dup"
+    ],
+    "docs": [
+      "docs_required_or_na"
+    ],
+    "guards": [
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": [
+      "changed_test_required"
+    ]
+  },
+  "runtime": "claude-code",
+  "schema_version": 2,
+  "scope_events": [
+    {
+      "action": "add-include",
+      "at": "2026-06-29T21:22:47.962625Z",
+      "pattern": "frontend/src/store/gitSlice.ts",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-29T21:22:47.962633Z",
+      "pattern": "frontend/src/store/__tests__/gitSlice.test.ts",
+      "reason": "plan"
+    }
+  ],
+  "session_id": "3c5a1896-a629-46b7-a81b-97669baf6bfd",
+  "strictness_tier": 2,
+  "task_kind": "guided",
+  "test_events": [
+    {
+      "at": "2026-06-29T21:22:47.962672Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/store/__tests__/gitSlice.test.ts",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/frontend/src/store/__tests__/gitSlice.test.ts
+++ b/frontend/src/store/__tests__/gitSlice.test.ts
@@ -37,6 +37,7 @@ vi.mock("../../lib/api", async () => {
       gitBranchCreate: vi.fn().mockResolvedValue({ status: "ok", name: "x" }),
       gitBranchDelete: vi.fn().mockResolvedValue({ status: "ok" }),
       gitRestore: vi.fn().mockResolvedValue({ status: "ok", auto_commit_sha: null }),
+      getWorkflow: vi.fn().mockResolvedValue({ id: "wf-a", nodes: [], edges: [] }),
     },
   };
 });
@@ -297,6 +298,39 @@ describe("gitSlice — mutation actions", () => {
     const { api } = await import("../../lib/api");
     expect(api.gitBranchSwitch).toHaveBeenCalledWith("feature");
     expect(get().lastError).toBeNull();
+  });
+
+  it("switchBranch reloads the active workflow from disk so the canvas is not stale (#1872)", async () => {
+    let state: any = {};
+    const set = (partial: any) => {
+      state =
+        typeof partial === "function" ? { ...state, ...partial(state) } : { ...state, ...partial };
+    };
+    const get = () => state;
+    const slice = createGitSlice(set, get, {} as any);
+    const setWorkflow = vi.fn();
+    // Seed the workflow-slice surface the gitSlice reads via the shared store.
+    state = { ...slice, workflowId: "wf-a", setWorkflow };
+
+    const { api } = await import("../../lib/api");
+    const fresh = { id: "wf-a", nodes: [], edges: [] };
+    (api.getWorkflow as any).mockResolvedValueOnce(fresh);
+
+    await slice.switchBranch("feature");
+
+    // The fix: refetch the active workflow and replace the slice in place,
+    // mirroring the lineage Restore precedent, so the config panel reflects
+    // the new branch's params instead of the previous branch's stale values.
+    expect(api.getWorkflow).toHaveBeenCalledWith("wf-a");
+    expect(setWorkflow).toHaveBeenCalledWith(fresh);
+  });
+
+  it("switchBranch does not refetch a workflow when no canvas is open (#1872)", async () => {
+    const { slice } = makeSlice();
+    const { api } = await import("../../lib/api");
+    // Default slice has no workflowId / setWorkflow, so the refresh is skipped.
+    await slice.switchBranch("feature");
+    expect(api.getWorkflow).not.toHaveBeenCalled();
   });
 
   it("switchBranch with clean tree returns auto_commit_sha=null and leaves lastNotice null (#1354)", async () => {

--- a/frontend/src/store/gitSlice.ts
+++ b/frontend/src/store/gitSlice.ts
@@ -125,6 +125,34 @@ function describeApiError(err: unknown, fallback: string): string {
   return fallback;
 }
 
+/**
+ * #1872: after a git checkout (branch switch) the active workflow YAML on disk
+ * has been replaced, but the store still holds the previous branch's
+ * `workflowNodes`. Refetch the active workflow and reload it into the workflow
+ * slice so the canvas + config panel reflect the new branch's content.
+ *
+ * Best-effort: a fetch failure leaves the previous canvas in place rather than
+ * blanking it (the user can still reload via the file tree). The post-fetch
+ * `workflowId` guard avoids clobbering the canvas if the user switched tabs
+ * while the refetch was in flight. Scoped to the active tab only; other open
+ * tabs reload from disk when next selected. Defensive existence checks keep the
+ * slice usable in isolation (unit tests construct it without the workflow
+ * slice).
+ */
+async function refreshOpenWorkflowFromDisk(get: () => AppStore): Promise<void> {
+  const openId = get().workflowId;
+  const setWorkflow = get().setWorkflow;
+  if (!openId || typeof setWorkflow !== "function") return;
+  try {
+    const fresh = await api.getWorkflow(openId);
+    if (get().workflowId === openId) {
+      setWorkflow(fresh);
+    }
+  } catch {
+    // best-effort — keep the existing canvas; user can reload from the file tree.
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Pure helpers (always safe to call — no IO, no TODO)
 // ---------------------------------------------------------------------------
@@ -300,6 +328,15 @@ export const createGitSlice: StateCreator<AppStore, [], [], GitSlice> = (set, ge
       await get().loadBranches();
       void get().loadStatus();
       void get().loadLog(name);
+      // #1872: the checkout replaced the workflow YAML on disk, but the open
+      // canvas still holds the previous branch's `workflowNodes` (and thus the
+      // config panel's stale `selectedNode.config.params`). The backend
+      // `workflow.changed` WS event is unreliable for git-checkout replacements
+      // — it is dropped by the ADR-045 version-vector guard (cross-branch
+      // versions are not comparable) and by the dirty-conflict branch. Mirror
+      // the lineage Restore precedent (RunDetail `onRestored`, the #1400 hotfix)
+      // and explicitly reload the active workflow from disk. Active tab only.
+      await refreshOpenWorkflowFromDisk(get);
       return { auto_commit_sha: autoSha };
     } catch (err) {
       set({ lastError: describeApiError(err, `Failed to switch to '${name}'`) });


### PR DESCRIPTION
## Summary

Switching the in-app workflow git **branch** left the block config panel showing the *previous* branch's parameter values (e.g. `branch1`'s `1000` still rendered after editing it to `2000` on `branch2` and switching back).

## Root cause

`gitSlice.switchBranch` only invalidated git view caches (branches/status/log) and relied on the backend `workflow.changed` WS event to refresh the canvas. That event is unreliable for git-checkout file replacements:

- the ADR-045 version-vector guard drops it (`eventVersion <= baseVersion`) — cross-branch versions are not comparable;
- the `workflowIsDirty()` conflict branch can suppress it.

So `workflowNodes` — and therefore the config panel's `selectedNode.config.params` — stayed stale. The config render chain (ConfigPanel → ConfigField → CaretPreservingTextInput) is a pure controlled read of the store, so a stale store yields a stale panel.

## Fix

After a successful `switchBranch`, explicitly refetch the active workflow and reload it into the workflow slice, mirroring the lineage **Restore** precedent (`RunDetail` `onRestored`, the #1400 hotfix that already worked around this exact unreliable WS path). Scoped to the active tab only; other open tabs reload from disk when next selected. Best-effort with a post-fetch `workflowId` guard so a tab switch mid-refetch cannot clobber the canvas.

## Lineage recover

Investigated as requested — **not affected**. The lineage Restore path already does the explicit `api.getWorkflow → setWorkflow(fresh)` refetch, so it does not depend on the fragile WS/version-vector path and does not go stale.

## Tests

- `frontend/src/store/__tests__/gitSlice.test.ts`: `switchBranch` reloads the active workflow from disk; and skips the refetch when no canvas is open.

Gate record: .workflow/records/1872-guided-1872-branch-switch-stale-config.json

Closes #1872
