### PR TITLE
fix(#1929): stop tutorial from pre-filling block palette search

### DIFF
--- a/.workflow/records/1929-guided-1929-tutorial-palette-search.json
+++ b/.workflow/records/1929-guided-1929-tutorial-palette-search.json
@@ -82,7 +82,13 @@
     }
   ],
   "check_na": [],
-  "commit": null,
+  "commit": {
+    "sha": "0695425ced4158cba329dfea8e3595c9a47a339e",
+    "shas": [
+      "0695425ced4158cba329dfea8e3595c9a47a339e"
+    ],
+    "trailers": []
+  },
   "declared_scope": {
     "exclude": [],
     "include": [
@@ -199,6 +205,88 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-07-08T20:35:15.184291Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-08T20:35:15.194714Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-08T20:35:15.204745Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-08T20:35:15.214631Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-08T20:35:15.224054Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-08T20:35:15.234012Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-08T20:35:15.243972Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-08T20:35:15.253152Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-08T20:35:15.262177Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-08T20:35:15.272508Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -219,9 +307,9 @@
       "frontend/src/components/TutorialPanel.test.tsx",
       "frontend/src/components/TutorialPanel.tsx"
     ],
-    "diff_fingerprint": "sha256:d696a92bd09eb1cd8d8b404511ccc549fd91976ad5f255391e83fd287f891eb8",
+    "diff_fingerprint": "sha256:089b238edc243c1ea9f8d05eaed4f566c1154994e1dcaaeb0cd63ca70f08232a",
     "head": "HEAD",
-    "head_sha": "e8f6debc",
+    "head_sha": "0695425c",
     "surfaces": {
       "docs": 0,
       "frontend": 3,
@@ -237,12 +325,27 @@
   },
   "owner_directive": "Tutorial \u62d6 block \u6b65\u9aa4\u4f1a\u81ea\u52a8\u586b\u5145 palette search \u4e3a\u81ea\u5b9a\u4e49 block \u540d(Normalize Fluorescence),\u5bfc\u81f4\u4e0b\u4e00\u6b65\u627e\u4e0d\u5230 Load;\u53bb\u6389\u8fd9\u4e2a\u81ea\u52a8\u586b\u5145,\u8ba9\u7528\u6237\u81ea\u5df1\u5728 palette \u91cc\u627e\u3002",
   "persona": "live_implementer",
-  "pull_request": null,
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [
+      1929
+    ],
+    "number": null,
+    "url": null
+  },
   "reconcile_events": [
     {
       "at": "2026-07-08T20:34:50.476388Z",
       "diff_fingerprint": "sha256:d696a92bd09eb1cd8d8b404511ccc549fd91976ad5f255391e83fd287f891eb8",
       "mode": "local",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-07-08T20:35:15.272538Z",
+      "diff_fingerprint": "sha256:089b238edc243c1ea9f8d05eaed4f566c1154994e1dcaaeb0cd63ca70f08232a",
+      "mode": "pre-pr",
       "result": "pass",
       "tier": 2,
       "unsatisfied": []

--- a/.workflow/records/1929-guided-1929-tutorial-palette-search.json
+++ b/.workflow/records/1929-guided-1929-tutorial-palette-search.json
@@ -1,0 +1,80 @@
+{
+  "branch": "guided/1929-tutorial-palette-search",
+  "check_events": [],
+  "check_na": [],
+  "commit": null,
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "frontend/src/components/TutorialPanel.tsx",
+      "frontend/src/App.tsx",
+      "frontend/src/components/TutorialPanel.test.tsx"
+    ]
+  },
+  "directive_events": [
+    {
+      "at": "2026-07-08T20:30:31.045863Z",
+      "owner_directive": "\u53bb\u6389 tutorial create-custom-block \u6b65\u9aa4\u5bf9 palette search \u7684\u81ea\u52a8\u586b\u5145;\u65b0\u589e TutorialPanel \u56de\u5f52\u6d4b\u8bd5\u3002",
+      "reason": "plan"
+    }
+  ],
+  "docs_events": [
+    {
+      "at": "2026-07-08T20:30:31.046037Z",
+      "class": "user_docs",
+      "kind": "na",
+      "path": null,
+      "rationale": "UI-only behavior fix \u2014 removes an unintended palette-search pre-fill in the onboarding tutorial; no documented contract, schema, or workflow changes.",
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-07-08T20:30:31.046048Z",
+      "class": "adr",
+      "kind": "na",
+      "path": null,
+      "rationale": "No architectural decision; a one-line UI side-effect removal in a frontend component.",
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": false,
+  "guard_events": [],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1929,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": null,
+  "owner_directive": "Tutorial \u62d6 block \u6b65\u9aa4\u4f1a\u81ea\u52a8\u586b\u5145 palette search \u4e3a\u81ea\u5b9a\u4e49 block \u540d(Normalize Fluorescence),\u5bfc\u81f4\u4e0b\u4e00\u6b65\u627e\u4e0d\u5230 Load;\u53bb\u6389\u8fd9\u4e2a\u81ea\u52a8\u586b\u5145,\u8ba9\u7528\u6237\u81ea\u5df1\u5728 palette \u91cc\u627e\u3002",
+  "persona": "live_implementer",
+  "pull_request": null,
+  "reconcile_events": [],
+  "record_id": "1929-guided-1929-tutorial-palette-search",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [],
+    "docs": [],
+    "guards": [],
+    "tests": []
+  },
+  "runtime": "claude",
+  "schema_version": 2,
+  "scope_events": [],
+  "session_id": "5a717180-fa5c-4185-9ab8-7e722c1bb9e5",
+  "strictness_tier": null,
+  "task_kind": "guided",
+  "test_events": [
+    {
+      "at": "2026-07-08T20:30:31.046055Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/components/TutorialPanel.test.tsx",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/.workflow/records/1929-guided-1929-tutorial-palette-search.json
+++ b/.workflow/records/1929-guided-1929-tutorial-palette-search.json
@@ -1,6 +1,86 @@
 {
   "branch": "guided/1929-tutorial-palette-search",
-  "check_events": [],
+  "check_events": [
+    {
+      "at": "2026-07-08T20:31:35.269118Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:bee0017f30f552d2df2de1173f9ac14b9aee5192ca5e5c1de574bb119512b275",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-07-08T20:32:21.162939Z",
+      "command": "(cd frontend && npm run check:ci)",
+      "covered_surface": "frontend",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:0c3a8a74b36b805c2743caa719b676b46f18123b4728d3ea4b20da298cbbd4d5",
+      "name": "frontend",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/frontend.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-08T20:32:26.043634Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:77c97c69830b145e4623f4b8a266ed5702c186d6c87daabafd91909b0dc8b6df",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-08T20:32:26.125628Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e31351abfc33f0b3c0f28bc9f2f3d59ae3bc5d4925dc1159a7f931aa932441ed",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-07-08T20:34:50.339574Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:8afc3501bdb4221295bac8b2d3420236ffe65d8c6c18aa8f10351fd7d3e7e1f8",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    }
+  ],
   "check_na": [],
   "commit": null,
   "declared_scope": {
@@ -37,7 +117,90 @@
     }
   ],
   "governance_touch": false,
-  "guard_events": [],
+  "guard_events": [
+    {
+      "at": "2026-07-08T20:34:50.384395Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-08T20:34:50.394065Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-08T20:34:50.404668Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-08T20:34:50.414164Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-08T20:34:50.423403Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-08T20:34:50.433061Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-08T20:34:50.442552Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-08T20:34:50.455077Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-08T20:34:50.465152Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-08T20:34:50.476342Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
   "issues": [
     {
       "close_in_pr": true,
@@ -47,25 +210,79 @@
     }
   ],
   "observed_admin_labels": [],
-  "observed_diff": null,
+  "observed_diff": {
+    "base": "origin/main",
+    "base_sha": "fc241476",
+    "changed_files": [
+      ".workflow/records/1929-guided-1929-tutorial-palette-search.json",
+      "frontend/src/App.tsx",
+      "frontend/src/components/TutorialPanel.test.tsx",
+      "frontend/src/components/TutorialPanel.tsx"
+    ],
+    "diff_fingerprint": "sha256:d696a92bd09eb1cd8d8b404511ccc549fd91976ad5f255391e83fd287f891eb8",
+    "head": "HEAD",
+    "head_sha": "e8f6debc",
+    "surfaces": {
+      "docs": 0,
+      "frontend": 3,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 3,
+      "packaging": 0,
+      "protected_core": 0,
+      "sentrux": 3,
+      "test": 1,
+      "workflow_ci": 0
+    }
+  },
   "owner_directive": "Tutorial \u62d6 block \u6b65\u9aa4\u4f1a\u81ea\u52a8\u586b\u5145 palette search \u4e3a\u81ea\u5b9a\u4e49 block \u540d(Normalize Fluorescence),\u5bfc\u81f4\u4e0b\u4e00\u6b65\u627e\u4e0d\u5230 Load;\u53bb\u6389\u8fd9\u4e2a\u81ea\u52a8\u586b\u5145,\u8ba9\u7528\u6237\u81ea\u5df1\u5728 palette \u91cc\u627e\u3002",
   "persona": "live_implementer",
   "pull_request": null,
-  "reconcile_events": [],
+  "reconcile_events": [
+    {
+      "at": "2026-07-08T20:34:50.476388Z",
+      "diff_fingerprint": "sha256:d696a92bd09eb1cd8d8b404511ccc549fd91976ad5f255391e83fd287f891eb8",
+      "mode": "local",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    }
+  ],
   "record_id": "1929-guided-1929-tutorial-palette-search",
   "requested_admin_labels": [],
   "required_obligations": {
     "admin_labels": [],
-    "checks": [],
-    "docs": [],
-    "guards": [],
-    "tests": []
+    "checks": [
+      "format_check",
+      "frontend",
+      "full_audit",
+      "lint_format",
+      "semantic_dup"
+    ],
+    "docs": [
+      "docs_required_or_na"
+    ],
+    "guards": [
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": [
+      "changed_test_required"
+    ]
   },
   "runtime": "claude",
   "schema_version": 2,
   "scope_events": [],
   "session_id": "5a717180-fa5c-4185-9ab8-7e722c1bb9e5",
-  "strictness_tier": null,
+  "strictness_tier": 2,
   "task_kind": "guided",
   "test_events": [
     {

--- a/.workflow/records/1929-guided-1929-tutorial-palette-search.json
+++ b/.workflow/records/1929-guided-1929-tutorial-palette-search.json
@@ -287,6 +287,88 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-07-08T20:35:33.860320Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-08T20:35:33.869404Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-08T20:35:33.878381Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-08T20:35:33.887285Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-08T20:35:33.896106Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-08T20:35:33.905797Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-08T20:35:33.914841Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-08T20:35:33.923876Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-08T20:35:33.932929Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-08T20:35:33.942997Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -307,9 +389,9 @@
       "frontend/src/components/TutorialPanel.test.tsx",
       "frontend/src/components/TutorialPanel.tsx"
     ],
-    "diff_fingerprint": "sha256:089b238edc243c1ea9f8d05eaed4f566c1154994e1dcaaeb0cd63ca70f08232a",
+    "diff_fingerprint": "sha256:b4d17455e03d800858b7bd1daa1251e4c05b4d1fabc8706cf3057909ec08640b",
     "head": "HEAD",
-    "head_sha": "0695425c",
+    "head_sha": "5b38ac76",
     "surfaces": {
       "docs": 0,
       "frontend": 3,
@@ -345,6 +427,14 @@
     {
       "at": "2026-07-08T20:35:15.272538Z",
       "diff_fingerprint": "sha256:089b238edc243c1ea9f8d05eaed4f566c1154994e1dcaaeb0cd63ca70f08232a",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-07-08T20:35:33.943030Z",
+      "diff_fingerprint": "sha256:b4d17455e03d800858b7bd1daa1251e4c05b4d1fabc8706cf3057909ec08640b",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 2,

--- a/.workflow/records/1929-guided-1929-tutorial-palette-search.json
+++ b/.workflow/records/1929-guided-1929-tutorial-palette-search.json
@@ -83,9 +83,9 @@
   ],
   "check_na": [],
   "commit": {
-    "sha": "0695425ced4158cba329dfea8e3595c9a47a339e",
+    "sha": "cd62187ad90416d9f1e0b15485d82c78b4444d83",
     "shas": [
-      "0695425ced4158cba329dfea8e3595c9a47a339e"
+      "cd62187ad90416d9f1e0b15485d82c78b4444d83"
     ],
     "trailers": []
   },
@@ -369,6 +369,88 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-07-08T20:36:04.861174Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-08T20:36:04.870354Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-08T20:36:04.880053Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-08T20:36:04.889081Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-08T20:36:04.897951Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-08T20:36:04.906983Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-08T20:36:04.915935Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-08T20:36:04.925203Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-08T20:36:04.934079Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-08T20:36:04.944795Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -381,7 +463,7 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "origin/main",
+    "base": "fc241476069bd1145bd870a62d86c37641ae9c5d",
     "base_sha": "fc241476",
     "changed_files": [
       ".workflow/records/1929-guided-1929-tutorial-palette-search.json",
@@ -389,9 +471,9 @@
       "frontend/src/components/TutorialPanel.test.tsx",
       "frontend/src/components/TutorialPanel.tsx"
     ],
-    "diff_fingerprint": "sha256:b4d17455e03d800858b7bd1daa1251e4c05b4d1fabc8706cf3057909ec08640b",
+    "diff_fingerprint": "sha256:d8edd90c775183750776bcedfbe3b1b143cf09bed4325479b17e836448652ca3",
     "head": "HEAD",
-    "head_sha": "5b38ac76",
+    "head_sha": "cd62187a",
     "surfaces": {
       "docs": 0,
       "frontend": 3,
@@ -412,8 +494,8 @@
     "closes": [
       1929
     ],
-    "number": null,
-    "url": null
+    "number": 1931,
+    "url": "https://github.com/jiazhenz026/SciStudio/pull/1931"
   },
   "reconcile_events": [
     {
@@ -435,6 +517,14 @@
     {
       "at": "2026-07-08T20:35:33.943030Z",
       "diff_fingerprint": "sha256:b4d17455e03d800858b7bd1daa1251e4c05b4d1fabc8706cf3057909ec08640b",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-07-08T20:36:04.944824Z",
+      "diff_fingerprint": "sha256:d8edd90c775183750776bcedfbe3b1b143cf09bed4325479b17e836448652ca3",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 2,

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -496,7 +496,6 @@ export default function App() {
                 onReloadBlocks={reloadBlocks}
                 onSaveWorkflow={saveWorkflow}
                 onShowBlocks={() => setLeftTab("blocks")}
-                onPaletteSearch={setPaletteSearch}
               />
             </>
           ) : (

--- a/frontend/src/components/TutorialPanel.test.tsx
+++ b/frontend/src/components/TutorialPanel.test.tsx
@@ -1,0 +1,110 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// TutorialPanel and the shared store read named methods off the `api` object;
+// mock the ones this surface touches and keep the rest intact.
+const putProjectFile = vi.fn();
+const listPlots = vi.fn();
+vi.mock("../lib/api", async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  const actualApi = (actual.api ?? {}) as Record<string, unknown>;
+  return {
+    ...actual,
+    api: {
+      ...actualApi,
+      putProjectFile: (...a: unknown[]) => putProjectFile(...a),
+      listPlots: (...a: unknown[]) => listPlots(...a),
+    },
+  };
+});
+
+import { useAppStore } from "../store";
+import type { RunFirstWorkflowTutorialInstance } from "../store/types";
+import type { ProjectResponse } from "../types/api";
+import { resetAppStore } from "../testUtils";
+
+import { TutorialPanel } from "./TutorialPanel";
+
+const PROJECT_ID = "proj-1";
+
+function makeInstance(): RunFirstWorkflowTutorialInstance {
+  return {
+    tutorialId: "run-first-scistudio-workflow",
+    projectId: PROJECT_ID,
+    datasetPath: "data/raw/cell_viability_fluorescence.csv",
+    workflowId: "main",
+    customBlockPath: "blocks/normalize_fluorescence.py",
+    customBlockType: "normalize_fluorescence",
+    customBlockName: "Normalize Fluorescence",
+    plotId: "normalized-activity",
+    plotTitle: "Normalized cell activity",
+    negativeControl: "neg_control",
+    positiveControl: "pos_control",
+  };
+}
+
+function makeProject(): ProjectResponse {
+  return {
+    id: PROJECT_ID,
+    name: "Demo",
+    description: "",
+    path: "/tmp/proj-1",
+    workflow_count: 1,
+    workflows: ["main"],
+    current_workflow_id: "main",
+  };
+}
+
+function makeProps() {
+  return {
+    onOpenFile: vi.fn(),
+    onReloadBlocks: vi.fn().mockResolvedValue(undefined),
+    onSaveWorkflow: vi.fn().mockResolvedValue(undefined),
+    onShowBlocks: vi.fn(),
+  };
+}
+
+beforeEach(() => {
+  putProjectFile.mockReset().mockResolvedValue(undefined);
+  listPlots.mockReset().mockResolvedValue({ plots: [] });
+  resetAppStore();
+  useAppStore.setState({
+    currentProject: makeProject(),
+    runFirstWorkflowTutorialActive: true,
+    runFirstWorkflowTutorialStep: "create-custom-block",
+    runFirstWorkflowTutorialInstance: makeInstance(),
+    paletteSearch: "",
+  });
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("TutorialPanel create-custom-block step", () => {
+  it("does not pre-fill the block palette search (Load must stay findable, #1929)", async () => {
+    const props = makeProps();
+    render(<TutorialPanel {...props} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /create block/i }));
+
+    // The create-block action creates the tutorial block, shows the palette,
+    // opens the block file, and advances to the build-workflow step.
+    await waitFor(() => {
+      expect(useAppStore.getState().runFirstWorkflowTutorialStep).toBe("build-workflow");
+    });
+    expect(putProjectFile).toHaveBeenCalledWith(
+      PROJECT_ID,
+      "blocks/normalize_fluorescence.py",
+      expect.stringContaining("NormalizeFluorescenceBlock"),
+      { createParentDirs: true },
+    );
+    expect(props.onShowBlocks).toHaveBeenCalled();
+    expect(props.onOpenFile).toHaveBeenCalledWith("blocks/normalize_fluorescence.py");
+
+    // Regression guard: the tutorial must never seed the palette search. A
+    // lingering "Normalize Fluorescence" filter hid the Load block in the next
+    // step and forced users to clear the field by hand.
+    expect(useAppStore.getState().paletteSearch).toBe("");
+  });
+});

--- a/frontend/src/components/TutorialPanel.tsx
+++ b/frontend/src/components/TutorialPanel.tsx
@@ -23,7 +23,6 @@ interface TutorialPanelProps {
   onReloadBlocks: () => Promise<void>;
   onSaveWorkflow: () => Promise<void>;
   onShowBlocks: () => void;
-  onPaletteSearch: (search: string) => void;
 }
 
 function nextStep(step: RunFirstWorkflowTutorialStep): RunFirstWorkflowTutorialStep {
@@ -43,7 +42,6 @@ export function TutorialPanel({
   onReloadBlocks,
   onSaveWorkflow,
   onShowBlocks,
-  onPaletteSearch,
 }: TutorialPanelProps) {
   const currentProject = useAppStore((state) => state.currentProject);
   const workflowId = useAppStore((state) => state.workflowId);
@@ -120,7 +118,9 @@ export function TutorialPanel({
         );
         await onReloadBlocks();
         onShowBlocks();
-        onPaletteSearch(instance.customBlockName);
+        // Do not pre-fill the block palette search: the next step asks the user
+        // to drag "Load" from the palette, and a lingering filter would hide it.
+        // Users find blocks from the palette themselves (#1929).
         onOpenFile(instance.customBlockPath);
         setStep("build-workflow");
       } else if (stepId === "create-plot-card") {


### PR DESCRIPTION
## Summary

The "Run Your First SciStudio Workflow" onboarding tutorial's **Create your
normalization block** step auto-filled the block palette search with the custom
block name (`Normalize Fluorescence`). The next step (**Build the workflow**)
asks the user to drag **Load** from the palette, but the lingering search filter
hid Load, so users could not find it until they manually cleared the field.

This removes the palette-search auto-fill from the tutorial's create-custom-block
action (and the now-unused `onPaletteSearch` wiring in `App.tsx`). Users find
blocks from the palette themselves.

## Changes

- `frontend/src/components/TutorialPanel.tsx`: drop the `onPaletteSearch` prop
  and its `onPaletteSearch(instance.customBlockName)` call in the
  create-custom-block step.
- `frontend/src/App.tsx`: remove the `onPaletteSearch={setPaletteSearch}` wiring
  (`setPaletteSearch` is still used by the workspace palette).
- `frontend/src/components/TutorialPanel.test.tsx`: new regression test asserting
  the create-custom-block action does not seed the palette search.

## Testing

- `gate_record check` (tier 2) passed: `format_check`, `frontend`,
  `full_audit`, `lint_format`, `semantic_dup`.

Gate record: .workflow/records/1929-guided-1929-tutorial-palette-search.json

Closes #1929
