### PR TITLE
feat(#1882): teach in-app agent to prefer interactive/App/Code block shapes

### DIFF
--- a/.workflow/records/1882-guided-1882-agent-block-shape-skill.json
+++ b/.workflow/records/1882-guided-1882-agent-block-shape-skill.json
@@ -1,0 +1,1043 @@
+{
+  "branch": "guided/1882-agent-block-shape-skill",
+  "check_events": [
+    {
+      "at": "2026-06-30T03:14:56.828751Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:c98046aa27df686e36d6e950028c0cd3dcd2f19f06ece4f90fb222ef2e384c29",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-30T03:15:00.640426Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:b7b1863ce63547a13a7d5dad731d891a0609000d7579f5c602b64b880e342fe4",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-30T03:15:00.678791Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:02e362c2c0010cbbade9c88bf1f5b80967394a4209528348d3e569c938875ddf",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-30T03:16:48.063142Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:3820cb38f5a324b1a9e1cf2711b92b7a3666ad541d10d2906f34b7cb357175a0",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-30T03:18:39.905332Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:241ef4d1c93cf2acfd0fe0c3fd5ed4f52565c748170ba683b580b9bfed5e33f2",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-30T03:20:41.396220Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:c98046aa27df686e36d6e950028c0cd3dcd2f19f06ece4f90fb222ef2e384c29",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-30T03:22:10.071704Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:3820cb38f5a324b1a9e1cf2711b92b7a3666ad541d10d2906f34b7cb357175a0",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-30T03:23:02.147700Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:c98046aa27df686e36d6e950028c0cd3dcd2f19f06ece4f90fb222ef2e384c29",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-30T03:24:32.541528Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cb00ded0011df4a0e504c88a2e596d0a12d3c240ae4ef5a2289a353aafc8820c",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-30T03:24:36.306982Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:8930416a35aeeebbe1eabf0935214c7b661f76f0ca353ca50ded1c5f3e63a957",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-30T03:24:36.329355Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:a130611e9518a5a7e1de9cad8a2de35cfa56c4ccefe517d08f5c525b009cab36",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-30T03:26:08.781389Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:7cdbf282f551cbec1a0c3f6ba3e3acdb2d7faaa2472faa14dc8929659fede98c",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-30T03:29:35.134757Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:3d2c11ba7ee8f72ff5856260e6bac4325bf2a923e45ede99ec5e1fe99639adbb",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    }
+  ],
+  "check_na": [],
+  "commit": {
+    "sha": "1d71f339a98d38bde6464644e4cb5c689b5298fd",
+    "shas": [
+      "1d71f339a98d38bde6464644e4cb5c689b5298fd"
+    ],
+    "trailers": []
+  },
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "src/scistudio/_skills/scistudio/**",
+      "src/scistudio/_agent_reference/block-contract.md",
+      "tests/blocks/**"
+    ]
+  },
+  "directive_events": [
+    {
+      "at": "2026-06-30T03:09:28.995616Z",
+      "owner_directive": "Optimize write-block skill: bias agent toward interactive/App/Code shapes and never hard-code data-dependent decisions (pure skill/docs). Add a test to back the project-local custom-panel path being taught.",
+      "reason": "Begin implementation; add an end-to-end test proving a project-local (tier-1) interactive block with a project-relative custom panel asset_root registers and serves, since the skill now teaches agents to author exactly that path and it currently has no combined test coverage."
+    },
+    {
+      "at": "2026-06-30T03:14:10.745195Z",
+      "owner_directive": "Pure skill/agent-reference optimization: block-shape accessibility ladder + interactive/App/Code worked examples; backed by a tier-1 custom-panel serving test.",
+      "reason": "plan"
+    }
+  ],
+  "docs_events": [
+    {
+      "at": "2026-06-30T03:14:10.745350Z",
+      "class": null,
+      "kind": "path",
+      "path": "src/scistudio/_skills/scistudio/scistudio-write-block/SKILL.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-30T03:14:10.745367Z",
+      "class": null,
+      "kind": "path",
+      "path": "src/scistudio/_agent_reference/block-contract.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-30T03:14:10.745369Z",
+      "class": null,
+      "kind": "path",
+      "path": "src/scistudio/_skills/scistudio/SKILL.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-30T03:14:10.745378Z",
+      "class": "adr",
+      "kind": "na",
+      "path": null,
+      "rationale": "no architectural change \u2014 teaches an existing capability (ADR-051 interactive panels); no new decision",
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-30T03:14:10.745384Z",
+      "class": "spec",
+      "kind": "na",
+      "path": null,
+      "rationale": "no contract/schema/runtime change \u2014 agent-facing guidance only",
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-30T03:14:10.745387Z",
+      "class": "user_guide",
+      "kind": "na",
+      "path": null,
+      "rationale": "human-facing writing-blocks guide out of scope for this agent-skill change; tracked as follow-up",
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": false,
+  "guard_events": [
+    {
+      "at": "2026-06-30T03:18:39.946369Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:18:39.956299Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:18:39.966725Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:18:39.976533Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:18:39.986005Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:18:39.995076Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:18:40.004027Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:18:40.014789Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:18:40.024818Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:18:40.036670Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:20:25.059558Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:20:25.069012Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:20:25.077675Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:20:25.086132Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:20:25.094406Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:20:25.103529Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:20:25.112380Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:20:25.121590Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:20:25.130960Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:20:25.142267Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:22:10.103297Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:22:10.113455Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:22:10.123103Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:22:10.134157Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:22:10.144298Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:22:10.154209Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:22:10.164553Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:22:10.175358Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:22:10.184938Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:22:10.196147Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:23:02.171763Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:23:02.181739Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:23:02.191000Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:23:02.200180Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:23:02.208842Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:23:02.218602Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:23:02.227868Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:23:02.236628Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:23:02.245831Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:23:02.256796Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:23:30.295276Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:23:30.306158Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:23:30.315890Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:23:30.325875Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:23:30.335927Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:23:30.345917Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:23:30.355277Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:23:30.366848Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:23:30.377726Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:23:30.390204Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:29:35.191449Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:29:35.204237Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:29:35.217104Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:29:35.231855Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:29:35.244567Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:29:35.256975Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:29:35.269363Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:29:35.282371Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:29:35.293840Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:29:35.308608Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:29:35.778112Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:29:35.788833Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:29:35.799886Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:29:35.812023Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:29:35.822966Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:29:35.833941Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:29:35.845252Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:29:35.857015Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:29:35.868535Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:29:35.882755Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1882,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": {
+    "base": "origin/main",
+    "base_sha": "353496e9",
+    "changed_files": [
+      ".workflow/records/1882-guided-1882-agent-block-shape-skill.json",
+      "src/scistudio/_agent_reference/block-contract.md",
+      "src/scistudio/_skills/scistudio/SKILL.md",
+      "src/scistudio/_skills/scistudio/scistudio-write-block/SKILL.md",
+      "tests/api/test_interactive_panels.py"
+    ],
+    "diff_fingerprint": "sha256:bc54cc263f4465b5caece23084c283ef4d67417b2bd7c6cbec234c444fb8e937",
+    "head": "HEAD",
+    "head_sha": "1d71f339",
+    "surfaces": {
+      "docs": 0,
+      "frontend": 0,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 3,
+      "packaging": 0,
+      "protected_core": 0,
+      "sentrux": 4,
+      "test": 1,
+      "workflow_ci": 0
+    }
+  },
+  "owner_directive": "Optimize the in-app AI agent's write-block skill so it biases toward user-friendly block shapes (interactive blocks incl. custom vanilla-JS panels, AppBlock, CodeBlock) instead of always chaining ProcessBlocks, and never hard-codes a data-dependent decision. Pure skill/agent-reference docs. Package API reference (C) is owner's separate PR #1881 and out of scope.",
+  "persona": "live_implementer",
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [
+      1882
+    ],
+    "number": null,
+    "url": null
+  },
+  "reconcile_events": [
+    {
+      "at": "2026-06-30T03:18:40.036693Z",
+      "diff_fingerprint": "sha256:8d34a9d3afd94d93623433849f70cd2ae239faa0dc8239c236ba6c860342dae5",
+      "mode": "local",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.format_check",
+        "checks.python_tests"
+      ]
+    },
+    {
+      "at": "2026-06-30T03:20:25.142302Z",
+      "diff_fingerprint": "sha256:8d34a9d3afd94d93623433849f70cd2ae239faa0dc8239c236ba6c860342dae5",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.format_check",
+        "checks.python_tests"
+      ]
+    },
+    {
+      "at": "2026-06-30T03:22:10.196180Z",
+      "diff_fingerprint": "sha256:8d34a9d3afd94d93623433849f70cd2ae239faa0dc8239c236ba6c860342dae5",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.format_check"
+      ]
+    },
+    {
+      "at": "2026-06-30T03:23:02.256849Z",
+      "diff_fingerprint": "sha256:8d34a9d3afd94d93623433849f70cd2ae239faa0dc8239c236ba6c860342dae5",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-30T03:23:30.390239Z",
+      "diff_fingerprint": "sha256:bc54cc263f4465b5caece23084c283ef4d67417b2bd7c6cbec234c444fb8e937",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.format_check",
+        "checks.full_audit",
+        "checks.lint_format",
+        "checks.python_tests",
+        "checks.semantic_dup"
+      ]
+    },
+    {
+      "at": "2026-06-30T03:29:35.308648Z",
+      "diff_fingerprint": "sha256:bc54cc263f4465b5caece23084c283ef4d67417b2bd7c6cbec234c444fb8e937",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-30T03:29:35.882795Z",
+      "diff_fingerprint": "sha256:bc54cc263f4465b5caece23084c283ef4d67417b2bd7c6cbec234c444fb8e937",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    }
+  ],
+  "record_id": "1882-guided-1882-agent-block-shape-skill",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [
+      "format_check",
+      "full_audit",
+      "lint_format",
+      "python_tests",
+      "semantic_dup"
+    ],
+    "docs": [
+      "docs_required_or_na"
+    ],
+    "guards": [
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": [
+      "changed_test_required"
+    ]
+  },
+  "runtime": "claude",
+  "schema_version": 2,
+  "scope_events": [
+    {
+      "action": "add-include",
+      "at": "2026-06-30T03:09:28.995752Z",
+      "pattern": "tests/api/test_interactive_panels.py",
+      "reason": "Begin implementation; add an end-to-end test proving a project-local (tier-1) interactive block with a project-relative custom panel asset_root registers and serves, since the skill now teaches agents to author exactly that path and it currently has no combined test coverage."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-30T03:09:28.995760Z",
+      "pattern": "src/scistudio/_skills/scistudio/SKILL.md",
+      "reason": "Begin implementation; add an end-to-end test proving a project-local (tier-1) interactive block with a project-relative custom panel asset_root registers and serves, since the skill now teaches agents to author exactly that path and it currently has no combined test coverage."
+    }
+  ],
+  "session_id": "17563202-9d78-4704-8083-f6f22e3b7c6a",
+  "strictness_tier": 2,
+  "task_kind": "guided",
+  "test_events": [
+    {
+      "at": "2026-06-30T03:14:10.745390Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/api/test_interactive_panels.py",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/.workflow/records/1882-guided-1882-agent-block-shape-skill.json
+++ b/.workflow/records/1882-guided-1882-agent-block-shape-skill.json
@@ -211,9 +211,9 @@
   ],
   "check_na": [],
   "commit": {
-    "sha": "1d71f339a98d38bde6464644e4cb5c689b5298fd",
+    "sha": "1bb1018e9cc1936dbbbcddd4999b2cb63282f88e",
     "shas": [
-      "1d71f339a98d38bde6464644e4cb5c689b5298fd"
+      "1bb1018e9cc1936dbbbcddd4999b2cb63282f88e"
     ],
     "trailers": []
   },
@@ -862,6 +862,252 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:30:35.587486Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:30:35.609184Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:30:35.628181Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:30:35.645688Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:30:35.667525Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:30:35.689109Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:30:35.706114Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:30:35.725962Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:30:35.748630Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:30:35.779304Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:30:56.226817Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:30:56.242371Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:30:56.255889Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:30:56.279913Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:30:56.304188Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:30:56.324533Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:30:56.348080Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:30:56.372321Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:30:56.392906Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:30:56.422386Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:31:07.400219Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:31:07.423897Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:31:07.446684Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:31:07.464554Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:31:07.486053Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:31:07.507126Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:31:07.531475Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:31:07.554659Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:31:07.579344Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T03:31:07.605791Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -874,8 +1120,8 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "origin/main",
-    "base_sha": "353496e9",
+    "base": "fb73515cb462170f4e6bf2d1c0a4fe94a0ba61f2",
+    "base_sha": "fb73515c",
     "changed_files": [
       ".workflow/records/1882-guided-1882-agent-block-shape-skill.json",
       "src/scistudio/_agent_reference/block-contract.md",
@@ -883,9 +1129,9 @@
       "src/scistudio/_skills/scistudio/scistudio-write-block/SKILL.md",
       "tests/api/test_interactive_panels.py"
     ],
-    "diff_fingerprint": "sha256:bc54cc263f4465b5caece23084c283ef4d67417b2bd7c6cbec234c444fb8e937",
+    "diff_fingerprint": "sha256:c135fa3df07e826c2a701adea7287418d9de9ac5fe248af9dd34b5927044f2e7",
     "head": "HEAD",
-    "head_sha": "1d71f339",
+    "head_sha": "1bb1018e",
     "surfaces": {
       "docs": 0,
       "frontend": 0,
@@ -906,7 +1152,7 @@
     "closes": [
       1882
     ],
-    "number": null,
+    "number": 1883,
     "url": null
   },
   "reconcile_events": [
@@ -975,6 +1221,30 @@
     {
       "at": "2026-06-30T03:29:35.882795Z",
       "diff_fingerprint": "sha256:bc54cc263f4465b5caece23084c283ef4d67417b2bd7c6cbec234c444fb8e937",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-30T03:30:35.779363Z",
+      "diff_fingerprint": "sha256:c135fa3df07e826c2a701adea7287418d9de9ac5fe248af9dd34b5927044f2e7",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-30T03:30:56.422451Z",
+      "diff_fingerprint": "sha256:c135fa3df07e826c2a701adea7287418d9de9ac5fe248af9dd34b5927044f2e7",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-30T03:31:07.605893Z",
+      "diff_fingerprint": "sha256:c135fa3df07e826c2a701adea7287418d9de9ac5fe248af9dd34b5927044f2e7",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 2,

--- a/.workflow/records/1882-guided-1882-agent-block-shape-skill.json
+++ b/.workflow/records/1882-guided-1882-agent-block-shape-skill.json
@@ -207,13 +207,92 @@
       "status": "pass",
       "summary": "clean",
       "tool_versions": {}
+    },
+    {
+      "at": "2026-06-30T05:04:02.216152Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e80cefb5d740e9cbdae05b6e7b742dc3db1db01303af0e6066391b7ff5bbf478",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-30T05:04:06.013607Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:740d277ebbd9cb7ee769edd624cdb471ed34d2923b0b9903c10c89012a4438f4",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-30T05:04:06.028092Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:481440e66056aa4f60aefa24e558e9c16a0ab4617ff40d2dc8e6d14296d8ab7b",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-30T05:05:23.820864Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:a0638e6a9bd9a46c99a7a7e289a71bd53b1bbdaf35e224b36fd7c28d6d9224c2",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-30T05:07:18.280656Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:57bcc5cadabbf92dcef3eb2caf48eeb6613d34d0cf1906202dc3546cccbb684c",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
     }
   ],
   "check_na": [],
   "commit": {
-    "sha": "1bb1018e9cc1936dbbbcddd4999b2cb63282f88e",
+    "sha": "8ed70d2542ccea53b1a1b6f6027cf9ef411d9c78",
     "shas": [
-      "1bb1018e9cc1936dbbbcddd4999b2cb63282f88e"
+      "8ed70d2542ccea53b1a1b6f6027cf9ef411d9c78"
     ],
     "trailers": []
   },
@@ -235,6 +314,11 @@
       "at": "2026-06-30T03:14:10.745195Z",
       "owner_directive": "Pure skill/agent-reference optimization: block-shape accessibility ladder + interactive/App/Code worked examples; backed by a tier-1 custom-panel serving test.",
       "reason": "plan"
+    },
+    {
+      "at": "2026-06-30T04:44:58.279617Z",
+      "owner_directive": "Revise write-block skill: (1) skill contains NO inline code examples \u2014 move them to the separate examples channel, keep skill short; (2) interactive is an OPTIONAL shape, not preferred \u2014 drop the climb-the-ladder advocacy; (3) hard-coding is not prohibited, only mildly discouraged (sometimes convenient). Make the agent AWARE of config-param/interactive/App/Code as options to consider, without pushing any.",
+      "reason": "Owner course-correction on PR #1883 before merge: rebalance skill tone and structure."
     }
   ],
   "docs_events": [
@@ -1108,6 +1192,170 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-06-30T05:07:18.321807Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T05:07:18.331490Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T05:07:18.340920Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T05:07:18.350259Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T05:07:18.359290Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T05:07:18.368640Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T05:07:18.377935Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T05:07:18.388866Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T05:07:18.398408Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T05:07:18.412251Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T05:07:18.850942Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T05:07:18.860127Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T05:07:18.869170Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T05:07:18.878316Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T05:07:18.887209Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T05:07:18.896093Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T05:07:18.904833Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T05:07:18.913937Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T05:07:18.922912Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T05:07:18.935217Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -1129,9 +1377,9 @@
       "src/scistudio/_skills/scistudio/scistudio-write-block/SKILL.md",
       "tests/api/test_interactive_panels.py"
     ],
-    "diff_fingerprint": "sha256:c135fa3df07e826c2a701adea7287418d9de9ac5fe248af9dd34b5927044f2e7",
+    "diff_fingerprint": "sha256:f26b1628585e1ba7c49fa7dfff4f8ab6786427a2d9bed79503b5339cfae450be",
     "head": "HEAD",
-    "head_sha": "1bb1018e",
+    "head_sha": "8ed70d25",
     "surfaces": {
       "docs": 0,
       "frontend": 0,
@@ -1245,6 +1493,22 @@
     {
       "at": "2026-06-30T03:31:07.605893Z",
       "diff_fingerprint": "sha256:c135fa3df07e826c2a701adea7287418d9de9ac5fe248af9dd34b5927044f2e7",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-30T05:07:18.412289Z",
+      "diff_fingerprint": "sha256:f26b1628585e1ba7c49fa7dfff4f8ab6786427a2d9bed79503b5339cfae450be",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-30T05:07:18.935246Z",
+      "diff_fingerprint": "sha256:f26b1628585e1ba7c49fa7dfff4f8ab6786427a2d9bed79503b5339cfae450be",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 2,

--- a/src/scistudio/_agent_reference/block-contract.md
+++ b/src/scistudio/_agent_reference/block-contract.md
@@ -17,6 +17,72 @@ a body. Imports come from canonical roots ([public-api.md](public-api.md)).
 ([public-api.md](public-api.md)). `base_category` is **inferred** from the parent
 class — never set it as a ClassVar (silently ignored).
 
+## Make it interactive (let the user decide in the GUI)
+
+Interaction is a **capability**, not a separate base class. Any category can
+pause mid-run, open a window onto its real input data, take a data-dependent
+decision from the user, and compute outputs from it — instead of hard-coding a
+choice that depends on looking at the data. Mix in `InteractiveMixin`, set
+`execution_mode = ExecutionMode.INTERACTIVE`, declare an `interactive_panel`,
+and override `prepare_prompt`. Import all four from `scistudio.blocks.base`
+(`InteractiveMixin`, `ExecutionMode`, `PanelManifest`, `InteractivePrompt`).
+
+- `prepare_prompt(self, inputs, config) -> dict | InteractivePrompt` — runs
+  first, in its own worker, with the block's full input collections. Reduce the
+  real data to a small, **plain-JSON** view the window renders (a downsampled
+  trace, a summary table, a list of choices); the runtime rejects a non-JSON
+  payload. A bare dict is shorthand for `InteractivePrompt(panel_payload=...)`.
+- `run` / `process_item` — runs after the user confirms; reads the panel's JSON
+  decision from `config.get("interactive_response", {})` and computes outputs.
+
+Two panel options:
+
+- **Reuse a built-in panel** when the interaction is routing or pairing — no
+  frontend code: `PanelManifest(panel_id="core.interactive.data_router")` (drag
+  items from N inputs to M outputs) or `"core.interactive.pair_editor"` (reorder
+  items to fix pairing across collections).
+- **Ship your own panel** for anything data-specific (pick a baseline region on
+  a trace, click a peak, set a threshold against a preview). A panel is one
+  self-contained ES module — plain JS, no React, no build step — served from
+  beside the block:
+
+  ```python
+  from pathlib import Path
+  interactive_panel = PanelManifest(
+      panel_id="myproj.pick_baseline",
+      module_url="/api/blocks/panels/myproj.pick_baseline/index.js",
+      asset_root=str(Path(__file__).parent / "pick_baseline"),  # dir holding index.js
+      version="1",
+  )
+  ```
+
+  `asset_root` is the on-disk directory (next to the block `.py`) holding the
+  panel files; it is served path-confined and never sent to the browser.
+  `module_url` is always `/api/blocks/panels/<panel_id>/<file>`. The module
+  exports `{ apiVersion: "1", mount(container, host) }`; `host.panelPayload` is
+  what `prepare_prompt` returned, `host.confirm(decision)` sends the JSON that
+  becomes `config["interactive_response"]`, and `host.cancel()` cancels the
+  block. `mount` returns `{ unmount() {...} }`.
+
+The registry rejects an interactive block that declares the mixin without the
+mode (or vice versa), omits `prepare_prompt`, or has no valid `interactive_panel`.
+
+## Hand off to an app (AppBlock) or a script (CodeBlock)
+
+- **AppBlock** (`scistudio.blocks.app`) — hand the step to a desktop GUI/CLI
+  program. Set `app_command` (the executable) and declare output ports
+  (optionally keyed by file extension); the block stages inputs to an exchange
+  dir, launches the tool, and packs the result files it writes back into
+  outputs. Override `prepare_launch(exchange_dir, output_dir, config)` only for
+  tools that need a generated config file and a custom argv. Reach for it when a
+  real tool (Fiji, a converter, an analysis GUI) already does the job better
+  than code.
+- **CodeBlock** (`scistudio.blocks.code`) — run a project-local script (Python,
+  R, shell, MATLAB, notebook) as a step without rewriting it as a block. The
+  user keeps their script; the block exchanges declared inputs/outputs through
+  files located by `SCISTUDIO_*` env vars. Reach for it to wrap an existing
+  analysis the user already trusts.
+
 ## Metadata (ClassVars)
 
 ```python

--- a/src/scistudio/_agent_reference/block-contract.md
+++ b/src/scistudio/_agent_reference/block-contract.md
@@ -17,12 +17,13 @@ a body. Imports come from canonical roots ([public-api.md](public-api.md)).
 ([public-api.md](public-api.md)). `base_category` is **inferred** from the parent
 class — never set it as a ClassVar (silently ignored).
 
-## Make it interactive (let the user decide in the GUI)
+## Interactive blocks (optional)
 
 Interaction is a **capability**, not a separate base class. Any category can
 pause mid-run, open a window onto its real input data, take a data-dependent
-decision from the user, and compute outputs from it — instead of hard-coding a
-choice that depends on looking at the data. Mix in `InteractiveMixin`, set
+decision from the user, and compute outputs from it. Use it when a value can
+only be judged by looking at the specific data; it is one option, not a default.
+Mix in `InteractiveMixin`, set
 `execution_mode = ExecutionMode.INTERACTIVE`, declare an `interactive_panel`,
 and override `prepare_prompt`. Import all four from `scistudio.blocks.base`
 (`InteractiveMixin`, `ExecutionMode`, `PanelManifest`, `InteractivePrompt`).

--- a/src/scistudio/_skills/scistudio/SKILL.md
+++ b/src/scistudio/_skills/scistudio/SKILL.md
@@ -29,11 +29,10 @@ deep work in that area.
   build or modify a pipeline.
 - **`scistudio-write-block`** — author a custom block subclassing `Block`
   (or `ProcessBlock` / `IOBlock` / `AppBlock` / `CodeBlock`), optionally
-  **interactive** (a block that pauses to let the user decide in the GUI).
-  `AIBlock` / `SubWorkflowBlock` are runtime base classes, not author extension
-  points. Use when the user wants new processing logic; ALWAYS check
-  `list_blocks` first and reuse a matching block. Prefer a config parameter or
-  an interactive panel over hard-coding a data-dependent decision.
+  **interactive** (it can pause to let the user decide in the GUI). `AIBlock` /
+  `SubWorkflowBlock` are runtime base classes, not author extension points.
+  Use when the user wants new processing logic; ALWAYS check `list_blocks`
+  first and reuse a matching block.
 - **`scistudio-debug-run`** — diagnose a failed or stuck run. Covers
   run-status inspection, block log retrieval, and lineage navigation.
 - **`scistudio-inspect-data`** — explore data references and previews

--- a/src/scistudio/_skills/scistudio/SKILL.md
+++ b/src/scistudio/_skills/scistudio/SKILL.md
@@ -28,10 +28,12 @@ deep work in that area.
   edge wiring, validation, run lifecycle). Use when the user wants to
   build or modify a pipeline.
 - **`scistudio-write-block`** — author a custom block subclassing `Block`
-  (or `ProcessBlock` / `IOBlock` / `AppBlock` / `CodeBlock`). `AIBlock` /
-  `SubWorkflowBlock` are runtime base classes, not author extension points.
-  Use when the user wants new processing logic; ALWAYS check `list_blocks`
-  first and reuse a matching block.
+  (or `ProcessBlock` / `IOBlock` / `AppBlock` / `CodeBlock`), optionally
+  **interactive** (a block that pauses to let the user decide in the GUI).
+  `AIBlock` / `SubWorkflowBlock` are runtime base classes, not author extension
+  points. Use when the user wants new processing logic; ALWAYS check
+  `list_blocks` first and reuse a matching block. Prefer a config parameter or
+  an interactive panel over hard-coding a data-dependent decision.
 - **`scistudio-debug-run`** — diagnose a failed or stuck run. Covers
   run-status inspection, block log retrieval, and lineage navigation.
 - **`scistudio-inspect-data`** — explore data references and previews

--- a/src/scistudio/_skills/scistudio/scistudio-write-block/SKILL.md
+++ b/src/scistudio/_skills/scistudio/scistudio-write-block/SKILL.md
@@ -27,6 +27,32 @@ Author a project-local custom block. This skill is the **task flow**; the block
 - **`.scistudio/agent-reference/package-discovery.md`** — using package types.
 - **`user-guide/api-reference/`** — exact signatures of every public symbol.
 
+## Choose the block shape — climb the accessibility ladder
+
+Your users drive blocks from the GUI; they are bench scientists, not your
+analyst. **Never hard-code a decision that depends on looking at the user's
+specific data.** The moment you catch yourself inspecting their data and baking
+in a constant — which rows are background, where a peak sits, a cutoff that
+"looks right" — stop and push that decision out to the user. A pipeline of
+`ProcessBlock`s with baked-in constants is the default failure mode; the user
+cannot change what you hid in code. Pick the lowest rung that fits:
+
+| Rung | Shape | Reach for it when |
+|---|---|---|
+| ❌ | hard-coded constant in the body | never, for a value that depends on the data |
+| 1 | **config parameter** (`config_schema` + `config.get`) | the user can set it without seeing the data (a default that is usually right, units they know) |
+| 2 | **interactive, built-in panel** | the choice is routing items (`core.interactive.data_router`) or fixing pairing (`core.interactive.pair_editor`) — no frontend code |
+| 3 | **interactive, custom panel** | the user must look at *their* data to decide — pick a baseline region on a trace, click a peak, set a threshold against a preview |
+| 4 | **AppBlock / CodeBlock** | an external GUI/CLI tool or an existing script the user already trusts does the job |
+
+Default to rung 1 — always cheap, always available. Climb to rung 3 when the
+decision is inherently visual or data-dependent: that is the line between a
+block that runs and one a scientist can actually use. (Example: an LCMS
+"subtract background" should not guess which scans are background from the data
+— it should open a panel and let the user mark the baseline region.) The
+interactive / App / Code authoring details are in `block-contract.md`; a compact
+interactive example is below.
+
 ## Non-negotiables (full detail in the reference docs)
 
 1. **Reuse first.** Call `mcp__scistudio__list_blocks` BEFORE authoring and
@@ -102,6 +128,93 @@ A package type is imported from the package top level
 (`from scistudio_blocks_spectroscopy import Spectrum`), never a deep path — see
 `package-discovery.md`.
 
+## Worked example — interactive block (rung 3, custom panel)
+
+When the decision needs the user's eyes on their own data, make the block
+interactive instead of guessing. Mix in `InteractiveMixin`, set
+`execution_mode = INTERACTIVE`, point `interactive_panel` at a panel file you
+write beside the block, build a JSON view in `prepare_prompt`, and read the
+user's choice in `run` from `config["interactive_response"]`. Full contract in
+`block-contract.md`.
+
+```python
+# blocks/pick_baseline.py — interactive: the user marks the baseline region.
+"""Subtract a baseline the user selects on the trace, instead of guessing it."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, ClassVar
+
+from scistudio.blocks.base import (
+    BlockConfig, ExecutionMode, InputPort, InteractiveMixin,
+    InteractivePrompt, OutputPort, PanelManifest,
+)
+from scistudio.blocks.process import ProcessBlock
+from scistudio.core.types import Array, Collection
+
+
+class PickBaseline(InteractiveMixin, ProcessBlock):
+    name: ClassVar[str] = "Pick Baseline"
+    description: ClassVar[str] = "Mark a baseline region on the trace, then subtract it."
+    input_ports: ClassVar[list[InputPort]] = [
+        InputPort(name="trace", accepted_types=[Array], required=True,
+                  description="Signal to baseline-correct"),
+    ]
+    output_ports: ClassVar[list[OutputPort]] = [
+        OutputPort(name="corrected", accepted_types=[Array],
+                   description="Trace with the selected baseline subtracted"),
+    ]
+    execution_mode: ClassVar[ExecutionMode] = ExecutionMode.INTERACTIVE
+    interactive_panel: ClassVar[PanelManifest] = PanelManifest(
+        panel_id="myproj.pick_baseline",
+        module_url="/api/blocks/panels/myproj.pick_baseline/index.js",
+        asset_root=str(Path(__file__).parent / "pick_baseline"),  # dir holding index.js
+        version="1",
+    )
+
+    def prepare_prompt(self, inputs: dict[str, Any], config: BlockConfig) -> InteractivePrompt:
+        # Reduce the REAL data to a small JSON view the window draws (downsample if large).
+        first = next(iter(inputs["trace"]))  # Collection is iterable; one item per length-1 batch
+        return InteractivePrompt(panel_payload={"y": first.to_memory().tolist()})
+
+    def run(self, inputs: dict[str, Any], config: BlockConfig) -> dict[str, Collection]:
+        region = config.get("interactive_response", {}).get("region", [0, 0])
+
+        def subtract(item: Array) -> Array:
+            data = item.to_memory()
+            lo, hi = int(region[0]), int(region[1])
+            baseline = data[lo:hi].mean() if hi > lo else 0.0
+            return Array(axes=list(item.axes), data=data - baseline)
+
+        return {"corrected": self.map_items(subtract, inputs["trace"])}
+```
+
+```javascript
+// blocks/pick_baseline/index.js — the window the block opens (plain ES module, no build step).
+export default {
+  apiVersion: "1",
+  mount(container, host) {
+    const y = host.panelPayload.y || [];           // what prepare_prompt returned
+    // A real panel draws `y` and lets the user drag a span; kept minimal here.
+    container.innerHTML =
+      `<p>Baseline region for a ${y.length}-point trace:</p>` +
+      `<input id="lo" type="number" placeholder="start index"> ` +
+      `<input id="hi" type="number" placeholder="end index"> ` +
+      `<button id="ok">Confirm</button> <button id="no">Cancel</button>`;
+    const val = (id) => Number(container.querySelector(id).value);
+    container.querySelector("#ok").onclick = () =>
+      host.confirm({ region: [val("#lo"), val("#hi")] });  // -> config["interactive_response"]
+    container.querySelector("#no").onclick = () => host.cancel();
+    return { unmount() { container.innerHTML = ""; } };
+  },
+};
+```
+
+For a routing or pairing interaction, skip the custom panel and reuse a built-in
+one (`PanelManifest(panel_id="core.interactive.data_router")` or
+`"core.interactive.pair_editor"`) — no JS to write. For an external tool or an
+existing script, use an `AppBlock` or `CodeBlock` instead (see `block-contract.md`).
+
 ## Make it usable — label everything the user sees
 
 The user drives your block from the GUI, where the only thing they see is the
@@ -143,12 +256,22 @@ it, surface it.
 - `list_types` before choosing port types; concrete types only.
 - Canonical-root imports only (`public-api.md`); no deep paths / `_support`.
 - Do not subclass `AIBlock` / `SubWorkflowBlock`; do not set `base_category`.
+- Never hard-code a data-dependent decision. Climb the shape ladder: config
+  parameter, then interactive (built-in or custom panel), then App/Code.
 - After `scaffold_block`, read every `warnings[]`. After writing, `reload_blocks`
   then `run_block_tests`; read the result `next_step`.
 
 ## Anti-patterns
 
 - Authoring without `list_blocks` first.
+- **Hard-coding a value read off the user's data** (background region, peak
+  location, a cutoff that "looks right") instead of a config param or an
+  interactive panel — the #1 reason agent-written blocks are unusable.
+- Reflexively chaining `ProcessBlock`s when an interactive, App, or Code block
+  would let the user steer the decision.
 - Deep-path or `_support` imports; bare `DataObject` ports on a non-generic block.
 - Subclassing `AIBlock`/`SubWorkflowBlock`, or setting `base_category`.
 - `run()` returning a non-dict; skipping `reload_blocks` / `run_block_tests`.
+- Interactive block missing its pair (`InteractiveMixin` without
+  `execution_mode=INTERACTIVE`, or no `prepare_prompt` / `interactive_panel`) —
+  the registry rejects it at scan time.

--- a/src/scistudio/_skills/scistudio/scistudio-write-block/SKILL.md
+++ b/src/scistudio/_skills/scistudio/scistudio-write-block/SKILL.md
@@ -16,42 +16,21 @@ description: |
 
 # scistudio-write-block
 
-Author a project-local custom block. This skill is the **task flow**; the block
-**contract** lives in the provisioned reference docs — read them, do not guess:
+Author a project-local custom block. This skill is the **task flow**; the
+**contract** and **worked patterns** live elsewhere — read them, do not guess:
 
-- **`.scistudio/agent-reference/block-contract.md`** — base classes, ports,
-  `config_schema`, `run` vs `process_item`, Collection helpers.
-- **`.scistudio/agent-reference/public-api.md`** — canonical import roots and the
-  rules below. Import from roots only.
+- **`.scistudio/agent-reference/block-contract.md`** — base classes; the optional
+  interactive / App / Code shapes; ports, `config_schema`, `run` vs
+  `process_item`, Collection helpers.
+- **`.scistudio/agent-reference/public-api.md`** — canonical import roots. Import
+  from roots only.
 - **`.scistudio/agent-reference/data-types.md`** — reading/constructing values.
 - **`.scistudio/agent-reference/package-discovery.md`** — using package types.
 - **`user-guide/api-reference/`** — exact signatures of every public symbol.
-
-## Choose the block shape — climb the accessibility ladder
-
-Your users drive blocks from the GUI; they are bench scientists, not your
-analyst. **Never hard-code a decision that depends on looking at the user's
-specific data.** The moment you catch yourself inspecting their data and baking
-in a constant — which rows are background, where a peak sits, a cutoff that
-"looks right" — stop and push that decision out to the user. A pipeline of
-`ProcessBlock`s with baked-in constants is the default failure mode; the user
-cannot change what you hid in code. Pick the lowest rung that fits:
-
-| Rung | Shape | Reach for it when |
-|---|---|---|
-| ❌ | hard-coded constant in the body | never, for a value that depends on the data |
-| 1 | **config parameter** (`config_schema` + `config.get`) | the user can set it without seeing the data (a default that is usually right, units they know) |
-| 2 | **interactive, built-in panel** | the choice is routing items (`core.interactive.data_router`) or fixing pairing (`core.interactive.pair_editor`) — no frontend code |
-| 3 | **interactive, custom panel** | the user must look at *their* data to decide — pick a baseline region on a trace, click a peak, set a threshold against a preview |
-| 4 | **AppBlock / CodeBlock** | an external GUI/CLI tool or an existing script the user already trusts does the job |
-
-Default to rung 1 — always cheap, always available. Climb to rung 3 when the
-decision is inherently visual or data-dependent: that is the line between a
-block that runs and one a scientist can actually use. (Example: an LCMS
-"subtract background" should not guess which scans are background from the data
-— it should open a panel and let the user mark the baseline region.) The
-interactive / App / Code authoring details are in `block-contract.md`; a compact
-interactive example is below.
+- **Worked patterns:** call `mcp__scistudio__list_block_examples` then
+  `mcp__scistudio__read_block_source` to read real, registered blocks for the
+  shape you need (process, io, app, code) and copy the pattern — do not invent a
+  shape the examples already show.
 
 ## Non-negotiables (full detail in the reference docs)
 
@@ -73,6 +52,23 @@ interactive example is below.
    are runtime base classes; for AI-in-workflow the user adds the built-in **AI
    Agent** block and configures it). Do not set `base_category` (it is inferred).
 
+## Block shapes
+
+A block need not be a plain `ProcessBlock`. These shapes are all available — none
+is preferred; pick whichever fits, and reach for a richer one only when it
+genuinely helps the user. See `block-contract.md` for how to author each.
+
+- **config parameter** — expose a tunable in `config_schema` and read it with
+  `config.get(...)` so the user can reach it. Prefer this over a buried constant
+  for a value the user may want to change; hard-coding is fine when the value is
+  intrinsic or just a convenient default.
+- **interactive (optional)** — a block can pause and let the user make a
+  data-dependent decision in the GUI (route items, mark a region). Reuse a
+  built-in panel (`core.interactive.data_router`, `core.interactive.pair_editor`)
+  or ship a small custom panel.
+- **AppBlock / CodeBlock** — hand the step to an external GUI/CLI tool, or to a
+  project-local script.
+
 ## Tool-call sequence
 
 ```
@@ -89,132 +85,6 @@ mcp__scistudio__run_block_tests type_name="<registered name>"   # read pytest ou
 `category` → parent: `process`→ProcessBlock, `io`→IOBlock, `app`→AppBlock,
 `code`→CodeBlock. Every write-class tool returns a `next_step` — read and follow.
 
-## Worked example
-
-A minimal `ProcessBlock` (one item → one item). Adapt names/algorithm; for IO,
-App, and Code blocks see `block-contract.md`.
-
-```python
-# blocks/scale_image.py — project-local custom block.
-"""Scale every image in the batch by a gain factor."""
-from __future__ import annotations
-
-from typing import Any, ClassVar
-
-from scistudio.blocks.base import BlockConfig, InputPort, OutputPort
-from scistudio.blocks.process import ProcessBlock
-from scistudio.core.types import Array
-
-
-class ScaleImage(ProcessBlock):
-    name: ClassVar[str] = "Scale Image"
-    description: ClassVar[str] = "Multiply each image by a gain factor."
-    input_ports: ClassVar[list[InputPort]] = [
-        InputPort(name="input", accepted_types=[Array], required=True),
-    ]
-    output_ports: ClassVar[list[OutputPort]] = [
-        OutputPort(name="output", accepted_types=[Array]),
-    ]
-    config_schema: ClassVar[dict[str, Any]] = {
-        "type": "object",
-        "properties": {"gain": {"type": "number", "default": 1.0}},
-    }
-
-    def process_item(self, item: Array, config: BlockConfig, state: Any = None) -> Array:
-        return Array(axes=list(item.axes), data=item.to_memory() * config.get("gain", 1.0))
-```
-
-A package type is imported from the package top level
-(`from scistudio_blocks_spectroscopy import Spectrum`), never a deep path — see
-`package-discovery.md`.
-
-## Worked example — interactive block (rung 3, custom panel)
-
-When the decision needs the user's eyes on their own data, make the block
-interactive instead of guessing. Mix in `InteractiveMixin`, set
-`execution_mode = INTERACTIVE`, point `interactive_panel` at a panel file you
-write beside the block, build a JSON view in `prepare_prompt`, and read the
-user's choice in `run` from `config["interactive_response"]`. Full contract in
-`block-contract.md`.
-
-```python
-# blocks/pick_baseline.py — interactive: the user marks the baseline region.
-"""Subtract a baseline the user selects on the trace, instead of guessing it."""
-from __future__ import annotations
-
-from pathlib import Path
-from typing import Any, ClassVar
-
-from scistudio.blocks.base import (
-    BlockConfig, ExecutionMode, InputPort, InteractiveMixin,
-    InteractivePrompt, OutputPort, PanelManifest,
-)
-from scistudio.blocks.process import ProcessBlock
-from scistudio.core.types import Array, Collection
-
-
-class PickBaseline(InteractiveMixin, ProcessBlock):
-    name: ClassVar[str] = "Pick Baseline"
-    description: ClassVar[str] = "Mark a baseline region on the trace, then subtract it."
-    input_ports: ClassVar[list[InputPort]] = [
-        InputPort(name="trace", accepted_types=[Array], required=True,
-                  description="Signal to baseline-correct"),
-    ]
-    output_ports: ClassVar[list[OutputPort]] = [
-        OutputPort(name="corrected", accepted_types=[Array],
-                   description="Trace with the selected baseline subtracted"),
-    ]
-    execution_mode: ClassVar[ExecutionMode] = ExecutionMode.INTERACTIVE
-    interactive_panel: ClassVar[PanelManifest] = PanelManifest(
-        panel_id="myproj.pick_baseline",
-        module_url="/api/blocks/panels/myproj.pick_baseline/index.js",
-        asset_root=str(Path(__file__).parent / "pick_baseline"),  # dir holding index.js
-        version="1",
-    )
-
-    def prepare_prompt(self, inputs: dict[str, Any], config: BlockConfig) -> InteractivePrompt:
-        # Reduce the REAL data to a small JSON view the window draws (downsample if large).
-        first = next(iter(inputs["trace"]))  # Collection is iterable; one item per length-1 batch
-        return InteractivePrompt(panel_payload={"y": first.to_memory().tolist()})
-
-    def run(self, inputs: dict[str, Any], config: BlockConfig) -> dict[str, Collection]:
-        region = config.get("interactive_response", {}).get("region", [0, 0])
-
-        def subtract(item: Array) -> Array:
-            data = item.to_memory()
-            lo, hi = int(region[0]), int(region[1])
-            baseline = data[lo:hi].mean() if hi > lo else 0.0
-            return Array(axes=list(item.axes), data=data - baseline)
-
-        return {"corrected": self.map_items(subtract, inputs["trace"])}
-```
-
-```javascript
-// blocks/pick_baseline/index.js — the window the block opens (plain ES module, no build step).
-export default {
-  apiVersion: "1",
-  mount(container, host) {
-    const y = host.panelPayload.y || [];           // what prepare_prompt returned
-    // A real panel draws `y` and lets the user drag a span; kept minimal here.
-    container.innerHTML =
-      `<p>Baseline region for a ${y.length}-point trace:</p>` +
-      `<input id="lo" type="number" placeholder="start index"> ` +
-      `<input id="hi" type="number" placeholder="end index"> ` +
-      `<button id="ok">Confirm</button> <button id="no">Cancel</button>`;
-    const val = (id) => Number(container.querySelector(id).value);
-    container.querySelector("#ok").onclick = () =>
-      host.confirm({ region: [val("#lo"), val("#hi")] });  // -> config["interactive_response"]
-    container.querySelector("#no").onclick = () => host.cancel();
-    return { unmount() { container.innerHTML = ""; } };
-  },
-};
-```
-
-For a routing or pairing interaction, skip the custom panel and reuse a built-in
-one (`PanelManifest(panel_id="core.interactive.data_router")` or
-`"core.interactive.pair_editor"`) — no JS to write. For an external tool or an
-existing script, use an `AppBlock` or `CodeBlock` instead (see `block-contract.md`).
-
 ## Make it usable — label everything the user sees
 
 The user drives your block from the GUI, where the only thing they see is the
@@ -229,26 +99,11 @@ all typed `Image` with no names/descriptions are unusable):
 | Each parameter panel field | the `config_schema` property's `title` (the label) **and** `description` (what it does / units / when to change it) |
 | In the code | short, plain comments explaining the *why*, not the obvious |
 
-```python
-input_ports = [
-    InputPort(name="image",   accepted_types=[Image], description="Image to segment"),
-    InputPort(name="markers", accepted_types=[Image], description="Seed markers for watershed"),
-]
-config_schema = {"type": "object", "properties": {
-    "sigma": {"type": "number", "default": 1.0,
-              "title": "Smoothing (sigma)", "description": "Gaussian blur before thresholding; 0 disables."},
-}}
-```
-
-Keep it terse but specific. Distinct names + a one-line description per port and
-per parameter is the bar.
-
-**Expose tunables as config, never hard-code them.** Any value a user might
-reasonably want to choose — a processing parameter, threshold, window size,
-method choice — goes in `config_schema` (with a `title`/`description` and a sane
-`default`) and is read in the body with `config.get(...)`. Do not bury a tunable
-constant in the code where the user cannot reach it; if they might want to change
-it, surface it.
+Distinct names + a one-line description per port and per parameter is the bar.
+A value the user may reasonably want to change usually belongs in `config_schema`
+(with a `title`/`description` and a sane `default`) rather than buried as an
+unreachable constant — though a hard-coded value is fine when it is intrinsic or
+a convenient default.
 
 ## Mandatory rules
 
@@ -256,22 +111,15 @@ it, surface it.
 - `list_types` before choosing port types; concrete types only.
 - Canonical-root imports only (`public-api.md`); no deep paths / `_support`.
 - Do not subclass `AIBlock` / `SubWorkflowBlock`; do not set `base_category`.
-- Never hard-code a data-dependent decision. Climb the shape ladder: config
-  parameter, then interactive (built-in or custom panel), then App/Code.
 - After `scaffold_block`, read every `warnings[]`. After writing, `reload_blocks`
   then `run_block_tests`; read the result `next_step`.
 
 ## Anti-patterns
 
 - Authoring without `list_blocks` first.
-- **Hard-coding a value read off the user's data** (background region, peak
-  location, a cutoff that "looks right") instead of a config param or an
-  interactive panel — the #1 reason agent-written blocks are unusable.
-- Reflexively chaining `ProcessBlock`s when an interactive, App, or Code block
-  would let the user steer the decision.
 - Deep-path or `_support` imports; bare `DataObject` ports on a non-generic block.
 - Subclassing `AIBlock`/`SubWorkflowBlock`, or setting `base_category`.
 - `run()` returning a non-dict; skipping `reload_blocks` / `run_block_tests`.
-- Interactive block missing its pair (`InteractiveMixin` without
-  `execution_mode=INTERACTIVE`, or no `prepare_prompt` / `interactive_panel`) —
-  the registry rejects it at scan time.
+- An interactive block declaring `InteractiveMixin` without
+  `execution_mode=INTERACTIVE` (or vice versa), or missing `prepare_prompt` /
+  `interactive_panel` — the registry rejects it at scan time.

--- a/tests/api/test_interactive_panels.py
+++ b/tests/api/test_interactive_panels.py
@@ -82,3 +82,67 @@ def test_panel_asset_route_rejects_path_escape(tmp_path: Path) -> None:
     with pytest.raises(HTTPException) as exc:
         asyncio.run(serve_panel_asset("pkg.interactive.panel", "../secret.js", registry))
     assert exc.value.status_code == 404
+
+
+# A project-local (tier-1) interactive block whose custom panel lives beside the
+# block .py (asset_root = Path(__file__).parent / "<dir>") — the exact shape the
+# scistudio-write-block skill teaches agents to author. The cases above cover
+# tier-1 registration and packaged-panel serving separately, against a faked
+# registry; this proves the combination end to end through a REAL tier-1 scan.
+_PROJECT_LOCAL_PANEL_BLOCK = """
+from pathlib import Path
+from scistudio.blocks.base import (
+    ExecutionMode, InteractiveMixin, InteractivePrompt, PanelManifest,
+)
+from scistudio.blocks.process import ProcessBlock
+
+
+class ProjectLocalPanelBlock(InteractiveMixin, ProcessBlock):
+    name = "ProjectLocalPanelBlock"
+    execution_mode = ExecutionMode.INTERACTIVE
+    interactive_panel = PanelManifest(
+        panel_id="proj.pick_baseline",
+        module_url="/api/blocks/panels/proj.pick_baseline/index.js",
+        asset_root=str(Path(__file__).parent / "pick_baseline"),
+        version="1",
+    )
+
+    def prepare_prompt(self, inputs, config):
+        return InteractivePrompt(panel_payload={"ok": True})
+
+    def run(self, inputs, config):
+        return {}
+"""
+
+
+def test_project_local_interactive_block_panel_registers_and_serves(tmp_path: Path) -> None:
+    """#1882: a tier-1 dropin with a project-relative asset_root registers and serves its panel.
+
+    The write-block skill tells agents to author a project-local interactive
+    block whose custom panel sits next to the block .py. Prove that path: a real
+    tier-1 scan registers the block with ``panel_asset_root`` resolving into the
+    project (and off the wire), and ``serve_panel_asset`` serves ``index.js``
+    from it through the real registry.
+    """
+    scan_dir = tmp_path / "blocks"
+    scan_dir.mkdir()
+    (scan_dir / "project_local_panel.py").write_text(_PROJECT_LOCAL_PANEL_BLOCK, encoding="utf-8")
+    panel_dir = scan_dir / "pick_baseline"
+    panel_dir.mkdir()
+    (panel_dir / "index.js").write_text("export default { apiVersion: '1', mount() {} };", encoding="utf-8")
+
+    registry = BlockRegistry()
+    registry.add_scan_dir(scan_dir)
+    registry._scan_tier1()
+
+    spec = registry.get_spec("ProjectLocalPanelBlock")
+    assert spec is not None, "project-local interactive block did not register"
+    assert spec.execution_mode == "interactive"
+    # Server-only asset_root resolves into the project; never serialized to the wire.
+    assert spec.panel_asset_root == str(panel_dir)
+    assert "asset_root" not in (spec.panel_manifest or {})
+
+    # The panel route serves the project-local index.js through the real registry.
+    response = asyncio.run(serve_panel_asset("proj.pick_baseline", "index.js", registry))
+    assert Path(response.path) == (panel_dir / "index.js").resolve()
+    assert response.media_type in {"text/javascript", "application/javascript"}


### PR DESCRIPTION
## What

Optimize the in-app AI agent's `scistudio-write-block` skill so it stops
defaulting to chains of `ProcessBlock`s with baked-in constants and instead
reaches for the user-friendlier block shapes SciStudio already offers.

Trigger: when a value depends on *looking at the user's specific data* (e.g. an
LCMS "subtract background" picking which scans are baseline), the agent would
hard-code it. Now the skill teaches it to push that decision out to the user.

## Changes (pure agent skill / reference docs + one test)

- **`scistudio-write-block/SKILL.md`** — a block-shape **accessibility ladder**
  (hard-coded ❌ → config param → interactive built-in panel → interactive
  custom panel → App/Code) and the principle *never hard-code a data-dependent
  decision*; a worked example for an interactive block with a custom
  vanilla-JS panel (Python + `index.js`); updated mandatory rules / anti-patterns.
- **`_agent_reference/block-contract.md`** — new **interactive capability**
  section (`InteractiveMixin` / `execution_mode=INTERACTIVE` / `prepare_prompt`
  / `PanelManifest`, built-in vs custom panels) and AppBlock / CodeBlock detail.
- **base `SKILL.md`** — index note that blocks can be interactive and the
  no-hard-code rule.
- **`tests/api/test_interactive_panels.py`** — end-to-end test that a
  project-local (tier-1) interactive block with a project-relative custom panel
  `asset_root` registers and serves its panel (the exact path the skill now
  teaches; previously only covered for packaged panels against a faked registry).

## Out of scope

- Package API-reference visibility for the agent — owner's separate PR #1881 (#1880).
- GUI starter template and any `src/scistudio/blocks/**` change (protected core).

## Notes

No protected-core paths; no governance surface. Stays Tier 2. Local gate
reconciliation passed; 4 unrelated image/previewer tests fail only from
local user-plugin registry leakage and pass under a clean HOME (CI-equivalent).

Gate record: .workflow/records/1882-guided-1882-agent-block-shape-skill.json

Closes #1882
