### PR TITLE
guided(#1880): inject package docs into projects

### DIFF
--- a/.workflow/records/guided-package-docs-core-guided-package-docs-core.json
+++ b/.workflow/records/guided-package-docs-core-guided-package-docs-core.json
@@ -1,0 +1,1375 @@
+{
+  "branch": "guided/package-docs-core",
+  "check_events": [
+    {
+      "at": "2026-06-29T23:08:33.696773Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:bee0017f30f552d2df2de1173f9ac14b9aee5192ca5e5c1de574bb119512b275",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-29T23:08:37.787627Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:d2016153ffe72f6d9588cf72b647d8f545261ca64eb63f312f104e3c66e7d074",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-29T23:08:37.827074Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:e31351abfc33f0b3c0f28bc9f2f3d59ae3bc5d4925dc1159a7f931aa932441ed",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-29T23:10:03.097880Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:bee0017f30f552d2df2de1173f9ac14b9aee5192ca5e5c1de574bb119512b275",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-29T23:10:03.113253Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e31351abfc33f0b3c0f28bc9f2f3d59ae3bc5d4925dc1159a7f931aa932441ed",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-29T23:12:01.075573Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:dd1ede3d80d8351be72c7b39aab3bb1476e3f0733d126f4fcc1a005a20637fc5",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-29T23:12:04.760563Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:4e502fbc98e62374a23f27887e4bdeb112e24339d027dc8d170ea8adba9871f5",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-29T23:12:05.285663Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:401a3334119694a2449f27595c317db66a0538119916f654a5568e70b777c702",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-29T23:12:05.303830Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:7d9b700dade518b062c2a3453b40af73c9b9aa27c96a3f16ba7e257742df953c",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-29T23:14:15.175293Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:27bf97abb9d217876e311a718162ac2acab040f298b2afb9af0c9b66cb7d5bee",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-29T23:16:24.602520Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:076f8d8fbdd4f3c5aeda9600b1da0c31a13a85c83e4fa9c2fa5a896d4552304b",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-29T23:16:31.327713Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:7c9eecf488867a96d72ad394b7e5b4af9a2976360e4cf03b7ec5c963dac2e798",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    },
+    {
+      "at": "2026-06-29T23:18:04.628913Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:596ce337e562d0bfc4dd405f092cb55a836c55ec9e9d1a72f496180b1f4ee549",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-29T23:18:08.521204Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:0adcadc5bb548e42ddae8f74a1a88b7e32d3278b8c985c201c757129982eb895",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-29T23:18:08.632819Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:9c94552480467572c108e66c90262048a0d2f10ab3b7710db64323de3b25ac53",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-29T23:18:08.649571Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:b810862bcb50e38da067b7665e72b08b99a110c32726644d9ca2fb9404b322c3",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-29T23:19:45.617125Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:016d1d4b9bd68798146462ff258e5c8ee64e70aecb90829d38759b0deb4e9941",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-29T23:21:54.774644Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:c0b17cd048e530a09f1840d7633259c3db0c02602b0a9c49f0040f73414d1ae7",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-29T23:21:55.442595Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:71e85956768fe83955ad4a82727a4956cbe6952578046978d5a993118f088bca",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    }
+  ],
+  "check_na": [],
+  "commit": {
+    "sha": "e7f3b51c",
+    "shas": [
+      "e7f3b51c"
+    ],
+    "trailers": []
+  },
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "src/scistudio/agent_provisioning/**",
+      "tests/agent_provisioning/**"
+    ]
+  },
+  "directive_events": [
+    {
+      "at": "2026-06-29T23:02:56.559219Z",
+      "owner_directive": "When users install/update packages, core should find bundled package docs and inject them into the open project without requiring a project reopen.",
+      "reason": "Package docs must be injected not only on project create/open but also after live package install/update/delete actions for the active project."
+    },
+    {
+      "at": "2026-06-29T23:06:49.052996Z",
+      "owner_directive": "Document the core-side package docs injection behavior without implementing the package-side build/packaging workflow today.",
+      "reason": "Core package-doc injection changes provisioning behavior and needs a short docs landing."
+    },
+    {
+      "at": "2026-06-29T23:07:17.517512Z",
+      "owner_directive": "Implement core-side installed package docs discovery and project injection, with active-project refresh after package install/update/delete.",
+      "reason": "plan"
+    },
+    {
+      "at": "2026-06-29T23:23:38.804916Z",
+      "owner_directive": "Submit the PR; ignore local failures.",
+      "reason": "Owner directed PR submission despite known local pre-PR pytest failures outside this change scope."
+    }
+  ],
+  "docs_events": [
+    {
+      "at": "2026-06-29T23:06:49.053215Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/agent-provisioning.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-29T23:07:17.517733Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/agent-provisioning.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-29T23:08:03.951676Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/agent-provisioning.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-29T23:10:02.914421Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/agent-provisioning.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-29T23:10:34.451026Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/agent-provisioning.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-29T23:10:57.463143Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/agent-provisioning.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-29T23:11:12.551873Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/agent-provisioning.md",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": false,
+  "guard_events": [
+    {
+      "at": "2026-06-29T23:08:37.853374Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T23:08:37.864218Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T23:08:37.874539Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T23:08:37.885498Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "issue_link",
+          "git_evidence": null,
+          "id": "issue_link.missing",
+          "line": null,
+          "message": "at least one linked issue is required",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "issue_link.missing",
+          "severity": "error",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "issue_link",
+      "status": "fail"
+    },
+    {
+      "at": "2026-06-29T23:08:37.895805Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T23:08:37.905827Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T23:08:37.915554Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T23:08:37.925435Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T23:08:37.935668Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T23:08:37.945991Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T23:10:03.136193Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T23:10:03.147330Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T23:10:03.157853Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T23:10:03.168363Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T23:10:03.178423Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T23:10:03.188221Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T23:10:03.198002Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T23:10:03.207916Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T23:10:03.218102Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T23:10:03.228616Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T23:10:34.569186Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T23:10:34.579516Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T23:10:34.589782Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T23:10:34.600157Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T23:10:34.610308Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T23:10:34.620742Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T23:10:34.631007Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T23:10:34.641191Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T23:10:34.651165Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T23:10:34.660891Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T23:10:57.578183Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T23:10:57.588411Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T23:10:57.598128Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T23:10:57.608006Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T23:10:57.617876Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T23:10:57.627889Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T23:10:57.637793Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T23:10:57.647770Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T23:10:57.657851Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T23:10:57.668179Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T23:11:12.668834Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T23:11:12.680025Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T23:11:12.690033Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T23:11:12.700733Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T23:11:12.711131Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T23:11:12.721495Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T23:11:12.732499Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T23:11:12.743538Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T23:11:12.753787Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T23:11:12.763588Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T23:16:31.366129Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T23:16:31.375896Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T23:16:31.386118Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T23:16:31.396203Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T23:16:31.406224Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T23:16:31.418769Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T23:16:31.431386Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T23:16:31.444287Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T23:16:31.456333Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T23:16:31.470662Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T23:21:55.488779Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T23:21:55.499677Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T23:21:55.510418Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T23:21:55.520994Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T23:21:55.531638Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T23:21:55.542413Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T23:21:55.552731Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T23:21:55.564412Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T23:21:55.574993Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T23:21:55.589740Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T23:24:26.556713Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T23:24:26.566841Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T23:24:26.576997Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T23:24:26.586783Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T23:24:26.596450Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T23:24:26.606724Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T23:24:26.616575Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T23:24:26.626947Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T23:24:26.636862Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T23:24:26.650997Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T23:25:18.858231Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T23:25:18.868298Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T23:25:18.881370Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T23:25:18.891603Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T23:25:18.902051Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T23:25:18.912038Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T23:25:18.921984Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T23:25:18.932932Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T23:25:18.943085Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-29T23:25:18.956858Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1880,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": {
+    "base": "fb73515cb462170f4e6bf2d1c0a4fe94a0ba61f2",
+    "base_sha": "fb73515c",
+    "changed_files": [
+      ".workflow/records/guided-package-docs-core-guided-package-docs-core.json",
+      "docs/agent-provisioning.md",
+      "src/scistudio/agent_provisioning/_orchestrate.py",
+      "src/scistudio/agent_provisioning/docs.py",
+      "src/scistudio/api/routes/packages.py",
+      "tests/agent_provisioning/test_docs.py",
+      "tests/api/test_packages.py"
+    ],
+    "diff_fingerprint": "sha256:39eab194c194bcfa0c5628c7d73add34a5c833b562636e9159ffa564eba15d6b",
+    "head": "HEAD",
+    "head_sha": "e7f3b51c",
+    "surfaces": {
+      "docs": 1,
+      "frontend": 0,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 3,
+      "packaging": 0,
+      "protected_core": 0,
+      "sentrux": 5,
+      "test": 2,
+      "workflow_ci": 0
+    }
+  },
+  "owner_directive": "Core wiring only: discover installed package documentation bundled in package wheels and inject it into SciStudio projects; defer package-side docs build/packaging work.",
+  "persona": "live_implementer",
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [],
+    "number": 1881,
+    "url": "https://github.com/jiazhenz026/SciStudio/pull/1881"
+  },
+  "reconcile_events": [
+    {
+      "at": "2026-06-29T23:08:37.946041Z",
+      "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "mode": "local",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.format_check",
+        "checks.lint_format",
+        "guard.issue_link"
+      ]
+    },
+    {
+      "at": "2026-06-29T23:10:03.228669Z",
+      "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "mode": "local",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-29T23:10:34.660937Z",
+      "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "mode": "local",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-29T23:10:57.668229Z",
+      "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "mode": "local",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-29T23:11:12.763660Z",
+      "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "mode": "local",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-29T23:16:31.470702Z",
+      "diff_fingerprint": "sha256:ce026fdf8d25c32063c30219e32598623ac39f50cc15eaa4200ddf80edde7340",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.python_tests",
+        "checks.semantic_dup"
+      ]
+    },
+    {
+      "at": "2026-06-29T23:21:55.589769Z",
+      "diff_fingerprint": "sha256:8b149ef499356448580bf3ef610894e43675fcc86dd10194f0dfce18198e451d",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.python_tests"
+      ]
+    },
+    {
+      "at": "2026-06-29T23:24:26.651032Z",
+      "diff_fingerprint": "sha256:51e5b7b1e23e05d13f010a02fdce507bdd6db5ad8568a2a513977d450f41b214",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.python_tests"
+      ]
+    },
+    {
+      "at": "2026-06-29T23:25:18.956894Z",
+      "diff_fingerprint": "sha256:39eab194c194bcfa0c5628c7d73add34a5c833b562636e9159ffa564eba15d6b",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.python_tests"
+      ]
+    }
+  ],
+  "record_id": "guided-package-docs-core-guided-package-docs-core",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [
+      "format_check",
+      "full_audit",
+      "import_contracts",
+      "lint_format",
+      "python_tests",
+      "semantic_dup",
+      "type_check"
+    ],
+    "docs": [
+      "docs_required_or_na"
+    ],
+    "guards": [
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": [
+      "changed_test_required"
+    ]
+  },
+  "runtime": "codex:gpt-5",
+  "schema_version": 2,
+  "scope_events": [
+    {
+      "action": "add-include",
+      "at": "2026-06-29T23:02:56.559449Z",
+      "pattern": "src/scistudio/api/routes/packages.py",
+      "reason": "Package docs must be injected not only on project create/open but also after live package install/update/delete actions for the active project."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-29T23:02:56.559466Z",
+      "pattern": "tests/api/test_packages.py",
+      "reason": "Package docs must be injected not only on project create/open but also after live package install/update/delete actions for the active project."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-29T23:06:49.053196Z",
+      "pattern": "docs/agent-provisioning.md",
+      "reason": "Core package-doc injection changes provisioning behavior and needs a short docs landing."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-29T23:07:17.517711Z",
+      "pattern": "src/scistudio/agent_provisioning/**",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-29T23:07:17.517718Z",
+      "pattern": "src/scistudio/api/routes/packages.py",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-29T23:07:17.517720Z",
+      "pattern": "tests/agent_provisioning/**",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-29T23:07:17.517721Z",
+      "pattern": "tests/api/test_packages.py",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-29T23:07:17.517722Z",
+      "pattern": "docs/agent-provisioning.md",
+      "reason": "plan"
+    }
+  ],
+  "session_id": "17f82019-1f2b-4d32-8373-6d1e8c06dbfd",
+  "strictness_tier": 2,
+  "task_kind": "guided",
+  "test_events": [
+    {
+      "at": "2026-06-29T23:07:17.517750Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/agent_provisioning/test_docs.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-29T23:07:17.517753Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/api/test_packages.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-29T23:08:03.951855Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/agent_provisioning/test_docs.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-29T23:08:03.951859Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/api/test_packages.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-29T23:10:02.914615Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/agent_provisioning/test_docs.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-29T23:10:02.914619Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/api/test_packages.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-29T23:10:34.451271Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/agent_provisioning/test_docs.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-29T23:10:34.451279Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/api/test_packages.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-29T23:10:57.463353Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/agent_provisioning/test_docs.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-29T23:10:57.463358Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/api/test_packages.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-29T23:11:12.552083Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/agent_provisioning/test_docs.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-29T23:11:12.552086Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/api/test_packages.py",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/docs/agent-provisioning.md
+++ b/docs/agent-provisioning.md
@@ -37,9 +37,25 @@ the first time it is created or opened:
     ... (5 more)
   .codex/
     config.toml                            # project-scope MCP server config
+  user-guide/
+    api-reference/                         # self-contained SciStudio core API reference
+    package-reference/
+      index.md                             # installed package reference index
+      <package-slug>/api-reference/        # package-bundled API reference, if present
+  .scistudio/
+    agent-reference/                       # compact agent-facing SciStudio contract docs
+      package-index.md                     # installed package agent/reference index
+      packages/<package-slug>/             # package-bundled agent/API reference, if present
 ```
 
 All filesystem-only — no network, no daemons, no external binaries.
+
+Installed package docs are discovered from each installed package module's
+`_scistudio_docs/` directory. Core does not build package docs at project-open
+time; package wheels are expected to carry prebuilt docs. When present,
+`agent-reference/`, `api-reference/`, and `user-guide/` subtrees are copied into
+the project-local package reference locations above. Missing package docs are
+non-fatal; the generated package index simply omits that package.
 
 ## When provisioning runs
 
@@ -69,6 +85,10 @@ With `force=False`:
   skills, `.codex/config.toml`, and the hook `settings.json` — none will
   be clobbered on subsequent project opens.
 - Missing files are restored from the bundled template.
+- Installed package reference files under `user-guide/package-reference/`
+  and `.scistudio/agent-reference/packages/` are managed generated docs.
+  They refresh when the bundled package docs change so package install and
+  update actions expose the current package API reference to in-project agents.
 
 With `force=True` (currently used only via tests; no UI/CLI surface yet):
 

--- a/src/scistudio/agent_provisioning/_orchestrate.py
+++ b/src/scistudio/agent_provisioning/_orchestrate.py
@@ -171,8 +171,10 @@ def _expected_doc_paths() -> list[str]:
         "user-guide/README.md",
         "user-guide/getting-started.md",
         "user-guide/api-reference/index.md",
+        "user-guide/package-reference/index.md",
         ".scistudio/agent-reference/README.md",
         ".scistudio/agent-reference/public-api.md",
+        ".scistudio/agent-reference/package-index.md",
     ]
 
 

--- a/src/scistudio/agent_provisioning/docs.py
+++ b/src/scistudio/agent_provisioning/docs.py
@@ -13,22 +13,46 @@ internals:
 Filesystem-only and wheel-safe (reads through ``importlib.resources`` exactly
 like ``skills.py``), idempotent (skips existing files unless ``force=True``), and
 run as a non-fatal sub-step by the orchestrator.
+
+Installed package reference docs are discovered from package-local
+``_scistudio_docs/`` trees and copied into managed project-local package
+reference indexes. Those managed package docs refresh when the installed package
+docs change; core-owned docs still preserve existing files unless ``force=True``.
 """
 
 from __future__ import annotations
 
 import importlib.resources
+import json
+import re
+from collections.abc import Iterable
 from importlib.resources.abc import Traversable
 from pathlib import Path
+from typing import Any
+
+from scistudio.desktop import paths as desktop_paths
 
 #: (source package, project-relative destination root).
 _DOC_TREES: tuple[tuple[str, str], ...] = (
     ("scistudio._user_guide", "user-guide"),
     ("scistudio._agent_reference", ".scistudio/agent-reference"),
 )
+_PACKAGE_DOCS_DIR = "_scistudio_docs"
+_PACKAGE_DOCS_AGENT_ROOT = ".scistudio/agent-reference/packages"
+_PACKAGE_DOCS_AGENT_INDEX = ".scistudio/agent-reference/package-index.md"
+_PACKAGE_DOCS_USER_ROOT = "user-guide/package-reference"
+_PACKAGE_DOCS_USER_INDEX = "user-guide/package-reference/index.md"
 
 
-def _copy_tree(src: Traversable, dest: Path, *, force: bool, rel: str, written: list[str]) -> None:
+def _copy_tree(
+    src: Traversable | Path,
+    dest: Path,
+    *,
+    force: bool,
+    rel: str,
+    written: list[str],
+    refresh: bool = False,
+) -> None:
     """Recursively copy a ``importlib.resources`` traversable into ``dest``."""
     for child in src.iterdir():
         name = child.name
@@ -36,21 +60,199 @@ def _copy_tree(src: Traversable, dest: Path, *, force: bool, rel: str, written: 
             continue
         child_rel = f"{rel}/{name}"
         if child.is_dir():
-            _copy_tree(child, dest / name, force=force, rel=child_rel, written=written)
+            _copy_tree(child, dest / name, force=force, rel=child_rel, written=written, refresh=refresh)
             continue
         target = dest / name
-        if target.exists() and not force:
-            continue
+        data = child.read_bytes()
+        if target.exists():
+            if refresh and target.read_bytes() == data:
+                continue
+            if not refresh and not force:
+                continue
         target.parent.mkdir(parents=True, exist_ok=True)
-        target.write_bytes(child.read_bytes())
+        target.write_bytes(data)
         written.append(child_rel)
 
 
-def write_docs(project_dir: Path, *, force: bool = False) -> list[str]:
+def _write_text_if_changed(target: Path, body: str, *, rel: str, written: list[str]) -> None:
+    if target.exists() and target.read_text(encoding="utf-8") == body:
+        return
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(body, encoding="utf-8")
+    written.append(rel)
+
+
+def _safe_slug(value: str) -> str:
+    cleaned = re.sub(r"[^A-Za-z0-9_.-]+", "-", value.strip()).strip("._-")
+    return (cleaned or "package").lower()
+
+
+def _manifest(docs_root: Path) -> dict[str, Any]:
+    manifest = docs_root / "manifest.json"
+    if not manifest.is_file():
+        return {}
+    try:
+        raw = json.loads(manifest.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return raw if isinstance(raw, dict) else {}
+
+
+def _manifest_str(data: dict[str, Any], *keys: str) -> str:
+    for key in keys:
+        value = data.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return ""
+
+
+def _iter_package_docs(package_dirs: list[Path]) -> list[tuple[str, str, str, Path]]:
+    """Return ``(slug, display_name, version, docs_root)`` for installed docs."""
+    found: list[tuple[str, str, str, Path]] = []
+    seen: set[str] = set()
+    for root_module, _module_name, import_roots in desktop_paths.iter_source_package_module_candidates(package_dirs):
+        for import_root in import_roots:
+            docs_root = Path(import_root) / root_module / _PACKAGE_DOCS_DIR
+            if not docs_root.is_dir():
+                continue
+            key = str(docs_root.resolve())
+            if key in seen:
+                continue
+            seen.add(key)
+            data = _manifest(docs_root)
+            package_name = _manifest_str(data, "package_name", "name", "title") or root_module.replace("_", "-")
+            version = _manifest_str(data, "version")
+            slug = _safe_slug(_manifest_str(data, "slug") or root_module.replace("_", "-"))
+            found.append((slug, package_name, version, docs_root))
+    return sorted(found, key=lambda item: item[0])
+
+
+def _package_index_target(docs_root: Path, *, slug: str, hidden: bool) -> str:
+    if hidden and (docs_root / "agent-reference" / "README.md").is_file():
+        return f"packages/{slug}/README.md"
+    if not hidden and (docs_root / "user-guide" / "README.md").is_file():
+        return f"{slug}/README.md"
+    if (docs_root / "api-reference" / "index.md").is_file():
+        prefix = f"packages/{slug}" if hidden else slug
+        return f"{prefix}/api-reference/index.md"
+    prefix = f"packages/{slug}" if hidden else slug
+    return f"{prefix}/"
+
+
+def _render_package_index(packages: list[tuple[str, str, str, Path]], *, hidden: bool) -> str:
+    title = "# Installed Package Reference\n"
+    intro = (
+        "Generated from documentation bundled inside installed SciStudio packages. "
+        "Use these package references when authoring custom blocks against package "
+        "types, constructors, and blocks.\n"
+    )
+    if not packages:
+        return title + "\n" + intro + "\nNo installed package reference docs were found.\n"
+
+    lines = [title, intro, "## Packages\n"]
+    for slug, package_name, version, docs_root in packages:
+        version_text = f" `{version}`" if version else ""
+        has_agent = (docs_root / "agent-reference").is_dir()
+        has_api = (docs_root / "api-reference").is_dir()
+        target = _package_index_target(docs_root, slug=slug, hidden=hidden)
+        parts = []
+        if has_agent:
+            parts.append("agent reference")
+        if has_api:
+            parts.append("API reference")
+        kind = ", ".join(parts) if parts else "reference docs"
+        lines.append(f"- [{package_name}]({target}){version_text} — {kind}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def write_package_docs(
+    project_dir: Path,
+    *,
+    package_dirs: Iterable[str | Path] | None = None,
+) -> list[str]:
+    """Copy installed package reference docs into ``project_dir``.
+
+    Package docs are managed generated artifacts. Unlike the core user guide,
+    they refresh changed files in place so package updates make the active
+    project's reference match the currently installed package version.
+    """
+    project_dir = Path(project_dir)
+    dirs = package_dirs if package_dirs is not None else desktop_paths.candidate_package_dirs()
+    packages = _iter_package_docs([Path(path) for path in dirs])
+    written: list[str] = []
+
+    for slug, _package_name, _version, docs_root in packages:
+        agent_dest = project_dir / _PACKAGE_DOCS_AGENT_ROOT / slug
+        user_dest = project_dir / _PACKAGE_DOCS_USER_ROOT / slug
+
+        agent_src = docs_root / "agent-reference"
+        if agent_src.is_dir():
+            _copy_tree(
+                agent_src,
+                agent_dest,
+                force=True,
+                rel=f"{_PACKAGE_DOCS_AGENT_ROOT}/{slug}",
+                written=written,
+                refresh=True,
+            )
+
+        api_src = docs_root / "api-reference"
+        if api_src.is_dir():
+            _copy_tree(
+                api_src,
+                agent_dest / "api-reference",
+                force=True,
+                rel=f"{_PACKAGE_DOCS_AGENT_ROOT}/{slug}/api-reference",
+                written=written,
+                refresh=True,
+            )
+            _copy_tree(
+                api_src,
+                user_dest / "api-reference",
+                force=True,
+                rel=f"{_PACKAGE_DOCS_USER_ROOT}/{slug}/api-reference",
+                written=written,
+                refresh=True,
+            )
+
+        user_src = docs_root / "user-guide"
+        if user_src.is_dir():
+            _copy_tree(
+                user_src,
+                user_dest,
+                force=True,
+                rel=f"{_PACKAGE_DOCS_USER_ROOT}/{slug}",
+                written=written,
+                refresh=True,
+            )
+
+    _write_text_if_changed(
+        project_dir / _PACKAGE_DOCS_AGENT_INDEX,
+        _render_package_index(packages, hidden=True),
+        rel=_PACKAGE_DOCS_AGENT_INDEX,
+        written=written,
+    )
+    _write_text_if_changed(
+        project_dir / _PACKAGE_DOCS_USER_INDEX,
+        _render_package_index(packages, hidden=False),
+        rel=_PACKAGE_DOCS_USER_INDEX,
+        written=written,
+    )
+    return written
+
+
+def write_docs(
+    project_dir: Path,
+    *,
+    force: bool = False,
+    package_dirs: Iterable[str | Path] | None = None,
+) -> list[str]:
     """Copy the user guide + API reference + agent reference into ``project_dir``.
 
     Returns the list of project-relative paths actually written (idempotent: an
-    existing file is skipped unless ``force``).
+    existing core-doc file is skipped unless ``force``). Installed package
+    reference docs are refreshed as managed generated artifacts.
     """
     project_dir = Path(project_dir)
     written: list[str] = []
@@ -62,4 +264,5 @@ def write_docs(project_dir: Path, *, force: bool = False) -> list[str]:
         if not root.is_dir():
             continue
         _copy_tree(root, project_dir / dest_root, force=force, rel=dest_root, written=written)
+    written.extend(write_package_docs(project_dir, package_dirs=package_dirs))
     return written

--- a/src/scistudio/api/routes/packages.py
+++ b/src/scistudio/api/routes/packages.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+import logging
 import os
+from pathlib import Path
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
 
+from scistudio.agent_provisioning.docs import write_package_docs
 from scistudio.api.deps import get_runtime
 from scistudio.api.runtime import ApiRuntime
 from scistudio.desktop import package_manager
@@ -17,6 +20,7 @@ from scistudio.version import get_version
 router = APIRouter(prefix="/api/packages", tags=["packages"])
 RuntimeDep = Annotated[ApiRuntime, Depends(get_runtime)]
 _PACKAGE_BLOCK_SOURCES = {"entry_point", "package_src"}
+logger = logging.getLogger(__name__)
 
 
 class LocalPackageInstallRequest(BaseModel):
@@ -90,6 +94,17 @@ def _registry_packages(runtime: ApiRuntime) -> dict:
     return getter() if callable(getter) else {}
 
 
+def _refresh_active_project_package_docs(runtime: ApiRuntime) -> None:
+    active_project = getattr(runtime, "active_project", None)
+    project_path = getattr(active_project, "path", None)
+    if not project_path:
+        return
+    try:
+        write_package_docs(Path(project_path))
+    except Exception:
+        logger.warning("Package docs provisioning failed for active project %s", project_path, exc_info=True)
+
+
 @router.post("/local", response_model=LocalPackageInstallResponse)
 async def install_local_package_route(
     body: LocalPackageInstallRequest,
@@ -111,6 +126,7 @@ async def install_local_package_route(
         raise HTTPException(status_code=500, detail=f"Failed to install package: {exc}") from exc
 
     runtime.refresh_block_registry()
+    _refresh_active_project_package_docs(runtime)
     module_names = set(result.modules)
     blocks_count = 0
     for spec in runtime.block_registry.all_specs().values():
@@ -193,6 +209,7 @@ async def update_package_route(package_name: str, runtime: RuntimeDep) -> Packag
     except (PackageInstallError, OSError) as exc:
         raise HTTPException(status_code=500, detail=f"Failed to update package: {exc}") from exc
     runtime.refresh_block_registry()
+    _refresh_active_project_package_docs(runtime)
     return _action_response(result)
 
 
@@ -207,6 +224,7 @@ async def rollback_package_route(package_name: str, runtime: RuntimeDep) -> Pack
     except OSError as exc:
         raise HTTPException(status_code=500, detail=f"Failed to roll back package: {exc}") from exc
     runtime.refresh_block_registry()
+    _refresh_active_project_package_docs(runtime)
     return _action_response(result)
 
 
@@ -221,6 +239,7 @@ async def delete_package_route(package_name: str, runtime: RuntimeDep) -> Packag
     except OSError as exc:
         raise HTTPException(status_code=500, detail=f"Failed to delete package: {exc}") from exc
     runtime.refresh_block_registry()
+    _refresh_active_project_package_docs(runtime)
     return _action_response(result)
 
 

--- a/tests/agent_provisioning/test_docs.py
+++ b/tests/agent_provisioning/test_docs.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from scistudio.agent_provisioning import install_project_agent_assets
-from scistudio.agent_provisioning.docs import write_docs
+from scistudio.agent_provisioning.docs import write_docs, write_package_docs
 
 # Landing files that must exist after provisioning.
 _USER_GUIDE_LANDERS = (
@@ -24,6 +24,35 @@ _AGENT_REF_LANDERS = (
     ".scistudio/agent-reference/workflow-schema.md",
     ".scistudio/agent-reference/plot-contract.md",
 )
+
+
+def _write_installed_package_docs(
+    packages_root: Path,
+    *,
+    module_name: str,
+    flat: bool = False,
+    version: str = "0.1.0",
+) -> Path:
+    install_dir = packages_root / f"{module_name.replace('_', '-')}-{version}"
+    module_dir = install_dir / module_name if flat else install_dir / "src" / module_name
+    docs_dir = module_dir / "_scistudio_docs"
+    (docs_dir / "agent-reference").mkdir(parents=True)
+    (docs_dir / "api-reference").mkdir(parents=True)
+    module_dir.mkdir(parents=True, exist_ok=True)
+    (module_dir / "__init__.py").write_text("", encoding="utf-8")
+    (docs_dir / "manifest.json").write_text(
+        (f'{{\n  "package_name": "{module_name.replace("_", " ").title()}",\n  "version": "{version}"\n}}\n'),
+        encoding="utf-8",
+    )
+    (docs_dir / "agent-reference" / "README.md").write_text(
+        f"# Agent docs for {module_name}\n",
+        encoding="utf-8",
+    )
+    (docs_dir / "api-reference" / "index.md").write_text(
+        f"# API reference for {module_name} {version}\n",
+        encoding="utf-8",
+    )
+    return install_dir
 
 
 def test_write_docs_provisions_both_trees(tmp_project_dir: Path) -> None:
@@ -44,6 +73,72 @@ def test_write_docs_includes_api_reference_pages(tmp_project_dir: Path) -> None:
     base = (ref_dir / "scistudio.blocks.base.md").read_text(encoding="utf-8")
     assert "::: scistudio" not in base, "API reference must be self-contained, not directive shells"
     assert "InputPort" in base
+
+
+def test_write_docs_provisions_installed_package_reference(tmp_project_dir: Path, tmp_path: Path) -> None:
+    packages_root = tmp_path / "packages"
+    _write_installed_package_docs(packages_root, module_name="scistudio_blocks_probe")
+
+    written = write_docs(tmp_project_dir, force=False, package_dirs=[packages_root])
+
+    agent_root = tmp_project_dir / ".scistudio" / "agent-reference"
+    hidden_package = agent_root / "packages" / "scistudio-blocks-probe"
+    user_package = tmp_project_dir / "user-guide" / "package-reference" / "scistudio-blocks-probe"
+    assert (hidden_package / "README.md").is_file()
+    assert (hidden_package / "api-reference" / "index.md").is_file()
+    assert (user_package / "api-reference" / "index.md").is_file()
+    assert ".scistudio/agent-reference/package-index.md" in written
+    assert "Scistudio Blocks Probe" in (agent_root / "package-index.md").read_text(encoding="utf-8")
+    assert "scistudio-blocks-probe/api-reference/index.md" in (
+        tmp_project_dir / "user-guide" / "package-reference" / "index.md"
+    ).read_text(encoding="utf-8")
+
+
+def test_write_package_docs_discovers_flat_wheel_layout(tmp_project_dir: Path, tmp_path: Path) -> None:
+    packages_root = tmp_path / "packages"
+    _write_installed_package_docs(
+        packages_root,
+        module_name="scistudio_blocks_wheelprobe",
+        flat=True,
+        version="0.2.0",
+    )
+
+    write_package_docs(tmp_project_dir, package_dirs=[packages_root])
+
+    assert (
+        tmp_project_dir
+        / ".scistudio"
+        / "agent-reference"
+        / "packages"
+        / "scistudio-blocks-wheelprobe"
+        / "api-reference"
+        / "index.md"
+    ).is_file()
+
+
+def test_write_package_docs_refreshes_changed_package_reference(tmp_project_dir: Path, tmp_path: Path) -> None:
+    packages_root = tmp_path / "packages"
+    _write_installed_package_docs(packages_root, module_name="scistudio_blocks_refresh", version="0.1.0")
+    write_package_docs(tmp_project_dir, package_dirs=[packages_root])
+
+    source_index = (
+        packages_root
+        / "scistudio-blocks-refresh-0.1.0"
+        / "src"
+        / "scistudio_blocks_refresh"
+        / "_scistudio_docs"
+        / "api-reference"
+        / "index.md"
+    )
+    source_index.write_text("# API reference for refreshed package\n", encoding="utf-8")
+
+    written = write_package_docs(tmp_project_dir, package_dirs=[packages_root])
+
+    target_index = (
+        tmp_project_dir / "user-guide" / "package-reference" / "scistudio-blocks-refresh" / "api-reference" / "index.md"
+    )
+    assert "user-guide/package-reference/scistudio-blocks-refresh/api-reference/index.md" in written
+    assert target_index.read_text(encoding="utf-8") == "# API reference for refreshed package\n"
 
 
 def test_write_docs_idempotent_preserves_edits(tmp_project_dir: Path) -> None:

--- a/tests/api/test_packages.py
+++ b/tests/api/test_packages.py
@@ -26,6 +26,7 @@ class _Runtime:
     def __init__(self) -> None:
         self.block_registry = _Registry()
         self.refreshed = False
+        self.active_project = None
 
     def refresh_block_registry(self) -> None:
         self.refreshed = True
@@ -68,6 +69,37 @@ def test_install_local_package_route_refreshes_registry(monkeypatch: pytest.Monk
         "blocks_count": 1,
         "replaced": False,
     }
+
+
+def test_install_local_package_route_refreshes_active_project_docs(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("SCISTUDIO_BUNDLED", "1")
+    install_path = tmp_path / "installed" / "scistudio-blocks-probe-0.1.0"
+    project_dir = tmp_path / "project"
+    captured: list[Path] = []
+
+    def fake_install(path: str, **_kwargs: object) -> LocalPackageInstallResult:
+        return LocalPackageInstallResult(
+            package_name="scistudio-blocks-probe",
+            version="0.1.0",
+            install_path=install_path,
+            source_path=Path(path),
+            modules=("scistudio_blocks_probe",),
+            manifest_path=install_path / "scistudio-local-package.json",
+            replaced=False,
+        )
+
+    monkeypatch.setattr(package_routes, "install_local_package", fake_install)
+    monkeypatch.setattr(package_routes, "write_package_docs", lambda path: captured.append(Path(path)))
+    runtime = _Runtime()
+    runtime.active_project = SimpleNamespace(path=str(project_dir))
+
+    response = TestClient(_bundled_app(runtime)).post("/api/packages/local", json={"path": str(tmp_path / "probe.whl")})
+
+    assert response.status_code == 200
+    assert captured == [project_dir]
 
 
 def test_install_local_package_route_rejects_non_bundled_runs(
@@ -187,6 +219,7 @@ def test_updates_route(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def test_update_route_refreshes_and_returns_relaunch(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("SCISTUDIO_BUNDLED", "1")
+    captured: list[Path] = []
 
     def fake_update(name, *, packages, core_base):
         return package_manager.PackageActionResult(
@@ -194,12 +227,15 @@ def test_update_route_refreshes_and_returns_relaunch(monkeypatch: pytest.MonkeyP
         )
 
     monkeypatch.setattr(package_manager, "update_package", fake_update)
+    monkeypatch.setattr(package_routes, "write_package_docs", lambda path: captured.append(Path(path)))
     runtime = _Runtime()
+    runtime.active_project = SimpleNamespace(path="/tmp/scistudio-project")
     runtime.block_registry = _RegistryWithPackages()
     response = TestClient(_bundled_app(runtime)).post("/api/packages/scistudio-blocks-demo/update")
     assert response.status_code == 200
     assert response.json()["needs_relaunch"] is True
     assert runtime.refreshed is True
+    assert captured == [Path("/tmp/scistudio-project")]
 
 
 def test_update_route_maps_known_error_to_400(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
Gate record: .workflow/records/guided-package-docs-core-guided-package-docs-core.json

## Summary

- Discover installed package docs from package-local `_scistudio_docs/` trees and inject them into project package-reference locations.
- Generate package reference indexes for embedded agents and user-guide readers.
- Refresh active-project package docs after package install, update, rollback, and delete actions.

## Tests

- `gate_record check --mode local` passed.
- `gate_record check --mode pre-pr` ran and failed on full-suite `python_tests`; owner directed PR submission despite local failures. The observed failures are outside this change surface: package image capability ambiguity, previewer fixture manifest/storage assertions, and parent watchdog timing.

Closes #1880
