### PR TITLE
chore(#1908): add release-build inputs to Linux AppImage workflow

### DIFF
--- a/.github/workflows/desktop-linux-appimage.yml
+++ b/.github/workflows/desktop-linux-appimage.yml
@@ -7,6 +7,14 @@ on:
         description: "Git ref to build"
         required: false
         default: "main"
+      build_number:
+        description: "Release build number to stamp (e.g. 11). Empty = committed dev build0000."
+        required: false
+        default: ""
+      ota_channel:
+        description: "OTA channel to enable (alpha|beta|stable). Empty = OTA disabled (dev build)."
+        required: false
+        default: ""
 
 permissions:
   contents: read
@@ -36,13 +44,29 @@ jobs:
           cache: npm
           cache-dependency-path: desktop/package-lock.json
 
+      # #1908: For a release build, stamp the SSOT-derived version onto every
+      # manifest before install so electron-builder names the AppImage
+      # SciStudio-<base>-<channel>-build<NNNN>. Empty build_number leaves the
+      # committed dev build0000 in place. Runs before `npm ci` so package.json
+      # and package-lock.json stay consistent for the install.
+      - name: Stamp release version
+        if: ${{ github.event.inputs.build_number != '' }}
+        env:
+          SCISTUDIO_BUILD_NUMBER: ${{ github.event.inputs.build_number }}
+        run: python3 scripts/version.py sync
+
       - name: Install desktop dependencies
         run: npm --prefix desktop ci
 
       - name: Build portable Python runtime
         run: npm --prefix desktop run build:python:linux
 
+      # #1908: An OTA channel enables launch-time update checks against that
+      # channel's manifest (stage-resources.sh). Empty ota_channel keeps OTA
+      # disabled, matching a local/dev build.
       - name: Stage resources
+        env:
+          SCISTUDIO_OTA_CHANNEL: ${{ github.event.inputs.ota_channel }}
         run: npm --prefix desktop run stage:sh
 
       - name: Build AppImage

--- a/.workflow/records/1908-linux-appimage-release-inputs.json
+++ b/.workflow/records/1908-linux-appimage-release-inputs.json
@@ -1,8 +1,156 @@
 {
   "branch": "feat/1908-linux-appimage-release-inputs",
-  "check_events": [],
+  "check_events": [
+    {
+      "at": "2026-07-02T16:16:36.968007Z",
+      "command": "pytest tests/architecture/ -v --no-cov",
+      "covered_surface": "architecture",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:7630bc49b365c9b45dc958ee423c03d6392f1539622be4a6793dc03cbe751822",
+      "name": "architecture_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/architecture_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-02T16:16:37.994209Z",
+      "command": "python scripts/deferral_scan.py --check docs/audit/baselines/deferral-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:fcad47181803d549e95d133476be6139438def6f855ddecb7c94df1c19ded9a5",
+      "name": "deferral_discipline",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/deferral_discipline.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-02T16:16:38.035258Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:228ee80c53c055d6120b2810615db7deb2ca00089bcfdb0abf6050d989d86fde",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-07-02T16:16:47.259284Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:46743c4d9c0ca3dec5aca3640d84570c1498301d1224a89c7046a3374e43a5d4",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-02T16:16:47.493036Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e1041a0fc0701b272eccecfc7a544d66e18115b83ed852efc62754be0b1192e5",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-02T16:16:47.527275Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:335e1a949b26d46aae6104f6b5b846f83ca646b388afc6d9ab4a5a18db55de9b",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-07-02T16:19:56.645792Z",
+      "command": "pytest -n auto --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:293d8c96986cf23b1f3661321bde396e0f386f0e6e1c85f2ef49c09ed2ce5991",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-02T16:21:02.090238Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:dba5ded9fc25d46b16b7f6056ac07a07687f5f5d3e47a16fac68d56eb1b2ecb4",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-02T16:21:02.739157Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:71faa144565e6310506342334bb2fb0991a609c13663fb1931d6a3da5700eb44",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    }
+  ],
   "check_na": [],
-  "commit": null,
+  "commit": {
+    "sha": "dbf871df",
+    "shas": [
+      "dbf871df"
+    ],
+    "trailers": []
+  },
   "declared_scope": {
     "exclude": [],
     "include": []
@@ -19,7 +167,172 @@
     }
   ],
   "governance_touch": true,
-  "guard_events": [],
+  "guard_events": [
+    {
+      "at": "2026-07-02T16:21:02.845309Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T16:21:02.893997Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T16:21:02.949059Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T16:21:02.996422Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T16:21:03.053308Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T16:21:03.100524Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T16:21:03.150265Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T16:21:03.199017Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T16:21:03.255195Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T16:21:03.305028Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T16:21:55.998718Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T16:21:56.047576Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T16:21:56.101536Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T16:21:56.149624Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T16:21:56.198628Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T16:21:56.252273Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T16:21:56.301168Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T16:21:56.350327Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T16:21:56.399648Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T16:21:56.449447Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
   "issues": [
     {
       "close_in_pr": true,
@@ -29,19 +342,93 @@
     }
   ],
   "observed_admin_labels": [],
-  "observed_diff": null,
+  "observed_diff": {
+    "base": "ba049af6138f1f0d85a5657f51c509a2138d9e1f",
+    "base_sha": "ba049af6",
+    "changed_files": [
+      ".github/workflows/desktop-linux-appimage.yml",
+      ".workflow/records/1908-linux-appimage-release-inputs.json",
+      "desktop/README.md"
+    ],
+    "diff_fingerprint": "sha256:97e4b315403827df45f6bc26f7d02697b4f6bbc242e39004cb14b0e173c9ae2c",
+    "head": "HEAD",
+    "head_sha": "dbf871df",
+    "surfaces": {
+      "docs": 0,
+      "frontend": 0,
+      "governance": 1,
+      "governed_docs": 0,
+      "implementation": 1,
+      "packaging": 0,
+      "protected_core": 0,
+      "sentrux": 1,
+      "test": 0,
+      "workflow_ci": 1
+    }
+  },
   "owner_directive": "Add build_number + ota_channel workflow_dispatch inputs to desktop-linux-appimage.yml so CI can produce release-consistent (build-numbered, OTA-enabled) AppImages for the ota-alpha release (issue #1908)",
   "persona": "implementer",
-  "pull_request": null,
-  "reconcile_events": [],
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [],
+    "number": 1909,
+    "url": "https://github.com/jiazhenz026/SciStudio/pull/1909"
+  },
+  "reconcile_events": [
+    {
+      "at": "2026-07-02T16:21:03.305054Z",
+      "diff_fingerprint": "sha256:97e4b315403827df45f6bc26f7d02697b4f6bbc242e39004cb14b0e173c9ae2c",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.python_tests"
+      ]
+    },
+    {
+      "at": "2026-07-02T16:21:56.449473Z",
+      "diff_fingerprint": "sha256:97e4b315403827df45f6bc26f7d02697b4f6bbc242e39004cb14b0e173c9ae2c",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.python_tests"
+      ]
+    }
+  ],
   "record_id": "1908-linux-appimage-release-inputs",
   "requested_admin_labels": [],
   "required_obligations": {
     "admin_labels": [],
-    "checks": [],
-    "docs": [],
-    "guards": [],
-    "tests": []
+    "checks": [
+      "architecture_tests",
+      "deferral_discipline",
+      "format_check",
+      "full_audit",
+      "import_contracts",
+      "lint_format",
+      "python_tests",
+      "semantic_dup",
+      "type_check"
+    ],
+    "docs": [
+      "docs_required_or_na"
+    ],
+    "guards": [
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": [
+      "changed_test_required"
+    ]
   },
   "runtime": "claude",
   "schema_version": 2,
@@ -60,7 +447,7 @@
     }
   ],
   "session_id": "44f21b43-c9a4-464b-a489-e62039758bf7",
-  "strictness_tier": null,
+  "strictness_tier": 1,
   "task_kind": "maintenance",
   "test_events": [
     {

--- a/.workflow/records/1908-linux-appimage-release-inputs.json
+++ b/.workflow/records/1908-linux-appimage-release-inputs.json
@@ -1,0 +1,75 @@
+{
+  "branch": "feat/1908-linux-appimage-release-inputs",
+  "check_events": [],
+  "check_na": [],
+  "commit": null,
+  "declared_scope": {
+    "exclude": [],
+    "include": []
+  },
+  "directive_events": [],
+  "docs_events": [
+    {
+      "at": "2026-07-02T16:14:01.929499Z",
+      "class": null,
+      "kind": "path",
+      "path": "desktop/README.md",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": true,
+  "guard_events": [],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1908,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": null,
+  "owner_directive": "Add build_number + ota_channel workflow_dispatch inputs to desktop-linux-appimage.yml so CI can produce release-consistent (build-numbered, OTA-enabled) AppImages for the ota-alpha release (issue #1908)",
+  "persona": "implementer",
+  "pull_request": null,
+  "reconcile_events": [],
+  "record_id": "1908-linux-appimage-release-inputs",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [],
+    "docs": [],
+    "guards": [],
+    "tests": []
+  },
+  "runtime": "claude",
+  "schema_version": 2,
+  "scope_events": [
+    {
+      "action": "add-include",
+      "at": "2026-07-02T16:14:01.929466Z",
+      "pattern": ".github/workflows/desktop-linux-appimage.yml",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-07-02T16:14:01.929490Z",
+      "pattern": "desktop/README.md",
+      "reason": "plan"
+    }
+  ],
+  "session_id": "44f21b43-c9a4-464b-a489-e62039758bf7",
+  "strictness_tier": null,
+  "task_kind": "maintenance",
+  "test_events": [
+    {
+      "at": "2026-07-02T16:14:01.929510Z",
+      "class": "ci-config",
+      "kind": "na",
+      "path": null,
+      "rationale": "CI workflow_dispatch input wiring only; no unit-testable code path. Validated by the release dispatch (build_number=11 ota_channel=alpha) producing SciStudio-0.3.2-alpha-build0011 with OTA enabled.",
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -70,6 +70,14 @@ to upload `scistudio-windows-installer`, run
 `.github/workflows/desktop-macos-dmg.yml` to upload `scistudio-macos-dmg`, and run
 `.github/workflows/desktop-linux-appimage.yml` to upload `scistudio-linux-appimage`.
 
+By default the Linux workflow produces a dev `build0000`, OTA-disabled AppImage.
+For a **release** build that joins the `ota-alpha` release alongside the mac/win
+installers, dispatch it with the `build_number` and `ota_channel` inputs: e.g.
+`build_number=11 ota_channel=alpha` stamps the SSOT version
+(`python scripts/version.py sync`) so electron-builder names the artifact
+`SciStudio-0.3.2-alpha-build0011-*.AppImage` and enables launch-time OTA against
+the channel manifest. Leave both inputs empty for a plain dev build.
+
 The packaged app uses the SciStudio icon assets in `desktop/assets`: `icon.svg`
 is the source, `icon.png` is the runtime window icon (and the Linux AppImage
 icon), and `icon.ico`/`icon.icns` are the Windows and macOS packaging icons.


### PR DESCRIPTION
## Summary

Adds release-build inputs to `desktop-linux-appimage.yml` so CI can produce a
release-consistent Linux AppImage that joins the `ota-alpha` release next to the
build-numbered, OTA-enabled mac/win installers. Closes #1908.

Today the workflow always emits a dev `build0000`, OTA-disabled AppImage — it
never stamps the version or sets the OTA channel, so it can't sit alongside the
`SciStudio-0.3.2-alpha-build00XX-*.dmg/.exe` assets.

## Changes

- Two `workflow_dispatch` inputs on `desktop-linux-appimage.yml`:
  - `build_number` — when set, runs `SCISTUDIO_BUILD_NUMBER=<n> python
    scripts/version.py sync` before install so electron-builder names the
    artifact `SciStudio-<base>-<channel>-build<NNNN>.AppImage` (SSOT-derived).
  - `ota_channel` — when set, exports `SCISTUDIO_OTA_CHANNEL` for `stage:sh` so
    `ota-config.json` enables launch-time OTA against the channel manifest.
  - Empty inputs preserve today's dev-build behavior.
- README: documents the release-build dispatch (`build_number=11 ota_channel=alpha`).

## Testing

- YAML validated; step order/env wiring checked (stamp runs after checkout,
  before `npm ci`, so package.json + lock stay consistent).
- Gate test N/A: CI workflow_dispatch input wiring has no unit-testable code
  path; validated by the release dispatch producing
  `SciStudio-0.3.2-alpha-build0011-*.AppImage` with OTA enabled.
- Local Windows tier-1 `python_tests` shows the pre-existing platform false-
  failures (Unix sockets, bash rc, `-n auto` xlsx flakiness) — unrelated to this
  Python-free change; the other 8 checks pass. CI (Linux) is authoritative.

Closes #1908

🤖 Generated with [Claude Code](https://claude.com/claude-code)
