### PR TITLE
docs(#1901): add Simplified Chinese README

### DIFF
--- a/.workflow/records/1901-readme-zh-cn.json
+++ b/.workflow/records/1901-readme-zh-cn.json
@@ -19,9 +19,9 @@
   ],
   "check_na": [],
   "commit": {
-    "sha": "de69f85ec2d0033807b3654cd43369a8f45958dc",
+    "sha": "6106e554d04109c1b0f601e78162171e363e7e89",
     "shas": [
-      "de69f85ec2d0033807b3654cd43369a8f45958dc"
+      "6106e554d04109c1b0f601e78162171e363e7e89"
     ],
     "trailers": []
   },
@@ -169,6 +169,126 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:23:50.877809Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:23:50.897692Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:23:50.923576Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:23:50.947645Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:23:50.969549Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:23:50.996957Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:23:51.031385Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:23:51.065509Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:23:51.108933Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:23:51.141225Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:24:01.198645Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:24:01.224356Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:24:01.264938Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:24:01.284667Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:24:01.302663Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:24:01.342207Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:24:01.376016Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:24:01.404766Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:24:01.426118Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:24:01.452608Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -181,16 +301,16 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "main",
+    "base": "99a1dc61bac5eccd62c5a7688efbf6e278dfd9a9",
     "base_sha": "99a1dc61",
     "changed_files": [
       ".workflow/records/1901-readme-zh-cn.json",
       "README.md",
       "README.zh-CN.md"
     ],
-    "diff_fingerprint": "sha256:02c20064c94e77fe2b2407abb9ea13c84edbb8c62071fcbed15ba2407069a324",
+    "diff_fingerprint": "sha256:f06a0da57d1168f370136c98bb972c57f920eec65d04ccd035d44d7f527f9fd5",
     "head": "HEAD",
-    "head_sha": "de69f85e",
+    "head_sha": "6106e554",
     "surfaces": {
       "docs": 0,
       "frontend": 0,
@@ -211,8 +331,8 @@
     "closes": [
       1901
     ],
-    "number": null,
-    "url": null
+    "number": 1902,
+    "url": "https://github.com/jiazhenz026/SciStudio/pull/1902"
   },
   "reconcile_events": [
     {
@@ -226,6 +346,22 @@
     {
       "at": "2026-07-01T17:23:16.056667Z",
       "diff_fingerprint": "sha256:02c20064c94e77fe2b2407abb9ea13c84edbb8c62071fcbed15ba2407069a324",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 3,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-07-01T17:23:51.142437Z",
+      "diff_fingerprint": "sha256:f06a0da57d1168f370136c98bb972c57f920eec65d04ccd035d44d7f527f9fd5",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 3,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-07-01T17:24:01.452733Z",
+      "diff_fingerprint": "sha256:f06a0da57d1168f370136c98bb972c57f920eec65d04ccd035d44d7f527f9fd5",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 3,

--- a/.workflow/records/1901-readme-zh-cn.json
+++ b/.workflow/records/1901-readme-zh-cn.json
@@ -1,0 +1,75 @@
+{
+  "branch": "docs/1901-readme-zh-cn",
+  "check_events": [],
+  "check_na": [],
+  "commit": null,
+  "declared_scope": {
+    "exclude": [],
+    "include": []
+  },
+  "directive_events": [],
+  "docs_events": [
+    {
+      "at": "2026-07-01T17:21:54.536474Z",
+      "class": null,
+      "kind": "path",
+      "path": "README.zh-CN.md",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": false,
+  "guard_events": [],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1901,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": null,
+  "owner_directive": "Add a Simplified Chinese version of the top-level README (README.zh-CN.md) with a language switcher on both files.",
+  "persona": "implementer",
+  "pull_request": null,
+  "reconcile_events": [],
+  "record_id": "1901-readme-zh-cn",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [],
+    "docs": [],
+    "guards": [],
+    "tests": []
+  },
+  "runtime": "claude",
+  "schema_version": 2,
+  "scope_events": [
+    {
+      "action": "add-include",
+      "at": "2026-07-01T17:21:54.536232Z",
+      "pattern": "README.md",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-07-01T17:21:54.536453Z",
+      "pattern": "README.zh-CN.md",
+      "reason": "plan"
+    }
+  ],
+  "session_id": "cd42ace0-7d21-49f9-926e-0ffefe2d90b7",
+  "strictness_tier": null,
+  "task_kind": "docs",
+  "test_events": [
+    {
+      "at": "2026-07-01T17:21:54.536694Z",
+      "class": "implementation",
+      "kind": "na",
+      "path": null,
+      "rationale": "docs-only change \u2014 adds a Chinese translation of README and language switcher links; no runtime/code behavior changes",
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/.workflow/records/1901-readme-zh-cn.json
+++ b/.workflow/records/1901-readme-zh-cn.json
@@ -1,8 +1,30 @@
 {
   "branch": "docs/1901-readme-zh-cn",
-  "check_events": [],
+  "check_events": [
+    {
+      "at": "2026-07-01T17:22:58.897444Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:078640a845850ff62a01d0c063c5dca9fe42b8bead479b802e4553cf206fa7f4",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    }
+  ],
   "check_na": [],
-  "commit": null,
+  "commit": {
+    "sha": "de69f85ec2d0033807b3654cd43369a8f45958dc",
+    "shas": [
+      "de69f85ec2d0033807b3654cd43369a8f45958dc"
+    ],
+    "trailers": []
+  },
   "declared_scope": {
     "exclude": [],
     "include": []
@@ -16,10 +38,139 @@
       "path": "README.zh-CN.md",
       "rationale": null,
       "verified_in_diff": null
+    },
+    {
+      "at": "2026-07-01T17:22:17.303823Z",
+      "class": null,
+      "kind": "path",
+      "path": "README.zh-CN.md",
+      "rationale": null,
+      "verified_in_diff": null
     }
   ],
   "governance_touch": false,
-  "guard_events": [],
+  "guard_events": [
+    {
+      "at": "2026-07-01T17:22:58.927532Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:22:58.936935Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:22:58.946637Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:22:58.956121Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:22:58.965109Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:22:58.974040Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:22:58.982867Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:22:58.991745Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:22:59.000555Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:22:59.010121Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:23:15.681275Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:23:15.711587Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:23:15.737676Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:23:15.771004Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:23:15.802802Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:23:15.867748Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:23:15.930469Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:23:15.975445Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:23:16.014725Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:23:16.056553Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
   "issues": [
     {
       "close_in_pr": true,
@@ -29,18 +180,78 @@
     }
   ],
   "observed_admin_labels": [],
-  "observed_diff": null,
+  "observed_diff": {
+    "base": "main",
+    "base_sha": "99a1dc61",
+    "changed_files": [
+      ".workflow/records/1901-readme-zh-cn.json",
+      "README.md",
+      "README.zh-CN.md"
+    ],
+    "diff_fingerprint": "sha256:02c20064c94e77fe2b2407abb9ea13c84edbb8c62071fcbed15ba2407069a324",
+    "head": "HEAD",
+    "head_sha": "de69f85e",
+    "surfaces": {
+      "docs": 0,
+      "frontend": 0,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 0,
+      "packaging": 0,
+      "protected_core": 0,
+      "sentrux": 0,
+      "test": 0,
+      "workflow_ci": 0
+    }
+  },
   "owner_directive": "Add a Simplified Chinese version of the top-level README (README.zh-CN.md) with a language switcher on both files.",
   "persona": "implementer",
-  "pull_request": null,
-  "reconcile_events": [],
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [
+      1901
+    ],
+    "number": null,
+    "url": null
+  },
+  "reconcile_events": [
+    {
+      "at": "2026-07-01T17:22:59.010160Z",
+      "diff_fingerprint": "sha256:02c20064c94e77fe2b2407abb9ea13c84edbb8c62071fcbed15ba2407069a324",
+      "mode": "local",
+      "result": "pass",
+      "tier": 3,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-07-01T17:23:16.056667Z",
+      "diff_fingerprint": "sha256:02c20064c94e77fe2b2407abb9ea13c84edbb8c62071fcbed15ba2407069a324",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 3,
+      "unsatisfied": []
+    }
+  ],
   "record_id": "1901-readme-zh-cn",
   "requested_admin_labels": [],
   "required_obligations": {
     "admin_labels": [],
-    "checks": [],
+    "checks": [
+      "full_audit"
+    ],
     "docs": [],
-    "guards": [],
+    "guards": [
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
     "tests": []
   },
   "runtime": "claude",
@@ -60,7 +271,7 @@
     }
   ],
   "session_id": "cd42ace0-7d21-49f9-926e-0ffefe2d90b7",
-  "strictness_tier": null,
+  "strictness_tier": 3,
   "task_kind": "docs",
   "test_events": [
     {
@@ -69,6 +280,14 @@
       "kind": "na",
       "path": null,
       "rationale": "docs-only change \u2014 adds a Chinese translation of README and language switcher links; no runtime/code behavior changes",
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-07-01T17:22:17.304022Z",
+      "class": "implementation",
+      "kind": "na",
+      "path": null,
+      "rationale": "docs-only change \u2014 Chinese README translation and language switcher; no code behavior changes",
       "verified_in_diff": null
     }
   ]

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@
 [![Slack](https://img.shields.io/badge/Slack-join-4A154B.svg?logo=slack&logoColor=white)](https://join.slack.com/t/scistudioalph-mau9124/shared_invite/zt-42dsj9af8-lmEWPOwQRcqOkaYiULbABg)
 [![Discord](https://img.shields.io/badge/Discord-join-5865F2.svg?logo=discord&logoColor=white)](https://discord.gg/5b7kTRU2k)
 
+**English** | [简体中文](README.zh-CN.md)
+
 </div>
 
 ---

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,119 @@
+<div align="center">
+
+<img src="desktop/assets/icon.png" alt="SciStudio" width="120" />
+
+# SciStudio
+
+**为你的科研而生:每一份数据,每一个工具,汇于同一条工作流。**
+
+[![Status: alpha](https://img.shields.io/badge/status-alpha-orange.svg)]()
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
+[![Python 3.11+](https://img.shields.io/badge/python-3.11%2B-blue.svg)](https://www.python.org/downloads/)
+[![CI](https://github.com/jiazhenz026/SciStudio/actions/workflows/ci.yml/badge.svg)](https://github.com/jiazhenz026/SciStudio/actions/workflows/ci.yml)
+[![Docs](https://img.shields.io/badge/docs-online-blue.svg)](https://jiazhenz026.github.io/SciStudio/)
+[![Slack](https://img.shields.io/badge/Slack-join-4A154B.svg?logo=slack&logoColor=white)](https://join.slack.com/t/scistudioalph-mau9124/shared_invite/zt-42dsj9af8-lmEWPOwQRcqOkaYiULbABg)
+[![Discord](https://img.shields.io/badge/Discord-join-5865F2.svg?logo=discord&logoColor=white)](https://discord.gg/5b7kTRU2k)
+
+[English](README.md) | **简体中文**
+
+</div>
+
+---
+
+<div align="center">
+
+<!-- Drop the home-page workflow canvas screenshot at docs/assets/scistudio-canvas.png -->
+<img src="docs/assets/scistudio-canvas.png" alt="SciStudio workflow canvas" width="820" />
+
+</div>
+
+## SciStudio 是什么?
+
+SciStudio 是一个**面向多模态科学数据的 AI 原生工作流运行时**。
+显微成像、LC-MS、光谱、表格、仪器文件——每一种模态往往都需要各自的软件和格式。
+SciStudio 把这些散落在桌面上、彼此独立的应用、脚本和文件收拢到同一个工作台上,
+让带类型的**区块(blocks)**接线成一条完整的工作流。
+
+- **每种模态,同一张图** —— 成像、LC-MS、光谱、表格与文件共享带类型的数据,
+  在同一条工作流中流转。
+- **沿用你现有的工具,而不是替换它们** —— 把 R 或 Python 脚本当作普通区块运行,
+  也能像区块一样在流程中启动 Fiji 等桌面应用。
+- **AI 原生** —— 内置助手(Claude Code 或 Codex)帮你搭建工作流、编写新区块、
+  并检视你的数据。
+- **手动步骤是一等公民** —— 审阅、标注、审批都是真正的工作流步骤,而非临时变通。
+- **可扩展** —— 添加你自己的区块、数据类型和图表,并以可安装的软件包形式分享出去。
+
+## 安装
+
+### 面向使用者
+
+从 [**Releases 页面**](https://github.com/jiazhenz026/SciStudio/releases) 下载最新的
+SciStudio 桌面应用 —— macOS 的 `.dmg` 或 Windows 安装包。打开即用;Python 与全部
+依赖都已内置,无需另行配置。
+
+随后按 [**快速上手**](https://jiazhenz026.github.io/SciStudio/user-guide/getting-started.html) 操作。
+
+### 面向开发者(从源码运行)
+
+```bash
+git clone https://github.com/jiazhenz026/SciStudio.git
+cd SciStudio
+
+# Python 后端(使用 conda 环境或 virtualenv)
+python -m pip install ".[dev]"
+
+# 前端依赖
+npm --prefix frontend install
+
+# 以源码运行桌面应用:
+# 前端使用 Vite HMR + SciStudio 后端 + Electron。
+npm --prefix desktop run dev
+```
+
+前端改动会热更新;后端改动需重启该命令才能生效。打包应用(`.dmg` /
+Windows 安装包)的说明见 [`desktop/README.md`](desktop/README.md)。
+
+## 文档
+
+完整文档见 **[jiazhenz026.github.io/SciStudio](https://jiazhenz026.github.io/SciStudio/)**:
+
+- [**用户指南**](https://jiazhenz026.github.io/SciStudio/user-guide/README.html)
+  —— 搭建与运行工作流、预览数据、历史与分支、AI 助手,以及编写你自己的区块、
+  类型和图表。
+- [**快速上手**](https://jiazhenz026.github.io/SciStudio/user-guide/getting-started.html)
+  —— 从全新安装到跑通第一条工作流。
+- [**API 参考**](https://jiazhenz026.github.io/SciStudio/user-guide/api-reference/index.html)
+  —— 你可以依赖的公开 API,附带签名与稳定性分级。
+- [**软件包开发**](https://jiazhenz026.github.io/SciStudio/package-development/index.html)
+  —— 构建可分发的 SciStudio 软件包(区块、类型、预览器)。
+- [**架构**](docs/architecture/ARCHITECTURE.md) —— SciStudio 如何构建,以及为何如此设计。
+
+用户指南与 API 参考和 SciStudio 注入到每个项目里的文档是同一套,因此你在线上读到的
+内容与随应用一同发布的内容一致。
+
+## 参与贡献
+
+欢迎各种形式的贡献 —— 缺陷报告、功能建议、文档与代码。请先阅读
+[**CONTRIBUTING.md**](CONTRIBUTING.md),完整的开发流程(分支、issue、gate、测试、
+文档、评审)见 [`AGENTS.md`](AGENTS.md)。
+
+若你想构建并发布自己的区块(而非改动核心),请参阅
+[软件包开发指南](https://jiazhenz026.github.io/SciStudio/package-development/index.html)。
+
+## 社区
+
+在 SciStudio 处于 alpha 阶段期间,我们非常欢迎提问、反馈与缺陷报告:
+
+- [Slack](https://join.slack.com/t/scistudioalph-mau9124/shared_invite/zt-42dsj9af8-lmEWPOwQRcqOkaYiULbABg)
+- [Discord](https://discord.gg/5b7kTRU2k)
+- [GitHub Issues](https://github.com/jiazhenz026/SciStudio/issues)
+
+## 状态
+
+SciStudio 目前处于 **alpha** 阶段,正在积极开发中。各版本之间接口与 API 可能发生变化;
+[API 参考](https://jiazhenz026.github.io/SciStudio/user-guide/api-reference/index.html)
+标注了每个公开符号的稳定性分级。
+
+## 许可证
+
+SciStudio 以 MIT 许可证发布。完整条款见 [LICENSE](LICENSE)。


### PR DESCRIPTION
## Summary

Add a Simplified Chinese version of the top-level README so Chinese-speaking users can read the project overview, install steps, and doc links in their language.

- Add `README.zh-CN.md` — a faithful translation of `README.md` (badges, links, and image paths kept identical).
- Add a language switcher (`English | 简体中文`) to the top of both `README.md` and `README.zh-CN.md`.

Docs-only change; no runtime or code behavior changes.

## Out of scope

- Translating `CONTRIBUTING.md`, `desktop/README.md`, or the docs site — can be tracked separately if wanted.

Closes #1901

🤖 Generated with [Claude Code](https://claude.com/claude-code)
