### PR TITLE
fix(#1889): inject PYTHONPATH into MCP bridge env so Codex can import scistudio

### DIFF
--- a/.workflow/records/1889-jiazhenz026-bugfix-1889-codex-mcp-pythonpath.json
+++ b/.workflow/records/1889-jiazhenz026-bugfix-1889-codex-mcp-pythonpath.json
@@ -351,7 +351,13 @@
     }
   ],
   "check_na": [],
-  "commit": null,
+  "commit": {
+    "sha": "ade32a50a6ee903dd197b2d0a68aa0d39f8a29d4",
+    "shas": [
+      "ade32a50a6ee903dd197b2d0a68aa0d39f8a29d4"
+    ],
+    "trailers": []
+  },
   "declared_scope": {
     "exclude": [],
     "include": [
@@ -708,6 +714,88 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:29:49.936731Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:29:49.945132Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:29:49.953642Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:29:49.962064Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:29:49.971020Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:29:49.979613Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:29:49.987908Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:29:49.996979Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:29:50.005582Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:29:50.016519Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -720,7 +808,7 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "origin/main",
+    "base": "751d6574272d609bd3eb97797a7be2a0a169a7c7",
     "base_sha": "751d6574",
     "changed_files": [
       ".workflow/records/1889-jiazhenz026-bugfix-1889-codex-mcp-pythonpath.json",
@@ -729,9 +817,9 @@
       "tests/ai/test_windows_executable_resolution.py",
       "tests/cli/test_install.py"
     ],
-    "diff_fingerprint": "sha256:c09c31bceb1ad81c8e5b659ab3416883e6f7ab90c73d255cd3c75e5310c70908",
+    "diff_fingerprint": "sha256:f426ad575d2806907116ce539658baa68ca6fd92e1223a4ff509b8a10f27c581",
     "head": "HEAD",
-    "head_sha": "d98b504c",
+    "head_sha": "ade32a50",
     "surfaces": {
       "docs": 0,
       "frontend": 0,
@@ -747,7 +835,12 @@
   },
   "owner_directive": "Fix codex MCP server failing to connect (No module named scistudio); unify codex and claude MCP launch env by injecting PYTHONPATH",
   "persona": "implementer",
-  "pull_request": null,
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [],
+    "number": 1894,
+    "url": null
+  },
   "reconcile_events": [
     {
       "at": "2026-06-30T19:57:14.235437Z",
@@ -785,6 +878,16 @@
       "at": "2026-06-30T20:27:14.765398Z",
       "diff_fingerprint": "sha256:c09c31bceb1ad81c8e5b659ab3416883e6f7ab90c73d255cd3c75e5310c70908",
       "mode": "local",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.python_tests"
+      ]
+    },
+    {
+      "at": "2026-06-30T20:29:50.016556Z",
+      "diff_fingerprint": "sha256:f426ad575d2806907116ce539658baa68ca6fd92e1223a4ff509b8a10f27c581",
+      "mode": "pre-pr",
       "result": "fail",
       "tier": 2,
       "unsatisfied": [

--- a/.workflow/records/1889-jiazhenz026-bugfix-1889-codex-mcp-pythonpath.json
+++ b/.workflow/records/1889-jiazhenz026-bugfix-1889-codex-mcp-pythonpath.json
@@ -1,0 +1,858 @@
+{
+  "branch": "jiazhenz026/bugfix/1889-codex-mcp-pythonpath",
+  "check_events": [
+    {
+      "at": "2026-06-30T19:53:14.331316Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:f8f4da360ed88d778fbcf1d3f2a944b03e9adcfaa5f07251901e875a1e1e27b5",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-30T19:53:17.940113Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:daee2b155dde72f9cc2bef8486153b2479e3a6a3e36aa5ae01063be6db815f4c",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-30T19:53:18.055130Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:7db7823c782bddb81a690e46dfb6cc482c94353cf6f507dc3cb7516bf88d94c9",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-30T19:53:18.071334Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:01a441d3790626324704bbab7c83d3eda212b7341f74edf4d0b4f729f0957255",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-30T19:55:10.019510Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:3549e2757e34572e0018b79385a11bd0d28b0bbac8c09c9fc40ac3c827c3b30c",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-30T19:57:07.222066Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:fa66bed31b4cbbf096a2d58626c701a9abc58a1314df25870af8753e90d7584c",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-30T19:57:14.123300Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:95eec8ff4804409c3577336e96447f5a2586a6ac00b4fe167f6c994eeb971c69",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    },
+    {
+      "at": "2026-06-30T19:59:56.219896Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:acbbad5ed8110c74a8ddffe85c61bd6315964afde3881a0442d77ef922a1a18a",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-30T20:00:00.454438Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:8f4f1594e72d7e109232b79626860d79c5cd0163a1d0c366e74389b34614d31c",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-30T20:00:00.628006Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:4038f84befadccabe33597b2bb2b7932d54f8b8fcf0e497f93c8087761ffb466",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-30T20:00:00.651533Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:4f46c864d67a58587b82248594914d3c80340142da12c1dace33aabbde828b20",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-30T20:02:33.314249Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:de8224adb3c07e31c3c5665dc6c1f236fb49080f36af4c32c97919c500b2ad83",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-30T20:07:16.633802Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:d883b4ea0abf865da01566e03b098d73fa8fec14559585a6f80eb3bacda41da3",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-30T20:07:18.345095Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:1f7d28311942879722f738989be4076c85a05991a1283d8913128fd9ee3031e0",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    },
+    {
+      "at": "2026-06-30T20:10:48.726256Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cd1bf6b5af29875d0fb9c35b78f450dfe7d5104a0e830cfdecf7484256c51497",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-30T20:11:09.237489Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:9ff591c22eb6e8096253cfe83bd811e1c3499bc62a4410b98a504061e982b136",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-30T20:11:09.458993Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:43c7f3f418091b7ac045c06c9099eed85cd21a8ae4487dd77916dc2efa67ef07",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-30T20:11:09.516950Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:5bd9f4ac181859c9a48e22fce630cf9813c33bee07730271f1eb7a7660ab2bd0",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-30T20:14:43.324720Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:a7d5d52296caf4fa5070b9618e90bb34f9b105686fe8021d46ace327ea9e79dc",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-30T20:20:16.107900Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:8aabafd6abd9a33a3b340a1194894e66e5c72a3ab1f02316cdfe9fe4d40890d1",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-30T20:20:16.669398Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:516ac8a0bb00054a78b2585fe4ea53a159b40fb5a530e7e19755453324bf1d86",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    },
+    {
+      "at": "2026-06-30T20:27:14.616230Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:a7d5d52296caf4fa5070b9618e90bb34f9b105686fe8021d46ace327ea9e79dc",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    }
+  ],
+  "check_na": [],
+  "commit": null,
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "src/scistudio/cli/install.py",
+      "tests/cli/test_install.py",
+      "tests/ai/test_terminal_codex_overrides.py"
+    ]
+  },
+  "directive_events": [],
+  "docs_events": [
+    {
+      "at": "2026-06-30T19:50:45.075943Z",
+      "class": "adr",
+      "kind": "na",
+      "path": null,
+      "rationale": "Implementation-level env-passing bugfix; ADR-040 \u00a73.7 MCP config structure ([mcp_servers.scistudio] + env table) is unchanged \u2014 PYTHONPATH is an implementation detail inside the existing env table, recorded via #1889 and code docstrings",
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-30T19:50:45.076128Z",
+      "class": "spec",
+      "kind": "na",
+      "path": null,
+      "rationale": "No contract/tool/schema change; MCP toolset and bridge protocol unchanged, only the launch env is made self-contained",
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": false,
+  "guard_events": [
+    {
+      "at": "2026-06-30T19:57:14.150497Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T19:57:14.160348Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T19:57:14.169328Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T19:57:14.178685Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T19:57:14.187829Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T19:57:14.197467Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T19:57:14.206644Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T19:57:14.217008Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T19:57:14.225666Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T19:57:14.235411Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:07:18.398366Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:07:18.413851Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:07:18.436050Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:07:18.453354Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:07:18.472385Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:07:18.494173Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:07:18.515952Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:07:18.537153Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:07:18.557372Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:07:18.577744Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:20:16.720519Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:20:16.741708Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:20:16.759432Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:20:16.775960Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:20:16.791582Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:20:16.813530Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:20:16.835770Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:20:16.851915Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:20:16.874100Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:20:16.895483Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:27:14.663562Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:27:14.675164Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:27:14.686887Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:27:14.697936Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:27:14.708887Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:27:14.719361Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:27:14.729931Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:27:14.741674Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:27:14.752535Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T20:27:14.765367Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1889,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": {
+    "base": "origin/main",
+    "base_sha": "751d6574",
+    "changed_files": [
+      ".workflow/records/1889-jiazhenz026-bugfix-1889-codex-mcp-pythonpath.json",
+      "src/scistudio/cli/install.py",
+      "tests/ai/test_terminal_codex_overrides.py",
+      "tests/ai/test_windows_executable_resolution.py",
+      "tests/cli/test_install.py"
+    ],
+    "diff_fingerprint": "sha256:c09c31bceb1ad81c8e5b659ab3416883e6f7ab90c73d255cd3c75e5310c70908",
+    "head": "HEAD",
+    "head_sha": "d98b504c",
+    "surfaces": {
+      "docs": 0,
+      "frontend": 0,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 1,
+      "packaging": 0,
+      "protected_core": 0,
+      "sentrux": 4,
+      "test": 3,
+      "workflow_ci": 0
+    }
+  },
+  "owner_directive": "Fix codex MCP server failing to connect (No module named scistudio); unify codex and claude MCP launch env by injecting PYTHONPATH",
+  "persona": "implementer",
+  "pull_request": null,
+  "reconcile_events": [
+    {
+      "at": "2026-06-30T19:57:14.235437Z",
+      "diff_fingerprint": "sha256:27bbd1d83a842449e5b3f4f4fba35c8767e9a412df78157d0edf591a5caf98b0",
+      "mode": "local",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.python_tests",
+        "checks.semantic_dup",
+        "checks.type_check"
+      ]
+    },
+    {
+      "at": "2026-06-30T20:07:18.578036Z",
+      "diff_fingerprint": "sha256:2c57467d87c1a673776d37f752dc42919f2bf81534f5877997b440928cb09572",
+      "mode": "local",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.python_tests"
+      ]
+    },
+    {
+      "at": "2026-06-30T20:20:16.895516Z",
+      "diff_fingerprint": "sha256:c09c31bceb1ad81c8e5b659ab3416883e6f7ab90c73d255cd3c75e5310c70908",
+      "mode": "local",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.python_tests"
+      ]
+    },
+    {
+      "at": "2026-06-30T20:27:14.765398Z",
+      "diff_fingerprint": "sha256:c09c31bceb1ad81c8e5b659ab3416883e6f7ab90c73d255cd3c75e5310c70908",
+      "mode": "local",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.python_tests"
+      ]
+    }
+  ],
+  "record_id": "1889-jiazhenz026-bugfix-1889-codex-mcp-pythonpath",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [
+      "format_check",
+      "full_audit",
+      "import_contracts",
+      "lint_format",
+      "python_tests",
+      "semantic_dup",
+      "type_check"
+    ],
+    "docs": [
+      "docs_required_or_na"
+    ],
+    "guards": [
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": [
+      "changed_test_required"
+    ]
+  },
+  "runtime": "claude-code",
+  "schema_version": 2,
+  "scope_events": [
+    {
+      "action": "add-include",
+      "at": "2026-06-30T20:09:25.111539Z",
+      "pattern": "tests/ai/test_windows_executable_resolution.py",
+      "reason": "Update codex overrides regression test for PYTHONPATH injection (#1889)"
+    }
+  ],
+  "session_id": "cb5d597f-2348-4a42-b71a-6e61c3f3f6e0",
+  "strictness_tier": 2,
+  "task_kind": "bugfix",
+  "test_events": [
+    {
+      "at": "2026-06-30T19:50:45.076137Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/cli/test_install.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-06-30T19:50:45.076140Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/ai/test_terminal_codex_overrides.py",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/src/scistudio/cli/install.py
+++ b/src/scistudio/cli/install.py
@@ -91,21 +91,70 @@ def _scistudio_command_for_env() -> tuple[str, list[str]]:
     return sys.executable, ["-m", "scistudio"]
 
 
+def _mcp_bridge_pythonpath() -> str | None:
+    """PYTHONPATH that lets ``<python> -m scistudio mcp-bridge`` import scistudio.
+
+    The bridge command pins ``sys.executable`` (see
+    :func:`_scistudio_command_for_env`), but in dev checkouts and the packaged
+    desktop app the ``scistudio`` package is **not** in that interpreter's
+    site-packages — it is importable only via ``PYTHONPATH`` pointing at the
+    backend ``src`` snapshot.
+
+    The two embedded providers launch the MCP server with different inherited
+    environments, which is why Claude Code worked while Codex did not (#1889):
+
+    * **Claude Code** launches the stdio MCP server inheriting the backend
+      process's full environment, so its ``PYTHONPATH`` carries through and
+      ``-m scistudio`` resolves.
+    * **Codex** launches the stdio MCP server in a *stripped* environment that
+      drops ``PYTHONPATH``; the only env it sees is what we inject. With no
+      ``PYTHONPATH`` the bridge dies with ``No module named scistudio`` and
+      Codex reports ``MCP server failed``.
+
+    Injecting ``PYTHONPATH`` into the server ``env`` makes the launch
+    environment self-contained and identical for both providers regardless of
+    whether the launcher inherits the parent environment. Returns ``None`` only
+    when no path can be determined (``scistudio`` already on the default path
+    and no ambient ``PYTHONPATH``).
+    """
+    import scistudio
+
+    parts: list[str] = [str(Path(scistudio.__file__).resolve().parents[1])]
+    existing = os.environ.get("PYTHONPATH")
+    if existing:
+        parts.extend(existing.split(os.pathsep))
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for part in parts:
+        if part and part not in seen:
+            seen.add(part)
+            ordered.append(part)
+    return os.pathsep.join(ordered) if ordered else None
+
+
 def _mcp_entry_payload(project_dir: Path | None) -> dict[str, object]:
     """Build the MCP server entry written into Claude/Codex config.
 
     The env var ``SCISTUDIO_PROJECT_DIR`` is the contract the standalone
     bridge uses to locate the project; we pin it at install time when
     a project scope is in play, or leave it unset (the bridge falls
-    back to ``cwd``) at user scope.
+    back to ``cwd``) at user scope. ``PYTHONPATH`` is injected so the bridge
+    imports ``scistudio`` even when the launcher (Codex) strips the parent
+    environment — see :func:`_mcp_bridge_pythonpath` (#1889).
     """
     command, prefix_args = _scistudio_command_for_env()
     entry: dict[str, object] = {
         "command": command,
         "args": [*prefix_args, "mcp-bridge"],
     }
+    env: dict[str, str] = {}
     if project_dir is not None:
-        entry["env"] = {"SCISTUDIO_PROJECT_DIR": str(project_dir)}
+        env["SCISTUDIO_PROJECT_DIR"] = str(project_dir)
+    pythonpath = _mcp_bridge_pythonpath()
+    if pythonpath:
+        env["PYTHONPATH"] = pythonpath
+    if env:
+        entry["env"] = env
     return entry
 
 
@@ -253,10 +302,15 @@ def _render_codex_block(project_dir: Path | None) -> str:
         f"command = {_format_toml_string(command)}",
         f"args = {args_literal}",
     ]
-    if project_dir is not None:
+    # Reuse the shared entry env so the codex TOML matches the claude mcp.json.
+    env = _mcp_entry_payload(project_dir).get("env", {})
+    if isinstance(env, dict) and env:
         lines.append("")
         lines.append(f"[mcp_servers.{MCP_SERVER_NAME}.env]")
-        lines.append(f"SCISTUDIO_PROJECT_DIR = {_format_toml_string(str(project_dir))}")
+        # SCISTUDIO_PROJECT_DIR first (when present), then PYTHONPATH (#1889).
+        for key in ("SCISTUDIO_PROJECT_DIR", "PYTHONPATH"):
+            if key in env:
+                lines.append(f"{key} = {_format_toml_string(env[key])}")
     return "\n".join(lines) + "\n"
 
 

--- a/tests/ai/test_terminal_codex_overrides.py
+++ b/tests/ai/test_terminal_codex_overrides.py
@@ -1,0 +1,51 @@
+"""Regression tests for Codex MCP ``-c`` overrides (#1889).
+
+Codex launches the stdio MCP bridge in a *stripped* environment that does not
+inherit the backend's ``PYTHONPATH`` (unlike Claude Code, which inherits the
+full parent env). In dev + packaged-desktop installs ``scistudio`` is importable
+only via ``PYTHONPATH``, so without injecting it the bridge dies with
+``No module named scistudio`` and Codex reports ``MCP server failed``.
+
+These tests pin that the embedded-GUI Codex spawn path injects ``PYTHONPATH``
+into the MCP server ``env`` and that the rendered ``-c`` value is valid TOML
+(Codex parses ``-c key=value`` as TOML).
+"""
+
+from __future__ import annotations
+
+import os
+import tomllib
+from pathlib import Path
+
+from scistudio.ai.agent.terminal import _codex_mcp_config_overrides
+
+
+def _scistudio_src_root() -> str:
+    import scistudio
+
+    return str(Path(scistudio.__file__).resolve().parents[1])
+
+
+def _env_override_line(project_dir: Path) -> str:
+    overrides = _codex_mcp_config_overrides(project_dir)
+    # Overrides are flat ``["-c", "<assignment>", "-c", "<assignment>", ...]``.
+    for token in overrides:
+        if token.startswith("mcp_servers.scistudio.env="):
+            return token
+    raise AssertionError(f"no env override found in {overrides!r}")
+
+
+def test_codex_overrides_inject_pythonpath() -> None:
+    line = _env_override_line(Path("/tmp/proj/x"))
+    assert "PYTHONPATH=" in line
+    assert _scistudio_src_root() in line
+
+
+def test_codex_env_override_is_valid_toml_inline_table() -> None:
+    # Codex parses ``-c key=value`` as TOML; the env inline table must round-trip.
+    project_dir = Path("/tmp/some proj/oxidized-lipid-imaging")
+    line = _env_override_line(project_dir)
+    parsed = tomllib.loads(line)
+    env = parsed["mcp_servers"]["scistudio"]["env"]
+    assert env["SCISTUDIO_PROJECT_DIR"] == str(project_dir)
+    assert _scistudio_src_root() in env["PYTHONPATH"].split(os.pathsep)

--- a/tests/ai/test_terminal_codex_overrides.py
+++ b/tests/ai/test_terminal_codex_overrides.py
@@ -38,7 +38,11 @@ def _env_override_line(project_dir: Path) -> str:
 def test_codex_overrides_inject_pythonpath() -> None:
     line = _env_override_line(Path("/tmp/proj/x"))
     assert "PYTHONPATH=" in line
-    assert _scistudio_src_root() in line
+    # Parse the ``-c`` assignment as TOML (codex does the same) before comparing
+    # the path: on Windows the value is backslash-escaped in the literal, so the
+    # raw path is not a substring of the assignment line (PR #1894 P2).
+    env = tomllib.loads(line)["mcp_servers"]["scistudio"]["env"]
+    assert _scistudio_src_root() in env["PYTHONPATH"].split(os.pathsep)
 
 
 def test_codex_env_override_is_valid_toml_inline_table() -> None:

--- a/tests/ai/test_windows_executable_resolution.py
+++ b/tests/ai/test_windows_executable_resolution.py
@@ -157,18 +157,21 @@ def test_spawn_codex_injects_project_mcp_config_overrides(monkeypatch: Any, tmp_
     terminal.spawn_codex(project_dir=tmp_path, dangerous=False)
 
     argv = spawned["argv"]
-    assert argv[:7] == [
+    # command + args overrides are exact.
+    assert argv[:6] == [
         "codex",
         "-c",
         f"mcp_servers.scistudio.command={json.dumps(sys.executable)}",
         "-c",
         'mcp_servers.scistudio.args=["-m", "scistudio", "mcp-bridge"]',
         "-c",
-        f"mcp_servers.scistudio.env={{SCISTUDIO_PROJECT_DIR={json.dumps(str(tmp_path))}}}",
     ]
-    assert f"mcp_servers.scistudio.command={json.dumps(sys.executable)}" in argv
-    assert 'mcp_servers.scistudio.args=["-m", "scistudio", "mcp-bridge"]' in argv
-    assert f"SCISTUDIO_PROJECT_DIR={json.dumps(str(tmp_path))}" in argv[-1]
+    # The env override pins the project dir and also injects PYTHONPATH (#1889)
+    # so codex's stripped launch environment can still import scistudio.
+    env_override = argv[6]
+    assert env_override.startswith("mcp_servers.scistudio.env={")
+    assert f"SCISTUDIO_PROJECT_DIR={json.dumps(str(tmp_path))}" in env_override
+    assert "PYTHONPATH=" in env_override
 
 
 def test_spawn_claude_appends_prompt_after_dashdash(monkeypatch: Any, tmp_path: Path) -> None:

--- a/tests/cli/test_install.py
+++ b/tests/cli/test_install.py
@@ -11,6 +11,7 @@ Covers:
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 from unittest.mock import patch
 
@@ -18,6 +19,9 @@ import pytest
 
 from scistudio.cli.install import (
     MCP_SERVER_NAME,
+    _mcp_bridge_pythonpath,
+    _mcp_entry_payload,
+    _render_codex_block,
     _strip_codex_block,
     perform_install,
 )
@@ -140,6 +144,71 @@ def test_remove_codex_round_trip(fake_home: Path, fake_cwd: Path) -> None:
 
     text = (fake_home / ".codex" / "config.toml").read_text(encoding="utf-8")
     assert f"[mcp_servers.{MCP_SERVER_NAME}]" not in text
+
+
+# ---------------------------------------------------------------------------
+# #1889 — bridge env carries PYTHONPATH so Codex (stripped launch env) can
+# import scistudio, matching Claude Code (which inherits the parent env).
+# ---------------------------------------------------------------------------
+
+
+def _scistudio_src_root() -> str:
+    import scistudio
+
+    return str(Path(scistudio.__file__).resolve().parents[1])
+
+
+def test_pythonpath_helper_includes_scistudio_root_and_ambient(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PYTHONPATH", f"/custom/a{os.pathsep}/custom/b")
+    result = _mcp_bridge_pythonpath()
+    assert result is not None
+    parts = result.split(os.pathsep)
+    # scistudio's own source root must be present so `-m scistudio` resolves.
+    assert _scistudio_src_root() in parts
+    # The ambient PYTHONPATH segments are preserved (and de-duplicated).
+    assert "/custom/a" in parts
+    assert "/custom/b" in parts
+    assert len(parts) == len(set(parts)), "PYTHONPATH segments must be de-duplicated"
+
+
+def test_mcp_entry_payload_injects_pythonpath_project_scope(tmp_path: Path) -> None:
+    entry = _mcp_entry_payload(tmp_path)
+    env = entry["env"]
+    assert isinstance(env, dict)
+    assert env["SCISTUDIO_PROJECT_DIR"] == str(tmp_path)
+    # #1889: without this, Codex's stripped launch env hits No module named scistudio.
+    assert _scistudio_src_root() in env["PYTHONPATH"].split(os.pathsep)
+
+
+def test_mcp_entry_payload_injects_pythonpath_user_scope() -> None:
+    # User scope (project_dir=None) still needs PYTHONPATH so the bridge imports.
+    entry = _mcp_entry_payload(None)
+    env = entry["env"]
+    assert isinstance(env, dict)
+    assert "SCISTUDIO_PROJECT_DIR" not in env
+    assert _scistudio_src_root() in env["PYTHONPATH"].split(os.pathsep)
+
+
+def test_claude_and_codex_share_identical_mcp_env(tmp_path: Path) -> None:
+    """#1889: both providers go through one env builder, so their launch env matches."""
+    claude_entry = _mcp_entry_payload(tmp_path)
+    codex_block = _render_codex_block(tmp_path)
+    claude_env = claude_entry["env"]
+    assert isinstance(claude_env, dict)
+    pythonpath = claude_env["PYTHONPATH"]
+    # The same PYTHONPATH the claude mcp.json carries appears in the codex TOML.
+    assert pythonpath in codex_block
+    assert claude_env["SCISTUDIO_PROJECT_DIR"] in codex_block
+
+
+def test_render_codex_block_includes_pythonpath_env(tmp_path: Path) -> None:
+    text = _render_codex_block(tmp_path)
+    assert f"[mcp_servers.{MCP_SERVER_NAME}.env]" in text
+    assert "PYTHONPATH = " in text
+    # SCISTUDIO_PROJECT_DIR must still be emitted before PYTHONPATH.
+    assert text.index("SCISTUDIO_PROJECT_DIR") < text.index("PYTHONPATH")
 
 
 def test_strip_codex_block_handles_nested_env() -> None:


### PR DESCRIPTION
## Summary

In the embedded AI chat, the **codex** provider reported `MCP server failed` and
exposed none of SciStudio's MCP tools, while **claude** worked in the same project.

Root cause: both providers launch the same bridge command
`<sys.executable> -m scistudio mcp-bridge`, but `scistudio` is not in the
interpreter's site-packages (true for dev checkouts and the packaged desktop app,
which import `scistudio` only via `PYTHONPATH` pointing at the backend/src snapshot).

- **claude** launches the stdio MCP server inheriting the backend's full
  environment, so `PYTHONPATH` carries through and `-m scistudio` resolves.
- **codex** launches the stdio MCP server in a **stripped** environment that drops
  `PYTHONPATH`; with only `SCISTUDIO_PROJECT_DIR` injected, the bridge died with
  `No module named scistudio` → `MCP server failed`.

Reproduced with codex 0.142.3:

```
codex_rmcp_client::stdio_server_launcher: MCP server stderr (.../python):
  .../python: No module named scistudio
```

Injecting `PYTHONPATH` into the MCP server `env` makes scistudio's MCP server
initialize successfully under codex.

## Fix

Make the injected MCP `env` self-contained (and identical) for both providers:

- `_mcp_entry_payload` (shared by the Claude `mcp.json` and the Codex `-c`
  overrides) and the on-disk `_render_codex_block` now add `PYTHONPATH` via a new
  `_mcp_bridge_pythonpath()` helper (scistudio source root + ambient `PYTHONPATH`,
  de-duplicated).
- This unifies the two providers' effective launch environment instead of relying
  on codex/claude differing in whether they inherit the parent environment.

## Tests

- `tests/cli/test_install.py`: payload + codex-block now carry `PYTHONPATH`
  (project and user scope); claude/codex env parity.
- `tests/ai/test_terminal_codex_overrides.py`: codex `-c` overrides inject
  `PYTHONPATH` and the env inline table is valid TOML (codex parses `-c` as TOML).

## Docs

N/A — implementation-level env-passing fix. ADR-040 §3.7 MCP config structure
(`[mcp_servers.scistudio]` + env table) is unchanged; `PYTHONPATH` is an
implementation detail inside the existing env table. No MCP contract, tool, or
schema change.

Gate record: .workflow/records/1889-jiazhenz026-bugfix-1889-codex-mcp-pythonpath.json

Closes #1889
