### PR TITLE
guided(#1900): surface canonical type_name + guard block_type in agent MCP tools

### DIFF
--- a/.workflow/records/1900-guided-1900-agent-block-type-mcp-guard.json
+++ b/.workflow/records/1900-guided-1900-agent-block-type-mcp-guard.json
@@ -143,10 +143,127 @@
       "status": "pass",
       "summary": "clean",
       "tool_versions": {}
+    },
+    {
+      "at": "2026-07-01T17:26:09.954307Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:8e14c5538a907ff7caf70c726e00ebd8cd7a29be7078831bc03f527e415f69a7",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-07-01T17:26:13.522576Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:2e2b5491d8e2ddb6c8dba44ced35ba7e721a3056b41de23d593746a88908328e",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-01T17:26:13.654456Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:d783d805d979f6c44953cc744ee2d996984e3d47d5621b8105f07068b7ea9e3a",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-01T17:26:13.677242Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:8c7a33de06cd218040226b92e7b5d5984d8b3148dcf680a52e4f71178d830851",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-07-01T17:28:38.105381Z",
+      "command": "python -m scistudio.qa.testing.run_python_tests --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:ccbd2d08c080599142e88396606f992411af2ba680fbf358f56100ba39e58926",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-01T17:30:44.881349Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:9322c562774f21f1782894337f540191a73cf3653a0fdc3f9ad8dc0894576a1b",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-01T17:30:45.842591Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:765384043b8de0f34492f861e8b1fa031693f4127042b7d811794a76b6744e53",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
     }
   ],
   "check_na": [],
-  "commit": null,
+  "commit": {
+    "sha": "eec7e917b445c8ef2f0df54fb8e32e0695c3b4b3",
+    "shas": [
+      "eec7e917b445c8ef2f0df54fb8e32e0695c3b4b3"
+    ],
+    "trailers": []
+  },
   "declared_scope": {
     "exclude": [],
     "include": [
@@ -335,6 +452,170 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:30:45.884371Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:30:45.895853Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:30:45.906041Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:30:45.915961Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:30:45.925215Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:30:45.935201Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:30:45.944792Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:30:45.955463Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:30:45.965289Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:30:45.977368Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:31:12.570459Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:31:12.582157Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:31:12.591871Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:31:12.600630Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:31:12.609274Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:31:12.617885Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:31:12.626382Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:31:12.635084Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:31:12.644215Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:31:12.655678Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -360,9 +641,9 @@
       "tests/ai/test_mcp_tools_disk_integration.py",
       "tests/ai/test_mcp_tools_workflow.py"
     ],
-    "diff_fingerprint": "sha256:25b240ae986c3acf53c69d893e69c0272eb53f47a67964033947fe4de0e330d1",
+    "diff_fingerprint": "sha256:d3638c110fb85f8c5fcfc4ace98bdc925e8ea5aad4115b1dd53464136e68cfef",
     "head": "HEAD",
-    "head_sha": "eed32f73",
+    "head_sha": "eec7e917",
     "surfaces": {
       "docs": 0,
       "frontend": 0,
@@ -378,7 +659,14 @@
   },
   "owner_directive": "Fix two agent workflow-authoring problems: (1) agent uses package-specific IO load blocks instead of the generic core load_data + config; (2) agent confuses display name vs canonical type_name and writes an unresolvable block_type into workflow YAML so the GUI can't resolve it.",
   "persona": "live_implementer",
-  "pull_request": null,
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [
+      1900
+    ],
+    "number": null,
+    "url": null
+  },
   "reconcile_events": [
     {
       "at": "2026-07-01T17:22:08.101624Z",
@@ -400,6 +688,22 @@
       "unsatisfied": [
         "checks.format_check"
       ]
+    },
+    {
+      "at": "2026-07-01T17:30:45.977410Z",
+      "diff_fingerprint": "sha256:d3638c110fb85f8c5fcfc4ace98bdc925e8ea5aad4115b1dd53464136e68cfef",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-07-01T17:31:12.655717Z",
+      "diff_fingerprint": "sha256:d3638c110fb85f8c5fcfc4ace98bdc925e8ea5aad4115b1dd53464136e68cfef",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
     }
   ],
   "record_id": "1900-guided-1900-agent-block-type-mcp-guard",

--- a/.workflow/records/1900-guided-1900-agent-block-type-mcp-guard.json
+++ b/.workflow/records/1900-guided-1900-agent-block-type-mcp-guard.json
@@ -258,9 +258,9 @@
   ],
   "check_na": [],
   "commit": {
-    "sha": "eec7e917b445c8ef2f0df54fb8e32e0695c3b4b3",
+    "sha": "ea0c685b3b34d8d0b712274f986150c619e7ccf8",
     "shas": [
-      "eec7e917b445c8ef2f0df54fb8e32e0695c3b4b3"
+      "ea0c685b3b34d8d0b712274f986150c619e7ccf8"
     ],
     "trailers": []
   },
@@ -616,6 +616,252 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:31:52.936525Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:31:52.946165Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:31:52.955656Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:31:52.964787Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:31:52.973334Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:31:52.981783Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:31:52.990018Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:31:52.998431Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:31:53.006830Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:31:53.019154Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:32:07.982976Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:32:07.991892Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:32:08.000295Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:32:08.008598Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:32:08.016702Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:32:08.025472Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:32:08.034694Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:32:08.045131Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:32:08.054081Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:32:08.065638Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:32:23.099614Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:32:23.108351Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:32:23.117003Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:32:23.125608Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:32:23.134629Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:32:23.143807Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:32:23.152185Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:32:23.161817Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:32:23.170269Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:32:23.181522Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -628,7 +874,7 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "origin/main",
+    "base": "99a1dc61bac5eccd62c5a7688efbf6e278dfd9a9",
     "base_sha": "99a1dc61",
     "changed_files": [
       ".workflow/records/1900-guided-1900-agent-block-type-mcp-guard.json",
@@ -641,9 +887,9 @@
       "tests/ai/test_mcp_tools_disk_integration.py",
       "tests/ai/test_mcp_tools_workflow.py"
     ],
-    "diff_fingerprint": "sha256:d3638c110fb85f8c5fcfc4ace98bdc925e8ea5aad4115b1dd53464136e68cfef",
+    "diff_fingerprint": "sha256:4367ce1bb6e298de5c60db9667fad9ad9a413e3c5d51b0207c791850c909ba67",
     "head": "HEAD",
-    "head_sha": "eec7e917",
+    "head_sha": "ea0c685b",
     "surfaces": {
       "docs": 0,
       "frontend": 0,
@@ -664,8 +910,8 @@
     "closes": [
       1900
     ],
-    "number": null,
-    "url": null
+    "number": 1903,
+    "url": "https://github.com/jiazhenz026/SciStudio/pull/1903"
   },
   "reconcile_events": [
     {
@@ -700,6 +946,30 @@
     {
       "at": "2026-07-01T17:31:12.655717Z",
       "diff_fingerprint": "sha256:d3638c110fb85f8c5fcfc4ace98bdc925e8ea5aad4115b1dd53464136e68cfef",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-07-01T17:31:53.019207Z",
+      "diff_fingerprint": "sha256:4367ce1bb6e298de5c60db9667fad9ad9a413e3c5d51b0207c791850c909ba67",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-07-01T17:32:08.065669Z",
+      "diff_fingerprint": "sha256:4367ce1bb6e298de5c60db9667fad9ad9a413e3c5d51b0207c791850c909ba67",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-07-01T17:32:23.181553Z",
+      "diff_fingerprint": "sha256:4367ce1bb6e298de5c60db9667fad9ad9a413e3c5d51b0207c791850c909ba67",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 2,

--- a/.workflow/records/1900-guided-1900-agent-block-type-mcp-guard.json
+++ b/.workflow/records/1900-guided-1900-agent-block-type-mcp-guard.json
@@ -1,0 +1,482 @@
+{
+  "branch": "guided/1900-agent-block-type-mcp-guard",
+  "check_events": [
+    {
+      "at": "2026-07-01T17:16:21.776192Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:4201a64bc13eb0717704db8c4c7b6d4cdffcf276191f7ca7a816911fec6f4bb9",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-07-01T17:16:28.447381Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:094a6b661f709df4582c10d5356a13fce034783e43c6358c7145aeb7d1cdfc3e",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-01T17:16:29.125279Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:54e25ed8411fd7c93c9d4adb88286df316f632d94813affba79a0b63ae8336f6",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-01T17:16:29.215046Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:2c40dd733660451feab44a545c841fd0168eae6f86e7d86483d949841f11bb3d",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-07-01T17:19:57.609086Z",
+      "command": "python -m scistudio.qa.testing.run_python_tests --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:aa49ea113cd27ba4df7a68763f0eba791fadac97ac0edf355074c78725e7886d",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-01T17:22:00.503994Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:52a30576136fb4bee3eaf8efb912b12dbf1017f0bfc029db1bd150937a0ed0fc",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-01T17:22:07.965607Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:dc4facedc9ca05b86b81282b99ad6e7b3d969b73adb2b9974338be58114b4965",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    },
+    {
+      "at": "2026-07-01T17:23:07.370593Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:4201a64bc13eb0717704db8c4c7b6d4cdffcf276191f7ca7a816911fec6f4bb9",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-07-01T17:25:10.009113Z",
+      "command": "python -m scistudio.qa.testing.run_python_tests --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:aa49ea113cd27ba4df7a68763f0eba791fadac97ac0edf355074c78725e7886d",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    }
+  ],
+  "check_na": [],
+  "commit": null,
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "src/scistudio/ai/agent/mcp/**"
+    ]
+  },
+  "directive_events": [
+    {
+      "at": "2026-07-01T16:58:03.265642Z",
+      "owner_directive": "Problem 2 (naming): surface canonical type_name in list_blocks/get_block_schema and hard-fail unresolvable block_type in write_workflow. Problem 1 (package IO): list_blocks should tell the agent not to use non-core package IO blocks and use load_data/save_data + core_type instead; write_workflow should WARN (not hard-block) on such blocks. GUI grey-fallback rendering is explicitly out of scope (owner dropped it). All changes confined to src/scistudio/ai/agent/mcp/**.",
+      "reason": "Owner finalized enforcement strength for each problem during discussion"
+    }
+  ],
+  "docs_events": [
+    {
+      "at": "2026-07-01T17:14:42.065731Z",
+      "class": null,
+      "kind": "path",
+      "path": "src/scistudio/_skills/scistudio/scistudio-build-workflow/SKILL.md",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": false,
+  "guard_events": [
+    {
+      "at": "2026-07-01T17:22:08.005835Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:22:08.016169Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:22:08.026499Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:22:08.036767Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:22:08.047170Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:22:08.058564Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:22:08.068759Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:22:08.078597Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:22:08.088525Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:22:08.101585Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:25:10.045577Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:25:10.054920Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:25:10.064036Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:25:10.074003Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:25:10.083639Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:25:10.093152Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:25:10.103018Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:25:10.112193Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:25:10.121116Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T17:25:10.132785Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1900,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": {
+    "base": "origin/main",
+    "base_sha": "99a1dc61",
+    "changed_files": [
+      ".workflow/records/1900-guided-1900-agent-block-type-mcp-guard.json",
+      "src/scistudio/_skills/scistudio/scistudio-build-workflow/SKILL.md",
+      "src/scistudio/ai/agent/mcp/tools_workflow/_helpers.py",
+      "src/scistudio/ai/agent/mcp/tools_workflow/_models.py",
+      "src/scistudio/ai/agent/mcp/tools_workflow/read.py",
+      "src/scistudio/ai/agent/mcp/tools_workflow/write.py",
+      "tests/ai/agent/mcp/test_workflow_block_type_guard.py",
+      "tests/ai/test_mcp_tools_disk_integration.py",
+      "tests/ai/test_mcp_tools_workflow.py"
+    ],
+    "diff_fingerprint": "sha256:25b240ae986c3acf53c69d893e69c0272eb53f47a67964033947fe4de0e330d1",
+    "head": "HEAD",
+    "head_sha": "eed32f73",
+    "surfaces": {
+      "docs": 0,
+      "frontend": 0,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 5,
+      "packaging": 0,
+      "protected_core": 0,
+      "sentrux": 8,
+      "test": 3,
+      "workflow_ci": 0
+    }
+  },
+  "owner_directive": "Fix two agent workflow-authoring problems: (1) agent uses package-specific IO load blocks instead of the generic core load_data + config; (2) agent confuses display name vs canonical type_name and writes an unresolvable block_type into workflow YAML so the GUI can't resolve it.",
+  "persona": "live_implementer",
+  "pull_request": null,
+  "reconcile_events": [
+    {
+      "at": "2026-07-01T17:22:08.101624Z",
+      "diff_fingerprint": "sha256:25b240ae986c3acf53c69d893e69c0272eb53f47a67964033947fe4de0e330d1",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.format_check",
+        "checks.python_tests"
+      ]
+    },
+    {
+      "at": "2026-07-01T17:25:10.132831Z",
+      "diff_fingerprint": "sha256:25b240ae986c3acf53c69d893e69c0272eb53f47a67964033947fe4de0e330d1",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.format_check"
+      ]
+    }
+  ],
+  "record_id": "1900-guided-1900-agent-block-type-mcp-guard",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [
+      "format_check",
+      "full_audit",
+      "import_contracts",
+      "lint_format",
+      "python_tests",
+      "semantic_dup",
+      "type_check"
+    ],
+    "docs": [
+      "docs_required_or_na"
+    ],
+    "guards": [
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": [
+      "changed_test_required"
+    ]
+  },
+  "runtime": "claude",
+  "schema_version": 2,
+  "scope_events": [
+    {
+      "action": "add-include",
+      "at": "2026-07-01T17:14:42.065410Z",
+      "pattern": "tests/ai/**",
+      "reason": "Record tests + build-workflow skill doc as the work became concrete"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-07-01T17:14:42.065613Z",
+      "pattern": "src/scistudio/_skills/scistudio/scistudio-build-workflow/**",
+      "reason": "Record tests + build-workflow skill doc as the work became concrete"
+    }
+  ],
+  "session_id": "a88dac08-aeab-460c-9b81-904608a2f435",
+  "strictness_tier": 2,
+  "task_kind": "guided",
+  "test_events": [
+    {
+      "at": "2026-07-01T17:14:42.065753Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/ai/agent/mcp/test_workflow_block_type_guard.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-07-01T17:14:42.065756Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/ai/test_mcp_tools_workflow.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-07-01T17:14:42.065757Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/ai/test_mcp_tools_disk_integration.py",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/src/scistudio/_skills/scistudio/scistudio-build-workflow/SKILL.md
+++ b/src/scistudio/_skills/scistudio/scistudio-build-workflow/SKILL.md
@@ -64,7 +64,7 @@ workflow:                            # REQUIRED top-level key
 | Key | Type | Required | Notes |
 |---|---|---|---|
 | `id` | string | yes | Unique within the workflow |
-| `block_type` | string | yes | Must match a registered block (call `list_blocks`) |
+| `block_type` | string | yes | A registered block's canonical `type_name` from `list_blocks` — NOT its display `name`. The GUI resolves nodes by `type_name`. |
 | `config` | dict | yes (may be `{}`) | Validated against the block's `config_schema` |
 
 **Edge shape** — two strings only:
@@ -123,10 +123,12 @@ YAML.
    `get_block_schema(block_type)` and copy the exact
    `input_ports[].name` / `output_ports[].name` strings. Never type
    from memory.
-4. **Wrong `block_type` casing or missing namespace.** Block types
-   are namespaced (`imaging.threshold`, not `threshold`;
-   `lcms.peak_pick`, not `peakpick`). `list_blocks` returns the
-   canonical name.
+4. **Wrong `block_type`: display name instead of `type_name`.** Put a
+   block's canonical `type_name` in `block_type` (`load_data`,
+   `imaging.threshold`), never its display `name` (`Load`, `Threshold`).
+   `list_blocks` returns both fields — copy `type_name`. The GUI resolves
+   nodes by `type_name`, and `write_workflow` hard-fails an unregistered
+   `block_type` with the nearest valid suggestion.
 5. **Missing required config field.** Each block's `config_schema`
    has a `required` list. `write_workflow` validates and rejects with
    the specific JSON-Schema error.

--- a/src/scistudio/ai/agent/mcp/tools_workflow/_helpers.py
+++ b/src/scistudio/ai/agent/mcp/tools_workflow/_helpers.py
@@ -120,6 +120,91 @@ def _spec_signature(spec: Any) -> str:
     return f"{inputs} → {outputs}"
 
 
+# ---------------------------------------------------------------------------
+# Core-IO steering (#1900): flag package-specific IO blocks whose data the
+# core Load/Save block already covers via its dynamic ``core_type`` enum.
+# ---------------------------------------------------------------------------
+
+
+_PACKAGE_MODULE_PREFIX = "scistudio_blocks_"
+
+
+def _is_package_io_block(spec: Any) -> bool:
+    """True for an IO block contributed by a ``scistudio_blocks_*`` plugin package.
+
+    The core Load/Save block (``load_data`` / ``save_data``) already covers every
+    loadable/saveable package type through its dynamic ``core_type`` enum and
+    delegates to the owning package under the hood (see
+    ``blocks.io._config_enrichment``). A package's own IO block is therefore
+    redundant and yields a different, inconsistent canvas node for the same data.
+
+    Detection keys off the block's importable ``module_path`` (plugin packages
+    live under the ``scistudio_blocks_*`` install module). ``package_name`` is
+    not used because core blocks registered via entry points carry the entry-point
+    name there (e.g. ``load_data``), so it is not a reliable core-vs-package
+    signal. User drop-in ``.py`` blocks are intentionally excluded — they may
+    handle a type the core block does not cover.
+    """
+    if getattr(spec, "base_category", "") != "io":
+        return False
+    return str(getattr(spec, "module_path", "") or "").startswith(_PACKAGE_MODULE_PREFIX)
+
+
+def _first_port_type_name(port: Any) -> str | None:
+    """Return the first accepted-type name of *port*, or ``None``."""
+    if isinstance(port, dict):
+        accepted = port.get("accepted_types") or []
+    else:
+        accepted = getattr(port, "accepted_types", None) or []
+    names = [getattr(t, "__name__", str(t)) for t in accepted]
+    return names[0] if names else None
+
+
+def _core_io_equivalent(spec: Any) -> tuple[str, str | None]:
+    """Return ``(core_block_type, core_type_value)`` for a package IO block.
+
+    ``core_block_type`` is ``"load_data"`` for a loader (reads a file, exposes an
+    output port) or ``"save_data"`` for a saver (writes a file, exposes an input
+    port). ``core_type_value`` is the concrete data type the block handles (e.g.
+    ``"Image"``), read from the relevant port's accepted types, or ``None`` when
+    it cannot be determined.
+    """
+    direction = getattr(spec, "direction", "") or ""
+    input_ports = getattr(spec, "input_ports", None) or []
+    output_ports = getattr(spec, "output_ports", None) or []
+    is_saver = direction == "output" or (bool(input_ports) and not output_ports)
+    if is_saver:
+        core_block, ports = "save_data", input_ports
+    else:
+        core_block, ports = "load_data", output_ports
+    core_type: str | None = None
+    for port in ports:
+        core_type = _first_port_type_name(port)
+        if core_type:
+            break
+    return core_block, core_type
+
+
+def _io_redirect_hint(spec: Any) -> str | None:
+    """Build a 'use the core block instead' hint for a package IO block.
+
+    Returns ``None`` for core blocks and non-IO blocks.
+    """
+    if not _is_package_io_block(spec):
+        return None
+    core_block, core_type = _core_io_equivalent(spec)
+    if core_type:
+        return (
+            f"Do not use this package IO block. Use the core '{core_block}' block "
+            f"with core_type='{core_type}' instead — it delegates to the same "
+            f"package loader/saver and keeps one consistent GUI node."
+        )
+    return (
+        f"Do not use this package IO block. Use the core '{core_block}' block "
+        f"configured with the matching core_type instead."
+    )
+
+
 def _atomic_write_text(path: Path, text: str) -> int:
     """Write *text* to *path* via tempfile + rename. Returns bytes written."""
     path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/scistudio/ai/agent/mcp/tools_workflow/_models.py
+++ b/src/scistudio/ai/agent/mcp/tools_workflow/_models.py
@@ -24,7 +24,21 @@ class BlockSummary(BaseModel):
     fetch them on demand via ``get_block_schema``.
     """
 
-    name: str = Field(description="Registered block type name.")
+    type_name: str = Field(
+        description=(
+            "Canonical block type id. THIS is the exact string to put in a "
+            "workflow node's 'block_type'. The GUI resolves nodes by type_name, "
+            "so writing anything else (a display name, a guessed dotted name) "
+            "produces a node the GUI cannot resolve."
+        ),
+    )
+    name: str = Field(
+        description=(
+            "Human-readable display name shown in the palette (e.g. 'Load'). "
+            "For display only — do NOT use this as a workflow 'block_type'; "
+            "use 'type_name' there."
+        ),
+    )
     base_category: str = Field(description="One of io/process/code/app/ai/subworkflow.")
     subcategory: str | None = Field(default=None, description="Optional subcategory string.")
     package_name: str = Field(
@@ -34,6 +48,15 @@ class BlockSummary(BaseModel):
     description: str = Field(description="One-line block description from BlockSpec.")
     signature: str = Field(
         description="One-line I/O signature, e.g. 'image:Image, mask?:Array → result:Image'.",
+    )
+    use_instead: str | None = Field(
+        default=None,
+        description=(
+            "Set for package-specific IO blocks that the core Load/Save block "
+            "already covers via its core_type enum. When present, do NOT use "
+            "this block: use the named core block ('load_data'/'save_data') "
+            "configured with the given core_type instead."
+        ),
     )
 
 
@@ -50,8 +73,9 @@ class ListBlocksResult(BaseModel):
     count: int = Field(description="Total number of registered block types.")
     next_step: str = Field(
         default=(
-            "Call mcp__scistudio__get_block_schema with a block's name to fetch its "
-            "full I/O ports and config_schema before wiring edges or setting params."
+            "Call mcp__scistudio__get_block_schema with a block's 'type_name' to fetch "
+            "its full I/O ports and config_schema before wiring edges or setting params. "
+            "Always copy 'type_name' (not the display 'name') into a node's 'block_type'."
         ),
         description="Suggested next MCP call to obtain a block's full configuration.",
     )
@@ -60,9 +84,9 @@ class ListBlocksResult(BaseModel):
             "To read or write data, default to the core 'load_data' / 'save_data' block "
             "configured with a 'core_type' (its enum covers package-registered types like "
             "Image, Spectrum, SpectralDataset, Mask and delegates to the package loader/saver "
-            "under the hood, keeping one consistent GUI Load/Save node). Use a package-specific "
-            "IO block (e.g. imaging.load_image) only when no core_type value covers the "
-            "type/format you need."
+            "under the hood, keeping one consistent GUI Load/Save node). Package-specific IO "
+            "blocks are redundant and are flagged with a 'use_instead' hint in this catalog; "
+            "do not use them."
         ),
         description="Guidance to prefer the core Load/Save block + core_type over package-specific IO blocks.",
     )
@@ -126,6 +150,15 @@ class WriteWorkflowResult(BaseModel):
     path: str = Field(description="Absolute resolved path of the written workflow.")
     bytes_written: int = Field(description="Number of bytes written to disk.")
     diff_summary: str = Field(description="Compact diff vs prior file contents.")
+    warnings: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Non-blocking advisories about the written workflow, e.g. a node that "
+            "uses a package-specific IO block the core Load/Save block already "
+            "covers. The write still succeeds; act on these to keep the canvas "
+            "consistent."
+        ),
+    )
     next_step: str = Field(
         default="Call mcp__scistudio__validate_workflow with the same path to confirm runtime acceptance.",
         description="Suggested next MCP call to maintain workflow integrity.",

--- a/src/scistudio/ai/agent/mcp/tools_workflow/read.py
+++ b/src/scistudio/ai/agent/mcp/tools_workflow/read.py
@@ -24,6 +24,7 @@ from scistudio.ai.agent.mcp.tools_workflow._errors import (
 )
 from scistudio.ai.agent.mcp.tools_workflow._helpers import (
     _get_workflow_runtime,
+    _io_redirect_hint,
     _looks_like_inline_yaml,
     _port_to_dict,
     _spec_signature,
@@ -74,12 +75,14 @@ async def list_blocks() -> ListBlocksResult:
     specs = ctx.block_registry.all_specs()
     blocks = [
         BlockSummary(
+            type_name=spec.type_name,
             name=spec.name,
             base_category=spec.base_category,
             subcategory=spec.subcategory or None,
             package_name=getattr(spec, "package_name", "") or "",
             description=spec.description,
             signature=_spec_signature(spec),
+            use_instead=_io_redirect_hint(spec),
         )
         for spec in specs.values()
     ]
@@ -111,13 +114,14 @@ async def get_block_schema(
     if spec is None:
         raise KeyError(f"Block type '{type_name}' is not registered")
     return BlockSchemaResult(
-        type_name=spec.name,
+        type_name=spec.type_name,
         ports={
             "input": [_port_to_dict(p) for p in (spec.input_ports or [])],
             "output": [_port_to_dict(p) for p in (spec.output_ports or [])],
         },
         config_schema=enrich_io_config_schema(spec, ctx.block_registry, ctx.type_registry),
         metadata={
+            "display_name": spec.name,
             "description": spec.description,
             "version": spec.version,
             "base_category": spec.base_category,

--- a/src/scistudio/ai/agent/mcp/tools_workflow/write.py
+++ b/src/scistudio/ai/agent/mcp/tools_workflow/write.py
@@ -9,6 +9,7 @@ umbrella #1427). No behavior change.
 from __future__ import annotations
 
 import contextlib
+import difflib
 import json
 import logging
 from pathlib import Path
@@ -18,7 +19,7 @@ import yaml as yaml_module
 from filelock import FileLock, Timeout
 from pydantic import Field, ValidationError
 
-from scistudio.ai.agent.mcp._context import _resolve_project_path
+from scistudio.ai.agent.mcp._context import _resolve_project_path, get_context
 from scistudio.ai.agent.mcp.server import mcp
 from scistudio.ai.agent.mcp.tools_workflow._errors import (
     _ensure_error_subscriber,
@@ -27,8 +28,10 @@ from scistudio.ai.agent.mcp.tools_workflow._errors import (
 from scistudio.ai.agent.mcp.tools_workflow._helpers import (
     _LOCK_TIMEOUT_SECONDS,
     _atomic_write_text,
+    _core_io_equivalent,
     _diff_summary,
     _get_workflow_runtime,
+    _is_package_io_block,
 )
 from scistudio.ai.agent.mcp.tools_workflow._models import (
     CancelRunResult,
@@ -75,12 +78,19 @@ async def write_workflow(
     except yaml_module.YAMLError as exc:
         raise ValueError(f"write_workflow: YAML parse failure: {exc}") from exc
     try:
-        WorkflowFileModel.model_validate(parsed)
+        wf_file = WorkflowFileModel.model_validate(parsed)
     except ValidationError as exc:
         raise ValueError(
             "write_workflow: refusing to write — workflow does not match "
             "the SciStudio schema. Errors (JSON):\n" + json.dumps(exc.errors(), indent=2, default=str)
         ) from exc
+
+    # Resolve every node's block_type against the live registry (#1900).
+    # Unknown/unresolvable types hard-fail here so the agent cannot persist a
+    # workflow the GUI would render as an unresolved grey node. Package-specific
+    # IO blocks are allowed but surfaced as non-blocking warnings that point at
+    # the core Load/Save block.
+    block_type_warnings = _reconcile_node_block_types(wf_file)
 
     p = _resolve_project_path(path)
     lock_path = str(p) + ".lock"
@@ -119,7 +129,86 @@ async def write_workflow(
         version_context=version_context,
     )
     logger.info("write_workflow: wrote %s (%s)", p, summary)
-    return WriteWorkflowResult(path=str(p), bytes_written=bytes_written, diff_summary=summary)
+    return WriteWorkflowResult(
+        path=str(p),
+        bytes_written=bytes_written,
+        diff_summary=summary,
+        warnings=block_type_warnings,
+    )
+
+
+def _reconcile_node_block_types(wf_file: Any) -> list[str]:
+    """Validate node ``block_type`` values against the live block registry (#1900).
+
+    Two problems this closes:
+
+    * The agent copies a display name (e.g. ``"Load"``) or invents a dotted name
+      (e.g. ``"imaging.segmentation"``) into ``block_type``. The GUI resolves
+      nodes by their canonical ``type_name`` only, so such a node renders as an
+      unresolved grey node. We **hard-fail** with the nearest valid ``type_name``.
+    * The agent uses a package-specific IO block the core Load/Save block already
+      covers. That is allowed but inconsistent, so we return a non-blocking
+      **warning** naming the core equivalent.
+
+    Returns the list of warnings. Raises ``ValueError`` when any node references
+    an unregistered ``block_type``.
+    """
+    context = get_context()
+    registry = getattr(context, "block_registry", None)
+    if registry is None:
+        return []
+    try:
+        specs = registry.all_specs()
+    except Exception:  # pragma: no cover - defensive: registry not ready
+        return []
+    if not specs:
+        # An empty/unscanned registry cannot judge block_type validity; skip
+        # rather than reject an otherwise-valid workflow.
+        return []
+
+    by_type_name = {spec.type_name: spec for spec in specs.values() if spec.type_name}
+    display_to_type = {spec.name: spec.type_name for spec in specs.values() if spec.name}
+    valid_type_names = sorted(by_type_name)
+
+    errors: list[str] = []
+    warnings: list[str] = []
+    for node in wf_file.workflow.nodes:
+        block_type = node.block_type
+        spec = by_type_name.get(block_type)
+        if spec is None:
+            hint = display_to_type.get(block_type)
+            if hint is not None:
+                detail = (
+                    f"'{block_type}' is a block's display name; its type_name is "
+                    f"'{hint}'. Put the type_name in 'block_type'."
+                )
+            else:
+                close = difflib.get_close_matches(block_type, valid_type_names, n=3, cutoff=0.4)
+                detail = (
+                    ("Did you mean: " + ", ".join(repr(c) for c in close) + "? ") if close else ""
+                ) + "Call list_blocks and copy a block's 'type_name'."
+            errors.append(f"node '{node.id}': block_type '{block_type}' is not a registered block type. {detail}")
+            continue
+        if _is_package_io_block(spec):
+            core_block, core_type = _core_io_equivalent(spec)
+            core_hint = (
+                f"'{core_block}' with core_type='{core_type}'"
+                if core_type
+                else f"'{core_block}' with the matching core_type"
+            )
+            warnings.append(
+                f"node '{node.id}': block_type '{block_type}' is a package-specific "
+                f"IO block. Prefer the core {core_hint} — it delegates to the same "
+                f"package loader/saver and keeps one consistent GUI node."
+            )
+
+    if errors:
+        raise ValueError(
+            "write_workflow: refusing to write — one or more nodes reference a "
+            "block_type the GUI cannot resolve (the GUI resolves nodes by their "
+            "canonical type_name):\n- " + "\n- ".join(errors)
+        )
+    return warnings
 
 
 def _workflow_change_context() -> tuple[Any, Any] | None:

--- a/tests/ai/agent/mcp/test_workflow_block_type_guard.py
+++ b/tests/ai/agent/mcp/test_workflow_block_type_guard.py
@@ -1,0 +1,185 @@
+"""Block-type surfacing + write-time guard for the agent workflow tools (#1900).
+
+Two agent-authoring failure modes are covered:
+
+* ``list_blocks`` / ``get_block_schema`` must surface the canonical
+  ``type_name`` (the string that belongs in a node's ``block_type``) rather
+  than only the display name, and must flag package-specific IO blocks with a
+  ``use_instead`` redirect to the core Load/Save block.
+* ``write_workflow`` must hard-fail a node whose ``block_type`` is not a
+  registered ``type_name`` (the GUI resolves nodes by ``type_name``), and must
+  emit a non-blocking warning — not a failure — when a node uses a
+  package-specific IO block the core block already covers.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from scistudio.ai.agent.mcp import _context, tools_workflow
+from scistudio.blocks.base.ports import InputPort, OutputPort
+from scistudio.blocks.registry import BlockRegistry, BlockSpec
+from scistudio.core.types.array import Array
+from scistudio.core.types.registry import TypeRegistry
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+@dataclass
+class _StubRuntime:
+    block_registry: BlockRegistry = field(default_factory=BlockRegistry)
+    type_registry: TypeRegistry = field(default_factory=TypeRegistry)
+    workflow_runs: dict[str, Any] = field(default_factory=dict)
+    _project_dir: Path | None = None
+
+    @property
+    def project_dir(self) -> Path | None:
+        return self._project_dir
+
+    def start_workflow(self, workflow_id: str) -> dict[str, Any]:
+        self.workflow_runs[workflow_id] = object()
+        return {"workflow_id": workflow_id, "status": "started"}
+
+
+@pytest.fixture
+def ctx(tmp_path: Path):
+    root = (tmp_path / "proj").resolve()
+    root.mkdir()
+    (root / "workflows").mkdir()
+    runtime = _StubRuntime(_project_dir=root)
+    runtime.block_registry.scan()
+    runtime.type_registry.scan_builtins()
+    _context.set_context(runtime)
+    yield runtime
+    _context.set_context(None)
+
+
+def _register_fake_package_io(registry: BlockRegistry, *, type_name: str, name: str, direction: str = "input") -> None:
+    """Inject a synthetic ``scistudio_blocks_*`` IO block into *registry*.
+
+    CI has no plugin packages installed, so a package-specific IO block is
+    fabricated here to make the redirect/warning behavior deterministic.
+    """
+    port = (
+        OutputPort(name="data", accepted_types=[Array])
+        if direction == "input"
+        else InputPort(name="data", accepted_types=[Array])
+    )
+    spec = BlockSpec(
+        name=name,
+        type_name=type_name,
+        base_category="io",
+        module_path="scistudio_blocks_fake.io." + type_name.replace(".", "_"),
+        direction=direction,
+        input_ports=[port] if direction == "output" else [],
+        output_ports=[port] if direction == "input" else [],
+    )
+    registry._registry[spec.name] = spec
+    registry._aliases[spec.type_name] = spec.name
+
+
+def _wf_yaml(block_type: str) -> str:
+    return (
+        "workflow:\n"
+        "  id: guard_test\n"
+        "  version: 1.0.0\n"
+        "  nodes:\n"
+        "    - id: n1\n"
+        f"      block_type: {block_type}\n"
+        "      config: {}\n"
+        "  edges: []\n"
+    )
+
+
+# ---------------------------------------------------------------------------
+# list_blocks / get_block_schema surfacing
+# ---------------------------------------------------------------------------
+
+
+def test_list_blocks_surfaces_canonical_type_name(ctx: _StubRuntime) -> None:
+    result = _run(tools_workflow.list_blocks())
+    by_type = {b.type_name: b for b in result.blocks}
+    # Core Load: canonical type_name is 'load_data'; display name is 'Load'.
+    assert "load_data" in by_type
+    load = by_type["load_data"]
+    assert load.name == "Load"
+    assert load.type_name == "load_data"
+    # Every entry's type_name is a real registered type_name, never a display name.
+    specs = ctx.block_registry.all_specs()
+    real_type_names = {s.type_name for s in specs.values()}
+    for entry in result.blocks:
+        assert entry.type_name in real_type_names
+
+
+def test_core_load_block_is_not_flagged_use_instead(ctx: _StubRuntime) -> None:
+    result = _run(tools_workflow.list_blocks())
+    load = next(b for b in result.blocks if b.type_name == "load_data")
+    assert load.use_instead is None
+
+
+def test_list_blocks_flags_package_io_use_instead(ctx: _StubRuntime) -> None:
+    _register_fake_package_io(ctx.block_registry, type_name="fake.load_thing", name="Load Thing")
+    result = _run(tools_workflow.list_blocks())
+    entry = next(b for b in result.blocks if b.type_name == "fake.load_thing")
+    assert entry.use_instead is not None
+    assert "load_data" in entry.use_instead
+    assert "core_type" in entry.use_instead
+
+
+# ---------------------------------------------------------------------------
+# write_workflow guard: unresolvable block_type hard-fails
+# ---------------------------------------------------------------------------
+
+
+def test_write_workflow_accepts_canonical_core_type_name(ctx: _StubRuntime) -> None:
+    result = _run(tools_workflow.write_workflow("workflows/ok.yaml", _wf_yaml("load_data")))
+    assert result.bytes_written > 0
+    assert result.warnings == []
+
+
+def test_write_workflow_rejects_unknown_block_type(ctx: _StubRuntime) -> None:
+    with pytest.raises(ValueError) as exc:
+        _run(tools_workflow.write_workflow("workflows/bad.yaml", _wf_yaml("load_dataa")))
+    msg = str(exc.value)
+    assert "not a registered" in msg
+    # Nearest-match suggestion points at the real type_name.
+    assert "load_data" in msg
+
+
+def test_write_workflow_rejects_display_name_as_block_type(ctx: _StubRuntime) -> None:
+    # 'Load' is the display name; its canonical type_name is 'load_data'.
+    with pytest.raises(ValueError) as exc:
+        _run(tools_workflow.write_workflow("workflows/disp.yaml", _wf_yaml("Load")))
+    msg = str(exc.value)
+    assert "display name" in msg
+    assert "load_data" in msg
+
+
+def test_write_workflow_unknown_block_type_does_not_write_file(ctx: _StubRuntime) -> None:
+    target = ctx.project_dir / "workflows" / "never.yaml"
+    with pytest.raises(ValueError):
+        _run(tools_workflow.write_workflow("workflows/never.yaml", _wf_yaml("nope_block")))
+    assert not target.exists()
+
+
+# ---------------------------------------------------------------------------
+# write_workflow guard: package IO block warns but is not blocked
+# ---------------------------------------------------------------------------
+
+
+def test_write_workflow_warns_on_package_io_block(ctx: _StubRuntime) -> None:
+    _register_fake_package_io(ctx.block_registry, type_name="fake.load_thing", name="Load Thing")
+    result = _run(tools_workflow.write_workflow("workflows/pkg_io.yaml", _wf_yaml("fake.load_thing")))
+    # Write succeeds (non-blocking) ...
+    assert result.bytes_written > 0
+    # ... but a warning names the core equivalent.
+    assert len(result.warnings) == 1
+    assert "load_data" in result.warnings[0]
+    assert "fake.load_thing" in result.warnings[0]

--- a/tests/ai/test_mcp_tools_disk_integration.py
+++ b/tests/ai/test_mcp_tools_disk_integration.py
@@ -103,7 +103,7 @@ workflow:
   version: 1.0.0
   nodes:
     - id: b1
-      block_type: LoadData
+      block_type: load_data
       config:
         params:
           backend: csv
@@ -270,7 +270,7 @@ workflow:
   version: 1.0.0
   nodes:
     - id: b1
-      block_type: LoadData
+      block_type: load_data
       config:
         params:
           backend: csv

--- a/tests/ai/test_mcp_tools_workflow.py
+++ b/tests/ai/test_mcp_tools_workflow.py
@@ -223,7 +223,10 @@ def test_get_block_schema_happy(ctx: _StubRuntime) -> None:
     assert specs, "ctx fixture scanned the registry but no blocks were registered"
     name = next(iter(specs))
     schema = _run(tools_workflow.get_block_schema(name))
-    assert schema.type_name == specs[name].name
+    # get_block_schema returns the canonical type_name (the string that goes
+    # into a workflow node's block_type), not the display name (#1900).
+    assert schema.type_name == specs[name].type_name
+    assert schema.metadata["display_name"] == specs[name].name
     assert "input" in schema.ports and "output" in schema.ports
     assert schema.config_schema is not None
 


### PR DESCRIPTION
## What

Fixes two agent workflow-authoring failure modes, entirely within the
`tools_workflow` MCP surface the embedded agent uses.

**Problem 2 — wrong `block_type` → unresolvable node.** `list_blocks` /
`get_block_schema` never surfaced a block's canonical `type_name`:
`BlockSummary.name` carried the display name and was even mislabeled
"Registered block type name". The agent copied the display name (or invented a
dotted name like `imaging.segmentation`) into the YAML `block_type`, which the
GUI (matching on `type_name`) could not resolve.

- `BlockSummary` now carries both `type_name` (the string that goes into
  `block_type`) and the display `name`, each clearly labeled; `get_block_schema`
  returns `spec.type_name`.
- `write_workflow` hard-fails a node whose `block_type` is not a registered
  `type_name`, with a nearest-match / display-name suggestion, and does not
  write the file.

**Problem 1 — package-specific IO blocks instead of core Load/Save.** The core
`load_data` / `save_data` + `core_type` already covers every loadable/saveable
package type via capability injection, so a package IO block is redundant.

- `list_blocks` flags such blocks with a `use_instead` redirect to the core
  block + `core_type`.
- `write_workflow` emits a non-blocking **warning** (owner decision: warn, do
  not block) naming the core equivalent.

Detection keys off the `scistudio_blocks_*` install-module prefix (`package_name`
is unreliable — core blocks registered via entry points carry the entry-point
name there).

## Out of scope

GUI rendering of unresolved nodes (the grey-puzzle fallback) is intentionally
not changed (owner decision).

## Tests / docs

- New `tests/ai/agent/mcp/test_workflow_block_type_guard.py` covers type_name
  surfacing, the `use_instead` redirect, the unknown-`block_type` hard-fail
  (including display-name input and no-file-written), and the package-IO
  warning.
- Updated `test_get_block_schema_happy` and the disk-integration fixtures to the
  canonical `load_data` type_name.
- Reinforced the `scistudio-build-workflow` skill: use `type_name` (not the
  display name) in `block_type`.

Gate record: .workflow/records/1900-guided-1900-agent-block-type-mcp-guard.json

Closes #1900
