### PR TITLE
ux(#1915): default load/save file dialogs to the active project root

### DIFF
--- a/.workflow/records/1915-guided-1915-dialog-project-root.json
+++ b/.workflow/records/1915-guided-1915-dialog-project-root.json
@@ -250,9 +250,9 @@
   ],
   "check_na": [],
   "commit": {
-    "sha": "13195f041cf53951f5392b1632dd3b5537e70608",
+    "sha": "f50505cf17b9f9493cc1409254113ed8c5a70d06",
     "shas": [
-      "13195f041cf53951f5392b1632dd3b5537e70608"
+      "f50505cf17b9f9493cc1409254113ed8c5a70d06"
     ],
     "trailers": []
   },
@@ -720,6 +720,170 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:06:38.937912Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:06:38.948685Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:06:38.970226Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:06:38.987382Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:06:39.004675Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:06:39.016783Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:06:39.043785Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:06:39.075554Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:06:39.085539Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:06:39.097205Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:06:49.254597Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:06:49.263300Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:06:49.271712Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:06:49.280630Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:06:49.289473Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:06:49.298163Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:06:49.306582Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:06:49.315035Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:06:49.323400Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:06:49.334660Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -732,7 +896,7 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "origin/main",
+    "base": "a0eb440d5606a36c9b2b37294076ede4ba86cd09",
     "base_sha": "a0eb440d",
     "changed_files": [
       ".workflow/records/1915-guided-1915-dialog-project-root.json",
@@ -745,9 +909,9 @@
       "src/scistudio/api/routes/filesystem.py",
       "tests/api/test_native_dialog.py"
     ],
-    "diff_fingerprint": "sha256:a141e8ce755f04038a5a8c252c324e34154178002c63fce9caa2a4fcced4364f",
+    "diff_fingerprint": "sha256:829083a1680a63387321ceae2a9f374e569967390c35c7fbd1660f2c74fdf81a",
     "head": "HEAD",
-    "head_sha": "13195f04",
+    "head_sha": "f50505cf",
     "surfaces": {
       "docs": 0,
       "frontend": 5,
@@ -768,7 +932,7 @@
     "closes": [
       1915
     ],
-    "number": null,
+    "number": 1916,
     "url": null
   },
   "reconcile_events": [
@@ -819,6 +983,22 @@
     {
       "at": "2026-07-02T22:06:25.260154Z",
       "diff_fingerprint": "sha256:a141e8ce755f04038a5a8c252c324e34154178002c63fce9caa2a4fcced4364f",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-07-02T22:06:39.097241Z",
+      "diff_fingerprint": "sha256:829083a1680a63387321ceae2a9f374e569967390c35c7fbd1660f2c74fdf81a",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-07-02T22:06:49.334694Z",
+      "diff_fingerprint": "sha256:829083a1680a63387321ceae2a9f374e569967390c35c7fbd1660f2c74fdf81a",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 2,

--- a/.workflow/records/1915-guided-1915-dialog-project-root.json
+++ b/.workflow/records/1915-guided-1915-dialog-project-root.json
@@ -126,6 +126,51 @@
       "tool_versions": {
         "mypy": "2.1.0"
       }
+    },
+    {
+      "at": "2026-07-02T21:40:56.475638Z",
+      "command": "(cd frontend && npm run check:ci)",
+      "covered_surface": "frontend",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:b6265b0c07db1411cdaec53715f7f780de0ac093872ba5c199888dc27cea1be7",
+      "name": "frontend",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/frontend.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-02T21:41:03.143898Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:d26a5e7ebfd41d94b210794351bdb3525fd192f819fce829587cdba360e3805f",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-02T21:45:31.722182Z",
+      "command": "python -m scistudio.qa.testing.run_python_tests --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:1e6a2c604c1a80f9c5416f841bd36bbb538656dd31299cecace0ab8c02222eff",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
     }
   ],
   "check_na": [],
@@ -266,6 +311,88 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:45:31.770443Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:45:31.781880Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:45:31.794404Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:45:31.806218Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:45:31.818178Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:45:31.829648Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:45:31.840578Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:45:31.852723Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:45:31.863689Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:45:31.877267Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -282,6 +409,7 @@
     "base_sha": "a0eb440d",
     "changed_files": [
       ".workflow/records/1915-guided-1915-dialog-project-root.json",
+      "CHANGELOG.md",
       "frontend/src/components/ProjectDialog.tsx",
       "frontend/src/lib/__tests__/logger.test.ts",
       "frontend/src/lib/api/__tests__/filesystem.test.ts",
@@ -290,9 +418,9 @@
       "src/scistudio/api/routes/filesystem.py",
       "tests/api/test_native_dialog.py"
     ],
-    "diff_fingerprint": "sha256:8c7e1c802c6217be957049fbf5651fe817bd4ca12de70dc2a6b3fbbb772996bc",
+    "diff_fingerprint": "sha256:0aa21b67cba166676f9c4e82d3ad7a4b5d2ee587891c9d7d4df0b6eece597eaa",
     "head": "HEAD",
-    "head_sha": "192f004a",
+    "head_sha": "d732b496",
     "surfaces": {
       "docs": 0,
       "frontend": 5,
@@ -322,6 +450,18 @@
         "docs.docs_required_or_na",
         "guard.docs_landing",
         "tests.changed_test_required"
+      ]
+    },
+    {
+      "at": "2026-07-02T21:45:31.877313Z",
+      "diff_fingerprint": "sha256:0aa21b67cba166676f9c4e82d3ad7a4b5d2ee587891c9d7d4df0b6eece597eaa",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.frontend",
+        "checks.python_tests",
+        "scope.out-of-scope"
       ]
     }
   ],
@@ -360,7 +500,14 @@
   },
   "runtime": "claude",
   "schema_version": 2,
-  "scope_events": [],
+  "scope_events": [
+    {
+      "action": "add-include",
+      "at": "2026-07-02T21:48:21.144730Z",
+      "pattern": "CHANGELOG.md",
+      "reason": "CHANGELOG.md is the docs-landing evidence for this change; include it in scope"
+    }
+  ],
   "session_id": "c6816fbb-5bce-4bc0-b71a-f922a9c6363e",
   "strictness_tier": 2,
   "task_kind": "guided",

--- a/.workflow/records/1915-guided-1915-dialog-project-root.json
+++ b/.workflow/records/1915-guided-1915-dialog-project-root.json
@@ -1,0 +1,51 @@
+{
+  "branch": "guided/1915-dialog-project-root",
+  "check_events": [],
+  "check_na": [],
+  "commit": null,
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "src/scistudio/api/routes/filesystem.py",
+      "frontend/src/lib/api/filesystem.ts",
+      "frontend/src/components/ProjectDialog.tsx",
+      "frontend/src/lib/logger.ts",
+      "tests/**",
+      "frontend/src/**/*.test.ts"
+    ]
+  },
+  "directive_events": [],
+  "docs_events": [],
+  "governance_touch": false,
+  "guard_events": [],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1915,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": null,
+  "owner_directive": "All load/save file dialogs should default to the current project root instead of the user home; exclude create/open project and diagnostic-bundle export (keep home)",
+  "persona": "live_implementer",
+  "pull_request": null,
+  "reconcile_events": [],
+  "record_id": "1915-guided-1915-dialog-project-root",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [],
+    "docs": [],
+    "guards": [],
+    "tests": []
+  },
+  "runtime": "claude",
+  "schema_version": 2,
+  "scope_events": [],
+  "session_id": "c6816fbb-5bce-4bc0-b71a-f922a9c6363e",
+  "strictness_tier": null,
+  "task_kind": "guided",
+  "test_events": []
+}

--- a/.workflow/records/1915-guided-1915-dialog-project-root.json
+++ b/.workflow/records/1915-guided-1915-dialog-project-root.json
@@ -249,7 +249,13 @@
     }
   ],
   "check_na": [],
-  "commit": null,
+  "commit": {
+    "sha": "13195f041cf53951f5392b1632dd3b5537e70608",
+    "shas": [
+      "13195f041cf53951f5392b1632dd3b5537e70608"
+    ],
+    "trailers": []
+  },
   "declared_scope": {
     "exclude": [],
     "include": [
@@ -632,6 +638,88 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:06:25.174986Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:06:25.184599Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:06:25.194647Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:06:25.204129Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:06:25.213232Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:06:25.222441Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:06:25.231158Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:06:25.239864Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:06:25.248722Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:06:25.260111Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -657,9 +745,9 @@
       "src/scistudio/api/routes/filesystem.py",
       "tests/api/test_native_dialog.py"
     ],
-    "diff_fingerprint": "sha256:cac10b4bf1db4e197ac21028bb84b8d8ff77c999c3676b6864a8d13a0abc33da",
+    "diff_fingerprint": "sha256:a141e8ce755f04038a5a8c252c324e34154178002c63fce9caa2a4fcced4364f",
     "head": "HEAD",
-    "head_sha": "4fb8d88a",
+    "head_sha": "13195f04",
     "surfaces": {
       "docs": 0,
       "frontend": 5,
@@ -675,7 +763,14 @@
   },
   "owner_directive": "All load/save file dialogs should default to the current project root instead of the user home; exclude create/open project and diagnostic-bundle export (keep home)",
   "persona": "live_implementer",
-  "pull_request": null,
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [
+      1915
+    ],
+    "number": null,
+    "url": null
+  },
   "reconcile_events": [
     {
       "at": "2026-07-02T21:38:57.478295Z",
@@ -716,6 +811,14 @@
     {
       "at": "2026-07-02T22:05:50.130437Z",
       "diff_fingerprint": "sha256:cac10b4bf1db4e197ac21028bb84b8d8ff77c999c3676b6864a8d13a0abc33da",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-07-02T22:06:25.260154Z",
+      "diff_fingerprint": "sha256:a141e8ce755f04038a5a8c252c324e34154178002c63fce9caa2a4fcced4364f",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 2,

--- a/.workflow/records/1915-guided-1915-dialog-project-root.json
+++ b/.workflow/records/1915-guided-1915-dialog-project-root.json
@@ -1,6 +1,133 @@
 {
   "branch": "guided/1915-dialog-project-root",
-  "check_events": [],
+  "check_events": [
+    {
+      "at": "2026-07-02T21:28:55.650272Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:4b66e6176c94ca83a7a9c641b784f8d62f919824f476e6be5ab7b50e277b9154",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-07-02T21:29:07.095605Z",
+      "command": "(cd frontend && npm run check:ci)",
+      "covered_surface": "frontend",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:b6265b0c07db1411cdaec53715f7f780de0ac093872ba5c199888dc27cea1be7",
+      "name": "frontend",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/frontend.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-02T21:29:13.506161Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:b61250aab51592304849f599c118c7770139f0b5ad8ad073763fdb3364a4309c",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-02T21:29:14.083373Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:b517a132d936990734efb8cdd0d8a032eeb9ccf78bcbd1a995caf4143b0903f9",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-02T21:29:14.196033Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:2118353d8d962227d8530219d8825d780a30decc2851905ca65515f8a403aa86",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-07-02T21:34:57.485263Z",
+      "command": "python -m scistudio.qa.testing.run_python_tests --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:1e6a2c604c1a80f9c5416f841bd36bbb538656dd31299cecace0ab8c02222eff",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-02T21:38:47.988559Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e95f60d91cf3469c406735658f45c764856f794374c97124b028e6a5fae15b1e",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-02T21:38:57.322914Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:08622f4e4ed52b28c8ad2f7b0b524459af8d8cc70650247d68ef475ad7716b6c",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    }
+  ],
   "check_na": [],
   "commit": null,
   "declared_scope": {
@@ -15,9 +142,132 @@
     ]
   },
   "directive_events": [],
-  "docs_events": [],
+  "docs_events": [
+    {
+      "at": "2026-07-02T21:40:34.936654Z",
+      "class": null,
+      "kind": "path",
+      "path": "CHANGELOG.md",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ],
   "governance_touch": false,
-  "guard_events": [],
+  "guard_events": [
+    {
+      "at": "2026-07-02T21:38:57.376255Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:38:57.391583Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {
+            "governed_files": [
+              "frontend/src/components/ProjectDialog.tsx",
+              "frontend/src/lib/__tests__/logger.test.ts",
+              "frontend/src/lib/api/__tests__/filesystem.test.ts",
+              "frontend/src/lib/api/filesystem.ts",
+              "frontend/src/lib/logger.ts",
+              "src/scistudio/api/routes/filesystem.py"
+            ]
+          },
+          "expected": null,
+          "file": "",
+          "finding_class": "docs_landing",
+          "git_evidence": null,
+          "id": "docs_landing.missing-landing",
+          "line": null,
+          "message": "governed change requires docs/changelog/checklist landing evidence or an explicit N/A rationale",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "docs_landing.missing-landing",
+          "severity": "error",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "docs_landing",
+      "status": "fail"
+    },
+    {
+      "at": "2026-07-02T21:38:57.403307Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:38:57.414033Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:38:57.425096Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:38:57.435902Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:38:57.445840Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:38:57.455568Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:38:57.465519Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:38:57.478247Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
   "issues": [
     {
       "close_in_pr": true,
@@ -27,25 +277,117 @@
     }
   ],
   "observed_admin_labels": [],
-  "observed_diff": null,
+  "observed_diff": {
+    "base": "origin/main",
+    "base_sha": "a0eb440d",
+    "changed_files": [
+      ".workflow/records/1915-guided-1915-dialog-project-root.json",
+      "frontend/src/components/ProjectDialog.tsx",
+      "frontend/src/lib/__tests__/logger.test.ts",
+      "frontend/src/lib/api/__tests__/filesystem.test.ts",
+      "frontend/src/lib/api/filesystem.ts",
+      "frontend/src/lib/logger.ts",
+      "src/scistudio/api/routes/filesystem.py",
+      "tests/api/test_native_dialog.py"
+    ],
+    "diff_fingerprint": "sha256:8c7e1c802c6217be957049fbf5651fe817bd4ca12de70dc2a6b3fbbb772996bc",
+    "head": "HEAD",
+    "head_sha": "192f004a",
+    "surfaces": {
+      "docs": 0,
+      "frontend": 5,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 6,
+      "packaging": 0,
+      "protected_core": 0,
+      "sentrux": 7,
+      "test": 3,
+      "workflow_ci": 0
+    }
+  },
   "owner_directive": "All load/save file dialogs should default to the current project root instead of the user home; exclude create/open project and diagnostic-bundle export (keep home)",
   "persona": "live_implementer",
   "pull_request": null,
-  "reconcile_events": [],
+  "reconcile_events": [
+    {
+      "at": "2026-07-02T21:38:57.478295Z",
+      "diff_fingerprint": "sha256:8c7e1c802c6217be957049fbf5651fe817bd4ca12de70dc2a6b3fbbb772996bc",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.frontend",
+        "checks.python_tests",
+        "docs.docs_required_or_na",
+        "guard.docs_landing",
+        "tests.changed_test_required"
+      ]
+    }
+  ],
   "record_id": "1915-guided-1915-dialog-project-root",
   "requested_admin_labels": [],
   "required_obligations": {
     "admin_labels": [],
-    "checks": [],
-    "docs": [],
-    "guards": [],
-    "tests": []
+    "checks": [
+      "format_check",
+      "frontend",
+      "full_audit",
+      "import_contracts",
+      "lint_format",
+      "python_tests",
+      "semantic_dup",
+      "type_check"
+    ],
+    "docs": [
+      "docs_required_or_na"
+    ],
+    "guards": [
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": [
+      "changed_test_required"
+    ]
   },
   "runtime": "claude",
   "schema_version": 2,
   "scope_events": [],
   "session_id": "c6816fbb-5bce-4bc0-b71a-f922a9c6363e",
-  "strictness_tier": null,
+  "strictness_tier": 2,
   "task_kind": "guided",
-  "test_events": []
+  "test_events": [
+    {
+      "at": "2026-07-02T21:40:34.937082Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/api/test_native_dialog.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-07-02T21:40:34.937089Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/lib/api/__tests__/filesystem.test.ts",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-07-02T21:40:34.937091Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/lib/__tests__/logger.test.ts",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
 }

--- a/.workflow/records/1915-guided-1915-dialog-project-root.json
+++ b/.workflow/records/1915-guided-1915-dialog-project-root.json
@@ -246,13 +246,124 @@
       "status": "pass",
       "summary": "clean",
       "tool_versions": {}
+    },
+    {
+      "at": "2026-07-02T22:30:43.665285Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:2db3b6247552182ef2634c83f74a740e0dbbeb0186c26773b3a0198e1b4e6eac",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-07-02T22:30:47.777839Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:4a5b7c8e56dc975f0b266227d34632ba64e2bef8629c096d291f11110cd0d287",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-02T22:30:47.913746Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:92316251d6b3bf5ecf940284634d36956b06118e5da26d43943f87b02720990b",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-02T22:30:47.935146Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:5dedd239dc0faef2f769cf004d330fc11bce314fe42ab4430576a36a4d9c2e5a",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-07-02T22:33:31.259580Z",
+      "command": "python -m scistudio.qa.testing.run_python_tests --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:3a7eb9404b6cbc1047dc9ef6e83cb5db3fb8570c31628a9f86a286c4af01d034",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-02T22:36:46.759727Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:8ec400070546f65e307bee86ee0fb2fbe10516950473495dc63df67e64358c6e",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-02T22:36:47.883272Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:f117611e1506fdb60e0b8a01e67f7562e3a38a247157aa3f0c5acac63238cc3c",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
     }
   ],
   "check_na": [],
   "commit": {
-    "sha": "f50505cf17b9f9493cc1409254113ed8c5a70d06",
+    "sha": "8864f87545c36c0215811546ea97d3572b2b9925",
     "shas": [
-      "f50505cf17b9f9493cc1409254113ed8c5a70d06"
+      "8864f87545c36c0215811546ea97d3572b2b9925"
     ],
     "trailers": []
   },
@@ -884,6 +995,170 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:36:47.931642Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:36:47.945368Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:36:47.959481Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:36:47.972601Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:36:47.986183Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:36:48.003179Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:36:48.016974Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:36:48.031311Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:36:48.044935Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:36:48.065196Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:37:08.865531Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:37:08.877382Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:37:08.889796Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:37:08.902591Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:37:08.914328Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:37:08.930369Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:37:08.942641Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:37:08.953958Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:37:08.968540Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:37:08.984470Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -909,9 +1184,9 @@
       "src/scistudio/api/routes/filesystem.py",
       "tests/api/test_native_dialog.py"
     ],
-    "diff_fingerprint": "sha256:829083a1680a63387321ceae2a9f374e569967390c35c7fbd1660f2c74fdf81a",
+    "diff_fingerprint": "sha256:a354fcbdf6ae3f76c8394434f791cbb2cbb068975f55fe0c063ef5b26ecbbbee",
     "head": "HEAD",
-    "head_sha": "f50505cf",
+    "head_sha": "8864f875",
     "surfaces": {
       "docs": 0,
       "frontend": 5,
@@ -999,6 +1274,22 @@
     {
       "at": "2026-07-02T22:06:49.334694Z",
       "diff_fingerprint": "sha256:829083a1680a63387321ceae2a9f374e569967390c35c7fbd1660f2c74fdf81a",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-07-02T22:36:48.065268Z",
+      "diff_fingerprint": "sha256:a354fcbdf6ae3f76c8394434f791cbb2cbb068975f55fe0c063ef5b26ecbbbee",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-07-02T22:37:08.984505Z",
+      "diff_fingerprint": "sha256:a354fcbdf6ae3f76c8394434f791cbb2cbb068975f55fe0c063ef5b26ecbbbee",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 2,

--- a/.workflow/records/1915-guided-1915-dialog-project-root.json
+++ b/.workflow/records/1915-guided-1915-dialog-project-root.json
@@ -171,6 +171,81 @@
       "status": "fail",
       "summary": "exit 1",
       "tool_versions": {}
+    },
+    {
+      "at": "2026-07-02T21:54:08.976554Z",
+      "command": "(cd frontend && npm run check:ci)",
+      "covered_surface": "frontend",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:edeb6f390af6c1c50c554a4c8daadb81018780a6ab0aeffcd4ea5489fb4dd92b",
+      "name": "frontend",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/frontend.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-02T21:54:15.302456Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:c7d0c0ed3843680f06dc2414e01914ce087462e7ece5ec26f57e7aff4de8093c",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-02T21:58:25.896599Z",
+      "command": "python -m scistudio.qa.testing.run_python_tests --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:1e6a2c604c1a80f9c5416f841bd36bbb538656dd31299cecace0ab8c02222eff",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-02T22:00:44.739965Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:2759089ed928024e9eca90fbfe0c0c4261bdb6de5365bb53f7986eb136d5ba3c",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-02T22:05:49.995448Z",
+      "command": "python -m scistudio.qa.testing.run_python_tests --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:1e6a2c604c1a80f9c5416f841bd36bbb538656dd31299cecace0ab8c02222eff",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
     }
   ],
   "check_na": [],
@@ -393,6 +468,170 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:00:44.792187Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:00:44.801588Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:00:44.811326Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:00:44.820678Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:00:44.829836Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:00:44.839360Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:00:44.848554Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:00:44.857993Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:00:44.867611Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:00:44.879146Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:05:50.042802Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:05:50.052401Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:05:50.062553Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:05:50.072324Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:05:50.081934Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:05:50.091117Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:05:50.100064Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:05:50.110319Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:05:50.119067Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:05:50.130392Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -418,9 +657,9 @@
       "src/scistudio/api/routes/filesystem.py",
       "tests/api/test_native_dialog.py"
     ],
-    "diff_fingerprint": "sha256:0aa21b67cba166676f9c4e82d3ad7a4b5d2ee587891c9d7d4df0b6eece597eaa",
+    "diff_fingerprint": "sha256:cac10b4bf1db4e197ac21028bb84b8d8ff77c999c3676b6864a8d13a0abc33da",
     "head": "HEAD",
-    "head_sha": "d732b496",
+    "head_sha": "4fb8d88a",
     "surfaces": {
       "docs": 0,
       "frontend": 5,
@@ -463,6 +702,24 @@
         "checks.python_tests",
         "scope.out-of-scope"
       ]
+    },
+    {
+      "at": "2026-07-02T22:00:44.879461Z",
+      "diff_fingerprint": "sha256:cac10b4bf1db4e197ac21028bb84b8d8ff77c999c3676b6864a8d13a0abc33da",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.python_tests"
+      ]
+    },
+    {
+      "at": "2026-07-02T22:05:50.130437Z",
+      "diff_fingerprint": "sha256:cac10b4bf1db4e197ac21028bb84b8d8ff77c999c3676b6864a8d13a0abc33da",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
     }
   ],
   "record_id": "1915-guided-1915-dialog-project-root",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- [#1915] Load/save native file dialogs now default to the active project root instead of the user home directory. The backend `native_file_dialog` route resolves the start directory through a new pure helper `_resolve_dialog_start_dir` (project-scope: valid `initial_dir` → `runtime.project_dir` → session last-used → home; home-scope → last-used → home). A `prefer_home` request flag is the only per-caller opt-out, used by the create/open-project dialog (picks a project *location*) and the diagnostic-bundle export (a machine artifact, not a project file); every other load/save caller now defaults to the project root with no code change. Tests: `tests/api/test_native_dialog.py` (`_resolve_dialog_start_dir` matrix), `frontend/src/lib/api/__tests__/filesystem.test.ts`, `frontend/src/lib/__tests__/logger.test.ts`. (@claude, 2026-07-02, branch: guided/1915-dialog-project-root)
+
 ## [0.3.2] - 2026-06-28
 
 Standardized the public API surface (ADR-052) and added the alpha testing token

--- a/frontend/src/components/ProjectDialog.tsx
+++ b/frontend/src/components/ProjectDialog.tsx
@@ -40,7 +40,9 @@ export function ProjectDialog({
 
   async function handleBrowse() {
     try {
-      const result = await api.openNativeDialog("directory");
+      // prefer_home: creating/opening a project picks a location outside any
+      // project, so this dialog opens at home, not the active project root (#1915).
+      const result = await api.openNativeDialog("directory", undefined, true);
       if (result.paths.length > 0) {
         onChange({ path: result.paths[0] });
         setPathError(null);

--- a/frontend/src/lib/__tests__/logger.test.ts
+++ b/frontend/src/lib/__tests__/logger.test.ts
@@ -88,6 +88,9 @@ describe("frontend logger (#1741)", () => {
 
     // Native save dialog is requested FIRST, then the bundle is written to the path.
     expect(calls[0].url).toContain("/api/filesystem/native-dialog");
+    // #1915: a diagnostic bundle is a machine artifact, so its save dialog opts
+    // out of the project-root default and opens at home.
+    expect(JSON.parse(calls[0].init!.body as string).prefer_home).toBe(true);
     const bundleCall = calls.find((c) => c.url.includes("/api/diagnostics/bundle"));
     expect(bundleCall).toBeDefined();
     expect(JSON.parse(bundleCall!.init!.body as string).path).toBe("/home/u/report.zip");

--- a/frontend/src/lib/api/__tests__/filesystem.test.ts
+++ b/frontend/src/lib/api/__tests__/filesystem.test.ts
@@ -1,0 +1,58 @@
+/**
+ * #1915: native file/directory dialogs default to the active project root.
+ *
+ * The `preferHome` flag is the only per-caller opt-out (create/open project and
+ * the diagnostic export). These tests pin the request body the helpers send so
+ * the exclusion contract can't silently regress.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { filesystemApi } from "../filesystem";
+
+function mockFetchOk(): { url: string; init: RequestInit }[] {
+  const calls: { url: string; init: RequestInit }[] = [];
+  const mock = vi.fn((url: string, init: RequestInit) => {
+    calls.push({ url, init });
+    return Promise.resolve({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ paths: [] }),
+    } as unknown as Response);
+  });
+  vi.stubGlobal("fetch", mock);
+  return calls;
+}
+
+const bodyOf = (calls: { init: RequestInit }[]) => JSON.parse(calls[0].init.body as string);
+
+describe("filesystemApi native-dialog prefer_home (#1915)", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("openNativeDialog omits prefer_home by default (project-scope)", async () => {
+    const calls = mockFetchOk();
+    await filesystemApi.openNativeDialog("directory");
+    const body = bodyOf(calls);
+    expect(body.mode).toBe("directory");
+    expect(body.prefer_home).toBeUndefined();
+  });
+
+  it("openNativeDialog forwards prefer_home=true for excluded dialogs", async () => {
+    const calls = mockFetchOk();
+    await filesystemApi.openNativeDialog("directory", undefined, true);
+    expect(bodyOf(calls).prefer_home).toBe(true);
+  });
+
+  it("openNativeSaveDialog forwards prefer_home", async () => {
+    const calls = mockFetchOk();
+    await filesystemApi.openNativeSaveDialog({ defaultFilename: "x.zip", preferHome: true });
+    const body = bodyOf(calls);
+    expect(body.mode).toBe("save_file");
+    expect(body.prefer_home).toBe(true);
+  });
+
+  it("openNativeSaveDialog omits prefer_home by default (project-scope)", async () => {
+    const calls = mockFetchOk();
+    await filesystemApi.openNativeSaveDialog({ defaultFilename: "x.zip" });
+    expect(bodyOf(calls).prefer_home).toBeUndefined();
+  });
+});

--- a/frontend/src/lib/api/filesystem.ts
+++ b/frontend/src/lib/api/filesystem.ts
@@ -18,16 +18,20 @@ export const filesystemApi = {
       headers: JSON_HEADERS,
       body: JSON.stringify({ path }),
     }),
-  openNativeDialog: (mode: "file" | "directory", initialDir?: string) =>
+  // `preferHome` opens the dialog at the last-used location / user home instead
+  // of the active project root (#1915) — used only by the create/open-project
+  // and diagnostic-export dialogs, which pick a location outside any project.
+  openNativeDialog: (mode: "file" | "directory", initialDir?: string, preferHome?: boolean) =>
     apiFetch<{ paths: string[] }>("/api/filesystem/native-dialog", {
       method: "POST",
       headers: JSON_HEADERS,
-      body: JSON.stringify({ mode, initial_dir: initialDir }),
+      body: JSON.stringify({ mode, initial_dir: initialDir, prefer_home: preferHome }),
     }),
   openNativeSaveDialog: (options: {
     initialDir?: string;
     defaultFilename?: string;
     fileFilter?: string;
+    preferHome?: boolean;
   }) =>
     apiFetch<{ paths: string[]; available?: boolean }>("/api/filesystem/native-dialog", {
       method: "POST",
@@ -37,6 +41,7 @@ export const filesystemApi = {
         initial_dir: options.initialDir,
         default_filename: options.defaultFilename,
         file_filter: options.fileFilter,
+        prefer_home: options.preferHome,
       }),
     }),
 };

--- a/frontend/src/lib/logger.ts
+++ b/frontend/src/lib/logger.ts
@@ -177,7 +177,11 @@ async function openNativeSaveDialog(
       headers: { "Content-Type": "application/json" },
       // prefer_home: a diagnostic bundle is a machine artifact, not a project
       // file, so it saves from home rather than the active project root (#1915).
-      body: JSON.stringify({ mode: "save_file", default_filename: defaultFilename, prefer_home: true }),
+      body: JSON.stringify({
+        mode: "save_file",
+        default_filename: defaultFilename,
+        prefer_home: true,
+      }),
     });
     if (!response.ok) return { path: null, available: false };
     const data = (await response.json()) as { paths?: string[]; available?: boolean };

--- a/frontend/src/lib/logger.ts
+++ b/frontend/src/lib/logger.ts
@@ -175,7 +175,9 @@ async function openNativeSaveDialog(
     const response = await fetch("/api/filesystem/native-dialog", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ mode: "save_file", default_filename: defaultFilename }),
+      // prefer_home: a diagnostic bundle is a machine artifact, not a project
+      // file, so it saves from home rather than the active project root (#1915).
+      body: JSON.stringify({ mode: "save_file", default_filename: defaultFilename, prefer_home: true }),
     });
     if (!response.ok) return { path: null, available: false };
     const data = (await response.json()) as { paths?: string[]; available?: boolean };

--- a/src/scistudio/api/routes/filesystem.py
+++ b/src/scistudio/api/routes/filesystem.py
@@ -502,12 +502,31 @@ public interface IShellItem {
 }
 
 public static class FolderPicker {
-    public static string Pick(string title, IntPtr owner) {
+    // Create an IShellItem from a filesystem path so the folder dialog can be
+    // pointed at a start directory (the project root) via IFileDialog.SetFolder.
+    [DllImport("shell32.dll", CharSet = CharSet.Unicode, PreserveSig = false)]
+    private static extern void SHCreateItemFromParsingName(
+        [MarshalAs(UnmanagedType.LPWStr)] string pszPath,
+        IntPtr pbc,
+        [In] ref Guid riid,
+        [MarshalAs(UnmanagedType.Interface)] out IShellItem ppv);
+
+    public static string Pick(string title, string initialDir, IntPtr owner) {
         var dlg = (IFileDialog)new FileOpenDialogClass();
         uint opts;
         dlg.GetOptions(out opts);
         dlg.SetOptions(opts | 0x20 | 0x40);
         if (title != null) dlg.SetTitle(title);
+        if (!string.IsNullOrEmpty(initialDir)) {
+            try {
+                Guid iidShellItem = new Guid("43826D1E-E718-42EE-BC55-A1E261C37BFE");
+                IShellItem folder;
+                SHCreateItemFromParsingName(initialDir, IntPtr.Zero, ref iidShellItem, out folder);
+                if (folder != null) dlg.SetFolder(folder);
+            } catch {
+                // Invalid/unreachable start dir -> fall back to the shell default.
+            }
+        }
         int hr = dlg.Show(owner);
         if (hr != 0) return null;
         IShellItem item;
@@ -525,7 +544,7 @@ public static class FolderPicker {
             + cs_source.replace("'", "''")
             + "';"
             + "try {"
-            + "$result = [FolderPicker]::Pick('Select Folder', $owner.Handle);"
+            + f"$result = [FolderPicker]::Pick('Select Folder', '{safe_initial_dir}', $owner.Handle);"
             + "if ($result) { $result } else { '' }"
             + "} finally {"
             + owner_form_teardown

--- a/src/scistudio/api/routes/filesystem.py
+++ b/src/scistudio/api/routes/filesystem.py
@@ -353,6 +353,14 @@ class NativeDialogRequest(BaseModel):
     initial_dir: str | None = Field(None, description="Optional starting directory for the dialog")
     default_filename: str | None = Field(None, description="Default filename for save_file mode")
     file_filter: str | None = Field(None, description="File type filter description (e.g. 'YAML files (*.yaml)')")
+    prefer_home: bool = Field(
+        False,
+        description=(
+            "When True, open at the last-used location or the user home instead of the "
+            "active project root. Used by the create/open-project and diagnostic-export "
+            "dialogs, which select a location outside any project."
+        ),
+    )
 
 
 class NativeDialogResponse(BaseModel):
@@ -370,6 +378,32 @@ class NativeDialogResponse(BaseModel):
 
 # Per-session last-used directory (in-memory, resets on restart).
 _last_used_directory: str | None = None
+
+
+def _resolve_dialog_start_dir(
+    initial_dir: str | None,
+    prefer_home: bool,
+    project_root: str | None,
+    last_used: str | None,
+) -> str:
+    """Choose the directory a native file/directory dialog should open in.
+
+    Project-scope dialogs (the default) prefer the active project root so that
+    load/save browsing starts inside the user's project instead of ``$HOME``
+    (#1915). Home-scope dialogs (``prefer_home`` — create/open project and the
+    diagnostic-bundle export) keep opening at the last-used location or the user
+    home, because they select a location *outside* any project.
+
+    ``_safe_is_dir`` swallows ``OSError`` so an over-length or offline candidate
+    degrades to the next fallback instead of raising a 500 (#1753).
+    """
+    if initial_dir and _safe_is_dir(initial_dir):
+        return initial_dir
+    candidates: list[str | None] = [last_used] if prefer_home else [project_root, last_used]
+    for candidate in candidates:
+        if candidate and _safe_is_dir(candidate):
+            return candidate
+    return str(Path.home())
 
 
 def _ps_single_quote_escape(value: str) -> str:
@@ -643,7 +677,7 @@ def _native_dialog_linux(
 
 
 @router.post("/api/filesystem/native-dialog", response_model=NativeDialogResponse)
-async def native_file_dialog(body: NativeDialogRequest) -> NativeDialogResponse:
+async def native_file_dialog(body: NativeDialogRequest, runtime: RuntimeDep) -> NativeDialogResponse:
     """Open a native OS file or directory dialog and return the selected path.
 
     Uses platform-specific subprocess calls (PowerShell on Windows, osascript
@@ -651,14 +685,15 @@ async def native_file_dialog(body: NativeDialogRequest) -> NativeDialogResponse:
     """
     global _last_used_directory
 
-    # Determine starting directory: request param > last-used > home.
-    # ``_safe_is_dir`` swallows OSError so an over-length or offline ``initial_dir``
-    # falls back to home instead of raising a 500 (#1753).
-    initial_dir = body.initial_dir
-    if not initial_dir or not _safe_is_dir(initial_dir):
-        initial_dir = _last_used_directory
-    if not initial_dir or not _safe_is_dir(initial_dir):
-        initial_dir = str(Path.home())
+    # Determine starting directory. Project-scope dialogs default to the active
+    # project root; home-scope dialogs (prefer_home) default to last-used/home.
+    project_dir = runtime.project_dir
+    initial_dir = _resolve_dialog_start_dir(
+        body.initial_dir,
+        body.prefer_home,
+        str(project_dir) if project_dir else None,
+        _last_used_directory,
+    )
 
     system = platform.system()
     try:

--- a/tests/api/test_native_dialog.py
+++ b/tests/api/test_native_dialog.py
@@ -137,3 +137,80 @@ class TestNativeDialogNoTimeout:
             _native_dialog_linux("file", None)
 
         self._assert_no_timeout(mock_run)
+
+
+class TestResolveDialogStartDir:
+    """#1915: load/save dialogs default to the active project root, not $HOME.
+
+    Project-scope dialogs (the default) prefer ``project_root``; home-scope
+    dialogs (``prefer_home`` — create/open project, diagnostic export) keep
+    opening at last-used / home.
+    """
+
+    def test_explicit_initial_dir_wins(self, tmp_path) -> None:
+        from scistudio.api.routes.filesystem import _resolve_dialog_start_dir
+
+        chosen = tmp_path / "chosen"
+        chosen.mkdir()
+        project = tmp_path / "project"
+        project.mkdir()
+        # Explicit, valid initial_dir beats project root regardless of scope.
+        assert _resolve_dialog_start_dir(str(chosen), False, str(project), None) == str(chosen)
+        assert _resolve_dialog_start_dir(str(chosen), True, str(project), None) == str(chosen)
+
+    def test_project_scope_defaults_to_project_root(self, tmp_path) -> None:
+        from scistudio.api.routes.filesystem import _resolve_dialog_start_dir
+
+        project = tmp_path / "project"
+        project.mkdir()
+        assert _resolve_dialog_start_dir(None, False, str(project), None) == str(project)
+
+    def test_project_root_beats_last_used(self, tmp_path) -> None:
+        from scistudio.api.routes.filesystem import _resolve_dialog_start_dir
+
+        project = tmp_path / "project"
+        project.mkdir()
+        last_used = tmp_path / "elsewhere"
+        last_used.mkdir()
+        # Project-scope: project root is the reliable default, above last-used.
+        assert _resolve_dialog_start_dir(None, False, str(project), str(last_used)) == str(project)
+
+    def test_prefer_home_ignores_project_root(self, tmp_path) -> None:
+        from scistudio.api.routes.filesystem import _resolve_dialog_start_dir
+
+        project = tmp_path / "project"
+        project.mkdir()
+        last_used = tmp_path / "picked-before"
+        last_used.mkdir()
+        # Home-scope: project root is skipped; last-used is honored.
+        assert _resolve_dialog_start_dir(None, True, str(project), str(last_used)) == str(last_used)
+
+    def test_prefer_home_falls_back_to_home(self, tmp_path) -> None:
+        from pathlib import Path
+
+        from scistudio.api.routes.filesystem import _resolve_dialog_start_dir
+
+        project = tmp_path / "project"
+        project.mkdir()
+        # Home-scope with no last-used: home, never the project root.
+        assert _resolve_dialog_start_dir(None, True, str(project), None) == str(Path.home())
+
+    def test_no_active_project_falls_back_to_last_used_then_home(self, tmp_path) -> None:
+        from pathlib import Path
+
+        from scistudio.api.routes.filesystem import _resolve_dialog_start_dir
+
+        last_used = tmp_path / "last"
+        last_used.mkdir()
+        assert _resolve_dialog_start_dir(None, False, None, str(last_used)) == str(last_used)
+        assert _resolve_dialog_start_dir(None, False, None, None) == str(Path.home())
+
+    def test_nonexistent_candidates_are_skipped(self, tmp_path) -> None:
+        from pathlib import Path
+
+        from scistudio.api.routes.filesystem import _resolve_dialog_start_dir
+
+        missing_initial = str(tmp_path / "does-not-exist")
+        missing_project = str(tmp_path / "also-missing")
+        # An invalid initial_dir and a stale project_root both degrade to home.
+        assert _resolve_dialog_start_dir(missing_initial, False, missing_project, None) == str(Path.home())

--- a/tests/api/test_native_dialog.py
+++ b/tests/api/test_native_dialog.py
@@ -35,7 +35,7 @@ class TestNativeDialogWindowsDirectory:
         assert "IFileDialog" in ps_script
         assert "Add-Type -TypeDefinition" in ps_script
         assert "$owner.TopMost = $true;" in ps_script
-        assert "[FolderPicker]::Pick('Select Folder', $owner.Handle)" in ps_script
+        assert "[FolderPicker]::Pick('Select Folder', '', $owner.Handle)" in ps_script
         assert "FolderBrowserDialog" not in ps_script
 
         assert result == [r"C:\Users\test\Documents"]
@@ -214,3 +214,57 @@ class TestResolveDialogStartDir:
         missing_project = str(tmp_path / "also-missing")
         # An invalid initial_dir and a stale project_root both degrade to home.
         assert _resolve_dialog_start_dir(missing_initial, False, missing_project, None) == str(Path.home())
+
+
+class TestWindowsDirectoryInitialDir:
+    """#1916: the Windows folder picker must open at the resolved start dir.
+
+    The COM ``FolderPicker.Pick`` path previously ignored ``initial_dir``, so
+    directory load/save dialogs (and the home-scoped create/open-project
+    exclusion) opened wherever the shell chose. It must now thread the resolved
+    directory in and apply it via ``IFileDialog.SetFolder``. These assert on the
+    generated PowerShell (subprocess mocked) so they run on any platform.
+    """
+
+    def test_directory_mode_threads_initial_dir_into_setfolder(self) -> None:
+        from scistudio.api.routes.filesystem import _native_dialog_windows
+
+        mock_result = MagicMock()
+        mock_result.stdout = r"C:\proj\out"
+        mock_result.returncode = 0
+
+        with patch("scistudio.api.routes.filesystem.subprocess.run", return_value=mock_result) as mock_run:
+            _native_dialog_windows("directory", r"C:\proj")
+
+        ps_script = mock_run.call_args[0][0][-1]
+        assert r"[FolderPicker]::Pick('Select Folder', 'C:\proj', $owner.Handle)" in ps_script
+        # The start dir is materialized into an IShellItem and applied.
+        assert "SHCreateItemFromParsingName" in ps_script
+        assert "dlg.SetFolder(folder)" in ps_script
+
+    def test_directory_mode_escapes_single_quote_in_initial_dir(self) -> None:
+        from scistudio.api.routes.filesystem import _native_dialog_windows
+
+        mock_result = MagicMock()
+        mock_result.stdout = ""
+        mock_result.returncode = 0
+
+        with patch("scistudio.api.routes.filesystem.subprocess.run", return_value=mock_result) as mock_run:
+            _native_dialog_windows("directory", "C:\\a'b")
+
+        ps_script = mock_run.call_args[0][0][-1]
+        # Single quotes doubled for the PowerShell single-quoted string (#617).
+        assert "Pick('Select Folder', 'C:\\a''b'," in ps_script
+
+    def test_directory_mode_no_initial_dir_passes_empty(self) -> None:
+        from scistudio.api.routes.filesystem import _native_dialog_windows
+
+        mock_result = MagicMock()
+        mock_result.stdout = ""
+        mock_result.returncode = 0
+
+        with patch("scistudio.api.routes.filesystem.subprocess.run", return_value=mock_result) as mock_run:
+            _native_dialog_windows("directory", None)
+
+        ps_script = mock_run.call_args[0][0][-1]
+        assert "[FolderPicker]::Pick('Select Folder', '', $owner.Handle)" in ps_script


### PR DESCRIPTION
## Summary

Load/save native file dialogs now default to the **active project root** instead of the user's home directory. Previously every browse (previewer Save/Export, block-config path/filename, Workflow Save As, subworkflow picker, package install) opened at `~`.

## Change

- **Backend** (`api/routes/filesystem.py`): `native_file_dialog` now takes the runtime and resolves the start directory through a new pure helper `_resolve_dialog_start_dir`. Project-scope (default): valid `initial_dir` → `runtime.project_dir` → session last-used → home. Home-scope: last-used → home. New `prefer_home` request flag is the only per-caller opt-out.
- **Frontend**: `openNativeDialog` / `openNativeSaveDialog` thread an optional `preferHome`. Every load/save caller now defaults to the project root with no change. Excluded (pass `preferHome: true`, keep home): the create/open-project dialog (`ProjectDialog.tsx`, picks a project *location*) and the diagnostic-bundle export (`logger.ts`, a machine artifact).

## Tests

- `tests/api/test_native_dialog.py` — `_resolve_dialog_start_dir` matrix (explicit dir, project-scope default, project-root beats last-used, prefer_home skips project root, home fallback, no-active-project, invalid candidates).
- `frontend/src/lib/api/__tests__/filesystem.test.ts` — helper request-body threading.
- `frontend/src/lib/__tests__/logger.test.ts` — diagnostic export sends `prefer_home`.

Gate check green (Tier 2). No protected-core paths.

Gate record: .workflow/records/1915-guided-1915-dialog-project-root.json

Closes #1915
