### PR TITLE
fix(#1885): unify plugin type/previewer discovery with block discovery

### DIFF
--- a/.workflow/records/1885-guided-1885-unify-plugin-type-discovery.json
+++ b/.workflow/records/1885-guided-1885-unify-plugin-type-discovery.json
@@ -286,9 +286,9 @@
   ],
   "check_na": [],
   "commit": {
-    "sha": "ec43fdd1c4774685a2b1c41a4597b787d37ee80c",
+    "sha": "487d853eab6780efdd3fcb672c65ac23ca377b78",
     "shas": [
-      "ec43fdd1c4774685a2b1c41a4597b787d37ee80c"
+      "487d853eab6780efdd3fcb672c65ac23ca377b78"
     ],
     "trailers": []
   },
@@ -629,6 +629,318 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-07-10T16:23:56.690831Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/core/types/registry.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/core/types/registry.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T16:23:56.701419Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T16:23:56.711749Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T16:23:56.722929Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T16:23:56.733368Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T16:23:56.744151Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T16:23:56.754561Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T16:23:56.764769Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T16:23:56.774815Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T16:23:56.788316Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T16:24:06.767470Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/core/types/registry.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/core/types/registry.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T16:24:06.800032Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T16:24:06.835197Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T16:24:06.851738Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T16:24:06.868760Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T16:24:06.889792Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T16:24:06.903570Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T16:24:06.918496Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T16:24:06.930667Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T16:24:06.944675Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T16:24:21.165494Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/core/types/registry.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/core/types/registry.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T16:24:21.175554Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T16:24:21.185322Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T16:24:21.194909Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T16:24:21.203866Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T16:24:21.213162Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T16:24:21.222276Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T16:24:21.231604Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T16:24:21.241845Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T16:24:21.253816Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -641,7 +953,7 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "origin/main",
+    "base": "4760f84107abf70c05a7c420541b0740f25e844e",
     "base_sha": "4760f841",
     "changed_files": [
       ".workflow/records/1885-guided-1885-unify-plugin-type-discovery.json",
@@ -650,9 +962,9 @@
       "src/scistudio/previewers/registry.py",
       "tests/desktop/test_source_package_discovery.py"
     ],
-    "diff_fingerprint": "sha256:c52b99f2433a0b329e9610a40190d7beef5a50585d53c0efda1dfb006866761c",
+    "diff_fingerprint": "sha256:6f0441ae4f84db70046c07670c472ade9635b6e0947b3a64b2d9d3266f5aa86a",
     "head": "HEAD",
-    "head_sha": "ec43fdd1",
+    "head_sha": "487d853e",
     "surfaces": {
       "docs": 1,
       "frontend": 0,
@@ -673,7 +985,7 @@
     "closes": [
       1885
     ],
-    "number": null,
+    "number": 1939,
     "url": null
   },
   "reconcile_events": [
@@ -698,6 +1010,30 @@
     {
       "at": "2026-07-10T16:22:56.975102Z",
       "diff_fingerprint": "sha256:c52b99f2433a0b329e9610a40190d7beef5a50585d53c0efda1dfb006866761c",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-07-10T16:23:56.788350Z",
+      "diff_fingerprint": "sha256:6f0441ae4f84db70046c07670c472ade9635b6e0947b3a64b2d9d3266f5aa86a",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-07-10T16:24:06.944725Z",
+      "diff_fingerprint": "sha256:6f0441ae4f84db70046c07670c472ade9635b6e0947b3a64b2d9d3266f5aa86a",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-07-10T16:24:21.253846Z",
+      "diff_fingerprint": "sha256:6f0441ae4f84db70046c07670c472ade9635b6e0947b3a64b2d9d3266f5aa86a",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 1,

--- a/.workflow/records/1885-guided-1885-unify-plugin-type-discovery.json
+++ b/.workflow/records/1885-guided-1885-unify-plugin-type-discovery.json
@@ -1,0 +1,779 @@
+{
+  "branch": "guided/1885-unify-plugin-type-discovery",
+  "check_events": [
+    {
+      "at": "2026-07-10T16:09:30.734639Z",
+      "command": "pytest tests/architecture/ -v --no-cov",
+      "covered_surface": "architecture",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:76eb5610658b01a0448778003f43830b88da16df1548bfeb1c157fddfb19c82d",
+      "name": "architecture_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/architecture_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-10T16:09:31.459795Z",
+      "command": "python scripts/deferral_scan.py --check docs/audit/baselines/deferral-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:706b5704a9087d8af1231ce511aa41abf64c432a151e62c7ba446d64262fcce7",
+      "name": "deferral_discipline",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/deferral_discipline.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-10T16:09:31.808153Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:6dd52da05294899592b296dc19a719e0f408b8fcbe51da5070bc442940baf70a",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-07-10T16:09:35.356176Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:850fead9cd80d5cb95bc21fcbcfa46f6fcebf7c6da77ffc8d847eac7e6b44796",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-10T16:09:35.847252Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3735ffce2d153965b10cf3f9966c7c433db5828e2ee59256bf5dc2b03acd0fc",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-10T16:09:35.888568Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e44f38cc2ed62d0d5349d2734ce081f3435c6f8d00defff3f49c8d1dcfdf973d",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-07-10T16:11:32.963998Z",
+      "command": "python -m scistudio.qa.testing.run_python_tests --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:8184fb8f4335c2459636185759b979e69367dc3372070c6a6abd56abdd4a35ce",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-10T16:13:52.253462Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:e5d1a56195ebd2cac45259aa5a1b22a55f2eadb1573db352ef796cd08deeca28",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-10T16:13:59.853811Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:ee890012ee27082ce5740cd2d697ff8038f483085fe9d05282566cecd17df4a7",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    },
+    {
+      "at": "2026-07-10T16:18:09.614937Z",
+      "command": "pytest tests/architecture/ -v --no-cov",
+      "covered_surface": "architecture",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:ff90d4f396fd21452c1514a7c8df9df8e662b740b2ffd501a9c9f19bd89651b8",
+      "name": "architecture_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/architecture_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-10T16:18:10.341410Z",
+      "command": "python scripts/deferral_scan.py --check docs/audit/baselines/deferral-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:1776e09ee984ab8497beaa9f2c9ad322507558974d5d45d0ac23b782c264c0ad",
+      "name": "deferral_discipline",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/deferral_discipline.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-10T16:18:10.384530Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:823fc3db76d95e943ffa8d5239d5b843f09d40ecfea4363b47e85dfd702036ee",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-07-10T16:18:14.302331Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:de8163f69a2b15ccd94cec9e593564bfcdb3b6a8576f852ab1542e2bf1c2cd12",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-10T16:18:14.421841Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:6ab832a1c7a9a85cbc17e550ca6d0a965ca656b35c4ef92099ef07fa93e2ff28",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-10T16:18:14.447354Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:7975330ba4e4424367b0088c593794d9d89e7cb42eef68836e5abfebef6604c7",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-07-10T16:19:53.554065Z",
+      "command": "python -m scistudio.qa.testing.run_python_tests --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:f6be4585d75b4c5ef98c204475bd0971ceda5fe4daf30afdd74e3f16e252250c",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-10T16:22:20.045424Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:6bd81a81c4e3bde4d46bbe7f226fed2e4da80dc3ccfc1e0cbe09e862e16ae241",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-10T16:22:21.092128Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:7a989509429f05a61fced141aa53a1bda22cceab354629f4a240fcd604d55afa",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    }
+  ],
+  "check_na": [],
+  "commit": {
+    "sha": "ec43fdd1c4774685a2b1c41a4597b787d37ee80c",
+    "shas": [
+      "ec43fdd1c4774685a2b1c41a4597b787d37ee80c"
+    ],
+    "trailers": []
+  },
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "src/scistudio/core/types/registry.py",
+      "src/scistudio/previewers/registry.py"
+    ]
+  },
+  "directive_events": [
+    {
+      "at": "2026-07-10T16:08:19.122398Z",
+      "owner_directive": "Unify type + previewer source-package discovery onto the unconditional module-glob scan blocks use; add non-bundled regression tests; document unified discovery in ARCHITECTURE.md.",
+      "reason": "plan"
+    }
+  ],
+  "docs_events": [
+    {
+      "at": "2026-07-10T16:08:19.122553Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/architecture/ARCHITECTURE.md",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": false,
+  "guard_events": [
+    {
+      "at": "2026-07-10T16:13:59.912246Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/core/types/registry.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/core/types/registry.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T16:13:59.923882Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T16:13:59.935919Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T16:13:59.947677Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T16:13:59.959831Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T16:13:59.970433Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T16:13:59.982143Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T16:13:59.993422Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T16:14:00.006399Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T16:14:00.019871Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T16:22:21.136996Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/core/types/registry.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/core/types/registry.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T16:22:21.146814Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T16:22:21.157124Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T16:22:21.167994Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T16:22:21.177870Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T16:22:21.187468Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T16:22:21.197022Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T16:22:21.206648Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T16:22:21.215854Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T16:22:21.226540Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T16:22:56.851748Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/core/types/registry.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/core/types/registry.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T16:22:56.864090Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T16:22:56.877619Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T16:22:56.891846Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T16:22:56.904631Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T16:22:56.917393Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T16:22:56.930020Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T16:22:56.943931Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T16:22:56.960005Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T16:22:56.975046Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1885,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": {
+    "base": "origin/main",
+    "base_sha": "4760f841",
+    "changed_files": [
+      ".workflow/records/1885-guided-1885-unify-plugin-type-discovery.json",
+      "docs/architecture/ARCHITECTURE.md",
+      "src/scistudio/core/types/registry.py",
+      "src/scistudio/previewers/registry.py",
+      "tests/desktop/test_source_package_discovery.py"
+    ],
+    "diff_fingerprint": "sha256:c52b99f2433a0b329e9610a40190d7beef5a50585d53c0efda1dfb006866761c",
+    "head": "HEAD",
+    "head_sha": "ec43fdd1",
+    "surfaces": {
+      "docs": 1,
+      "frontend": 0,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 2,
+      "packaging": 0,
+      "protected_core": 1,
+      "sentrux": 4,
+      "test": 1,
+      "workflow_ci": 0
+    }
+  },
+  "owner_directive": "Fix #1885: plugin types (and previewers) silently fail to register in desktop because their module-glob src-dir scan is gated behind SCISTUDIO_BUNDLED while blocks scan candidate_package_dirs() unconditionally. Unify type + previewer discovery onto the same unconditional module-glob path blocks use. Owner authorized admin-approved:core-change for src/scistudio/core/**.",
+  "persona": "live_implementer",
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [
+      1885
+    ],
+    "number": null,
+    "url": null
+  },
+  "reconcile_events": [
+    {
+      "at": "2026-07-10T16:14:00.019897Z",
+      "diff_fingerprint": "sha256:77ccac2c89a0b254efa8220b9acc36125b4ef0060ec9e364787bb20a45a0ef42",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.semantic_dup"
+      ]
+    },
+    {
+      "at": "2026-07-10T16:22:21.226576Z",
+      "diff_fingerprint": "sha256:c52b99f2433a0b329e9610a40190d7beef5a50585d53c0efda1dfb006866761c",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-07-10T16:22:56.975102Z",
+      "diff_fingerprint": "sha256:c52b99f2433a0b329e9610a40190d7beef5a50585d53c0efda1dfb006866761c",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    }
+  ],
+  "record_id": "1885-guided-1885-unify-plugin-type-discovery",
+  "requested_admin_labels": [
+    {
+      "actor_permission": null,
+      "applied_at": null,
+      "applied_by": null,
+      "name": "admin-approved:core-change"
+    }
+  ],
+  "required_obligations": {
+    "admin_labels": [
+      "admin-approved:core-change"
+    ],
+    "checks": [
+      "architecture_tests",
+      "deferral_discipline",
+      "format_check",
+      "full_audit",
+      "import_contracts",
+      "lint_format",
+      "python_tests",
+      "semantic_dup",
+      "type_check"
+    ],
+    "docs": [
+      "docs_required_or_na"
+    ],
+    "guards": [
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": [
+      "changed_test_required"
+    ]
+  },
+  "runtime": "claude",
+  "schema_version": 2,
+  "scope_events": [
+    {
+      "action": "add-include",
+      "at": "2026-07-10T16:08:19.122538Z",
+      "pattern": "tests/desktop/test_source_package_discovery.py",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-07-10T16:08:19.122545Z",
+      "pattern": "docs/architecture/ARCHITECTURE.md",
+      "reason": "plan"
+    }
+  ],
+  "session_id": "dcf93c65-c570-4abb-a3df-5e3e5047505e",
+  "strictness_tier": 1,
+  "task_kind": "guided",
+  "test_events": [
+    {
+      "at": "2026-07-10T16:08:19.122571Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/desktop/test_source_package_discovery.py",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -2307,7 +2307,11 @@ means they survive app upgrades and never modify the bundled runtime.
 setuptools entry points (§12.4). Instead the registry scans the user package
 directories (plus any bundled or development package directories) and imports
 each source package through the package protocol (a get_block_package() entry
-point, with get_blocks as a fallback). After an install the runtime refreshes the registry and
+point, with get_blocks as a fallback). A package's blocks, its DataObject types
+(get_types()), and its previewers (get_previewers()) are all resolved from this
+same package-directory scan, so a package's types and previewers register
+alongside its blocks rather than depending on installed entry-point metadata
+being on the import path. After an install the runtime refreshes the registry and
 invalidates import caches so discovery is immediate.
 
 **How dependencies are injected.** A package's dependencies are installed with

--- a/src/scistudio/core/types/registry.py
+++ b/src/scistudio/core/types/registry.py
@@ -42,7 +42,6 @@ import importlib
 import importlib.metadata
 import importlib.util
 import logging
-import os
 import sys
 from dataclasses import dataclass
 from pathlib import Path
@@ -58,12 +57,6 @@ if TYPE_CHECKING:
     from pydantic import BaseModel
 
 logger = logging.getLogger(__name__)
-
-
-def _bundled_candidate_package_dirs() -> tuple[Path, ...]:
-    if os.environ.get("SCISTUDIO_BUNDLED") != "1":
-        return ()
-    return tuple(candidate_package_dirs())
 
 
 @dataclass
@@ -486,7 +479,14 @@ class TypeRegistry:
 
     def _scan_package_src_dirs(self) -> None:
         """Discover desktop source-package types through conventional ``get_types()``."""
-        package_dirs = [*self._package_src_dirs, *_bundled_candidate_package_dirs()]
+        # Issue #1885: scan candidate_package_dirs() unconditionally — matching
+        # BlockRegistry._scan_package_src_dirs — so a plugin's types register
+        # from the same module-glob pass as its blocks. This used to be gated
+        # behind SCISTUDIO_BUNDLED, which left plugin types unregistered in a
+        # non-bundled desktop run whenever the entry-point pass could not see
+        # the plugin's .dist-info on sys.path. Entry-point registrations still
+        # win: the loop below skips any cls.__name__ already registered.
+        package_dirs = [*self._package_src_dirs, *candidate_package_dirs()]
         for _root_name, module_name, import_roots in iter_source_package_module_candidates(package_dirs):
             try:
                 with prepended_sys_paths(import_roots):

--- a/src/scistudio/previewers/registry.py
+++ b/src/scistudio/previewers/registry.py
@@ -22,8 +22,6 @@ from __future__ import annotations
 import importlib
 import importlib.metadata
 import logging
-import os
-from pathlib import Path
 from typing import Any
 
 from scistudio.desktop.paths import (
@@ -42,12 +40,6 @@ logger = logging.getLogger(__name__)
 
 PREVIEWER_ENTRY_POINT_GROUP = "scistudio.previewers"
 COMPANION_ENTRY_POINT_GROUPS = ("scistudio.blocks", "scistudio.types")
-
-
-def _bundled_candidate_package_dirs() -> tuple[Path, ...]:
-    if os.environ.get("SCISTUDIO_BUNDLED") != "1":
-        return ()
-    return tuple(candidate_package_dirs())
 
 
 @internal()
@@ -213,8 +205,14 @@ class PreviewerRegistry:
                     break
 
     def _scan_package_src_dirs(self) -> None:
-        """Discover bundled desktop source-package previewers via ``get_previewers()``."""
-        package_dirs = _bundled_candidate_package_dirs()
+        """Discover desktop/installed source-package previewers via ``get_previewers()``."""
+        # Issue #1885: scan candidate_package_dirs() unconditionally — matching
+        # block/type discovery — so a plugin's previewers register from the same
+        # module-glob pass as its blocks. This used to be gated behind
+        # SCISTUDIO_BUNDLED, which dropped plugin previewers in a non-bundled
+        # desktop run. Explicit entry-point registrations still win because
+        # registration below uses skip_existing=True.
+        package_dirs = candidate_package_dirs()
         registered_roots: set[str] = set()
         candidates = iter_source_package_module_candidates(package_dirs, module_suffixes=("previewers",))
         for root_name, module_name, import_roots in candidates:

--- a/tests/desktop/test_source_package_discovery.py
+++ b/tests/desktop/test_source_package_discovery.py
@@ -1,4 +1,10 @@
-"""Desktop source-package discovery coverage for non-block plugin surfaces."""
+"""Desktop source-package discovery coverage for non-block plugin surfaces.
+
+Covers both the bundled desktop app (``SCISTUDIO_BUNDLED=1``) and the
+non-bundled desktop runtime. Issue #1885: type and previewer module-glob
+discovery must run unconditionally, matching block discovery, so plugin types
+and previewers are not silently dropped when the bundled flag is absent.
+"""
 
 from __future__ import annotations
 
@@ -83,6 +89,23 @@ def bundled_desktop_packages(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) ->
     return packages_dir
 
 
+@pytest.fixture
+def desktop_packages(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    """Point desktop plugin dirs at a temp install *without* ``SCISTUDIO_BUNDLED``.
+
+    Issue #1885: the non-bundled desktop runtime is the case where plugin type
+    and previewer discovery used to silently fail — the module-glob scan was
+    gated behind ``SCISTUDIO_BUNDLED == "1"`` while blocks scanned
+    unconditionally. This fixture mirrors :func:`bundled_desktop_packages`
+    with the bundled flag explicitly absent.
+    """
+    monkeypatch.delenv("SCISTUDIO_BUNDLED", raising=False)
+    monkeypatch.setattr(desktop_paths, "_platformdirs_dir", lambda kind: tmp_path / kind)
+    packages_dir = tmp_path / "packages"
+    monkeypatch.setenv("SCISTUDIO_PLUGIN_PACKAGE_DIRS", str(packages_dir))
+    return packages_dir
+
+
 def test_type_registry_discovers_bundled_desktop_source_package_types(
     bundled_desktop_packages: Path,
 ) -> None:
@@ -104,6 +127,44 @@ def test_previewer_registry_discovers_bundled_desktop_source_package_previewers(
 ) -> None:
     """Bundled desktop source packages must register ``get_previewers()`` payloads."""
     src_dir = _write_previewer_package(bundled_desktop_packages)
+
+    registry = PreviewerRegistry()
+    registry.load_packages()
+
+    spec = registry.get("desktop.typeprobe.viewer")
+    assert spec is not None
+    assert spec.owner_kind is OwnerKind.PACKAGE
+    assert spec.owner_name == "scistudio-blocks-previewprobe"
+    assert spec.target_type == "DesktopSpectrum"
+    assert str(src_dir.resolve()) not in sys.path
+
+
+def test_type_registry_discovers_non_bundled_desktop_source_package_types(
+    desktop_packages: Path,
+) -> None:
+    """#1885: plugin types must register in a non-bundled desktop run too.
+
+    Regression guard: before the fix the module-glob scan was gated behind
+    ``SCISTUDIO_BUNDLED == "1"``, so without that flag the type never
+    registered even though the same package's blocks would.
+    """
+    src_dir = _write_type_package(desktop_packages)
+
+    registry = TypeRegistry()
+    registry.scan_all()
+
+    assert "DesktopSpectrum" in registry.all_types()
+    resolved = registry.resolve(["DataObject", "Series", "DesktopSpectrum"])
+    assert resolved is not None
+    assert resolved.__name__ == "DesktopSpectrum"
+    assert str(src_dir.resolve()) not in sys.path
+
+
+def test_previewer_registry_discovers_non_bundled_desktop_source_package_previewers(
+    desktop_packages: Path,
+) -> None:
+    """#1885: plugin previewers must register in a non-bundled desktop run too."""
+    src_dir = _write_previewer_package(desktop_packages)
 
     registry = PreviewerRegistry()
     registry.load_packages()


### PR DESCRIPTION
## Summary

Plugin **types** and **previewers** were only discovered through the
module-glob source-package scan when `SCISTUDIO_BUNDLED == "1"`, while
**blocks** scanned `candidate_package_dirs()` unconditionally. In a
non-bundled desktop run the type/previewer scan returned nothing, leaving only
the entry-point pass — which needs the plugin's `.dist-info` on `sys.path`
at call time, a window the desktop opens only transiently during the block
scan. Result: a plugin's blocks registered but its types/previewers silently
did not (e.g. the `(DataFrame)`/`(Array)` core-base annotation from #1840 was
missing for plugin types).

## Change

- Drop the `SCISTUDIO_BUNDLED` gate in `TypeRegistry` and `PreviewerRegistry`
  so both scan `candidate_package_dirs()` unconditionally, matching
  `BlockRegistry`. The now-redundant private helper is removed and the call
  is inlined with a rationale comment.
- Entry-point registrations still win (existing-name skip / `skip_existing`),
  so pip-installed dev environments see no duplicate registration.
- Add non-bundled regression tests for both surfaces in
  `tests/desktop/test_source_package_discovery.py`.
- Document the unified package-directory discovery (blocks + types +
  previewers) in `ARCHITECTURE.md` §13.

## Tests

- `tests/desktop/test_source_package_discovery.py` — bundled + new non-bundled
  cases for types and previewers, all passing.
- Tier-1 gate check (lint/type/tests/audit/semantic-dup/import-contracts)
  reconciliation passed.

Gate record: .workflow/records/1885-guided-1885-unify-plugin-type-discovery.json

Closes #1885
