### PR TITLE
feat(#1887): show block detail popover on canvas node hover

### DIFF
--- a/.workflow/records/1887-guided-1887-canvas-block-hover-detail.json
+++ b/.workflow/records/1887-guided-1887-canvas-block-hover-detail.json
@@ -1,0 +1,655 @@
+{
+  "branch": "guided/1887-canvas-block-hover-detail",
+  "check_events": [
+    {
+      "at": "2026-06-30T16:32:35.783554Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:bee0017f30f552d2df2de1173f9ac14b9aee5192ca5e5c1de574bb119512b275",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-30T16:32:41.953672Z",
+      "command": "(cd frontend && npm run check:ci)",
+      "covered_surface": "frontend",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:45e3840231dbbcc8d8e895e95f3f0257da85e0a61bc8cf020c7ff98a95da7c36",
+      "name": "frontend",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/frontend.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-30T16:32:46.394079Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:a274d111fae4798c9e06813eea1945b01d9107ad9dd6ef24f5707584078dab2d",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-30T16:32:46.472608Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e31351abfc33f0b3c0f28bc9f2f3d59ae3bc5d4925dc1159a7f931aa932441ed",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-30T16:35:27.981371Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:6a008f30642d3be5c7474922c0f2a508864f689291233142c6a73506be8cf6e5",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-30T16:36:37.001621Z",
+      "command": "(cd frontend && npm run check:ci)",
+      "covered_surface": "frontend",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:5d03f1d536f339037d49a5ddeaea9bfa967a4e06ba0ecf42f4944d8d4bc3e106",
+      "name": "frontend",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/frontend.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-30T16:36:41.222728Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:4133f07ee39bf43c7232fcc045129050a3a19013a79d2ac83815e8dc409fbd03",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-30T16:39:07.668341Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:bbc207cd680e0c7af0174747865673a59515e51421f9cbcd32c43bb3cbb5bfc8",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    }
+  ],
+  "check_na": [],
+  "commit": {
+    "sha": "afdb790fbe0737500dff42264e7ef697ad035d20",
+    "shas": [
+      "afdb790fbe0737500dff42264e7ef697ad035d20"
+    ],
+    "trailers": []
+  },
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "frontend/src/components/BlockDetailPopover.tsx",
+      "frontend/src/components/BlockPalette.tsx",
+      "frontend/src/components/BlockPalette.parts/BlockDetailPopover.tsx",
+      "frontend/src/components/nodes/BlockNode.tsx",
+      "frontend/src/components/nodes/BlockNode.parts/nodeDetailAnchor.ts",
+      "frontend/src/**/__tests__/**",
+      "docs/specs/frontend-block-palette.md"
+    ]
+  },
+  "directive_events": [
+    {
+      "at": "2026-06-30T16:31:20.404758Z",
+      "owner_directive": "Canvas block nodes reuse the shared BlockDetailPopover on hover (400ms dwell, right-side anchor flipping left near the viewport edge); popover moved to components/ and shared with the palette.",
+      "reason": "plan"
+    }
+  ],
+  "docs_events": [
+    {
+      "at": "2026-06-30T16:31:20.404940Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/specs/frontend-block-palette.md",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": false,
+  "guard_events": [
+    {
+      "at": "2026-06-30T16:35:28.054429Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T16:35:28.066500Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T16:35:28.078321Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T16:35:28.089583Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T16:35:28.100594Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T16:35:28.112848Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T16:35:28.124677Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T16:35:28.141656Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T16:35:28.153128Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T16:35:28.166910Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T16:39:07.738474Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T16:39:07.750216Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T16:39:07.761940Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T16:39:07.774560Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T16:39:07.785727Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T16:39:07.796967Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T16:39:07.808079Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T16:39:07.822590Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T16:39:07.834213Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T16:39:07.847664Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T16:39:29.374020Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T16:39:29.385077Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T16:39:29.395270Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T16:39:29.405590Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T16:39:29.417573Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T16:39:29.427882Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T16:39:29.438200Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T16:39:29.450045Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T16:39:29.460821Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T16:39:29.473453Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T16:39:41.345499Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T16:39:41.356147Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T16:39:41.366650Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T16:39:41.376980Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T16:39:41.388538Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T16:39:41.400005Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T16:39:41.410276Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T16:39:41.420725Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T16:39:41.431215Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T16:39:41.443917Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1887,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": {
+    "base": "origin/main",
+    "base_sha": "751d6574",
+    "changed_files": [
+      ".workflow/records/1887-guided-1887-canvas-block-hover-detail.json",
+      "docs/specs/frontend-block-palette.md",
+      "frontend/src/components/BlockDetailPopover.tsx",
+      "frontend/src/components/BlockPalette.test.tsx",
+      "frontend/src/components/BlockPalette.tsx",
+      "frontend/src/components/nodes/BlockNode.parts/nodeDetailAnchor.test.ts",
+      "frontend/src/components/nodes/BlockNode.parts/nodeDetailAnchor.ts",
+      "frontend/src/components/nodes/BlockNode.tsx",
+      "frontend/src/components/nodes/__tests__/BlockNode/hoverDetail.test.tsx"
+    ],
+    "diff_fingerprint": "sha256:aaa1e448d8ed7c986ff7860ea0b21ea4e050c81f6e5244d006cddf323775ef7b",
+    "head": "HEAD",
+    "head_sha": "afdb790f",
+    "surfaces": {
+      "docs": 1,
+      "frontend": 7,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 7,
+      "packaging": 0,
+      "protected_core": 0,
+      "sentrux": 8,
+      "test": 3,
+      "workflow_ci": 0
+    }
+  },
+  "owner_directive": "Add a block detail hover popover on canvas block nodes, mirroring the palette hover detail. Reuse BlockDetailPopover (move it to a shared location), show after ~400ms dwell, anchored to the right of the node and flipping left near the viewport edge.",
+  "persona": "live_implementer",
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [
+      1887
+    ],
+    "number": null,
+    "url": null
+  },
+  "reconcile_events": [
+    {
+      "at": "2026-06-30T16:35:28.167126Z",
+      "diff_fingerprint": "sha256:d7c892fd176ea0e40a19f4672bfb51796ed9918e04189054966b82ae2858a6b4",
+      "mode": "local",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.frontend"
+      ]
+    },
+    {
+      "at": "2026-06-30T16:39:07.847704Z",
+      "diff_fingerprint": "sha256:aaa1e448d8ed7c986ff7860ea0b21ea4e050c81f6e5244d006cddf323775ef7b",
+      "mode": "local",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-30T16:39:29.473491Z",
+      "diff_fingerprint": "sha256:aaa1e448d8ed7c986ff7860ea0b21ea4e050c81f6e5244d006cddf323775ef7b",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-30T16:39:41.443952Z",
+      "diff_fingerprint": "sha256:aaa1e448d8ed7c986ff7860ea0b21ea4e050c81f6e5244d006cddf323775ef7b",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    }
+  ],
+  "record_id": "1887-guided-1887-canvas-block-hover-detail",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [
+      "format_check",
+      "frontend",
+      "full_audit",
+      "lint_format",
+      "semantic_dup"
+    ],
+    "docs": [
+      "docs_required_or_na"
+    ],
+    "guards": [
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": [
+      "changed_test_required"
+    ]
+  },
+  "runtime": "claude-code",
+  "schema_version": 2,
+  "scope_events": [
+    {
+      "action": "add-include",
+      "at": "2026-06-30T16:31:20.404922Z",
+      "pattern": "frontend/src/components/BlockPalette.test.tsx",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-30T16:31:20.404928Z",
+      "pattern": "frontend/src/components/nodes/BlockNode.parts/nodeDetailAnchor.test.ts",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-30T16:31:20.404930Z",
+      "pattern": "frontend/src/components/nodes/__tests__/BlockNode/hoverDetail.test.tsx",
+      "reason": "plan"
+    }
+  ],
+  "session_id": "1bb4a543-8c29-4ec4-991e-2c780eaeaf5a",
+  "strictness_tier": 2,
+  "task_kind": "guided",
+  "test_events": [
+    {
+      "at": "2026-06-30T16:31:20.404959Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/components/nodes/BlockNode.parts/nodeDetailAnchor.test.ts",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-30T16:31:20.404962Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/components/nodes/__tests__/BlockNode/hoverDetail.test.tsx",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/.workflow/records/1887-guided-1887-canvas-block-hover-detail.json
+++ b/.workflow/records/1887-guided-1887-canvas-block-hover-detail.json
@@ -124,13 +124,58 @@
       "status": "pass",
       "summary": "clean",
       "tool_versions": {}
+    },
+    {
+      "at": "2026-06-30T20:49:19.251517Z",
+      "command": "(cd frontend && npm run check:ci)",
+      "covered_surface": "frontend",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:78bd3c609664b2555814c613ecbd764c1b7a96480b95418d70c7c1d8dda858e6",
+      "name": "frontend",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/frontend.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-30T20:49:23.730507Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:f0a8ffa048cb57242a558fdb4de67ea902b420441781c4bdf9bebfe4e49e8a31",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-30T20:53:29.507596Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:998df8574cfa1a8870911e2ff82b7a8fd97ead2278715234b939cd6ab3030ea8",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
     }
   ],
   "check_na": [],
   "commit": {
-    "sha": "e798532d61216b9a194b0e889a1db6d8392df4d2",
+    "sha": "0c73d4db34c663e8ebc53876d18f1e3abbfd42bc",
     "shas": [
-      "e798532d61216b9a194b0e889a1db6d8392df4d2"
+      "0c73d4db34c663e8ebc53876d18f1e3abbfd42bc"
     ],
     "trailers": []
   },
@@ -151,6 +196,11 @@
       "at": "2026-06-30T16:31:20.404758Z",
       "owner_directive": "Canvas block nodes reuse the shared BlockDetailPopover on hover (400ms dwell, right-side anchor flipping left near the viewport edge); popover moved to components/ and shared with the palette.",
       "reason": "plan"
+    },
+    {
+      "at": "2026-06-30T20:46:17.121294Z",
+      "owner_directive": "Render the canvas hover popover outside ReactFlow's transforms \u2014 portal it to document.body so position:fixed uses the real viewport coordinate space that getBoundingClientRect() returns.",
+      "reason": "Owner-reported P2: position:fixed popover is offset under ReactFlow's transformed viewport after pan/zoom"
     }
   ],
   "docs_events": [
@@ -738,6 +788,170 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:53:29.585876Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:53:29.604412Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:53:29.624200Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:53:29.646565Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:53:29.671568Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:53:29.689449Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:53:29.711118Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:53:29.729001Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:53:29.745017Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:53:29.775297Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:53:38.649631Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:53:38.674249Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:53:38.693126Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:53:38.711335Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:53:38.735570Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:53:38.752882Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:53:38.776627Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:53:38.793843Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:53:38.815735Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:53:38.838705Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -763,9 +977,9 @@
       "frontend/src/components/nodes/BlockNode.tsx",
       "frontend/src/components/nodes/__tests__/BlockNode/hoverDetail.test.tsx"
     ],
-    "diff_fingerprint": "sha256:604ac6e74a787f30257a4751792eaf15da341d8446f619d44338a74c1b8e223b",
+    "diff_fingerprint": "sha256:c06e61df5984cdaa54dc30b40e8a74bed058daaeba81c9f6bdc18f4e0e2d305e",
     "head": "HEAD",
-    "head_sha": "e798532d",
+    "head_sha": "0c73d4db",
     "surfaces": {
       "docs": 1,
       "frontend": 7,
@@ -843,6 +1057,22 @@
     {
       "at": "2026-06-30T16:40:50.859368Z",
       "diff_fingerprint": "sha256:604ac6e74a787f30257a4751792eaf15da341d8446f619d44338a74c1b8e223b",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-30T20:53:29.775374Z",
+      "diff_fingerprint": "sha256:c06e61df5984cdaa54dc30b40e8a74bed058daaeba81c9f6bdc18f4e0e2d305e",
+      "mode": "local",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-30T20:53:38.838771Z",
+      "diff_fingerprint": "sha256:c06e61df5984cdaa54dc30b40e8a74bed058daaeba81c9f6bdc18f4e0e2d305e",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 2,

--- a/.workflow/records/1887-guided-1887-canvas-block-hover-detail.json
+++ b/.workflow/records/1887-guided-1887-canvas-block-hover-detail.json
@@ -128,9 +128,9 @@
   ],
   "check_na": [],
   "commit": {
-    "sha": "afdb790fbe0737500dff42264e7ef697ad035d20",
+    "sha": "e798532d61216b9a194b0e889a1db6d8392df4d2",
     "shas": [
-      "afdb790fbe0737500dff42264e7ef697ad035d20"
+      "e798532d61216b9a194b0e889a1db6d8392df4d2"
     ],
     "trailers": []
   },
@@ -492,6 +492,252 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-06-30T16:40:27.221232Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T16:40:27.232207Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T16:40:27.242672Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T16:40:27.252229Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T16:40:27.262879Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T16:40:27.273392Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T16:40:27.283670Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T16:40:27.294831Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T16:40:27.305213Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T16:40:27.317626Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T16:40:37.960142Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T16:40:37.971154Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T16:40:37.981036Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T16:40:37.991118Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T16:40:38.001594Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T16:40:38.012206Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T16:40:38.021953Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T16:40:38.032999Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T16:40:38.043187Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T16:40:38.055845Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T16:40:50.759997Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T16:40:50.770251Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T16:40:50.781061Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T16:40:50.791363Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T16:40:50.801373Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T16:40:50.811925Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T16:40:50.822480Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T16:40:50.833469Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T16:40:50.845887Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T16:40:50.859338Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -504,7 +750,7 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "origin/main",
+    "base": "751d6574272d609bd3eb97797a7be2a0a169a7c7",
     "base_sha": "751d6574",
     "changed_files": [
       ".workflow/records/1887-guided-1887-canvas-block-hover-detail.json",
@@ -517,9 +763,9 @@
       "frontend/src/components/nodes/BlockNode.tsx",
       "frontend/src/components/nodes/__tests__/BlockNode/hoverDetail.test.tsx"
     ],
-    "diff_fingerprint": "sha256:aaa1e448d8ed7c986ff7860ea0b21ea4e050c81f6e5244d006cddf323775ef7b",
+    "diff_fingerprint": "sha256:604ac6e74a787f30257a4751792eaf15da341d8446f619d44338a74c1b8e223b",
     "head": "HEAD",
-    "head_sha": "afdb790f",
+    "head_sha": "e798532d",
     "surfaces": {
       "docs": 1,
       "frontend": 7,
@@ -540,7 +786,7 @@
     "closes": [
       1887
     ],
-    "number": null,
+    "number": 1888,
     "url": null
   },
   "reconcile_events": [
@@ -573,6 +819,30 @@
     {
       "at": "2026-06-30T16:39:41.443952Z",
       "diff_fingerprint": "sha256:aaa1e448d8ed7c986ff7860ea0b21ea4e050c81f6e5244d006cddf323775ef7b",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-30T16:40:27.317681Z",
+      "diff_fingerprint": "sha256:604ac6e74a787f30257a4751792eaf15da341d8446f619d44338a74c1b8e223b",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-30T16:40:38.055898Z",
+      "diff_fingerprint": "sha256:604ac6e74a787f30257a4751792eaf15da341d8446f619d44338a74c1b8e223b",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-30T16:40:50.859368Z",
+      "diff_fingerprint": "sha256:604ac6e74a787f30257a4751792eaf15da341d8446f619d44338a74c1b8e223b",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 2,

--- a/docs/specs/frontend-block-palette.md
+++ b/docs/specs/frontend-block-palette.md
@@ -227,6 +227,13 @@ trigger; it does not change the popover's content or the palette behavior above.
   card would overflow the right viewport edge (clamped off the left edge), and
   clamp the top into `[gap, viewportHeight − maxHeight]`. Reading the live
   on-screen rect keeps placement correct under any zoom/pan.
+- **Portalled outside ReactFlow.** The popover is rendered through a React
+  portal to `document.body`, not inline in the node subtree. ReactFlow's
+  viewport applies a CSS `transform`, which makes it the containing block for a
+  `position: fixed` descendant; rendering the popover inside it would place the
+  card in the transformed coordinate space and drift it from the node after
+  pan/zoom. Portalling to `<body>` restores the real viewport coordinate space
+  that the `getBoundingClientRect()`-derived anchor is expressed in.
 - **Coexistence.** The detail popover floats to the side of the 104×104 square;
   the existing `NodeActionToolbar` floats above it (ADR-050 §2.2). They do not
   overlap and both may be visible on hover.

--- a/docs/specs/frontend-block-palette.md
+++ b/docs/specs/frontend-block-palette.md
@@ -24,7 +24,7 @@ scope:
     - Backend or schema changes (none — base_category, subcategory, ports, direction already exist on BlockSummary).
     - Per-block custom icons (still tracked as the categoryVisuals follow-up; palette keeps the category-icon fallback).
     - Plugin-shipped loader/saver blocks as distinct palette entries (consolidated into the unified core Load/Save).
-    - Canvas BlockNode rendering (unchanged; this spec only consumes its categoryVisuals table).
+    - Canvas BlockNode rendering (unchanged by #1797; §10 amendment (#1887) later reuses the shared hover-detail popover on canvas nodes).
     - Collapsed/rail palette mode redesign (the collapsed prop is preserved as-is, not re-themed).
 governs:
   modules:
@@ -146,10 +146,17 @@ non-interactive (display only). It replaces the information previously shown
 always-on (description) and adds the typed port contract, which the old text
 `X in / Y out` line did not convey.
 
+The popover is implemented as a standalone display-only component
+(`components/BlockDetailPopover.tsx`, testid `block-detail-popover`) taking a
+`BlockSummary` and a viewport-space `{ left, top }` anchor. It is shared with
+the canvas, which reuses it for the on-node hover detail (§10, #1887).
+
 ## 7. Out Of Scope
 
 - No backend, schema, or `BlockSummary` contract change.
-- No change to `categoryVisuals.ts` (consumed read-only) or to the canvas node.
+- No change to `categoryVisuals.ts` (consumed read-only). The original #1797 work
+  left the canvas node untouched; the §10 amendment (#1887) later reuses the
+  shared popover on canvas nodes without otherwise changing node rendering.
 - Per-block custom icons remain the separately tracked `categoryVisuals` follow-up.
 - Collapsed/rail palette mode keeps its current minimal rendering; only the
   expanded palette is redesigned.
@@ -173,6 +180,11 @@ Component behavior is covered by the rewritten `BlockPalette.test.tsx`:
 - Activating a category chip filters the visible tiles.
 - Hovering a tile reveals the detail popover with description and port signature.
 
+Canvas hover-detail behavior (§10, #1887) is covered by
+`nodes/BlockNode.parts/nodeDetailAnchor.test.ts` (right/left flip + top clamp of
+the anchor) and `nodes/__tests__/BlockNode/hoverDetail.test.tsx` (dwell-delayed
+open, description + typed ports, dismiss on leave, no-op without a summary).
+
 ## 9. Reload Flash
 
 The palette Reload control gives an at-a-glance confirmation that the catalog
@@ -191,3 +203,32 @@ nodes), so both side panels share one consistent reload feedback.
 
 The hook is covered by `frontend/src/hooks/__tests__/useReloadFlash.test.ts`;
 the palette wiring is covered by `BlockPalette.test.tsx`.
+
+## 10. Canvas Node Hover Detail (#1887 Amendment)
+
+Hovering a placed block node on the workflow canvas opens the same hover-detail
+popover the palette uses, so a user can recall what a block does and its port
+types without opening the BottomPanel Config tab. This amendment adds the canvas
+trigger; it does not change the popover's content or the palette behavior above.
+
+- **Reuse, not reimplementation.** The canvas renders the shared
+  `BlockDetailPopover` (§6) with the node's existing `data.summary`
+  (`BlockSummary`). No new fetch or backend change — the summary is already
+  carried on the node.
+- **Trigger and dwell.** The popover opens after a ~400ms hover dwell — longer
+  than the palette's ~150ms so it does not flash while the user wires or drags
+  nodes — and dismisses immediately when the cursor leaves the node. It is
+  display-only and `pointer-events-none`.
+- **Anchor (canvas-specific).** Unlike the palette (fixed left rail, always
+  opens right), a canvas node can sit anywhere and the canvas pans/zooms, so the
+  anchor is computed from the node's on-screen bounding rect by
+  `computeNodeDetailAnchor` (`nodes/BlockNode.parts/nodeDetailAnchor.ts`):
+  prefer the right side with an 8px gap, flip to the left when the 256px-wide
+  card would overflow the right viewport edge (clamped off the left edge), and
+  clamp the top into `[gap, viewportHeight − maxHeight]`. Reading the live
+  on-screen rect keeps placement correct under any zoom/pan.
+- **Coexistence.** The detail popover floats to the side of the 104×104 square;
+  the existing `NodeActionToolbar` floats above it (ADR-050 §2.2). They do not
+  overlap and both may be visible on hover.
+- **Graceful no-op.** When `data.summary` is absent (e.g. an unresolved
+  custom/plugin block), no popover opens.

--- a/frontend/src/components/BlockDetailPopover.tsx
+++ b/frontend/src/components/BlockDetailPopover.tsx
@@ -1,14 +1,18 @@
-// Hover detail popover — anchored to the right of a tile, showing the block's
-// icon + name, full description, and typed port signature. Display-only.
+// Hover detail popover — a display-only card showing a block's icon + name,
+// full description, and typed port signature. Shared between the left block
+// palette (hover a tile) and the workflow canvas (hover a placed node), so it
+// lives at the components root rather than under a single surface's `.parts`.
 //
-// Spec: docs/specs/frontend-block-palette.md §6 Hover Detail Popover.
+// Specs:
+//   docs/specs/frontend-block-palette.md §6 (palette hover detail)
+//   docs/specs/frontend-block-palette.md §7 (canvas node hover detail, #1887)
 
-import { getCategoryVisual } from "../nodes/BlockNode.parts/categoryVisuals";
-import type { BlockSummary } from "../../types/api";
-import { portSignature } from "./paletteModel";
+import { getCategoryVisual } from "./nodes/BlockNode.parts/categoryVisuals";
+import { portSignature } from "./BlockPalette.parts/paletteModel";
+import type { BlockSummary } from "../types/api";
 
 export interface PopoverAnchor {
-  /** Viewport-space left edge for the popover (tile right + gap). */
+  /** Viewport-space left edge for the popover. */
   left: number;
   /** Viewport-space top edge for the popover. */
   top: number;
@@ -29,7 +33,7 @@ export function BlockDetailPopover({ block, anchor }: BlockDetailPopoverProps) {
   return (
     <div
       className="pointer-events-none fixed z-50 w-64 rounded-xl border border-stone-200 bg-white p-3 shadow-panel"
-      data-testid="palette-detail-popover"
+      data-testid="block-detail-popover"
       style={{ left: anchor.left, top: anchor.top }}
     >
       <div className="flex items-center gap-2">

--- a/frontend/src/components/BlockPalette.test.tsx
+++ b/frontend/src/components/BlockPalette.test.tsx
@@ -130,14 +130,14 @@ describe("BlockPalette — grid redesign (#1797)", () => {
     vi.useFakeTimers();
     render(<BlockPalette {...defaultProps} blocks={[cellpose]} />);
 
-    expect(screen.queryByTestId("palette-detail-popover")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("block-detail-popover")).not.toBeInTheDocument();
 
     fireEvent.mouseEnter(screen.getByTestId("palette-block-tile"));
     act(() => {
       vi.advanceTimersByTime(200);
     });
 
-    const popover = screen.getByTestId("palette-detail-popover");
+    const popover = screen.getByTestId("block-detail-popover");
     expect(
       within(popover).getByText("Run Cellpose model on an image to produce instance masks."),
     ).toBeInTheDocument();

--- a/frontend/src/components/BlockPalette.tsx
+++ b/frontend/src/components/BlockPalette.tsx
@@ -3,7 +3,7 @@ import { useEffect, useRef, useState } from "react";
 import { useReloadFlash } from "../hooks/useReloadFlash";
 import type { BlockSummary } from "../types/api";
 import { getCategoryVisual } from "./nodes/BlockNode.parts/categoryVisuals";
-import { BlockDetailPopover, type PopoverAnchor } from "./BlockPalette.parts/BlockDetailPopover";
+import { BlockDetailPopover, type PopoverAnchor } from "./BlockDetailPopover";
 import { BlockTile } from "./BlockPalette.parts/BlockTile";
 import { CategoryChips } from "./BlockPalette.parts/CategoryChips";
 import { buildPaletteSections, type PaletteSection } from "./BlockPalette.parts/paletteModel";

--- a/frontend/src/components/nodes/BlockNode.parts/nodeDetailAnchor.test.ts
+++ b/frontend/src/components/nodes/BlockNode.parts/nodeDetailAnchor.test.ts
@@ -1,0 +1,48 @@
+// Unit tests for the canvas node hover-detail anchor geometry (#1887).
+
+import { describe, expect, it } from "vitest";
+
+import {
+  NODE_DETAIL_POPOVER_GAP,
+  NODE_DETAIL_POPOVER_MAX_HEIGHT,
+  NODE_DETAIL_POPOVER_WIDTH,
+  computeNodeDetailAnchor,
+} from "./nodeDetailAnchor";
+
+const VIEWPORT = { width: 1280, height: 800 };
+
+describe("computeNodeDetailAnchor", () => {
+  it("anchors to the right of the node when it fits", () => {
+    const rect = { left: 200, right: 304, top: 150 };
+    const anchor = computeNodeDetailAnchor(rect, VIEWPORT);
+    expect(anchor.left).toBe(rect.right + NODE_DETAIL_POPOVER_GAP);
+    expect(anchor.top).toBe(150);
+  });
+
+  it("flips to the left of the node when the right side would overflow", () => {
+    // Node hugging the right edge: right + gap + width exceeds the viewport.
+    const rect = { left: 1180, right: 1260, top: 150 };
+    const anchor = computeNodeDetailAnchor(rect, VIEWPORT);
+    expect(anchor.left).toBe(rect.left - NODE_DETAIL_POPOVER_GAP - NODE_DETAIL_POPOVER_WIDTH);
+    expect(anchor.left).toBeGreaterThanOrEqual(NODE_DETAIL_POPOVER_GAP);
+  });
+
+  it("never runs off the left edge when flipping for a node near the left", () => {
+    // Pathologically wide-but-left node so the flipped left would be negative.
+    const rect = { left: 4, right: 1270, top: 150 };
+    const anchor = computeNodeDetailAnchor(rect, VIEWPORT);
+    expect(anchor.left).toBe(NODE_DETAIL_POPOVER_GAP);
+  });
+
+  it("clamps the top so a node near the bottom edge stays fully visible", () => {
+    const rect = { left: 200, right: 304, top: 790 };
+    const anchor = computeNodeDetailAnchor(rect, VIEWPORT);
+    expect(anchor.top).toBe(VIEWPORT.height - NODE_DETAIL_POPOVER_MAX_HEIGHT);
+  });
+
+  it("clamps the top to the gap for a node above the viewport top", () => {
+    const rect = { left: 200, right: 304, top: -50 };
+    const anchor = computeNodeDetailAnchor(rect, VIEWPORT);
+    expect(anchor.top).toBe(NODE_DETAIL_POPOVER_GAP);
+  });
+});

--- a/frontend/src/components/nodes/BlockNode.parts/nodeDetailAnchor.ts
+++ b/frontend/src/components/nodes/BlockNode.parts/nodeDetailAnchor.ts
@@ -1,0 +1,64 @@
+// Canvas node hover-detail popover geometry (#1887).
+//
+// The palette anchors its hover detail to the right of a fixed-position tile.
+// On the canvas a node can sit anywhere in the viewport (and the canvas pans /
+// zooms), so the anchor is computed from the node's on-screen bounding rect:
+// prefer the right side, flip to the left when the popover would overflow the
+// right viewport edge, and clamp the top so the card stays on screen.
+//
+// Spec: docs/specs/frontend-block-palette.md §7 Canvas Node Hover Detail.
+
+import type { PopoverAnchor } from "../../BlockDetailPopover";
+
+/** Gap between the node and the popover, in px (matches the palette). */
+export const NODE_DETAIL_POPOVER_GAP = 8;
+/** Popover width, in px — mirrors the `w-64` (16rem) card. */
+export const NODE_DETAIL_POPOVER_WIDTH = 256;
+/** Max popover height used for top clamping, in px (matches the palette). */
+export const NODE_DETAIL_POPOVER_MAX_HEIGHT = 240;
+/**
+ * Dwell before the canvas popover opens, in ms. Longer than the palette's
+ * 150ms so it does not flash while the user is wiring or dragging nodes
+ * (owner directive, #1887).
+ */
+export const NODE_DETAIL_OPEN_DELAY_MS = 400;
+
+/** On-screen rectangle of the node, viewport-space (a `DOMRect` subset). */
+export interface NodeRect {
+  left: number;
+  right: number;
+  top: number;
+}
+
+export interface Viewport {
+  width: number;
+  height: number;
+}
+
+/**
+ * Compute the viewport-space anchor for a canvas node's hover-detail popover.
+ *
+ * Prefers placing the popover to the right of the node with a small gap. When
+ * it would overflow the right edge, it flips to the left of the node (clamped
+ * so it never runs off the left edge). The top is clamped into
+ * `[GAP, viewport.height - MAX_HEIGHT]` so a node near the top or bottom edge
+ * still yields a fully visible card.
+ */
+export function computeNodeDetailAnchor(rect: NodeRect, viewport: Viewport): PopoverAnchor {
+  const rightLeft = rect.right + NODE_DETAIL_POPOVER_GAP;
+  const fitsRight = rightLeft + NODE_DETAIL_POPOVER_WIDTH <= viewport.width;
+  const left = fitsRight
+    ? rightLeft
+    : Math.max(
+        NODE_DETAIL_POPOVER_GAP,
+        rect.left - NODE_DETAIL_POPOVER_GAP - NODE_DETAIL_POPOVER_WIDTH,
+      );
+
+  const maxTop = Math.max(
+    NODE_DETAIL_POPOVER_GAP,
+    viewport.height - NODE_DETAIL_POPOVER_MAX_HEIGHT,
+  );
+  const top = Math.min(Math.max(rect.top, NODE_DETAIL_POPOVER_GAP), maxTop);
+
+  return { left, top };
+}

--- a/frontend/src/components/nodes/BlockNode.tsx
+++ b/frontend/src/components/nodes/BlockNode.tsx
@@ -24,11 +24,16 @@ import { useEffect, useRef, useState } from "react";
 import type { BlockNodeData } from "../../types/ui";
 import { computeEffectivePorts } from "../../utils/computeEffectivePorts";
 
+import { BlockDetailPopover, type PopoverAnchor } from "../BlockDetailPopover";
 import { NodeActionToolbar } from "./BlockNode.parts/NodeActionToolbar";
 import { NodeStatusSurface } from "./BlockNode.parts/NodeStatusSurface";
 import { PortHandles } from "./BlockNode.parts/PortHandles";
 import { getCategoryVisual } from "./BlockNode.parts/categoryVisuals";
 import { NODE_BORDER_RADIUS, NODE_SIZE } from "./BlockNode.parts/nodeGeometry";
+import {
+  NODE_DETAIL_OPEN_DELAY_MS,
+  computeNodeDetailAnchor,
+} from "./BlockNode.parts/nodeDetailAnchor";
 
 export function BlockNode({ id: nodeId, data, selected }: NodeProps<Node<BlockNodeData>>) {
   // ADR-050 §2.1 — block-kind mark + macaron body colour from the base
@@ -84,12 +89,39 @@ export function BlockNode({ id: nodeId, data, selected }: NodeProps<Node<BlockNo
   // without first selecting the node (#1698 canvas UX).
   const [hovered, setHovered] = useState(false);
   const hideTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // #1887 — hover detail popover. Mirrors the palette's hover detail but for a
+  // placed node: after a short dwell, show the shared BlockDetailPopover with
+  // this block's summary, anchored beside the node's on-screen rect (so it is
+  // correct under any canvas zoom/pan). It floats to the side of the square and
+  // is pointer-events-none, so it never collides with the action toolbar that
+  // floats above. No-op when the block summary is unavailable (e.g. an
+  // unresolved custom/plugin block).
+  const shellRef = useRef<HTMLDivElement>(null);
+  const [detailAnchor, setDetailAnchor] = useState<PopoverAnchor | null>(null);
+  const detailTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const summary = data.summary;
+
   const showActions = () => {
     if (hideTimer.current) {
       clearTimeout(hideTimer.current);
       hideTimer.current = null;
     }
     setHovered(true);
+    if (summary && typeof window !== "undefined") {
+      if (detailTimer.current) clearTimeout(detailTimer.current);
+      detailTimer.current = setTimeout(() => {
+        const rect = shellRef.current?.getBoundingClientRect();
+        if (!rect) return;
+        setDetailAnchor(
+          computeNodeDetailAnchor(rect, {
+            width: window.innerWidth,
+            height: window.innerHeight,
+          }),
+        );
+        detailTimer.current = null;
+      }, NODE_DETAIL_OPEN_DELAY_MS);
+    }
   };
   const scheduleHideActions = () => {
     if (hideTimer.current) clearTimeout(hideTimer.current);
@@ -97,10 +129,18 @@ export function BlockNode({ id: nodeId, data, selected }: NodeProps<Node<BlockNo
       setHovered(false);
       hideTimer.current = null;
     }, 450);
+    // The detail popover sits beside the node and has no controls to reach, so
+    // it dismisses immediately on leave rather than after the toolbar delay.
+    if (detailTimer.current) {
+      clearTimeout(detailTimer.current);
+      detailTimer.current = null;
+    }
+    setDetailAnchor(null);
   };
   useEffect(
     () => () => {
       if (hideTimer.current) clearTimeout(hideTimer.current);
+      if (detailTimer.current) clearTimeout(detailTimer.current);
     },
     [],
   );
@@ -108,6 +148,7 @@ export function BlockNode({ id: nodeId, data, selected }: NodeProps<Node<BlockNo
 
   return (
     <div
+      ref={shellRef}
       data-testid="block-node-shell"
       className="relative"
       onMouseEnter={showActions}
@@ -120,6 +161,12 @@ export function BlockNode({ id: nodeId, data, selected }: NodeProps<Node<BlockNo
         onRestart={data.onRestart}
         onDelete={data.onDelete}
       />
+
+      {/* Hover detail popover beside the node (#1887). Shared with the palette;
+          pointer-events-none + fixed positioning keep it out of layout flow. */}
+      {detailAnchor && summary ? (
+        <BlockDetailPopover anchor={detailAnchor} block={summary} />
+      ) : null}
 
       {/* ----------------------------------------------------------------- */}
       {/* Fixed 104×104 square body — identity only (ADR-050 §2.1)          */}

--- a/frontend/src/components/nodes/BlockNode.tsx
+++ b/frontend/src/components/nodes/BlockNode.tsx
@@ -20,6 +20,7 @@
 
 import { type Node, type NodeProps } from "@xyflow/react";
 import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 
 import type { BlockNodeData } from "../../types/ui";
 import { computeEffectivePorts } from "../../utils/computeEffectivePorts";
@@ -163,10 +164,14 @@ export function BlockNode({ id: nodeId, data, selected }: NodeProps<Node<BlockNo
       />
 
       {/* Hover detail popover beside the node (#1887). Shared with the palette;
-          pointer-events-none + fixed positioning keep it out of layout flow. */}
-      {detailAnchor && summary ? (
-        <BlockDetailPopover anchor={detailAnchor} block={summary} />
-      ) : null}
+          pointer-events-none + fixed positioning keep it out of layout flow.
+          Portalled to <body> so it escapes ReactFlow's transformed viewport: a
+          position:fixed descendant of a `transform`ed ancestor is positioned in
+          that ancestor's coordinate space, so the getBoundingClientRect-derived
+          viewport anchor would drift from the node after pan/zoom. */}
+      {detailAnchor && summary && typeof document !== "undefined"
+        ? createPortal(<BlockDetailPopover anchor={detailAnchor} block={summary} />, document.body)
+        : null}
 
       {/* ----------------------------------------------------------------- */}
       {/* Fixed 104×104 square body — identity only (ADR-050 §2.1)          */}

--- a/frontend/src/components/nodes/__tests__/BlockNode/hoverDetail.test.tsx
+++ b/frontend/src/components/nodes/__tests__/BlockNode/hoverDetail.test.tsx
@@ -90,4 +90,23 @@ describe("BlockNode — hover detail popover (#1887)", () => {
 
     expect(screen.queryByTestId("block-detail-popover")).not.toBeInTheDocument();
   });
+
+  it("portals the popover outside the node subtree (escapes ReactFlow transforms)", () => {
+    // #1887 P2: a position:fixed popover under ReactFlow's transformed viewport
+    // would be placed in the transformed coordinate space and drift after
+    // pan/zoom. Portalling to <body> keeps it in the real viewport space that
+    // getBoundingClientRect() (used for the anchor) reports in.
+    const { container } = renderNode({ summary: makeSummary() });
+
+    fireEvent.mouseEnter(screen.getByTestId("block-node-shell"));
+    act(() => {
+      vi.advanceTimersByTime(NODE_DETAIL_OPEN_DELAY_MS);
+    });
+
+    const popover = screen.getByTestId("block-detail-popover");
+    // Not rendered inside the node's own subtree...
+    expect(container.querySelector('[data-testid="block-detail-popover"]')).toBeNull();
+    // ...but mounted on document.body via the portal.
+    expect(document.body.contains(popover)).toBe(true);
+  });
 });

--- a/frontend/src/components/nodes/__tests__/BlockNode/hoverDetail.test.tsx
+++ b/frontend/src/components/nodes/__tests__/BlockNode/hoverDetail.test.tsx
@@ -1,0 +1,93 @@
+// Canvas node hover-detail popover behavior (#1887).
+//
+// Hovering a placed block node opens the shared BlockDetailPopover after a
+// ~400ms dwell, showing the block's description and typed ports — mirroring the
+// palette hover detail. It dismisses on leave and no-ops without a summary.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, fireEvent, screen, within } from "@testing-library/react";
+
+import type { BlockSummary } from "../../../../types/api";
+import { NODE_DETAIL_OPEN_DELAY_MS } from "../../BlockNode.parts/nodeDetailAnchor";
+import { makePort, openNativeDialogMock, renderNode } from "./test-utils";
+
+function makeSummary(overrides: Partial<BlockSummary> = {}): BlockSummary {
+  return {
+    name: "Cellpose Segment",
+    type_name: "cellpose_segment",
+    base_category: "ai",
+    subcategory: "",
+    description: "Run Cellpose model on an image to produce instance masks.",
+    version: "1.0",
+    input_ports: [makePort("image", "input", ["Image"])],
+    output_ports: [makePort("masks", "output", ["Mask"])],
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.runOnlyPendingTimers();
+  vi.useRealTimers();
+  cleanup();
+  openNativeDialogMock.mockReset();
+});
+
+describe("BlockNode — hover detail popover (#1887)", () => {
+  it("opens the detail popover after the dwell, with description and typed ports", () => {
+    renderNode({ summary: makeSummary() });
+
+    expect(screen.queryByTestId("block-detail-popover")).not.toBeInTheDocument();
+
+    fireEvent.mouseEnter(screen.getByTestId("block-node-shell"));
+    act(() => {
+      vi.advanceTimersByTime(NODE_DETAIL_OPEN_DELAY_MS);
+    });
+
+    const popover = screen.getByTestId("block-detail-popover");
+    expect(
+      within(popover).getByText("Run Cellpose model on an image to produce instance masks."),
+    ).toBeInTheDocument();
+    expect(within(popover).getByText("Image")).toBeInTheDocument();
+    expect(within(popover).getByText("Mask")).toBeInTheDocument();
+  });
+
+  it("does not open before the dwell elapses", () => {
+    renderNode({ summary: makeSummary() });
+
+    fireEvent.mouseEnter(screen.getByTestId("block-node-shell"));
+    act(() => {
+      vi.advanceTimersByTime(NODE_DETAIL_OPEN_DELAY_MS - 50);
+    });
+
+    expect(screen.queryByTestId("block-detail-popover")).not.toBeInTheDocument();
+  });
+
+  it("dismisses the popover when the cursor leaves the node", () => {
+    renderNode({ summary: makeSummary() });
+
+    const shell = screen.getByTestId("block-node-shell");
+    fireEvent.mouseEnter(shell);
+    act(() => {
+      vi.advanceTimersByTime(NODE_DETAIL_OPEN_DELAY_MS);
+    });
+    expect(screen.getByTestId("block-detail-popover")).toBeInTheDocument();
+
+    fireEvent.mouseLeave(shell);
+    expect(screen.queryByTestId("block-detail-popover")).not.toBeInTheDocument();
+  });
+
+  it("no-ops when the block summary is unavailable", () => {
+    renderNode({ summary: undefined });
+
+    fireEvent.mouseEnter(screen.getByTestId("block-node-shell"));
+    act(() => {
+      vi.advanceTimersByTime(NODE_DETAIL_OPEN_DELAY_MS);
+    });
+
+    expect(screen.queryByTestId("block-detail-popover")).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Hovering a placed block node on the workflow canvas now opens the same
hover-detail popover the left palette uses, so users can recall what a block
does and its port types without opening the BottomPanel Config tab.

## Changes

- Move `BlockDetailPopover` from `BlockPalette.parts/` to `components/` — it is
  now shared between the palette and the canvas — and rename its testid to
  `block-detail-popover`.
- `BlockNode` reuses the popover via the node's existing `data.summary` on hover,
  after a ~400ms dwell (longer than the palette's 150ms to avoid flicker while
  wiring/dragging), dismissing on leave. No-op when the summary is unavailable.
- Add `computeNodeDetailAnchor`: prefer the right side, flip left near the right
  viewport edge, clamp the top — computed from the node's live on-screen rect so
  it stays correct under any canvas zoom/pan. Coexists with the existing
  `NodeActionToolbar` (which floats above the node).

## Tests

- `nodes/BlockNode.parts/nodeDetailAnchor.test.ts` — right/left flip + top clamp.
- `nodes/__tests__/BlockNode/hoverDetail.test.tsx` — dwell-delayed open,
  description + typed ports, dismiss on leave, no-op without a summary.

## Docs

- `docs/specs/frontend-block-palette.md` §10 amendment documents the canvas
  hover detail and the now-shared popover.

Gate record: .workflow/records/1887-guided-1887-canvas-block-hover-detail.json

Closes #1887
