### PR TITLE
feat(#1912): edit_workflow MCP tool for surgical partial workflow edits

### DIFF
--- a/.workflow/records/1912-guided-1912-edit-workflow-mcp.json
+++ b/.workflow/records/1912-guided-1912-edit-workflow-mcp.json
@@ -443,7 +443,13 @@
     }
   ],
   "check_na": [],
-  "commit": null,
+  "commit": {
+    "sha": "1cce43da6a6ca0d9e002d24909dac90e5c601da7",
+    "shas": [
+      "1cce43da6a6ca0d9e002d24909dac90e5c601da7"
+    ],
+    "trailers": []
+  },
   "declared_scope": {
     "exclude": [],
     "include": [
@@ -840,6 +846,88 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:14:58.666581Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:14:58.677746Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:14:58.688722Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:14:58.698734Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:14:58.709071Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:14:58.726559Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:14:58.739984Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:14:58.752634Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:14:58.765984Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:14:58.782708Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -872,9 +960,9 @@
       "tests/contracts/test_runtime_import_contract.py",
       "tests/integration/test_phase2_mcp_end_to_end.py"
     ],
-    "diff_fingerprint": "sha256:87c7f1a41c6c492bb3798bf89b5039efe33c9698756781efa469931b0e20018a",
+    "diff_fingerprint": "sha256:c94dc3f43ba80cd47efb50d70f231afa17f6ace51f7b01a40bc2eb031d88fe52",
     "head": "HEAD",
-    "head_sha": "424414ec",
+    "head_sha": "1cce43da",
     "surfaces": {
       "docs": 1,
       "frontend": 0,
@@ -890,7 +978,14 @@
   },
   "owner_directive": "Add single edit_workflow MCP tool for surgical partial workflow edits so AI edits stop clobbering user-set block config; keep protect_workflow_yaml hook; update build-workflow skill + descriptive docs",
   "persona": "implementer",
-  "pull_request": null,
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [
+      1912
+    ],
+    "number": null,
+    "url": null
+  },
   "reconcile_events": [
     {
       "at": "2026-07-02T21:36:22.290576Z",
@@ -928,6 +1023,14 @@
     {
       "at": "2026-07-02T22:14:40.126586Z",
       "diff_fingerprint": "sha256:87c7f1a41c6c492bb3798bf89b5039efe33c9698756781efa469931b0e20018a",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-07-02T22:14:58.782759Z",
+      "diff_fingerprint": "sha256:c94dc3f43ba80cd47efb50d70f231afa17f6ace51f7b01a40bc2eb031d88fe52",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 1,

--- a/.workflow/records/1912-guided-1912-edit-workflow-mcp.json
+++ b/.workflow/records/1912-guided-1912-edit-workflow-mcp.json
@@ -444,9 +444,9 @@
   ],
   "check_na": [],
   "commit": {
-    "sha": "1cce43da6a6ca0d9e002d24909dac90e5c601da7",
+    "sha": "ab1766ad5c4c3adef5215d875ba812104214719e",
     "shas": [
-      "1cce43da6a6ca0d9e002d24909dac90e5c601da7"
+      "ab1766ad5c4c3adef5215d875ba812104214719e"
     ],
     "trailers": []
   },
@@ -928,6 +928,170 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:15:10.475979Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:15:10.485537Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:15:10.495548Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:15:10.505961Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:15:10.515802Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:15:10.526605Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:15:10.538178Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:15:10.549732Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:15:10.560942Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:15:10.575326Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:15:22.710676Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:15:22.721930Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:15:22.731267Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:15:22.739797Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:15:22.748812Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:15:22.758565Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:15:22.767396Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:15:22.775867Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:15:22.785088Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:15:22.798638Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -940,7 +1104,7 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "origin/main",
+    "base": "a0eb440d5606a36c9b2b37294076ede4ba86cd09",
     "base_sha": "a0eb440d",
     "changed_files": [
       ".workflow/records/1912-guided-1912-edit-workflow-mcp.json",
@@ -960,9 +1124,9 @@
       "tests/contracts/test_runtime_import_contract.py",
       "tests/integration/test_phase2_mcp_end_to_end.py"
     ],
-    "diff_fingerprint": "sha256:c94dc3f43ba80cd47efb50d70f231afa17f6ace51f7b01a40bc2eb031d88fe52",
+    "diff_fingerprint": "sha256:5a7f41c08b44618553e3dc389057c339a86b3d407e5634ce8950270c24d82779",
     "head": "HEAD",
-    "head_sha": "1cce43da",
+    "head_sha": "ab1766ad",
     "surfaces": {
       "docs": 1,
       "frontend": 0,
@@ -983,7 +1147,7 @@
     "closes": [
       1912
     ],
-    "number": null,
+    "number": 1917,
     "url": null
   },
   "reconcile_events": [
@@ -1031,6 +1195,22 @@
     {
       "at": "2026-07-02T22:14:58.782759Z",
       "diff_fingerprint": "sha256:c94dc3f43ba80cd47efb50d70f231afa17f6ace51f7b01a40bc2eb031d88fe52",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-07-02T22:15:10.575360Z",
+      "diff_fingerprint": "sha256:5a7f41c08b44618553e3dc389057c339a86b3d407e5634ce8950270c24d82779",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-07-02T22:15:22.798665Z",
+      "diff_fingerprint": "sha256:5a7f41c08b44618553e3dc389057c339a86b3d407e5634ce8950270c24d82779",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 1,

--- a/.workflow/records/1912-guided-1912-edit-workflow-mcp.json
+++ b/.workflow/records/1912-guided-1912-edit-workflow-mcp.json
@@ -1,0 +1,179 @@
+{
+  "branch": "guided/1912-edit-workflow-mcp",
+  "check_events": [],
+  "check_na": [],
+  "commit": null,
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "src/scistudio/ai/agent/mcp/**",
+      "src/scistudio/_skills/**",
+      "docs/**",
+      "tests/**",
+      "CHANGELOG.md"
+    ]
+  },
+  "directive_events": [
+    {
+      "at": "2026-07-02T21:10:52.039338Z",
+      "owner_directive": "Placement: edit_workflow lives in tools_workflow/write.py next to write_workflow (both are workflow-write-class tools decorating @mcp.tool with tags category:workflow+write; reuses that module's _atomic_write_text, _LOCK_TIMEOUT_SECONDS, _workflow_change_context, _emit_agent_workflow_changed). EditWorkflowResult model added to tools_workflow/_models.py next to WriteWorkflowResult. Search/replace on file TEXT preserves config/comments/key-order verbatim; result re-parsed + validated against WorkflowFileModel exactly like write_workflow; refuse write on validation failure. Public surface snapshot (ADR-052) unaffected (MCP tool, not a public Python symbol) \u2014 verified. No new ADR/spec per owner.",
+      "reason": "plan"
+    }
+  ],
+  "docs_events": [
+    {
+      "at": "2026-07-02T21:10:52.039597Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/architecture/ARCHITECTURE.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-07-02T21:10:52.039828Z",
+      "class": null,
+      "kind": "path",
+      "path": "src/scistudio/_skills/scistudio/scistudio-build-workflow/SKILL.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-07-02T21:10:52.039832Z",
+      "class": null,
+      "kind": "path",
+      "path": "src/scistudio/_skills/scistudio/SKILL.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-07-02T21:10:52.039836Z",
+      "class": null,
+      "kind": "path",
+      "path": "CHANGELOG.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-07-02T21:10:52.039849Z",
+      "class": "adr",
+      "kind": "na",
+      "path": null,
+      "rationale": "owner decided NO new ADR; edit_workflow is agent tooling within the existing ADR-040 MCP-write model, not an architectural decision",
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-07-02T21:10:52.039856Z",
+      "class": "spec",
+      "kind": "na",
+      "path": null,
+      "rationale": "owner decided NO new spec; no contract/schema change \u2014 edit_workflow reuses WorkflowFileModel validation unchanged",
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": false,
+  "guard_events": [],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1912,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": null,
+  "owner_directive": "Add single edit_workflow MCP tool for surgical partial workflow edits so AI edits stop clobbering user-set block config; keep protect_workflow_yaml hook; update build-workflow skill + descriptive docs",
+  "persona": "implementer",
+  "pull_request": null,
+  "reconcile_events": [],
+  "record_id": "1912-guided-1912-edit-workflow-mcp",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [],
+    "docs": [],
+    "guards": [],
+    "tests": []
+  },
+  "runtime": "claude",
+  "schema_version": 2,
+  "scope_events": [
+    {
+      "action": "add-include",
+      "at": "2026-07-02T21:10:52.039571Z",
+      "pattern": "src/scistudio/ai/agent/mcp/tools_workflow/write.py",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-07-02T21:10:52.039582Z",
+      "pattern": "src/scistudio/ai/agent/mcp/tools_workflow/_models.py",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-07-02T21:10:52.039584Z",
+      "pattern": "src/scistudio/ai/agent/mcp/tools_workflow/__init__.py",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-07-02T21:10:52.039586Z",
+      "pattern": "docs/architecture/ARCHITECTURE.md",
+      "reason": "plan"
+    }
+  ],
+  "session_id": "44c52890-3348-4012-aa3c-98d8fa677175",
+  "strictness_tier": null,
+  "task_kind": "feature",
+  "test_events": [
+    {
+      "at": "2026-07-02T21:10:52.039860Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/ai/test_mcp_tools_workflow.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-07-02T21:10:52.039863Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/ai/test_mcp_tools_disk_integration.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-07-02T21:10:52.039864Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/ai/test_mcp_fastmcp.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-07-02T21:10:52.039865Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/contracts/test_runtime_import_contract.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-07-02T21:10:52.039866Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/ai/test_finish_ai_block_skeleton.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-07-02T21:10:52.039867Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/ai/agent/mcp/test_tools_workflow_surface.py",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/.workflow/records/1912-guided-1912-edit-workflow-mcp.json
+++ b/.workflow/records/1912-guided-1912-edit-workflow-mcp.json
@@ -440,13 +440,169 @@
       "tool_versions": {
         "mypy": "2.1.0"
       }
+    },
+    {
+      "at": "2026-07-02T22:22:24.026337Z",
+      "command": "pytest tests/architecture/ -v --no-cov",
+      "covered_surface": "architecture",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:833bd59abf3dae1d773380078b79402e334d5a4333b795fdf11f97f564657447",
+      "name": "architecture_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/architecture_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-02T22:22:24.932536Z",
+      "command": "python scripts/deferral_scan.py --check docs/audit/baselines/deferral-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:9a0168ccfdb4bb6c79d73a3828346c60966cddaf9388d2a67d791ed4458e7fbc",
+      "name": "deferral_discipline",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/deferral_discipline.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-02T22:22:25.056075Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:1ef403017a9d0139a770aaf7a4c5842f70c1fcb9c29837554d505621d12a8c51",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-07-02T22:22:29.794785Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:1f0e5d146c26022241cccc06f20bcdae354f916c20f34f03256311432ed1b447",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-02T22:22:29.935426Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:b306f262c10523ea97dbd0dfb9ec2f02b792e6c459c4d51614c09d8c94d3c82e",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-02T22:22:29.988798Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:9a9c0bba3fa5d1a3f9a5e338ac9998f26460dcf4794ade75575c4225628d8af0",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-07-02T22:25:32.809464Z",
+      "command": "python -m scistudio.qa.testing.run_python_tests --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:a2dae00486d48381875794197a7d1f208fa25e954fdfa50b916139f929e74b01",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-02T22:27:30.482290Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3030a63fc55a0a99cb24e5c702392fbe41a351a7cc920d17aec97a18f9b5732",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-02T22:27:31.986686Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:c2d78014c401292a9b5bae8569ab2e22329a827148e1706a80cc13b97d73c19c",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    },
+    {
+      "at": "2026-07-02T22:30:15.185517Z",
+      "command": "python -m scistudio.qa.testing.run_python_tests --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:a2dae00486d48381875794197a7d1f208fa25e954fdfa50b916139f929e74b01",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
     }
   ],
   "check_na": [],
   "commit": {
-    "sha": "ab1766ad5c4c3adef5215d875ba812104214719e",
+    "sha": "e1b56a0fc3883979fba0b11f3053a597e023f662",
     "shas": [
-      "ab1766ad5c4c3adef5215d875ba812104214719e"
+      "e1b56a0fc3883979fba0b11f3053a597e023f662"
     ],
     "trailers": []
   },
@@ -1092,6 +1248,252 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:27:32.046913Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:27:32.056672Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:27:32.066565Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:27:32.075855Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:27:32.085301Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:27:32.094385Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:27:32.103354Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:27:32.113440Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:27:32.122213Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:27:32.136205Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:30:15.237872Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:30:15.248394Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:30:15.258358Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:30:15.267908Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:30:15.277901Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:30:15.288035Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:30:15.297728Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:30:15.308273Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:30:15.319317Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:30:15.335454Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:30:28.363100Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:30:28.372894Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:30:28.382576Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:30:28.392192Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:30:28.401482Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:30:28.411419Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:30:28.421819Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:30:28.432156Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:30:28.441899Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:30:28.456908Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -1124,9 +1526,9 @@
       "tests/contracts/test_runtime_import_contract.py",
       "tests/integration/test_phase2_mcp_end_to_end.py"
     ],
-    "diff_fingerprint": "sha256:5a7f41c08b44618553e3dc389057c339a86b3d407e5634ce8950270c24d82779",
+    "diff_fingerprint": "sha256:cf30ba3f674ff9f78452e50694e50ddc4d1a38642c0163a2015fe065b6f8837c",
     "head": "HEAD",
-    "head_sha": "ab1766ad",
+    "head_sha": "e1b56a0f",
     "surfaces": {
       "docs": 1,
       "frontend": 0,
@@ -1211,6 +1613,32 @@
     {
       "at": "2026-07-02T22:15:22.798665Z",
       "diff_fingerprint": "sha256:5a7f41c08b44618553e3dc389057c339a86b3d407e5634ce8950270c24d82779",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-07-02T22:27:32.136240Z",
+      "diff_fingerprint": "sha256:cf30ba3f674ff9f78452e50694e50ddc4d1a38642c0163a2015fe065b6f8837c",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.python_tests"
+      ]
+    },
+    {
+      "at": "2026-07-02T22:30:15.335493Z",
+      "diff_fingerprint": "sha256:cf30ba3f674ff9f78452e50694e50ddc4d1a38642c0163a2015fe065b6f8837c",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-07-02T22:30:28.456938Z",
+      "diff_fingerprint": "sha256:cf30ba3f674ff9f78452e50694e50ddc4d1a38642c0163a2015fe065b6f8837c",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 1,

--- a/.workflow/records/1912-guided-1912-edit-workflow-mcp.json
+++ b/.workflow/records/1912-guided-1912-edit-workflow-mcp.json
@@ -1,6 +1,447 @@
 {
   "branch": "guided/1912-edit-workflow-mcp",
-  "check_events": [],
+  "check_events": [
+    {
+      "at": "2026-07-02T21:24:05.169757Z",
+      "command": "pytest tests/architecture/ -v --no-cov",
+      "covered_surface": "architecture",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:887e47765ebf1ae7220244d08604a9c44c83751439a4629994e7eeda9e37b1bb",
+      "name": "architecture_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/architecture_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-02T21:24:05.973986Z",
+      "command": "python scripts/deferral_scan.py --check docs/audit/baselines/deferral-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:67f5ac025c1055e41ad5d440bb6022d80d4559bbf6bfd150b0bb48aab6bc6f08",
+      "name": "deferral_discipline",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/deferral_discipline.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-02T21:24:06.331594Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:d07d25c4d3b5f5c8c22f6326d3f85ffc7dc77bbe215e4a465cabc58aa34796a8",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-07-02T21:24:10.209619Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:43ad5c692cdbfc0fd184eca877642ffa13b88581b92e31314adee1d518821f6d",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-02T21:24:10.701183Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:00a049d76c86464bbf50843fe69c1f65e7c2d406e6a0fa1b2e70be662102508f",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-02T21:24:10.743158Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:9fd4c77bb27e688a3f6115ee8d1ecd7a1893ce46c5a0e7011e30b635e2ddecc8",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-07-02T21:28:47.453335Z",
+      "command": "python -m scistudio.qa.testing.run_python_tests --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:0ff2e01676d86d842e54ab5808ae1c74211d241c4775e6278aea547f45efb8da",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-02T21:36:08.104190Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:8ee603c9873afbf19a379a5ec43ce0df8ca79830330a38db9ca9f113eed3a5a6",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-02T21:36:22.015958Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:524d1a2739d5ee92ab059afddb813d8c744f179d4b12c8849b8fb287d1ab76a2",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    },
+    {
+      "at": "2026-07-02T21:47:50.385607Z",
+      "command": "pytest tests/architecture/ -v --no-cov",
+      "covered_surface": "architecture",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:3ddd26ee33330344ec1cf66ac188249b5374e68eb23ab71b6b0128af19341c3c",
+      "name": "architecture_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/architecture_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-02T21:47:51.210780Z",
+      "command": "python scripts/deferral_scan.py --check docs/audit/baselines/deferral-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:d51f9e5b01e29249228c18dea6c1bbb58ad43853d82582044962421b92a625d4",
+      "name": "deferral_discipline",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/deferral_discipline.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-02T21:47:51.266310Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:00d1425cdba5b58cf49e80cc1fa2b3492c5cac1110da21ad77544a18d5cffee8",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-07-02T21:47:55.572842Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:2a045b925b1dd4e7b9aa24b8179c955955a2e825daf542cfd315e4d01144078a",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-02T21:47:55.709023Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:32649c5a5d6ba37d16c74a5e68c08f36b544e0de6d97ac9f8102e8ed55fd02eb",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-02T21:47:55.730161Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:186e2a0473077c892b174ac477e9102e83845f842296ff9a050d318941c23e03",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-07-02T21:51:30.238855Z",
+      "command": "python -m scistudio.qa.testing.run_python_tests --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:d4d82f19983cb4bba05bac0a40e73a7e2d91aeed4ee69fe20d8387269221287f",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-02T21:58:56.801988Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:ed09ab67eba0eea08831bb195b5f6b1f085620da6737ca4d6ea54cd6216a75a6",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-02T21:58:58.535781Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:c1d51d1570a77687717779a67cca16dfd18ec7ad1638685d32d885b99030695f",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    },
+    {
+      "at": "2026-07-02T22:07:31.980653Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:00d1425cdba5b58cf49e80cc1fa2b3492c5cac1110da21ad77544a18d5cffee8",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-07-02T22:09:52.874637Z",
+      "command": "python -m scistudio.qa.testing.run_python_tests --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:d4d82f19983cb4bba05bac0a40e73a7e2d91aeed4ee69fe20d8387269221287f",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-02T22:10:48.376820Z",
+      "command": "python scripts/deferral_scan.py --check docs/audit/baselines/deferral-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:131ccdd5f9f515d611d4a7f55b80f98619c4be1e90a140d7c74502517425c76e",
+      "name": "deferral_discipline",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/deferral_discipline.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-02T22:10:48.425238Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:97fbf7be5d25e6ea7994ab4afe37633c2030878eeffb77d2c3e35960f987e84b",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-07-02T22:10:52.261151Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:0b0e98074d951cce39763fa4a2646a310f9b00c521e1634204b0029236f0eb44",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-02T22:10:52.395621Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:acf966e61e0e4ff22db4fe1cd136d8a2d4d4d7bb983a7753235be6dd237b45f9",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-02T22:10:52.422381Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:3da5ea2da982ade7d5a09b7b4a3c8a37771f1fe16766a368e1635bd0ee167479",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-07-02T22:12:22.698953Z",
+      "command": "python -m scistudio.qa.testing.run_python_tests --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:6c1b131eecf9e9e7f6567aa7cc2d2a4086d62780ccc4fa813700464dc25dab5b",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-02T22:14:38.817257Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:1b9c88d80a6705dc0847cedde08478532277b1925c71cba9dda5c92adaec245c",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-02T22:14:39.940579Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:66157b9af5d69d5ed25c5fe5452910558881cf3b39ff4b7794403bca3c7ecdd3",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    }
+  ],
   "check_na": [],
   "commit": null,
   "declared_scope": {
@@ -71,7 +512,336 @@
     }
   ],
   "governance_touch": false,
-  "guard_events": [],
+  "guard_events": [
+    {
+      "at": "2026-07-02T21:36:22.096808Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:36:22.120013Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:36:22.135947Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:36:22.156217Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:36:22.173513Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:36:22.189520Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:36:22.211754Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:36:22.241928Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:36:22.265023Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:36:22.290521Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:58:58.618038Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:58:58.637245Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:58:58.658073Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:58:58.676257Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:58:58.697885Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:58:58.719366Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:58:58.736579Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:58:58.761569Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:58:58.781134Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T21:58:58.808904Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:09:52.920425Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:09:52.929217Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:09:52.937931Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:09:52.946422Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:09:52.955392Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:09:52.964176Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:09:52.972675Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:09:52.982648Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:09:52.991060Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:09:53.002441Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:14:39.996513Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:14:40.007368Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:14:40.018079Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:14:40.030638Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:14:40.044382Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:14:40.064174Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:14:40.086289Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:14:40.101468Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:14:40.113274Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:14:40.126551Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
   "issues": [
     {
       "close_in_pr": true,
@@ -81,19 +851,122 @@
     }
   ],
   "observed_admin_labels": [],
-  "observed_diff": null,
+  "observed_diff": {
+    "base": "origin/main",
+    "base_sha": "a0eb440d",
+    "changed_files": [
+      ".workflow/records/1912-guided-1912-edit-workflow-mcp.json",
+      "CHANGELOG.md",
+      "docs/architecture/ARCHITECTURE.md",
+      "src/scistudio/_skills/scistudio/SKILL.md",
+      "src/scistudio/_skills/scistudio/scistudio-build-workflow/SKILL.md",
+      "src/scistudio/ai/agent/mcp/tools_workflow/__init__.py",
+      "src/scistudio/ai/agent/mcp/tools_workflow/_models.py",
+      "src/scistudio/ai/agent/mcp/tools_workflow/write.py",
+      "tests/ai/agent/mcp/test_tools_workflow_surface.py",
+      "tests/ai/test_finish_ai_block_skeleton.py",
+      "tests/ai/test_mcp_fastmcp.py",
+      "tests/ai/test_mcp_tools_disk_integration.py",
+      "tests/ai/test_mcp_tools_workflow.py",
+      "tests/cli/test_mcp_bridge.py",
+      "tests/contracts/test_runtime_import_contract.py",
+      "tests/integration/test_phase2_mcp_end_to_end.py"
+    ],
+    "diff_fingerprint": "sha256:87c7f1a41c6c492bb3798bf89b5039efe33c9698756781efa469931b0e20018a",
+    "head": "HEAD",
+    "head_sha": "424414ec",
+    "surfaces": {
+      "docs": 1,
+      "frontend": 0,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 5,
+      "packaging": 0,
+      "protected_core": 0,
+      "sentrux": 14,
+      "test": 8,
+      "workflow_ci": 0
+    }
+  },
   "owner_directive": "Add single edit_workflow MCP tool for surgical partial workflow edits so AI edits stop clobbering user-set block config; keep protect_workflow_yaml hook; update build-workflow skill + descriptive docs",
   "persona": "implementer",
   "pull_request": null,
-  "reconcile_events": [],
+  "reconcile_events": [
+    {
+      "at": "2026-07-02T21:36:22.290576Z",
+      "diff_fingerprint": "sha256:71e7118098679e047f3493eb3e3a65255706aeccb30d8fb60675b484f06a78bb",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.format_check",
+        "checks.python_tests",
+        "checks.type_check"
+      ]
+    },
+    {
+      "at": "2026-07-02T21:58:58.809004Z",
+      "diff_fingerprint": "sha256:0bf1cfb3101112d8b032969daa63fa573f6b9bdbf179306dbe5347af2f7c39ed",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.format_check",
+        "checks.python_tests"
+      ]
+    },
+    {
+      "at": "2026-07-02T22:09:53.002713Z",
+      "diff_fingerprint": "sha256:0bf1cfb3101112d8b032969daa63fa573f6b9bdbf179306dbe5347af2f7c39ed",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.format_check"
+      ]
+    },
+    {
+      "at": "2026-07-02T22:14:40.126586Z",
+      "diff_fingerprint": "sha256:87c7f1a41c6c492bb3798bf89b5039efe33c9698756781efa469931b0e20018a",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    }
+  ],
   "record_id": "1912-guided-1912-edit-workflow-mcp",
   "requested_admin_labels": [],
   "required_obligations": {
     "admin_labels": [],
-    "checks": [],
-    "docs": [],
-    "guards": [],
-    "tests": []
+    "checks": [
+      "architecture_tests",
+      "deferral_discipline",
+      "format_check",
+      "full_audit",
+      "import_contracts",
+      "lint_format",
+      "python_tests",
+      "semantic_dup",
+      "type_check"
+    ],
+    "docs": [
+      "docs_required_or_na"
+    ],
+    "guards": [
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": [
+      "changed_test_required"
+    ]
   },
   "runtime": "claude",
   "schema_version": 2,
@@ -124,7 +997,7 @@
     }
   ],
   "session_id": "44c52890-3348-4012-aa3c-98d8fa677175",
-  "strictness_tier": null,
+  "strictness_tier": 1,
   "task_kind": "feature",
   "test_events": [
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- [#1912] `edit_workflow` MCP tool — a surgical partial-edit path for existing
+  workflow YAML. The agent previously had to re-emit a whole workflow through
+  `write_workflow` (full-file replace) for any structural change, which dropped
+  the user's GUI-set block `config` and comments. `edit_workflow(workflow_path,
+  edits=[{old_string, new_string}])` applies search/replace patches to the file
+  text (each `old_string` must match exactly once, or `replace_all`), preserving
+  everything untouched, then parses + validates the result against
+  `WorkflowFileModel` exactly like `write_workflow` and refuses to write on
+  failure. Atomic (all edits or none), file-locked, and emits the same versioned
+  `workflow.changed` event for GUI sync. `write_workflow` is now reserved for
+  CREATING a workflow; `update_block_config` for pure config patches. The
+  `protect_workflow_yaml` hook is unchanged — this is the sanctioned partial-edit
+  path. Updates the `scistudio-build-workflow` skill and the MCP tool surface doc
+  (33 → 34 tools). (@claude, 2026-07-02, branch: guided/1912-edit-workflow-mcp)
+
 ## [0.3.2] - 2026-06-28
 
 Standardized the public API surface (ADR-052) and added the alpha testing token

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -1321,7 +1321,7 @@ state, and event bus context that the backend uses. This is why MCP calls can
 validate workflows, reload blocks, start runs, inspect lineage, and reflect live
 runtime state instead of operating as disconnected file edits.
 
-The production MCP surface contains 33 tools:
+The production MCP surface contains 34 tools:
 
 | Area | MCP tool | Purpose | Access |
 |---|---|---|---|
@@ -1330,7 +1330,8 @@ The production MCP surface contains 33 tools:
 | Workflow | <code>mcp&#95;&#95;scistudio&#95;&#95;list_types</code> | List registered data types for port and workflow authoring. | Read |
 | Workflow | <code>mcp&#95;&#95;scistudio&#95;&#95;get_workflow</code> | Read a project workflow definition. | Read |
 | Workflow | <code>mcp&#95;&#95;scistudio&#95;&#95;validate_workflow</code> | Validate workflow structure before execution or save. | Read |
-| Workflow | <code>mcp&#95;&#95;scistudio&#95;&#95;write_workflow</code> | Persist schema-validated workflow YAML. | Write |
+| Workflow | <code>mcp&#95;&#95;scistudio&#95;&#95;write_workflow</code> | Persist schema-validated workflow YAML (whole-file write; use to create a new workflow). | Write |
+| Workflow | <code>mcp&#95;&#95;scistudio&#95;&#95;edit_workflow</code> | Surgically edit part of an existing workflow via schema-validated search/replace patches, preserving untouched block config and comments. | Write |
 | Workflow | <code>mcp&#95;&#95;scistudio&#95;&#95;run_workflow</code> | Start a workflow run through the SciStudio runtime. | Write |
 | Workflow | <code>mcp&#95;&#95;scistudio&#95;&#95;cancel_run</code> | Cancel an active workflow run. | Write |
 | Workflow | <code>mcp&#95;&#95;scistudio&#95;&#95;get_run_status</code> | Poll run state, block state, and terminal outcome. | Read |

--- a/src/scistudio/_skills/scistudio/SKILL.md
+++ b/src/scistudio/_skills/scistudio/SKILL.md
@@ -72,8 +72,10 @@ underscore module.
 - The `mcp__scistudio__*` tools are your only interface to SciStudio; there
   is no command-line tool. Do not try to drive SciStudio from Bash.
 - Do NOT directly Edit/Write `workflows/*.yaml`. Use
-  `mcp__scistudio__write_workflow` / `update_block_config` so changes
-  flow through schema validation and lineage tracking. Hooks
+  `mcp__scistudio__write_workflow` (create a new workflow),
+  `mcp__scistudio__edit_workflow` (surgical partial edit of an existing
+  workflow), or `mcp__scistudio__update_block_config` (one block's config)
+  so changes flow through schema validation and lineage tracking. Hooks
   block direct edits.
 - Before writing a new block, call `mcp__scistudio__list_blocks` and
   reuse if any existing block's I/O contract matches.
@@ -96,7 +98,7 @@ plugins). Trust the rendered values; do not invent project metadata.
 ## Tool catalog
 
 The injected block below is replaced at prompt-composition time with
-the live MCP tool catalog (33 tools across workflow / authoring /
+the live MCP tool catalog (34 tools across workflow / authoring /
 inspection / qa / plot). Use tool names and descriptions from the rendered
 catalog; do not type from memory if uncertain.
 
@@ -112,14 +114,15 @@ skill (`scistudio-build-workflow`, `scistudio-write-block`,
 `scistudio-write-plot`) for the documented call sequence.
 
 <!-- tool_catalog:begin -->
-**Static fallback (33 tools — Codex sees this; Claude sees the live
+**Static fallback (34 tools — Codex sees this; Claude sees the live
 catalog re-spliced from FastMCP at compose time).**
 
-- **Workflow (11)** — `list_blocks`, `get_block_schema`, `list_types`,
-  `get_workflow`, `validate_workflow`, `write_workflow`,
+- **Workflow (12)** — `list_blocks`, `get_block_schema`, `list_types`,
+  `get_workflow`, `validate_workflow`, `write_workflow`, `edit_workflow`,
   `run_workflow`, `cancel_run`, `get_run_status`, `finish_ai_block`,
   `get_active_workflow_context`.
-  Read schemas and write/run workflow YAML; poll run status; close
+  Read schemas, create (`write_workflow`) or surgically edit
+  (`edit_workflow`) workflow YAML, and run it; poll run status; close
   out AI blocks; retrieve active workflow context for the current session.
 - **Authoring (5)** — `read_block_source`, `list_block_examples`,
   `scaffold_block`, `reload_blocks`, `run_block_tests`. Author and

--- a/src/scistudio/_skills/scistudio/scistudio-build-workflow/SKILL.md
+++ b/src/scistudio/_skills/scistudio/scistudio-build-workflow/SKILL.md
@@ -288,9 +288,26 @@ inspect_data(ref)                      # shape, dtype, axes
 preview_data(ref, fmt)                 # thumbnail / first rows
 ```
 
-Every write-class tool (`write_workflow`, `run_workflow`,
-`cancel_run`, `update_block_config`, `finish_ai_block`) returns a
-result envelope with a `next_step: str` field. Read it and follow.
+Every write-class tool (`write_workflow`, `edit_workflow`,
+`run_workflow`, `cancel_run`, `update_block_config`, `finish_ai_block`)
+returns a result envelope with a `next_step: str` field. Read it and follow.
+
+### 4.1 Creating vs editing an existing workflow
+
+`write_workflow` replaces the whole file — use it only to CREATE a new
+workflow. To change part of an *existing* workflow, do NOT re-emit the
+full YAML through `write_workflow`: re-emitting drops the user's GUI-set
+block `config` and comments. Instead:
+
+- Use `edit_workflow(workflow_path, edits=[{old_string, new_string}])` for
+  any partial edit (add or remove a node, rewire an edge, change a
+  description). It applies search/replace patches to the file and
+  preserves everything you do not touch; each `old_string` must match
+  exactly once (set `replace_all` to replace every occurrence). Call
+  `get_workflow` first to copy the exact text to replace, then
+  `validate_workflow` after.
+- Use `update_block_config(workflow_path, block_id, params)` when you only
+  need to change one block's config params.
 
 ## 5. When validation fails
 
@@ -338,8 +355,13 @@ changing something; the failure mode will recur.
   `Load`/`Save` can do the job.
 - Always call `list_blocks` + `get_block_schema` for each block before
   writing a workflow.
-- Always call `validate_workflow` after `write_workflow`. NEVER call
-  `run_workflow` on an unvalidated YAML.
+- Always call `validate_workflow` after `write_workflow` or
+  `edit_workflow`. NEVER call `run_workflow` on an unvalidated YAML.
+- Use `write_workflow` only to CREATE a workflow. To change an existing
+  one, use `edit_workflow` (partial edit) or `update_block_config` (config
+  only) so the user's block config and comments survive (§4.1).
+- Never edit `workflows/*.yaml` with Bash/Edit/Write; those are blocked by
+  the protect_workflow_yaml hook. Go through the MCP tools.
 - Edge port format is `"node_id:port_name"` (single colon, two
   strings) — NOT the canvas 4-field shape.
 - Always poll `get_run_status` until terminal (`succeeded` / `failed`
@@ -356,3 +378,6 @@ changing something; the failure mode will recur.
 - Polling `get_run_status` once and declaring done on `running`.
 - Hallucinating port names instead of calling `get_block_schema`.
 - Re-running a failed workflow without diagnosing the failure first.
+- Re-emitting a whole existing workflow through `write_workflow` for a
+  small change — it clobbers the user's block config and comments. Use
+  `edit_workflow` or `update_block_config` instead.

--- a/src/scistudio/ai/agent/mcp/tools_workflow/__init__.py
+++ b/src/scistudio/ai/agent/mcp/tools_workflow/__init__.py
@@ -76,6 +76,7 @@ from scistudio.ai.agent.mcp.tools_workflow._models import (
     BlockSchemaResult,
     BlockSummary,
     CancelRunResult,
+    EditWorkflowResult,
     FinishAIBlockError,
     FinishAIBlockOK,
     GetRunStatusResult,
@@ -101,7 +102,9 @@ from scistudio.ai.agent.mcp.tools_workflow.read import (
     validate_workflow,
 )
 from scistudio.ai.agent.mcp.tools_workflow.write import (
+    WorkflowEdit,
     cancel_run,
+    edit_workflow,
     run_workflow,
     write_workflow,
 )
@@ -128,6 +131,7 @@ __all__ = [  # noqa: RUF022 — grouped by role (helpers / models / tools)
     "BlockSchemaResult",
     "BlockSummary",
     "CancelRunResult",
+    "EditWorkflowResult",
     "FinishAIBlockError",
     "FinishAIBlockOK",
     "GetRunStatusResult",
@@ -137,9 +141,11 @@ __all__ = [  # noqa: RUF022 — grouped by role (helpers / models / tools)
     "TypeEntry",
     "ValidateWorkflowResult",
     "WorkflowDefinitionEnvelope",
+    "WorkflowEdit",
     "WriteWorkflowResult",
-    # ---- 11 MCP tool functions ----
+    # ---- 12 MCP tool functions ----
     "cancel_run",
+    "edit_workflow",
     "finish_ai_block",
     "get_active_workflow_context",
     "get_block_schema",

--- a/src/scistudio/ai/agent/mcp/tools_workflow/_models.py
+++ b/src/scistudio/ai/agent/mcp/tools_workflow/_models.py
@@ -165,6 +165,19 @@ class WriteWorkflowResult(BaseModel):
     )
 
 
+class EditWorkflowResult(BaseModel):
+    """Result envelope for ``edit_workflow`` (surgical partial edit)."""
+
+    path: str = Field(description="Absolute resolved path of the edited workflow.")
+    bytes_written: int = Field(description="Number of bytes written to disk.")
+    diff_summary: str = Field(description="Compact diff vs prior file contents.")
+    edits_applied: int = Field(description="Number of search/replace edits applied to the workflow text.")
+    next_step: str = Field(
+        default="Call mcp__scistudio__validate_workflow with the same path to confirm runtime acceptance.",
+        description="Suggested next MCP call to maintain workflow integrity.",
+    )
+
+
 class RunWorkflowResult(BaseModel):
     """Result envelope for ``run_workflow``."""
 
@@ -260,6 +273,7 @@ __all__ = [
     "BlockSchemaResult",
     "BlockSummary",
     "CancelRunResult",
+    "EditWorkflowResult",
     "FinishAIBlockError",
     "FinishAIBlockOK",
     "GetRunStatusResult",

--- a/src/scistudio/ai/agent/mcp/tools_workflow/write.py
+++ b/src/scistudio/ai/agent/mcp/tools_workflow/write.py
@@ -12,12 +12,13 @@ import contextlib
 import difflib
 import json
 import logging
+from collections.abc import Sequence
 from pathlib import Path
-from typing import Any
+from typing import Annotated, Any
 
 import yaml as yaml_module
 from filelock import FileLock, Timeout
-from pydantic import Field, ValidationError
+from pydantic import BaseModel, Field, ValidationError
 
 from scistudio.ai.agent.mcp._context import _resolve_project_path, get_context
 from scistudio.ai.agent.mcp.server import mcp
@@ -35,6 +36,7 @@ from scistudio.ai.agent.mcp.tools_workflow._helpers import (
 )
 from scistudio.ai.agent.mcp.tools_workflow._models import (
     CancelRunResult,
+    EditWorkflowResult,
     RunWorkflowResult,
     WriteWorkflowResult,
 )
@@ -134,6 +136,183 @@ async def write_workflow(
         bytes_written=bytes_written,
         diff_summary=summary,
         warnings=block_type_warnings,
+    )
+
+
+# ---------------------------------------------------------------------------
+# (a.6b) edit_workflow  (write-class, surgical search/replace)
+# ---------------------------------------------------------------------------
+
+
+class WorkflowEdit(BaseModel):
+    """One search/replace edit applied to a workflow YAML's text."""
+
+    old_string: str = Field(description="Exact text to find in the workflow YAML.")
+    new_string: str = Field(description="Text to replace it with.")
+    replace_all: bool = Field(
+        default=False,
+        description=(
+            "When true, replace every occurrence of old_string. When false "
+            "(default), old_string must match exactly once (like the Edit tool)."
+        ),
+    )
+
+
+def _apply_edits(text: str, edits: Sequence[WorkflowEdit | dict[str, Any]]) -> str:
+    """Apply ordered search/replace *edits* to *text*.
+
+    Each edit's ``old_string`` must match exactly once unless
+    ``replace_all`` is set. A zero-match or (non-``replace_all``)
+    multi-match edit raises ``ValueError`` before any write, mirroring the
+    Edit tool's uniqueness contract. Edits are applied in order to the
+    running text so a later edit sees the result of earlier ones;
+    everything the edits do not touch is preserved verbatim.
+    """
+    result = text
+    for index, raw in enumerate(edits):
+        # Coerce plain dicts (direct callers / non-FastMCP invocation) into the
+        # typed model. FastMCP coerces via the annotation, but internal callers
+        # and tests may pass dicts.
+        edit = raw if isinstance(raw, WorkflowEdit) else WorkflowEdit.model_validate(raw)
+        if edit.old_string == edit.new_string:
+            raise ValueError(
+                f"edit_workflow: edit #{index + 1} has identical old_string and new_string (no-op edits are rejected)."
+            )
+        count = result.count(edit.old_string)
+        if count == 0:
+            raise ValueError(
+                f"edit_workflow: edit #{index + 1} old_string not found in the "
+                f"workflow. Read the current YAML (get_workflow) and copy the exact "
+                f"text to replace, including indentation."
+            )
+        if count > 1 and not edit.replace_all:
+            raise ValueError(
+                f"edit_workflow: edit #{index + 1} old_string matched {count} times; "
+                f"it must match exactly once. Add more surrounding context to make it "
+                f"unique, or set replace_all=true to replace every occurrence."
+            )
+        result = result.replace(edit.old_string, edit.new_string)
+    return result
+
+
+@mcp.tool(name="edit_workflow", tags={"category:workflow", "write"})
+async def edit_workflow(
+    workflow_path: Annotated[str, Field(description="Project-relative path under workflows/.")],
+    edits: Annotated[
+        list[WorkflowEdit],
+        Field(description="Ordered search/replace edits applied atomically to the workflow YAML text."),
+    ],
+) -> EditWorkflowResult:
+    """Surgically edit part of an existing workflow YAML via search/replace patches.
+
+    Applies one or more ``{old_string, new_string}`` edits to the file's
+    text and preserves everything the edits do not touch — user-set block
+    ``config``, comments, and key order all survive. Each ``old_string``
+    must match exactly once (set ``replace_all`` to replace every match).
+    All edits apply atomically: if any edit fails to match or the result
+    fails schema validation, the file is left unchanged.
+
+    Use when:
+      - You're changing part of an existing workflow (add/remove a node,
+        rewire an edge, tweak a description) and must NOT clobber the
+        user's GUI-set block config or comments.
+
+    Do NOT use to:
+      - Create a new workflow — use ``write_workflow`` (whole-file write).
+      - Patch one block's config params — use ``update_block_config``
+        (schema-aware per-block patch).
+      - Edit ``workflows/*.yaml`` via Bash/Edit/Write tools — the
+        protect_workflow_yaml hook (ADR-040 §3.6) blocks such calls;
+        this is the sanctioned partial-edit path.
+
+    Returns ``EditWorkflowResult`` with ``next_step`` pointing at
+    ``validate_workflow`` for canonical post-edit verification.
+    """
+    from scistudio.workflow.schema import WorkflowFileModel
+
+    if not edits:
+        raise ValueError("edit_workflow: 'edits' must contain at least one edit.")
+
+    p = _resolve_project_path(workflow_path)
+    if not p.exists():
+        raise FileNotFoundError(
+            f"edit_workflow: workflow file not found: {p}. Use write_workflow to create a new workflow."
+        )
+    lock_path = str(p) + ".lock"
+
+    # Best-effort versioned event (GUI sync). A headless/minimal MCP context
+    # without a workflow runtime must still edit the YAML, so degrade to
+    # "no event" instead of raising — same pattern as update_block_config.
+    try:
+        version_context = _workflow_change_context()
+    except Exception:
+        version_context = None
+    version: int | None = None
+
+    try:
+        with FileLock(lock_path, timeout=_LOCK_TIMEOUT_SECONDS):
+            old = p.read_text(encoding="utf-8")
+
+            # Apply the search/replace edits to the file TEXT. Uniqueness /
+            # match errors raise before any write.
+            new_text = _apply_edits(old, edits)
+
+            # Pre-write validation: parse + validate the RESULT against the same
+            # pydantic model write_workflow / the runtime / the GET route use.
+            # Refuse to write on failure (leave the file unchanged).
+            try:
+                parsed = yaml_module.safe_load(new_text)
+            except yaml_module.YAMLError as exc:
+                raise ValueError(f"edit_workflow: edited YAML no longer parses: {exc}") from exc
+            try:
+                wf_file = WorkflowFileModel.model_validate(parsed)
+            except ValidationError as exc:
+                raise ValueError(
+                    "edit_workflow: refusing to write — the edited workflow no longer "
+                    "matches the SciStudio schema. Errors (JSON):\n" + json.dumps(exc.errors(), indent=2, default=str)
+                ) from exc
+            # Same block_type reconciliation write_workflow runs: unknown types
+            # hard-fail, package IO blocks are non-blocking (edit_workflow does
+            # not surface warnings, so we discard the return here).
+            _reconcile_node_block_types(wf_file)
+
+            if version_context is not None:
+                _, runtime = version_context
+                version = runtime.bump_workflow_version(p.stem)
+                mark_entity_write = getattr(runtime, "mark_entity_first_party_write", None)
+                if mark_entity_write is not None:
+                    with contextlib.suppress(TypeError):
+                        mark_entity_write(
+                            "workflow",
+                            p.stem,
+                            version,
+                            path=p,
+                            kind="modified",
+                            pending=True,
+                        )
+
+            bytes_written = _atomic_write_text(p, new_text)
+            summary = _diff_summary(old, new_text)
+    except Timeout as exc:
+        raise TimeoutError(
+            f"edit_workflow: could not acquire lock for {p} within {_LOCK_TIMEOUT_SECONDS}s (someone else is editing?)"
+        ) from exc
+
+    if version_context is not None:
+        await _emit_agent_workflow_changed(
+            workflow_id=p.stem,
+            path=p,
+            kind="modified",
+            version=version,
+            version_context=version_context,
+        )
+
+    logger.info("edit_workflow: edited %s with %d edit(s) (%s)", p, len(edits), summary)
+    return EditWorkflowResult(
+        path=str(p),
+        bytes_written=bytes_written,
+        diff_summary=summary,
+        edits_applied=len(edits),
     )
 
 
@@ -358,7 +537,10 @@ async def cancel_run(
 
 
 __all__: list[str] = [
+    "WorkflowEdit",
+    "_apply_edits",
     "cancel_run",
+    "edit_workflow",
     "run_workflow",
     "write_workflow",
 ]

--- a/src/scistudio/ai/agent/mcp/tools_workflow/write.py
+++ b/src/scistudio/ai/agent/mcp/tools_workflow/write.py
@@ -164,8 +164,8 @@ def _apply_edits(text: str, edits: Sequence[WorkflowEdit | dict[str, Any]]) -> s
     Each edit's ``old_string`` must match exactly once unless
     ``replace_all`` is set. A zero-match or (non-``replace_all``)
     multi-match edit raises ``ValueError`` before any write, mirroring the
-    Edit tool's uniqueness contract. Edits are applied in order to the
-    running text so a later edit sees the result of earlier ones;
+    Edit tool's uniqueness contract. Edits are applied in sequence to the
+    running text so each edit sees the result of the ones before it;
     everything the edits do not touch is preserved verbatim.
     """
     result = text

--- a/tests/ai/agent/mcp/test_tools_workflow_surface.py
+++ b/tests/ai/agent/mcp/test_tools_workflow_surface.py
@@ -70,6 +70,7 @@ _EXPECTED_TOOL_NAMES = (
     "get_workflow",
     "validate_workflow",
     "write_workflow",
+    "edit_workflow",
     "run_workflow",
     "cancel_run",
     "get_run_status",
@@ -85,6 +86,7 @@ _EXPECTED_MODEL_NAMES = (
     "WorkflowDefinitionEnvelope",
     "ValidateWorkflowResult",
     "WriteWorkflowResult",
+    "EditWorkflowResult",
     "RunWorkflowResult",
     "CancelRunResult",
     "BlockErrorEntry",
@@ -110,7 +112,7 @@ _EXPECTED_INTERNAL_NAMES = (
 
 
 def test_package_exposes_every_legacy_tool_name() -> None:
-    """All 10 ``@mcp.tool`` functions remain attribute-addressable on the package."""
+    """Every ``@mcp.tool`` function remains attribute-addressable on the package."""
     for name in _EXPECTED_TOOL_NAMES:
         assert hasattr(tools_workflow, name), f"missing tool {name!r} after refactor"
         assert callable(getattr(tools_workflow, name)), f"{name!r} is not callable"

--- a/tests/ai/test_finish_ai_block_skeleton.py
+++ b/tests/ai/test_finish_ai_block_skeleton.py
@@ -32,12 +32,12 @@ def test_finish_ai_block_is_registered() -> None:
     assert "write" in tags
 
 
-def test_registry_now_has_33_tools() -> None:
-    """ADR-035 §3.5 + ADR-040 §3.1 + Addendum 5 + ADR-048 SPEC 2: FastMCP exposes 33 tools."""
+def test_registry_now_has_34_tools() -> None:
+    """ADR-035 §3.5 + ADR-040 §3.1 + Addendum 5 + ADR-048 SPEC 2 + edit_workflow (#1912): FastMCP exposes 34 tools."""
     from scistudio.ai.agent.mcp.server import mcp
 
     tools = _run(mcp.list_tools())
-    assert len(tools) == 33
+    assert len(tools) == 34
 
 
 def test_finish_ai_block_handler_has_docstring() -> None:

--- a/tests/ai/test_mcp_fastmcp.py
+++ b/tests/ai/test_mcp_fastmcp.py
@@ -2,7 +2,7 @@
 
 Asserts the FastMCP-backed MCP server matches the ADR-040 contract:
 
-* 33 tools discoverable via ``await mcp.list_tools()``
+* 34 tools discoverable via ``await mcp.list_tools()``
   (26 from ADR-040 §3.1 + 1 from Addendum 5 / #1488 + 6 plot tools
   from ADR-048 SPEC 2).
 * Every write-class tool's result model has ``next_step: str``.
@@ -39,6 +39,8 @@ _EXPECTED_TOOL_NAMES = {
     "get_workflow",
     "validate_workflow",
     "write_workflow",
+    # #1912: surgical partial-edit workflow tool
+    "edit_workflow",
     "run_workflow",
     "cancel_run",
     "get_run_status",
@@ -83,10 +85,10 @@ def _run(coro):
 # ---------------------------------------------------------------------------
 
 
-def test_fastmcp_lists_33_tools() -> None:
-    """ADR-040 §3.1 + Addendum 5 + ADR-048 SPEC 2: 33 tools (27 + 6 plot)."""
+def test_fastmcp_lists_34_tools() -> None:
+    """ADR-040 §3.1 + Addendum 5 + ADR-048 SPEC 2 + edit_workflow (#1912): 34 tools (28 + 6 plot)."""
     tools = _run(mcp.list_tools())
-    assert len(tools) == 33
+    assert len(tools) == 34
     names = {t.name for t in tools}
     assert names == _EXPECTED_TOOL_NAMES, (
         f"missing: {_EXPECTED_TOOL_NAMES - names}; extra: {names - _EXPECTED_TOOL_NAMES}"
@@ -97,6 +99,7 @@ def test_write_class_tools_have_next_step() -> None:
     """ADR-040 §3.2: every write-class tool's result model has next_step: str."""
     write_class = {
         "write_workflow",
+        "edit_workflow",
         "run_workflow",
         "cancel_run",
         "finish_ai_block",

--- a/tests/ai/test_mcp_tools_disk_integration.py
+++ b/tests/ai/test_mcp_tools_disk_integration.py
@@ -335,7 +335,12 @@ def test_edit_workflow_preserves_config_and_resolves_path(
     user-set block ``config`` and structural comments untouched. The result
     envelope returns the absolute resolved path under project_dir.
     """
-    _run(tools_workflow.write_workflow(path="workflows/edit_target.yaml", yaml=_COMMENTED_WF))
+    # #1910: the file-name stem must equal the internal id.
+    _run(
+        tools_workflow.write_workflow(
+            path="workflows/edit_target.yaml", yaml=_COMMENTED_WF.replace("id: commented", "id: edit_target")
+        )
+    )
     out = _run(
         tools_workflow.edit_workflow(
             workflow_path="workflows/edit_target.yaml",
@@ -375,7 +380,12 @@ def test_concurrent_edit_workflow_serialises(
     project_root: Path,
 ) -> None:
     """Two concurrent edits on the same path serialise via the shared file lock."""
-    _run(tools_workflow.write_workflow(path="workflows/concurrent_edit.yaml", yaml=_COMMENTED_WF))
+    # #1910: the file-name stem must equal the internal id.
+    _run(
+        tools_workflow.write_workflow(
+            path="workflows/concurrent_edit.yaml", yaml=_COMMENTED_WF.replace("id: commented", "id: concurrent_edit")
+        )
+    )
     results: list[Any] = []
     errors: list[BaseException] = []
 
@@ -393,7 +403,7 @@ def test_concurrent_edit_workflow_serialises(
 
     # Two edits touching different lines: both should apply once the lock
     # serialises them (each old_string still matches exactly once).
-    t1 = threading.Thread(target=_worker, args=("id: commented_wf", "id: renamed_wf"))
+    t1 = threading.Thread(target=_worker, args=("id: concurrent_edit", "id: renamed_wf"))
     t2 = threading.Thread(target=_worker, args=("backend: csv", "backend: json"))
     t1.start()
     t2.start()

--- a/tests/ai/test_mcp_tools_disk_integration.py
+++ b/tests/ai/test_mcp_tools_disk_integration.py
@@ -311,6 +311,93 @@ def test_update_block_config_preserves_comments(
 
 
 # ---------------------------------------------------------------------------
+# Case 9b: edit_workflow surgical partial edit preserves untouched content (#1912).
+# ---------------------------------------------------------------------------
+
+
+def test_edit_workflow_preserves_config_and_resolves_path(
+    ctx_with_project: _StubRuntime,
+    project_root: Path,
+) -> None:
+    """edit_workflow applies a search/replace to file text, preserving the rest.
+
+    Unlike write_workflow (full-file replace), a partial edit must leave a
+    user-set block ``config`` and structural comments untouched. The result
+    envelope returns the absolute resolved path under project_dir.
+    """
+    _run(tools_workflow.write_workflow(path="workflows/edit_target.yaml", yaml=_COMMENTED_WF))
+    out = _run(
+        tools_workflow.edit_workflow(
+            workflow_path="workflows/edit_target.yaml",
+            edits=[{"old_string": "backend: csv", "new_string": "backend: parquet"}],
+        )
+    )
+    target = (project_root / "workflows" / "edit_target.yaml").resolve()
+    text = target.read_text(encoding="utf-8")
+    # The targeted edit landed; the untouched comment survives verbatim.
+    assert "backend: parquet" in text
+    assert "backend: csv" not in text
+    assert "Top-level comment preserved by ruamel" in text
+    # Envelope echoes the resolved absolute path.
+    assert Path(out.path).resolve() == target
+    assert Path(out.path).is_absolute()
+    assert out.edits_applied == 1
+
+
+def test_edit_workflow_relative_traversal_escape_raises_permission_error(
+    ctx_with_project: _StubRuntime,
+    project_root: Path,
+) -> None:
+    """A ``../`` escape in the path is normalised and rejected before any read/write."""
+    with pytest.raises(PermissionError, match="resolves outside project root"):
+        _run(
+            tools_workflow.edit_workflow(
+                workflow_path="../escape_edit.yaml",
+                edits=[{"old_string": "a", "new_string": "b"}],
+            )
+        )
+    bogus = (project_root.parent / "escape_edit.yaml").resolve()
+    assert not bogus.exists()
+
+
+def test_concurrent_edit_workflow_serialises(
+    ctx_with_project: _StubRuntime,
+    project_root: Path,
+) -> None:
+    """Two concurrent edits on the same path serialise via the shared file lock."""
+    _run(tools_workflow.write_workflow(path="workflows/concurrent_edit.yaml", yaml=_COMMENTED_WF))
+    results: list[Any] = []
+    errors: list[BaseException] = []
+
+    def _worker(old: str, new: str) -> None:
+        try:
+            r = _run(
+                tools_workflow.edit_workflow(
+                    workflow_path="workflows/concurrent_edit.yaml",
+                    edits=[{"old_string": old, "new_string": new}],
+                )
+            )
+            results.append(r)
+        except BaseException as exc:
+            errors.append(exc)
+
+    # Two edits touching different lines: both should apply once the lock
+    # serialises them (each old_string still matches exactly once).
+    t1 = threading.Thread(target=_worker, args=("id: commented_wf", "id: renamed_wf"))
+    t2 = threading.Thread(target=_worker, args=("backend: csv", "backend: json"))
+    t1.start()
+    t2.start()
+    t1.join()
+    t2.join()
+
+    assert not errors, f"unexpected errors: {errors}"
+    assert len(results) == 2
+    content = (project_root / "workflows" / "concurrent_edit.yaml").resolve().read_text(encoding="utf-8")
+    assert "renamed_wf" in content
+    assert "backend: json" in content
+
+
+# ---------------------------------------------------------------------------
 # Case 10: every write tool returns an absolute path.
 # ---------------------------------------------------------------------------
 

--- a/tests/ai/test_mcp_tools_workflow.py
+++ b/tests/ai/test_mcp_tools_workflow.py
@@ -391,6 +391,184 @@ def test_write_workflow_rejects_unparseable_yaml(ctx: _StubRuntime, tmp_path: Pa
     assert not target.exists()
 
 
+# --- edit_workflow (#1912) -------------------------------------------------
+
+# A workflow that carries user-set block config + a structural comment. The
+# partial-edit tool must preserve everything the edits do not touch.
+_WF_WITH_CONFIG = """\
+# user comment: do not lose me
+workflow:
+  id: edit_wf
+  version: 1.0.0
+  description: original description
+  nodes:
+    - id: b1
+      block_type: load_data
+      config:
+        core_type: DataFrame
+        path: data/raw/in.csv   # user-tuned inline value
+  edges: []
+"""
+
+
+def test_edit_workflow_partial_edit_preserves_config_and_comments(ctx: _StubRuntime, tmp_path: Path) -> None:
+    target = tmp_path / "workflows" / "edit_wf.yaml"
+    _run(tools_workflow.write_workflow(str(target), _WF_WITH_CONFIG))
+
+    result = _run(
+        tools_workflow.edit_workflow(
+            workflow_path=str(target),
+            edits=[{"old_string": "original description", "new_string": "updated description"}],
+        )
+    )
+
+    text = target.read_text(encoding="utf-8")
+    # The targeted edit landed.
+    assert "updated description" in text
+    assert "original description" not in text
+    # Everything untouched survives verbatim: comment, block config, inline note.
+    assert "# user comment: do not lose me" in text
+    assert "core_type: DataFrame" in text
+    assert "path: data/raw/in.csv   # user-tuned inline value" in text
+    # Envelope contract.
+    assert result.edits_applied == 1
+    assert result.bytes_written > 0
+    assert Path(result.path).resolve() == target.resolve()
+    assert "validate_workflow" in result.next_step
+
+
+def test_edit_workflow_zero_match_rejected_no_write(ctx: _StubRuntime, tmp_path: Path) -> None:
+    target = tmp_path / "workflows" / "edit_wf.yaml"
+    _run(tools_workflow.write_workflow(str(target), _WF_WITH_CONFIG))
+    before = target.read_text(encoding="utf-8")
+
+    with pytest.raises(ValueError, match=r"not found"):
+        _run(
+            tools_workflow.edit_workflow(
+                workflow_path=str(target),
+                edits=[{"old_string": "no such text anywhere", "new_string": "x"}],
+            )
+        )
+    # File is unchanged.
+    assert target.read_text(encoding="utf-8") == before
+
+
+def test_edit_workflow_non_unique_match_rejected(ctx: _StubRuntime, tmp_path: Path) -> None:
+    target = tmp_path / "workflows" / "edit_wf.yaml"
+    _run(tools_workflow.write_workflow(str(target), _WF_WITH_CONFIG))
+    before = target.read_text(encoding="utf-8")
+
+    # "id:" appears more than once (workflow id + node id).
+    with pytest.raises(ValueError, match=r"matched .* times"):
+        _run(
+            tools_workflow.edit_workflow(
+                workflow_path=str(target),
+                edits=[{"old_string": "id:", "new_string": "id: "}],
+            )
+        )
+    assert target.read_text(encoding="utf-8") == before
+
+
+def test_edit_workflow_replace_all(ctx: _StubRuntime, tmp_path: Path) -> None:
+    target = tmp_path / "workflows" / "edit_wf.yaml"
+    _run(tools_workflow.write_workflow(str(target), _WF_WITH_CONFIG))
+
+    # DataFrame -> Series everywhere it appears (schema still valid).
+    result = _run(
+        tools_workflow.edit_workflow(
+            workflow_path=str(target),
+            edits=[{"old_string": "DataFrame", "new_string": "Series", "replace_all": True}],
+        )
+    )
+    text = target.read_text(encoding="utf-8")
+    assert "DataFrame" not in text
+    assert "core_type: Series" in text
+    assert result.edits_applied == 1
+
+
+def test_edit_workflow_multi_edit_atomic_rejects_on_invalid_result(ctx: _StubRuntime, tmp_path: Path) -> None:
+    target = tmp_path / "workflows" / "edit_wf.yaml"
+    _run(tools_workflow.write_workflow(str(target), _WF_WITH_CONFIG))
+    before = target.read_text(encoding="utf-8")
+
+    # First edit is fine, second breaks the schema (removes the required
+    # top-level `workflow:` key). The whole batch must roll back — no write.
+    with pytest.raises(ValueError, match=r"schema|parse"):
+        _run(
+            tools_workflow.edit_workflow(
+                workflow_path=str(target),
+                edits=[
+                    {"old_string": "original description", "new_string": "new description"},
+                    {"old_string": "workflow:", "new_string": "not_workflow:"},
+                ],
+            )
+        )
+    # Atomicity: neither edit persisted.
+    assert target.read_text(encoding="utf-8") == before
+
+
+def test_edit_workflow_missing_file_raises(ctx: _StubRuntime, tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError, match=r"not found"):
+        _run(
+            tools_workflow.edit_workflow(
+                workflow_path=str(tmp_path / "workflows" / "nope.yaml"),
+                edits=[{"old_string": "a", "new_string": "b"}],
+            )
+        )
+
+
+def test_edit_workflow_emits_agent_versioned_change_event(tmp_path: Path) -> None:
+    runtime = _VersionedStubRuntime(tmp_path)
+    _context.set_context(runtime)
+    try:
+        target = tmp_path / "workflows" / "edit_wf.yaml"
+        _run(tools_workflow.write_workflow(str(target), _WF_WITH_CONFIG))
+        # Reset write_workflow's create event so we assert only the edit event.
+        runtime.event_bus.events.clear()
+        runtime.first_party_writes.clear()
+        runtime.pending_first_party_writes.clear()
+
+        result = _run(
+            tools_workflow.edit_workflow(
+                workflow_path=str(target),
+                edits=[{"old_string": "original description", "new_string": "edited"}],
+            )
+        )
+    finally:
+        _context.set_context(None)
+
+    assert result.edits_applied == 1
+    # The edit bumps the version and emits one modified event.
+    assert len(runtime.event_bus.events) == 1
+    event = runtime.event_bus.events[0]
+    assert event.event_type == WORKFLOW_CHANGED
+    assert event.data["entity_id"] == "edit_wf"
+    assert event.data["kind"] == "modified"
+    assert event.data["source"] == "agent"
+    assert event.data["path"] == "workflows/edit_wf.yaml"
+
+
+def test_edit_workflow_headless_context_still_edits(ctx: _StubRuntime, tmp_path: Path) -> None:
+    """A minimal context with no versioned runtime still edits (degrade to no event)."""
+    target = tmp_path / "workflows" / "edit_wf.yaml"
+    _run(tools_workflow.write_workflow(str(target), _WF_WITH_CONFIG))
+    result = _run(
+        tools_workflow.edit_workflow(
+            workflow_path=str(target),
+            edits=[{"old_string": "original description", "new_string": "headless edit"}],
+        )
+    )
+    assert "headless edit" in target.read_text(encoding="utf-8")
+    assert result.edits_applied == 1
+
+
+def test_edit_workflow_empty_edits_rejected(ctx: _StubRuntime, tmp_path: Path) -> None:
+    target = tmp_path / "workflows" / "edit_wf.yaml"
+    _run(tools_workflow.write_workflow(str(target), _WF_WITH_CONFIG))
+    with pytest.raises(ValueError, match=r"at least one edit"):
+        _run(tools_workflow.edit_workflow(workflow_path=str(target), edits=[]))
+
+
 # --- run_workflow ----------------------------------------------------------
 
 

--- a/tests/cli/test_mcp_bridge.py
+++ b/tests/cli/test_mcp_bridge.py
@@ -148,9 +148,9 @@ def test_run_standalone_mode_returns_tools_list(tmp_path: Path, monkeypatch: pyt
     assert response.get("id") == 1
     tools = response.get("result", {}).get("tools")
     assert isinstance(tools, list), response
-    assert len(tools) == 33, (
-        f"expected 33 tools (26 baseline + get_active_workflow_context per ADR-040 Addendum 5 "
-        f"+ 6 ADR-048 SPEC 2 plot tools), got {len(tools)}"
+    assert len(tools) == 34, (
+        f"expected 34 tools (26 baseline + get_active_workflow_context per ADR-040 Addendum 5 "
+        f"+ 6 ADR-048 SPEC 2 plot tools + edit_workflow #1912), got {len(tools)}"
     )
 
 
@@ -218,7 +218,7 @@ def test_run_attached_mode_proxies_to_backend(tmp_path: Path, monkeypatch: pytes
         response = json.loads(lines[0].decode("utf-8"))
         assert response.get("id") == 99
         tools = response.get("result", {}).get("tools")
-        assert isinstance(tools, list) and len(tools) == 33  # ADR-040 Addendum 5 + ADR-048 SPEC 2 plot tools
+        assert isinstance(tools, list) and len(tools) == 34  # ADR-040 Addendum 5 + ADR-048 SPEC 2 plot + edit_workflow #1912
     finally:
         _shutdown.set()
         if server_thread is not None:

--- a/tests/cli/test_mcp_bridge.py
+++ b/tests/cli/test_mcp_bridge.py
@@ -218,7 +218,9 @@ def test_run_attached_mode_proxies_to_backend(tmp_path: Path, monkeypatch: pytes
         response = json.loads(lines[0].decode("utf-8"))
         assert response.get("id") == 99
         tools = response.get("result", {}).get("tools")
-        assert isinstance(tools, list) and len(tools) == 34  # ADR-040 Addendum 5 + ADR-048 SPEC 2 plot + edit_workflow #1912
+        assert (
+            isinstance(tools, list) and len(tools) == 34
+        )  # ADR-040 Addendum 5 + ADR-048 SPEC 2 plot + edit_workflow #1912
     finally:
         _shutdown.set()
         if server_thread is not None:

--- a/tests/contracts/test_runtime_import_contract.py
+++ b/tests/contracts/test_runtime_import_contract.py
@@ -15,7 +15,7 @@ the other contract files in tests/contracts/:
    contract break.
 
 3. **MCP tool registry contract**: The MCP server must always expose
-   exactly 33 tools (ADR-040 §3.1 + Addendum 5 + ADR-048 SPEC 2 plot
+   exactly 34 tools (ADR-040 §3.1 + Addendum 5 + ADR-048 SPEC 2 plot + edit_workflow #1912
    tools). This is a separate
    invariant from the parity test in test_mcp_fastmcp.py — it ensures
    the contract is also enforced from the contracts test suite so that
@@ -202,15 +202,16 @@ def test_api_ai_routes_are_registered(app_routes: set[str]) -> None:
 # 3. MCP tool registry contract.
 # ---------------------------------------------------------------------------
 
-# ADR-040 §3.1 + Addendum 5 (#1488) + ADR-048 SPEC 2: 33 tools total.
+# ADR-040 §3.1 + Addendum 5 (#1488) + ADR-048 SPEC 2 + edit_workflow (#1912): 34 tools total.
 _MCP_EXPECTED_TOOL_NAMES = {
-    # category (a) workflow (10 + 1 addendum5)
+    # category (a) workflow (11 + 1 addendum5)
     "list_blocks",
     "get_block_schema",
     "list_types",
     "get_workflow",
     "validate_workflow",
     "write_workflow",
+    "edit_workflow",
     "run_workflow",
     "cancel_run",
     "get_run_status",
@@ -243,11 +244,11 @@ _MCP_EXPECTED_TOOL_NAMES = {
     "validate_plot",
     "run_plot_job",
 }
-_MCP_EXPECTED_COUNT = 33
+_MCP_EXPECTED_COUNT = 34
 
 
-def test_mcp_server_exposes_33_tools() -> None:
-    """ADR-040 §3.1 + Addendum 5 + ADR-048 SPEC 2: MCP server must expose 33 tools.
+def test_mcp_server_exposes_34_tools() -> None:
+    """ADR-040 §3.1 + Addendum 5 + ADR-048 SPEC 2 + edit_workflow (#1912): MCP server must expose 34 tools.
 
     This contract test mirrors the parity check in test_mcp_fastmcp.py but
     lives in the contracts suite so a regression is flagged as an

--- a/tests/integration/test_phase2_mcp_end_to_end.py
+++ b/tests/integration/test_phase2_mcp_end_to_end.py
@@ -4,7 +4,7 @@ Drives the JSON-RPC dispatcher over the actual transport (Unix socket
 on POSIX, TCP loopback on Windows). Verifies:
 
 * ``initialize`` handshake returns server info.
-* ``tools/list`` enumerates all 33 tools (25 baseline + finish_ai_block + ADR-040 Addendum 5 get_active_workflow_context + 6 ADR-048 SPEC 2 plot tools).
+* ``tools/list`` enumerates all 34 tools (25 baseline + finish_ai_block + ADR-040 Addendum 5 get_active_workflow_context + 6 ADR-048 SPEC 2 plot tools).
 * ``tools/call`` for a read-only tool (``list_types``) round-trips.
 * Graceful start / stop, no orphan socket files on POSIX.
 """
@@ -76,14 +76,15 @@ async def _test_mcp_server_initialize_tools_list_and_call(tmp_path: Path) -> Non
         assert "result" in init
         assert init["result"]["serverInfo"]["name"] == "scistudio-mcp"
 
-        # tools/list — expect all 33 (25 baseline + finish_ai_block from ADR-035
+        # tools/list — expect all 34 (25 baseline + finish_ai_block from ADR-035
         # + get_active_workflow_context from ADR-040 Addendum 5
-        # + 6 plot tools from ADR-048 SPEC 2).
+        # + 6 plot tools from ADR-048 SPEC 2 + edit_workflow from #1912).
         listed = await _connect_and_call(server, {"jsonrpc": "2.0", "id": 2, "method": "tools/list"})
         tools = listed["result"]["tools"]
-        assert len(tools) == 33
+        assert len(tools) == 34
         names = {t["name"] for t in tools}
         assert "list_blocks" in names and "preview_data" in names and "search_docs" in names
+        assert "edit_workflow" in names
 
         # tools/call list_types
         called = await _connect_and_call(


### PR DESCRIPTION
## Summary

Adds a single `edit_workflow` MCP tool for surgical partial edits of existing
workflow YAML, so AI edits stop clobbering user-set block `config` and comments.
`write_workflow` re-emits the whole file (full replace); `edit_workflow` applies
search/replace patches to the text, preserving everything untouched, then
validates the result against `WorkflowFileModel` exactly like `write_workflow`
and refuses to write on failure. Atomic, file-locked, versioned-event-emitting.

`write_workflow` is now reserved for CREATING a workflow; `update_block_config`
for pure config patches; `edit_workflow` for partial structural edits. The
`protect_workflow_yaml` hook is unchanged — `edit_workflow` is the sanctioned
partial-edit path.

## Changes

- New `edit_workflow` tool + `EditWorkflowResult` model in
  `tools_workflow/write.py` / `_models.py` (registered as MCP tool 34).
- `scistudio-build-workflow` skill + top-level skill: create-vs-edit guidance.
- ARCHITECTURE.md MCP tool surface (33 → 34) and CHANGELOG entry.
- Tests: config/comment preservation, zero/non-unique match rejection,
  `replace_all`, multi-edit atomicity, version-bump + event, headless, path
  resolution + concurrency; updated 33 → 34 tool-count / tool-set assertions.

ADR-052 frozen public Python surface is unaffected (MCP tool, not a public
Python symbol). No new ADR / spec per owner direction.

Gate record: .workflow/records/1912-guided-1912-edit-workflow-mcp.json

Closes #1912
