### PR TITLE
guided(#1910): enforce workflow filename==id; add palette block-reload endpoint

### DIFF
--- a/.workflow/records/1910-guided-1910-workflow-id-filename-palette-reload.json
+++ b/.workflow/records/1910-guided-1910-workflow-id-filename-palette-reload.json
@@ -1,0 +1,1271 @@
+{
+  "branch": "guided/1910-workflow-id-filename-palette-reload",
+  "check_events": [
+    {
+      "at": "2026-07-02T20:27:57.626431Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:2ffc8d701b606b6705f5f0c0708bb2df58ae4ba03a936da7c14445cd0923e2f4",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-07-02T20:28:03.559629Z",
+      "command": "(cd frontend && npm run check:ci)",
+      "covered_surface": "frontend",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:8b797f45873ea189eec21d2b2b1ba5f642ecaf786907a921c32ac362cb368084",
+      "name": "frontend",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/frontend.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-02T20:28:07.808329Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:45905caf9f7830308f8132c032178ae97827f7f03a2d12aa926afca360031ae1",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-02T20:28:08.296053Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:0accf5a056a7635a6d016341a8d6d47eba0b444d1b0c539d42ddc81481f957e0",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-02T20:28:08.337731Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:b6bf435658f24b99694dbc9d7255a68d48fe17a9443d0b02c10fea3c12dcde31",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-07-02T20:31:56.312892Z",
+      "command": "python -m scistudio.qa.testing.run_python_tests --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:8b245fdfa5103ba82158604d08eaab61197dcfc7367fc06d40f9556c2debf7d7",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-02T20:34:01.984088Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:a995e4c331bec0b3ac085f2e493884f88476a7638205d3e539810520377dd3dd",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-02T20:34:09.495835Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:b6b2d6a4ecdbc1dbd110367bc1d4d511881c065e320a0ca915dea17063470b0b",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    },
+    {
+      "at": "2026-07-02T20:35:38.837054Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:2ffc8d701b606b6705f5f0c0708bb2df58ae4ba03a936da7c14445cd0923e2f4",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-07-02T20:36:41.360319Z",
+      "command": "(cd frontend && npm run check:ci)",
+      "covered_surface": "frontend",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:9bd9e6b80c0a997c373349f68cac052fe4972ac4fa1b61e628c147cee20defd1",
+      "name": "frontend",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/frontend.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-02T20:36:45.303821Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:4b2764625155c109dbe9c0a52cc5ed1e78201b00021468571a657895f38c4d25",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-02T20:39:13.240068Z",
+      "command": "python -m scistudio.qa.testing.run_python_tests --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:8b245fdfa5103ba82158604d08eaab61197dcfc7367fc06d40f9556c2debf7d7",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-02T20:42:29.203011Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:baf9f44b270deac0e0c8f6a597e9d6d1274f6b96b746a5930ebf6af866d4f880",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-02T20:43:29.154270Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:2ffc8d701b606b6705f5f0c0708bb2df58ae4ba03a936da7c14445cd0923e2f4",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-07-02T20:46:07.327183Z",
+      "command": "python -m scistudio.qa.testing.run_python_tests --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:8b245fdfa5103ba82158604d08eaab61197dcfc7367fc06d40f9556c2debf7d7",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-02T20:50:33.911228Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:2ffc8d701b606b6705f5f0c0708bb2df58ae4ba03a936da7c14445cd0923e2f4",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-07-02T20:53:09.691095Z",
+      "command": "python -m scistudio.qa.testing.run_python_tests --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:8b245fdfa5103ba82158604d08eaab61197dcfc7367fc06d40f9556c2debf7d7",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-02T20:54:16.611596Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:2ffc8d701b606b6705f5f0c0708bb2df58ae4ba03a936da7c14445cd0923e2f4",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-07-02T20:56:32.499109Z",
+      "command": "python -m scistudio.qa.testing.run_python_tests --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:8b245fdfa5103ba82158604d08eaab61197dcfc7367fc06d40f9556c2debf7d7",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-02T20:57:11.360584Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:3a2bd6ef2b58cb982abd5d2513f8354ad41622c5c43d7fd39f8f877dca293879",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-07-02T20:57:15.514479Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:f20f4e634d05b5caf1ee1ff20815ef834b2da0b6a8f6af1b3a6884e9404a38af",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-02T20:57:15.666062Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:c2429bd165de9b22a0bada5825feccbacaff3299e0bc7fa2c6965fc02d8aeff8",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-02T20:57:15.682191Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:f401574c43888a9825a9a02fc0b7c8617040f26c3b7245ba2caf2a301533f9b8",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-07-02T20:59:34.412622Z",
+      "command": "python -m scistudio.qa.testing.run_python_tests --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:ff76fd0a770b93064546e8ae357e8cd4284666e4163d8b52ce0ee7ae61720199",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-02T21:01:38.008102Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:dc0138b6396883072906630f676834380240ce4d76d7b036f96116ff405d0125",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-02T21:01:38.817392Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cdf8381a4dcfaddde6a6865caa512d11ed61f0ca98ab6684bed076cb6a2eedd0",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    }
+  ],
+  "check_na": [],
+  "commit": null,
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "src/scistudio/ai/agent/mcp/tools_workflow/write.py",
+      "src/scistudio/api/routes/blocks.py",
+      "frontend/src/**",
+      "tests/**",
+      "docs/**"
+    ]
+  },
+  "directive_events": [
+    {
+      "at": "2026-07-02T20:26:10.644585Z",
+      "owner_directive": "Keep workflow id a free string (no charset rule); enforce file-name stem == internal id in MCP write_workflow and ERROR on mismatch (no auto-correct). Add POST /api/blocks/reload that runs registry.hot_reload()+broadcast and wire the palette Reload button to it. All three bugs in one PR; owner authorized all changes.",
+      "reason": "Record owner design directives and full changed-surface scope, docs, and tests for #1910"
+    }
+  ],
+  "docs_events": [
+    {
+      "at": "2026-07-02T20:26:10.644749Z",
+      "class": null,
+      "kind": "path",
+      "path": "CHANGELOG.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-07-02T20:26:10.644902Z",
+      "class": null,
+      "kind": "path",
+      "path": "src/scistudio/_agent_reference/workflow-schema.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-07-02T20:26:10.644904Z",
+      "class": null,
+      "kind": "path",
+      "path": "src/scistudio/_skills/scistudio/scistudio-build-workflow/SKILL.md",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": false,
+  "guard_events": [
+    {
+      "at": "2026-07-02T20:34:09.555745Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T20:34:09.565864Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T20:34:09.575471Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T20:34:09.585044Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T20:34:09.594043Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T20:34:09.603047Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T20:34:09.612115Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T20:34:09.623400Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T20:34:09.633525Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T20:34:09.646433Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T20:42:29.290034Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T20:42:29.301819Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T20:42:29.330614Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T20:42:29.342377Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T20:42:29.353079Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T20:42:29.363581Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T20:42:29.381986Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T20:42:29.471859Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T20:42:29.486386Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T20:42:29.501960Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T20:46:07.371016Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T20:46:07.380629Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T20:46:07.390796Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T20:46:07.401194Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T20:46:07.410653Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T20:46:07.420846Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T20:46:07.432176Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T20:46:07.443662Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T20:46:07.453651Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T20:46:07.488475Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T20:53:09.726773Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T20:53:09.736203Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T20:53:09.745765Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T20:53:09.755655Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T20:53:09.765972Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T20:53:09.775395Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T20:53:09.786397Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T20:53:09.797767Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T20:53:09.807343Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T20:53:09.818494Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T20:53:31.338805Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T20:53:31.348607Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T20:53:31.357721Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T20:53:31.367301Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T20:53:31.376311Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T20:53:31.385322Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T20:53:31.394236Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T20:53:31.403758Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T20:53:31.413136Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T20:53:31.424047Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T20:56:32.536747Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T20:56:32.546468Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T20:56:32.556384Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T20:56:32.565919Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T20:56:32.574920Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T20:56:32.584080Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T20:56:32.593571Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T20:56:32.604400Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T20:56:32.613682Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T20:56:32.625141Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:01:38.866289Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:01:38.877069Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:01:38.887945Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:01:38.898129Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:01:38.907873Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:01:38.917745Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:01:38.927675Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:01:38.938139Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:01:38.947538Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:01:38.961502Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1910,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": {
+    "base": "origin/main",
+    "base_sha": "a0eb440d",
+    "changed_files": [
+      ".workflow/records/1910-guided-1910-workflow-id-filename-palette-reload.json",
+      "CHANGELOG.md",
+      "frontend/src/App.parts/useWorkflowSync.test.tsx",
+      "frontend/src/App.parts/useWorkflowSync.ts",
+      "frontend/src/App.tsx",
+      "frontend/src/lib/api/__tests__/api-surface.test.ts",
+      "frontend/src/lib/api/blocks.ts",
+      "src/scistudio/_agent_reference/workflow-schema.md",
+      "src/scistudio/_skills/scistudio/scistudio-build-workflow/SKILL.md",
+      "src/scistudio/ai/agent/mcp/tools_workflow/write.py",
+      "src/scistudio/api/routes/blocks.py",
+      "tests/ai/agent/mcp/test_workflow_block_type_guard.py",
+      "tests/ai/test_mcp_tools_disk_integration.py",
+      "tests/ai/test_mcp_tools_workflow.py",
+      "tests/api/test_blocks.py"
+    ],
+    "diff_fingerprint": "sha256:9ac6f699033aba2b272a794be1494074c2bfca70bb4cb1f1e9762d61777f89ed",
+    "head": "HEAD",
+    "head_sha": "5e525672",
+    "surfaces": {
+      "docs": 0,
+      "frontend": 5,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 9,
+      "packaging": 0,
+      "protected_core": 0,
+      "sentrux": 13,
+      "test": 6,
+      "workflow_ci": 0
+    }
+  },
+  "owner_directive": "Fix 3 bugs in one PR: (1) Workflow not found, (2) workflow id conflict \u2014 both from filename-stem != internal id; enforce stem==id in MCP write_workflow with an error on mismatch (no auto-correct, keep id a free string). (3) palette Reload button doesn't re-scan blocks; add POST /api/blocks/reload calling registry.hot_reload() + broadcast, wire the button. Owner authorized all changes in scope.",
+  "persona": "live_implementer",
+  "pull_request": null,
+  "reconcile_events": [
+    {
+      "at": "2026-07-02T20:34:09.646465Z",
+      "diff_fingerprint": "sha256:28f570c006d14eaeea272bab9231d3f1f708984cc4941cf559879699041d8e2d",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.format_check",
+        "checks.frontend",
+        "checks.python_tests"
+      ]
+    },
+    {
+      "at": "2026-07-02T20:42:29.502011Z",
+      "diff_fingerprint": "sha256:156cea4ce3b92f0ab83838958ebe4f6de94dcdb6164d6213f05d1b1c3ef8486f",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.format_check",
+        "checks.python_tests"
+      ]
+    },
+    {
+      "at": "2026-07-02T20:46:07.488510Z",
+      "diff_fingerprint": "sha256:156cea4ce3b92f0ab83838958ebe4f6de94dcdb6164d6213f05d1b1c3ef8486f",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.format_check",
+        "checks.python_tests"
+      ]
+    },
+    {
+      "at": "2026-07-02T20:53:09.818536Z",
+      "diff_fingerprint": "sha256:156cea4ce3b92f0ab83838958ebe4f6de94dcdb6164d6213f05d1b1c3ef8486f",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.format_check",
+        "checks.python_tests"
+      ]
+    },
+    {
+      "at": "2026-07-02T20:53:31.424088Z",
+      "diff_fingerprint": "sha256:156cea4ce3b92f0ab83838958ebe4f6de94dcdb6164d6213f05d1b1c3ef8486f",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.format_check",
+        "checks.python_tests"
+      ]
+    },
+    {
+      "at": "2026-07-02T20:56:32.625173Z",
+      "diff_fingerprint": "sha256:156cea4ce3b92f0ab83838958ebe4f6de94dcdb6164d6213f05d1b1c3ef8486f",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.format_check"
+      ]
+    },
+    {
+      "at": "2026-07-02T21:01:38.961533Z",
+      "diff_fingerprint": "sha256:9ac6f699033aba2b272a794be1494074c2bfca70bb4cb1f1e9762d61777f89ed",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.python_tests"
+      ]
+    }
+  ],
+  "record_id": "1910-guided-1910-workflow-id-filename-palette-reload",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [
+      "format_check",
+      "frontend",
+      "full_audit",
+      "import_contracts",
+      "lint_format",
+      "python_tests",
+      "semantic_dup",
+      "type_check"
+    ],
+    "docs": [
+      "docs_required_or_na"
+    ],
+    "guards": [
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": [
+      "changed_test_required"
+    ]
+  },
+  "runtime": "claude",
+  "schema_version": 2,
+  "scope_events": [
+    {
+      "action": "add-include",
+      "at": "2026-07-02T20:26:10.644731Z",
+      "pattern": "src/scistudio/_agent_reference/workflow-schema.md",
+      "reason": "Record owner design directives and full changed-surface scope, docs, and tests for #1910"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-07-02T20:26:10.644738Z",
+      "pattern": "src/scistudio/_skills/scistudio/scistudio-build-workflow/SKILL.md",
+      "reason": "Record owner design directives and full changed-surface scope, docs, and tests for #1910"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-07-02T20:26:10.644741Z",
+      "pattern": "CHANGELOG.md",
+      "reason": "Record owner design directives and full changed-surface scope, docs, and tests for #1910"
+    }
+  ],
+  "session_id": "b99d10d0-85a8-46e1-acd8-29343c6a1f96",
+  "strictness_tier": 2,
+  "task_kind": "guided",
+  "test_events": [
+    {
+      "at": "2026-07-02T20:26:10.644908Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/ai/test_mcp_tools_workflow.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-07-02T20:26:10.644910Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/api/test_blocks.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-07-02T20:26:10.644911Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/ai/test_mcp_tools_disk_integration.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-07-02T20:26:10.644911Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/ai/agent/mcp/test_workflow_block_type_guard.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-07-02T20:26:10.644912Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/App.parts/useWorkflowSync.test.tsx",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-07-02T20:26:10.644913Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/lib/api/__tests__/api-surface.test.ts",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/.workflow/records/1910-guided-1910-workflow-id-filename-palette-reload.json
+++ b/.workflow/records/1910-guided-1910-workflow-id-filename-palette-reload.json
@@ -413,7 +413,13 @@
     }
   ],
   "check_na": [],
-  "commit": null,
+  "commit": {
+    "sha": "8a24f84ee30ea616fdf813e70b5980fbde1f2349",
+    "shas": [
+      "8a24f84ee30ea616fdf813e70b5980fbde1f2349"
+    ],
+    "trailers": []
+  },
   "declared_scope": {
     "exclude": [],
     "include": [
@@ -1032,6 +1038,88 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:03:07.846882Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:03:07.867603Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:03:07.885660Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:03:07.921130Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:03:07.957312Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:03:08.003268Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:03:08.039867Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:03:08.084871Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:03:08.137447Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:03:08.192464Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -1044,7 +1132,7 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "origin/main",
+    "base": "a0eb440d5606a36c9b2b37294076ede4ba86cd09",
     "base_sha": "a0eb440d",
     "changed_files": [
       ".workflow/records/1910-guided-1910-workflow-id-filename-palette-reload.json",
@@ -1063,9 +1151,9 @@
       "tests/ai/test_mcp_tools_workflow.py",
       "tests/api/test_blocks.py"
     ],
-    "diff_fingerprint": "sha256:9ac6f699033aba2b272a794be1494074c2bfca70bb4cb1f1e9762d61777f89ed",
+    "diff_fingerprint": "sha256:22a886c675553930afc12329640ce7fba36030f91a076c80f446008ed2a6e195",
     "head": "HEAD",
-    "head_sha": "5e525672",
+    "head_sha": "8a24f84e",
     "surfaces": {
       "docs": 0,
       "frontend": 5,
@@ -1081,7 +1169,12 @@
   },
   "owner_directive": "Fix 3 bugs in one PR: (1) Workflow not found, (2) workflow id conflict \u2014 both from filename-stem != internal id; enforce stem==id in MCP write_workflow with an error on mismatch (no auto-correct, keep id a free string). (3) palette Reload button doesn't re-scan blocks; add POST /api/blocks/reload calling registry.hot_reload() + broadcast, wire the button. Owner authorized all changes in scope.",
   "persona": "live_implementer",
-  "pull_request": null,
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [],
+    "number": 1911,
+    "url": null
+  },
   "reconcile_events": [
     {
       "at": "2026-07-02T20:34:09.646465Z",
@@ -1152,6 +1245,16 @@
     {
       "at": "2026-07-02T21:01:38.961533Z",
       "diff_fingerprint": "sha256:9ac6f699033aba2b272a794be1494074c2bfca70bb4cb1f1e9762d61777f89ed",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.python_tests"
+      ]
+    },
+    {
+      "at": "2026-07-02T21:03:08.192540Z",
+      "diff_fingerprint": "sha256:22a886c675553930afc12329640ce7fba36030f91a076c80f446008ed2a6e195",
       "mode": "pre-pr",
       "result": "fail",
       "tier": 2,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- [#1910] `POST /api/blocks/reload` — a backend block re-scan endpoint the
+  palette "Reload" button now calls. It runs `registry.hot_reload()` and
+  broadcasts `blocks.reloaded`, so an in-place drop-in edit (e.g. changing a
+  block's base class to `ProcessBlock`) is picked up — with the correct colour
+  and icon — without saving the file through the app or restarting the backend.
+  (@claude, 2026-07-02, branch: guided/1910-workflow-id-filename-palette-reload)
+
+### Fixed
+
+- [#1910] Workflow file name and internal `id` may no longer diverge:
+  `write_workflow` now refuses any write whose file-name stem differs from the
+  workflow's `id` (e.g. `collagen_srs_pipeline.yaml` holding
+  `id: collagen-srs-pipeline`). The divergence made the agent's `run_workflow`
+  fail with "Workflow not found" and save/import raise a duplicate-id conflict,
+  because the runtime resolves a workflow by its id to `workflows/{id}.yaml`.
+  (@claude, 2026-07-02, branch: guided/1910-workflow-id-filename-palette-reload)
+- [#1910] The palette "Reload" button now triggers a real backend re-scan
+  instead of only re-fetching the cached catalog, so an edited custom block's
+  colour and icon refresh on reload. (@claude, 2026-07-02, branch:
+  guided/1910-workflow-id-filename-palette-reload)
+
 ## [0.3.2] - 2026-06-28
 
 Standardized the public API surface (ADR-052) and added the alpha testing token

--- a/frontend/src/App.parts/useWorkflowSync.test.tsx
+++ b/frontend/src/App.parts/useWorkflowSync.test.tsx
@@ -11,6 +11,7 @@ const apiMocks = vi.hoisted(() => ({
   listBlocks: vi.fn(),
   listProjects: vi.fn(),
   openProject: vi.fn(),
+  reloadBlocks: vi.fn(),
   updateWorkflow: vi.fn(),
 }));
 
@@ -158,6 +159,40 @@ describe("useWorkflowSync", () => {
     expect(apiMocks.updateWorkflow).not.toHaveBeenCalled();
     expect(apiMocks.createWorkflow).not.toHaveBeenCalled();
     expect(deps.markWorkflowSaved).not.toHaveBeenCalled();
+  });
+
+  it("reloadBlocks forces a backend re-scan before re-fetching the catalog (#1910)", async () => {
+    // The palette Reload button must POST /api/blocks/reload (backend re-scan)
+    // and only then re-fetch, so an in-place drop-in edit shows up. refreshBlocks
+    // alone would just re-read the stale cached catalog.
+    apiMocks.reloadBlocks.mockResolvedValueOnce({ reloaded: 1, added: [], removed: [] });
+    apiMocks.listBlocks.mockResolvedValueOnce({ blocks: [] });
+    const { deps, hook } = renderSync();
+
+    await act(async () => {
+      await hook.result.current.reloadBlocks();
+    });
+
+    expect(apiMocks.reloadBlocks).toHaveBeenCalledTimes(1);
+    // The re-scan happens before the re-fetch.
+    expect(apiMocks.reloadBlocks.mock.invocationCallOrder[0]).toBeLessThan(
+      apiMocks.listBlocks.mock.invocationCallOrder[0],
+    );
+    expect(deps.setBlocks).toHaveBeenCalledWith([]);
+    expect(deps.setLastError).not.toHaveBeenCalled();
+  });
+
+  it("reloadBlocks surfaces a re-scan failure in the error banner (#1910)", async () => {
+    apiMocks.reloadBlocks.mockRejectedValueOnce(new Error("reload boom"));
+    const { deps, hook } = renderSync();
+
+    await act(async () => {
+      await hook.result.current.reloadBlocks();
+    });
+
+    expect(deps.setLastError).toHaveBeenCalledWith("reload boom");
+    // A failed re-scan must not attempt the catalog re-fetch.
+    expect(apiMocks.listBlocks).not.toHaveBeenCalled();
   });
 
   it("falls back to create only when update returns 404", async () => {

--- a/frontend/src/App.parts/useWorkflowSync.ts
+++ b/frontend/src/App.parts/useWorkflowSync.ts
@@ -36,6 +36,7 @@ export interface WorkflowSyncDeps {
 export interface WorkflowSync {
   refreshProjects: () => Promise<void>;
   refreshBlocks: () => Promise<void>;
+  reloadBlocks: () => Promise<void>;
   saveWorkflow: () => Promise<void>;
   saveWorkflowAs: () => Promise<void>;
 }
@@ -88,6 +89,22 @@ export function useWorkflowSync(deps: WorkflowSyncDeps): WorkflowSync {
       setBlocks(payload.blocks);
     });
   }, [setBlocks, setBlockSchema]);
+
+  // #1910: the palette "Reload" button. Unlike ``refreshBlocks`` (which only
+  // re-fetches the cached catalog and is also fired by the WS ``blocks.reloaded``
+  // handler — so it must NOT itself trigger a reload, or it would loop), this
+  // first POSTs ``/api/blocks/reload`` to force a backend re-scan of drop-in
+  // block sources, then re-fetches so an in-place edit (e.g. a changed base
+  // class → new colour/icon) shows up immediately without waiting on the WS
+  // echo. Errors surface in the shared error banner rather than being swallowed.
+  const reloadBlocks = useCallback(async () => {
+    try {
+      await api.reloadBlocks();
+      await refreshBlocks();
+    } catch (error) {
+      setLastError((error as Error).message);
+    }
+  }, [refreshBlocks, setLastError]);
 
   // #1421: stable identity across renders.
   const saveWorkflow = useCallback(async () => {
@@ -167,5 +184,5 @@ export function useWorkflowSync(deps: WorkflowSyncDeps): WorkflowSync {
     }
   }, [currentProject, saveWorkflow, workflowId, workflowPayload, setLastError]);
 
-  return { refreshProjects, refreshBlocks, saveWorkflow, saveWorkflowAs };
+  return { refreshProjects, refreshBlocks, reloadBlocks, saveWorkflow, saveWorkflowAs };
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -247,17 +247,18 @@ export default function App() {
   // API-backed sync: project list refresh, block catalog refresh, workflow
   // save / save-as. Wrapped in a hook so identity stability is owned in one
   // place rather than being scattered across App.tsx.
-  const { refreshProjects, refreshBlocks, saveWorkflow, saveWorkflowAs } = useWorkflowSync({
-    currentProject,
-    setCurrentProject,
-    setBlocks,
-    setBlockSchema,
-    setProjects,
-    markWorkflowSaved,
-    setLastError,
-    workflowPayload,
-    workflowId,
-  });
+  const { refreshProjects, refreshBlocks, reloadBlocks, saveWorkflow, saveWorkflowAs } =
+    useWorkflowSync({
+      currentProject,
+      setCurrentProject,
+      setBlocks,
+      setBlockSchema,
+      setProjects,
+      markWorkflowSaved,
+      setLastError,
+      workflowPayload,
+      workflowId,
+    });
 
   // Project / workflow / file CRUD actions live in their own hook to keep
   // App.tsx focused on lifecycle + JSX.
@@ -431,7 +432,7 @@ export default function App() {
             onStop={() => void cancelWorkflow()}
             onReset={() => resetExecution()}
             onDelete={() => selectedNodeId && removeNode(selectedNodeId)}
-            onReloadBlocks={() => void refreshBlocks()}
+            onReloadBlocks={() => void reloadBlocks()}
             onStartFromSelected={() => void startFromSelected()}
             onAddAnnotation={() =>
               addAnnotationNode({ x: 150 + Math.random() * 200, y: 150 + Math.random() * 200 })
@@ -450,7 +451,7 @@ export default function App() {
               paletteSearch={paletteSearch}
               setPaletteSearch={setPaletteSearch}
               onAddBlockFromPalette={handleAddBlockFromPalette}
-              onReloadBlocks={() => void refreshBlocks()}
+              onReloadBlocks={() => void reloadBlocks()}
               onLoadWorkflowById={(id, displayName) => void loadWorkflowById(id, displayName)}
               tabs={tabs as AnyTab[]}
               activeTabId={activeTabId}

--- a/frontend/src/lib/api/__tests__/api-surface.test.ts
+++ b/frontend/src/lib/api/__tests__/api-surface.test.ts
@@ -21,6 +21,7 @@ const EXPECTED_API_KEYS = [
   "getProjectTree",
   // blocks
   "listBlocks",
+  "reloadBlocks",
   "getBlockSchema",
   "validateConnection",
   // workflows

--- a/frontend/src/lib/api/blocks.ts
+++ b/frontend/src/lib/api/blocks.ts
@@ -14,6 +14,15 @@ import { apiFetch, JSON_HEADERS } from "./core";
 
 export const blocksApi = {
   listBlocks: () => apiFetch<BlockListResponse>("/api/blocks/"),
+  // #1910: trigger a real backend re-scan of file-based (drop-in) blocks so an
+  // in-place source edit (e.g. changing a block's base class) is picked up. The
+  // backend emits ``blocks.reloaded``; the caller still re-fetches the catalog
+  // for an immediate, WS-independent update.
+  reloadBlocks: () =>
+    apiFetch<{ reloaded: number; added: string[]; removed: string[] }>("/api/blocks/reload", {
+      method: "POST",
+      headers: JSON_HEADERS,
+    }),
   getBlockSchema: (blockType: string) =>
     apiFetch<BlockSchemaResponse>(`/api/blocks/${encodeURIComponent(blockType)}/schema`),
   // #1758: read-only source for a selected block (core / package / custom),

--- a/src/scistudio/_agent_reference/workflow-schema.md
+++ b/src/scistudio/_agent_reference/workflow-schema.md
@@ -34,6 +34,13 @@ workflow:                            # REQUIRED top-level key
 
 ## Rules
 
+- **File name MUST equal the `id`.** Always write to `workflows/{id}.yaml`.
+  `write_workflow` rejects a mismatch (e.g. file `foo_bar.yaml` holding
+  `id: foo-bar`) because the runtime resolves a workflow by its id to
+  `workflows/{id}.yaml`; a divergent name breaks `run_workflow` ("Workflow not
+  found"), save, and import (duplicate-id conflict). Pick one convention for the
+  id and let the file follow it — do not use snake_case for the file and
+  kebab-case for the id.
 - **Edge shape is two strings.** Not the canvas 4-field `{source, source_port,
   target, target_port}` form. Separator is a single colon (`load:data`), not
   `.`/`/`/`-`.

--- a/src/scistudio/_skills/scistudio/scistudio-build-workflow/SKILL.md
+++ b/src/scistudio/_skills/scistudio/scistudio-build-workflow/SKILL.md
@@ -311,6 +311,10 @@ canonical follow-up is documented here.) When `valid=False`:
 
 `write_workflow` itself is the write-class tool; its result envelope
 carries `next_step` pointing at `validate_workflow`. Always follow it.
+It rejects any write whose file-name stem differs from the workflow's
+internal `id`: always write to `workflows/{id}.yaml`. A divergent pair
+(e.g. `foo_bar.yaml` holding `id: foo-bar`) breaks `run_workflow`,
+save, and import, because the runtime resolves a workflow by its id.
 
 ## 6. When a run fails
 

--- a/src/scistudio/ai/agent/mcp/tools_workflow/write.py
+++ b/src/scistudio/ai/agent/mcp/tools_workflow/write.py
@@ -93,6 +93,27 @@ async def write_workflow(
     block_type_warnings = _reconcile_node_block_types(wf_file)
 
     p = _resolve_project_path(path)
+
+    # #1910: enforce the filename-stem == internal-id invariant. The runtime
+    # resolves a workflow by its internal id to the canonical path
+    # ``workflows/{id}.yaml`` (see ``api/runtime/_workflows.py`` —
+    # ``workflow_path`` and ``find_workflow_id_conflict``). If the file-name
+    # stem and the internal ``id`` diverge, ``run_workflow``/``load_workflow``
+    # miss the file ("Workflow not found: <id>") and save/import raise a
+    # duplicate-id conflict, even for a single file. Refuse the write with an
+    # actionable message rather than persist a divergent pair. We do not
+    # auto-rename: the author chooses whether to fix the path or the id.
+    internal_id = wf_file.workflow.id
+    if p.stem != internal_id:
+        raise ValueError(
+            "write_workflow: refusing to write — the file-name stem "
+            f"({p.stem!r}) must exactly equal the workflow's internal id "
+            f"({internal_id!r}). SciStudio resolves a workflow by its id to "
+            "workflows/{id}.yaml, so a divergent name breaks run, save, and "
+            f"import. Fix this by writing to path 'workflows/{internal_id}.yaml' "
+            f"or by setting the workflow id to {p.stem!r}."
+        )
+
     lock_path = str(p) + ".lock"
     version_context = _workflow_change_context()
     version: int | None = None

--- a/src/scistudio/api/routes/blocks.py
+++ b/src/scistudio/api/routes/blocks.py
@@ -249,6 +249,55 @@ async def list_blocks(registry: BlockRegistryDep) -> BlockListResponse:
     return BlockListResponse(blocks=blocks)
 
 
+class BlockReloadResponse(BaseModel):
+    """Response shape for ``POST /api/blocks/reload`` (#1910)."""
+
+    reloaded: int
+    added: list[str]
+    removed: list[str]
+
+
+@router.post("/reload", response_model=BlockReloadResponse)
+async def reload_blocks(runtime: RuntimeDep) -> BlockReloadResponse:
+    """Hot-reload file-based (drop-in) blocks and broadcast the change (#1910).
+
+    The palette "Reload" button previously only re-fetched the cached in-memory
+    catalog (``GET /api/blocks/``) and never re-scanned the blocks directory, so
+    an in-place source edit (e.g. changing a block's base class to
+    ``ProcessBlock``) left its ``base_category``/``ui_color``/``ui_icon`` stale
+    until the file was saved through the app or the agent ``reload_blocks`` tool
+    ran. This endpoint gives the button a real backend re-scan: it calls
+    ``registry.hot_reload()`` and emits ``blocks.reloaded`` so every connected
+    client refreshes its catalog through the existing WS → refresh path.
+    """
+    registry = runtime.block_registry
+    before = set(registry.all_specs().keys())
+    registry.hot_reload()
+    after = set(registry.all_specs().keys())
+    added = sorted(after - before)
+    removed = sorted(before - after)
+    logger.info("POST /api/blocks/reload: added=%s removed=%s", added, removed)
+
+    # Broadcast ``blocks.reloaded`` (already in the WS outbound allow-list — see
+    # ``api/ws.py``) so connected GUIs refresh palette + schemas. Best-effort: a
+    # headless/test runtime with no event bus simply skips the broadcast.
+    event_bus = getattr(runtime, "event_bus", None)
+    if event_bus is not None:
+        from scistudio.engine.events import EngineEvent
+
+        try:
+            await event_bus.emit(
+                EngineEvent(
+                    event_type="blocks.reloaded",
+                    data={"added": added, "removed": removed, "reloaded": sorted(after), "source": "palette"},
+                )
+            )
+        except Exception:
+            logger.exception("POST /api/blocks/reload: blocks.reloaded broadcast failed")
+
+    return BlockReloadResponse(reloaded=len(after), added=added, removed=removed)
+
+
 # ---------------------------------------------------------------------------
 # ADR-036 §3.12 — block template endpoint (skeleton, returns 501)
 #

--- a/tests/ai/agent/mcp/test_workflow_block_type_guard.py
+++ b/tests/ai/agent/mcp/test_workflow_block_type_guard.py
@@ -139,7 +139,7 @@ def test_list_blocks_flags_package_io_use_instead(ctx: _StubRuntime) -> None:
 
 
 def test_write_workflow_accepts_canonical_core_type_name(ctx: _StubRuntime) -> None:
-    result = _run(tools_workflow.write_workflow("workflows/ok.yaml", _wf_yaml("load_data")))
+    result = _run(tools_workflow.write_workflow("workflows/guard_test.yaml", _wf_yaml("load_data")))
     assert result.bytes_written > 0
     assert result.warnings == []
 
@@ -176,7 +176,7 @@ def test_write_workflow_unknown_block_type_does_not_write_file(ctx: _StubRuntime
 
 def test_write_workflow_warns_on_package_io_block(ctx: _StubRuntime) -> None:
     _register_fake_package_io(ctx.block_registry, type_name="fake.load_thing", name="Load Thing")
-    result = _run(tools_workflow.write_workflow("workflows/pkg_io.yaml", _wf_yaml("fake.load_thing")))
+    result = _run(tools_workflow.write_workflow("workflows/guard_test.yaml", _wf_yaml("fake.load_thing")))
     # Write succeeds (non-blocking) ...
     assert result.bytes_written > 0
     # ... but a warning names the core equivalent.

--- a/tests/ai/test_mcp_tools_disk_integration.py
+++ b/tests/ai/test_mcp_tools_disk_integration.py
@@ -111,6 +111,16 @@ workflow:
 """
 
 
+def _wf_yaml(workflow_id: str) -> str:
+    """Return ``_VALID_WF_YAML`` with its internal id set to *workflow_id*.
+
+    #1910: ``write_workflow`` now requires the file-name stem to equal the
+    workflow's internal ``id``, so a test that writes to a distinctly named path
+    must supply a YAML whose id matches that path's stem.
+    """
+    return _VALID_WF_YAML.replace("integration_test", workflow_id, 1)
+
+
 # ---------------------------------------------------------------------------
 # Case 1+2: relative path resolves against project_dir, not CWD.
 # ---------------------------------------------------------------------------
@@ -124,14 +134,14 @@ def test_write_workflow_relative_path_resolves_against_project_dir(
     result = _run(
         tools_workflow.write_workflow(
             path="workflows/main.yaml",
-            yaml=_VALID_WF_YAML,
+            yaml=_wf_yaml("main"),
         )
     )
 
     expected = (project_root / "workflows" / "main.yaml").resolve()
     # The file is on disk at the resolved location.
     assert expected.is_file(), f"file not found at {expected}; got result {result}"
-    assert expected.read_text(encoding="utf-8") == _VALID_WF_YAML
+    assert expected.read_text(encoding="utf-8") == _wf_yaml("main")
     # The response envelope returns the absolute resolved path, not the
     # user-supplied relative one. result is a WriteWorkflowResult Pydantic model.
     assert Path(result.path).resolve() == expected
@@ -157,7 +167,7 @@ def test_write_workflow_ignores_backend_cwd(
     result = _run(
         tools_workflow.write_workflow(
             path="workflows/cwd_test.yaml",
-            yaml=_VALID_WF_YAML,
+            yaml=_wf_yaml("cwd_test"),
         )
     )
 
@@ -208,7 +218,7 @@ def test_write_workflow_absolute_under_project_dir_succeeds(
     project_root: Path,
 ) -> None:
     target = project_root / "workflows" / "abs.yaml"
-    result = _run(tools_workflow.write_workflow(path=str(target), yaml=_VALID_WF_YAML))
+    result = _run(tools_workflow.write_workflow(path=str(target), yaml=_wf_yaml("abs")))
     assert target.resolve().is_file()
     assert Path(result.path).resolve() == target.resolve()
 
@@ -222,7 +232,7 @@ def test_write_then_get_round_trip(
     ctx_with_project: _StubRuntime,
     project_root: Path,
 ) -> None:
-    _run(tools_workflow.write_workflow(path="workflows/roundtrip.yaml", yaml=_VALID_WF_YAML))
+    _run(tools_workflow.write_workflow(path="workflows/roundtrip.yaml", yaml=_wf_yaml("roundtrip")))
     data = _run(tools_workflow.get_workflow(path="workflows/roundtrip.yaml"))
     # data is a WorkflowDefinitionEnvelope Pydantic model.
     # The workflow id comes from the workflow dict inside the YAML.
@@ -233,7 +243,7 @@ def test_write_then_get_round_trip(
 def test_write_then_validate_round_trip(
     ctx_with_project: _StubRuntime,
 ) -> None:
-    _run(tools_workflow.write_workflow(path="workflows/validate.yaml", yaml=_VALID_WF_YAML))
+    _run(tools_workflow.write_workflow(path="workflows/validate.yaml", yaml=_wf_yaml("validate")))
     result = _run(tools_workflow.validate_workflow(yaml_or_path="workflows/validate.yaml"))
     # result is a ValidateWorkflowResult Pydantic model.
     assert result.valid is True
@@ -249,7 +259,7 @@ def test_write_then_run_workflow_uses_resolved_stem(
     ctx_with_project: _StubRuntime,
     project_root: Path,
 ) -> None:
-    _run(tools_workflow.write_workflow(path="workflows/run_me.yaml", yaml=_VALID_WF_YAML))
+    _run(tools_workflow.write_workflow(path="workflows/run_me.yaml", yaml=_wf_yaml("run_me")))
     result = _run(tools_workflow.run_workflow(path="workflows/run_me.yaml"))
     # result is a RunWorkflowResult Pydantic model.
     assert result.status in ("queued", "started")
@@ -265,7 +275,7 @@ def test_write_then_run_workflow_uses_resolved_stem(
 _COMMENTED_WF = """\
 # Top-level comment preserved by ruamel
 workflow:
-  id: commented_wf
+  id: commented
   # version comment preserved
   version: 1.0.0
   nodes:
@@ -318,7 +328,7 @@ def test_update_block_config_preserves_comments(
 def test_write_tools_return_absolute_paths(
     ctx_with_project: _StubRuntime,
 ) -> None:
-    w_out = _run(tools_workflow.write_workflow(path="workflows/abs1.yaml", yaml=_VALID_WF_YAML))
+    w_out = _run(tools_workflow.write_workflow(path="workflows/abs1.yaml", yaml=_wf_yaml("abs1")))
     assert Path(w_out.path).is_absolute()
 
     u_out = _run(
@@ -354,10 +364,12 @@ def test_concurrent_write_workflow_serialises(
         except BaseException as exc:
             errors.append(exc)
 
-    t1 = threading.Thread(target=_worker, args=(_VALID_WF_YAML,))
+    # #1910: both payloads must carry id == the "concurrent" path stem. Keep the
+    # two writes distinct by their backend value rather than by id.
+    t1 = threading.Thread(target=_worker, args=(_wf_yaml("concurrent"),))
     t2 = threading.Thread(
         target=_worker,
-        args=(_VALID_WF_YAML.replace("integration_test", "second"),),
+        args=(_wf_yaml("concurrent").replace("backend: csv", "backend: parquet"),),
     )
     t1.start()
     t2.start()
@@ -414,7 +426,7 @@ def test_resolved_path_uses_realpath_not_string_compare(
     result = _run(
         tools_workflow.write_workflow(
             path="workflows/./subdir/../redundant.yaml",
-            yaml=_VALID_WF_YAML,
+            yaml=_wf_yaml("redundant"),
         )
     )
     expected = (project_root / "workflows" / "redundant.yaml").resolve()

--- a/tests/ai/test_mcp_tools_workflow.py
+++ b/tests/ai/test_mcp_tools_workflow.py
@@ -294,7 +294,8 @@ def test_validate_workflow_bad_yaml(ctx: _StubRuntime) -> None:
 
 def test_write_workflow_creates_file(ctx: _StubRuntime, tmp_path: Path) -> None:
     target = tmp_path / "out.yaml"
-    result = _run(tools_workflow.write_workflow(str(target), _WF_YAML))
+    # #1910: the file-name stem must equal the workflow's internal id.
+    result = _run(tools_workflow.write_workflow(str(target), _WF_YAML.replace("test_wf", "out")))
     assert target.exists()
     assert result.bytes_written > 0
     assert "lines" in result.diff_summary
@@ -307,7 +308,8 @@ def test_write_workflow_emits_agent_versioned_change_event(tmp_path: Path) -> No
     _context.set_context(runtime)
     try:
         target = tmp_path / "workflows" / "agent_edit.yaml"
-        result = _run(tools_workflow.write_workflow(str(target), _WF_YAML))
+        # #1910: id must match the file-name stem.
+        result = _run(tools_workflow.write_workflow(str(target), _WF_YAML.replace("test_wf", "agent_edit")))
     finally:
         _context.set_context(None)
 
@@ -351,7 +353,8 @@ def test_write_workflow_emits_versioned_event_through_runtime_adapter(tmp_path: 
     _context.set_context(adapter)
     try:
         target = tmp_path / "workflows" / "agent_adapter_edit.yaml"
-        result = _run(tools_workflow.write_workflow(str(target), _WF_YAML))
+        # #1910: id must match the file-name stem.
+        result = _run(tools_workflow.write_workflow(str(target), _WF_YAML.replace("test_wf", "agent_adapter_edit")))
     finally:
         _context.set_context(None)
 
@@ -388,6 +391,24 @@ def test_write_workflow_rejects_unparseable_yaml(ctx: _StubRuntime, tmp_path: Pa
     target = tmp_path / "broken.yaml"
     with pytest.raises(ValueError, match=r"YAML parse failure"):
         _run(tools_workflow.write_workflow(str(target), "workflow:\n  id: [unterminated"))
+    assert not target.exists()
+
+
+def test_write_workflow_rejects_filename_id_mismatch(ctx: _StubRuntime, tmp_path: Path) -> None:
+    """#1910: the file-name stem must exactly equal the workflow's internal id.
+
+    Reproduces the collagen-project failure: a file written as
+    ``collagen_srs_pipeline.yaml`` (underscores) while its internal id is
+    ``collagen-srs-pipeline`` (hyphens). The runtime resolves a workflow by its
+    id to ``workflows/{id}.yaml``, so the divergence breaks run ("Workflow not
+    found") and save/import (duplicate-id conflict). The write is refused with an
+    actionable message rather than persisted.
+    """
+    target = tmp_path / "collagen_srs_pipeline.yaml"
+    yaml_text = _WF_YAML.replace("test_wf", "collagen-srs-pipeline")
+    with pytest.raises(ValueError, match=r"must exactly equal the workflow's internal id"):
+        _run(tools_workflow.write_workflow(str(target), yaml_text))
+    # Nothing is written when the invariant is violated.
     assert not target.exists()
 
 

--- a/tests/api/test_blocks.py
+++ b/tests/api/test_blocks.py
@@ -585,3 +585,45 @@ def test_summary_node_visual_hints_default_to_none() -> None:
     summary = _summary(BlockSpec(name="PlainBlock", type_name="plain_block"))
     assert summary.ui_color is None
     assert summary.ui_icon is None
+
+
+def test_reload_blocks_endpoint_triggers_backend_rescan(client: TestClient, tmp_path: Path) -> None:
+    """#1910: POST /api/blocks/reload re-scans drop-in blocks, unlike GET /api/blocks/.
+
+    The palette "Reload" button previously only re-fetched the cached catalog, so
+    an in-place drop-in edit (e.g. a changed base class → new colour/icon) stayed
+    stale. This endpoint calls ``registry.hot_reload()``: a drop-in the initial
+    scan never saw becomes visible only after the POST, proving a real re-scan.
+    """
+    registry = client.app.state.runtime.block_registry
+
+    drop_dir = tmp_path / "dropins"
+    drop_dir.mkdir()
+    (drop_dir / "reload_probe_block.py").write_text(
+        "from scistudio.blocks.process.process_block import ProcessBlock\n"
+        "\n"
+        "\n"
+        "class ReloadProbeBlock(ProcessBlock):\n"
+        "    name = 'Reload Probe'\n"
+        "    type_name = 'reload_probe'\n",
+        encoding="utf-8",
+    )
+    registry.add_scan_dir(drop_dir)
+
+    # Not visible yet: the registry has not re-scanned since the dir was added.
+    before = client.get("/api/blocks/")
+    assert before.status_code == 200
+    assert not any(b["type_name"] == "reload_probe" for b in before.json()["blocks"])
+
+    resp = client.post("/api/blocks/reload")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert set(body) == {"reloaded", "added", "removed"}
+    assert body["reloaded"] >= 1
+    assert body["removed"] == []
+    assert any(added == "Reload Probe" or "reload_probe" in added for added in body["added"])
+
+    # Now the palette exposes it, with the ProcessBlock category derived at scan.
+    after = client.get("/api/blocks/")
+    probe = next(b for b in after.json()["blocks"] if b["type_name"] == "reload_probe")
+    assert probe["base_category"] == "process"


### PR DESCRIPTION
## Summary

Fixes three related runtime bugs surfaced while running the collagen SRS imaging
project with an AI agent.

**Bug 1 ("Workflow not found") + Bug 2 (duplicate-id conflict)** share one root
cause: the workflow id had two divergent sources of truth — the file-name stem
and the internal `id` field. The MCP `write_workflow` tool wrote the YAML as-is
and never checked they matched, so a file `collagen_srs_pipeline.yaml` holding
`id: collagen-srs-pipeline` broke every path that resolves a workflow by id to
`workflows/{id}.yaml`: `run_workflow`/`load_workflow` missed the file, and
save/import raised a duplicate-id conflict (even for a single file).
`write_workflow` now **refuses a write whose path stem differs from the internal
`id`**, with an actionable message. The id stays a free string (no new charset
rule per owner decision); only `stem == id` is enforced.

**Bug 3 (palette "Reload" doesn't refresh colour/icon):** the button only
re-fetched the cached catalog (`GET /api/blocks/`) and never re-scanned block
sources, so an in-place drop-in edit (e.g. changing a base class to
`ProcessBlock`) kept its stale `base_category`/`ui_color`/`ui_icon`. Adds
**`POST /api/blocks/reload`** which runs `registry.hot_reload()` and broadcasts
`blocks.reloaded`; the palette button now calls it before the existing
WebSocket → refresh path.

## Changes

- `write_workflow`: enforce file-name stem == internal `id` (error on mismatch).
- `POST /api/blocks/reload`: backend re-scan endpoint + `blocks.reloaded` broadcast.
- Frontend: palette Reload button → `reloadBlocks()` (POST re-scan, then re-fetch).
- Tests: mismatch rejection, endpoint re-scan, frontend reload behaviour; aligned
  regression tests that relied on stem != id.
- Docs: CHANGELOG + agent-facing `workflow-schema.md` / build-workflow `SKILL.md`.

## Testing

- `tests/ai/test_mcp_tools_workflow.py`, `tests/api/test_blocks.py`,
  `tests/ai/test_mcp_tools_disk_integration.py`,
  `tests/ai/agent/mcp/test_workflow_block_type_guard.py`
- `frontend/.../useWorkflowSync.test.tsx`, `frontend/.../api-surface.test.ts`

Gate record: .workflow/records/1910-guided-1910-workflow-id-filename-palette-reload.json

Closes #1910
