### PR TITLE
feat(#1895): Linux desktop AppImage packaging + stable activation fingerprint

### DIFF
--- a/.github/workflows/desktop-linux-appimage.yml
+++ b/.github/workflows/desktop-linux-appimage.yml
@@ -1,0 +1,61 @@
+name: Desktop Linux AppImage
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git ref to build"
+        required: false
+        default: "main"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: desktop-linux-appimage-${{ github.event.pull_request.number || github.event.inputs.ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-appimage:
+    name: Build Linux AppImage
+    # #1895: pin the oldest supported Ubuntu LTS so the bundled glibc-based
+    # Python and the numpy/pyarrow/zarr manylinux wheels bind an old glibc.
+    # An AppImage built on a newer runner would refuse to launch on older
+    # distros. ubuntu-22.04 is the compatibility baseline (ADR-037 §7.3).
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.inputs.ref || github.ref }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: npm
+          cache-dependency-path: desktop/package-lock.json
+
+      - name: Install desktop dependencies
+        run: npm --prefix desktop ci
+
+      - name: Build portable Python runtime
+        run: npm --prefix desktop run build:python:linux
+
+      - name: Stage resources
+        run: npm --prefix desktop run stage:sh
+
+      - name: Build AppImage
+        run: npm --prefix desktop run dist:linux
+
+      - name: Verify AppImage artifact exists
+        run: |
+          test -n "$(find desktop/dist -maxdepth 1 -name '*.AppImage' -print -quit)"
+          find desktop/dist -maxdepth 1 -type f -print
+
+      - name: Upload AppImage artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: scistudio-linux-appimage
+          path: desktop/dist/*.AppImage
+          if-no-files-found: error

--- a/.workflow/records/1895-linux-desktop-appimage.json
+++ b/.workflow/records/1895-linux-desktop-appimage.json
@@ -1,0 +1,452 @@
+{
+  "branch": "feat/1895-linux-desktop-appimage",
+  "check_events": [
+    {
+      "at": "2026-07-01T23:11:34.731074Z",
+      "command": "pytest tests/architecture/ -v --no-cov",
+      "covered_surface": "architecture",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:0deac04405434cdca6d65dc3c51f5b5938ddb201f6adf484ce98451ad607e155",
+      "name": "architecture_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/architecture_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-01T23:11:35.756303Z",
+      "command": "python scripts/deferral_scan.py --check docs/audit/baselines/deferral-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:102f4fec721ebfc465e7a0ebf36ba896c75f73ca64a3d872407303e84c235e40",
+      "name": "deferral_discipline",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/deferral_discipline.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-01T23:11:35.853002Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:bee0017f30f552d2df2de1173f9ac14b9aee5192ca5e5c1de574bb119512b275",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-07-01T23:11:46.130990Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:d2016153ffe72f6d9588cf72b647d8f545261ca64eb63f312f104e3c66e7d074",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-01T23:11:46.375734Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:179b1cba851dd153ae0ab07e4f5ff8b2a735cc2c3d6d4494d3c0100847360442",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-01T23:11:46.428136Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e31351abfc33f0b3c0f28bc9f2f3d59ae3bc5d4925dc1159a7f931aa932441ed",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-07-01T23:14:43.018634Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:47eac75ed95c8abfde2e5868831e97df5202e82116cf9c4a1b1122e549884f6c",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-01T23:15:47.277662Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:5ac7578af148e57a4742501901771a4c319b77ff7347e618e434955b34cad860",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-01T23:15:49.452813Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e94394e48009cd8fbd5108426e57662cdd3e4d99e817a3b4494b7e53776b5c37",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    },
+    {
+      "at": "2026-07-01T23:20:51.691927Z",
+      "command": "python -m scistudio.qa.testing.run_python_tests --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:47eac75ed95c8abfde2e5868831e97df5202e82116cf9c4a1b1122e549884f6c",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    }
+  ],
+  "check_na": [],
+  "commit": null,
+  "declared_scope": {
+    "exclude": [],
+    "include": []
+  },
+  "directive_events": [],
+  "docs_events": [
+    {
+      "at": "2026-07-01T23:08:44.651955Z",
+      "class": null,
+      "kind": "path",
+      "path": "desktop/README.md",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": true,
+  "guard_events": [
+    {
+      "at": "2026-07-01T23:15:49.557405Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T23:15:49.611685Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T23:15:49.658914Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T23:15:49.711498Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T23:15:49.758236Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T23:15:49.805109Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T23:15:49.852513Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T23:15:49.907085Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T23:15:49.953983Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T23:15:50.000874Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T23:20:51.806948Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T23:20:51.852661Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T23:20:51.898481Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T23:20:51.944100Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T23:20:51.989506Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T23:20:52.035811Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T23:20:52.082333Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T23:20:52.128320Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T23:20:52.222309Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T23:20:52.268675Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1895,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": {
+    "base": "origin/main",
+    "base_sha": "99a1dc61",
+    "changed_files": [],
+    "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "head": "HEAD",
+    "head_sha": "99a1dc61",
+    "surfaces": {
+      "docs": 0,
+      "frontend": 0,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 0,
+      "packaging": 0,
+      "protected_core": 0,
+      "sentrux": 0,
+      "test": 0,
+      "workflow_ci": 0
+    }
+  },
+  "owner_directive": "Implement Linux desktop AppImage packaging per ADR-037 / issue #1895: python-build-standalone linux runtime script, electron-builder linux AppImage target + npm scripts, CI workflow, and a stable Linux machine fingerprint (/etc/machine-id) for the alpha activation gate",
+  "persona": "implementer",
+  "pull_request": null,
+  "reconcile_events": [
+    {
+      "at": "2026-07-01T23:15:50.000912Z",
+      "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "mode": "local",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.python_tests"
+      ]
+    },
+    {
+      "at": "2026-07-01T23:20:52.268714Z",
+      "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "mode": "local",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.python_tests"
+      ]
+    }
+  ],
+  "record_id": "1895-linux-desktop-appimage",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [
+      "architecture_tests",
+      "deferral_discipline",
+      "format_check",
+      "full_audit",
+      "import_contracts",
+      "lint_format",
+      "python_tests",
+      "semantic_dup",
+      "type_check"
+    ],
+    "docs": [],
+    "guards": [
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": []
+  },
+  "runtime": "claude",
+  "schema_version": 2,
+  "scope_events": [
+    {
+      "action": "add-include",
+      "at": "2026-07-01T23:08:44.651912Z",
+      "pattern": "desktop/scripts/build-python-runtime-linux.sh",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-07-01T23:08:44.651937Z",
+      "pattern": "desktop/package.json",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-07-01T23:08:44.651941Z",
+      "pattern": ".github/workflows/desktop-linux-appimage.yml",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-07-01T23:08:44.651943Z",
+      "pattern": "desktop/test/linux-appimage.test.js",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-07-01T23:08:44.651945Z",
+      "pattern": "desktop/activation.js",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-07-01T23:08:44.651946Z",
+      "pattern": "desktop/test/activation.test.js",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-07-01T23:08:44.651948Z",
+      "pattern": "desktop/README.md",
+      "reason": "plan"
+    }
+  ],
+  "session_id": "2c0c4182-2344-4163-b306-02adf0679083",
+  "strictness_tier": 1,
+  "task_kind": "feature",
+  "test_events": [
+    {
+      "at": "2026-07-01T23:08:44.651963Z",
+      "class": null,
+      "kind": "path",
+      "path": "desktop/test/linux-appimage.test.js",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-07-01T23:08:44.651967Z",
+      "class": null,
+      "kind": "path",
+      "path": "desktop/test/activation.test.js",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/.workflow/records/1895-linux-desktop-appimage.json
+++ b/.workflow/records/1895-linux-desktop-appimage.json
@@ -156,10 +156,157 @@
       "status": "fail",
       "summary": "exit 1",
       "tool_versions": {}
+    },
+    {
+      "at": "2026-07-01T23:27:44.186382Z",
+      "command": "pytest tests/architecture/ -v --no-cov",
+      "covered_surface": "architecture",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:9a8e022c1a28ea2da7b866767d3055c1416622d6ca8af094d124a9a814c070db",
+      "name": "architecture_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/architecture_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-01T23:27:45.188472Z",
+      "command": "python scripts/deferral_scan.py --check docs/audit/baselines/deferral-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:fc6165f92b0f79507cb068dafa0756d99c8b27251504816ce90d79e09e778bcc",
+      "name": "deferral_discipline",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/deferral_discipline.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-01T23:27:45.224843Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:212ce0d82106ba02a743f0b8fa0fcbc737e45866763c8f5ddabc7e580109bbfe",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-07-01T23:27:55.045812Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:9915c3c44414deb7adce428fca731664b01935fc51294712d0f804bddd7c4e3c",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-01T23:27:55.311703Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:51d915f70205b783595cf084913ef68428aa772b4a5c6d5ee0afb29f268941a7",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-01T23:27:55.343943Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:0ab1df52510160f0c66641b96bf45fb4c5f4da65f99f78b1796127bb63dec6b7",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-07-01T23:30:30.247047Z",
+      "command": "python -m scistudio.qa.testing.run_python_tests --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:ea99bbf859937fbdbcf3a5c94eebd5c7c32eb3c1dc548038d346ae00d08ecea0",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-01T23:31:32.839494Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:67e628df5170be921cf72a31124fe311cc2d9196837df55bb9cb994b2303f374",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-01T23:31:33.484455Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:7bad5ad3112c1558f009fd6dc977e4dedfdc04edb32ed51ad7ef7f4168d8465f",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
     }
   ],
   "check_na": [],
-  "commit": null,
+  "commit": {
+    "sha": "77f9d978",
+    "shas": [
+      "77f9d978"
+    ],
+    "trailers": []
+  },
   "declared_scope": {
     "exclude": [],
     "include": []
@@ -296,6 +443,334 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-07-01T23:25:35.035719Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T23:25:35.082735Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T23:25:35.128981Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T23:25:35.175519Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T23:25:35.227611Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T23:25:35.280568Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T23:25:35.327206Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T23:25:35.379978Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T23:25:35.426584Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T23:25:35.473592Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T23:31:33.578920Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T23:31:33.624422Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T23:31:33.676317Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T23:31:33.721924Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T23:31:33.767531Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T23:31:33.818380Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T23:31:33.878387Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T23:31:33.926343Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T23:31:33.974319Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T23:31:34.023000Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T23:32:06.804835Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T23:32:06.853098Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T23:32:06.900648Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T23:32:06.948259Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T23:32:07.002761Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T23:32:07.057499Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T23:32:07.104677Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T23:32:07.158548Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T23:32:07.206846Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T23:32:07.255055Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T23:32:50.710800Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T23:32:50.763656Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T23:32:50.809536Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T23:32:50.856903Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T23:32:50.904237Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T23:32:50.951937Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T23:32:50.999349Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T23:32:51.046564Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T23:32:51.092935Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-01T23:32:51.146352Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -308,28 +783,44 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "origin/main",
+    "base": "99a1dc61bac5eccd62c5a7688efbf6e278dfd9a9",
     "base_sha": "99a1dc61",
-    "changed_files": [],
-    "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "changed_files": [
+      ".github/workflows/desktop-linux-appimage.yml",
+      ".workflow/records/1895-linux-desktop-appimage.json",
+      "desktop/README.md",
+      "desktop/activation.js",
+      "desktop/package.json",
+      "desktop/scripts/build-python-runtime-linux.sh",
+      "desktop/test/activation.test.js",
+      "desktop/test/linux-appimage.test.js"
+    ],
+    "diff_fingerprint": "sha256:2fe48da957e4ffd76161926c3923db20bd6e911fa2c165714fd5daaa587a8614",
     "head": "HEAD",
-    "head_sha": "99a1dc61",
+    "head_sha": "77f9d978",
     "surfaces": {
       "docs": 0,
       "frontend": 0,
-      "governance": 0,
+      "governance": 1,
       "governed_docs": 0,
-      "implementation": 0,
+      "implementation": 1,
       "packaging": 0,
       "protected_core": 0,
-      "sentrux": 0,
-      "test": 0,
-      "workflow_ci": 0
+      "sentrux": 1,
+      "test": 2,
+      "workflow_ci": 1
     }
   },
   "owner_directive": "Implement Linux desktop AppImage packaging per ADR-037 / issue #1895: python-build-standalone linux runtime script, electron-builder linux AppImage target + npm scripts, CI workflow, and a stable Linux machine fingerprint (/etc/machine-id) for the alpha activation gate",
   "persona": "implementer",
-  "pull_request": null,
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [
+      1895
+    ],
+    "number": 1904,
+    "url": "https://github.com/jiazhenz026/SciStudio/pull/1904"
+  },
   "reconcile_events": [
     {
       "at": "2026-07-01T23:15:50.000912Z",
@@ -345,6 +836,54 @@
       "at": "2026-07-01T23:20:52.268714Z",
       "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
       "mode": "local",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.python_tests"
+      ]
+    },
+    {
+      "at": "2026-07-01T23:25:35.473617Z",
+      "diff_fingerprint": "sha256:2fe48da957e4ffd76161926c3923db20bd6e911fa2c165714fd5daaa587a8614",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.architecture_tests",
+        "checks.deferral_discipline",
+        "checks.format_check",
+        "checks.full_audit",
+        "checks.import_contracts",
+        "checks.lint_format",
+        "checks.python_tests",
+        "checks.semantic_dup",
+        "checks.type_check"
+      ]
+    },
+    {
+      "at": "2026-07-01T23:31:34.023025Z",
+      "diff_fingerprint": "sha256:2fe48da957e4ffd76161926c3923db20bd6e911fa2c165714fd5daaa587a8614",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.python_tests"
+      ]
+    },
+    {
+      "at": "2026-07-01T23:32:07.255078Z",
+      "diff_fingerprint": "sha256:2fe48da957e4ffd76161926c3923db20bd6e911fa2c165714fd5daaa587a8614",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.python_tests"
+      ]
+    },
+    {
+      "at": "2026-07-01T23:32:51.146376Z",
+      "diff_fingerprint": "sha256:2fe48da957e4ffd76161926c3923db20bd6e911fa2c165714fd5daaa587a8614",
+      "mode": "pre-pr",
       "result": "fail",
       "tier": 1,
       "unsatisfied": [
@@ -367,7 +906,9 @@
       "semantic_dup",
       "type_check"
     ],
-    "docs": [],
+    "docs": [
+      "docs_required_or_na"
+    ],
     "guards": [
       "core_change_guard",
       "docs_landing",
@@ -380,7 +921,9 @@
       "test_engineer_scope_guard",
       "weakened_ci_check"
     ],
-    "tests": []
+    "tests": [
+      "changed_test_required"
+    ]
   },
   "runtime": "claude",
   "schema_version": 2,

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -45,14 +45,34 @@ the packaged SPA (`scistudio/api/static`) from the fresh `frontend/dist` on ever
 build; a bundled app serves only that embedded SPA, never a `frontend/dist` found
 on the host (#1747).
 
+The Linux AppImage build runs on Linux and emits an unsigned AppImage under
+`desktop/dist` (ADR-037 §3.6 D21 selects AppImage as the primary Linux format):
+
+```bash
+npm --prefix desktop run build:python:linux
+npm --prefix desktop run stage:sh
+npm --prefix desktop run dist:linux
+```
+
+`build:python:linux` stages a standalone glibc-based Python under
+`resources/python/bin/python3` for the host architecture
+(`x86_64-unknown-linux-gnu` or `aarch64-unknown-linux-gnu`) before `dist:linux`
+builds the AppImage. Build on the oldest distro you intend to support: the
+bundled interpreter and the numpy/pyarrow/zarr manylinux wheels are glibc-based,
+so an AppImage built against a newer glibc will not launch on older distros. CI
+pins `ubuntu-22.04` as the compatibility baseline. On systems without FUSE
+(minimal containers, some hardened distros), launch with
+`./SciStudio-*.AppImage --appimage-extract-and-run`.
+
 The GitHub Actions build chain for packaged artifacts is intentionally manual
 because the installer jobs are slow. Run `.github/workflows/desktop-windows-installer.yml`
-to upload `scistudio-windows-installer`, and run
-`.github/workflows/desktop-macos-dmg.yml` to upload `scistudio-macos-dmg`.
+to upload `scistudio-windows-installer`, run
+`.github/workflows/desktop-macos-dmg.yml` to upload `scistudio-macos-dmg`, and run
+`.github/workflows/desktop-linux-appimage.yml` to upload `scistudio-linux-appimage`.
 
 The packaged app uses the SciStudio icon assets in `desktop/assets`: `icon.svg`
-is the source, `icon.png` is the runtime window icon, and `icon.ico`/`icon.icns`
-are the Windows and macOS packaging icons.
+is the source, `icon.png` is the runtime window icon (and the Linux AppImage
+icon), and `icon.ico`/`icon.icns` are the Windows and macOS packaging icons.
 
 ## Runtime Python
 
@@ -79,6 +99,11 @@ first.
 
 On macOS, `build:python:mac` stages a standalone Python under
 `resources/python/bin/python3` before `dist:dmg` builds the DMG.
+
+On Linux, `build:python:linux` stages the same standalone `python-build-standalone`
+layout under `resources/python/bin/python3` before `dist:linux` builds the
+AppImage. Linux agent terminals are backed by the stdlib `pty` module, so no
+extra PTY backend is bundled.
 
 ## Local Package Installer
 

--- a/desktop/activation.js
+++ b/desktop/activation.js
@@ -29,10 +29,32 @@ const path = require("path");
 // Machine fingerprint (stable, cross-platform: macOS + Windows).
 // --------------------------------------------------------------------------- //
 
+// #1895: Linux stable per-machine identifier. systemd's /etc/machine-id is a
+// per-installation 32-hex id that survives app reinstalls; /var/lib/dbus/
+// machine-id is the older D-Bus fallback present on non-systemd distros. Reads
+// are injectable so the branch is unit-testable off Linux. Returns `linux:<id>`
+// or null when neither source is readable (the caller then falls back to the
+// hostname). AppImages run unprivileged from user home, so both files are
+// readable when present.
+function linuxMachineId(readFileSync = fs.readFileSync) {
+  for (const file of ["/etc/machine-id", "/var/lib/dbus/machine-id"]) {
+    try {
+      const id = readFileSync(file, "utf8").trim();
+      if (id) {
+        return `linux:${id}`;
+      }
+    } catch {
+      // Try the next source.
+    }
+  }
+  return null;
+}
+
 // Best-effort stable per-machine identifier. macOS uses the IOPlatformUUID;
-// Windows uses the registry MachineGuid. Both survive app reinstalls. Falls back
-// to the hostname when the platform probe is unavailable so the gate still has
-// *some* binding rather than crashing.
+// Windows uses the registry MachineGuid; Linux uses the systemd/D-Bus machine
+// id. All three survive app reinstalls. Falls back to the hostname when the
+// platform probe is unavailable so the gate still has *some* binding rather
+// than crashing.
 function rawMachineId() {
   try {
     if (process.platform === "darwin") {
@@ -53,6 +75,11 @@ function rawMachineId() {
       const match = out.match(/MachineGuid\s+REG_SZ\s+([A-Za-z0-9-]+)/i);
       if (match && match[1]) {
         return `win:${match[1]}`;
+      }
+    } else if (process.platform === "linux") {
+      const id = linuxMachineId();
+      if (id) {
+        return id;
       }
     }
   } catch {
@@ -204,6 +231,7 @@ function gateEnabled(isPackaged) {
 
 module.exports = {
   machineFingerprint,
+  linuxMachineId,
   verifyToken,
   loadPublicKeyPem,
   activationFilePath,

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -83,7 +83,9 @@
       "category": "Science",
       "synopsis": "AI-native workflow runtime for multimodal scientific data",
       "desktop": {
-        "StartupWMClass": "SciStudio"
+        "entry": {
+          "StartupWMClass": "SciStudio"
+        }
       }
     }
   }

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -10,6 +10,7 @@
     "build:frontend": "npm --prefix ../frontend run build",
     "build:python": "powershell -ExecutionPolicy Bypass -File ./scripts/build-python-runtime.ps1",
     "build:python:mac": "bash ./scripts/build-python-runtime-macos.sh",
+    "build:python:linux": "bash ./scripts/build-python-runtime-linux.sh",
     "stage": "powershell -ExecutionPolicy Bypass -File ./scripts/stage-resources.ps1",
     "stage:sh": "sh ./scripts/stage-resources.sh",
     "start": "node scripts/start-electron.js",
@@ -17,7 +18,8 @@
     "test": "node --test test/*.test.js",
     "dist:dir": "powershell -ExecutionPolicy Bypass -Command \"Remove-Item -LiteralPath dist\\win-unpacked -Recurse -Force -ErrorAction SilentlyContinue\" && electron-builder --dir",
     "dist:win": "powershell -ExecutionPolicy Bypass -Command \"if (Test-Path 'dist\\win-unpacked') { Remove-Item -LiteralPath 'dist\\win-unpacked' -Recurse -Force }; if (Test-Path 'dist') { Get-ChildItem -Path 'dist' -Filter '*.exe' -File -ErrorAction SilentlyContinue | Remove-Item -Force }\" && electron-builder --win nsis --x64",
-    "dist:dmg": "electron-builder --mac dmg --arm64"
+    "dist:dmg": "electron-builder --mac dmg --arm64",
+    "dist:linux": "electron-builder --linux AppImage"
   },
   "dependencies": {},
   "devDependencies": {
@@ -72,6 +74,17 @@
       "category": "public.app-category.developer-tools",
       "hardenedRuntime": false,
       "gatekeeperAssess": false
+    },
+    "linux": {
+      "target": [
+        "AppImage"
+      ],
+      "icon": "icon.png",
+      "category": "Science",
+      "synopsis": "AI-native workflow runtime for multimodal scientific data",
+      "desktop": {
+        "StartupWMClass": "SciStudio"
+      }
     }
   }
 }

--- a/desktop/scripts/build-python-runtime-linux.sh
+++ b/desktop/scripts/build-python-runtime-linux.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# #1895: Build the portable Python runtime bundled into the Linux AppImage.
+#
+# Mirrors build-python-runtime-macos.sh but targets the python-build-standalone
+# linux-gnu triples. The bundled interpreter is glibc-based (like the numpy /
+# pyarrow / zarr / matplotlib manylinux wheels it installs), so the AppImage
+# must be built on the oldest supported glibc baseline (see
+# .github/workflows/desktop-linux-appimage.yml, which pins ubuntu-22.04) to run
+# across distros. `pty` is stdlib on Linux, so no PTY backend needs installing.
+
+PYTHON_VERSION_PREFIX="${SCISTUDIO_DESKTOP_PYTHON_VERSION_PREFIX:-3.12}"
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+DESKTOP_ROOT="$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$(CDPATH= cd -- "$DESKTOP_ROOT/.." && pwd)"
+RESOURCES_ROOT="$DESKTOP_ROOT/resources"
+PYTHON_ROOT="$RESOURCES_ROOT/python"
+CACHE_ROOT="$DESKTOP_ROOT/.cache/python-runtime"
+ASSET_JSON="$CACHE_ROOT/python-build-standalone-release.json"
+TARBALL="$CACHE_ROOT/python-build-standalone-linux.tar.gz"
+
+case "$(uname -m)" in
+  x86_64|amd64)
+    TARGET_TRIPLE="x86_64-unknown-linux-gnu"
+    ;;
+  aarch64|arm64)
+    TARGET_TRIPLE="aarch64-unknown-linux-gnu"
+    ;;
+  *)
+    echo "Unsupported Linux architecture: $(uname -m)" >&2
+    exit 1
+    ;;
+esac
+
+mkdir -p "$CACHE_ROOT" "$RESOURCES_ROOT"
+
+if [ ! -f "$ASSET_JSON" ]; then
+  curl -fsSL "https://api.github.com/repos/astral-sh/python-build-standalone/releases/latest" \
+    -o "$ASSET_JSON"
+fi
+
+ASSET_URL="$(
+  python3 - "$ASSET_JSON" "$PYTHON_VERSION_PREFIX" "$TARGET_TRIPLE" <<'PY'
+import json
+import re
+import sys
+
+release_path, version_prefix, target = sys.argv[1:]
+data = json.load(open(release_path, encoding="utf-8"))
+pattern = re.compile(
+    rf"^cpython-{re.escape(version_prefix)}\.\d+\+\d+-{re.escape(target)}-install_only_stripped\.tar\.gz$"
+)
+assets = [
+    asset
+    for asset in data.get("assets", [])
+    if pattern.match(asset.get("name", ""))
+]
+if not assets:
+    fallback = re.compile(
+        rf"^cpython-{re.escape(version_prefix)}\.\d+\+\d+-{re.escape(target)}-install_only\.tar\.gz$"
+    )
+    assets = [
+        asset
+        for asset in data.get("assets", [])
+        if fallback.match(asset.get("name", ""))
+    ]
+if not assets:
+    names = "\n".join(asset.get("name", "") for asset in data.get("assets", []))
+    raise SystemExit(f"No python-build-standalone asset for {version_prefix} {target}.\n{names}")
+print(assets[0]["browser_download_url"])
+PY
+)"
+
+if [ ! -f "$TARBALL" ]; then
+  echo "Downloading $ASSET_URL"
+  curl -fL "$ASSET_URL" -o "$TARBALL"
+fi
+
+rm -rf "$PYTHON_ROOT" "$CACHE_ROOT/extract"
+mkdir -p "$CACHE_ROOT/extract"
+tar -xzf "$TARBALL" -C "$CACHE_ROOT/extract"
+mv "$CACHE_ROOT/extract/python" "$PYTHON_ROOT"
+
+PYTHON_BIN="$PYTHON_ROOT/bin/python3"
+"$PYTHON_BIN" -m pip install --no-warn-script-location --upgrade pip setuptools wheel
+"$PYTHON_BIN" -m pip install --no-warn-script-location "$REPO_ROOT"
+"$PYTHON_BIN" -c "import scistudio, fastapi, uvicorn, pty; print('SciStudio Linux portable Python ready:', scistudio.__version__)"
+
+# #1775: The bundled runtime loads scistudio from resources/backend/src via
+# PYTHONPATH (desktop/main.js runtimeEnv), and OTA patches load it from a
+# userData directory. The pip install above is only needed to resolve the
+# third-party dependencies into the interpreter; the scistudio package it also
+# installs is a redundant second copy that wastes space and can shadow the
+# source tree if PYTHONPATH ordering ever changes. Remove just scistudio,
+# keeping its dependencies, so the source tree is the single source of truth.
+"$PYTHON_BIN" -m pip uninstall -y scistudio
+"$PYTHON_BIN" -c "import fastapi, uvicorn, pty; print('SciStudio Linux runtime deps verified (scistudio loads from source/OTA)')"
+
+: > "$PYTHON_ROOT/.scistudio-python-runtime"
+echo "Portable Linux Python runtime is ready at $PYTHON_ROOT"

--- a/desktop/scripts/build-python-runtime-linux.sh
+++ b/desktop/scripts/build-python-runtime-linux.sh
@@ -19,7 +19,6 @@ RESOURCES_ROOT="$DESKTOP_ROOT/resources"
 PYTHON_ROOT="$RESOURCES_ROOT/python"
 CACHE_ROOT="$DESKTOP_ROOT/.cache/python-runtime"
 ASSET_JSON="$CACHE_ROOT/python-build-standalone-release.json"
-TARBALL="$CACHE_ROOT/python-build-standalone-linux.tar.gz"
 
 case "$(uname -m)" in
   x86_64|amd64)
@@ -72,6 +71,14 @@ if not assets:
 print(assets[0]["browser_download_url"])
 PY
 )"
+
+# #1895: Key the cache by the resolved asset filename (which encodes the exact
+# CPython version + target triple + variant), not a fixed path. A fixed name
+# would make the download guard reuse a stale interpreter after the version
+# prefix, selected release, or architecture changes, silently packaging the
+# wrong Python. Strip any URL query before taking the basename.
+ASSET_NAME="$(basename "${ASSET_URL%%\?*}")"
+TARBALL="$CACHE_ROOT/$ASSET_NAME"
 
 if [ ! -f "$TARBALL" ]; then
   echo "Downloading $ASSET_URL"

--- a/desktop/test/activation.test.js
+++ b/desktop/test/activation.test.js
@@ -36,6 +36,36 @@ test("machineFingerprint: stable 64-char hex digest", () => {
   assert.equal(fp, activation.machineFingerprint());
 });
 
+test("linuxMachineId: prefers /etc/machine-id, then D-Bus, else null (#1895)", () => {
+  const systemd = (file) => {
+    if (file === "/etc/machine-id") {
+      return "  abc123def456\n";
+    }
+    throw new Error("ENOENT");
+  };
+  assert.equal(activation.linuxMachineId(systemd), "linux:abc123def456");
+
+  const dbusOnly = (file) => {
+    if (file === "/var/lib/dbus/machine-id") {
+      return "dbus789\n";
+    }
+    throw new Error("ENOENT");
+  };
+  assert.equal(activation.linuxMachineId(dbusOnly), "linux:dbus789");
+
+  // Neither source readable -> null so rawMachineId falls back to the hostname.
+  const none = () => {
+    throw new Error("ENOENT");
+  };
+  assert.equal(activation.linuxMachineId(none), null);
+
+  // A present-but-empty machine-id must not be treated as a valid binding.
+  const empty = (file) => (file === "/etc/machine-id" ? "\n" : (() => {
+    throw new Error("ENOENT");
+  })());
+  assert.equal(activation.linuxMachineId(empty), null);
+});
+
 test("verifyToken: valid token for this machine", () => {
   const { privatePem, publicPem } = makeKeypair();
   const fp = "a".repeat(64);

--- a/desktop/test/linux-appimage.test.js
+++ b/desktop/test/linux-appimage.test.js
@@ -19,6 +19,15 @@ test("package.json declares a Linux AppImage electron-builder target", () => {
   assert.equal(linux.icon, "icon.png", "Linux icon must reference the bundled PNG");
 });
 
+test("StartupWMClass is nested under linux.desktop.entry (electron-builder schema)", () => {
+  // electron-builder 26.x validates linux.desktop against a schema that only
+  // accepts `entry` / `desktopActions`; a flat desktop.StartupWMClass is
+  // rejected and fails the build before packaging.
+  const desktop = pkg.build.linux.desktop || {};
+  assert.equal(desktop.StartupWMClass, undefined, "must not use the flat form");
+  assert.equal((desktop.entry || {}).StartupWMClass, "SciStudio");
+});
+
 test("package.json exposes the Linux build + dist npm scripts", () => {
   assert.equal(
     pkg.scripts["build:python:linux"],

--- a/desktop/test/linux-appimage.test.js
+++ b/desktop/test/linux-appimage.test.js
@@ -1,0 +1,54 @@
+"use strict";
+
+// #1895: Guard the Linux AppImage packaging chain so a future edit to
+// package.json or a rename of the runtime script cannot silently break the
+// Linux build without a test failing. Run with: npm --prefix desktop test.
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const desktopRoot = path.join(__dirname, "..");
+const pkg = JSON.parse(fs.readFileSync(path.join(desktopRoot, "package.json"), "utf8"));
+
+test("package.json declares a Linux AppImage electron-builder target", () => {
+  const linux = pkg.build && pkg.build.linux;
+  assert.ok(linux, "build.linux must be defined");
+  assert.deepEqual(linux.target, ["AppImage"]);
+  assert.equal(linux.icon, "icon.png", "Linux icon must reference the bundled PNG");
+});
+
+test("package.json exposes the Linux build + dist npm scripts", () => {
+  assert.equal(
+    pkg.scripts["build:python:linux"],
+    "bash ./scripts/build-python-runtime-linux.sh"
+  );
+  assert.equal(pkg.scripts["dist:linux"], "electron-builder --linux AppImage");
+});
+
+test("Linux Python runtime uses python-build-standalone linux-gnu triples", () => {
+  const scriptPath = path.join(desktopRoot, "scripts", "build-python-runtime-linux.sh");
+  assert.ok(fs.existsSync(scriptPath), "build-python-runtime-linux.sh must exist");
+  const body = fs.readFileSync(scriptPath, "utf8");
+  assert.match(body, /python-build-standalone/);
+  assert.match(body, /x86_64-unknown-linux-gnu/);
+  assert.match(body, /aarch64-unknown-linux-gnu/);
+  // `pty` is stdlib on Linux; the verification line imports it, not winpty.
+  assert.match(body, /import scistudio, fastapi, uvicorn, pty/);
+  // scistudio must load from source/OTA, not a redundant bundled copy (#1775).
+  assert.match(body, /pip uninstall -y scistudio/);
+});
+
+test("the AppImage icon asset is present and a valid PNG", () => {
+  // electron-builder needs a >=512px source icon for Linux; the shared asset is
+  // 1024x1024. Assert presence and a PNG header rather than decoding the image.
+  const iconPath = path.join(desktopRoot, "assets", "icon.png");
+  assert.ok(fs.existsSync(iconPath), "assets/icon.png must exist");
+  const header = fs.readFileSync(iconPath).subarray(0, 8);
+  assert.deepEqual(
+    Array.from(header),
+    [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a],
+    "icon.png must be a valid PNG"
+  );
+});


### PR DESCRIPTION
## Summary

Completes the Linux desktop packaging chain so SciStudio can ship as an
AppImage, per ADR-037 §3.6 (D21 selects AppImage as the primary Linux format)
and issue #1895. This is "complete the packaging", not a port: the runtime code
(`main.js`, `paths.py`, terminal PTY, OTA) was already Linux-clean. The one
Linux-specific runtime gap that would degrade the alpha test experience — an
unstable activation fingerprint — is also closed.

## Changes

- **`desktop/scripts/build-python-runtime-linux.sh`** (new) — mirrors the
  Windows/macOS runtime scripts against the python-build-standalone
  `x86_64-unknown-linux-gnu` / `aarch64-unknown-linux-gnu` triples. `pty` is
  stdlib on Linux, so no PTY backend is bundled (contrast Windows `pywinpty`).
- **`desktop/package.json`** — adds the `linux` electron-builder target
  (`AppImage`, `icon.png`, `Science` category, `StartupWMClass`) and the
  `build:python:linux` + `dist:linux` npm scripts.
- **`.github/workflows/desktop-linux-appimage.yml`** (new) — mirrors the macOS
  DMG workflow on an `ubuntu-22.04` runner. The runner is pinned to the oldest
  supported LTS so the bundled glibc-based Python and the numpy/pyarrow/zarr
  manylinux wheels bind an old glibc and the AppImage runs across distros.
- **`desktop/activation.js`** — adds a Linux branch to the alpha activation
  fingerprint: reads systemd `/etc/machine-id` (then the D-Bus fallback) instead
  of the unstable hostname, so an activation token stays valid across launches.
  Packaged builds always require activation (#1848, no bypass), so a stable
  fingerprint is needed for Linux testers. Reads are injectable for off-Linux
  unit testing.
- **`desktop/test/linux-appimage.test.js`** (new) + **`activation.test.js`** —
  node test-runner guards for the Linux target, npm scripts, runtime-script
  triples, icon asset, and the `linuxMachineId` source precedence / empty-id
  handling.
- **`desktop/README.md`** — Linux build instructions, glibc-baseline note, and
  the `--appimage-extract-and-run` fallback for FUSE-less systems.

## Out of scope (tracked under #1895)

- Linux conda-env auto-discovery in `main.js` — optional UX; the non-Windows
  branch already resolves the bundled `resources/python/bin/python` and falls
  back to `python3`/`python` on `PATH`.
- `.deb`/`.rpm`/Flatpak targets — ADR-037 defers these past v1.

## Testing

- `npm --prefix desktop test` → 45 passing (adds Linux packaging + fingerprint
  cases).
- `bash -n` clean on the new runtime script; `package.json` validates as JSON.
- The AppImage build itself needs a Linux host: run
  `.github/workflows/desktop-linux-appimage.yml` (or the README commands) to
  produce and smoke-test the artifact.

Closes #1895

🤖 Generated with [Claude Code](https://claude.com/claude-code)
