### PR TITLE
ux(#1913): rename agent save-path convention data/derived → data/processed

### DIFF
--- a/.workflow/records/1913-guided-1913-data-processed-rename.json
+++ b/.workflow/records/1913-guided-1913-data-processed-rename.json
@@ -1,0 +1,48 @@
+{
+  "branch": "guided/1913-data-processed-rename",
+  "check_events": [],
+  "check_na": [],
+  "commit": null,
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "src/scistudio/_skills/scistudio/scistudio-build-workflow/SKILL.md",
+      "src/scistudio/_skills/scistudio/scistudio-inspect-data/SKILL.md",
+      "docs/planning/adr-040-skill-design.md"
+    ]
+  },
+  "directive_events": [],
+  "docs_events": [],
+  "governance_touch": false,
+  "guard_events": [],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1913,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": null,
+  "owner_directive": "Rename the agent save-path convention data/derived -> data/processed for user-friendliness; it is only a skill-example convention, not a system directory",
+  "persona": "live_implementer",
+  "pull_request": null,
+  "reconcile_events": [],
+  "record_id": "1913-guided-1913-data-processed-rename",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [],
+    "docs": [],
+    "guards": [],
+    "tests": []
+  },
+  "runtime": "claude",
+  "schema_version": 2,
+  "scope_events": [],
+  "session_id": "bc8789d0-9cec-4fdc-a973-795f9dbe1703",
+  "strictness_tier": null,
+  "task_kind": "guided",
+  "test_events": []
+}

--- a/.workflow/records/1913-guided-1913-data-processed-rename.json
+++ b/.workflow/records/1913-guided-1913-data-processed-rename.json
@@ -68,9 +68,9 @@
   ],
   "check_na": [],
   "commit": {
-    "sha": "9bf7e205de3e478a2be033bee3a884f692144ea1",
+    "sha": "dcfd22dd18cecd33f1e070af8cda90e8928359da",
     "shas": [
-      "9bf7e205de3e478a2be033bee3a884f692144ea1"
+      "dcfd22dd18cecd33f1e070af8cda90e8928359da"
     ],
     "trailers": []
   },
@@ -266,6 +266,170 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:17:10.007176Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:17:10.017825Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:17:10.032543Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:17:10.044378Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:17:10.055625Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:17:10.071250Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:17:10.086677Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:17:10.102269Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:17:10.114459Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:17:10.127596Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:17:20.946026Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:17:20.962811Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:17:20.982128Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:17:21.030193Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:17:21.056756Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:17:21.077679Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:17:21.095604Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:17:21.112657Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:17:21.128135Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:17:21.141625Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -278,7 +442,7 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "origin/main",
+    "base": "a0eb440d5606a36c9b2b37294076ede4ba86cd09",
     "base_sha": "a0eb440d",
     "changed_files": [
       ".workflow/records/1913-guided-1913-data-processed-rename.json",
@@ -286,9 +450,9 @@
       "src/scistudio/_skills/scistudio/scistudio-build-workflow/SKILL.md",
       "src/scistudio/_skills/scistudio/scistudio-inspect-data/SKILL.md"
     ],
-    "diff_fingerprint": "sha256:400acd63c86d22effceeee91f29905e549de1f00d78ed5362a93a612919b3ff2",
+    "diff_fingerprint": "sha256:a4f75e26451e3868d2f9904a1ff270e7b7df9af7b54376c2ee89567df55ed726",
     "head": "HEAD",
-    "head_sha": "9bf7e205",
+    "head_sha": "dcfd22dd",
     "surfaces": {
       "docs": 1,
       "frontend": 0,
@@ -309,7 +473,7 @@
     "closes": [
       1913
     ],
-    "number": null,
+    "number": 1914,
     "url": null
   },
   "reconcile_events": [
@@ -324,6 +488,22 @@
     {
       "at": "2026-07-02T21:16:38.814002Z",
       "diff_fingerprint": "sha256:400acd63c86d22effceeee91f29905e549de1f00d78ed5362a93a612919b3ff2",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-07-02T21:17:10.127633Z",
+      "diff_fingerprint": "sha256:a4f75e26451e3868d2f9904a1ff270e7b7df9af7b54376c2ee89567df55ed726",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-07-02T21:17:21.141705Z",
+      "diff_fingerprint": "sha256:a4f75e26451e3868d2f9904a1ff270e7b7df9af7b54376c2ee89567df55ed726",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 2,

--- a/.workflow/records/1913-guided-1913-data-processed-rename.json
+++ b/.workflow/records/1913-guided-1913-data-processed-rename.json
@@ -1,8 +1,79 @@
 {
   "branch": "guided/1913-data-processed-rename",
-  "check_events": [],
+  "check_events": [
+    {
+      "at": "2026-07-02T21:13:09.251507Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:55d97588daeaaca1aeeff9e41766bb06e39e871a1052c61eb9945d0e4b152c85",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-07-02T21:13:14.191464Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:d1eee49d7c2d961f851cf4efeaba648495346d76d8f74700a2ac5a10c747420d",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-02T21:13:14.237504Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:1ed9832c1cc74a4c382679e58236b2ddf00a76149a9f195e6af7ea5883d8ee37",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-07-02T21:16:14.240158Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cb8156d8cdc199a38d81c82247b19e42535f0119df56c7601737dec68828eafc",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    }
+  ],
   "check_na": [],
-  "commit": null,
+  "commit": {
+    "sha": "9bf7e205de3e478a2be033bee3a884f692144ea1",
+    "shas": [
+      "9bf7e205de3e478a2be033bee3a884f692144ea1"
+    ],
+    "trailers": []
+  },
   "declared_scope": {
     "exclude": [],
     "include": [
@@ -12,9 +83,191 @@
     ]
   },
   "directive_events": [],
-  "docs_events": [],
+  "docs_events": [
+    {
+      "at": "2026-07-02T21:11:51.858062Z",
+      "class": null,
+      "kind": "path",
+      "path": "src/scistudio/_skills/scistudio/scistudio-build-workflow/SKILL.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-07-02T21:11:51.858222Z",
+      "class": null,
+      "kind": "path",
+      "path": "src/scistudio/_skills/scistudio/scistudio-inspect-data/SKILL.md",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ],
   "governance_touch": false,
-  "guard_events": [],
+  "guard_events": [
+    {
+      "at": "2026-07-02T21:16:14.297711Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:16:14.311837Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:16:14.327257Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:16:14.344936Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:16:14.371301Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:16:14.388917Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:16:14.403208Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:16:14.421560Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:16:14.436428Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:16:14.449994Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:16:38.627077Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:16:38.652480Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:16:38.675615Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:16:38.697091Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:16:38.718995Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:16:38.736382Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:16:38.751315Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:16:38.770744Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:16:38.793929Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:16:38.813916Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
   "issues": [
     {
       "close_in_pr": true,
@@ -24,25 +277,102 @@
     }
   ],
   "observed_admin_labels": [],
-  "observed_diff": null,
+  "observed_diff": {
+    "base": "origin/main",
+    "base_sha": "a0eb440d",
+    "changed_files": [
+      ".workflow/records/1913-guided-1913-data-processed-rename.json",
+      "docs/planning/adr-040-skill-design.md",
+      "src/scistudio/_skills/scistudio/scistudio-build-workflow/SKILL.md",
+      "src/scistudio/_skills/scistudio/scistudio-inspect-data/SKILL.md"
+    ],
+    "diff_fingerprint": "sha256:400acd63c86d22effceeee91f29905e549de1f00d78ed5362a93a612919b3ff2",
+    "head": "HEAD",
+    "head_sha": "9bf7e205",
+    "surfaces": {
+      "docs": 1,
+      "frontend": 0,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 2,
+      "packaging": 0,
+      "protected_core": 0,
+      "sentrux": 2,
+      "test": 0,
+      "workflow_ci": 0
+    }
+  },
   "owner_directive": "Rename the agent save-path convention data/derived -> data/processed for user-friendliness; it is only a skill-example convention, not a system directory",
   "persona": "live_implementer",
-  "pull_request": null,
-  "reconcile_events": [],
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [
+      1913
+    ],
+    "number": null,
+    "url": null
+  },
+  "reconcile_events": [
+    {
+      "at": "2026-07-02T21:16:14.450048Z",
+      "diff_fingerprint": "sha256:400acd63c86d22effceeee91f29905e549de1f00d78ed5362a93a612919b3ff2",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-07-02T21:16:38.814002Z",
+      "diff_fingerprint": "sha256:400acd63c86d22effceeee91f29905e549de1f00d78ed5362a93a612919b3ff2",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    }
+  ],
   "record_id": "1913-guided-1913-data-processed-rename",
   "requested_admin_labels": [],
   "required_obligations": {
     "admin_labels": [],
-    "checks": [],
-    "docs": [],
-    "guards": [],
-    "tests": []
+    "checks": [
+      "format_check",
+      "full_audit",
+      "lint_format",
+      "semantic_dup"
+    ],
+    "docs": [
+      "docs_required_or_na"
+    ],
+    "guards": [
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": [
+      "changed_test_required"
+    ]
   },
   "runtime": "claude",
   "schema_version": 2,
   "scope_events": [],
   "session_id": "bc8789d0-9cec-4fdc-a973-795f9dbe1703",
-  "strictness_tier": null,
+  "strictness_tier": 2,
   "task_kind": "guided",
-  "test_events": []
+  "test_events": [
+    {
+      "at": "2026-07-02T21:11:51.858234Z",
+      "class": "implementation",
+      "kind": "na",
+      "path": null,
+      "rationale": "pure skill-example path rename (data/derived->data/processed); no code or runtime behavior changes",
+      "verified_in_diff": null
+    }
+  ]
 }

--- a/docs/planning/adr-040-skill-design.md
+++ b/docs/planning/adr-040-skill-design.md
@@ -51,7 +51,7 @@ workflow:                            # REQUIRED top-level key
     - id: save
       block_type: imaging.save_image
       config:
-        path: data/derived/mask.tif
+        path: data/processed/mask.tif
         format: tiff
   edges:                             # connections between node ports
     - source: "load:images"          # MUST be "<node_id>:<port_name>" — colon, not dot
@@ -125,7 +125,7 @@ workflow:
     - id: save
       block_type: imaging.save_image
       config:
-        path: data/derived/beads_mask.tif
+        path: data/processed/beads_mask.tif
         format: tiff
   edges:
     - source: "load:images"
@@ -200,7 +200,7 @@ workflow:
     - id: stats
       block_type: imaging.intensity_stats
       config:
-        output_path: data/derived/microplastics_stats.csv
+        output_path: data/processed/microplastics_stats.csv
   edges:
     - source: "load:images"
       target: "pre:image"

--- a/src/scistudio/_skills/scistudio/scistudio-build-workflow/SKILL.md
+++ b/src/scistudio/_skills/scistudio/scistudio-build-workflow/SKILL.md
@@ -39,7 +39,7 @@ workflow:                            # REQUIRED top-level key
       block_type: save_data          # core Save — configured by core_type
       config:
         core_type: Image
-        path: data/derived/mask.tif
+        path: data/processed/mask.tif
   edges:                             # connections between node ports
     - source: "load:data"            # MUST be "<node_id>:<port_name>" — colon, not dot
       target: "thr:image"
@@ -173,7 +173,7 @@ workflow:
       block_type: save_data
       config:
         core_type: Image
-        path: data/derived/beads_mask.tif
+        path: data/processed/beads_mask.tif
   edges:
     - source: "load:data"
       target: "thr:image"
@@ -251,7 +251,7 @@ workflow:
     - id: stats
       block_type: imaging.intensity_stats
       config:
-        output_path: data/derived/microplastics_stats.csv
+        output_path: data/processed/microplastics_stats.csv
   edges:
     - source: "load:data"
       target: "pre:image"

--- a/src/scistudio/_skills/scistudio/scistudio-inspect-data/SKILL.md
+++ b/src/scistudio/_skills/scistudio/scistudio-inspect-data/SKILL.md
@@ -107,7 +107,7 @@ When reporting results to the user, cite the `inspect_data` return
 values verbatim. Never fabricate shapes, dtypes, or axes from memory.
 
 Example phrasing: "The output mask is shape `(512, 512)`, dtype
-`bool`, axes `YX`, backed by Zarr at `data/derived/mask.zarr`."
+`bool`, axes `YX`, backed by Zarr at `data/processed/mask.zarr`."
 
 If you don't yet know a value, call `inspect_data` before reporting.
 


### PR DESCRIPTION
## Summary

Rename the AI agent's `data/derived/` save-path convention to `data/processed/`. The agent copies this path verbatim from the build-workflow / inspect-data skill examples; `data/derived` is only a skill-example convention (no hardcoded output root exists in the runtime), and `processed` is friendlier for the bench-scientist target users.

## Changes

- `scistudio-build-workflow/SKILL.md` — 3 example save paths
- `scistudio-inspect-data/SKILL.md` — 1 mention
- `docs/planning/adr-040-skill-design.md` — 3 (historical design doc, for grep-consistency)

## No migration

Save paths are per-workflow, relative, and agent-written at authoring time; existing workflows and already-saved data are unaffected. Docs-only change (no runtime behavior), so no test file changes (recorded N/A in the ledger).

Gate record: .workflow/records/1913-guided-1913-data-processed-rename.json

Closes #1913
