### PR TITLE
Steer agent to core Load/Save + core_type (skill, AGENTS.md, list_blocks)

### DIFF
--- a/.workflow/records/1890-agent-core-io-default.json
+++ b/.workflow/records/1890-agent-core-io-default.json
@@ -111,10 +111,142 @@
       "tool_versions": {
         "mypy": "2.1.0"
       }
+    },
+    {
+      "at": "2026-06-30T20:10:21.230111Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:262fd9ed3671c055568889e6f70b47e6905058419d0623658f9d9d633a572fdd",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-30T20:10:26.803895Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e871f3245549188a7e8436a7ac2f81cd8691e6fa1f591322d14237528175d333",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-30T20:10:26.982569Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:64837b80bd27833eca130ad8dfc59291ebae1414df6ff572bd01ce85e1febd49",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-30T20:10:27.014679Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:dc42e587f3bb1e62ff5803a62503fde05b54869fb5b232f6f817154d88cfcd4e",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-30T20:14:23.673824Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:7788c02f572c39ab496e459a9354875d717c2cb51f8bc5b1c5d9c3de2e5d6d7d",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-30T20:19:58.904371Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:c5ca05259cd88164af8a6db074c2cc61edd839739e8aa956991c10346d412707",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-30T20:19:59.647825Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:989c6f08e0659194282dd123f79bf4542e5c5912342a74f6027198587524f4b1",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    },
+    {
+      "at": "2026-06-30T20:27:24.609012Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:7788c02f572c39ab496e459a9354875d717c2cb51f8bc5b1c5d9c3de2e5d6d7d",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
     }
   ],
   "check_na": [],
-  "commit": null,
+  "commit": {
+    "sha": "46498002e66725b954fc00fd2f9dbf481bd1b285",
+    "shas": [
+      "46498002e66725b954fc00fd2f9dbf481bd1b285"
+    ],
+    "trailers": []
+  },
   "declared_scope": {
     "exclude": [],
     "include": []
@@ -249,6 +381,334 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:19:59.738106Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:19:59.762377Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:19:59.787280Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:19:59.813075Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:19:59.839803Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:19:59.863791Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:19:59.895409Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:19:59.927436Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:19:59.961370Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:20:00.024186Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:21:24.706475Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:21:24.717040Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:21:24.728191Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:21:24.738465Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:21:24.749443Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:21:24.760067Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:21:24.770313Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:21:24.780793Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:21:24.791393Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:21:24.802956Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:27:24.655026Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:27:24.667185Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:27:24.679801Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:27:24.692598Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:27:24.704855Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:27:24.715321Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:27:24.725054Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:27:24.734996Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:27:24.746718Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:27:24.761360Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:28:15.946614Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:28:15.954916Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:28:15.963539Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:28:15.972206Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:28:15.980496Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:28:15.989517Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:28:15.998140Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:28:16.006834Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:28:16.015385Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:28:16.025760Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -261,17 +721,18 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "main",
+    "base": "751d6574272d609bd3eb97797a7be2a0a169a7c7",
     "base_sha": "751d6574",
     "changed_files": [
       ".workflow/records/1890-agent-core-io-default.json",
       "src/scistudio/_skills/scistudio/scistudio-build-workflow/SKILL.md",
       "src/scistudio/agent_provisioning/templates/claude_agents_md.md",
-      "src/scistudio/ai/agent/mcp/tools_workflow/_models.py"
+      "src/scistudio/ai/agent/mcp/tools_workflow/_models.py",
+      "tests/ai/test_mcp_tools_workflow.py"
     ],
-    "diff_fingerprint": "sha256:42c70bff653d787aec867fb3135c8e7fa642ac9b3227489f08b8d1f14f0b4f57",
+    "diff_fingerprint": "sha256:c7843ea5448f8155d4acda6868211ab2ad7752902a344482837d58d8c66b85d3",
     "head": "HEAD",
-    "head_sha": "f6a6ef4e",
+    "head_sha": "46498002",
     "surfaces": {
       "docs": 0,
       "frontend": 0,
@@ -280,14 +741,19 @@
       "implementation": 3,
       "packaging": 0,
       "protected_core": 0,
-      "sentrux": 3,
-      "test": 0,
+      "sentrux": 4,
+      "test": 1,
       "workflow_ci": 0
     }
   },
   "owner_directive": "\u7a0d\u5fae\u4fee\u6539 scistudio \u5185\u90e8 agent \u7684 skill\uff1a\u89e3\u91ca core Load/Save \u7528 core_type \u914d\u7f6e\u7c7b\u578b\uff08\u542b package \u7c7b\u578b\uff09\u5e76\u5e95\u5c42 delegate \u7684\u673a\u5236\uff0c\u8ba9 agent \u9ed8\u8ba4\u7528 core load \u4fdd\u8bc1 UI \u4e00\u81f4\u6027\u3002skill \u548c AGENTS.md \u90fd\u8981\u6539\uff0c\u5e76\u5728 list_blocks MCP \u5de5\u5177\u8fd4\u56de\u91cc\u52a0\u63d0\u793a\u3002",
   "persona": "live_implementer",
-  "pull_request": null,
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [],
+    "number": 1893,
+    "url": "https://github.com/jiazhenz026/SciStudio/pull/1893"
+  },
   "reconcile_events": [
     {
       "at": "2026-06-30T20:08:30.536988Z",
@@ -300,6 +766,46 @@
         "docs.docs_required_or_na",
         "guard.docs_landing",
         "tests.changed_test_required"
+      ]
+    },
+    {
+      "at": "2026-06-30T20:20:00.024270Z",
+      "diff_fingerprint": "sha256:c7843ea5448f8155d4acda6868211ab2ad7752902a344482837d58d8c66b85d3",
+      "mode": "local",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.python_tests"
+      ]
+    },
+    {
+      "at": "2026-06-30T20:21:24.802984Z",
+      "diff_fingerprint": "sha256:c7843ea5448f8155d4acda6868211ab2ad7752902a344482837d58d8c66b85d3",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.python_tests"
+      ]
+    },
+    {
+      "at": "2026-06-30T20:27:24.761402Z",
+      "diff_fingerprint": "sha256:c7843ea5448f8155d4acda6868211ab2ad7752902a344482837d58d8c66b85d3",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.python_tests"
+      ]
+    },
+    {
+      "at": "2026-06-30T20:28:16.025799Z",
+      "diff_fingerprint": "sha256:c7843ea5448f8155d4acda6868211ab2ad7752902a344482837d58d8c66b85d3",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.python_tests"
       ]
     }
   ],

--- a/.workflow/records/1890-agent-core-io-default.json
+++ b/.workflow/records/1890-agent-core-io-default.json
@@ -1,6 +1,118 @@
 {
   "branch": "guided/1890-agent-core-io-default",
-  "check_events": [],
+  "check_events": [
+    {
+      "at": "2026-06-30T20:02:00.937056Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:3305082b4ddf6cc98c352c0d0e9b375554c2db8ca951b57cb981c89e8de9e8ad",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-30T20:02:04.794312Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cbfea8b9c6c8b82926fd1223dbae1351d8c349c7bedc30321213f014023d70ac",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-30T20:02:04.909139Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:1e09529fff109fc4625a1971eeeccb8cc681f3320197d1490daa80cfe432296e",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-30T20:02:04.928822Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:5c6387758b2fcf827dc8776b9f90566fce87fbf3db7b2a5303630bf5e0d96f0d",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-30T20:05:06.732177Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:222363db64963f41f96d44fee86409cd89326abbf3ee3972ec0a467ecff5ba00",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-30T20:08:22.228632Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:2fa0d5a955d655fbdb11dbed5111b1f7df9097ae686cd274d79dea23ec7bc30a",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-30T20:08:30.375268Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e4bd27f3afa80691d38dac129b6650b04113859d539b3b83332a00cb5ab42aa2",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    }
+  ],
   "check_na": [],
   "commit": null,
   "declared_scope": {
@@ -8,9 +120,137 @@
     "include": []
   },
   "directive_events": [],
-  "docs_events": [],
+  "docs_events": [
+    {
+      "at": "2026-06-30T20:09:46.790727Z",
+      "class": null,
+      "kind": "path",
+      "path": "src/scistudio/_skills/scistudio/scistudio-build-workflow/SKILL.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-30T20:09:46.790953Z",
+      "class": null,
+      "kind": "path",
+      "path": "src/scistudio/agent_provisioning/templates/claude_agents_md.md",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ],
   "governance_touch": false,
-  "guard_events": [],
+  "guard_events": [
+    {
+      "at": "2026-06-30T20:08:30.410771Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:08:30.424188Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {
+            "governed_files": [
+              "src/scistudio/_skills/scistudio/scistudio-build-workflow/SKILL.md",
+              "src/scistudio/agent_provisioning/templates/claude_agents_md.md",
+              "src/scistudio/ai/agent/mcp/tools_workflow/_models.py"
+            ]
+          },
+          "expected": null,
+          "file": "",
+          "finding_class": "docs_landing",
+          "git_evidence": null,
+          "id": "docs_landing.missing-landing",
+          "line": null,
+          "message": "governed change requires docs/changelog/checklist landing evidence or an explicit N/A rationale",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "docs_landing.missing-landing",
+          "severity": "error",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "docs_landing",
+      "status": "fail"
+    },
+    {
+      "at": "2026-06-30T20:08:30.436297Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:08:30.449026Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:08:30.460900Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:08:30.473504Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:08:30.485292Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:08:30.496921Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:08:30.512741Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:08:30.536878Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
   "issues": [
     {
       "close_in_pr": true,
@@ -20,25 +260,95 @@
     }
   ],
   "observed_admin_labels": [],
-  "observed_diff": null,
+  "observed_diff": {
+    "base": "main",
+    "base_sha": "751d6574",
+    "changed_files": [
+      ".workflow/records/1890-agent-core-io-default.json",
+      "src/scistudio/_skills/scistudio/scistudio-build-workflow/SKILL.md",
+      "src/scistudio/agent_provisioning/templates/claude_agents_md.md",
+      "src/scistudio/ai/agent/mcp/tools_workflow/_models.py"
+    ],
+    "diff_fingerprint": "sha256:42c70bff653d787aec867fb3135c8e7fa642ac9b3227489f08b8d1f14f0b4f57",
+    "head": "HEAD",
+    "head_sha": "f6a6ef4e",
+    "surfaces": {
+      "docs": 0,
+      "frontend": 0,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 3,
+      "packaging": 0,
+      "protected_core": 0,
+      "sentrux": 3,
+      "test": 0,
+      "workflow_ci": 0
+    }
+  },
   "owner_directive": "\u7a0d\u5fae\u4fee\u6539 scistudio \u5185\u90e8 agent \u7684 skill\uff1a\u89e3\u91ca core Load/Save \u7528 core_type \u914d\u7f6e\u7c7b\u578b\uff08\u542b package \u7c7b\u578b\uff09\u5e76\u5e95\u5c42 delegate \u7684\u673a\u5236\uff0c\u8ba9 agent \u9ed8\u8ba4\u7528 core load \u4fdd\u8bc1 UI \u4e00\u81f4\u6027\u3002skill \u548c AGENTS.md \u90fd\u8981\u6539\uff0c\u5e76\u5728 list_blocks MCP \u5de5\u5177\u8fd4\u56de\u91cc\u52a0\u63d0\u793a\u3002",
   "persona": "live_implementer",
   "pull_request": null,
-  "reconcile_events": [],
+  "reconcile_events": [
+    {
+      "at": "2026-06-30T20:08:30.536988Z",
+      "diff_fingerprint": "sha256:42c70bff653d787aec867fb3135c8e7fa642ac9b3227489f08b8d1f14f0b4f57",
+      "mode": "local",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.python_tests",
+        "docs.docs_required_or_na",
+        "guard.docs_landing",
+        "tests.changed_test_required"
+      ]
+    }
+  ],
   "record_id": "1890-agent-core-io-default",
   "requested_admin_labels": [],
   "required_obligations": {
     "admin_labels": [],
-    "checks": [],
-    "docs": [],
-    "guards": [],
-    "tests": []
+    "checks": [
+      "format_check",
+      "full_audit",
+      "import_contracts",
+      "lint_format",
+      "python_tests",
+      "semantic_dup",
+      "type_check"
+    ],
+    "docs": [
+      "docs_required_or_na"
+    ],
+    "guards": [
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": [
+      "changed_test_required"
+    ]
   },
   "runtime": "claude",
   "schema_version": 2,
   "scope_events": [],
   "session_id": "b4cbbde5-bf4a-46df-bd64-989f8043add5",
-  "strictness_tier": null,
+  "strictness_tier": 2,
   "task_kind": "guided",
-  "test_events": []
+  "test_events": [
+    {
+      "at": "2026-06-30T20:09:46.790967Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/ai/test_mcp_tools_workflow.py",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
 }

--- a/.workflow/records/1890-agent-core-io-default.json
+++ b/.workflow/records/1890-agent-core-io-default.json
@@ -1,0 +1,44 @@
+{
+  "branch": "guided/1890-agent-core-io-default",
+  "check_events": [],
+  "check_na": [],
+  "commit": null,
+  "declared_scope": {
+    "exclude": [],
+    "include": []
+  },
+  "directive_events": [],
+  "docs_events": [],
+  "governance_touch": false,
+  "guard_events": [],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1890,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": null,
+  "owner_directive": "\u7a0d\u5fae\u4fee\u6539 scistudio \u5185\u90e8 agent \u7684 skill\uff1a\u89e3\u91ca core Load/Save \u7528 core_type \u914d\u7f6e\u7c7b\u578b\uff08\u542b package \u7c7b\u578b\uff09\u5e76\u5e95\u5c42 delegate \u7684\u673a\u5236\uff0c\u8ba9 agent \u9ed8\u8ba4\u7528 core load \u4fdd\u8bc1 UI \u4e00\u81f4\u6027\u3002skill \u548c AGENTS.md \u90fd\u8981\u6539\uff0c\u5e76\u5728 list_blocks MCP \u5de5\u5177\u8fd4\u56de\u91cc\u52a0\u63d0\u793a\u3002",
+  "persona": "live_implementer",
+  "pull_request": null,
+  "reconcile_events": [],
+  "record_id": "1890-agent-core-io-default",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [],
+    "docs": [],
+    "guards": [],
+    "tests": []
+  },
+  "runtime": "claude",
+  "schema_version": 2,
+  "scope_events": [],
+  "session_id": "b4cbbde5-bf4a-46df-bd64-989f8043add5",
+  "strictness_tier": null,
+  "task_kind": "guided",
+  "test_events": []
+}

--- a/src/scistudio/_skills/scistudio/scistudio-build-workflow/SKILL.md
+++ b/src/scistudio/_skills/scistudio/scistudio-build-workflow/SKILL.md
@@ -27,23 +27,24 @@ workflow:                            # REQUIRED top-level key
   description: One-line summary.     # optional but recommended for the GUI
   nodes:                             # list of block instances
     - id: load                       # node id (referenced by edges; must be unique)
-      block_type: imaging.load_image # registered block name from list_blocks
+      block_type: load_data          # core Load — one block, configured by core_type (§1.1)
       config:                        # passes the block's config_schema
+        core_type: Image             # the type to read; the enum covers package types too
         path: data/raw/beads.tif
     - id: thr
       block_type: imaging.threshold
       config:
         method: otsu
     - id: save
-      block_type: imaging.save_image
+      block_type: save_data          # core Save — configured by core_type
       config:
+        core_type: Image
         path: data/derived/mask.tif
-        format: tiff
   edges:                             # connections between node ports
-    - source: "load:images"          # MUST be "<node_id>:<port_name>" — colon, not dot
+    - source: "load:data"            # MUST be "<node_id>:<port_name>" — colon, not dot
       target: "thr:image"
     - source: "thr:mask"
-      target: "save:images"
+      target: "save:data"
   metadata: {}                       # optional free-form dict
 ```
 
@@ -72,6 +73,36 @@ workflow:                            # REQUIRED top-level key
 |---|---|---|---|
 | `source` | string | yes | `"<node_id>:<port_name>"` — single colon |
 | `target` | string | yes | `"<node_id>:<port_name>"` — single colon |
+
+## 1.1 Loading and saving data: one core block, configured by `core_type`
+
+SciStudio ships a single built-in **Load** (`load_data`) and **Save**
+(`save_data`) block. You do NOT pick a different loader per data type — you
+pick the *type* on the one core block via its `core_type` config:
+
+- `core_type` is an enum computed live from the type registry, so it lists
+  the six built-in core types (Array, DataFrame, Series, Text, Artifact,
+  CompositeData) **and** every package-registered type that has an IO
+  capability — e.g. `Image`, `Spectrum`, `SpectralDataset`, `Mask`. Call
+  `get_block_schema("load_data")` / `get_block_schema("save_data")` to read
+  the live enum for the installed packages.
+- Under the hood the core block delegates to the owning package's
+  loader/saver (the imaging TIFF reader, the spectroscopy reader, …). The
+  delegation is invisible: the workflow YAML, the canvas node, and the port
+  colour all stay on the one stable core Load/Save block.
+
+A package MAY also register its own dedicated IO block
+(`imaging.load_image`, `spectroscopy.load_spectrum`). It reads the same
+data, but it shows up as a *different* node in the GUI — so a project that
+mixes them ends up with inconsistent Load/Save nodes for the same job.
+**Default to core `load_data` / `save_data` + `core_type` for UI
+consistency.** Reach for a package-specific IO block ONLY when no
+`core_type` value covers the type/format you need. The worked examples below
+all use the core blocks.
+
+Port names: the core Load output port is `data` (retyped + recoloured to the
+chosen `core_type`); the core Save input port is also `data`. Wire edges to
+`<node>:data` — not to a package loader's port name.
 
 ## 2. Common authoring pitfalls
 
@@ -128,23 +159,24 @@ workflow:
   description: Load a TIFF, Otsu-threshold, save the binary mask.
   nodes:
     - id: load
-      block_type: imaging.load_image
+      block_type: load_data
       config:
+        core_type: Image
         path: data/raw/beads.tif
     - id: thr
       block_type: imaging.threshold
       config:
         method: otsu
     - id: save
-      block_type: imaging.save_image
+      block_type: save_data
       config:
+        core_type: Image
         path: data/derived/beads_mask.tif
-        format: tiff
   edges:
-    - source: "load:images"
+    - source: "load:data"
       target: "thr:image"
     - source: "thr:mask"
-      target: "save:images"
+      target: "save:data"
 ```
 
 ### Example B — parallel fan-out (load → [denoise, threshold] → composite)
@@ -156,8 +188,9 @@ workflow:
   description: Side-by-side denoised vs raw thresholded mask.
   nodes:
     - id: load
-      block_type: imaging.load_image
+      block_type: load_data
       config:
+        core_type: Image
         path: data/raw/sample.tif
     - id: denoise
       block_type: imaging.denoise
@@ -175,9 +208,9 @@ workflow:
       config:
         labels: [raw, denoised]
   edges:
-    - source: "load:images"
+    - source: "load:data"
       target: "thr_raw:image"
-    - source: "load:images"
+    - source: "load:data"
       target: "denoise:image"
     - source: "denoise:image"
       target: "thr_denoised:image"
@@ -187,7 +220,7 @@ workflow:
       target: "composite:mask_b"
 ```
 
-Note `load:images` appears as the source of two edges — fan-out is
+Note `load:data` appears as the source of two edges — fan-out is
 just multiple edges with the same `source`. The runtime handles
 ref-counting; you do not need a "tee" block.
 
@@ -200,8 +233,9 @@ workflow:
   description: AI block paused for manual segmentation review before downstream stats.
   nodes:
     - id: load
-      block_type: imaging.load_image
+      block_type: load_data
       config:
+        core_type: Image
         path: data/raw/microplastics.tif
     - id: pre
       block_type: imaging.normalize
@@ -217,7 +251,7 @@ workflow:
       config:
         output_path: data/derived/microplastics_stats.csv
   edges:
-    - source: "load:images"
+    - source: "load:data"
       target: "pre:image"
     - source: "pre:image"
       target: "seg:image"
@@ -291,13 +325,12 @@ changing something; the failure mode will recur.
 
 ## Mandatory rules
 
-- Prefer the core `Load` (`load_data`) / `Save` (`save_data`) blocks
-  configured with a `core_type` for reading and writing data — including
-  package-registered types such as `Spectrum`, `SpectralDataset`, `Image`,
-  `Mask`. These now appear in the `core_type` enum returned by
-  `get_block_schema("load_data")` / `get_block_schema("save_data")`, and the
-  core block delegates to the right package loader/saver under the hood. Reach
-  for a package-specific IO block (e.g. `spectroscopy.load_spectrum`,
+- Default to the core `Load` (`load_data`) / `Save` (`save_data`) blocks
+  configured with a `core_type` for reading and writing data — see §1.1 for
+  the mechanism (the enum covers package types like `Spectrum`,
+  `SpectralDataset`, `Image`, `Mask`; the core block delegates to the right
+  package loader/saver under the hood, keeping one consistent GUI node).
+  Reach for a package-specific IO block (e.g. `spectroscopy.load_spectrum`,
   `imaging.load_image`) ONLY when no `core_type` value covers the type/format
   you need. Do not default to the package-specific IO loader when core
   `Load`/`Save` can do the job.

--- a/src/scistudio/agent_provisioning/templates/claude_agents_md.md
+++ b/src/scistudio/agent_provisioning/templates/claude_agents_md.md
@@ -35,6 +35,15 @@ rules: they keep the live GUI, the registry, and lineage consistent.
   matches. Build new only when nothing fits. (A PostToolUse hook
   blocks `blocks/*.py` writes if `list_blocks` was not called earlier in
   the session, on both providers.)
+- When a workflow node reads or writes data, DEFAULT to the core
+  `load_data` / `save_data` block configured with a `core_type`. Its
+  `core_type` enum is computed live from the type registry, so it already
+  covers package-registered types (`Image`, `Spectrum`, `SpectralDataset`,
+  `Mask`, …) and delegates to the owning package's loader/saver under the
+  hood — the user keeps ONE consistent Load/Save node and port colour in the
+  GUI. Reach for a package-specific IO block (e.g. `imaging.load_image`,
+  `spectroscopy.load_spectrum`) ONLY when no `core_type` value covers the
+  type/format you need.
 - BEFORE selecting port types for a new block, call
   `mcp__scistudio__list_types`. Pick the most specific applicable type;
   `DataObject` is reserved for `SubWorkflowBlock`, generic

--- a/src/scistudio/ai/agent/mcp/tools_workflow/_models.py
+++ b/src/scistudio/ai/agent/mcp/tools_workflow/_models.py
@@ -41,7 +41,9 @@ class ListBlocksResult(BaseModel):
     """Return shape for the ``list_blocks`` tool.
 
     A progressive-disclosure catalog: ``blocks`` is the lean index;
-    ``next_step`` points the agent at the detail tool for full schemas.
+    ``next_step`` points the agent at the detail tool for full schemas;
+    ``io_block_guidance`` reminds the agent to read/write data through the
+    core Load/Save block rather than a package-specific IO block.
     """
 
     blocks: list[BlockSummary] = Field(description="Lean catalog of every registered block type.")
@@ -52,6 +54,17 @@ class ListBlocksResult(BaseModel):
             "full I/O ports and config_schema before wiring edges or setting params."
         ),
         description="Suggested next MCP call to obtain a block's full configuration.",
+    )
+    io_block_guidance: str = Field(
+        default=(
+            "To read or write data, default to the core 'load_data' / 'save_data' block "
+            "configured with a 'core_type' (its enum covers package-registered types like "
+            "Image, Spectrum, SpectralDataset, Mask and delegates to the package loader/saver "
+            "under the hood, keeping one consistent GUI Load/Save node). Use a package-specific "
+            "IO block (e.g. imaging.load_image) only when no core_type value covers the "
+            "type/format you need."
+        ),
+        description="Guidance to prefer the core Load/Save block + core_type over package-specific IO blocks.",
     )
 
 

--- a/tests/ai/test_mcp_tools_workflow.py
+++ b/tests/ai/test_mcp_tools_workflow.py
@@ -181,6 +181,11 @@ def test_list_blocks_returns_registered_blocks(ctx: _StubRuntime) -> None:
     assert result.count == len(result.blocks)
     # next_step must route the agent to the detail tool for full schemas.
     assert "get_block_schema" in result.next_step
+    # io_block_guidance steers the agent to the core Load/Save block + core_type
+    # rather than a package-specific IO block, for GUI consistency (#1890).
+    assert result.io_block_guidance
+    assert "core_type" in result.io_block_guidance
+    assert "load_data" in result.io_block_guidance and "save_data" in result.io_block_guidance
     names = {b.name for b in result.blocks}
     assert any(isinstance(n, str) and n for n in names)
     sample = result.blocks[0]


### PR DESCRIPTION
## Summary

The embedded SciStudio agent kept reaching for package-specific IO blocks
(`imaging.load_image`, `spectroscopy.load_spectrum`, …) instead of the core
`load_data` / `save_data` block configured with a `core_type`. The core block
already covers package-registered types (`Image`, `Spectrum`, `SpectralDataset`,
`Mask`, …) via the live `core_type` enum and delegates to the owning package's
loader/saver under the hood, keeping a single consistent GUI Load/Save node and
port colour. Using a package-specific IO block produces a *different* canvas node
for the same data — inconsistent UI.

The guidance already existed as a Mandatory rule / Anti-pattern in the
`scistudio-build-workflow` skill, but the mechanism was unexplained and every
worked example modelled the package-loader pattern. This PR reinforces "default
to core Load/Save + `core_type`" across the three surfaces the agent actually
sees.

## Changes

- **AGENTS.md / CLAUDE.md template** (`agent_provisioning/templates/claude_agents_md.md`):
  add a non-negotiable bullet (one template → both providers) defaulting data IO
  to core `load_data` / `save_data` + `core_type`.
- **`scistudio-build-workflow` skill**: add §1.1 explaining the one-core-block +
  `core_type` + under-the-hood delegation mechanism; convert the top YAML
  template and all three worked examples' IO nodes to core `load_data` /
  `save_data` + `core_type: Image` (ports → `:data`); tighten the Mandatory rule
  to reference §1.1.
- **`list_blocks` MCP tool**: add an additive `io_block_guidance` field to
  `ListBlocksResult` (default text) so every catalog response carries the tip.
  Backward compatible; not under stability governance (tests assert only
  `.blocks` / `.count` / `.next_step`).

No runtime behavior change to the unified Load/Save dispatch itself.

## Test evidence

- New assertion in `tests/ai/test_mcp_tools_workflow.py` covering
  `ListBlocksResult.io_block_guidance`.
- Type correctness of the rewritten examples confirmed: `Mask(Image)` and the
  imaging load/save capabilities both declare `data_type=Image`, so loading and
  saving via `core_type: Image` exactly mirrors the previous
  `imaging.load_image` / `imaging.save_image` behavior.

Closes #1890
