### PR TITLE
guided(#1933): isolate ambient scistudio.blocks entry-point + desktop package pollution in tests

### DIFF
--- a/.workflow/records/1933-test-env-entrypoint-isolation.json
+++ b/.workflow/records/1933-test-env-entrypoint-isolation.json
@@ -83,9 +83,9 @@
   ],
   "check_na": [],
   "commit": {
-    "sha": "4f87c195d26dfabb33714a5f33d92bb66be927a7",
+    "sha": "a9e52dbde5b42babbc6b58187a8fb18f885cae85",
     "shas": [
-      "4f87c195d26dfabb33714a5f33d92bb66be927a7"
+      "a9e52dbde5b42babbc6b58187a8fb18f885cae85"
     ],
     "trailers": []
   },
@@ -453,6 +453,170 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-07-09T00:01:47.048954Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-09T00:01:47.058245Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-09T00:01:47.068011Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-09T00:01:47.077517Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-09T00:01:47.087048Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-09T00:01:47.096539Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-09T00:01:47.106393Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-09T00:01:47.116604Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-09T00:01:47.126385Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-09T00:01:47.137996Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-09T00:01:57.826172Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-09T00:01:57.836074Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-09T00:01:57.846578Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-09T00:01:57.856607Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-09T00:01:57.866225Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-09T00:01:57.876321Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-09T00:01:57.886046Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-09T00:01:57.896058Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-09T00:01:57.906101Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-09T00:01:57.918193Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -465,7 +629,7 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "origin/main",
+    "base": "2ec2b4adc4440ad5863f8611cc5df06b558c04ac",
     "base_sha": "2ec2b4ad",
     "changed_files": [
       ".workflow/records/1933-test-env-entrypoint-isolation.json",
@@ -473,9 +637,9 @@
       "tests/blocks/test_entry_point_isolation.py",
       "tests/conftest.py"
     ],
-    "diff_fingerprint": "sha256:677c646400befd22d8cd76f794a7ab1bf5bc44a06d0dfafda6aedd854660b44b",
+    "diff_fingerprint": "sha256:7938387f4891fbcc76104f1a1af4d2cdb6c660acdbf2d43d1fc0d1d269330f5d",
     "head": "HEAD",
-    "head_sha": "46560f28",
+    "head_sha": "a9e52dbd",
     "surfaces": {
       "docs": 0,
       "frontend": 0,
@@ -496,8 +660,8 @@
     "closes": [
       1933
     ],
-    "number": null,
-    "url": null
+    "number": 1934,
+    "url": "https://github.com/jiazhenz026/SciStudio/pull/1934"
   },
   "reconcile_events": [
     {
@@ -519,6 +683,22 @@
     {
       "at": "2026-07-09T00:01:06.365625Z",
       "diff_fingerprint": "sha256:677c646400befd22d8cd76f794a7ab1bf5bc44a06d0dfafda6aedd854660b44b",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-07-09T00:01:47.138040Z",
+      "diff_fingerprint": "sha256:7938387f4891fbcc76104f1a1af4d2cdb6c660acdbf2d43d1fc0d1d269330f5d",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-07-09T00:01:57.918227Z",
+      "diff_fingerprint": "sha256:7938387f4891fbcc76104f1a1af4d2cdb6c660acdbf2d43d1fc0d1d269330f5d",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 2,

--- a/.workflow/records/1933-test-env-entrypoint-isolation.json
+++ b/.workflow/records/1933-test-env-entrypoint-isolation.json
@@ -1,0 +1,184 @@
+{
+  "branch": "guided/1933-test-env-entrypoint-isolation",
+  "check_events": [],
+  "check_na": [],
+  "commit": null,
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "tests/conftest.py",
+      "tests/blocks/test_entry_point_isolation.py"
+    ]
+  },
+  "directive_events": [
+    {
+      "at": "2026-07-08T23:47:37.630323Z",
+      "owner_directive": "Solve local test flakiness completely; harden repo so tests are immune to env pollution; do both layers; ship a PR. Extends to neutralizing platform user-data desktop package discovery, not only entry points.",
+      "reason": "Full-suite run revealed a second local leak channel beyond entry points: desktop Tier-3 source-package discovery (candidate_package_dirs) scans the platform user-data plugins dir where real domain packages (imaging/lcms/spectroscopy) are installed, failing domain-prefix/previewer tests locally while CI with a clean profile is green. Isolating it in conftest is part of the owner directive to make local tests robust to env pollution."
+    },
+    {
+      "at": "2026-07-08T23:53:33.678343Z",
+      "owner_directive": "Document local test-env setup + the conftest self-isolation so future devs know a dirty dev machine still matches CI.",
+      "reason": "plan"
+    }
+  ],
+  "docs_events": [
+    {
+      "at": "2026-07-08T23:53:33.678528Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/README.md",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": false,
+  "guard_events": [
+    {
+      "at": "2026-07-08T23:39:52.936031Z",
+      "findings": [
+        {
+          "message": "AI-authored edits must happen in a dedicated worktree, not the main working tree (/private/var/folders/mk/xk0dqvn934l5425gwb19rsqc0000gn/T/pytest-of-jiazhenz/pytest-1158/popen-gw10/test_hook_payload_blocks_main_0/main). Create one with `git worktree add ../<name> <branch>` and run your edits there.",
+          "rule_id": "worktree.main-checkout-write"
+        }
+      ],
+      "guard": "worktree_write_guard",
+      "status": "fail"
+    },
+    {
+      "at": "2026-07-08T23:39:53.768617Z",
+      "findings": [
+        {
+          "message": "AI-authored edits must happen in a dedicated worktree, not the main working tree (/private/var/folders/mk/xk0dqvn934l5425gwb19rsqc0000gn/T/pytest-of-jiazhenz/pytest-1158/popen-gw10/test_hook_payload_extracts_mul0/main). Create one with `git worktree add ../<name> <branch>` and run your edits there.",
+          "rule_id": "worktree.main-checkout-write"
+        }
+      ],
+      "guard": "worktree_write_guard",
+      "status": "fail"
+    },
+    {
+      "at": "2026-07-08T23:48:45.483025Z",
+      "findings": [
+        {
+          "message": "AI-authored edits must happen in a dedicated worktree, not the main working tree (/private/var/folders/mk/xk0dqvn934l5425gwb19rsqc0000gn/T/pytest-of-jiazhenz/pytest-1163/popen-gw8/test_hook_payload_blocks_main_0/main). Create one with `git worktree add ../<name> <branch>` and run your edits there.",
+          "rule_id": "worktree.main-checkout-write"
+        }
+      ],
+      "guard": "worktree_write_guard",
+      "status": "fail"
+    },
+    {
+      "at": "2026-07-08T23:48:46.406234Z",
+      "findings": [
+        {
+          "message": "AI-authored edits must happen in a dedicated worktree, not the main working tree (/private/var/folders/mk/xk0dqvn934l5425gwb19rsqc0000gn/T/pytest-of-jiazhenz/pytest-1163/popen-gw8/test_hook_payload_extracts_mul0/main). Create one with `git worktree add ../<name> <branch>` and run your edits there.",
+          "rule_id": "worktree.main-checkout-write"
+        }
+      ],
+      "guard": "worktree_write_guard",
+      "status": "fail"
+    },
+    {
+      "at": "2026-07-08T23:50:01.984138Z",
+      "findings": [
+        {
+          "message": "AI-authored edits must happen in a dedicated worktree, not the main working tree (/private/var/folders/mk/xk0dqvn934l5425gwb19rsqc0000gn/T/pytest-of-jiazhenz/pytest-1165/popen-gw8/test_hook_payload_blocks_main_0/main). Create one with `git worktree add ../<name> <branch>` and run your edits there.",
+          "rule_id": "worktree.main-checkout-write"
+        }
+      ],
+      "guard": "worktree_write_guard",
+      "status": "fail"
+    },
+    {
+      "at": "2026-07-08T23:50:02.760503Z",
+      "findings": [
+        {
+          "message": "AI-authored edits must happen in a dedicated worktree, not the main working tree (/private/var/folders/mk/xk0dqvn934l5425gwb19rsqc0000gn/T/pytest-of-jiazhenz/pytest-1165/popen-gw8/test_hook_payload_extracts_mul0/main). Create one with `git worktree add ../<name> <branch>` and run your edits there.",
+          "rule_id": "worktree.main-checkout-write"
+        }
+      ],
+      "guard": "worktree_write_guard",
+      "status": "fail"
+    },
+    {
+      "at": "2026-07-08T23:51:30.169374Z",
+      "findings": [
+        {
+          "message": "AI-authored edits must happen in a dedicated worktree, not the main working tree (/private/var/folders/mk/xk0dqvn934l5425gwb19rsqc0000gn/T/pytest-of-jiazhenz/pytest-1167/popen-gw4/test_hook_payload_blocks_main_0/main). Create one with `git worktree add ../<name> <branch>` and run your edits there.",
+          "rule_id": "worktree.main-checkout-write"
+        }
+      ],
+      "guard": "worktree_write_guard",
+      "status": "fail"
+    },
+    {
+      "at": "2026-07-08T23:51:30.993370Z",
+      "findings": [
+        {
+          "message": "AI-authored edits must happen in a dedicated worktree, not the main working tree (/private/var/folders/mk/xk0dqvn934l5425gwb19rsqc0000gn/T/pytest-of-jiazhenz/pytest-1167/popen-gw4/test_hook_payload_extracts_mul0/main). Create one with `git worktree add ../<name> <branch>` and run your edits there.",
+          "rule_id": "worktree.main-checkout-write"
+        }
+      ],
+      "guard": "worktree_write_guard",
+      "status": "fail"
+    }
+  ],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1933,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": null,
+  "owner_directive": "Solve local test flakiness once and for all: (Layer 1) clean the scistudio conda env of leaked domain packages and missing dev deps; (Layer 2) harden tests/conftest.py so the core suite is immune to ambient scistudio.blocks entry-point pollution (stale editable metadata + leaked domain packages). Submit a PR.",
+  "persona": "live_implementer",
+  "pull_request": null,
+  "reconcile_events": [],
+  "record_id": "1933-test-env-entrypoint-isolation",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [],
+    "docs": [],
+    "guards": [],
+    "tests": []
+  },
+  "runtime": "claude",
+  "schema_version": 2,
+  "scope_events": [
+    {
+      "action": "add-include",
+      "at": "2026-07-08T23:47:37.630521Z",
+      "pattern": "tests/conftest.py",
+      "reason": "Full-suite run revealed a second local leak channel beyond entry points: desktop Tier-3 source-package discovery (candidate_package_dirs) scans the platform user-data plugins dir where real domain packages (imaging/lcms/spectroscopy) are installed, failing domain-prefix/previewer tests locally while CI with a clean profile is green. Isolating it in conftest is part of the owner directive to make local tests robust to env pollution."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-07-08T23:47:37.630528Z",
+      "pattern": "tests/blocks/test_entry_point_isolation.py",
+      "reason": "Full-suite run revealed a second local leak channel beyond entry points: desktop Tier-3 source-package discovery (candidate_package_dirs) scans the platform user-data plugins dir where real domain packages (imaging/lcms/spectroscopy) are installed, failing domain-prefix/previewer tests locally while CI with a clean profile is green. Isolating it in conftest is part of the owner directive to make local tests robust to env pollution."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-07-08T23:53:33.678513Z",
+      "pattern": "tests/README.md",
+      "reason": "plan"
+    }
+  ],
+  "session_id": "ac24b992-c5d4-4fa1-8b18-72beff256aa0",
+  "strictness_tier": null,
+  "task_kind": "guided",
+  "test_events": [
+    {
+      "at": "2026-07-08T23:53:33.678534Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/blocks/test_entry_point_isolation.py",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/.workflow/records/1933-test-env-entrypoint-isolation.json
+++ b/.workflow/records/1933-test-env-entrypoint-isolation.json
@@ -371,6 +371,88 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-07-09T00:01:06.273087Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-09T00:01:06.282599Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-09T00:01:06.292409Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-09T00:01:06.303210Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-09T00:01:06.313523Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-09T00:01:06.323319Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-09T00:01:06.333077Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-09T00:01:06.345378Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-09T00:01:06.354618Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-09T00:01:06.365578Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -391,9 +473,9 @@
       "tests/blocks/test_entry_point_isolation.py",
       "tests/conftest.py"
     ],
-    "diff_fingerprint": "sha256:5b49b7dfd0dc45161d17f9b23f2287b73b8427b86ad7794eeb31173c1fd77bda",
+    "diff_fingerprint": "sha256:677c646400befd22d8cd76f794a7ab1bf5bc44a06d0dfafda6aedd854660b44b",
     "head": "HEAD",
-    "head_sha": "4f87c195",
+    "head_sha": "46560f28",
     "surfaces": {
       "docs": 0,
       "frontend": 0,
@@ -429,6 +511,14 @@
     {
       "at": "2026-07-09T00:00:16.275600Z",
       "diff_fingerprint": "sha256:5b49b7dfd0dc45161d17f9b23f2287b73b8427b86ad7794eeb31173c1fd77bda",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-07-09T00:01:06.365625Z",
+      "diff_fingerprint": "sha256:677c646400befd22d8cd76f794a7ab1bf5bc44a06d0dfafda6aedd854660b44b",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 2,

--- a/.workflow/records/1933-test-env-entrypoint-isolation.json
+++ b/.workflow/records/1933-test-env-entrypoint-isolation.json
@@ -1,8 +1,94 @@
 {
   "branch": "guided/1933-test-env-entrypoint-isolation",
-  "check_events": [],
+  "check_events": [
+    {
+      "at": "2026-07-08T23:55:41.063597Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:f8bfab7ef68f7e1c77deb20586ccce7b7ce10238c56294d91d3036d4da74c046",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-07-08T23:55:44.993391Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e72f69da598db8fe924eb867d36cbc2a289db6df27d7ab30c5f0456e78662b58",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-08T23:55:45.036669Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:f079146f75bcb7d9d03a35e127732891616e0558ce616a075cb6bbb7c9a8c01c",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-07-08T23:57:36.671537Z",
+      "command": "python -m scistudio.qa.testing.run_python_tests --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:de1d1970487cd1cfa4fb059f953748ff4f12f737c16fc46d62024449cd45f5b2",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-08T23:59:39.615298Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:d6a5b5d87376caf29b3188ca68e362d55d279929b09268d0cfefa014a8353f5d",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    }
+  ],
   "check_na": [],
-  "commit": null,
+  "commit": {
+    "sha": "4f87c195d26dfabb33714a5f33d92bb66be927a7",
+    "shas": [
+      "4f87c195d26dfabb33714a5f33d92bb66be927a7"
+    ],
+    "trailers": []
+  },
   "declared_scope": {
     "exclude": [],
     "include": [
@@ -121,6 +207,170 @@
       ],
       "guard": "worktree_write_guard",
       "status": "fail"
+    },
+    {
+      "at": "2026-07-08T23:59:39.661315Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-08T23:59:39.672019Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-08T23:59:39.682289Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-08T23:59:39.692528Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-08T23:59:39.702288Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-08T23:59:39.711949Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-08T23:59:39.721666Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-08T23:59:39.733922Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-08T23:59:39.743786Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-08T23:59:39.755523Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-09T00:00:16.187862Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-09T00:00:16.197100Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-09T00:00:16.206215Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-09T00:00:16.216637Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-09T00:00:16.226592Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-09T00:00:16.235891Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-09T00:00:16.245144Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-09T00:00:16.254708Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-09T00:00:16.264353Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-09T00:00:16.275565Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -132,18 +382,83 @@
     }
   ],
   "observed_admin_labels": [],
-  "observed_diff": null,
+  "observed_diff": {
+    "base": "origin/main",
+    "base_sha": "2ec2b4ad",
+    "changed_files": [
+      ".workflow/records/1933-test-env-entrypoint-isolation.json",
+      "tests/README.md",
+      "tests/blocks/test_entry_point_isolation.py",
+      "tests/conftest.py"
+    ],
+    "diff_fingerprint": "sha256:5b49b7dfd0dc45161d17f9b23f2287b73b8427b86ad7794eeb31173c1fd77bda",
+    "head": "HEAD",
+    "head_sha": "4f87c195",
+    "surfaces": {
+      "docs": 0,
+      "frontend": 0,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 0,
+      "packaging": 0,
+      "protected_core": 0,
+      "sentrux": 3,
+      "test": 3,
+      "workflow_ci": 0
+    }
+  },
   "owner_directive": "Solve local test flakiness once and for all: (Layer 1) clean the scistudio conda env of leaked domain packages and missing dev deps; (Layer 2) harden tests/conftest.py so the core suite is immune to ambient scistudio.blocks entry-point pollution (stale editable metadata + leaked domain packages). Submit a PR.",
   "persona": "live_implementer",
-  "pull_request": null,
-  "reconcile_events": [],
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [
+      1933
+    ],
+    "number": null,
+    "url": null
+  },
+  "reconcile_events": [
+    {
+      "at": "2026-07-08T23:59:39.755566Z",
+      "diff_fingerprint": "sha256:5b49b7dfd0dc45161d17f9b23f2287b73b8427b86ad7794eeb31173c1fd77bda",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-07-09T00:00:16.275600Z",
+      "diff_fingerprint": "sha256:5b49b7dfd0dc45161d17f9b23f2287b73b8427b86ad7794eeb31173c1fd77bda",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    }
+  ],
   "record_id": "1933-test-env-entrypoint-isolation",
   "requested_admin_labels": [],
   "required_obligations": {
     "admin_labels": [],
-    "checks": [],
+    "checks": [
+      "format_check",
+      "full_audit",
+      "lint_format",
+      "python_tests",
+      "semantic_dup"
+    ],
     "docs": [],
-    "guards": [],
+    "guards": [
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
     "tests": []
   },
   "runtime": "claude",
@@ -169,7 +484,7 @@
     }
   ],
   "session_id": "ac24b992-c5d4-4fa1-8b18-72beff256aa0",
-  "strictness_tier": null,
+  "strictness_tier": 2,
   "task_kind": "guided",
   "test_events": [
     {

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,52 @@
+# SciStudio test suite
+
+## Running the suite locally
+
+Run the tests in a dedicated environment that has **core only** installed
+(editable) plus the `dev` extras — the same shape CI uses. Do **not** run them
+from a shared base environment, and do **not** `pip install -e .` into a shared
+environment (see `AGENTS.md`).
+
+The suite has a small set of PTY / subprocess / thread tests marked `serial`
+that must run outside `pytest-xdist`. Use the two-phase runner, which mirrors
+the two `pytest` invocations CI runs (see `.github/workflows/ci.yml`):
+
+```bash
+python -m scistudio.qa.testing.run_python_tests
+```
+
+It runs the parallel bulk (`-n auto -m "not serial"`) first, then the `serial`
+tests in-process (`-n 0 -m serial`). Forwarded args (e.g. `--no-cov`,
+`--timeout=90`) apply to both phases.
+
+## Environment-pollution isolation
+
+A clean, core-only install exposes **no** domain blocks: core registers its
+first-party palette in `BlockRegistry._scan_builtins`, and the
+`scistudio.blocks` entry-point group is reserved for third-party plugins
+(`_scan_tier2`, ADR-025). CI runs in exactly that clean state, so it is green.
+
+A developer's machine is rarely that clean. Two channels leak domain blocks into
+the registry and make discovery/registry tests fail locally even though CI
+passes:
+
+1. **Entry points** — a stale editable `*.dist-info/entry_points.txt` frozen
+   from an earlier build can still declare retired/relocated built-ins under the
+   `scistudio.blocks` group, and locally-installed domain packages
+   (imaging / lcms / spectroscopy / srs) contribute their own entries.
+2. **Desktop package discovery** — Tier 3 source-package discovery
+   (`candidate_package_dirs`) scans the platform user-data plugins directory,
+   where a real desktop install leaves domain packages behind.
+
+`tests/conftest.py` neutralizes **both** channels for the whole test session so
+the suite behaves like a clean core-only install regardless of what is installed
+on the machine:
+
+- the `scistudio.blocks` entry-point group is filtered out of
+  `importlib.metadata.entry_points`, and
+- the desktop user-data directory is redirected to a clean per-session temp root.
+
+Tests that exercise Tier 2 / Tier 3 discovery inject their own entry points or
+package dirs (via `unittest.mock.patch` / `monkeypatch`), which transparently
+override the session baseline and are restored afterwards. The isolation is
+locked in by `tests/blocks/test_entry_point_isolation.py`.

--- a/tests/blocks/test_entry_point_isolation.py
+++ b/tests/blocks/test_entry_point_isolation.py
@@ -1,0 +1,112 @@
+"""Regression tests for test-session entry-point isolation (#1933).
+
+``tests/conftest.py`` neutralizes the ambient ``scistudio.blocks`` entry-point
+group so the suite behaves like a clean, core-only install regardless of stale
+editable ``*.dist-info`` metadata or locally-installed domain packages leaking
+their entry points into the interpreter. Core registers its first-party palette
+in ``_scan_builtins``; the ``scistudio.blocks`` group is reserved for
+third-party plugins (``BlockRegistry._scan_tier2`` / ADR-025), so a clean
+install exposes zero entries. These tests lock that isolation in.
+"""
+
+from __future__ import annotations
+
+import importlib.metadata
+from unittest.mock import MagicMock, patch
+
+from scistudio.blocks.registry import BlockRegistry
+
+_ISOLATED_GROUP = "scistudio.blocks"
+
+
+def _select(group: str) -> list:
+    eps = importlib.metadata.entry_points()
+    if hasattr(eps, "select"):
+        return list(eps.select(group=group))
+    return list(eps.get(group, []))  # pragma: no cover - Python < 3.10 fallback
+
+
+def _make_mock_block_class(name: str) -> type:
+    """A minimal ``Block`` subclass stamped under the ``scistudio.*`` namespace.
+
+    Mirrors ``tests/blocks/test_registry.py`` so distribution-version resolution
+    reads ``scistudio.__version__`` instead of raising.
+    """
+    from scistudio.blocks.base.block import Block
+
+    cls = type(
+        name,
+        (Block,),
+        {
+            "name": name,
+            "description": f"Mock {name}",
+            "version": "0.1.0",
+            "input_ports": [],
+            "output_ports": [],
+            "config_schema": {"type": "object", "properties": {}},
+            "run": lambda self, inputs, config: {},
+        },
+    )
+    cls.__module__ = "scistudio.blocks._mock_for_entry_point_isolation_tests"
+    return cls
+
+
+def test_ambient_scistudio_blocks_group_is_isolated() -> None:
+    """The session must expose zero ambient ``scistudio.blocks`` entry points.
+
+    Fails without the conftest isolation whenever a stale editable
+    ``*.dist-info`` or a locally-installed domain package leaks entries into the
+    interpreter — the exact condition that breaks registry tests locally while
+    CI stays green.
+    """
+    assert _select(_ISOLATED_GROUP) == []
+
+
+def test_group_kwarg_form_is_also_isolated() -> None:
+    """``entry_points(group=...)`` is isolated too, not only the no-arg +
+    ``.select`` path that ``_scan_tier2`` uses."""
+    assert list(importlib.metadata.entry_points(group=_ISOLATED_GROUP)) == []
+
+
+def test_other_entry_point_groups_are_preserved() -> None:
+    """Isolation is surgical: only ``scistudio.blocks`` is removed. Other groups
+    (here ``console_scripts``, always populated by pytest/coverage) pass
+    through untouched."""
+    assert _select("console_scripts"), "unrelated entry-point groups must be preserved"
+
+
+def test_default_scan_has_no_retired_collection_blocks() -> None:
+    """Integration guard: a default scan never resurrects retired collection
+    blocks from leaked or stale ``scistudio.blocks`` entries (#1781)."""
+    reg = BlockRegistry()
+    reg.scan()
+    names = set(reg.all_specs())
+    for retired in ("Filter Collection", "Slice Collection", "Split Collection"):
+        assert retired not in names, f"{retired!r} leaked back into the palette: {sorted(names)}"
+    # Sanity: the genuine first-party palette is still present.
+    for expected in ("Load", "Save", "Data Router", "Merge Collection", "Pair Editor"):
+        assert expected in names, f"{expected!r} missing from palette: {sorted(names)}"
+
+
+def test_per_test_injection_still_overrides_isolation() -> None:
+    """Tier 2 tests inject their own entry points by patching
+    ``importlib.metadata.entry_points``; ``mock.patch`` restores the isolation
+    wrapper afterwards, so per-test injection is unaffected by the session-wide
+    filter."""
+    block_cls = _make_mock_block_class("InjectedIsolationBlock")
+
+    ep = MagicMock()
+    ep.name = "injected"
+    ep.value = "mock_module:injected"
+    ep.load.return_value = [block_cls]
+    mock_eps = MagicMock()
+    mock_eps.select.return_value = [ep]
+
+    reg = BlockRegistry()
+    with patch("importlib.metadata.entry_points", return_value=mock_eps):
+        reg._scan_tier2()
+
+    assert reg.get_spec("InjectedIsolationBlock") is not None
+
+    # After the patch exits, the isolation wrapper is back in force.
+    assert _select(_ISOLATED_GROUP) == []

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 """Shared test fixtures for the SciStudio test suite."""
 
 import sys
+from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
@@ -23,6 +24,65 @@ import pytest
 _FIXTURE_PKG_SRC = Path(__file__).resolve().parent / "fixtures" / "scistudio-blocks-fixture" / "src"
 if _FIXTURE_PKG_SRC.is_dir():
     sys.path.insert(0, str(_FIXTURE_PKG_SRC))
+
+# ---------------------------------------------------------------------------
+# Env-pollution isolation: neutralize ambient ``scistudio.blocks`` entry points
+# (issue #1933)
+# ---------------------------------------------------------------------------
+#
+# Core registers its first-party palette in ``_scan_builtins``; the
+# ``scistudio.blocks`` entry-point group is reserved for *third-party* plugin
+# packages (``BlockRegistry._scan_tier2`` / ADR-025). A clean, core-only
+# install — CI and the packaged desktop bundle — therefore exposes ZERO
+# ``scistudio.blocks`` entry points.
+#
+# A developer's editable checkout is not clean:
+#   * a stale ``*.dist-info/entry_points.txt`` frozen from an earlier build can
+#     still declare now-retired/relocated built-ins (``slice_collection``,
+#     ``split_collection``, ...) under this group, and
+#   * locally-installed domain packages (imaging / lcms / spectroscopy / srs)
+#     leak their own ``scistudio.blocks`` entry points into the interpreter.
+# Both pollute Tier 2 discovery and make registry tests fail locally even though
+# CI is green (#1770, #1933; the recurring "gate tests leak user plugins" pain).
+#
+# We make the whole test session behave like a clean core-only install by
+# filtering the ``scistudio.blocks`` group out of
+# ``importlib.metadata.entry_points`` for the session. Tests that exercise Tier
+# 2 discovery inject their own entry points by patching
+# ``importlib.metadata.entry_points`` (see tests/blocks/test_registry.py);
+# ``unittest.mock.patch`` restores this wrapper afterwards, so per-test
+# injection is unaffected. ``_scan_tier2`` reads the group through this same
+# module attribute, so the isolation reaches it without touching core code.
+import importlib.metadata as _im  # noqa: E402
+
+_ISOLATED_EP_GROUP = "scistudio.blocks"
+_real_entry_points = _im.entry_points
+_EntryPoints = getattr(_im, "EntryPoints", None)
+
+
+def _entry_points_without_leaked_blocks(*args: object, **kwargs: object) -> object:
+    """``importlib.metadata.entry_points`` with the ``scistudio.blocks`` group removed.
+
+    Handles every return shape across supported Pythons: an ``EntryPoints``
+    tuple (``group=`` calls, and 3.12+ no-arg calls) is filtered element-wise;
+    the deprecated ``SelectableGroups`` mapping (3.10/3.11 no-arg) has the group
+    key dropped and is rebuilt as the same type so ``.select(...)`` keeps
+    working.
+    """
+    result = _real_entry_points(*args, **kwargs)  # type: ignore[arg-type]
+    if _EntryPoints is not None and isinstance(result, _EntryPoints):
+        return _EntryPoints(ep for ep in result if ep.group != _ISOLATED_EP_GROUP)
+    try:
+        pruned = {group: eps for group, eps in result.items() if group != _ISOLATED_EP_GROUP}
+    except AttributeError:
+        return result
+    try:
+        return type(result)(pruned)
+    except Exception:  # pragma: no cover - defensive: unknown container shape
+        return pruned
+
+
+_im.entry_points = _entry_points_without_leaked_blocks  # type: ignore[assignment]
 
 # ---------------------------------------------------------------------------
 # Phase 11 / T-TRK-003 + T-TRK-004 — test-only block registration
@@ -70,6 +130,35 @@ def _patched_scan_builtins(self: "_registry_module.BlockRegistry") -> None:
 
 
 _registry_module.BlockRegistry._scan_builtins = _patched_scan_builtins  # type: ignore[method-assign]
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _isolate_desktop_user_data_dirs(tmp_path_factory: pytest.TempPathFactory) -> Iterator[None]:
+    """Redirect desktop user-data dirs to a clean temp root for the session (#1933).
+
+    Tier 3 source-package discovery (``candidate_package_dirs`` /
+    ``_scan_package_src_dirs``) scans the platform user-data plugins directory
+    for installed domain packages. A developer's machine has real packages there
+    (imaging / lcms / spectroscopy) that leak into the registry and fail
+    domain-prefix / previewer tests locally, even though CI — with a clean user
+    profile — discovers nothing. Pointing the platform dir at an empty session
+    temp root reproduces CI's clean state.
+
+    This is the second env-pollution channel alongside the ``scistudio.blocks``
+    entry-point isolation above. Tests that exercise desktop discovery override
+    this baseline by patching ``_platformdirs_dir`` themselves (see
+    tests/blocks/test_desktop_package_discovery.py); ``monkeypatch`` restores
+    this session baseline afterwards.
+    """
+    from scistudio.desktop import paths as _desktop_paths
+
+    root = tmp_path_factory.mktemp("scistudio-user-data")
+    original = _desktop_paths._platformdirs_dir
+    _desktop_paths._platformdirs_dir = lambda kind: root / kind  # type: ignore[assignment]
+    try:
+        yield
+    finally:
+        _desktop_paths._platformdirs_dir = original  # type: ignore[assignment]
 
 
 @pytest.fixture()


### PR DESCRIPTION
## Summary

The core Python test suite failed on developer machines while CI stayed green. Root cause was **environment entry-point / package pollution**, not flaky tests: a clean core-only install (CI, packaged bundle) exposes no domain blocks, but a developer's machine leaks them into the registry through two channels this PR isolates in `tests/conftest.py`.

## Channels neutralized (session-wide, in `tests/conftest.py`)

1. **`scistudio.blocks` entry points** — a stale editable `*.dist-info/entry_points.txt` frozen from an earlier build can still declare retired/relocated built-ins (`slice_collection`, `split_collection`, …), and locally-installed domain packages (imaging / lcms / spectroscopy / srs) contribute their own entries. The group is filtered out of `importlib.metadata.entry_points` for the session (core registers its palette via `_scan_builtins`; the group is reserved for third-party plugins per ADR-025).
2. **Desktop Tier-3 source-package discovery** — `candidate_package_dirs` scans the platform user-data plugins directory, where a real desktop install leaves domain packages. The desktop user-data dir is redirected to a clean per-session temp root.

Tests that exercise Tier 2/3 discovery inject their own entry points / package dirs (`unittest.mock.patch` / `monkeypatch`), which transparently override the session baseline and are restored afterwards.

## Changes

- `tests/conftest.py`: neutralize both pollution channels for the test session.
- `tests/blocks/test_entry_point_isolation.py`: regression tests locking the isolation in.
- `tests/README.md`: how to run the suite locally + how the self-isolation works.

## Verification

- Full two-phase suite (`python -m scistudio.qa.testing.run_python_tests`) green on a deliberately-dirty dev machine.
- Previously-failing registry / previewer / domain-prefix tests now pass under the isolation.
- `gate_record check --mode pre-pr`: reconciliation passed (tier 2: format_check, full_audit, lint_format, python_tests, semantic_dup).

Gate record: .workflow/records/1933-test-env-entrypoint-isolation.json

Closes #1933
