### PR TITLE
Isolate PTY/subprocess/thread tests from xdist to stop flaky CI (#1896)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,19 +126,37 @@ jobs:
         # diagnosable failure instead of timing out the whole job at 6 h.
         # ``timeout 600`` is a belt-and-suspenders shell-level kill in
         # case pytest-timeout itself wedges (xdist + pty edge cases).
+        #
+        # Two-phase run (#1896): the parallel bulk first (deselecting the
+        # ``serial`` marker), then the ``serial`` PTY/subprocess/thread tests
+        # in-process (``-n 0``) so a hang or leaked thread in one of them cannot
+        # crash an xdist worker and fail the whole job. The gate runs the same
+        # two phases via ``scistudio.qa.testing.run_python_tests``. On 3.13
+        # (coverage on) the parallel phase writes a fresh dataset without the
+        # floor and the serial phase appends with ``--cov-append`` so the
+        # combined ``--cov-fail-under`` still holds; 3.11 runs ``--no-cov``.
         run: |
           if [ "${{ matrix.python-version }}" = "3.13" ]; then
-            timeout 600 pytest -n auto --timeout=60 --timeout-method=thread
+            nocov=""
+            cov_parallel="--cov-fail-under=0"
+            cov_serial="--cov-append"
           else
-            timeout 600 pytest -n auto --no-cov --timeout=60 --timeout-method=thread
+            nocov="--no-cov"
+            cov_parallel=""
+            cov_serial=""
           fi
+          timeout 600 pytest -n auto -m "not serial" $nocov --timeout=60 --timeout-method=thread $cov_parallel
           rc=$?
-          if [ $rc -eq 5 ]; then
-            echo "No tests collected — skipping"
-            exit 0
-          fi
+          if [ $rc -eq 5 ]; then rc=0; fi
           if [ $rc -eq 124 ]; then
-            echo "::error::pytest exceeded 600s shell timeout (hang escaped --timeout=60)"
+            echo "::error::pytest parallel phase exceeded 600s shell timeout (hang escaped --timeout=60)"
+          fi
+          if [ $rc -ne 0 ]; then exit $rc; fi
+          timeout 600 pytest -n 0 -m serial $nocov --timeout=60 --timeout-method=thread $cov_serial
+          rc=$?
+          if [ $rc -eq 5 ]; then rc=0; fi
+          if [ $rc -eq 124 ]; then
+            echo "::error::pytest serial phase exceeded 600s shell timeout (hang escaped --timeout=60)"
           fi
           exit $rc
 

--- a/.workflow/records/1896-ci-serial-test-isolation.json
+++ b/.workflow/records/1896-ci-serial-test-isolation.json
@@ -1,0 +1,44 @@
+{
+  "branch": "guided/1896-ci-serial-test-isolation",
+  "check_events": [],
+  "check_na": [],
+  "commit": null,
+  "declared_scope": {
+    "exclude": [],
+    "include": []
+  },
+  "directive_events": [],
+  "docs_events": [],
+  "governance_touch": false,
+  "guard_events": [],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1896,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": null,
+  "owner_directive": "\u6839\u6cbb CI flaky:\u628a\u8fdb\u7a0b/PTY/watchdog \u7c7b\u6d4b\u8bd5\u4ece -n auto \u5e76\u884c\u6279\u91cc\u62ce\u51fa\u6765\u5355\u72ec\u4e32\u884c\u8dd1(\u65b9\u54112);CI \u548c gate \u4e24\u8fb9\u90fd\u6539,\u4fdd\u6301\u4e00\u81f4\u3002serial \u96c6\u5408=watchdog + \u5168\u90e8\u771f PTY \u6d4b\u8bd5\u3002",
+  "persona": "live_implementer",
+  "pull_request": null,
+  "reconcile_events": [],
+  "record_id": "1896-ci-serial-test-isolation",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [],
+    "docs": [],
+    "guards": [],
+    "tests": []
+  },
+  "runtime": "claude",
+  "schema_version": 2,
+  "scope_events": [],
+  "session_id": "9cb53f13-c5a0-49c3-b15d-20690eeb2946",
+  "strictness_tier": null,
+  "task_kind": "guided",
+  "test_events": []
+}

--- a/.workflow/records/1896-ci-serial-test-isolation.json
+++ b/.workflow/records/1896-ci-serial-test-isolation.json
@@ -175,7 +175,7 @@
       "verified_in_diff": null
     }
   ],
-  "governance_touch": false,
+  "governance_touch": true,
   "guard_events": [
     {
       "at": "2026-06-30T22:52:36.859410Z",
@@ -394,6 +394,194 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-06-30T22:59:36.247008Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T22:59:36.255833Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T22:59:36.264179Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T22:59:36.272408Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T22:59:36.280684Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": ".github/workflows/ci.yml",
+          "finding_class": "governance",
+          "git_evidence": null,
+          "id": "governance.mod_guard.unauthorized-change",
+          "line": null,
+          "message": "governance-critical file changed without authorization; declare governance_touch in the ledger and obtain owner review",
+          "path": ".github/workflows/ci.yml",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "governance.mod_guard.unauthorized-change",
+          "severity": "error",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "pyproject.toml",
+          "finding_class": "governance",
+          "git_evidence": null,
+          "id": "governance.mod_guard.unauthorized-change",
+          "line": null,
+          "message": "governance-critical file changed without authorization; declare governance_touch in the ledger and obtain owner review",
+          "path": "pyproject.toml",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "governance.mod_guard.unauthorized-change",
+          "severity": "error",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/qa/governance/gate_record/checks.py",
+          "finding_class": "governance",
+          "git_evidence": null,
+          "id": "governance.mod_guard.unauthorized-change",
+          "line": null,
+          "message": "governance-critical file changed without authorization; declare governance_touch in the ledger and obtain owner review",
+          "path": "src/scistudio/qa/governance/gate_record/checks.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "governance.mod_guard.unauthorized-change",
+          "severity": "error",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/qa/testing/__init__.py",
+          "finding_class": "governance",
+          "git_evidence": null,
+          "id": "governance.mod_guard.unauthorized-change",
+          "line": null,
+          "message": "governance-critical file changed without authorization; declare governance_touch in the ledger and obtain owner review",
+          "path": "src/scistudio/qa/testing/__init__.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "governance.mod_guard.unauthorized-change",
+          "severity": "error",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/qa/testing/run_python_tests.py",
+          "finding_class": "governance",
+          "git_evidence": null,
+          "id": "governance.mod_guard.unauthorized-change",
+          "line": null,
+          "message": "governance-critical file changed without authorization; declare governance_touch in the ledger and obtain owner review",
+          "path": "src/scistudio/qa/testing/run_python_tests.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "governance.mod_guard.unauthorized-change",
+          "severity": "error",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "mod_guard",
+      "status": "fail"
+    },
+    {
+      "at": "2026-06-30T22:59:36.289083Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T22:59:36.297277Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T22:59:36.305614Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T22:59:36.314326Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T22:59:36.323227Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -406,7 +594,7 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "main",
+    "base": "origin/main",
     "base_sha": "caed9809",
     "changed_files": [
       ".github/workflows/ci.yml",
@@ -424,9 +612,9 @@
       "tests/desktop/test_parent_watchdog.py",
       "tests/qa/testing/test_run_python_tests.py"
     ],
-    "diff_fingerprint": "sha256:b2fb3eac024c5f0394d9a3ecea3ac0b35fbb3bcd5a8d249b860b7a0cc7f506fe",
+    "diff_fingerprint": "sha256:211dd773becd538986c236224c097445369bc4ab14a01aa1116b608aaeba3c0b",
     "head": "HEAD",
-    "head_sha": "fa624d9a",
+    "head_sha": "a7644a9d",
     "surfaces": {
       "docs": 0,
       "frontend": 0,
@@ -455,6 +643,16 @@
         "guard.docs_landing",
         "guard.mod_guard",
         "tests.changed_test_required"
+      ]
+    },
+    {
+      "at": "2026-06-30T22:59:36.323256Z",
+      "diff_fingerprint": "sha256:211dd773becd538986c236224c097445369bc4ab14a01aa1116b608aaeba3c0b",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "guard.mod_guard"
       ]
     }
   ],

--- a/.workflow/records/1896-ci-serial-test-isolation.json
+++ b/.workflow/records/1896-ci-serial-test-isolation.json
@@ -1,6 +1,163 @@
 {
   "branch": "guided/1896-ci-serial-test-isolation",
-  "check_events": [],
+  "check_events": [
+    {
+      "at": "2026-06-30T22:48:35.643466Z",
+      "command": "pytest tests/architecture/ -v --no-cov",
+      "covered_surface": "architecture",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:87ee989adc446b938b8c64d5f3b283f01c6a88313ce9a78ef7a8e07d47eef17a",
+      "name": "architecture_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/architecture_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-30T22:48:36.425864Z",
+      "command": "python scripts/deferral_scan.py --check docs/audit/baselines/deferral-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:bcf943a86ff111a24eda6c179513de96ea00d17c58d66ab34d8b60560f45109d",
+      "name": "deferral_discipline",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/deferral_discipline.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-30T22:48:36.776945Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:7d18deb7a56b4ed14716e577df4d67a0b8e546e194fe1c026d5a0852378f8ad7",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-30T22:48:40.189604Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:f19d3e659e1612485de9e8032f137a05cfcca6d808e2b2aed5e01565a8c2441a",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-30T22:48:40.692967Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:437043027f18dda938d801c8903c86de22034aaf9ad3e6ab7fb521015470b385",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-30T22:48:40.733632Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:bce5437feabe56e2805c194eca78196c35a595916494f7e94ad499b9c533f00e",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-06-30T22:50:35.277643Z",
+      "command": "python -m scistudio.qa.testing.run_python_tests --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:f13c88807001748e1b664bced44032d590156db731b936311cd443a63b10b5b6",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-30T22:52:27.871426Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:59db70993ce8d2187069eb04707151aeb63ff4596d6a6253579a35b1812783f6",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-06-30T22:52:34.154450Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:a8df5192c87056bf755ff6c096bf49a0278ca2a501741f5f292074ba607a8795",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    },
+    {
+      "at": "2026-06-30T22:52:36.825315Z",
+      "command": "python -m build --wheel",
+      "covered_surface": "packaging",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:9bc59e4ec76fd1aa4c6a5426474eb3d61fcedc1cc5aa2159f7750878d7648ce7",
+      "name": "wheel_release_smoke",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/wheel_release_smoke.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    }
+  ],
   "check_na": [],
   "commit": null,
   "declared_scope": {
@@ -8,9 +165,237 @@
     "include": []
   },
   "directive_events": [],
-  "docs_events": [],
+  "docs_events": [
+    {
+      "at": "2026-06-30T22:59:05.806696Z",
+      "class": "implementation",
+      "kind": "na",
+      "path": null,
+      "rationale": "test-infra only; the 'serial' marker is self-documenting in pyproject [tool.pytest.ini_options].markers, the run_python_tests module docstring, and ci.yml comments; no developer doc enumerates pytest markers (requires_r/requires_fiji are likewise pyproject-only).",
+      "verified_in_diff": null
+    }
+  ],
   "governance_touch": false,
-  "guard_events": [],
+  "guard_events": [
+    {
+      "at": "2026-06-30T22:52:36.859410Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T22:52:36.869118Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {
+            "governed_files": [
+              ".github/workflows/ci.yml",
+              "pyproject.toml",
+              "src/scistudio/qa/governance/gate_record/checks.py",
+              "src/scistudio/qa/testing/__init__.py",
+              "src/scistudio/qa/testing/run_python_tests.py"
+            ]
+          },
+          "expected": null,
+          "file": "",
+          "finding_class": "docs_landing",
+          "git_evidence": null,
+          "id": "docs_landing.missing-landing",
+          "line": null,
+          "message": "governed change requires docs/changelog/checklist landing evidence or an explicit N/A rationale",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "docs_landing.missing-landing",
+          "severity": "error",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "docs_landing",
+      "status": "fail"
+    },
+    {
+      "at": "2026-06-30T22:52:36.877851Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T22:52:36.887021Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T22:52:36.896454Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": ".github/workflows/ci.yml",
+          "finding_class": "governance",
+          "git_evidence": null,
+          "id": "governance.mod_guard.unauthorized-change",
+          "line": null,
+          "message": "governance-critical file changed without authorization; declare governance_touch in the ledger and obtain owner review",
+          "path": ".github/workflows/ci.yml",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "governance.mod_guard.unauthorized-change",
+          "severity": "error",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "pyproject.toml",
+          "finding_class": "governance",
+          "git_evidence": null,
+          "id": "governance.mod_guard.unauthorized-change",
+          "line": null,
+          "message": "governance-critical file changed without authorization; declare governance_touch in the ledger and obtain owner review",
+          "path": "pyproject.toml",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "governance.mod_guard.unauthorized-change",
+          "severity": "error",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/qa/governance/gate_record/checks.py",
+          "finding_class": "governance",
+          "git_evidence": null,
+          "id": "governance.mod_guard.unauthorized-change",
+          "line": null,
+          "message": "governance-critical file changed without authorization; declare governance_touch in the ledger and obtain owner review",
+          "path": "src/scistudio/qa/governance/gate_record/checks.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "governance.mod_guard.unauthorized-change",
+          "severity": "error",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/qa/testing/__init__.py",
+          "finding_class": "governance",
+          "git_evidence": null,
+          "id": "governance.mod_guard.unauthorized-change",
+          "line": null,
+          "message": "governance-critical file changed without authorization; declare governance_touch in the ledger and obtain owner review",
+          "path": "src/scistudio/qa/testing/__init__.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "governance.mod_guard.unauthorized-change",
+          "severity": "error",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/qa/testing/run_python_tests.py",
+          "finding_class": "governance",
+          "git_evidence": null,
+          "id": "governance.mod_guard.unauthorized-change",
+          "line": null,
+          "message": "governance-critical file changed without authorization; declare governance_touch in the ledger and obtain owner review",
+          "path": "src/scistudio/qa/testing/run_python_tests.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "governance.mod_guard.unauthorized-change",
+          "severity": "error",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "mod_guard",
+      "status": "fail"
+    },
+    {
+      "at": "2026-06-30T22:52:36.906174Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T22:52:36.915409Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T22:52:36.924456Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T22:52:36.933282Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T22:52:36.942811Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
   "issues": [
     {
       "close_in_pr": true,
@@ -20,25 +405,108 @@
     }
   ],
   "observed_admin_labels": [],
-  "observed_diff": null,
+  "observed_diff": {
+    "base": "main",
+    "base_sha": "caed9809",
+    "changed_files": [
+      ".github/workflows/ci.yml",
+      ".workflow/records/1896-ci-serial-test-isolation.json",
+      "pyproject.toml",
+      "src/scistudio/qa/governance/gate_record/checks.py",
+      "src/scistudio/qa/testing/__init__.py",
+      "src/scistudio/qa/testing/run_python_tests.py",
+      "tests/ai/test_terminal.py",
+      "tests/ai/test_terminal_extra_env.py",
+      "tests/ai/test_terminal_macos_smoke.py",
+      "tests/api/test_ai_pty.py",
+      "tests/api/test_ai_pty_audit_fixes.py",
+      "tests/api/test_ai_pty_engine_spawn.py",
+      "tests/desktop/test_parent_watchdog.py",
+      "tests/qa/testing/test_run_python_tests.py"
+    ],
+    "diff_fingerprint": "sha256:b2fb3eac024c5f0394d9a3ecea3ac0b35fbb3bcd5a8d249b860b7a0cc7f506fe",
+    "head": "HEAD",
+    "head_sha": "fa624d9a",
+    "surfaces": {
+      "docs": 0,
+      "frontend": 0,
+      "governance": 5,
+      "governed_docs": 0,
+      "implementation": 5,
+      "packaging": 1,
+      "protected_core": 0,
+      "sentrux": 12,
+      "test": 8,
+      "workflow_ci": 1
+    }
+  },
   "owner_directive": "\u6839\u6cbb CI flaky:\u628a\u8fdb\u7a0b/PTY/watchdog \u7c7b\u6d4b\u8bd5\u4ece -n auto \u5e76\u884c\u6279\u91cc\u62ce\u51fa\u6765\u5355\u72ec\u4e32\u884c\u8dd1(\u65b9\u54112);CI \u548c gate \u4e24\u8fb9\u90fd\u6539,\u4fdd\u6301\u4e00\u81f4\u3002serial \u96c6\u5408=watchdog + \u5168\u90e8\u771f PTY \u6d4b\u8bd5\u3002",
   "persona": "live_implementer",
   "pull_request": null,
-  "reconcile_events": [],
+  "reconcile_events": [
+    {
+      "at": "2026-06-30T22:52:36.942850Z",
+      "diff_fingerprint": "sha256:b2fb3eac024c5f0394d9a3ecea3ac0b35fbb3bcd5a8d249b860b7a0cc7f506fe",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "docs.docs_required_or_na",
+        "guard.docs_landing",
+        "guard.mod_guard",
+        "tests.changed_test_required"
+      ]
+    }
+  ],
   "record_id": "1896-ci-serial-test-isolation",
   "requested_admin_labels": [],
   "required_obligations": {
     "admin_labels": [],
-    "checks": [],
-    "docs": [],
-    "guards": [],
-    "tests": []
+    "checks": [
+      "architecture_tests",
+      "deferral_discipline",
+      "format_check",
+      "full_audit",
+      "import_contracts",
+      "lint_format",
+      "python_tests",
+      "semantic_dup",
+      "type_check",
+      "wheel_release_smoke"
+    ],
+    "docs": [
+      "docs_required_or_na"
+    ],
+    "guards": [
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": [
+      "changed_test_required"
+    ]
   },
   "runtime": "claude",
   "schema_version": 2,
   "scope_events": [],
   "session_id": "9cb53f13-c5a0-49c3-b15d-20690eeb2946",
-  "strictness_tier": null,
+  "strictness_tier": 1,
   "task_kind": "guided",
-  "test_events": []
+  "test_events": [
+    {
+      "at": "2026-06-30T22:59:05.806835Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/qa/testing/test_run_python_tests.py",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
 }

--- a/.workflow/records/1896-ci-serial-test-isolation.json
+++ b/.workflow/records/1896-ci-serial-test-isolation.json
@@ -159,7 +159,13 @@
     }
   ],
   "check_na": [],
-  "commit": null,
+  "commit": {
+    "sha": "c39474dc45a12277db2be8507f0415616b76f3f0",
+    "shas": [
+      "c39474dc45a12277db2be8507f0415616b76f3f0"
+    ],
+    "trailers": []
+  },
   "declared_scope": {
     "exclude": [],
     "include": []
@@ -582,6 +588,252 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-06-30T23:00:39.034315Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T23:00:39.042520Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T23:00:39.051147Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T23:00:39.059830Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T23:00:39.068243Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T23:00:39.077127Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T23:00:39.085420Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T23:00:39.093713Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T23:00:39.101739Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T23:00:39.110402Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T23:00:48.181857Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T23:00:48.190392Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T23:00:48.199008Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T23:00:48.207508Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T23:00:48.215771Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T23:00:48.224483Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T23:00:48.232943Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T23:00:48.241447Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T23:00:48.250133Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T23:00:48.259128Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T23:00:58.681499Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T23:00:58.690241Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T23:00:58.698623Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T23:00:58.707102Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T23:00:58.715487Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T23:00:58.724401Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T23:00:58.732742Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T23:00:58.741215Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T23:00:58.749720Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-06-30T23:00:58.758536Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -594,7 +846,7 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "origin/main",
+    "base": "caed98095690b2881eabd976f0035f3353b6ec95",
     "base_sha": "caed9809",
     "changed_files": [
       ".github/workflows/ci.yml",
@@ -612,9 +864,9 @@
       "tests/desktop/test_parent_watchdog.py",
       "tests/qa/testing/test_run_python_tests.py"
     ],
-    "diff_fingerprint": "sha256:211dd773becd538986c236224c097445369bc4ab14a01aa1116b608aaeba3c0b",
+    "diff_fingerprint": "sha256:7dc0610d19930b3affad1b49378f5313870917459dc7ef3a9d739fc8d1bab4a2",
     "head": "HEAD",
-    "head_sha": "a7644a9d",
+    "head_sha": "c39474dc",
     "surfaces": {
       "docs": 0,
       "frontend": 0,
@@ -630,7 +882,12 @@
   },
   "owner_directive": "\u6839\u6cbb CI flaky:\u628a\u8fdb\u7a0b/PTY/watchdog \u7c7b\u6d4b\u8bd5\u4ece -n auto \u5e76\u884c\u6279\u91cc\u62ce\u51fa\u6765\u5355\u72ec\u4e32\u884c\u8dd1(\u65b9\u54112);CI \u548c gate \u4e24\u8fb9\u90fd\u6539,\u4fdd\u6301\u4e00\u81f4\u3002serial \u96c6\u5408=watchdog + \u5168\u90e8\u771f PTY \u6d4b\u8bd5\u3002",
   "persona": "live_implementer",
-  "pull_request": null,
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [],
+    "number": 1897,
+    "url": "https://github.com/jiazhenz026/SciStudio/pull/1897"
+  },
   "reconcile_events": [
     {
       "at": "2026-06-30T22:52:36.942850Z",
@@ -654,6 +911,30 @@
       "unsatisfied": [
         "guard.mod_guard"
       ]
+    },
+    {
+      "at": "2026-06-30T23:00:39.110432Z",
+      "diff_fingerprint": "sha256:7dc0610d19930b3affad1b49378f5313870917459dc7ef3a9d739fc8d1bab4a2",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-30T23:00:48.259161Z",
+      "diff_fingerprint": "sha256:7dc0610d19930b3affad1b49378f5313870917459dc7ef3a9d739fc8d1bab4a2",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-06-30T23:00:58.758578Z",
+      "diff_fingerprint": "sha256:7dc0610d19930b3affad1b49378f5313870917459dc7ef3a9d739fc8d1bab4a2",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
     }
   ],
   "record_id": "1896-ci-serial-test-isolation",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -251,6 +251,7 @@ python_functions = ["test_*"]
 markers = [
     "requires_r: tests that need an R installation with Rscript on PATH",
     "requires_fiji: marks tests that need a local Fiji install at the master-plan §10 path (deselect with '-m \"not requires_fiji\"').",
+    "serial: process/PTY/thread/timing-sensitive tests that must run OUTSIDE xdist (run with '-n0 -m serial'; the parallel batch deselects them via '-m \"not serial\"'). Under '-n auto' these can leak a thread/subprocess that hangs or crashes an xdist worker (#1867, #1896). See scistudio.qa.testing.run_python_tests.",
 ]
 # filterwarnings policy (issue #1560):
 #   - "error" is NOT applied globally — the suite uses third-party libraries

--- a/src/scistudio/qa/governance/gate_record/checks.py
+++ b/src/scistudio/qa/governance/gate_record/checks.py
@@ -99,7 +99,19 @@ CHECK_CATALOG: dict[str, CheckSpec] = {
     ),
     "python_tests": CheckSpec(
         name="python_tests",
-        command=("pytest", "-n", "auto", "--timeout=60", "--timeout-method=thread"),
+        # Two-phase runner: parallel bulk (`-n auto -m "not serial"`) then serial
+        # (`-n 0 -m serial`), so PTY/subprocess/thread tests cannot crash an xdist
+        # worker (#1896). This is the gate's single-command equivalent of the two
+        # literal `pytest` phases the CI `test` job runs inline; the weakened-CI
+        # guard requires the literal `pytest` token in ci.yml, so the two diverge
+        # in form but not policy. Forwarded flags apply to both phases.
+        command=(
+            "python",
+            "-m",
+            "scistudio.qa.testing.run_python_tests",
+            "--timeout=60",
+            "--timeout-method=thread",
+        ),
         covered_surface="python",
         ci_job="ci.yml/Test (Python 3.11, 3.13)",
         needs_src_import=True,

--- a/src/scistudio/qa/testing/__init__.py
+++ b/src/scistudio/qa/testing/__init__.py
@@ -1,0 +1,1 @@
+"""Test-suite execution helpers used by the gate (not by product code)."""

--- a/src/scistudio/qa/testing/run_python_tests.py
+++ b/src/scistudio/qa/testing/run_python_tests.py
@@ -1,0 +1,83 @@
+"""Two-phase pytest runner that isolates xdist-fragile tests (#1896).
+
+Most of the suite runs under ``pytest -n auto`` (xdist) for speed. A small set
+of tests drive a real PTY / subprocess / daemon thread and are marked ``serial``
+(see ``[tool.pytest.ini_options].markers`` in ``pyproject.toml``); under
+parallel load they can leak a thread or hang uninterruptibly and crash an xdist
+worker (#1867, #1896). This runner runs the parallel bulk first
+(``-n auto -m "not serial"``), then the serial tests in-process
+(``-n 0 -m serial``), so the fragile tests never share a worker with the rest of
+the suite.
+
+It is the gate-side (``gate_record`` ``python_tests`` check) single-command
+equivalent of the two ``pytest`` invocations the CI ``test`` job runs inline
+(``.github/workflows/ci.yml``). The weakened-CI guard requires the literal
+``pytest`` token in the workflow, so CI keeps explicit ``pytest`` lines while the
+gate runs ``python -m scistudio.qa.testing.run_python_tests``; both express the
+same two-phase policy.
+
+Coverage: when coverage is active (no ``--no-cov`` in the forwarded args), the
+parallel phase writes a fresh dataset with ``--cov-fail-under=0`` (a partial run
+must not trip the floor) and the serial phase appends with ``--cov-append`` so
+the configured ``fail_under`` is evaluated against the combined dataset — the
+gate's coverage floor is preserved across the split. If no serial test is
+selected, the floor is re-asserted with ``coverage report`` (which reads
+``[tool.coverage.report].fail_under``).
+
+Forwarded args (e.g. ``--timeout=60 --timeout-method=thread`` or ``--no-cov``)
+apply to both phases.
+
+Exit code: the first phase that fails (nonzero, other than pytest's
+"no tests collected" code 5) is returned; otherwise 0.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+# pytest's exit code when a phase's marker expression selects nothing.
+_NO_TESTS_COLLECTED = 5
+
+
+def _run(cmd: list[str]) -> int:
+    # Fixed argv, no shell — the only inputs are this module's own phase flags
+    # plus the gate/CI-supplied pytest options.
+    return subprocess.run(cmd).returncode
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the suite in a parallel phase then a serial phase.
+
+    ``argv`` defaults to ``sys.argv[1:]``; every forwarded arg is applied to both
+    phases. Returns a process exit code suitable for ``SystemExit``.
+    """
+    forwarded = list(sys.argv[1:] if argv is None else argv)
+    coverage_active = "--no-cov" not in forwarded
+    pytest = [sys.executable, "-m", "pytest"]
+
+    parallel = [*pytest, "-n", "auto", "-m", "not serial", *forwarded]
+    serial = [*pytest, "-n", "0", "-m", "serial", *forwarded]
+    if coverage_active:
+        # Partial parallel run must not trip the floor; the serial phase appends
+        # and the configured ``fail_under`` is enforced on the combined dataset.
+        parallel += ["--cov-fail-under=0"]
+        serial += ["--cov-append"]
+
+    rc = _run(parallel)
+    if rc not in (0, _NO_TESTS_COLLECTED):
+        return rc
+
+    rc = _run(serial)
+    if rc == _NO_TESTS_COLLECTED:
+        # No serial test selected: the parallel phase suppressed the floor, so
+        # re-assert it against the dataset already written. ``coverage report``
+        # reads ``[tool.coverage.report].fail_under``.
+        if coverage_active:
+            return _run([sys.executable, "-m", "coverage", "report"])
+        return 0
+    return rc
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/ai/test_terminal.py
+++ b/tests/ai/test_terminal.py
@@ -16,6 +16,10 @@ import pytest
 
 from scistudio.ai.agent.terminal import PtyProcess
 
+# Real PtyProcess + child subprocesses: isolate from xdist so a hang/leak cannot
+# crash a parallel worker (#1896).
+pytestmark = pytest.mark.serial
+
 
 def _python_echo_argv() -> list[str]:
     """A tiny line-echo subprocess that flushes on every newline."""

--- a/tests/ai/test_terminal_extra_env.py
+++ b/tests/ai/test_terminal_extra_env.py
@@ -24,6 +24,10 @@ import pytest
 
 from scistudio.ai.agent.terminal import PtyProcess, _build_child_env, resolve_windows_executable
 
+# Real PtyProcess + child subprocesses: isolate from xdist so a hang/leak cannot
+# crash a parallel worker (#1896).
+pytestmark = pytest.mark.serial
+
 
 def _python_print_env_argv(var: str) -> list[str]:
     """A tiny subprocess that prints one env var then exits."""

--- a/tests/ai/test_terminal_macos_smoke.py
+++ b/tests/ai/test_terminal_macos_smoke.py
@@ -35,10 +35,15 @@ import time
 
 import pytest
 
-pytestmark = pytest.mark.skipif(
-    sys.platform != "darwin",
-    reason="POSIX PTY smoke test — exercised on macOS only.",
-)
+pytestmark = [
+    # Real pty.openpty + Popen: isolate from xdist so a hang/leak cannot crash a
+    # parallel worker (#1896).
+    pytest.mark.serial,
+    pytest.mark.skipif(
+        sys.platform != "darwin",
+        reason="POSIX PTY smoke test — exercised on macOS only.",
+    ),
+]
 
 
 def test_openpty_plus_popen_echo_roundtrip() -> None:

--- a/tests/api/test_ai_pty.py
+++ b/tests/api/test_ai_pty.py
@@ -22,6 +22,10 @@ from scistudio.ai.agent.terminal import PtyProcess
 from scistudio.api.routes import ai_pty
 from scistudio.api.routes.ai_pty import _active_ptys
 
+# Real PtyProcess (echo child) + timing polls: isolate from xdist so a hang/leak
+# cannot crash a parallel worker (#1896).
+pytestmark = pytest.mark.serial
+
 
 def _echo_argv() -> list[str]:
     return [

--- a/tests/api/test_ai_pty_audit_fixes.py
+++ b/tests/api/test_ai_pty_audit_fixes.py
@@ -35,6 +35,10 @@ from scistudio.api.routes.ai_pty import (
     open_engine_initiated_tab,
 )
 
+# Real PtyProcess (echo child) + timing polls: isolate from xdist so a hang/leak
+# cannot crash a parallel worker (#1896).
+pytestmark = pytest.mark.serial
+
 # ---------------------------------------------------------------------------
 # Shared fakes
 # ---------------------------------------------------------------------------

--- a/tests/api/test_ai_pty_engine_spawn.py
+++ b/tests/api/test_ai_pty_engine_spawn.py
@@ -32,6 +32,10 @@ from scistudio.api.routes.ai_pty import (
     unregister_ai_pty_subscriber,
 )
 
+# Real PtyProcess (echo child) + timing polls: isolate from xdist so a hang/leak
+# cannot crash a parallel worker (#1896).
+pytestmark = pytest.mark.serial
+
 
 def _echo_argv() -> list[str]:
     return [

--- a/tests/desktop/test_parent_watchdog.py
+++ b/tests/desktop/test_parent_watchdog.py
@@ -15,6 +15,10 @@ import pytest
 
 from scistudio.desktop import parent_watchdog
 
+# Real daemon-thread watchdog with timing assertions: isolate from xdist so a
+# leaked thread cannot crash a parallel worker (#1867, #1896).
+pytestmark = pytest.mark.serial
+
 
 class TestBackendIsOrphaned:
     def test_unchanged_live_parent_is_not_orphaned(self) -> None:

--- a/tests/qa/testing/test_run_python_tests.py
+++ b/tests/qa/testing/test_run_python_tests.py
@@ -1,0 +1,109 @@
+"""Unit tests for the two-phase pytest runner (#1896).
+
+``subprocess.run`` is stubbed so these tests assert the runner's phase
+composition and exit-code logic without actually invoking pytest.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+
+from scistudio.qa.testing import run_python_tests
+
+
+class _FakeCompleted:
+    def __init__(self, returncode: int) -> None:
+        self.returncode = returncode
+
+
+@pytest.fixture
+def record_runs(monkeypatch: pytest.MonkeyPatch) -> Iterator[tuple[list[list[str]], list[int]]]:
+    """Record each ``subprocess.run`` argv; return rc from a scripted queue."""
+    calls: list[list[str]] = []
+    rcs: list[int] = []
+
+    def _fake_run(cmd: list[str], *_a: object, **_k: object) -> _FakeCompleted:
+        calls.append(list(cmd))
+        return _FakeCompleted(rcs.pop(0) if rcs else 0)
+
+    monkeypatch.setattr(run_python_tests.subprocess, "run", _fake_run)
+    yield calls, rcs
+
+
+def test_coverage_path_composes_two_phases(record_runs: tuple[list[list[str]], list[int]]) -> None:
+    calls, rcs = record_runs
+    rcs.extend([0, 0])
+
+    rc = run_python_tests.main(["--timeout=60", "--timeout-method=thread"])
+
+    assert rc == 0
+    assert len(calls) == 2
+    parallel, serial = calls
+    # Phase 1: parallel, deselect serial, suppress the floor on the partial run.
+    assert parallel[1:3] == ["-m", "pytest"]
+    assert "-n" in parallel and parallel[parallel.index("-n") + 1] == "auto"
+    assert "not serial" in parallel
+    assert "--cov-fail-under=0" in parallel
+    assert "--timeout=60" in parallel
+    # Phase 2: serial, in-process, append coverage so the combined floor holds.
+    assert "-n" in serial and serial[serial.index("-n") + 1] == "0"
+    assert "serial" in serial and "not serial" not in serial
+    assert "--cov-append" in serial
+    assert "--cov-fail-under=0" not in serial
+
+
+def test_no_cov_path_omits_coverage_flags(record_runs: tuple[list[list[str]], list[int]]) -> None:
+    calls, rcs = record_runs
+    rcs.extend([0, 0])
+
+    rc = run_python_tests.main(["--no-cov", "--timeout=60"])
+
+    assert rc == 0
+    parallel, serial = calls
+    assert "--cov-fail-under=0" not in parallel
+    assert "--cov-append" not in serial
+    assert "--no-cov" in parallel and "--no-cov" in serial
+
+
+def test_parallel_failure_short_circuits(record_runs: tuple[list[list[str]], list[int]]) -> None:
+    calls, rcs = record_runs
+    rcs.extend([1])  # parallel phase fails
+
+    rc = run_python_tests.main(["--no-cov"])
+
+    assert rc == 1
+    assert len(calls) == 1  # serial phase never runs
+
+
+def test_parallel_no_tests_collected_continues(record_runs: tuple[list[list[str]], list[int]]) -> None:
+    calls, rcs = record_runs
+    rcs.extend([5, 0])  # parallel collects nothing (exit 5), serial passes
+
+    rc = run_python_tests.main(["--no-cov"])
+
+    assert rc == 0
+    assert len(calls) == 2
+
+
+def test_empty_serial_reasserts_coverage_floor(record_runs: tuple[list[list[str]], list[int]]) -> None:
+    calls, rcs = record_runs
+    rcs.extend([0, 5, 0])  # parallel passes, serial collects nothing, coverage report passes
+
+    rc = run_python_tests.main(["--timeout=60"])
+
+    assert rc == 0
+    assert len(calls) == 3
+    assert calls[2][1:3] == ["-m", "coverage"]
+    assert calls[2][3] == "report"
+
+
+def test_empty_serial_without_coverage_returns_zero(record_runs: tuple[list[list[str]], list[int]]) -> None:
+    calls, rcs = record_runs
+    rcs.extend([0, 5])  # parallel passes, serial collects nothing, no coverage
+
+    rc = run_python_tests.main(["--no-cov"])
+
+    assert rc == 0
+    assert len(calls) == 2  # no coverage-report fallback when --no-cov


### PR DESCRIPTION
## Summary

The `Test (Python …)` CI job ran the whole suite under `pytest -n auto` (xdist).
A small set of tests that drive a **real PTY / subprocess / daemon thread**
(terminal/PTY tests, the desktop parent-death watchdog) could leak a thread or
hang uninterruptibly under parallel load and **crash an xdist worker**. Because
`timeout_method=thread` cannot kill a hang stuck in a C-level / subprocess call,
the hang escaped the per-test `--timeout=60` and only the 600s shell timeout
stopped it, failing the whole job. The failing test differed run-to-run; a plain
re-run went green (seen on PR #1893; history: #1867 — a leaked watchdog thread
crashed an xdist worker).

Fix (owner-approved): run the fragile tests **serially**, out of the parallel
batch.

## Changes

- **`pyproject.toml`**: register a `serial` pytest marker.
- **Mark the 7 modules** that construct a real `PtyProcess` / `openpty` / `fork`
  / daemon watchdog: `tests/ai/test_terminal*.py`, `tests/api/test_ai_pty*.py`,
  `tests/desktop/test_parent_watchdog.py`. The monkeypatched `ai_pty` route unit
  tests (which never spawn a real process) are intentionally **not** marked, to
  keep CI parallelism.
- **`.github/workflows/ci.yml`** `test` job: two phases — parallel
  `-n auto -m "not serial"` then serial `-n 0 -m serial`. On 3.13 (coverage on)
  the parallel phase writes a fresh dataset with `--cov-fail-under=0` and the
  serial phase appends with `--cov-append`, so the combined `--cov-fail-under`
  floor still holds; 3.11 runs `--no-cov`. Keeps the literal `pytest` /
  `--timeout=60` / `timeout 600` tokens (weakened-CI guard) and adds no
  `exit 0` / `|| true`.
- **Gate**: the `python_tests` check now runs the same two phases via a single
  `scistudio.qa.testing.run_python_tests` module, so the local mirror matches
  CI. (The weakened-CI guard requires the literal `pytest` token in `ci.yml`, so
  CI keeps explicit `pytest` lines while the gate calls the module — same
  policy, different form.)

Test-infra only; no production code changes.

## Test evidence

- New unit tests `tests/qa/testing/test_run_python_tests.py` cover the runner's
  two-phase composition, coverage-flag handling, short-circuit on failure, and
  the empty-serial coverage-floor fallback.
- Verified `-m serial` selects exactly the 7 marked modules; end-to-end smoke of
  the runner runs non-serial tests in the parallel phase and serial tests
  in-process.
- Confirmed the `weakened_ci_check` guard reports **0 findings** on the real
  `ci.yml` + `pyproject.toml` diff.

Closes #1896
