### PR TITLE
fix(#1920): stop flagging complete-but-paginated tables as truncated/incomplete

### DIFF
--- a/.workflow/records/1920-guided-1920-table-badge.json
+++ b/.workflow/records/1920-guided-1920-table-badge.json
@@ -1,0 +1,243 @@
+{
+  "branch": "guided/1920-table-badge",
+  "check_events": [
+    {
+      "at": "2026-07-06T18:28:02.425607Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:bee0017f30f552d2df2de1173f9ac14b9aee5192ca5e5c1de574bb119512b275",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-07-06T18:28:06.459541Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:d2016153ffe72f6d9588cf72b647d8f545261ca64eb63f312f104e3c66e7d074",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-06T18:28:06.497102Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e31351abfc33f0b3c0f28bc9f2f3d59ae3bc5d4925dc1159a7f931aa932441ed",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    }
+  ],
+  "check_na": [],
+  "commit": null,
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "src/scistudio/previewers/data_access.py",
+      "src/scistudio/previewers/fallbacks.py",
+      "tests/previewers/test_preview_data_access.py",
+      "tests/api/test_previewers.py"
+    ]
+  },
+  "directive_events": [
+    {
+      "at": "2026-07-06T18:26:26.871538Z",
+      "owner_directive": "Part 1 of #1886 only: remove misleading truncated/incomplete flags from the complete-but-paginated DataFrame preview path; backend-only; frontend badges vanish once flags are honest.",
+      "reason": "plan"
+    }
+  ],
+  "docs_events": [
+    {
+      "at": "2026-07-06T18:26:26.871687Z",
+      "class": null,
+      "kind": "path",
+      "path": "src/scistudio/_user_guide/api-reference/scistudio.previewers.data_access.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-07-06T18:26:26.871855Z",
+      "class": "spec",
+      "kind": "na",
+      "path": null,
+      "rationale": "ADR-048 \u00a77 defines the sampled/truncated/complete flag contract, which is preserved; no spec change \u2014 the DataFrame path now reports the existing flags honestly (paginated=complete), matching spec intent.",
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": false,
+  "guard_events": [
+    {
+      "at": "2026-07-06T18:28:06.519999Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-06T18:28:06.529136Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-06T18:28:06.537979Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-06T18:28:06.546627Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-06T18:28:06.555146Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-06T18:28:06.563582Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-06T18:28:06.571993Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-06T18:28:06.580300Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-06T18:28:06.588644Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-06T18:28:06.598083Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1920,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": {
+    "base": "origin/main",
+    "base_sha": "179fad61",
+    "changed_files": [],
+    "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "head": "HEAD",
+    "head_sha": "179fad61",
+    "surfaces": {
+      "docs": 0,
+      "frontend": 0,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 0,
+      "packaging": 0,
+      "protected_core": 0,
+      "sentrux": 0,
+      "test": 0,
+      "workflow_ci": 0
+    }
+  },
+  "owner_directive": "Fix only Part 1 of #1886: remove the misleading truncated/incomplete badge for complete-but-paginated DataFrame tables. One focused PR. New issue #1920 opened for this scope; #1886 stays as the Part 2 umbrella.",
+  "persona": "live_implementer",
+  "pull_request": null,
+  "reconcile_events": [
+    {
+      "at": "2026-07-06T18:28:06.598144Z",
+      "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "mode": "local",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    }
+  ],
+  "record_id": "1920-guided-1920-table-badge",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [
+      "format_check",
+      "full_audit",
+      "lint_format"
+    ],
+    "docs": [],
+    "guards": [
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": []
+  },
+  "runtime": "claude",
+  "schema_version": 2,
+  "scope_events": [],
+  "session_id": "6bb763a9-652e-4fd2-b34d-a9ff0d80e0a8",
+  "strictness_tier": 2,
+  "task_kind": "guided",
+  "test_events": [
+    {
+      "at": "2026-07-06T18:26:26.871863Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/previewers/test_preview_data_access.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-07-06T18:26:26.871867Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/api/test_previewers.py",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/.workflow/records/1920-guided-1920-table-badge.json
+++ b/.workflow/records/1920-guided-1920-table-badge.json
@@ -214,6 +214,11 @@
       "at": "2026-07-06T18:26:26.871538Z",
       "owner_directive": "Part 1 of #1886 only: remove misleading truncated/incomplete flags from the complete-but-paginated DataFrame preview path; backend-only; frontend badges vanish once flags are honest.",
       "reason": "plan"
+    },
+    {
+      "at": "2026-07-07T15:11:25.046898Z",
+      "owner_directive": "\u4feeCI \u2014 make the PR's CI green",
+      "reason": "Owner directive '\u4feeCI': fastmcp 3.3.1 drift raises fastmcp.exceptions.ValidationError (subclass of FastMCPError, not ToolError/ValueError) for malformed MCP calls, breaking test_input_schema_rejects_malformed_call on clean CI. Unrelated to #1920's previewer change but blocks this PR's CI; fold minimal test fix."
     }
   ],
   "docs_events": [
@@ -877,6 +882,12 @@
       "at": "2026-07-06T19:43:51.403176Z",
       "pattern": "src/scistudio/_user_guide/api-reference/scistudio.previewers.data_access.md",
       "reason": "ADR-052 generated API reference for scistudio.previewers.data_access regenerated because DataFramePage.truncated was removed; generated docs must stay generated (build_reference.py)."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-07-07T15:11:25.047041Z",
+      "pattern": "tests/ai/test_mcp_fastmcp.py",
+      "reason": "Owner directive '\u4feeCI': fastmcp 3.3.1 drift raises fastmcp.exceptions.ValidationError (subclass of FastMCPError, not ToolError/ValueError) for malformed MCP calls, breaking test_input_schema_rejects_malformed_call on clean CI. Unrelated to #1920's previewer change but blocks this PR's CI; fold minimal test fix."
     }
   ],
   "session_id": "6bb763a9-652e-4fd2-b34d-a9ff0d80e0a8",

--- a/.workflow/records/1920-guided-1920-table-badge.json
+++ b/.workflow/records/1920-guided-1920-table-badge.json
@@ -49,10 +49,157 @@
       "tool_versions": {
         "ruff": "0.15.15"
       }
+    },
+    {
+      "at": "2026-07-06T18:31:02.642934Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:d95aec79e9bc20f874a6a912cd87d9e0e9e06f9684d63815b4dad8a44f000bf5",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-07-06T18:31:06.207247Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e65bfeffdbc088fb3ac5efe6eebbe403b3ef8237d7d3e51efacd9c40a0b68c24",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-06T18:31:06.309789Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:2d7ed52819b562eace294fe6d036c79f58da1ea53b86d7c4d928f1df2a2fa6c8",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-06T18:31:06.324671Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:c524270981cfd2f1955ad6e4389811e83b9b12ad6fc6db61948ed2ebafe954fa",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-07-06T18:32:30.327652Z",
+      "command": "python -m scistudio.qa.testing.run_python_tests --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:9d32f059f13b4644cf7ed5ff36e5ae398c112f32bbd5acb923a4fa0808eb5e44",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-06T18:35:01.131723Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e447be35830b5695be1a393d69b7f15ef28595cc11273658887832de471e7fe5",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-06T18:35:08.185904Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:41d8f056a3d16a386a61e24f8842400018fb7a186641ddc67615747243f19520",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    },
+    {
+      "at": "2026-07-06T18:37:44.853259Z",
+      "command": "python -m scistudio.qa.testing.run_python_tests --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:9d32f059f13b4644cf7ed5ff36e5ae398c112f32bbd5acb923a4fa0808eb5e44",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-06T18:39:28.087172Z",
+      "command": "python -m scistudio.qa.testing.run_python_tests --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:9d32f059f13b4644cf7ed5ff36e5ae398c112f32bbd5acb923a4fa0808eb5e44",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
     }
   ],
   "check_na": [],
-  "commit": null,
+  "commit": {
+    "sha": "f0e325df61fa550cce3ef4297a447fa032769e6b",
+    "shas": [
+      "f0e325df61fa550cce3ef4297a447fa032769e6b"
+    ],
+    "trailers": []
+  },
   "declared_scope": {
     "exclude": [],
     "include": [
@@ -148,6 +295,438 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-07-06T18:30:03.735028Z",
+      "findings": [
+        {
+          "message": "AI-authored edits must happen in a dedicated worktree, not the main working tree (/private/var/folders/mk/xk0dqvn934l5425gwb19rsqc0000gn/T/pytest-of-jiazhenz/pytest-1124/popen-gw2/test_hook_payload_extracts_mul0/main). Create one with `git worktree add ../<name> <branch>` and run your edits there.",
+          "rule_id": "worktree.main-checkout-write"
+        }
+      ],
+      "guard": "worktree_write_guard",
+      "status": "fail"
+    },
+    {
+      "at": "2026-07-06T18:30:04.636564Z",
+      "findings": [
+        {
+          "message": "AI-authored edits must happen in a dedicated worktree, not the main working tree (/private/var/folders/mk/xk0dqvn934l5425gwb19rsqc0000gn/T/pytest-of-jiazhenz/pytest-1124/popen-gw0/test_hook_payload_blocks_main_0/main). Create one with `git worktree add ../<name> <branch>` and run your edits there.",
+          "rule_id": "worktree.main-checkout-write"
+        }
+      ],
+      "guard": "worktree_write_guard",
+      "status": "fail"
+    },
+    {
+      "at": "2026-07-06T18:35:08.243816Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-06T18:35:08.252987Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-06T18:35:08.261932Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-06T18:35:08.270808Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-06T18:35:08.279468Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-06T18:35:08.288346Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-06T18:35:08.296961Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-06T18:35:08.307454Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-06T18:35:08.315851Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-06T18:35:08.325744Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-06T18:37:44.890197Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-06T18:37:44.899200Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-06T18:37:44.908028Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-06T18:37:44.917204Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-06T18:37:44.926006Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-06T18:37:44.935115Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-06T18:37:44.944084Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-06T18:37:44.953077Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-06T18:37:44.961884Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-06T18:37:44.971597Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-06T18:39:28.120049Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-06T18:39:28.128917Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-06T18:39:28.138089Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-06T18:39:28.147069Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-06T18:39:28.155874Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-06T18:39:28.164879Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-06T18:39:28.173763Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-06T18:39:28.182895Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-06T18:39:28.191678Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-06T18:39:28.201505Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-06T19:43:13.760174Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-06T19:43:13.769042Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-06T19:43:13.778002Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-06T19:43:13.787253Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-06T19:43:13.796103Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-06T19:43:13.804733Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-06T19:43:13.813386Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-06T19:43:13.822747Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-06T19:43:13.831731Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-06T19:43:13.841835Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-06T19:44:05.006429Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-06T19:44:05.016815Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-06T19:44:05.027057Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-06T19:44:05.037771Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-06T19:44:05.048631Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-06T19:44:05.060196Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-06T19:44:05.072387Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-06T19:44:05.085896Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-06T19:44:05.096502Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-06T19:44:05.108639Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -160,28 +739,40 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "origin/main",
+    "base": "179fad61d1b640ca9e167cfd7e446cc68c711fb3",
     "base_sha": "179fad61",
-    "changed_files": [],
-    "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "changed_files": [
+      ".workflow/records/1920-guided-1920-table-badge.json",
+      "src/scistudio/_user_guide/api-reference/scistudio.previewers.data_access.md",
+      "src/scistudio/previewers/data_access.py",
+      "src/scistudio/previewers/fallbacks.py",
+      "tests/api/test_previewers.py",
+      "tests/previewers/test_preview_data_access.py"
+    ],
+    "diff_fingerprint": "sha256:e872303f85cf9dc4c30fcf4850e5ec219505e2659f69610438580e95788d81be",
     "head": "HEAD",
-    "head_sha": "179fad61",
+    "head_sha": "f0e325df",
     "surfaces": {
       "docs": 0,
       "frontend": 0,
       "governance": 0,
       "governed_docs": 0,
-      "implementation": 0,
+      "implementation": 3,
       "packaging": 0,
       "protected_core": 0,
-      "sentrux": 0,
-      "test": 0,
+      "sentrux": 5,
+      "test": 2,
       "workflow_ci": 0
     }
   },
   "owner_directive": "Fix only Part 1 of #1886: remove the misleading truncated/incomplete badge for complete-but-paginated DataFrame tables. One focused PR. New issue #1920 opened for this scope; #1886 stays as the Part 2 umbrella.",
   "persona": "live_implementer",
-  "pull_request": null,
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [],
+    "number": 1921,
+    "url": "https://github.com/jiazhenz026/SciStudio/pull/1921"
+  },
   "reconcile_events": [
     {
       "at": "2026-07-06T18:28:06.598144Z",
@@ -190,6 +781,60 @@
       "result": "pass",
       "tier": 2,
       "unsatisfied": []
+    },
+    {
+      "at": "2026-07-06T18:35:08.325781Z",
+      "diff_fingerprint": "sha256:e872303f85cf9dc4c30fcf4850e5ec219505e2659f69610438580e95788d81be",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.python_tests",
+        "scope.out-of-scope"
+      ]
+    },
+    {
+      "at": "2026-07-06T18:37:44.971632Z",
+      "diff_fingerprint": "sha256:e872303f85cf9dc4c30fcf4850e5ec219505e2659f69610438580e95788d81be",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.python_tests",
+        "scope.out-of-scope"
+      ]
+    },
+    {
+      "at": "2026-07-06T18:39:28.201551Z",
+      "diff_fingerprint": "sha256:e872303f85cf9dc4c30fcf4850e5ec219505e2659f69610438580e95788d81be",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.python_tests",
+        "scope.out-of-scope"
+      ]
+    },
+    {
+      "at": "2026-07-06T19:43:13.841879Z",
+      "diff_fingerprint": "sha256:e872303f85cf9dc4c30fcf4850e5ec219505e2659f69610438580e95788d81be",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.python_tests",
+        "scope.out-of-scope"
+      ]
+    },
+    {
+      "at": "2026-07-06T19:44:05.108670Z",
+      "diff_fingerprint": "sha256:e872303f85cf9dc4c30fcf4850e5ec219505e2659f69610438580e95788d81be",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.python_tests"
+      ]
     }
   ],
   "record_id": "1920-guided-1920-table-badge",
@@ -199,9 +844,15 @@
     "checks": [
       "format_check",
       "full_audit",
-      "lint_format"
+      "import_contracts",
+      "lint_format",
+      "python_tests",
+      "semantic_dup",
+      "type_check"
     ],
-    "docs": [],
+    "docs": [
+      "docs_required_or_na"
+    ],
     "guards": [
       "core_change_guard",
       "docs_landing",
@@ -214,11 +865,20 @@
       "test_engineer_scope_guard",
       "weakened_ci_check"
     ],
-    "tests": []
+    "tests": [
+      "changed_test_required"
+    ]
   },
   "runtime": "claude",
   "schema_version": 2,
-  "scope_events": [],
+  "scope_events": [
+    {
+      "action": "add-include",
+      "at": "2026-07-06T19:43:51.403176Z",
+      "pattern": "src/scistudio/_user_guide/api-reference/scistudio.previewers.data_access.md",
+      "reason": "ADR-052 generated API reference for scistudio.previewers.data_access regenerated because DataFramePage.truncated was removed; generated docs must stay generated (build_reference.py)."
+    }
+  ],
   "session_id": "6bb763a9-652e-4fd2-b34d-a9ff0d80e0a8",
   "strictness_tier": 2,
   "task_kind": "guided",

--- a/src/scistudio/_user_guide/api-reference/scistudio.previewers.data_access.md
+++ b/src/scistudio/_user_guide/api-reference/scistudio.previewers.data_access.md
@@ -80,7 +80,7 @@ The slot inventory of a composite target, with no child rendered.
 
 ```python
 class DataFramePage
-DataFramePage(columns: 'list[str]', rows: 'list[dict[str, Any]]', total_rows: 'int', page: 'int', page_size: 'int', total_pages: 'int', sort_by: 'str | None', sort_dir: 'str | None', truncated: 'bool') -> None
+DataFramePage(columns: 'list[str]', rows: 'list[dict[str, Any]]', total_rows: 'int', page: 'int', page_size: 'int', total_pages: 'int', sort_by: 'str | None', sort_dir: 'str | None') -> None
 ```
 
 One bounded page of a table, returned by `PreviewDataAccess.dataframe_page`.

--- a/src/scistudio/previewers/data_access.py
+++ b/src/scistudio/previewers/data_access.py
@@ -70,8 +70,6 @@ class DataFramePage:
     """Column the rows were sorted by, or ``None`` if unsorted."""
     sort_dir: str | None
     """Sort direction (``"asc"`` / ``"desc"``), or ``None`` if unsorted."""
-    truncated: bool
-    """True when the table has more rows than this page shows."""
 
 
 @provisional(since="0.3.1")
@@ -370,7 +368,6 @@ class PreviewDataAccess:
             total_pages=total_pages,
             sort_by=effective_sort_by,
             sort_dir=effective_sort_dir if effective_sort_by else None,
-            truncated=total_rows > effective_page_size,
         )
 
     @provisional(since="0.3.1")

--- a/src/scistudio/previewers/fallbacks.py
+++ b/src/scistudio/previewers/fallbacks.py
@@ -175,9 +175,13 @@ def dataframe_previewer(request: PreviewRequest) -> PreviewEnvelope:
             "sort_by": result.sort_by,
             "sort_dir": result.sort_dir,
         },
+        # A paginated table is complete and fully reachable: every row is
+        # available through total_rows/total_pages navigation. Never flag it as
+        # truncated/incomplete (#1920, Part 1 of #1886). truncated/incomplete is
+        # reserved for genuinely unavailable data (e.g. the failed read above).
         metadata=PreviewMetadata(
-            truncated=result.truncated,
-            complete=not result.truncated,
+            truncated=False,
+            complete=True,
             extra={"total_rows": result.total_rows},
         ),
     )

--- a/tests/ai/test_mcp_fastmcp.py
+++ b/tests/ai/test_mcp_fastmcp.py
@@ -265,10 +265,13 @@ def test_input_schema_rejects_malformed_call() -> None:
         f"get_block_schema inputSchema missing type_name property: {schema}"
     )
     # Calling with the wrong field name should fail validation at the boundary.
-    # FastMCP raises ToolError on input-schema validation failure.
-    from fastmcp.exceptions import ToolError
+    # FastMCP 3.x raises fastmcp.exceptions.ValidationError (a FastMCPError, not
+    # a ToolError/ValueError) for input-schema validation failures; older
+    # versions raised ToolError or a pydantic ValueError. Accept either so the
+    # boundary-rejection contract holds across the supported fastmcp range.
+    from fastmcp.exceptions import ToolError, ValidationError
 
-    with pytest.raises((ToolError, ValueError, TypeError)):
+    with pytest.raises((ValidationError, ToolError, ValueError, TypeError)):
         _run(mcp.call_tool("get_block_schema", {"not_a_param": "x"}))
 
 

--- a/tests/api/test_previewers.py
+++ b/tests/api/test_previewers.py
@@ -289,6 +289,21 @@ def test_read_and_patch_session_repaginate(client: TestClient, opened_project: P
     assert len(patched.json()["payload"]["rows"]) == 37
 
 
+def test_paginated_dataframe_is_not_flagged_truncated(client: TestClient, opened_project: Path) -> None:
+    """#1920 (Part 1 of #1886): a complete-but-paginated table must not carry the
+    misleading truncated/incomplete flags. Every row is reachable by paging, so
+    the metadata stays truncated=False / complete=True (regression of #1052)."""
+    header = "idx\n"
+    body = "".join(f"{i}\n" for i in range(137))  # multi-page at the default page size
+    upload = client.post("/api/data/upload", files={"file": ("m.csv", (header + body).encode(), "text/csv")})
+    ref = upload.json()["ref"]
+    created = _create_session(client, ref=ref, recorded_type="DataFrame", type_chain=["DataObject", "DataFrame"]).json()
+    meta = created["metadata"]
+    assert created["payload"]["total_pages"] > 1  # genuinely spans multiple pages
+    assert meta["truncated"] is False
+    assert meta["complete"] is True
+
+
 def test_patch_session_sorts_dataframe(client: TestClient, opened_project: Path) -> None:
     """#1604: sort flows through the routed session PATCH (was the legacy GET
     /api/data/{ref}/preview ?sort_by/sort_dir adapter, now removed)."""

--- a/tests/previewers/test_preview_data_access.py
+++ b/tests/previewers/test_preview_data_access.py
@@ -29,7 +29,10 @@ def test_dataframe_page_bounds_rows(tmp_path: Path) -> None:
     assert page.page_size == 200
     assert len(page.rows) == 200
     assert page.total_rows == 1000
-    assert page.truncated is True
+    # #1920: a bounded page is not "truncated" — every row stays reachable by
+    # paging. The page carries no truncation flag; reachability is total_pages.
+    assert page.total_pages == 5
+    assert not hasattr(page, "truncated")
 
 
 def test_dataframe_page_sort(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

The DataFrame preview showed amber **`truncated`** and **`incomplete`** status
badges for tables that are complete and fully reachable by pagination, implying
the shown data is partial/untrustworthy when it is not. This was a regression of
the faithful-display fix in #1052 (closed #1050), reintroduced by the ADR-048
preview rewrite. It is **Part 1** of #1886.

## Change

- Remove the misleading `truncated` field from the paginated `DataFramePage`: a
  bounded page is never truncated — `total_rows`/`total_pages` keep every row
  reachable.
- The DataFrame success path now emits `truncated=False, complete=True`.
  Genuinely unavailable data keeps its honest `complete=False, failed=True` path.
- No frontend change: the badges disappear once the backend flags are honest
  (backend stays the source of truth). The table pager already shows total rows
  and page count, so discoverability is unchanged.
- Regenerated the ADR-052 API reference for `scistudio.previewers.data_access`.

## Tests

- `tests/previewers/test_preview_data_access.py`: a bounded page carries no
  truncation flag; reachability is asserted via `total_pages`.
- `tests/api/test_previewers.py`: new regression test — a multi-page table
  reports `truncated=False` / `complete=True`.

## Out of scope

Part 2 of #1886 (arrays/images decimated by default, collection sampling,
NaN/masked-cell surfacing, auto-contrast labelling) stays tracked in #1886.
Text-chunk and array-plane `truncated` (a real read bound) are unchanged.

Gate record: .workflow/records/1920-guided-1920-table-badge.json

Closes #1920


---

### CI note (folded per owner "修CI" directive)

CI's Test job upgraded fastmcp to 3.3.1, which raises
`fastmcp.exceptions.ValidationError` (not `ToolError`/`ValueError`) for malformed
MCP calls. That broke `tests/ai/test_mcp_fastmcp.py::test_input_schema_rejects_malformed_call`
on clean CI — a fastmcp dependency drift unrelated to the previewer change. This
PR widens that test's accepted boundary-rejection exceptions to include fastmcp's
`ValidationError`.
