### PR TITLE
feat(#1918): multi-format plot save/export (png/pdf/svg/jpeg)

### DIFF
--- a/.workflow/records/1918-guided-1918-plot-save-format.json
+++ b/.workflow/records/1918-guided-1918-plot-save-format.json
@@ -1,0 +1,1238 @@
+{
+  "branch": "guided/1918-plot-save-format",
+  "check_events": [
+    {
+      "at": "2026-07-02T22:37:03.500971Z",
+      "command": "pytest tests/architecture/ -v --no-cov",
+      "covered_surface": "architecture",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:9c759f14e2b8527583424e7aeb99d2b9a1f5bc752032aef8735baab57efb16d9",
+      "name": "architecture_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/architecture_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-02T22:37:04.305818Z",
+      "command": "python scripts/deferral_scan.py --check docs/audit/baselines/deferral-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:b152837fd615e020e730cdd23f832a3657ff6abcbe5d387e27c4cd6d51817a9b",
+      "name": "deferral_discipline",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/deferral_discipline.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-02T22:37:04.654219Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:b1e5ae620c4896e218743781c4fd4c09955569956db3e9ba33b27c74fa14a6f0",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-07-02T22:37:10.116384Z",
+      "command": "(cd frontend && npm run check:ci)",
+      "covered_surface": "frontend",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:67d4c158648f5411761a164811e104585c3665a27908d0cbb0ea5287f046dd0d",
+      "name": "frontend",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/frontend.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-02T22:37:13.879378Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:bf71da8bdd617d3a0c57e2ce6ac25fc31874219d4790ee0beaf757d2272a7bed",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-02T22:37:14.378161Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:69488e8170378a6cf87536fc71cbf3ac2a36a4b25553fb8a89ef4dd9875fce52",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-02T22:37:14.422433Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:d048d25b022f4e6ede4b92f22b939bc38ce7125272ea28c6c196d3c6ac098f25",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-07-02T22:40:17.165027Z",
+      "command": "python -m scistudio.qa.testing.run_python_tests --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:a7a3ad0c4210fa817ea79e2dbd181af647b8dc68a0ebbc91edf80d615b519620",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-02T22:42:09.793636Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:c3727a3a1c9208bdf81be7cd02d4495fe18e42a6bb90e1ce67bdea88b5252e1b",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-02T22:42:15.800982Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e9c73ebb5da2dd22e4c1889ccb9fd2544e843afedc95aaa90970322699443d72",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    },
+    {
+      "at": "2026-07-02T22:42:42.799701Z",
+      "command": "python scripts/deferral_scan.py --check docs/audit/baselines/deferral-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:69aabf26e2935a961135f5ae3e3d95251372a3d7a1d4fccde2aa888d761ba5dd",
+      "name": "deferral_discipline",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/deferral_discipline.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-02T22:43:33.323245Z",
+      "command": "(cd frontend && npm run check:ci)",
+      "covered_surface": "frontend",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:0a3913578cdd58ebc0d39ffd3fe1b13c006516668e9f5bf59a857c66ce35e5e7",
+      "name": "frontend",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/frontend.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-02T22:43:38.915263Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:447ff59c093c35cb1210d28bf06124f2d1173b9e8ff204b1ddd1a039721504ff",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-02T22:45:36.155723Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:3cb032298a807e113613e61d180161af4a7b70dc0a2ebf83a22d73783942ef2d",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-02T22:48:14.939558Z",
+      "command": "pytest tests/architecture/ -v --no-cov",
+      "covered_surface": "architecture",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:2d828dee9e7eec2628415a23dd404b2a613152cd9284cfe1e75afa1cd9c4a8ce",
+      "name": "architecture_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/architecture_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-02T22:48:15.718312Z",
+      "command": "python scripts/deferral_scan.py --check docs/audit/baselines/deferral-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e85d58d53db0bb698d9c226b8a139b1dae4a600e25a03a833008c2d888dce5f2",
+      "name": "deferral_discipline",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/deferral_discipline.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-02T22:48:15.762305Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:54e2af78f71b13cb25696e8cc0f3499f2a6fa6ad248148eca4493dad77b0f5fc",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-07-02T22:49:02.365508Z",
+      "command": "(cd frontend && npm run check:ci)",
+      "covered_surface": "frontend",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:0a3913578cdd58ebc0d39ffd3fe1b13c006516668e9f5bf59a857c66ce35e5e7",
+      "name": "frontend",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/frontend.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-02T22:49:06.363534Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:6bbf26af7d95b39169e3d476760d82128f37a917684a94cf6591b660708bb255",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-02T22:49:06.486343Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:4a2b397f41c758d3144f083bba56c146a7d762a56b12ed86060225f6a90e7a53",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-02T22:49:06.530191Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:bf620b48db995e000ac8752a09e7aef38b1b8176a9e16ce32ba013858cba0996",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-07-02T22:51:14.935292Z",
+      "command": "python -m scistudio.qa.testing.run_python_tests --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:2ca40cd4d89d410c6a52661996289dfb2faf6e4c0c361cd73bf8222f5133c7a9",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-02T22:53:37.363158Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:b9b5ba743ef9e47dfd033387884c2daf74ec441c7b62ca827a1642dddb8641e1",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-02T22:53:38.334195Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:4d4b80acd31581304182ed976df04cb2e8ccba42ac149a063f4d679cb4aaedfd",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    }
+  ],
+  "check_na": [],
+  "commit": {
+    "sha": "9a2a9669fda35c25cd352c04e10783344cefb1f1",
+    "shas": [
+      "9a2a9669fda35c25cd352c04e10783344cefb1f1"
+    ],
+    "trailers": []
+  },
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "src/scistudio/plot/**",
+      "src/scistudio/previewers/**",
+      "frontend/**",
+      "tests/**",
+      "CHANGELOG.md",
+      "docs/**"
+    ]
+  },
+  "directive_events": [
+    {
+      "at": "2026-07-02T22:20:49.553747Z",
+      "owner_directive": "Trace: harness figure/ggplot save -> _promote_artifacts -> PlotArtifact/cache layout -> preview session read_resource/save_resource -> plot export resource in fallbacks.py -> frontend PlotViewer/PreviewHost save. Harness saves all allowed formats as sibling figure.<ext> files; _promote_artifacts promotes current.<ext> siblings under caps; plot_previewer exposes available_formats; _export_plot_resource resolves the sibling matching the requested format; PlotViewer offers a format menu that passes format to save.",
+      "reason": "plan"
+    }
+  ],
+  "docs_events": [
+    {
+      "at": "2026-07-02T22:20:49.553918Z",
+      "class": null,
+      "kind": "path",
+      "path": "CHANGELOG.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-07-02T22:20:49.553934Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/specs/adr-048-ai-plot-tools.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-07-02T22:34:21.118204Z",
+      "class": null,
+      "kind": "path",
+      "path": "CHANGELOG.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-07-02T22:34:21.118644Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/specs/adr-048-ai-plot-tools.md",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": false,
+  "guard_events": [
+    {
+      "at": "2026-07-02T22:42:15.844343Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:42:15.854642Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:42:15.863933Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:42:15.872902Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:42:15.881833Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:42:15.891545Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:42:15.900696Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:42:15.911741Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:42:15.920807Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:42:15.932249Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:45:36.246456Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:45:36.257778Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:45:36.268722Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:45:36.279990Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:45:36.290799Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:45:36.302467Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:45:36.314295Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:45:36.327594Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:45:36.338598Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:45:36.352694Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:46:01.294955Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:46:01.303610Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:46:01.312266Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:46:01.321327Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:46:01.329942Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:46:01.338459Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:46:01.347981Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:46:01.357094Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:46:01.365485Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:46:01.376924Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:46:16.661042Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:46:16.669703Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:46:16.678623Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:46:16.687787Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:46:16.696853Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:46:16.705934Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:46:16.714429Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:46:16.723232Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:46:16.731728Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:46:16.745328Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:46:32.627126Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:46:32.635534Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:46:32.643859Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:46:32.652413Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:46:32.660811Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:46:32.669326Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:46:32.677574Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:46:32.686301Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:46:32.694981Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:46:32.708174Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:46:40.366856Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:46:40.376737Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:46:40.385753Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:46:40.394269Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:46:40.402650Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:46:40.411265Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:46:40.421427Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:46:40.430817Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:46:40.439738Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:46:40.451962Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:53:38.397648Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:53:38.407754Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:53:38.418462Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:53:38.429097Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:53:38.439481Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:53:38.466113Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:53:38.498250Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:53:38.509287Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:53:38.519307Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-02T22:53:38.533897Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1918,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": {
+    "base": "0e80087c2c89b412857112fe1e11c3a14fff3b45",
+    "base_sha": "0e80087c",
+    "changed_files": [
+      ".workflow/records/1918-guided-1918-plot-save-format.json",
+      "CHANGELOG.md",
+      "docs/specs/adr-048-ai-plot-tools.md",
+      "frontend/src/components/DataPreview.parts/PlotViewer.tsx",
+      "frontend/src/components/DataPreview.parts/PreviewHost.tsx",
+      "frontend/src/components/DataPreview.parts/coreViewers.test.tsx",
+      "src/scistudio/plot/_harness.py",
+      "src/scistudio/plot/runtime.py",
+      "src/scistudio/previewers/fallbacks.py",
+      "src/scistudio/previewers/session.py",
+      "tests/adr052_contract/test_plot_render_contract.py",
+      "tests/api/test_plot_preview_wiring.py"
+    ],
+    "diff_fingerprint": "sha256:b1bd16b55705407e700f268162ff08c977d5576822f3f9c3bcdc9f98c5de840a",
+    "head": "HEAD",
+    "head_sha": "9a2a9669",
+    "surfaces": {
+      "docs": 1,
+      "frontend": 3,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 7,
+      "packaging": 0,
+      "protected_core": 0,
+      "sentrux": 10,
+      "test": 3,
+      "workflow_ci": 0
+    }
+  },
+  "owner_directive": "Render all allowed plot formats at plot-run time so previewer Save/Export can produce valid png/pdf/svg/jpeg (approach B); preview stays svg; export picks the file matching the chosen format",
+  "persona": "implementer",
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [
+      1918
+    ],
+    "number": 1919,
+    "url": null
+  },
+  "reconcile_events": [
+    {
+      "at": "2026-07-02T22:42:15.932280Z",
+      "diff_fingerprint": "sha256:6a9e0d33ecff28f827f2f961d54f1eb765491a17aa32c98609569a89c62cff75",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.frontend"
+      ]
+    },
+    {
+      "at": "2026-07-02T22:45:36.352745Z",
+      "diff_fingerprint": "sha256:ab5ca085c3fa27e53d9c973b52d78a648ec8d0b37904e869f927d89e3fff7d5e",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-07-02T22:46:01.376967Z",
+      "diff_fingerprint": "sha256:ab5ca085c3fa27e53d9c973b52d78a648ec8d0b37904e869f927d89e3fff7d5e",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-07-02T22:46:16.745391Z",
+      "diff_fingerprint": "sha256:466dbcfcd6394f4eb5827c1dc10af5808a6aa0f1aa2e49edcfe778a53f7ce156",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-07-02T22:46:32.708238Z",
+      "diff_fingerprint": "sha256:466dbcfcd6394f4eb5827c1dc10af5808a6aa0f1aa2e49edcfe778a53f7ce156",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-07-02T22:46:40.452016Z",
+      "diff_fingerprint": "sha256:466dbcfcd6394f4eb5827c1dc10af5808a6aa0f1aa2e49edcfe778a53f7ce156",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-07-02T22:53:38.533953Z",
+      "diff_fingerprint": "sha256:b1bd16b55705407e700f268162ff08c977d5576822f3f9c3bcdc9f98c5de840a",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    }
+  ],
+  "record_id": "1918-guided-1918-plot-save-format",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [
+      "architecture_tests",
+      "deferral_discipline",
+      "format_check",
+      "frontend",
+      "full_audit",
+      "import_contracts",
+      "lint_format",
+      "python_tests",
+      "semantic_dup",
+      "type_check"
+    ],
+    "docs": [
+      "docs_required_or_na"
+    ],
+    "guards": [
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": [
+      "changed_test_required"
+    ]
+  },
+  "runtime": "claude",
+  "schema_version": 2,
+  "scope_events": [
+    {
+      "action": "add-include",
+      "at": "2026-07-02T22:20:49.553889Z",
+      "pattern": "src/scistudio/plot/_harness.py",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-07-02T22:20:49.553898Z",
+      "pattern": "src/scistudio/plot/runtime.py",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-07-02T22:20:49.553899Z",
+      "pattern": "src/scistudio/previewers/fallbacks.py",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-07-02T22:20:49.553901Z",
+      "pattern": "src/scistudio/previewers/session.py",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-07-02T22:20:49.553902Z",
+      "pattern": "frontend/src/components/DataPreview.parts/PlotViewer.tsx",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-07-02T22:20:49.553903Z",
+      "pattern": "frontend/src/components/DataPreview.parts/PreviewHost.tsx",
+      "reason": "plan"
+    }
+  ],
+  "session_id": "97b3f1a2-7a76-4491-aeb7-49986a12b228",
+  "strictness_tier": 1,
+  "task_kind": "feature",
+  "test_events": [
+    {
+      "at": "2026-07-02T22:20:49.553939Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/api/test_plot_preview_wiring.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-07-02T22:20:49.553942Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/adr052_contract/test_plot_render_contract.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-07-02T22:20:49.553943Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/ai/test_mcp_tools_plot.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-07-02T22:20:49.553944Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/components/DataPreview.parts/coreViewers.test.tsx",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- [#1918] Plot preview **Save** can now produce a valid `png` / `pdf` / `svg` /
+  `jpeg` file. Previously Save only ever wrote the single preferred (SVG)
+  artifact, and changing the destination extension yielded a broken file because
+  the export blindly reused the cached SVG bytes. Re-rendering on save is
+  impossible (the matplotlib figure is closed immediately after render), so the
+  plot run now renders one sibling file per manifest `allowed_formats` up front
+  (`figure.svg` + `.pdf` + `.png` + `.jpg`, promoted to `current.<ext>` in the
+  preview cache); the preview still shows the preferred format, and Save/Export
+  resolves the sibling matching the user's chosen format. The plot viewer gains
+  a format menu offering the formats the run rendered, and requesting an
+  unrendered format now errors cleanly instead of writing a corrupt file. Extra
+  formats degrade gracefully under the output caps (keep the primary, warn).
+  (`src/scistudio/plot/_harness.py`, `src/scistudio/plot/runtime.py`,
+  `src/scistudio/previewers/{fallbacks,session}.py`,
+  `frontend/src/components/DataPreview.parts/{PlotViewer,PreviewHost}.tsx`)
+  (@claude, 2026-07-02, branch: guided/1918-plot-save-format)
+
 - [#1910] Workflow file name and internal `id` may no longer diverge:
   `write_workflow` now refuses any write whose file-name stem differs from the
   workflow's `id` (e.g. `collagen_srs_pipeline.yaml` holding

--- a/docs/specs/adr-048-ai-plot-tools.md
+++ b/docs/specs/adr-048-ai-plot-tools.md
@@ -275,6 +275,23 @@ Acceptance Scenarios:
   must be updated for the new plot tools and skill.
 - FR-035: The tool workflow must be documented separately from block authoring:
   plot jobs are preview-only artifacts, not reusable block definitions.
+- FR-036: When a render returns a figure object, plot execution must render one
+  sibling artifact file per manifest `allowed_formats` value up front
+  (`current.svg` + `current.pdf` + `current.png` + `current.jpg`), because the
+  figure is closed immediately after render and cannot be re-rendered at
+  save/export time. The preferred-format file is the canonical preview primary;
+  the siblings exist so the previewer's Save/Export can produce a valid file in
+  any rendered format. A render that returns an artifact *path* (not a figure)
+  stays single-format — the author already chose that format. When the extra
+  formats would exceed the output-byte or file-count caps, the run degrades
+  gracefully to the preferred format per figure and warns, rather than failing.
+- FR-037: The `PlotPreviewer` export resource must resolve the sibling file that
+  matches the format the caller requested (via the `format` param derived from
+  the user's Save-as choice or destination extension) rather than the primary
+  bytes. The PLOT envelope must advertise the rendered formats
+  (`payload.available_formats`) so the frontend can offer a Save-as format
+  choice. Requesting a format that was not rendered must return a clear error,
+  never a corrupt file written under a mismatched extension.
 
 ### Key Entities
 
@@ -536,4 +553,7 @@ manifests imply an output exists until validation or run confirms it.
 - R execution may be optional in CI but must be supported by the runtime when R
   and required packages are available.
 - Preview cache paths are not scientific result paths; users must explicitly
-  save or export plot artifacts they want to keep.
+  save or export plot artifacts they want to keep. A figure is rendered to every
+  manifest-allowed format up front so an explicit save can produce a valid file
+  in the user's chosen format without re-rendering (the figure is already
+  closed); see FR-036 / FR-037.

--- a/frontend/src/components/DataPreview.parts/PlotViewer.tsx
+++ b/frontend/src/components/DataPreview.parts/PlotViewer.tsx
@@ -7,6 +7,34 @@ function asString(value: unknown, fallback = ""): string {
   return typeof value === "string" ? value : fallback;
 }
 
+// Canonical order the Save-as menu offers plot export formats in.
+const PLOT_EXPORT_FORMAT_ORDER = ["svg", "pdf", "png", "jpeg"] as const;
+
+// Formats the plot run actually rendered (approach B, #1918): the backend
+// surfaces one sibling file per allowed format, so Save can produce a valid
+// png/pdf/svg/jpeg without re-rendering. Falls back to the primary format when
+// the list is absent (older runs / non-plot artifacts).
+function availableFormats(payload: PreviewEnvelope["payload"]): string[] {
+  const raw = payload?.available_formats;
+  const found = new Set<string>();
+  if (Array.isArray(raw)) {
+    for (const entry of raw) {
+      if (typeof entry === "string" && entry) found.add(entry === "jpg" ? "jpeg" : entry);
+    }
+  }
+  const primary = asString(payload?.format, "");
+  if (primary) found.add(primary === "jpg" ? "jpeg" : primary);
+  const ordered = PLOT_EXPORT_FORMAT_ORDER.filter((f) => found.has(f));
+  return ordered.length > 0 ? ordered : primary ? [primary] : [];
+}
+
+// Build the export resource for a chosen format by overriding the descriptor's
+// `format` param. The backend export resource resolves the sibling file for
+// that format and returns valid bytes (or a clean error if it was not rendered).
+function exportResourceForFormat(base: PreviewResource, format: string): PreviewResource {
+  return { ...base, params: { ...(base.params ?? {}), format } };
+}
+
 // The surface sizes to the figure (no fixed height) so the plot fills the width
 // with no large empty top/bottom margins, capped by max-height. A single
 // overflow here handles pan when zoomed; the parent preview panel already
@@ -107,6 +135,21 @@ export function PlotViewer({
   const hasRenderable = Boolean((format === "svg" && svg) || (format === "pdf" && src) || src);
   const svgRatio = format === "svg" && svg ? svgAspectRatio(svg) : null;
 
+  const formats = availableFormats(payload);
+  // The format the user chose to save in. Defaults to the preview (preferred)
+  // format so a plain Save keeps today's behaviour; the menu lets the user pick
+  // any format the run rendered (approach B, #1918).
+  const [saveFormat, setSaveFormat] = useState(format || formats[0] || "svg");
+  const effectiveSaveFormat = formats.includes(saveFormat)
+    ? saveFormat
+    : formats[0] || format || "svg";
+  const canSave = Boolean(exportResource) && formats.length > 0;
+
+  const handleSave = () => {
+    if (!exportResource || !onExport) return;
+    onExport(exportResourceForFormat(exportResource, effectiveSaveFormat));
+  };
+
   const [zoom, setZoom] = useState(1);
   // Clamp to a sensible range and snap to 25% steps.
   const applyZoom = (next: number) => setZoom(Math.min(4, Math.max(0.5, Math.round(next * 4) / 4)));
@@ -199,18 +242,35 @@ export function PlotViewer({
             </Button>
           </div>
         ) : null}
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          data-testid="plot-export-button"
-          aria-label={`Save plot as ${format || "file"}`}
-          disabled={!exportResource}
-          onClick={() => (exportResource && onExport ? onExport(exportResource) : undefined)}
-          className="ml-auto h-7"
-        >
-          Save
-        </Button>
+        <div className="ml-auto flex items-center gap-1">
+          {formats.length > 1 ? (
+            <select
+              data-testid="plot-format-select"
+              aria-label="Save format"
+              value={effectiveSaveFormat}
+              onChange={(e) => setSaveFormat(e.target.value)}
+              className="h-7 rounded border border-ink/20 bg-white px-1 text-xs uppercase tracking-wider text-ink/70"
+            >
+              {formats.map((f) => (
+                <option key={f} value={f}>
+                  {f.toUpperCase()}
+                </option>
+              ))}
+            </select>
+          ) : null}
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            data-testid="plot-export-button"
+            aria-label={`Save plot as ${effectiveSaveFormat || "file"}`}
+            disabled={!canSave}
+            onClick={handleSave}
+            className="h-7"
+          >
+            Save
+          </Button>
+        </div>
       </div>
       <PlotMetadataBadges envelope={envelope} />
     </div>

--- a/frontend/src/components/DataPreview.parts/PreviewHost.tsx
+++ b/frontend/src/components/DataPreview.parts/PreviewHost.tsx
@@ -565,19 +565,35 @@ function mergeResourceParams(
   return Object.keys(merged).length > 0 ? merged : undefined;
 }
 
+// Map an export format to the file extension the default save filename uses.
+// jpeg is conventionally saved as .jpg to match the on-disk artifact (#1918).
+function extensionForFormat(format: string): string {
+  return format === "jpeg" ? "jpg" : format;
+}
+
 function defaultResourceFilename(
   envelope: PreviewEnvelope,
   params?: Record<string, unknown>,
 ): string {
+  // When the caller requested a specific export format (the plot Save-as menu,
+  // #1918), the default filename must carry that format's extension so the
+  // native dialog defaults to the right type instead of the preview's format.
+  const requested =
+    typeof params?.format === "string" && params.format ? extensionForFormat(params.format) : "";
   const payloadPath = envelope.payload?.path;
   if (typeof payloadPath === "string" && payloadPath) {
     const normalized = payloadPath.replace(/[\\/]+$/, "");
     const parts = normalized.split(/[\\/]/);
     const name = parts[parts.length - 1];
-    if (name) return name;
+    if (name) {
+      if (requested) {
+        const base = name.replace(/\.[A-Za-z0-9]+$/, "");
+        return `${base}.${requested}`;
+      }
+      return name;
+    }
   }
-  const format = typeof params?.format === "string" && params.format ? params.format : "bin";
-  return `${envelope.previewer_id}.${format}`;
+  return `${envelope.previewer_id}.${requested || "bin"}`;
 }
 
 function fileFilterForFilename(filename: string): string {

--- a/frontend/src/components/DataPreview.parts/coreViewers.test.tsx
+++ b/frontend/src/components/DataPreview.parts/coreViewers.test.tsx
@@ -351,4 +351,57 @@ describe("PlotViewer", () => {
     expect(screen.getByTestId("plot-zoom-level").textContent).toBe("100%");
     expect(screen.getByTestId("plot-zoom-layer").style.transform).toBe("scale(1)");
   });
+
+  it("offers a Save-as format menu and passes the chosen format on export (#1918)", () => {
+    const onExport = vi.fn();
+    render(
+      <PlotViewer
+        envelope={plotEnvelope({
+          format: "svg",
+          mime_type: "image/svg+xml",
+          svg: '<svg width="1600" height="1000" viewBox="0 0 1600 1000"></svg>',
+          available_formats: ["svg", "pdf", "png", "jpeg"],
+        })}
+        onExport={onExport}
+      />,
+    );
+
+    const select = screen.getByTestId("plot-format-select") as HTMLSelectElement;
+    expect(Array.from(select.options).map((o) => o.value)).toEqual(["svg", "pdf", "png", "jpeg"]);
+
+    // Default Save keeps the preview (preferred) format.
+    fireEvent.click(screen.getByTestId("plot-export-button"));
+    expect(onExport).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        resource_id: "export",
+        params: expect.objectContaining({ format: "svg" }),
+      }),
+    );
+
+    // Choosing pdf sends the pdf format so the backend resolves the pdf sibling.
+    fireEvent.change(select, { target: { value: "pdf" } });
+    fireEvent.click(screen.getByTestId("plot-export-button"));
+    expect(onExport).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        resource_id: "export",
+        params: expect.objectContaining({ format: "pdf" }),
+      }),
+    );
+  });
+
+  it("hides the format menu when only one format is available", () => {
+    render(
+      <PlotViewer
+        envelope={plotEnvelope({
+          format: "svg",
+          mime_type: "image/svg+xml",
+          svg: '<svg width="1600" height="1000" viewBox="0 0 1600 1000"></svg>',
+          available_formats: ["svg"],
+        })}
+        onExport={vi.fn()}
+      />,
+    );
+    expect(screen.queryByTestId("plot-format-select")).toBeNull();
+    expect(screen.getByTestId("plot-export-button")).toBeTruthy();
+  });
 });

--- a/src/scistudio/plot/_harness.py
+++ b/src/scistudio/plot/_harness.py
@@ -453,23 +453,44 @@ def _apply_default_matplotlib_style(matplotlib):
     )
 
 
-def _artifact_name(index, preferred):
-    suffix = "jpg" if preferred == "jpeg" else preferred
+def _artifact_name(index, fmt):
+    suffix = "jpg" if fmt == "jpeg" else fmt
     return "figure." + suffix if index == 0 else "figure_" + str(index) + "." + suffix
+
+
+def _export_formats(preferred, allowed):
+    """Ordered export formats for a returned figure: the preferred format first,
+    then the rest of the manifest ``allowed`` set (deduped). With no ``allowed``
+    set only the preferred format is rendered.
+
+    Re-render-on-save is impossible (the figure is closed right after render),
+    so every allowed format is saved to a sibling file up front and the
+    previewer resolves the file matching the user's chosen export format (#1918).
+    """
+    order = [preferred]
+    for fmt in allowed:
+        if fmt and fmt not in order:
+            order.append(fmt)
+    return order
 
 
 def _save_matplotlib_figure(fig, out_dir, preferred, allowed, index):
     _check_allowed("figure." + preferred, allowed)
-    out = Path(out_dir) / _artifact_name(index, preferred)
-    fmt = "jpg" if preferred == "jpeg" else preferred
-    fig.savefig(out, format=fmt)
+    primary = None
+    for fmt in _export_formats(preferred, allowed):
+        _check_allowed("figure." + fmt, allowed)
+        out = Path(out_dir) / _artifact_name(index, fmt)
+        save_fmt = "jpg" if fmt == "jpeg" else fmt
+        fig.savefig(out, format=save_fmt)
+        if primary is None:
+            primary = out.name
     try:
         import matplotlib.pyplot as plt
 
         plt.close(fig)
     except Exception:
         pass
-    return out.name
+    return primary
 
 
 def _collect_path(value, out_dir, allowed):
@@ -823,17 +844,34 @@ safe_artifact_path <- function(path) {
   basename(resolved)
 }
 
+# Ordered export formats for a returned ggplot: preferred first, then the rest
+# of the manifest allowed set (deduped). Re-render-on-save is impossible, so
+# every allowed format is ggsave'd to a sibling file up front and the previewer
+# resolves the file matching the user's chosen export format (#1918).
+export_formats <- function() {
+  order <- preferred
+  for (fmt in allowed) {
+    if (nzchar(fmt) && !(fmt %in% order)) order <- c(order, fmt)
+  }
+  order
+}
+
 save_ggplot <- function(plot, index) {
-  ext <- check_format(paste0("figure.", preferred))
-  suffix <- if (preferred == "jpeg") "jpg" else preferred
-  filename <- if (index == 0) paste0("figure.", suffix) else paste0("figure_", index, ".", suffix)
-  out <- file.path(out_dir, filename)
+  check_format(paste0("figure.", preferred))
+  primary <- NULL
   fig <- resolve_fig()
-  ggplot2::ggsave(
-    out, plot = plot, device = if (ext == "jpeg") "jpeg" else ext,
-    width = fig[["width"]], height = fig[["height"]], units = "in"
-  )
-  basename(out)
+  for (fmt in export_formats()) {
+    ext <- check_format(paste0("figure.", fmt))
+    suffix <- if (fmt == "jpeg") "jpg" else fmt
+    filename <- if (index == 0) paste0("figure.", suffix) else paste0("figure_", index, ".", suffix)
+    out <- file.path(out_dir, filename)
+    ggplot2::ggsave(
+      out, plot = plot, device = if (ext == "jpeg") "jpeg" else ext,
+      width = fig[["width"]], height = fig[["height"]], units = "in"
+    )
+    if (is.null(primary)) primary <- basename(out)
+  }
+  primary
 }
 
 collect_returned <- function(value) {

--- a/src/scistudio/plot/runtime.py
+++ b/src/scistudio/plot/runtime.py
@@ -771,6 +771,38 @@ def _parse_harness_stdout(stdout: str) -> dict[str, Any] | None:
     return None
 
 
+_PLOT_EXTS = frozenset({"svg", "pdf", "png", "jpeg", "jpg"})
+
+
+def _norm_ext(path: Path) -> str:
+    """Canonical single-word format for a plot file (``jpg`` folds to ``jpeg``)."""
+    ext = path.suffix.lower().lstrip(".")
+    return "jpeg" if ext == "jpg" else ext
+
+
+def _figure_group_stem(name: str) -> str:
+    """Return the figure-group stem for a produced/on-disk artifact filename.
+
+    A single returned figure is now saved to one sibling file per allowed format
+    (``figure.svg`` / ``figure.pdf`` / ``figure.png`` / ``figure.jpg``); a second
+    figure uses ``figure_1.*`` and so on (#1918). Every sibling of one figure
+    shares the same stem, so grouping by stem folds the format siblings back into
+    one figure. The dot-suffix is stripped; ``jpg`` and ``jpeg`` already share a
+    stem because the stem excludes the extension.
+    """
+    return Path(name).stem
+
+
+def _cache_name(cache_stem: str, ext: str) -> str:
+    """Cache filename for a promoted artifact: ``current.<ext>`` for the first
+    figure, ``current_<n>.<ext>`` for each additional figure. The ``.jpg``
+    on-disk suffix is preserved so the browser/native dialog and MIME lookup
+    stay consistent.
+    """
+    suffix = "jpg" if ext == "jpeg" else ext
+    return f"{cache_stem}.{suffix}"
+
+
 def _promote_artifacts(
     work_dir: Path,
     cache_dir: Path,
@@ -779,55 +811,93 @@ def _promote_artifacts(
     max_files: int,
     manifest: PlotManifest,
 ) -> tuple[list[PlotArtifact], list[str], list[str]]:
-    """Move produced artifacts into the cache as current.* (FR-026, FR-027, FR-029)."""
+    """Move produced artifacts into the cache as current.* (FR-026, FR-027, FR-029).
+
+    Each returned figure is rendered to one sibling file per manifest-allowed
+    format so the previewer can export/save a valid file in the user's chosen
+    format without re-rendering (#1918, approach B). The siblings of one figure
+    are promoted together under a shared cache stem: the preferred-format file of
+    the first figure stays the canonical ``current.<preferred>`` primary (the
+    preview artifact), and the other formats land as ``current.<ext>`` siblings.
+    The byte/file caps are enforced against everything written; when the extra
+    formats would exceed a cap the run degrades gracefully to the primary of each
+    figure and warns, rather than failing.
+    """
     warnings: list[str] = []
     errors: list[str] = []
 
     # Re-scan the work dir for ALL produced output files to enforce the
     # file-count + byte caps against what the script actually wrote, not just
     # what it declared.
-    on_disk = [
-        p
-        for p in sorted(work_dir.iterdir())
-        if p.is_file() and p.suffix.lower().lstrip(".") in {"svg", "pdf", "png", "jpeg", "jpg"}
-    ]
-    if len(on_disk) > max_files:
-        errors.append(f"plot wrote {len(on_disk)} files; max_files cap is {max_files}.")
+    on_disk = [p for p in sorted(work_dir.iterdir()) if p.is_file() and _norm_ext(p) in _PLOT_EXTS]
+    if not on_disk:
+        errors.append("render returned success but wrote no recognised artifact.")
         return [], warnings, errors
-    total = sum(p.stat().st_size for p in on_disk)
-    if total > max_bytes:
-        errors.append(f"plot output is {total} bytes; max_output_bytes cap is {max_bytes}.")
-        return [], warnings, errors
+
+    # Group the on-disk files back into figures by shared stem, preserving a
+    # stable per-figure order: figures named by the harness declarations first
+    # (``produced`` carries each figure's primary/preferred file), then any extra
+    # figures discovered on disk.
+    by_stem: dict[str, list[Path]] = {}
+    for p in on_disk:
+        by_stem.setdefault(_figure_group_stem(p.name), []).append(p)
+
+    ordered_stems: list[str] = []
+    for name in produced:
+        stem = _figure_group_stem(name)
+        if stem in by_stem and stem not in ordered_stems:
+            ordered_stems.append(stem)
+    for stem in by_stem:
+        if stem not in ordered_stems:
+            ordered_stems.append(stem)
+
+    preferred = manifest.outputs.preferred_format
+
+    def _sibling_sort_key(path: Path) -> tuple[int, str]:
+        # Preferred format first within a figure so it becomes the primary; the
+        # rest keep a stable alphabetical order.
+        return (0 if _norm_ext(path) == preferred else 1, _norm_ext(path))
+
+    # Full plan: every format sibling of every figure. Enforce the caps against
+    # this first; degrade to primaries-only if it would exceed them.
+    full_plan: list[tuple[str, Path]] = []
+    primary_plan: list[tuple[str, Path]] = []
+    for idx, stem in enumerate(ordered_stems):
+        cache_stem = "current" if idx == 0 else f"current_{idx}"
+        siblings = sorted(by_stem[stem], key=_sibling_sort_key)
+        for sib_i, src in enumerate(siblings):
+            full_plan.append((cache_stem, src))
+            if sib_i == 0:
+                primary_plan.append((cache_stem, src))
+
+    def _plan_bytes(plan: list[tuple[str, Path]]) -> int:
+        return sum(src.stat().st_size for _, src in plan)
+
+    plan = full_plan
+    if len(full_plan) > max_files or _plan_bytes(full_plan) > max_bytes:
+        # Degrade gracefully: keep one file (the preferred/primary) per figure so
+        # the preview and at least one export format still work, and tell the user
+        # the extra formats were dropped (rather than failing the whole run).
+        plan = primary_plan
+        if len(primary_plan) > max_files:
+            errors.append(f"plot wrote {len(primary_plan)} figures; max_files cap is {max_files}.")
+            return [], warnings, errors
+        if _plan_bytes(primary_plan) > max_bytes:
+            errors.append(f"plot output is {_plan_bytes(primary_plan)} bytes; max_output_bytes cap is {max_bytes}.")
+            return [], warnings, errors
+        warnings.append(
+            "extra export formats exceeded the output caps; only the preferred format was kept per figure. "
+            "Saving in another format is unavailable for this run."
+        )
 
     cache_dir.mkdir(parents=True, exist_ok=True)
     # Current-overwrite: clear previous current.* before writing new ones (FR-027).
     _clear_current_artifacts(cache_dir)
 
-    # Order: declared artifacts first, then any extras found on disk.
-    ordered: list[Path] = []
-    for name in produced:
-        candidate = work_dir / Path(name).name
-        if candidate.is_file() and candidate not in ordered:
-            ordered.append(candidate)
-    for p in on_disk:
-        if p not in ordered:
-            ordered.append(p)
-    if not ordered:
-        errors.append("render returned success but wrote no recognised artifact.")
-        return [], warnings, errors
-
     artifacts: list[PlotArtifact] = []
-    for idx, src in enumerate(ordered):
-        ext = src.suffix.lower().lstrip(".")
-        if ext == "jpg":
-            ext = "jpeg"
-        # First artifact is the canonical current.<ext>; extras get an index.
-        dest_name = (
-            "current." + (src.suffix.lower().lstrip("."))
-            if idx == 0
-            else f"current_{idx}.{src.suffix.lower().lstrip('.')}"
-        )
-        dest = cache_dir / dest_name
+    for cache_stem, src in plan:
+        ext = _norm_ext(src)
+        dest = cache_dir / _cache_name(cache_stem, ext)
         shutil.copy2(src, dest)
         artifacts.append(
             PlotArtifact(filename=dest.name, format=ext, path=str(dest), size_bytes=dest.stat().st_size)  # type: ignore[arg-type]

--- a/src/scistudio/previewers/fallbacks.py
+++ b/src/scistudio/previewers/fallbacks.py
@@ -57,6 +57,38 @@ logger = logging.getLogger(__name__)
 # option c), so it is resolved from the stdlib ``mimetypes`` registry rather
 # than a hand-maintained map.
 _PLOT_SUFFIXES = frozenset({".png", ".jpg", ".jpeg", ".svg", ".pdf"})
+# Canonical export formats, and the order the frontend Save-as menu offers them.
+_PLOT_EXPORT_FORMAT_ORDER = ("svg", "pdf", "png", "jpeg")
+
+
+def _canonical_plot_format(suffix: str) -> str:
+    """Fold a ``.ext``/``ext`` suffix to a canonical plot format (``jpg``→``jpeg``)."""
+    ext = suffix.lower().lstrip(".")
+    return "jpeg" if ext == "jpg" else ext
+
+
+def _available_plot_formats(primary: object) -> list[str]:
+    """Formats actually rendered for this plot, resolved from the sibling files.
+
+    The plot run promotes one ``<stem>.<suffix>`` file per allowed format next to
+    the preferred-format primary (#1918). Globbing the primary's stem tells the
+    frontend which formats a Save-as menu can offer without re-rendering. Falls
+    back to just the primary's own format when siblings cannot be enumerated.
+    """
+    from pathlib import Path
+
+    path = primary if isinstance(primary, Path) else Path(str(primary))
+    own = _canonical_plot_format(path.suffix)
+    try:
+        found = {
+            _canonical_plot_format(sib.suffix)
+            for sib in path.parent.glob(f"{path.stem}.*")
+            if sib.is_file() and sib.suffix.lower() in _PLOT_SUFFIXES
+        }
+    except OSError:
+        found = set()
+    found.add(own)
+    return [fmt for fmt in _PLOT_EXPORT_FORMAT_ORDER if fmt in found]
 
 
 def _ref_for(request: PreviewRequest) -> StorageReference:
@@ -469,7 +501,17 @@ def plot_previewer(request: PreviewRequest) -> PreviewEnvelope:
         return _error_envelope(request, None, f"unsupported plot artifact format: {suffix or '<none>'}")
     mime = mimetypes.guess_type(path.name)[0] or "application/octet-stream"
 
-    payload: dict[str, object] = {"format": suffix.lstrip("."), "mime_type": mime, "path": ref.path}
+    # Approach B (#1918): the plot run renders one sibling file per allowed
+    # format alongside the preferred-format primary. Surface which formats are
+    # actually available on disk so the frontend can offer a Save-as format
+    # choice and the export resolves the matching sibling instead of forcing SVG.
+    available_formats = _available_plot_formats(path)
+    payload: dict[str, object] = {
+        "format": suffix.lstrip("."),
+        "mime_type": mime,
+        "path": ref.path,
+        "available_formats": available_formats,
+    }
     diagnostics: list[str] = []
 
     if suffix == ".svg":

--- a/src/scistudio/previewers/session.py
+++ b/src/scistudio/previewers/session.py
@@ -67,6 +67,37 @@ _PLOT_EXPORT_MIME = {
     ".svg": "image/svg+xml",
     ".pdf": "application/pdf",
 }
+# Canonical single-word plot formats a user may export to. ``jpg`` folds to
+# ``jpeg`` so the on-disk ``.jpg`` sibling and a ``jpeg`` request resolve to the
+# same file (#1918).
+_PLOT_EXPORT_FORMATS = frozenset({"svg", "pdf", "png", "jpeg"})
+# Format -> on-disk suffix used for the promoted ``current.<suffix>`` siblings.
+_PLOT_FORMAT_SUFFIX = {"svg": ".svg", "pdf": ".pdf", "png": ".png", "jpeg": ".jpg"}
+
+
+def _canonical_plot_format(suffix: str) -> str:
+    """Fold a ``.ext``/``ext`` suffix to a canonical plot format (``jpg``→``jpeg``)."""
+    ext = suffix.lower().lstrip(".")
+    return "jpeg" if ext == "jpg" else ext
+
+
+def _export_group_stem(primary: Path) -> str:
+    """Cache stem shared by a figure's format siblings, e.g. ``current`` for
+    ``current.svg`` and ``current_1`` for ``current_1.pdf`` (#1918)."""
+    return primary.stem
+
+
+def _sibling_for_format(primary: Path, fmt: str) -> Path:
+    """Resolve the sibling artifact file for *fmt* next to the *primary* file.
+
+    The plot run promotes one ``<stem>.<suffix>`` file per allowed format, so the
+    sibling for a requested format shares the primary's directory and stem and
+    only swaps the extension (``current.svg`` → ``current.pdf`` for ``pdf``).
+    """
+    suffix = _PLOT_FORMAT_SUFFIX.get(fmt, "." + fmt)
+    return primary.parent / (_export_group_stem(primary) + suffix)
+
+
 ChildContextResolver = Callable[[PreviewTarget, dict[str, Any]], tuple[PreviewTarget, dict[str, Any]]]
 ProviderT = TypeVar("ProviderT", bound=Callable[..., Any])
 
@@ -476,32 +507,44 @@ class PreviewSessionManager:
             )
 
         ref = _storage_ref_from_query(params, session.target.ref)
-        path = Path(ref.path)
-        suffix = path.suffix.lower()
-        mime = _PLOT_EXPORT_MIME.get(suffix)
-        if mime is None:
+        primary = Path(ref.path)
+        primary_suffix = primary.suffix.lower()
+        if _PLOT_EXPORT_MIME.get(primary_suffix) is None:
             raise ProviderError(
-                f"unsupported plot export format: {suffix or '<none>'}",
-                detail={"resource_id": "export", "format": suffix.lstrip(".")},
-            )
-        if not path.is_file():
-            raise ProviderError(
-                f"plot export source is unavailable: {path.name or session.target.ref}",
-                detail={"resource_id": "export"},
+                f"unsupported plot export format: {primary_suffix or '<none>'}",
+                detail={"resource_id": "export", "format": primary_suffix.lstrip(".")},
             )
 
-        actual_format = suffix.lstrip(".")
-        requested_format = str(params.get("format") or actual_format).lower().lstrip(".")
-        accepted_formats = {actual_format}
-        if actual_format in {"jpg", "jpeg"}:
-            accepted_formats.update({"jpg", "jpeg"})
-        if requested_format not in accepted_formats:
+        # Approach B (#1918): the plot run renders one sibling file per allowed
+        # format next to the preferred-format primary (``current.svg`` +
+        # ``current.pdf`` + ``current.png`` + ``current.jpg``). Resolve the file
+        # matching the user's chosen format instead of blindly returning the
+        # primary bytes; if that format was not rendered, error cleanly rather
+        # than write a corrupt file with the wrong extension.
+        primary_format = _canonical_plot_format(primary_suffix)
+        requested_format = str(params.get("format") or primary_format).lower().lstrip(".")
+        requested_format = _canonical_plot_format("." + requested_format)
+        if requested_format not in _PLOT_EXPORT_FORMATS:
             raise ProviderError(
-                f"plot export format {requested_format!r} does not match artifact format {actual_format!r}",
+                f"unsupported plot export format: {requested_format or '<none>'}",
                 detail={"resource_id": "export", "format": requested_format},
             )
 
-        if suffix == ".svg":
+        path = _sibling_for_format(primary, requested_format)
+        if not path.is_file():
+            available = sorted(
+                _canonical_plot_format(p.suffix)
+                for p in primary.parent.glob(f"{_export_group_stem(primary)}.*")
+                if _canonical_plot_format(p.suffix) in _PLOT_EXPORT_FORMATS
+            )
+            raise ProviderError(
+                f"plot format {requested_format!r} was not rendered for this plot; "
+                f"available formats: {', '.join(available) or '<none>'}",
+                detail={"resource_id": "export", "format": requested_format, "available_formats": available},
+            )
+
+        mime = _PLOT_EXPORT_MIME[path.suffix.lower()]
+        if path.suffix.lower() == ".svg":
             raw_text = path.read_text(encoding="utf-8", errors="replace")
             sanitized, removed = sanitize_svg(raw_text)
             payload = sanitized.encode("utf-8")
@@ -527,7 +570,7 @@ class PreviewSessionManager:
             )
         payload = path.read_bytes()
         return {
-            "format": "jpeg" if actual_format == "jpg" else actual_format,
+            "format": requested_format,
             "mime_type": mime,
             "filename": path.name,
             "size_bytes": len(payload),

--- a/tests/adr052_contract/test_plot_render_contract.py
+++ b/tests/adr052_contract/test_plot_render_contract.py
@@ -192,8 +192,24 @@ def test_plot_render_collection_contract(tmp_path: Path) -> None:
 
     fig = plt.figure()
     fig.add_subplot(111).plot([0, 1, 2], [2, 1, 0])
+    # The return value is still the single preferred-format primary, but the
+    # harness now also writes one sibling file per allowed format so the
+    # previewer can save/export any of them without re-rendering (#1918).
     assert collect(fig, str(out_dir), preferred, _ALL_FORMATS) == ["figure.png"]
     assert (out_dir / "figure.png").is_file()
+    for sibling in ("figure.svg", "figure.pdf", "figure.jpg"):
+        assert (out_dir / sibling).is_file(), sibling
+    # PNG magic bytes for the primary; PDF magic bytes for the sibling.
+    assert (out_dir / "figure.png").read_bytes()[:8] == b"\x89PNG\r\n\x1a\n"
+    assert (out_dir / "figure.pdf").read_bytes()[:5] == b"%PDF-"
+
+    # With no allowed set only the preferred format is rendered (no siblings).
+    single_dir = tmp_path / "single"
+    single_dir.mkdir()
+    fig_single = plt.figure()
+    fig_single.add_subplot(111).plot([0, 1], [0, 1])
+    assert collect(fig_single, str(single_dir), preferred, []) == ["figure.png"]
+    assert sorted(p.name for p in single_dir.iterdir()) == ["figure.png"]
 
     (out_dir / "made.png").write_bytes(b"x")
     assert collect("made.png", str(out_dir), preferred, _ALL_FORMATS) == ["made.png"]

--- a/tests/api/test_plot_preview_wiring.py
+++ b/tests/api/test_plot_preview_wiring.py
@@ -459,6 +459,173 @@ def test_plot_preview_resource_save_writes_export_to_user_selected_path(
     assert "<svg" in destination.read_text(encoding="utf-8")
 
 
+def _run_and_open_session(client: TestClient) -> tuple[str, dict[str, Any]]:
+    """Run p1 and open a preview session; return (session_id, envelope)."""
+    run = client.post("/api/plots/run", json={"plot_id": "p1"})
+    assert run.status_code == 200, run.text
+    body = run.json()
+    assert body["status"] == "succeeded", body
+    session = client.post(
+        "/api/previews/sessions",
+        json={
+            "target": {
+                "kind": "plot_artifact",
+                "ref": body["data_ref"],
+                "recorded_type": body["recorded_type"],
+                "type_chain": body["type_chain"],
+                "source": body["source"],
+            },
+            "query": {},
+        },
+    )
+    assert session.status_code == 200, session.text
+    env = session.json()
+    return env["session_id"], env
+
+
+def test_plot_run_renders_all_allowed_formats_as_siblings(
+    client: TestClient,
+    runtime: ApiRuntime,
+    opened_project: Path,
+) -> None:
+    """Approach B (#1918): a figure run writes one cache sibling per allowed format.
+
+    The preview still uses the preferred (svg) primary, but pdf/png/jpg siblings
+    exist so Save/Export can produce a valid file in any of them without
+    re-rendering (the figure is closed immediately after render).
+    """
+    _seed_block_output(runtime, opened_project)
+    _write_workflow_and_plot(client, opened_project)
+
+    run = client.post("/api/plots/run", json={"plot_id": "p1"})
+    assert run.status_code == 200, run.text
+    assert run.json()["status"] == "succeeded"
+
+    cache_dir = preview_cache_dir(opened_project, "main", "node_a", "measurements", "p1")
+    for name in ("current.svg", "current.pdf", "current.png", "current.jpg"):
+        assert (cache_dir / name).is_file(), name
+    # Magic bytes confirm the siblings are genuinely re-rendered, not renamed SVG.
+    assert (cache_dir / "current.png").read_bytes()[:8] == b"\x89PNG\r\n\x1a\n"
+    assert (cache_dir / "current.pdf").read_bytes()[:5] == b"%PDF-"
+
+
+def test_plot_preview_exposes_available_formats(
+    client: TestClient,
+    runtime: ApiRuntime,
+    opened_project: Path,
+) -> None:
+    """The PLOT envelope advertises the formats the run rendered (for the UI menu)."""
+    _seed_block_output(runtime, opened_project)
+    _write_workflow_and_plot(client, opened_project)
+    _sid, env = _run_and_open_session(client)
+    assert env["payload"]["format"] == "svg"
+    assert set(env["payload"]["available_formats"]) == {"svg", "pdf", "png", "jpeg"}
+
+
+@pytest.mark.parametrize(
+    ("fmt", "ext", "magic"),
+    [
+        ("pdf", "pdf", b"%PDF-"),
+        ("png", "png", b"\x89PNG\r\n\x1a\n"),
+    ],
+)
+def test_plot_save_in_chosen_format_writes_valid_file(
+    client: TestClient,
+    runtime: ApiRuntime,
+    opened_project: Path,
+    fmt: str,
+    ext: str,
+    magic: bytes,
+) -> None:
+    """Saving as pdf/png writes the matching sibling's real bytes, not the SVG."""
+    _seed_block_output(runtime, opened_project)
+    _write_workflow_and_plot(client, opened_project)
+    sid, _env = _run_and_open_session(client)
+
+    export_dir = opened_project / "exports"
+    export_dir.mkdir()
+    destination = export_dir / f"chosen.{ext}"
+    save = client.post(
+        f"/api/previews/sessions/{sid}/resources/export/save",
+        json={"destination_path": str(destination), "params": {"format": fmt}},
+    )
+    assert save.status_code == 200, save.text
+    assert destination.is_file()
+    assert destination.read_bytes()[: len(magic)] == magic
+
+
+def test_plot_save_jpeg_resolves_jpg_sibling(
+    client: TestClient,
+    runtime: ApiRuntime,
+    opened_project: Path,
+) -> None:
+    """A jpeg request resolves the on-disk .jpg sibling and writes JPEG bytes."""
+    _seed_block_output(runtime, opened_project)
+    _write_workflow_and_plot(client, opened_project)
+    sid, _env = _run_and_open_session(client)
+
+    export_dir = opened_project / "exports"
+    export_dir.mkdir()
+    destination = export_dir / "chosen.jpg"
+    save = client.post(
+        f"/api/previews/sessions/{sid}/resources/export/save",
+        json={"destination_path": str(destination), "params": {"format": "jpeg"}},
+    )
+    assert save.status_code == 200, save.text
+    assert destination.is_file()
+    # JPEG SOI marker.
+    assert destination.read_bytes()[:2] == b"\xff\xd8"
+
+
+def test_plot_save_unrendered_format_errors_cleanly(
+    client: TestClient,
+    runtime: ApiRuntime,
+    opened_project: Path,
+) -> None:
+    """Requesting a format that was not rendered errors, never writes a corrupt file.
+
+    The plot's manifest allows only svg/png, so a pdf save must be rejected with
+    a clear error rather than dumping the primary bytes under a .pdf extension.
+    """
+    _seed_block_output(runtime, opened_project)
+    _write_workflow_and_plot(client, opened_project)
+    # Restrict the manifest to svg (primary) + png; pdf/jpeg are not rendered.
+    (opened_project / "plots" / "p1" / "plot.yaml").write_text(
+        "schema_version: 1\n"
+        "id: p1\n"
+        "title: P1\n"
+        "target:\n"
+        "  workflow_path: workflows/main.yaml\n"
+        "  workflow_id: main\n"
+        "  node_id: node_a\n"
+        "  output_port: measurements\n"
+        "  display_label: Seg / measurements\n"
+        "script:\n"
+        "  language: python\n"
+        "  path: render.py\n"
+        "  entrypoint: render\n"
+        "outputs:\n"
+        "  preferred_format: svg\n"
+        "  allowed_formats:\n"
+        "    - svg\n"
+        "    - png\n",
+        encoding="utf-8",
+    )
+    sid, env = _run_and_open_session(client)
+    assert set(env["payload"]["available_formats"]) == {"svg", "png"}
+
+    export_dir = opened_project / "exports"
+    export_dir.mkdir()
+    destination = export_dir / "chosen.pdf"
+    save = client.post(
+        f"/api/previews/sessions/{sid}/resources/export/save",
+        json={"destination_path": str(destination), "params": {"format": "pdf"}},
+    )
+    assert save.status_code >= 400, save.text
+    assert not destination.exists()
+    assert "not rendered" in save.text
+
+
 def test_plot_preview_resource_save_rejects_relative_destination_path(
     client: TestClient,
     runtime: ApiRuntime,


### PR DESCRIPTION
## Summary

Plot preview **Save** could only ever produce a valid SVG. Changing the
destination extension to `.pdf` / `.png` / `.jpeg` produced a broken file
because the export path reused the cached SVG bytes. Neither the plot function
nor the GUI offered a format choice.

Re-render-on-save is impossible — the matplotlib figure is closed immediately
after render (`plt.close(fig)`), and re-rendering means re-running the whole
plot subprocess, which the previewer save path has no context for. So this PR
uses **approach B**: render every manifest-`allowed_formats` value up front at
plot-run time; the preview still uses the preferred (svg) format; Save/Export
resolves the sibling file matching the user's chosen format.

## Changes

- **Harness** (`src/scistudio/plot/_harness.py`): `_save_matplotlib_figure` and
  `save_ggplot` now save one sibling file per allowed format
  (`figure.svg`/`.pdf`/`.png`/`.jpg`) before closing the figure. Render returns
  of an artifact *path* stay single-format (the author chose that format).
- **Promotion** (`src/scistudio/plot/runtime.py`): `_promote_artifacts` groups
  a figure's format siblings by stem and promotes them together as
  `current.<ext>`; the preferred-format file of the first figure stays the
  canonical preview primary. The byte/file caps are enforced against everything
  written; when the extra formats would exceed a cap the run degrades gracefully
  to the preferred format per figure and warns, rather than failing.
- **Previewer** (`src/scistudio/previewers/fallbacks.py`,
  `src/scistudio/previewers/session.py`): the PLOT envelope advertises
  `payload.available_formats`; `_export_plot_resource` resolves the sibling file
  matching the requested `format` param (from the Save-as choice / destination
  extension) and returns a clear error when that format was not rendered,
  instead of writing a corrupt file.
- **Frontend** (`frontend/src/components/DataPreview.parts/PlotViewer.tsx`,
  `PreviewHost.tsx`): the plot viewer gains a Save-as format menu offering the
  rendered formats and passes the chosen format to the backend; the default
  save filename honors the chosen format's extension.
- **Docs**: CHANGELOG + ADR-048 spec (FR-036 / FR-037).

## Tests

- `tests/adr052_contract/test_plot_render_contract.py`: harness emits all
  allowed sibling formats (PNG/PDF magic bytes) and stays single-format with no
  allowed set.
- `tests/api/test_plot_preview_wiring.py`: end-to-end run writes all sibling
  formats; envelope advertises `available_formats`; saving as pdf/png/jpeg
  writes valid bytes (magic-byte checks); an unrendered format errors cleanly
  without writing a file.
- `frontend/.../coreViewers.test.tsx`: the format menu offers the rendered
  formats and passes the chosen format on Save; hidden when only one format.

Gate record: .workflow/records/1918-guided-1918-plot-save-format.json

Closes #1918
