### PR TITLE
guided(#1891): freeze canvas autosave on version conflict + resolution dialog

### DIFF
--- a/.workflow/records/1891-guided-1891-canvas-autosave-conflict-dialog.json
+++ b/.workflow/records/1891-guided-1891-canvas-autosave-conflict-dialog.json
@@ -128,9 +128,9 @@
   ],
   "check_na": [],
   "commit": {
-    "sha": "6c8b38cd3a8cd5cdeca68655d148c2fbc2f24a80",
+    "sha": "f48cb839b0967af9ee01d50c58199d18b0f73d40",
     "shas": [
-      "6c8b38cd3a8cd5cdeca68655d148c2fbc2f24a80"
+      "f48cb839b0967af9ee01d50c58199d18b0f73d40"
     ],
     "trailers": []
   },
@@ -486,6 +486,170 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:22:41.291908Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:22:41.301380Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:22:41.310571Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:22:41.319564Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:22:41.328707Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:22:41.337649Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:22:41.346399Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:22:41.355317Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:22:41.364051Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:22:41.375334Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:22:55.584617Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:22:55.596223Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:22:55.607803Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:22:55.622086Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:22:55.632584Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:22:55.642903Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:22:55.653093Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:22:55.663789Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:22:55.673671Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:22:55.690548Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -498,7 +662,7 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "origin/main",
+    "base": "751d6574272d609bd3eb97797a7be2a0a169a7c7",
     "base_sha": "751d6574",
     "changed_files": [
       ".workflow/records/1891-guided-1891-canvas-autosave-conflict-dialog.json",
@@ -511,9 +675,9 @@
       "frontend/src/store/types.ts",
       "frontend/src/store/workflowSlice.ts"
     ],
-    "diff_fingerprint": "sha256:403910086cafaf0d1902fb7577f6b9078cb4503e4992afd26ac2454695291d52",
+    "diff_fingerprint": "sha256:79676ef76485bdd733a017cea578212e5f43a9f290c28049525ab799bcec9aec",
     "head": "HEAD",
-    "head_sha": "6c8b38cd",
+    "head_sha": "f48cb839",
     "surfaces": {
       "docs": 1,
       "frontend": 7,
@@ -534,8 +698,8 @@
     "closes": [
       1891
     ],
-    "number": null,
-    "url": null
+    "number": 1892,
+    "url": "https://github.com/jiazhenz026/SciStudio/pull/1892"
   },
   "reconcile_events": [
     {
@@ -567,6 +731,22 @@
     {
       "at": "2026-06-30T20:21:49.729273Z",
       "diff_fingerprint": "sha256:403910086cafaf0d1902fb7577f6b9078cb4503e4992afd26ac2454695291d52",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-30T20:22:41.375377Z",
+      "diff_fingerprint": "sha256:79676ef76485bdd733a017cea578212e5f43a9f290c28049525ab799bcec9aec",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-30T20:22:55.690585Z",
+      "diff_fingerprint": "sha256:79676ef76485bdd733a017cea578212e5f43a9f290c28049525ab799bcec9aec",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 2,

--- a/.workflow/records/1891-guided-1891-canvas-autosave-conflict-dialog.json
+++ b/.workflow/records/1891-guided-1891-canvas-autosave-conflict-dialog.json
@@ -124,13 +124,58 @@
       "status": "pass",
       "summary": "clean",
       "tool_versions": {}
+    },
+    {
+      "at": "2026-06-30T20:49:45.922967Z",
+      "command": "(cd frontend && npm run check:ci)",
+      "covered_surface": "frontend",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:511ba24b7ce5263db352c6740c4ad3ab63cffebbec3e53c5ffe61e9b51eb787a",
+      "name": "frontend",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/frontend.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-30T20:49:52.781144Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:76f4c7f7a832b051ebce6ded8164cbc7b5b963a807a421e0657dceabf2c678b2",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-30T20:53:49.638350Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:07917dfff7ec5ba2298b965dfd30c576a3c5b16a49601de787cbd031dd11a401",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
     }
   ],
   "check_na": [],
   "commit": {
-    "sha": "f48cb839b0967af9ee01d50c58199d18b0f73d40",
+    "sha": "1ac1dff6342f8bf462fa1ef715475b830072b595",
     "shas": [
-      "f48cb839b0967af9ee01d50c58199d18b0f73d40"
+      "1ac1dff6342f8bf462fa1ef715475b830072b595"
     ],
     "trailers": []
   },
@@ -655,6 +700,170 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:53:49.674502Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:53:49.684147Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:53:49.694128Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:53:49.704233Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:53:49.714103Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:53:49.726377Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:53:49.736090Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:53:49.746004Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:53:49.755122Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:53:49.767574Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:54:02.427194Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:54:02.438378Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:54:02.449368Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:54:02.460993Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:54:02.472103Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:54:02.482747Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:54:02.493618Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:54:02.503875Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:54:02.514014Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:54:02.527995Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -673,6 +882,8 @@
       ".workflow/records/1891-guided-1891-canvas-autosave-conflict-dialog.json",
       "docs/adr/ADR-045.md",
       "frontend/src/App.parts/useAppLifecycleEffects.ts",
+      "frontend/src/App.parts/useWorkflowSync.test.tsx",
+      "frontend/src/App.parts/useWorkflowSync.ts",
       "frontend/src/App.tsx",
       "frontend/src/components/WorkflowConflictDialog.test.tsx",
       "frontend/src/components/WorkflowConflictDialog.tsx",
@@ -680,19 +891,19 @@
       "frontend/src/store/types.ts",
       "frontend/src/store/workflowSlice.ts"
     ],
-    "diff_fingerprint": "sha256:79676ef76485bdd733a017cea578212e5f43a9f290c28049525ab799bcec9aec",
+    "diff_fingerprint": "sha256:265b397d0d3dd8e5854020906ba337eb4d3f1d0d27b52c75c6426a103d0e7976",
     "head": "HEAD",
-    "head_sha": "f48cb839",
+    "head_sha": "1ac1dff6",
     "surfaces": {
       "docs": 1,
-      "frontend": 7,
+      "frontend": 9,
       "governance": 0,
       "governed_docs": 0,
-      "implementation": 7,
+      "implementation": 9,
       "packaging": 0,
       "protected_core": 0,
-      "sentrux": 8,
-      "test": 2,
+      "sentrux": 10,
+      "test": 3,
       "workflow_ci": 0
     }
   },
@@ -752,6 +963,22 @@
     {
       "at": "2026-06-30T20:22:55.690585Z",
       "diff_fingerprint": "sha256:79676ef76485bdd733a017cea578212e5f43a9f290c28049525ab799bcec9aec",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-30T20:53:49.767612Z",
+      "diff_fingerprint": "sha256:265b397d0d3dd8e5854020906ba337eb4d3f1d0d27b52c75c6426a103d0e7976",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-30T20:54:02.528031Z",
+      "diff_fingerprint": "sha256:265b397d0d3dd8e5854020906ba337eb4d3f1d0d27b52c75c6426a103d0e7976",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 2,

--- a/.workflow/records/1891-guided-1891-canvas-autosave-conflict-dialog.json
+++ b/.workflow/records/1891-guided-1891-canvas-autosave-conflict-dialog.json
@@ -145,6 +145,11 @@
       "at": "2026-06-30T20:07:24.657236Z",
       "owner_directive": "VS Code-style conflict dialog: freeze autosave while a conflict is pending, prompt Keep mine / Use remote, resume autosave after the choice.",
       "reason": "plan"
+    },
+    {
+      "at": "2026-06-30T20:45:59.148762Z",
+      "owner_directive": "Fix P1: gate all workflow-save entry points (incl. Ctrl/Cmd+S shortcut) on the pending conflict via the source saveWorkflow guard so no entry point can clobber while a conflict dialog is open.",
+      "reason": "PR #1892 review P1: Ctrl/Cmd+S bypasses the autosave conflict freeze and PUTs stale canvas before the user resolves the dialog"
     }
   ],
   "docs_events": [
@@ -797,6 +802,12 @@
       "at": "2026-06-30T20:07:24.657425Z",
       "pattern": "docs/adr/ADR-045.md",
       "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-30T20:45:59.148939Z",
+      "pattern": "frontend/src/App.parts/useWorkflowSync.ts",
+      "reason": "PR #1892 review P1: Ctrl/Cmd+S bypasses the autosave conflict freeze and PUTs stale canvas before the user resolves the dialog"
     }
   ],
   "session_id": "f0670a1e-93db-4291-8230-e692513131bb",
@@ -816,6 +827,14 @@
       "class": null,
       "kind": "path",
       "path": "frontend/src/components/WorkflowConflictDialog.test.tsx",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-30T20:45:59.148946Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/App.parts/useWorkflowSync.test.tsx",
       "rationale": null,
       "verified_in_diff": null
     }

--- a/.workflow/records/1891-guided-1891-canvas-autosave-conflict-dialog.json
+++ b/.workflow/records/1891-guided-1891-canvas-autosave-conflict-dialog.json
@@ -1,8 +1,139 @@
 {
   "branch": "guided/1891-canvas-autosave-conflict-dialog",
-  "check_events": [],
+  "check_events": [
+    {
+      "at": "2026-06-30T20:08:36.143369Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:bee0017f30f552d2df2de1173f9ac14b9aee5192ca5e5c1de574bb119512b275",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-30T20:08:41.366945Z",
+      "command": "(cd frontend && npm run check:ci)",
+      "covered_surface": "frontend",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:f4a0c7ac9cf76152f10bfde7c4628478ba1bb9ed8574b6936fb0e404609cf11f",
+      "name": "frontend",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/frontend.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-30T20:08:45.491676Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:6aca51dc45686fbdb1b9b6af9f8cc931c8b3e5afbd362670dbe876812a4b2b66",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-30T20:08:45.532698Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e31351abfc33f0b3c0f28bc9f2f3d59ae3bc5d4925dc1159a7f931aa932441ed",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-30T20:14:38.238314Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:82aa3e557d33e16a983fd85a8e993ffe994e35bedd1bebcd9ebef2aedde55c17",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-30T20:16:51.773107Z",
+      "command": "(cd frontend && npm run check:ci)",
+      "covered_surface": "frontend",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:6043a3dbcc392e4a7d599ae33033134f6f6f6ca435554e7003b11e9f7a204f32",
+      "name": "frontend",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/frontend.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-30T20:16:58.647950Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:eacca701cdcb97412351051d2c4601cd9b412749fdf3fc358096cfbb4792ff97",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-30T20:21:12.235705Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:c8e21cc3cd738129ae243c6468a5d11060bb968d60b99d9db75cb2eb26480af1",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    }
+  ],
   "check_na": [],
-  "commit": null,
+  "commit": {
+    "sha": "6c8b38cd3a8cd5cdeca68655d148c2fbc2f24a80",
+    "shas": [
+      "6c8b38cd3a8cd5cdeca68655d148c2fbc2f24a80"
+    ],
+    "trailers": []
+  },
   "declared_scope": {
     "exclude": [],
     "include": [
@@ -27,7 +158,336 @@
     }
   ],
   "governance_touch": false,
-  "guard_events": [],
+  "guard_events": [
+    {
+      "at": "2026-06-30T20:14:38.304245Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:14:38.323756Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:14:38.347821Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:14:38.370612Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:14:38.396124Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:14:38.418528Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:14:38.445383Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:14:38.468357Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:14:38.492944Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:14:38.520224Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:21:12.274369Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:21:12.285482Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:21:12.295515Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:21:12.306490Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:21:12.315946Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:21:12.327126Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:21:12.337130Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:21:12.347145Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:21:12.356536Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:21:12.367876Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:21:37.329064Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:21:37.338049Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:21:37.346800Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:21:37.355487Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:21:37.364057Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:21:37.372817Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:21:37.382015Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:21:37.391742Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:21:37.400516Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:21:37.410457Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:21:49.644641Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:21:49.654402Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:21:49.663603Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:21:49.673882Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:21:49.682846Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:21:49.691878Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:21:49.700442Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:21:49.709845Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:21:49.718692Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:21:49.729238Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
   "issues": [
     {
       "close_in_pr": true,
@@ -37,19 +497,111 @@
     }
   ],
   "observed_admin_labels": [],
-  "observed_diff": null,
+  "observed_diff": {
+    "base": "origin/main",
+    "base_sha": "751d6574",
+    "changed_files": [
+      ".workflow/records/1891-guided-1891-canvas-autosave-conflict-dialog.json",
+      "docs/adr/ADR-045.md",
+      "frontend/src/App.parts/useAppLifecycleEffects.ts",
+      "frontend/src/App.tsx",
+      "frontend/src/components/WorkflowConflictDialog.test.tsx",
+      "frontend/src/components/WorkflowConflictDialog.tsx",
+      "frontend/src/store/__tests__/workflowSlice.conflict.test.ts",
+      "frontend/src/store/types.ts",
+      "frontend/src/store/workflowSlice.ts"
+    ],
+    "diff_fingerprint": "sha256:403910086cafaf0d1902fb7577f6b9078cb4503e4992afd26ac2454695291d52",
+    "head": "HEAD",
+    "head_sha": "6c8b38cd",
+    "surfaces": {
+      "docs": 1,
+      "frontend": 7,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 7,
+      "packaging": 0,
+      "protected_core": 0,
+      "sentrux": 8,
+      "test": 2,
+      "workflow_ci": 0
+    }
+  },
   "owner_directive": "Fix: canvas autosave silently overwrites AI agent workflow writes. Add a VS Code-style conflict dialog: when a remote (agent) change is detected while the editor is dirty, freeze autosave, show a dialog with 'keep mine' vs 'load agent version', and resume autosave after the user chooses. Frontend-only.",
   "persona": "live_implementer",
-  "pull_request": null,
-  "reconcile_events": [],
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [
+      1891
+    ],
+    "number": null,
+    "url": null
+  },
+  "reconcile_events": [
+    {
+      "at": "2026-06-30T20:14:38.520275Z",
+      "diff_fingerprint": "sha256:a9540dd5ef2d27e391c56e7d688bed84589a127b103f4c736311c5ffae39acf2",
+      "mode": "local",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.frontend"
+      ]
+    },
+    {
+      "at": "2026-06-30T20:21:12.367905Z",
+      "diff_fingerprint": "sha256:403910086cafaf0d1902fb7577f6b9078cb4503e4992afd26ac2454695291d52",
+      "mode": "local",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-30T20:21:37.410488Z",
+      "diff_fingerprint": "sha256:403910086cafaf0d1902fb7577f6b9078cb4503e4992afd26ac2454695291d52",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-30T20:21:49.729273Z",
+      "diff_fingerprint": "sha256:403910086cafaf0d1902fb7577f6b9078cb4503e4992afd26ac2454695291d52",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    }
+  ],
   "record_id": "1891-guided-1891-canvas-autosave-conflict-dialog",
   "requested_admin_labels": [],
   "required_obligations": {
     "admin_labels": [],
-    "checks": [],
-    "docs": [],
-    "guards": [],
-    "tests": []
+    "checks": [
+      "format_check",
+      "frontend",
+      "full_audit",
+      "lint_format",
+      "semantic_dup"
+    ],
+    "docs": [
+      "docs_required_or_na"
+    ],
+    "guards": [
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": [
+      "changed_test_required"
+    ]
   },
   "runtime": "claude-code",
   "schema_version": 2,
@@ -68,7 +620,7 @@
     }
   ],
   "session_id": "f0670a1e-93db-4291-8230-e692513131bb",
-  "strictness_tier": null,
+  "strictness_tier": 2,
   "task_kind": "guided",
   "test_events": [
     {

--- a/.workflow/records/1891-guided-1891-canvas-autosave-conflict-dialog.json
+++ b/.workflow/records/1891-guided-1891-canvas-autosave-conflict-dialog.json
@@ -1,0 +1,91 @@
+{
+  "branch": "guided/1891-canvas-autosave-conflict-dialog",
+  "check_events": [],
+  "check_na": [],
+  "commit": null,
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "frontend/src/**"
+    ]
+  },
+  "directive_events": [
+    {
+      "at": "2026-06-30T20:07:24.657236Z",
+      "owner_directive": "VS Code-style conflict dialog: freeze autosave while a conflict is pending, prompt Keep mine / Use remote, resume autosave after the choice.",
+      "reason": "plan"
+    }
+  ],
+  "docs_events": [
+    {
+      "at": "2026-06-30T20:07:24.657434Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/adr/ADR-045.md",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": false,
+  "guard_events": [],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1891,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": null,
+  "owner_directive": "Fix: canvas autosave silently overwrites AI agent workflow writes. Add a VS Code-style conflict dialog: when a remote (agent) change is detected while the editor is dirty, freeze autosave, show a dialog with 'keep mine' vs 'load agent version', and resume autosave after the user chooses. Frontend-only.",
+  "persona": "live_implementer",
+  "pull_request": null,
+  "reconcile_events": [],
+  "record_id": "1891-guided-1891-canvas-autosave-conflict-dialog",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [],
+    "docs": [],
+    "guards": [],
+    "tests": []
+  },
+  "runtime": "claude-code",
+  "schema_version": 2,
+  "scope_events": [
+    {
+      "action": "add-include",
+      "at": "2026-06-30T20:07:24.657416Z",
+      "pattern": "frontend/src/**",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-06-30T20:07:24.657425Z",
+      "pattern": "docs/adr/ADR-045.md",
+      "reason": "plan"
+    }
+  ],
+  "session_id": "f0670a1e-93db-4291-8230-e692513131bb",
+  "strictness_tier": null,
+  "task_kind": "guided",
+  "test_events": [
+    {
+      "at": "2026-06-30T20:07:24.657442Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/store/__tests__/workflowSlice.conflict.test.ts",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-30T20:07:24.657446Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/components/WorkflowConflictDialog.test.tsx",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/docs/adr/ADR-045.md
+++ b/docs/adr/ADR-045.md
@@ -423,6 +423,35 @@ following minimum semantics are required:
   again) or by reloading the remote (which resets pendingVersion to the
   remote's version).
 
+#### 3.7.1 Implementation note — workflow YAML conflict UI (#1891)
+
+The initial ADR-045 rollout implemented only the **detection** half of the 4th
+branch for workflow YAML: the reconcile handler set `workflowConflict` in the
+store, but nothing consumed it. The autosave debounce guarded on
+`workflowDirty` alone, so it still fired ~800ms later and PUT the stale local
+state — silently overwriting the remote (typically agent) write and violating
+the "MUST NOT silently overwrite" requirement above.
+
+#1891 completes the workflow-YAML conflict UI:
+
+- The autosave debounce now also skips while `workflowConflict` is set
+  ([useAppLifecycleEffects.ts](../../frontend/src/App.parts/useAppLifecycleEffects.ts)),
+  freezing the save until the user resolves the conflict. Clearing the
+  conflict re-runs the effect, so autosave resumes automatically.
+- A `WorkflowConflictDialog`
+  ([WorkflowConflictDialog.tsx](../../frontend/src/components/WorkflowConflictDialog.tsx))
+  surfaces the prompt, identifies the `source`, and offers **Keep my version**
+  (`keepLocal`) and **Use remote** (`loadRemote`) per §3.7.
+- `resolveWorkflowConflict(resolution)` in the workflow slice applies the
+  choice: `keepLocal` drops the conflict marker so the still-dirty edits
+  resume autosaving (a now user-chosen last-write-wins); `loadRemote` adopts
+  the remote workflow as the new clean base via `setWorkflow`.
+
+The file-tab "Show diff" option (§3.7) remains unimplemented and out of scope
+for #1891; the narrow in-flight-PUT-vs-remote-write timing window is likewise
+not addressed (it would require server-side optimistic concurrency, which
+ADR-039 §5.2 deliberately removed).
+
 ## 4. Scope
 
 ### 4.1 In-Scope

--- a/frontend/src/App.parts/useAppLifecycleEffects.ts
+++ b/frontend/src/App.parts/useAppLifecycleEffects.ts
@@ -21,11 +21,19 @@
 
 import { useEffect, useRef } from "react";
 
+import type { VersionConflictState } from "../store/types";
 import type { ProjectResponse, WorkflowResponse } from "../types/api";
 
 export interface AppLifecycleDeps {
   currentProject: ProjectResponse | null;
   workflowDirty: boolean;
+  /**
+   * #1891: when a remote (e.g. AI agent) write conflicts with unsaved local
+   * edits the canvas surfaces a resolution dialog. Autosave is frozen while a
+   * conflict is pending so the debounced save cannot silently clobber the
+   * remote write before the user has chosen a side.
+   */
+  workflowConflict: VersionConflictState | null;
   workflowPayload: WorkflowResponse;
   refreshProjects: () => Promise<void>;
   refreshBlocks: () => Promise<void>;
@@ -45,6 +53,7 @@ export function useAppLifecycleEffects(deps: AppLifecycleDeps): void {
   const {
     currentProject,
     workflowDirty,
+    workflowConflict,
     workflowPayload,
     refreshProjects,
     refreshBlocks,
@@ -81,13 +90,16 @@ export function useAppLifecycleEffects(deps: AppLifecycleDeps): void {
 
   // Auto-save on dirty (workflow tabs). #1421: `saveWorkflow` is a stable
   // useCallback tied to the same reactive inputs the effect already lists.
+  // #1891: skip while a version conflict is pending — autosave must not PUT the
+  // stale local state and clobber the remote write until the user resolves it.
+  // Clearing the conflict re-runs this effect, so autosave resumes on its own.
   useEffect(() => {
-    if (!currentProject || !workflowDirty) return undefined;
+    if (!currentProject || !workflowDirty || workflowConflict) return undefined;
     const timeout = window.setTimeout(() => {
       void saveWorkflow();
     }, 800);
     return () => window.clearTimeout(timeout);
-  }, [currentProject, workflowDirty, workflowPayload, saveWorkflow]);
+  }, [currentProject, workflowDirty, workflowConflict, workflowPayload, saveWorkflow]);
 
   // Sync active tab snapshot when workflow state OR the active tab itself
   // changes. #1421: see PR #1435 commit message — `activeTabId` is in the

--- a/frontend/src/App.parts/useWorkflowSync.test.tsx
+++ b/frontend/src/App.parts/useWorkflowSync.test.tsx
@@ -1,6 +1,7 @@
 import { renderHook, act } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import type { VersionConflictState } from "../store/types";
 import type { ProjectResponse, WorkflowResponse } from "../types/api";
 import { useWorkflowSync } from "./useWorkflowSync";
 
@@ -11,6 +12,19 @@ const apiMocks = vi.hoisted(() => ({
   listProjects: vi.fn(),
   openProject: vi.fn(),
   updateWorkflow: vi.fn(),
+}));
+
+// Only the conflict gate in saveWorkflow reads the store, via getState. Mock it
+// narrowly so the test does not pull in the real store (whose init needs a
+// fuller ../lib/api surface than this file mocks).
+const storeMocks = vi.hoisted(() => ({
+  workflowConflict: null as VersionConflictState | null,
+}));
+
+vi.mock("../store", () => ({
+  useAppStore: {
+    getState: () => ({ workflowConflict: storeMocks.workflowConflict }),
+  },
 }));
 
 vi.mock("../lib/api", () => ({
@@ -61,9 +75,24 @@ function renderSync(overrides: Partial<{ currentProject: ProjectResponse | null 
   return { deps, hook };
 }
 
+const pendingConflict: VersionConflictState = {
+  entityClass: "workflow",
+  entityId: "main",
+  kind: "modified",
+  source: "agent",
+  sourceId: null,
+  baseVersion: 5,
+  pendingVersion: 5,
+  remoteVersion: 6,
+  detectedAt: "2026-06-30T00:00:00Z",
+  message: "remote change",
+  remoteWorkflow: null,
+};
+
 describe("useWorkflowSync", () => {
   afterEach(() => {
     vi.clearAllMocks();
+    storeMocks.workflowConflict = null;
   });
 
   it("reopens the current project and retries when backend session lost", async () => {
@@ -113,6 +142,22 @@ describe("useWorkflowSync", () => {
     });
     // The previous save errored, so this success clears its own banner.
     expect(deps.setLastError).toHaveBeenCalledWith(null);
+  });
+
+  it("does not PUT while a version conflict is pending (#1891 P1)", async () => {
+    // Every save entry point — autosave, Ctrl/Cmd+S, Save As — routes through
+    // saveWorkflow. With a conflict pending it must no-op so the stale local
+    // canvas cannot clobber the remote write before the user resolves it.
+    storeMocks.workflowConflict = pendingConflict;
+    const { deps, hook } = renderSync();
+
+    await act(async () => {
+      await hook.result.current.saveWorkflow();
+    });
+
+    expect(apiMocks.updateWorkflow).not.toHaveBeenCalled();
+    expect(apiMocks.createWorkflow).not.toHaveBeenCalled();
+    expect(deps.markWorkflowSaved).not.toHaveBeenCalled();
   });
 
   it("falls back to create only when update returns 404", async () => {

--- a/frontend/src/App.parts/useWorkflowSync.ts
+++ b/frontend/src/App.parts/useWorkflowSync.ts
@@ -13,6 +13,7 @@
 import { startTransition, useCallback, useRef } from "react";
 
 import { api, ApiError } from "../lib/api";
+import { useAppStore } from "../store";
 import type {
   BlockSchemaResponse,
   BlockSummary,
@@ -91,6 +92,13 @@ export function useWorkflowSync(deps: WorkflowSyncDeps): WorkflowSync {
   // #1421: stable identity across renders.
   const saveWorkflow = useCallback(async () => {
     if (!currentProject) return;
+    // #1891 P1: never PUT while a version conflict is pending. Gating at the
+    // source covers every entry point — debounced autosave, the Ctrl/Cmd+S
+    // shortcut, and Save As (which calls saveWorkflow first) — so none can PUT
+    // the stale local canvas and clobber the remote (agent) write before the
+    // user resolves the conflict dialog. Read live state via getState so the
+    // callback identity stays stable.
+    if (useAppStore.getState().workflowConflict) return;
     try {
       let saved: WorkflowResponse;
       let projectForState = currentProject;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -48,6 +48,7 @@ import { useWorkflowSync } from "./App.parts/useWorkflowSync";
 
 import { ProjectDialog } from "./components/ProjectDialog";
 import { PromptDialog } from "./components/PromptDialog";
+import { WorkflowConflictDialog } from "./components/WorkflowConflictDialog";
 import { Toolbar } from "./components/Toolbar";
 import { WelcomeScreen } from "./components/WelcomeScreen";
 import { TooltipProvider } from "./components/ui/tooltip";
@@ -133,6 +134,10 @@ export default function App() {
   const removeEdge = useAppStore((state) => state.removeEdge);
   const addAnnotationNode = useAppStore((state) => state.addAnnotationNode);
   const markWorkflowSaved = useAppStore((state) => state.markWorkflowSaved);
+  // #1891: surfaced by the canvas conflict dialog when a remote write collides
+  // with unsaved local edits; autosave is frozen until the user resolves it.
+  const workflowConflict = useAppStore((state) => state.workflowConflict);
+  const resolveWorkflowConflict = useAppStore((state) => state.resolveWorkflowConflict);
   const undoWorkflow = useAppStore((state) => state.undoWorkflow);
   const redoWorkflow = useAppStore((state) => state.redoWorkflow);
 
@@ -327,6 +332,7 @@ export default function App() {
   useAppLifecycleEffects({
     currentProject,
     workflowDirty,
+    workflowConflict,
     workflowPayload,
     refreshProjects,
     refreshBlocks,
@@ -517,6 +523,9 @@ export default function App() {
           />
 
           <PromptDialog request={promptRequest} onClose={clearPrompt} />
+
+          {/* #1891: version-conflict resolution for the open canvas workflow. */}
+          <WorkflowConflictDialog conflict={workflowConflict} onResolve={resolveWorkflowConflict} />
 
           {/* #591/#594: Interactive block modals. */}
           <InteractiveModals />

--- a/frontend/src/components/WorkflowConflictDialog.test.tsx
+++ b/frontend/src/components/WorkflowConflictDialog.test.tsx
@@ -1,0 +1,77 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { WorkflowConflictDialog } from "./WorkflowConflictDialog";
+import type { VersionConflictState } from "../store/types";
+
+afterEach(() => {
+  cleanup();
+});
+
+function conflict(overrides: Partial<VersionConflictState> = {}): VersionConflictState {
+  return {
+    entityClass: "workflow",
+    entityId: "demo",
+    kind: "modified",
+    source: "agent",
+    sourceId: null,
+    baseVersion: 5,
+    pendingVersion: 5,
+    remoteVersion: 6,
+    detectedAt: "2026-06-30T00:00:00Z",
+    message: "remote change",
+    remoteWorkflow: {
+      id: "demo",
+      version: "1.0.0",
+      description: "",
+      nodes: [],
+      edges: [],
+      metadata: {},
+    },
+    ...overrides,
+  };
+}
+
+describe("WorkflowConflictDialog (#1891)", () => {
+  it("renders nothing when there is no conflict", () => {
+    const { container } = render(<WorkflowConflictDialog conflict={null} onResolve={vi.fn()} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing for a non-workflow conflict", () => {
+    const { container } = render(
+      <WorkflowConflictDialog conflict={conflict({ entityClass: "file" })} onResolve={vi.fn()} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("names the agent as the remote writer", () => {
+    render(<WorkflowConflictDialog conflict={conflict()} onResolve={vi.fn()} />);
+    expect(screen.getByTestId("workflow-conflict-dialog")).toHaveTextContent("the AI agent");
+  });
+
+  it("resolves keepLocal when the user keeps their version", () => {
+    const onResolve = vi.fn();
+    render(<WorkflowConflictDialog conflict={conflict()} onResolve={onResolve} />);
+    fireEvent.click(screen.getByTestId("workflow-conflict-keep-local"));
+    expect(onResolve).toHaveBeenCalledWith("keepLocal");
+  });
+
+  it("resolves loadRemote when the user loads the remote version", () => {
+    const onResolve = vi.fn();
+    render(<WorkflowConflictDialog conflict={conflict()} onResolve={onResolve} />);
+    const button = screen.getByTestId("workflow-conflict-load-remote");
+    expect(button).toHaveTextContent("Load their version");
+    fireEvent.click(button);
+    expect(onResolve).toHaveBeenCalledWith("loadRemote");
+  });
+
+  it("labels the load button as a discard when there is no remote payload", () => {
+    render(
+      <WorkflowConflictDialog conflict={conflict({ remoteWorkflow: null })} onResolve={vi.fn()} />,
+    );
+    expect(screen.getByTestId("workflow-conflict-load-remote")).toHaveTextContent(
+      "Discard my edits",
+    );
+  });
+});

--- a/frontend/src/components/WorkflowConflictDialog.tsx
+++ b/frontend/src/components/WorkflowConflictDialog.tsx
@@ -1,0 +1,87 @@
+import type { VersionConflictState, WorkflowConflictResolution } from "../store/types";
+
+/**
+ * Canvas version-conflict dialog (#1891).
+ *
+ * The workflow file save is last-write-wins (ADR-039 §5.2). When an external
+ * writer — most commonly the AI agent's ``write_workflow`` — modifies the open
+ * workflow while the canvas has unsaved local edits, ADR-045 reconciliation
+ * detects the conflict and freezes autosave. Without a resolution step the
+ * debounced autosave would silently clobber the agent's write.
+ *
+ * This is the VS Code "the file has changed on disk" prompt, adapted for an
+ * autosave editor: instead of asking at save time, we ask the moment the
+ * conflict is detected and make the user choose a side. Clean-state remote
+ * changes auto-reload and never reach this dialog.
+ */
+function describeSource(source: VersionConflictState["source"]): string {
+  switch (source) {
+    case "agent":
+      return "the AI agent";
+    case "gitRestore":
+      return "a git restore";
+    case "import":
+      return "an import";
+    case "external":
+      return "an external edit";
+    default:
+      return "another writer";
+  }
+}
+
+export function WorkflowConflictDialog({
+  conflict,
+  onResolve,
+}: {
+  conflict: VersionConflictState | null;
+  onResolve: (resolution: WorkflowConflictResolution) => void;
+}) {
+  if (!conflict || conflict.entityClass !== "workflow") return null;
+
+  const who = describeSource(conflict.source);
+  // ``loadRemote`` discards local edits in favour of the remote version. When
+  // there is no remote payload (deleted/moved on disk, or the refetch failed)
+  // that resolution clears the canvas, so spell that out.
+  const remoteAvailable = Boolean(conflict.remoteWorkflow);
+  const loadLabel = remoteAvailable ? "Load their version" : "Discard my edits";
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-stone-950/55 p-4 backdrop-blur-sm">
+      <div
+        aria-modal="true"
+        role="dialog"
+        aria-labelledby="workflow-conflict-title"
+        className="w-full max-w-md rounded-[1.5rem] border border-stone-200 bg-stone-50 p-6 shadow-panel"
+        data-testid="workflow-conflict-dialog"
+      >
+        <h2 id="workflow-conflict-title" className="font-display text-2xl text-ink">
+          Workflow changed elsewhere
+        </h2>
+
+        <p className="mt-4 text-sm text-stone-700">
+          This workflow was modified by {who} while you had unsaved changes. Choose which version to
+          keep — saving yours will overwrite theirs.
+        </p>
+
+        <div className="mt-6 flex justify-end gap-3">
+          <button
+            className="rounded-full border border-stone-300 px-4 py-2 text-sm transition hover:border-ink"
+            onClick={() => onResolve("loadRemote")}
+            type="button"
+            data-testid="workflow-conflict-load-remote"
+          >
+            {loadLabel}
+          </button>
+          <button
+            className="rounded-full bg-ink px-5 py-2 text-sm font-medium text-stone-50 transition hover:bg-pine"
+            onClick={() => onResolve("keepLocal")}
+            type="button"
+            data-testid="workflow-conflict-keep-local"
+          >
+            Keep my version
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/store/__tests__/workflowSlice.conflict.test.ts
+++ b/frontend/src/store/__tests__/workflowSlice.conflict.test.ts
@@ -1,0 +1,115 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { useAppStore } from "../index";
+import type { VersionedWorkflowResponse } from "../../lib/api";
+import type { VersionConflictState } from "../types";
+
+function workflow(stateVersion: number, description = ""): VersionedWorkflowResponse {
+  return {
+    id: "demo",
+    version: "1.0.0",
+    state_version: stateVersion,
+    workflow_version: "1.0.0",
+    description,
+    nodes: [],
+    edges: [],
+    metadata: {},
+  };
+}
+
+function conflictAt(
+  remoteVersion: number,
+  remote: VersionedWorkflowResponse | null,
+): VersionConflictState {
+  return {
+    entityClass: "workflow",
+    entityId: "demo",
+    kind: "modified",
+    source: "agent",
+    sourceId: null,
+    baseVersion: 5,
+    pendingVersion: 5,
+    remoteVersion,
+    detectedAt: "2026-06-30T00:00:00Z",
+    message: "remote change",
+    remoteWorkflow: remote,
+  };
+}
+
+function resetStore(): void {
+  useAppStore.setState({
+    workflowId: null,
+    workflowName: "Untitled",
+    workflowDescription: "",
+    workflowVersion: "1.0.0",
+    workflowMetadata: {},
+    workflowNodes: [],
+    workflowEdges: [],
+    workflowDirty: false,
+    workflowBaseVersion: null,
+    workflowPendingVersion: null,
+    workflowPendingSourceId: null,
+    workflowConflict: null,
+    workflowHistory: [],
+    workflowFuture: [],
+  });
+}
+
+describe("workflowSlice #1891 conflict resolution", () => {
+  beforeEach(() => {
+    resetStore();
+  });
+
+  it("keepLocal drops the conflict but preserves the dirty local edits", () => {
+    useAppStore.getState().setWorkflow(workflow(5));
+    useAppStore.getState().setWorkflowDescription("local edit");
+    useAppStore.getState().markWorkflowRemoteConflict(conflictAt(6, workflow(6, "agent edit")));
+
+    expect(useAppStore.getState().workflowConflict).not.toBeNull();
+
+    useAppStore.getState().resolveWorkflowConflict("keepLocal");
+
+    const state = useAppStore.getState();
+    expect(state.workflowConflict).toBeNull();
+    // Local edits survive so the now-unfrozen autosave persists them.
+    expect(state.workflowDirty).toBe(true);
+    expect(state.workflowDescription).toBe("local edit");
+    expect(state.workflowBaseVersion).toBe(5);
+  });
+
+  it("loadRemote adopts the remote workflow as the new clean base", () => {
+    useAppStore.getState().setWorkflow(workflow(5));
+    useAppStore.getState().setWorkflowDescription("local edit");
+    useAppStore.getState().markWorkflowRemoteConflict(conflictAt(6, workflow(6, "agent edit")));
+
+    useAppStore.getState().resolveWorkflowConflict("loadRemote");
+
+    const state = useAppStore.getState();
+    expect(state.workflowConflict).toBeNull();
+    expect(state.workflowDirty).toBe(false);
+    expect(state.workflowDescription).toBe("agent edit");
+    expect(state.workflowBaseVersion).toBe(6);
+    expect(state.workflowPendingVersion).toBe(6);
+  });
+
+  it("loadRemote with no remote payload clears the canvas", () => {
+    useAppStore.getState().setWorkflow(workflow(5));
+    useAppStore.getState().setWorkflowDescription("local edit");
+    useAppStore.getState().markWorkflowRemoteConflict(conflictAt(6, null));
+
+    useAppStore.getState().resolveWorkflowConflict("loadRemote");
+
+    const state = useAppStore.getState();
+    expect(state.workflowConflict).toBeNull();
+    expect(state.workflowId).toBeNull();
+    expect(state.workflowDirty).toBe(false);
+  });
+
+  it("is a no-op when there is no active conflict", () => {
+    useAppStore.getState().setWorkflow(workflow(5));
+    useAppStore.getState().resolveWorkflowConflict("keepLocal");
+
+    expect(useAppStore.getState().workflowConflict).toBeNull();
+    expect(useAppStore.getState().workflowBaseVersion).toBe(5);
+  });
+});

--- a/frontend/src/store/types.ts
+++ b/frontend/src/store/types.ts
@@ -49,6 +49,16 @@ export type VersionedChangeSource =
 
 export type VersionedEntityClass = "workflow" | "file";
 
+/**
+ * How the user resolves a workflow version conflict surfaced by the canvas
+ * conflict dialog (#1891):
+ * - ``keepLocal``: keep the unsaved local edits and let autosave persist them,
+ *   overwriting the remote write (now a user-chosen last-write-wins).
+ * - ``loadRemote``: discard local edits and adopt the remote version as the
+ *   new base.
+ */
+export type WorkflowConflictResolution = "keepLocal" | "loadRemote";
+
 export interface VersionConflictState {
   entityClass: VersionedEntityClass;
   entityId: string;
@@ -132,6 +142,7 @@ export interface WorkflowSlice {
   confirmWorkflowVersion: (version: number, sourceId?: string | null) => void;
   markWorkflowRemoteConflict: (conflict: VersionConflictState) => void;
   clearWorkflowConflict: () => void;
+  resolveWorkflowConflict: (resolution: WorkflowConflictResolution) => void;
   undoWorkflow: () => void;
   redoWorkflow: () => void;
 }

--- a/frontend/src/store/workflowSlice.ts
+++ b/frontend/src/store/workflowSlice.ts
@@ -94,6 +94,21 @@ export const createWorkflowSlice: StateCreator<AppStore, [], [], WorkflowSlice> 
     markWorkflowRemoteConflict: (conflict) =>
       set({ workflowConflict: conflict, workflowDirty: true }),
     clearWorkflowConflict: () => set({ workflowConflict: null }),
+    // #1891: the canvas conflict dialog calls this once the user picks a side.
+    // ``loadRemote`` adopts the remote workflow as the new base via setWorkflow
+    // (which resets dirty/base/pending and clears the conflict). ``keepLocal``
+    // just drops the conflict marker so the (still-dirty) local edits resume
+    // autosaving and overwrite the remote write — now a user-chosen
+    // last-write-wins rather than a silent clobber.
+    resolveWorkflowConflict: (resolution) => {
+      const conflict = get().workflowConflict;
+      if (!conflict) return;
+      if (resolution === "loadRemote") {
+        get().setWorkflow(conflict.remoteWorkflow ?? null);
+        return;
+      }
+      set({ workflowConflict: null });
+    },
     undoWorkflow: () => {
       const state = get();
       const last = state.workflowHistory[state.workflowHistory.length - 1];


### PR DESCRIPTION
## Problem

When a user had a workflow open in the canvas with unsaved edits and an AI agent
modified the same workflow in the background, the 800ms debounced autosave
silently overwrote the agent's write (last-write-wins).

ADR-045's version vector **did** detect the conflict (the agent's
`workflow.changed` event advanced the version and the reconcile handler set
`workflowConflict`), but nothing acted on it: the autosave effect guarded only
on `workflowDirty`, `saveWorkflow` PUT unconditionally, `workflowConflict` had
no consuming UI, and `clearWorkflowConflict` was dead code. This left ADR-045
§3.7 ("the client MUST NOT silently overwrite remote changes when local edits
are pending") only half-implemented for workflow YAML.

This is a different path from #1872/#1873 — the agent write emits the WS event
directly on the event bus (MCP `write_workflow`), bypassing the filesystem
watcher guard that #1873 fixed.

## Change (VS Code-style conflict prompt)

- **Freeze autosave while a conflict is pending**: the autosave debounce now
  also skips when `workflowConflict` is set. Clearing the conflict re-runs the
  effect, so autosave resumes on its own.
- **`WorkflowConflictDialog`**: surfaces the prompt, names the `source`
  (e.g. "the AI agent"), and offers **Keep my version** / **Use remote**.
- **`resolveWorkflowConflict(resolution)`**: `keepLocal` drops the conflict
  marker so the still-dirty edits resume autosaving (a now user-chosen
  last-write-wins); `loadRemote` adopts the remote workflow as the new clean
  base via `setWorkflow`.

Clean-state remote changes still auto-reload and never reach the dialog.

## Out of scope

- The file-tab "Show diff" option (ADR-045 §3.7).
- The narrow in-flight-PUT-vs-remote-write timing window — would require
  server-side optimistic concurrency, which ADR-039 §5.2 deliberately removed.

## Tests / docs

- `frontend/src/store/__tests__/workflowSlice.conflict.test.ts` — resolution semantics.
- `frontend/src/components/WorkflowConflictDialog.test.tsx` — dialog behavior.
- ADR-045 §3.7.1 records the completed workflow-YAML conflict UI.

Gate record: .workflow/records/1891-guided-1891-canvas-autosave-conflict-dialog.json

Closes #1891
