### PR TITLE
guided(#1898): add reuse-last-output toggle to AI agent block

### DIFF
--- a/.workflow/records/1898-guided-1898-ai-agent-reuse-last-output.json
+++ b/.workflow/records/1898-guided-1898-ai-agent-reuse-last-output.json
@@ -346,9 +346,9 @@
   ],
   "check_na": [],
   "commit": {
-    "sha": "8e02342816b072abef8e30f080bb4bc7afb8c9c3",
+    "sha": "8f31ad5fc9ee3f0fce284cfc404649bceb1c8798",
     "shas": [
-      "8e02342816b072abef8e30f080bb4bc7afb8c9c3"
+      "8f31ad5fc9ee3f0fce284cfc404649bceb1c8798"
     ],
     "trailers": []
   },
@@ -792,6 +792,214 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-07-01T02:30:26.993495Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/ai/ai_block.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/ai/ai_block.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T02:30:27.002560Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T02:30:27.011493Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T02:30:27.019965Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T02:30:27.029118Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T02:30:27.039522Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T02:30:27.048620Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T02:30:27.057585Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T02:30:27.066461Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T02:30:27.079167Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T02:30:40.326651Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/ai/ai_block.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/ai/ai_block.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T02:30:40.336536Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T02:30:40.345738Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T02:30:40.354425Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T02:30:40.363907Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T02:30:40.373867Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T02:30:40.383120Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T02:30:40.391859Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T02:30:40.400921Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T02:30:40.413970Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -804,7 +1012,7 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "origin/main",
+    "base": "caed98095690b2881eabd976f0035f3353b6ec95",
     "base_sha": "caed9809",
     "changed_files": [
       ".workflow/records/1898-guided-1898-ai-agent-reuse-last-output.json",
@@ -812,9 +1020,9 @@
       "src/scistudio/blocks/ai/ai_block.py",
       "tests/blocks/ai/test_ai_block_skeleton.py"
     ],
-    "diff_fingerprint": "sha256:eedade7f1320202d17d36c4a3e4b6769fd19827f93bf35c44ded478de1142e70",
+    "diff_fingerprint": "sha256:e6af307ca259e79dedcbbc3a7971020352b2e7b00e533c8b726fc28c40a6f435",
     "head": "HEAD",
-    "head_sha": "8e023428",
+    "head_sha": "8f31ad5f",
     "surfaces": {
       "docs": 1,
       "frontend": 0,
@@ -835,7 +1043,7 @@
     "closes": [
       1898
     ],
-    "number": null,
+    "number": 1899,
     "url": null
   },
   "reconcile_events": [
@@ -871,6 +1079,22 @@
     {
       "at": "2026-07-01T02:29:46.339724Z",
       "diff_fingerprint": "sha256:eedade7f1320202d17d36c4a3e4b6769fd19827f93bf35c44ded478de1142e70",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-07-01T02:30:27.079218Z",
+      "diff_fingerprint": "sha256:e6af307ca259e79dedcbbc3a7971020352b2e7b00e533c8b726fc28c40a6f435",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-07-01T02:30:40.414000Z",
+      "diff_fingerprint": "sha256:e6af307ca259e79dedcbbc3a7971020352b2e7b00e533c8b726fc28c40a6f435",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 1,

--- a/.workflow/records/1898-guided-1898-ai-agent-reuse-last-output.json
+++ b/.workflow/records/1898-guided-1898-ai-agent-reuse-last-output.json
@@ -1,0 +1,827 @@
+{
+  "branch": "guided/1898-ai-agent-reuse-last-output",
+  "check_events": [
+    {
+      "at": "2026-07-01T02:10:44.356880Z",
+      "command": "pytest tests/architecture/ -v --no-cov",
+      "covered_surface": "architecture",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:a60337ed5df5f38633aa2def90823901526cce588b4855d1bbbad68d66ab861c",
+      "name": "architecture_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/architecture_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-01T02:10:45.124640Z",
+      "command": "python scripts/deferral_scan.py --check docs/audit/baselines/deferral-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:5c2890074b8c2a50e72f360c5104be3adaa9dccf48c3959cae2c7b63174c264d",
+      "name": "deferral_discipline",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/deferral_discipline.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-01T02:10:45.474319Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:916e92bfc45b2d0529623438c0bafabd171a8a6fe55fddb8b8553e3ade35ebc8",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-07-01T02:10:49.076765Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:5247a7a2b47e703f7a3c886571316da591af0154e3743e47ae387358860bae77",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-01T02:10:49.576051Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:3a01dc32e715ac5674c74d906dff404b45d56d2e5fff75b958578897afe9dbf6",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-01T02:10:49.613943Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:4a91da8e37a6fb86c33871d325c55e73be7f6a0e4967d60bb4efded29a5e8da2",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-07-01T02:12:58.902858Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:15db60e4ec4dd819d079f72edd1600f5cf8ebc75799014aee56ee071d74a2d14",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-01T02:15:21.010614Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:54e6f93bb3dcfde63c3fe8087a89bf03df94871a6e7f15c271df7623e63802f8",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-01T02:15:28.006218Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:a73d8a1f73416efa89f0a052d92c071364d6138b002eea3a52f39615ff565a4a",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    },
+    {
+      "at": "2026-07-01T02:20:22.305084Z",
+      "command": "pytest tests/architecture/ -v --no-cov",
+      "covered_surface": "architecture",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cb7945d57debb80c0930edc69a040e5142cc2473fd7dc2efebe423d34a68941b",
+      "name": "architecture_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/architecture_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-01T02:20:23.116466Z",
+      "command": "python scripts/deferral_scan.py --check docs/audit/baselines/deferral-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:0a43539d3fb25bf556b8e4a6917604d17a9fafb21a11faafbe6e74cdee404cda",
+      "name": "deferral_discipline",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/deferral_discipline.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-01T02:20:23.159296Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:546bb4c5f2c260085d33684e5b07a42a9529580d9bf2cc34ef3bf5c857bf1c97",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-07-01T02:20:27.319522Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:dec94725e4f5de4b9fc87d706554d456a7be7bfabbf4a70c5860e842d0a5b501",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-01T02:20:27.452971Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:73383c535fc0d0ef2b34bf9a0d9dc0527bbd53d2456563acd14c8f557130a0c6",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-01T02:20:27.474543Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:c451942097bae3ef411ccc6f7c35d5d4a63de4678a6b99ab56206655f7f58a8e",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-07-01T02:22:10.682215Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:08dafd417524ae926a76791da7aedb8acfab43d5bfdaec073766d6fa3c30e9df",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-01T02:24:05.227727Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:17e7eead75400f79740c4db1ec4e6c1396ad644b376d7a6c30e0f4a0534f516d",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-01T02:24:06.356937Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:5daab78bd42a670f0dc1f029e618f9e7167867815cccb101231c4603ecde9caa",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    },
+    {
+      "at": "2026-07-01T02:26:19.203414Z",
+      "command": "pytest tests/architecture/ -v --no-cov",
+      "covered_surface": "architecture",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:242f480e32bca8a46aad6f03bbd779f4756e7b5435ede337ed815d6c13f731e4",
+      "name": "architecture_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/architecture_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-01T02:26:19.979808Z",
+      "command": "python scripts/deferral_scan.py --check docs/audit/baselines/deferral-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:7d83d2c738d0c4d9ef2ae76d1de8ea756b10c064db2f6e6e20b38cd2fe7c0f49",
+      "name": "deferral_discipline",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/deferral_discipline.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-01T02:26:23.567146Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:f45ce21f977d9eb0bf1acdd74a33dd810ebe1a7e18181f00f3f98ce8e4c228e8",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-01T02:28:29.695259Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:08955837f020117918f38a9f81a2f827a8ca903c925e4e444130b19df066527a",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    }
+  ],
+  "check_na": [],
+  "commit": null,
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "src/scistudio/blocks/ai/ai_block.py"
+    ]
+  },
+  "directive_events": [
+    {
+      "at": "2026-07-01T02:04:16.128119Z",
+      "owner_directive": "reuse_last_output toggle on ai.agent; backend bypass in AIBlock.run() + new boolean config field (frontend renders it generically); ADR-035 addendum + tests",
+      "reason": "plan"
+    }
+  ],
+  "docs_events": [
+    {
+      "at": "2026-07-01T02:04:16.128350Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/adr/ADR-035-addendum1.md",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": false,
+  "guard_events": [
+    {
+      "at": "2026-07-01T02:15:28.054406Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/ai/ai_block.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/ai/ai_block.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T02:15:28.063862Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T02:15:28.073229Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T02:15:28.082600Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T02:15:28.091363Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T02:15:28.100396Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T02:15:28.108943Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T02:15:28.117836Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T02:15:28.126342Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T02:15:28.137198Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T02:24:06.419332Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/ai/ai_block.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/ai/ai_block.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T02:24:06.429465Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T02:24:06.439475Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T02:24:06.449148Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T02:24:06.458445Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T02:24:06.467849Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T02:24:06.476988Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T02:24:06.486411Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T02:24:06.496175Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T02:24:06.508009Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T02:28:29.751965Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/ai/ai_block.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/ai/ai_block.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T02:28:29.761685Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T02:28:29.770867Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T02:28:29.779845Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T02:28:29.788724Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T02:28:29.797970Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T02:28:29.807831Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T02:28:29.817723Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T02:28:29.827141Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T02:28:29.838720Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1898,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": {
+    "base": "origin/main",
+    "base_sha": "caed9809",
+    "changed_files": [
+      ".workflow/records/1898-guided-1898-ai-agent-reuse-last-output.json",
+      "docs/adr/ADR-035-addendum1.md",
+      "src/scistudio/blocks/ai/ai_block.py",
+      "tests/blocks/ai/test_ai_block_skeleton.py"
+    ],
+    "diff_fingerprint": "sha256:476773284394a416e6ed4853c4ff26196dfe682bd5a49a5a87453b547cdc83c5",
+    "head": "HEAD",
+    "head_sha": "2f9baa38",
+    "surfaces": {
+      "docs": 1,
+      "frontend": 0,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 1,
+      "packaging": 0,
+      "protected_core": 1,
+      "sentrux": 3,
+      "test": 1,
+      "workflow_ci": 0
+    }
+  },
+  "owner_directive": "Add a reuse_last_output checkbox to the ai.agent block: when checked, skip running the AI agent entirely and directly emit the outputs persisted at the declared expected paths from the previous run; fall back to a normal run if no reusable output exists; mark reused runs for traceability.",
+  "persona": "live_implementer",
+  "pull_request": null,
+  "reconcile_events": [
+    {
+      "at": "2026-07-01T02:15:28.137228Z",
+      "diff_fingerprint": "sha256:4dbee9cf11f6c0e772518f446e37a188815c9e473b76757b33c1f4c435bd5baa",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.format_check",
+        "checks.full_audit"
+      ]
+    },
+    {
+      "at": "2026-07-01T02:24:06.508048Z",
+      "diff_fingerprint": "sha256:ee2f55e43b7682c24b8e8a705c525181ceb8254c99b95ad3c3534313eab82e7f",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.full_audit"
+      ]
+    },
+    {
+      "at": "2026-07-01T02:28:29.838772Z",
+      "diff_fingerprint": "sha256:476773284394a416e6ed4853c4ff26196dfe682bd5a49a5a87453b547cdc83c5",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    }
+  ],
+  "record_id": "1898-guided-1898-ai-agent-reuse-last-output",
+  "requested_admin_labels": [
+    {
+      "actor_permission": null,
+      "applied_at": null,
+      "applied_by": null,
+      "name": "admin-approved:core-change"
+    }
+  ],
+  "required_obligations": {
+    "admin_labels": [
+      "admin-approved:core-change"
+    ],
+    "checks": [
+      "architecture_tests",
+      "deferral_discipline",
+      "format_check",
+      "full_audit",
+      "import_contracts",
+      "lint_format",
+      "python_tests",
+      "semantic_dup",
+      "type_check"
+    ],
+    "docs": [
+      "docs_required_or_na"
+    ],
+    "guards": [
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": [
+      "changed_test_required"
+    ]
+  },
+  "runtime": "claude-code",
+  "schema_version": 2,
+  "scope_events": [
+    {
+      "action": "add-include",
+      "at": "2026-07-01T02:04:16.128303Z",
+      "pattern": "tests/blocks/ai/test_ai_block_skeleton.py",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-07-01T02:04:16.128316Z",
+      "pattern": "docs/adr/ADR-035-addendum1.md",
+      "reason": "plan"
+    }
+  ],
+  "session_id": "1445cb7c-f363-4354-aa07-cf91bcd848ae",
+  "strictness_tier": 1,
+  "task_kind": "guided",
+  "test_events": [
+    {
+      "at": "2026-07-01T02:04:16.128386Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/blocks/ai/test_ai_block_skeleton.py",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/.workflow/records/1898-guided-1898-ai-agent-reuse-last-output.json
+++ b/.workflow/records/1898-guided-1898-ai-agent-reuse-last-output.json
@@ -345,7 +345,13 @@
     }
   ],
   "check_na": [],
-  "commit": null,
+  "commit": {
+    "sha": "8e02342816b072abef8e30f080bb4bc7afb8c9c3",
+    "shas": [
+      "8e02342816b072abef8e30f080bb4bc7afb8c9c3"
+    ],
+    "trailers": []
+  },
   "declared_scope": {
     "exclude": [],
     "include": [
@@ -682,6 +688,110 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-07-01T02:29:46.221051Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/ai/ai_block.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/ai/ai_block.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T02:29:46.242698Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T02:29:46.257308Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T02:29:46.269390Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T02:29:46.279812Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T02:29:46.289743Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T02:29:46.301403Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T02:29:46.311943Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T02:29:46.323059Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T02:29:46.339694Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -702,9 +812,9 @@
       "src/scistudio/blocks/ai/ai_block.py",
       "tests/blocks/ai/test_ai_block_skeleton.py"
     ],
-    "diff_fingerprint": "sha256:476773284394a416e6ed4853c4ff26196dfe682bd5a49a5a87453b547cdc83c5",
+    "diff_fingerprint": "sha256:eedade7f1320202d17d36c4a3e4b6769fd19827f93bf35c44ded478de1142e70",
     "head": "HEAD",
-    "head_sha": "2f9baa38",
+    "head_sha": "8e023428",
     "surfaces": {
       "docs": 1,
       "frontend": 0,
@@ -720,7 +830,14 @@
   },
   "owner_directive": "Add a reuse_last_output checkbox to the ai.agent block: when checked, skip running the AI agent entirely and directly emit the outputs persisted at the declared expected paths from the previous run; fall back to a normal run if no reusable output exists; mark reused runs for traceability.",
   "persona": "live_implementer",
-  "pull_request": null,
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [
+      1898
+    ],
+    "number": null,
+    "url": null
+  },
   "reconcile_events": [
     {
       "at": "2026-07-01T02:15:28.137228Z",
@@ -746,6 +863,14 @@
     {
       "at": "2026-07-01T02:28:29.838772Z",
       "diff_fingerprint": "sha256:476773284394a416e6ed4853c4ff26196dfe682bd5a49a5a87453b547cdc83c5",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-07-01T02:29:46.339724Z",
+      "diff_fingerprint": "sha256:eedade7f1320202d17d36c4a3e4b6769fd19827f93bf35c44ded478de1142e70",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 1,

--- a/.workflow/records/1898-guided-1898-ai-agent-reuse-last-output.json
+++ b/.workflow/records/1898-guided-1898-ai-agent-reuse-last-output.json
@@ -342,20 +342,161 @@
       "status": "pass",
       "summary": "clean",
       "tool_versions": {}
+    },
+    {
+      "at": "2026-07-01T03:01:34.463907Z",
+      "command": "pytest tests/architecture/ -v --no-cov",
+      "covered_surface": "architecture",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:84cb3508051b5793c3c6252d7ebd7e70e371d4bb7f1e40e1fd9943f20d773370",
+      "name": "architecture_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/architecture_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-01T03:01:35.240635Z",
+      "command": "python scripts/deferral_scan.py --check docs/audit/baselines/deferral-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:692c6573ab28b3dc16a65d868b799ba99b7267cc23c7d07d82d839e2a2775189",
+      "name": "deferral_discipline",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/deferral_discipline.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-01T03:01:35.281213Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:275406493d51d200d8da85f554fda840ee52d51411f2b1a096648b98bd756a24",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-07-01T03:01:39.190587Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:bd8008bc06ff45523ad977346275f61c823b5a1902b72c1d4b0df8f740b4ab97",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-01T03:01:39.321182Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:9fe1e912f699c30695c41061627b2ce892d427fceda99f415fd3a32f26a825dd",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-01T03:01:39.338894Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:1bd4e26cdfc85b97c54d8f4facb43d43ef628f9ff82812fa8b22ddbfb1afccf8",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-07-01T03:03:13.991791Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:0da9e8daac9ab16a4b9d4f1341372b17992a23f67bd37d4d85492a6fd423e746",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-01T03:05:08.948819Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:3c3f2df3f4a0a254fbd0cf441e3dd7f952690ce7b4e82f527e9cc8776cb2f3f8",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-01T03:05:10.161015Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:a8b100c29a89a2be8cf27f8b79e5a3ff10b34d0a3be232e4bac59a446d1fa2b3",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
     }
   ],
   "check_na": [],
   "commit": {
-    "sha": "8f31ad5fc9ee3f0fce284cfc404649bceb1c8798",
+    "sha": "273192fbd8183e12edda17575f1445125d15f210",
     "shas": [
-      "8f31ad5fc9ee3f0fce284cfc404649bceb1c8798"
+      "273192fbd8183e12edda17575f1445125d15f210"
     ],
     "trailers": []
   },
   "declared_scope": {
     "exclude": [],
     "include": [
-      "src/scistudio/blocks/ai/ai_block.py"
+      "src/scistudio/blocks/ai/run_dir.py"
     ]
   },
   "directive_events": [
@@ -1000,6 +1141,381 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-07-01T03:05:10.201071Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/ai/ai_block.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/ai/ai_block.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/ai/run_dir.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/ai/run_dir.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T03:05:10.211141Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T03:05:10.220639Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T03:05:10.229646Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T03:05:10.238941Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T03:05:10.248490Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T03:05:10.257798Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T03:05:10.266970Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T03:05:10.275710Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T03:05:10.288520Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T03:05:46.610291Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/ai/ai_block.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/ai/ai_block.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/ai/run_dir.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/ai/run_dir.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T03:05:46.619736Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T03:05:46.631037Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T03:05:46.642997Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T03:05:46.653779Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T03:05:46.664774Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T03:05:46.675792Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T03:05:46.686870Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T03:05:46.697814Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T03:05:46.711399Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T03:06:10.641607Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/ai/ai_block.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/ai/ai_block.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/ai/run_dir.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/ai/run_dir.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T03:06:10.653415Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T03:06:10.664817Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T03:06:10.675418Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T03:06:10.685387Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T03:06:10.696272Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T03:06:10.707388Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T03:06:10.718655Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T03:06:10.730083Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T03:06:10.747890Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -1018,20 +1534,21 @@
       ".workflow/records/1898-guided-1898-ai-agent-reuse-last-output.json",
       "docs/adr/ADR-035-addendum1.md",
       "src/scistudio/blocks/ai/ai_block.py",
+      "src/scistudio/blocks/ai/run_dir.py",
       "tests/blocks/ai/test_ai_block_skeleton.py"
     ],
-    "diff_fingerprint": "sha256:e6af307ca259e79dedcbbc3a7971020352b2e7b00e533c8b726fc28c40a6f435",
+    "diff_fingerprint": "sha256:65ba3e2a330ee2cee97ff6285c4ff5b49198eb1ba9904fa3efdc1d4fd774f5bd",
     "head": "HEAD",
-    "head_sha": "8f31ad5f",
+    "head_sha": "273192fb",
     "surfaces": {
       "docs": 1,
       "frontend": 0,
       "governance": 0,
       "governed_docs": 0,
-      "implementation": 1,
+      "implementation": 2,
       "packaging": 0,
-      "protected_core": 1,
-      "sentrux": 3,
+      "protected_core": 2,
+      "sentrux": 4,
       "test": 1,
       "workflow_ci": 0
     }
@@ -1099,6 +1616,32 @@
       "result": "pass",
       "tier": 1,
       "unsatisfied": []
+    },
+    {
+      "at": "2026-07-01T03:05:10.288566Z",
+      "diff_fingerprint": "sha256:65ba3e2a330ee2cee97ff6285c4ff5b49198eb1ba9904fa3efdc1d4fd774f5bd",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "scope.out-of-scope"
+      ]
+    },
+    {
+      "at": "2026-07-01T03:05:46.711431Z",
+      "diff_fingerprint": "sha256:65ba3e2a330ee2cee97ff6285c4ff5b49198eb1ba9904fa3efdc1d4fd774f5bd",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-07-01T03:06:10.747935Z",
+      "diff_fingerprint": "sha256:65ba3e2a330ee2cee97ff6285c4ff5b49198eb1ba9904fa3efdc1d4fd774f5bd",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
     }
   ],
   "record_id": "1898-guided-1898-ai-agent-reuse-last-output",
@@ -1158,6 +1701,24 @@
       "at": "2026-07-01T02:04:16.128316Z",
       "pattern": "docs/adr/ADR-035-addendum1.md",
       "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-07-01T03:05:28.921665Z",
+      "pattern": "src/scistudio/blocks/ai/ai_block.py",
+      "reason": "Codex P2 fix touches ai_block.py (reuse path) alongside run_dir.py; re-declare after ledger reopen"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-07-01T03:05:28.921858Z",
+      "pattern": "tests/blocks/ai/test_ai_block_skeleton.py",
+      "reason": "Codex P2 fix touches ai_block.py (reuse path) alongside run_dir.py; re-declare after ledger reopen"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-07-01T03:05:28.921861Z",
+      "pattern": "docs/adr/ADR-035-addendum1.md",
+      "reason": "Codex P2 fix touches ai_block.py (reuse path) alongside run_dir.py; re-declare after ledger reopen"
     }
   ],
   "session_id": "1445cb7c-f363-4354-aa07-cf91bcd848ae",

--- a/docs/adr/ADR-035-addendum1.md
+++ b/docs/adr/ADR-035-addendum1.md
@@ -1,0 +1,158 @@
+---
+adr: 35
+addendum: 1
+title: "AI Block Reuse-Last-Output Toggle — Skip The Run, Re-Emit Prior Output"
+status: Proposed
+date_created: 2026-06-30
+date_accepted: null
+date_superseded: null
+
+supersedes: []
+superseded_by: null
+related: [35, 51]
+closes_issues: []
+tracking_issue: 1898
+
+is_code_implementation: true
+governs:
+  modules:
+    - scistudio.blocks.ai.ai_block
+  contracts:
+    - scistudio.blocks.ai.ai_block.AIBlock
+    - scistudio.blocks.ai.ai_block.REUSE_LAST_OUTPUT_KEY
+  entry_points: []
+  files:
+    - docs/adr/ADR-035-addendum1.md
+    - src/scistudio/blocks/ai/ai_block.py
+    - tests/blocks/ai/test_ai_block_skeleton.py
+  excludes: []
+
+tests:
+  - tests/blocks/ai/test_ai_block_skeleton.py
+agent_editable: true
+assisted_by:
+  - "Claude:claude-opus-4-8"
+
+phase: planning
+tags: [adr-035, ai-block, ux, caching, iteration]
+owner: "@jiazhenz026"
+co_authors: ["@claude"]
+language_source: en
+translations: []
+---
+
+# ADR-035 Addendum 1: AI Block Reuse-Last-Output Toggle — Skip The Run, Re-Emit Prior Output
+
+## 1. Decision Summary
+
+ADR-035 defines the AI Block: each run spawns a claude/codex agent in a PTY
+tab, hands it a manifest, waits for completion, then loads the files the agent
+wrote at each declared `expected_path` back into the workflow as typed outputs.
+
+This addendum adds an opt-in `reuse_last_output` config toggle. When it is on,
+the block **does not run the agent at all**: it re-emits the output files left
+at each declared `expected_path` by the previous run and returns immediately.
+When there is nothing to reuse, it falls back to a normal agent run instead of
+erroring.
+
+The motivating workflow is iterating on the *downstream* half of a graph: an AI
+Block that already produced a good result should not re-run (slow, token-costly,
+and non-deterministic) every time the user re-runs the workflow to debug a later
+block.
+
+### 1.1 Problems Addressed
+
+| Problem | Risk | Response | Detailed section |
+|---|---|---|---|
+| An AI Block re-runs the agent every workflow run while a user debugs downstream blocks | Wasted time and tokens; a "fixed" result silently changes run-to-run | Opt-in toggle re-emits the previous run's output files and skips the agent entirely | Section 4 |
+| Reusing a computed output under changed inputs would be wrong | Silent wrong results if reuse were auto-gated by a heuristic | Reuse is unconditional and user-owned (enable only while inputs are unchanged); no input fingerprinting | Section 3 |
+| A node that never produced output has nothing to reuse | A hard error would block the very iteration the toggle is meant to help | Fall back to a normal agent run on any missing/empty declared output | Section 4.2 |
+| An audit could mistake a reused result for a genuine agent run | Misattributed lineage | Record `source="reused_last_output"` on the completion event | Section 4.3 |
+
+## 2. Context And Problem
+
+- An AI Block run is expensive and non-deterministic. Re-running it while
+  debugging unrelated downstream blocks wastes time and tokens and can silently
+  change a result the user was treating as fixed.
+- ADR-035 already persists each run's outputs at stable, project-relative
+  `expected_path`s (`./<block>_outputs/<port>.<ext>` by default). Those files
+  survive between runs; they are only removed by `_clear_expected_outputs()` at
+  the *start* of the next run (#1789). The "last output" is therefore already
+  durably on disk — no new artifact store is needed.
+
+## 3. Relationship To ADR-051 Interaction Memory
+
+ADR-051 Addendum 1 ("Interaction Memory") is superficially similar — both add a
+"skip" toggle — but the semantics are deliberately different:
+
+| | ADR-051 interaction memory | ADR-035 reuse-last-output (this addendum) |
+|---|---|---|
+| What is reused | The user's *decision* (a config value) | The block's *output files* |
+| Does it recompute | Yes — compute phase still runs | No — the agent never runs |
+| Input-change gating | Yes — replays only when the input fingerprint matches (`remap_saved_decision`) | No — unconditional; the user owns the decision to enable it |
+| Failure mode when stale | Re-opens the dialog | Falls back to a normal run |
+
+The reuse toggle is intentionally **unconditional**: it does not fingerprint
+inputs. Reusing a *decision* under changed inputs is safe (the compute step still
+runs on the new inputs); reusing a computed *output* under changed inputs is not,
+so gating it automatically would give false confidence. Instead the contract is
+explicit: the user enables the toggle only while inputs are unchanged, exactly
+the debug-the-downstream-blocks scenario. This keeps the mechanism simple and its
+correctness the user's call, not a heuristic's.
+
+## 4. Design
+
+### 4.1 Config Field
+
+A boolean `reuse_last_output` field is added to `AIBlock.config_schema`
+(default `false`, not required). Boolean schema fields already render as a
+checkbox in the config panel (`ConfigField`), so no frontend change is required.
+The block `version` is bumped `0.2.0 → 0.3.0` (contract change).
+
+`REUSE_LAST_OUTPUT_KEY = "reuse_last_output"` is the exported config key;
+`_reuse_last_output_enabled(config)` reads it (`BlockConfig.get` already looks in
+`params` first, then extra fields, so one lookup covers both storage locations).
+
+### 4.2 Bypass In `AIBlock.run()`
+
+`run()` resolves the declared output specs (`{port: {expected_path,
+expected_type}}`) up front — before any `run_dir`, manifest, or clear side
+effect. When the toggle is on, `_try_reuse_last_output()` is attempted first:
+
+- **Hit** — every declared output exists at its `expected_path` and is
+  non-empty. The files are loaded through the same `_validate_and_load_outputs()`
+  path a normal run uses, `run()` returns them, and no PTY tab is requested. The
+  prior files are left untouched (the bypass runs before `_clear_expected_outputs`).
+- **Miss** — any declared output is missing or empty (never ran, or a partial
+  prior run). `_try_reuse_last_output()` returns `None` and `run()` falls through
+  to the normal agent run.
+
+Requiring *every* declared output to be present-and-non-empty makes the miss
+boundary exactly the "never successfully ran" case the fallback is meant to
+cover. A present-but-corrupt file is loaded through the normal validator and
+surfaces its real load error rather than being silently re-run.
+
+### 4.3 Traceability
+
+A reuse hit emits a best-effort completion notification with
+`source = "reused_last_output"`, reusing the same `source` lineage field the
+normal completion path records (`{"source": event.source.value, ...}`). An audit
+can therefore distinguish a reused result from a genuine agent run. The reuse and
+fallback branches also log at INFO.
+
+## 5. Consequences
+
+- **Positive** — cheap, deterministic iteration on downstream blocks; no new
+  storage; frontend gets the checkbox for free; default-off preserves existing
+  behavior exactly.
+- **Negative / accepted** — correctness under changed inputs is the user's
+  responsibility (by design; see §3). Reuse depends on the prior run's files
+  still being present at their `expected_path`; if the user deleted them, the
+  block falls back to a normal run.
+
+## 6. Scope And Non-Goals
+
+- No input fingerprinting, no cross-run cache index, no cache invalidation — out
+  of scope by decision (§3). If a future need for input-aware reuse appears it is
+  a separate ADR, not a silent extension of this toggle.
+- No change to the completion-signal race, manifest schema, or PTY contract.

--- a/docs/adr/ADR-035-addendum1.md
+++ b/docs/adr/ADR-035-addendum1.md
@@ -67,7 +67,7 @@ block.
 | An AI Block re-runs the agent every workflow run while a user debugs downstream blocks | Wasted time and tokens; a "fixed" result silently changes run-to-run | Opt-in toggle re-emits the previous run's output files and skips the agent entirely | Section 4 |
 | Reusing a computed output under changed inputs would be wrong | Silent wrong results if reuse were auto-gated by a heuristic | Reuse is unconditional and user-owned (enable only while inputs are unchanged); no input fingerprinting | Section 3 |
 | A node that never produced output has nothing to reuse | A hard error would block the very iteration the toggle is meant to help | Fall back to a normal agent run on any missing/empty declared output | Section 4.2 |
-| An audit could mistake a reused result for a genuine agent run | Misattributed lineage | Record `source="reused_last_output"` on the completion event | Section 4.3 |
+| An audit could mistake a reused result for a genuine agent run | Misattributed lineage | Write a `reuse.json` marker (not a manifest) in the block execution's run dir | Section 4.3 |
 
 ## 2. Context And Problem
 
@@ -134,11 +134,18 @@ surfaces its real load error rather than being silently re-run.
 
 ### 4.3 Traceability
 
-A reuse hit emits a best-effort completion notification with
-`source = "reused_last_output"`, reusing the same `source` lineage field the
-normal completion path records (`{"source": event.source.value, ...}`). An audit
-can therefore distinguish a reused result from a genuine agent run. The reuse and
-fallback branches also log at INFO.
+A reuse hit records itself on the block execution's own run dir
+(`.scistudio/ai-block-runs/<execution-id>/`) by writing a `reuse.json` marker
+(`{"reused_last_output": true, "block": {...}, "outputs": {...}}`) *instead of* a
+`manifest.json` + `signals/`. The presence of `reuse.json` and the absence of a
+manifest is the durable, per-execution audit signal that distinguishes a reused
+result from a genuine agent run; the reuse and fallback branches also log at INFO.
+
+The PTY completion path (`notify_block_pty_event`) is deliberately not used on a
+reuse hit: it is a frontend-only WS broadcast that decorates a tab title and
+resolves `tab_id` from the engine's tab→run map. A reuse opens no tab, so a
+notify would carry `tab_id = null`, be dropped by the frontend, and record
+nothing durable — it is not a lineage channel.
 
 ## 5. Consequences
 

--- a/src/scistudio/blocks/ai/ai_block.py
+++ b/src/scistudio/blocks/ai/ai_block.py
@@ -362,28 +362,40 @@ class AIBlock(Block):
 
         # #1898: reuse-last-output bypass. When the toggle is on and every
         # declared output from the previous run is still present and non-empty,
-        # re-emit those files and skip the agent run entirely (no run_dir, no
-        # manifest, no PTY, no clearing). On a miss (never ran, or a
-        # missing/empty declared output) fall through to a normal run rather
-        # than erroring. See ADR-035 Addendum 1.
+        # re-emit those files and skip the agent run entirely (no manifest, no
+        # PTY, no clearing). On a miss (never ran, or a missing/empty declared
+        # output) fall through to a normal run rather than erroring. See
+        # ADR-035 Addendum 1.
         if _reuse_last_output_enabled(config):
             reused = self._try_reuse_last_output(output_specs, project_dir, str(config.get("output_dir", "")))
             if reused is not None:
+                # Record the reuse on this execution's own run dir — the durable
+                # per-execution audit trail. Unlike a normal run (manifest +
+                # signals), a reuse writes only ``reuse.json``, so an audit can
+                # tell a reused result from a genuine agent run. Best-effort: the
+                # outputs are already loaded, so a marker-write failure must not
+                # fail the reuse. The PTY completion notify is deliberately NOT
+                # used here — no tab is opened, so it would carry tab_id=null and
+                # be dropped by the frontend (ADR-035 Addendum 1 §4.3).
+                block_execution_id = _make_block_execution_id(
+                    getattr(self, "_instance_name", None) or type(self).__name__
+                )
+                reuse_run_dir = RunDir(project_dir, block_execution_id)
+                marker_path: Any = None
+                try:
+                    reuse_run_dir.create()
+                    marker_path = reuse_run_dir.write_reuse_marker(
+                        block_name=str(block_name),
+                        block_type=type(self).__name__,
+                        outputs={name: str(spec["expected_path"]) for name, spec in output_specs.items()},
+                    )
+                except OSError:
+                    logger.warning("AIBlock %s: could not write reuse marker", block_name, exc_info=True)
                 logger.info(
                     "AIBlock %s: reuse_last_output on and prior outputs present; "
-                    "skipping agent run and re-emitting last output.",
+                    "skipping agent run and re-emitting last output (reuse marker: %s).",
                     block_name,
-                )
-                # Best-effort lineage marker so an audit can tell this run
-                # reused a cached result rather than running the agent. Reuses
-                # the same ``source`` field the normal completion path records.
-                from scistudio.engine import pty_control as _pty_control
-
-                _safe_notify(
-                    _pty_control,
-                    _make_block_execution_id(getattr(self, "_instance_name", None) or type(self).__name__),
-                    "completed",
-                    {"source": "reused_last_output"},
+                    marker_path,
                 )
                 return reused
             logger.info(

--- a/src/scistudio/blocks/ai/ai_block.py
+++ b/src/scistudio/blocks/ai/ai_block.py
@@ -150,8 +150,11 @@ class AIBlock(Block):
     subcategory: ClassVar[str] = "ai"
     """Library grouping this block appears under."""
 
-    version: ClassVar[str] = "0.2.0"
-    """Block version, bumped when its contract or behavior changes."""
+    version: ClassVar[str] = "0.3.0"
+    """Block version, bumped when its contract or behavior changes.
+
+    0.3.0 (#1898): added the ``reuse_last_output`` config toggle, which
+    skips the agent run and re-emits the previous run's output files."""
 
     execution_mode: ClassVar[ExecutionMode] = ExecutionMode.EXTERNAL
     """Marks this as an external block: it launches an outside program (the
@@ -241,6 +244,29 @@ class AIBlock(Block):
                 ),
                 "ui_priority": 3,
             },
+            # #1898: reuse-last-output toggle. When on, the block skips the
+            # agent run entirely and re-emits the outputs left at each declared
+            # expected_path by the previous run. Semantics differ from ADR-051
+            # interaction memory (which reuses a *decision* and still
+            # recomputes): here nothing runs. Reuse is unconditional — no
+            # input-fingerprint gating — so the user is responsible for only
+            # enabling it while upstream inputs are unchanged (the intended use
+            # is iterating on downstream blocks without re-running the agent).
+            # If no reusable output exists (never ran, or a declared output is
+            # missing/empty) the block falls back to a normal run instead of
+            # erroring. Boolean schema fields render as a checkbox in the
+            # config panel (ConfigField), so no frontend change is needed.
+            "reuse_last_output": {
+                "type": "boolean",
+                "default": False,
+                "title": "Reuse last output (skip run)",
+                "description": (
+                    "When on, skip running the agent and re-emit the previous "
+                    "run's output files. Falls back to a normal run if no prior "
+                    "output exists. Only enable while inputs are unchanged."
+                ),
+                "ui_priority": 4,
+            },
             "input_ports": {
                 "type": "array",
                 "items": {
@@ -304,7 +330,68 @@ class AIBlock(Block):
         """
         from scistudio.core.types.collection import Collection
 
-        # 1. Resolve project_dir + block_execution_id, allocate run_dir.
+        # Resolve project_dir and the declared output specs up front: both the
+        # reuse-last-output bypass (#1898) and the normal run need them, and the
+        # bypass must run BEFORE any run_dir/manifest/clear side effect so a
+        # reuse hit leaves the previous run's output files untouched.
+        project_dir_raw = config.get("project_dir") or os.getcwd()
+        project_dir = _to_path(project_dir_raw)
+
+        # Resolve declared output ports + per-port expected_path overrides.
+        # The port editor stores ``expected_path`` on each entry under
+        # ``output_ports`` in the *instance* config (per ADR-029 D12); the
+        # run-time ``config`` may or may not duplicate it. Prefer run-time,
+        # fall back to instance config.
+        effective_outputs = self.get_effective_output_ports()
+        output_path_overrides = _output_path_overrides(config)
+        if not output_path_overrides:
+            output_path_overrides = _output_path_overrides(self.config)
+        block_name = config.get("block_id") or type(self).__name__
+
+        # Declared output specs: ``{port_name: {expected_path, expected_type}}``.
+        # Used both to decide a reuse hit and to clear stale leftovers before a
+        # real run.
+        output_specs: dict[str, dict[str, Any]] = {}
+        for port in effective_outputs:
+            expected_path = output_path_overrides.get(port.name) or RunDir._default_expected_path(str(block_name), port)
+            expected_type = port.accepted_types[0].__name__ if port.accepted_types else "DataObject"
+            output_specs[port.name] = {
+                "expected_path": expected_path,
+                "expected_type": expected_type,
+            }
+
+        # #1898: reuse-last-output bypass. When the toggle is on and every
+        # declared output from the previous run is still present and non-empty,
+        # re-emit those files and skip the agent run entirely (no run_dir, no
+        # manifest, no PTY, no clearing). On a miss (never ran, or a
+        # missing/empty declared output) fall through to a normal run rather
+        # than erroring. See ADR-035 Addendum 1.
+        if _reuse_last_output_enabled(config):
+            reused = self._try_reuse_last_output(output_specs, project_dir, str(config.get("output_dir", "")))
+            if reused is not None:
+                logger.info(
+                    "AIBlock %s: reuse_last_output on and prior outputs present; "
+                    "skipping agent run and re-emitting last output.",
+                    block_name,
+                )
+                # Best-effort lineage marker so an audit can tell this run
+                # reused a cached result rather than running the agent. Reuses
+                # the same ``source`` field the normal completion path records.
+                from scistudio.engine import pty_control as _pty_control
+
+                _safe_notify(
+                    _pty_control,
+                    _make_block_execution_id(getattr(self, "_instance_name", None) or type(self).__name__),
+                    "completed",
+                    {"source": "reused_last_output"},
+                )
+                return reused
+            logger.info(
+                "AIBlock %s: reuse_last_output on but no reusable prior output; falling back to a normal agent run.",
+                block_name,
+            )
+
+        # 1. Allocate the per-execution run_dir.
         # ADR-038 §5.2: this identifier is **per AI Block execution** (one
         # per invocation of this block in a workflow run). It is NOT the
         # workflow-level ``runs.run_id`` — see ADR-038 §3.1 for that table.
@@ -312,8 +399,6 @@ class AIBlock(Block):
         # two layers; the on-the-wire ``PtyTabSpec.block_run_id`` and the
         # manifest ``block.run_id`` JSON key keep their legacy spellings
         # (engine-surface + agent-facing contracts respectively).
-        project_dir_raw = config.get("project_dir") or os.getcwd()
-        project_dir = _to_path(project_dir_raw)
         block_execution_id = _make_block_execution_id(getattr(self, "_instance_name", None) or type(self).__name__)
         run_dir = RunDir(project_dir, block_execution_id)
         try:
@@ -332,21 +417,10 @@ class AIBlock(Block):
                 inputs_unpacked[port_name] = [v for v in value if isinstance(v, DataObject)]
             # else: ignore non-DataObject values (scalar configs etc.)
 
-        # 3. Resolve declared output ports + per-port expected_path overrides.
-        # The port editor stores ``expected_path`` on each entry under
-        # ``output_ports`` in the *instance* config (per ADR-029 D12); the
-        # run-time ``config`` may or may not duplicate it. Prefer run-time,
-        # fall back to instance config.
-        effective_outputs = self.get_effective_output_ports()
-        output_path_overrides = _output_path_overrides(config)
-        if not output_path_overrides:
-            output_path_overrides = _output_path_overrides(self.config)
-
-        # 4. Write manifest. AIBlock runs without a wall-clock timeout: the
+        # 3. Write manifest. AIBlock runs without a wall-clock timeout: the
         #    agent is driven interactively and only stops on completion or
         #    explicit cancellation (tab close / workflow cancel), so no
         #    deadline is computed, recorded, or enforced.
-        block_name = config.get("block_id") or type(self).__name__
         try:
             manifest_path = run_dir.write_manifest(
                 block_name=str(block_name),
@@ -360,21 +434,13 @@ class AIBlock(Block):
         except Exception as exc:
             raise RuntimeError(f"AIBlock: failed to write manifest: {exc}") from exc
 
-        # 4b. Resolve declared output specs and clear any stale leftovers BEFORE
-        # the agent starts (#1789). The FileWatcher completion path fires when all
-        # declared expected_path files exist and are size-stable; a leftover file
-        # from a previous run (the ``<block>_outputs`` dir persists) would
-        # otherwise complete the block instantly before the agent produces
-        # anything. Clearing them up front means completion only triggers on this
-        # run's output (or the MCP finish tool / user "Mark done").
-        output_specs: dict[str, dict[str, Any]] = {}
-        for port in effective_outputs:
-            expected_path = output_path_overrides.get(port.name) or RunDir._default_expected_path(str(block_name), port)
-            expected_type = port.accepted_types[0].__name__ if port.accepted_types else "DataObject"
-            output_specs[port.name] = {
-                "expected_path": expected_path,
-                "expected_type": expected_type,
-            }
+        # 3b. Clear any stale leftover outputs BEFORE the agent starts (#1789).
+        # The FileWatcher completion path fires when all declared expected_path
+        # files exist and are size-stable; a leftover file from a previous run
+        # (the ``<block>_outputs`` dir persists) would otherwise complete the
+        # block instantly before the agent produces anything. Clearing them up
+        # front means completion only triggers on this run's output (or the MCP
+        # finish tool / user "Mark done").
         _clear_expected_outputs(output_specs, project_dir)
 
         # 5. Build spawn argv.
@@ -587,10 +653,56 @@ class AIBlock(Block):
                 results[port_name] = Collection([obj], item_type=type(obj))
         return results
 
+    def _try_reuse_last_output(
+        self,
+        output_specs: dict[str, dict[str, Any]],
+        project_dir: Any,
+        output_dir: str,
+    ) -> dict[str, Collection] | None:
+        """#1898: load the previous run's outputs, or ``None`` on a cache miss.
+
+        A reuse hit requires **every** declared output to still be present at
+        its ``expected_path`` and be non-empty; that is exactly the "never ran /
+        no prior output" boundary the fallback is meant to cover. On a hit the
+        files are loaded through the same ``_validate_and_load_outputs`` path a
+        normal run uses (so a corrupt-but-present file surfaces its real load
+        error rather than being silently re-run). On a miss the caller falls
+        back to a normal agent run.
+        """
+        from pathlib import Path
+
+        if not output_specs:
+            return None
+        resolved_paths: dict[str, str] = {}
+        for port_name, spec in output_specs.items():
+            raw = spec.get("expected_path")
+            if not raw:
+                return None
+            path = Path(str(raw))
+            if not path.is_absolute():
+                path = (Path(str(project_dir)) / path).resolve()
+            if not path.exists() or not path.is_file() or path.stat().st_size == 0:
+                return None
+            resolved_paths[port_name] = str(path)
+        return self._validate_and_load_outputs(resolved_paths, output_specs, project_dir, output_dir)
+
 
 # ---------------------------------------------------------------------------
 # Module-level helpers
 # ---------------------------------------------------------------------------
+
+
+REUSE_LAST_OUTPUT_KEY = "reuse_last_output"
+"""Config key for the #1898 reuse-last-output toggle (see ADR-035 Addendum 1)."""
+
+
+def _reuse_last_output_enabled(config: BlockConfig) -> bool:
+    """True when the reuse-last-output toggle is on.
+
+    ``BlockConfig.get`` already reads ``params`` first then extra fields, so a
+    single lookup covers both the nested and top-level storage locations.
+    """
+    return bool(config.get(REUSE_LAST_OUTPUT_KEY, False))
 
 
 def _to_path(value: Any) -> Any:

--- a/src/scistudio/blocks/ai/run_dir.py
+++ b/src/scistudio/blocks/ai/run_dir.py
@@ -274,6 +274,41 @@ class RunDir:
         os.replace(tmp_name, manifest_path)
         return manifest_path
 
+    def write_reuse_marker(
+        self,
+        *,
+        block_name: str,
+        block_type: str,
+        outputs: dict[str, str],
+    ) -> Path:
+        """#1898: write ``reuse.json`` recording a reuse-last-output hit.
+
+        A reuse hit re-emits the previous run's output files without spawning
+        the agent, so this run dir gets a ``reuse.json`` marker instead of a
+        ``manifest.json`` + ``signals/``. The presence of this marker (and the
+        absence of a manifest) is the durable, per-execution audit signal that
+        distinguishes a reused result from a genuine agent run — see ADR-035
+        Addendum 1 §4.3. Atomic write via tempfile + ``os.replace``.
+        """
+        marker = {
+            "reused_last_output": True,
+            "block": {"name": block_name, "type": block_type},
+            "outputs": outputs,
+        }
+        marker_path = self.path / "reuse.json"
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            suffix=".json.tmp",
+            prefix="reuse-",
+            dir=str(self.path),
+            delete=False,
+            encoding="utf-8",
+        ) as handle:
+            json.dump(marker, handle, indent=2)
+            tmp_name = handle.name
+        os.replace(tmp_name, marker_path)
+        return marker_path
+
     @staticmethod
     def _default_expected_path(block_name: str, port: OutputPort) -> str:
         """Compute ``./{block_name}_outputs/{port.name}.{ext}`` per ADR-035 §3.3.

--- a/tests/blocks/ai/test_ai_block_skeleton.py
+++ b/tests/blocks/ai/test_ai_block_skeleton.py
@@ -457,8 +457,15 @@ def test_run_reuses_last_output_and_skips_agent(project_dir: Path, stub_agent: S
     assert stub_agent.request_calls == []
     # The prior output file was NOT cleared (reuse must leave it intact).
     assert prior.exists()
-    # Lineage marker records the reuse so an audit can distinguish it.
-    assert any(n[1] == "completed" and n[2].get("source") == "reused_last_output" for n in stub_agent.notifications)
+    # Durable audit marker: the execution's run dir carries reuse.json (and NOT
+    # a manifest.json), so an audit can tell a reuse from a genuine agent run.
+    runs_root = project_dir / ".scistudio" / "ai-block-runs"
+    run_dirs = list(runs_root.iterdir())
+    assert len(run_dirs) == 1
+    marker = json.loads((run_dirs[0] / "reuse.json").read_text(encoding="utf-8"))
+    assert marker["reused_last_output"] is True
+    assert marker["outputs"] == {"out": "./out.csv"}
+    assert not (run_dirs[0] / "manifest.json").exists()
 
 
 def test_run_reuse_falls_back_when_no_prior_output(project_dir: Path, stub_agent: StubAgent) -> None:

--- a/tests/blocks/ai/test_ai_block_skeleton.py
+++ b/tests/blocks/ai/test_ai_block_skeleton.py
@@ -13,8 +13,10 @@ import pytest
 
 from scistudio.blocks.ai.ai_block import (
     _BYPASS_FLAG,
+    REUSE_LAST_OUTPUT_KEY,
     AIBlock,
     _output_path_overrides,
+    _reuse_last_output_enabled,
 )
 from scistudio.blocks.base.config import BlockConfig
 from scistudio.blocks.base.state import ExecutionMode
@@ -412,3 +414,113 @@ def test_bypass_flag_table_per_provider() -> None:
     assert "codex" in _BYPASS_FLAG
     assert "bypassPermissions" in _BYPASS_FLAG["claude-code"]
     assert "--dangerously-bypass-approvals-and-sandbox" in _BYPASS_FLAG["codex"]
+
+
+# ---------------------------------------------------------------------------
+# reuse_last_output toggle (#1898 / ADR-035 Addendum 1)
+# ---------------------------------------------------------------------------
+
+
+def test_config_schema_has_reuse_last_output_boolean() -> None:
+    """The toggle is a boolean config field so it renders as a checkbox."""
+    field = AIBlock.config_schema["properties"]["reuse_last_output"]
+    assert field["type"] == "boolean"
+    assert field["default"] is False
+    # Not required — default off keeps the block's behavior unchanged.
+    assert "reuse_last_output" not in AIBlock.config_schema["required"]
+
+
+def test_reuse_last_output_enabled_reads_flag() -> None:
+    assert _reuse_last_output_enabled(_config(reuse_last_output=True)) is True
+    assert _reuse_last_output_enabled(_config(reuse_last_output=False)) is False
+    # Absent → off (unchanged default behavior).
+    assert _reuse_last_output_enabled(_config()) is False
+    assert REUSE_LAST_OUTPUT_KEY == "reuse_last_output"
+
+
+def test_run_reuses_last_output_and_skips_agent(project_dir: Path, stub_agent: StubAgent) -> None:
+    """Toggle on + prior output present → re-emit it without spawning the agent."""
+    prior = project_dir / "out.csv"
+    prior.write_text("a,b\n1,2\n", encoding="utf-8")
+    block = _prepared_block(output_ports=[{"name": "out", "types": ["DataFrame"], "expected_path": "./out.csv"}])
+    cfg = _config(
+        user_prompt="hi",
+        provider="claude-code",
+        project_dir=str(project_dir),
+        reuse_last_output=True,
+    )
+
+    result = block.run(inputs={}, config=cfg)
+
+    assert "out" in result
+    # No PTY tab requested: the agent never ran.
+    assert stub_agent.request_calls == []
+    # The prior output file was NOT cleared (reuse must leave it intact).
+    assert prior.exists()
+    # Lineage marker records the reuse so an audit can distinguish it.
+    assert any(n[1] == "completed" and n[2].get("source") == "reused_last_output" for n in stub_agent.notifications)
+
+
+def test_run_reuse_falls_back_when_no_prior_output(project_dir: Path, stub_agent: StubAgent) -> None:
+    """Toggle on but nothing to reuse → fall back to a normal agent run."""
+    stub_agent.outputs = {"out": ("out.csv", "a\n1\n")}
+    block = _prepared_block(output_ports=[{"name": "out", "types": ["DataFrame"], "expected_path": "./out.csv"}])
+    cfg = _config(
+        user_prompt="hi",
+        provider="claude-code",
+        project_dir=str(project_dir),
+        reuse_last_output=True,
+    )
+
+    result = block.run(inputs={}, config=cfg)
+
+    assert "out" in result
+    # Fallback ran the agent: exactly one PTY request.
+    assert len(stub_agent.request_calls) == 1
+
+
+def test_run_reuse_falls_back_when_any_declared_output_missing(project_dir: Path, stub_agent: StubAgent) -> None:
+    """Reuse requires every declared output; a partial prior run is a miss."""
+    # Only ``a`` exists from a prior run; ``b`` was never produced.
+    (project_dir / "a.csv").write_text("x\n1\n", encoding="utf-8")
+    stub_agent.outputs = {
+        "a": ("a.csv", "x\n1\n"),
+        "b": ("b.csv", "y\n2\n"),
+    }
+    block = _prepared_block(
+        output_ports=[
+            {"name": "a", "types": ["DataFrame"], "expected_path": "./a.csv"},
+            {"name": "b", "types": ["DataFrame"], "expected_path": "./b.csv"},
+        ]
+    )
+    cfg = _config(
+        user_prompt="hi",
+        provider="claude-code",
+        project_dir=str(project_dir),
+        reuse_last_output=True,
+    )
+
+    result = block.run(inputs={}, config=cfg)
+
+    assert {"a", "b"} <= set(result)
+    # Missing ``b`` forced a real run.
+    assert len(stub_agent.request_calls) == 1
+
+
+def test_run_ignores_prior_output_when_toggle_off(project_dir: Path, stub_agent: StubAgent) -> None:
+    """Default (toggle off): a prior output file must not short-circuit the run."""
+    (project_dir / "out.csv").write_text("stale\n", encoding="utf-8")
+    stub_agent.outputs = {"out": ("out.csv", "a\n1\n")}
+    block = _prepared_block(output_ports=[{"name": "out", "types": ["DataFrame"], "expected_path": "./out.csv"}])
+    cfg = _config(
+        user_prompt="hi",
+        provider="claude-code",
+        project_dir=str(project_dir),
+        # reuse_last_output omitted → defaults off.
+    )
+
+    result = block.run(inputs={}, config=cfg)
+
+    assert "out" in result
+    # Agent ran despite the pre-existing file (opt-in only).
+    assert len(stub_agent.request_calls) == 1


### PR DESCRIPTION
## Summary

Adds an opt-in `reuse_last_output` toggle to the `ai.agent` block. When on,
`AIBlock.run()` skips spawning the agent entirely and re-emits the output files
left at each declared `expected_path` by the previous run. On a miss (never
ran, or a missing/empty declared output) it falls back to a normal run rather
than erroring.

Reuse is **unconditional** (no input fingerprinting): the user owns enabling it
while inputs are unchanged — the intended use is iterating on downstream blocks
without re-running the agent (slow, token-costly, non-deterministic). This is
deliberately different from ADR-051 interaction memory, which reuses a *decision*
and still recomputes; here nothing runs.

## Changes

- New boolean config field `reuse_last_output` (default off). Boolean schema
  fields already render as a checkbox via the generic `ConfigField` path, so no
  frontend change is needed.
- `AIBlock.run()` resolves output specs up front and short-circuits before the
  manifest/clear side effects on a reuse hit (prior files untouched).
- A reuse hit writes a `reuse.json` marker (in place of a `manifest.json`) in the
  block execution's run dir, so an audit can distinguish a reused result from a
  genuine agent run. (Codex P2: the earlier PTY-notify approach was frontend-only
  and carried `tab_id=null` on a reuse, losing the marker.)
- Block `version` bumped 0.2.0 → 0.3.0 (contract change).
- ADR-035 Addendum 1 documents the decision and its contrast with ADR-051.
- Tests cover: schema field, flag read, reuse-hit skips agent + writes the
  reuse marker, no-output fallback, partial-output fallback, toggle-off.

Gate record: .workflow/records/1898-guided-1898-ai-agent-reuse-last-output.json

Closes #1898
