### PR TITLE
docs(#1941): add Data Types concept page to the user guide

### DIFF
--- a/.workflow/records/1941-guided-1941-data-types-doc.json
+++ b/.workflow/records/1941-guided-1941-data-types-doc.json
@@ -67,7 +67,13 @@
     }
   ],
   "check_na": [],
-  "commit": null,
+  "commit": {
+    "sha": "b8723981e6ec6b9d0f78de1c7e5731b701a41d64",
+    "shas": [
+      "b8723981e6ec6b9d0f78de1c7e5731b701a41d64"
+    ],
+    "trailers": []
+  },
   "declared_scope": {
     "exclude": [],
     "include": [
@@ -294,6 +300,88 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-07-10T18:39:08.138020Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T18:39:08.149083Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T18:39:08.161517Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T18:39:08.173600Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T18:39:08.186947Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T18:39:08.200877Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T18:39:08.214092Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T18:39:08.227249Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T18:39:08.239770Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T18:39:08.255041Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -313,9 +401,9 @@
       "src/scistudio/_user_guide/README.md",
       "src/scistudio/_user_guide/data-types.md"
     ],
-    "diff_fingerprint": "sha256:df3648e62cb916205daddd82eb1f91c002429e886cddc9effa23340fe3a06946",
+    "diff_fingerprint": "sha256:91a054c42985b76a4c4316c66d8339a2b0ed0ae50f6faa0c8696140bb4faac35",
     "head": "HEAD",
-    "head_sha": "12868883",
+    "head_sha": "b8723981",
     "surfaces": {
       "docs": 0,
       "frontend": 0,
@@ -331,7 +419,14 @@
   },
   "owner_directive": "Add a one-page Data Types concept page to the user guide. Table-driven, concept-first for bench scientists. Cover the core container types + Collection; introduce the two-layer model (core containers vs plugin domain types) using Image and Spectrum only as illustrative examples (no exhaustive list, no SRSImage). Register it in the user-guide README ahead of custom-types.md.",
   "persona": "live_implementer",
-  "pull_request": null,
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [
+      1941
+    ],
+    "number": null,
+    "url": null
+  },
   "reconcile_events": [
     {
       "at": "2026-07-10T18:37:14.636813Z",
@@ -348,6 +443,14 @@
     {
       "at": "2026-07-10T18:38:02.608879Z",
       "diff_fingerprint": "sha256:df3648e62cb916205daddd82eb1f91c002429e886cddc9effa23340fe3a06946",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-07-10T18:39:08.255084Z",
+      "diff_fingerprint": "sha256:91a054c42985b76a4c4316c66d8339a2b0ed0ae50f6faa0c8696140bb4faac35",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 2,

--- a/.workflow/records/1941-guided-1941-data-types-doc.json
+++ b/.workflow/records/1941-guided-1941-data-types-doc.json
@@ -1,0 +1,427 @@
+{
+  "branch": "guided/1941-data-types-doc",
+  "check_events": [
+    {
+      "at": "2026-07-10T18:34:08.498578Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cf24a57915545038b415945f1edcc71a9fd62acce003c37bf4f725aa72a705f5",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-07-10T18:34:13.095885Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cac4b6e16f4ea3a30defd817897aa968a034ef1d0eb353356021704ac34880c2",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-10T18:34:13.142294Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:d94545668224e7695143af857ed6e4ad7d59bf32f3fce1a850555221bc3aac2e",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-07-10T18:37:14.461210Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:3068951fa87697fc8851b3b1d27db331d470559a1a13f133a0a439a7eedc9c8e",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    }
+  ],
+  "check_na": [],
+  "commit": null,
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "src/scistudio/_user_guide/data-types.md",
+      "src/scistudio/_user_guide/README.md"
+    ]
+  },
+  "directive_events": [
+    {
+      "at": "2026-07-10T18:15:46.812644Z",
+      "owner_directive": "Draft had many factual errors. Correct the page by cross-checking against the architecture document.",
+      "reason": "Owner reviewed the draft and flagged factual errors; realign the page to ARCHITECTURE.md sec 4 (data foundation): data object as a lightweight reference, canonical zone / wire-by-type, and Collection as the universal transport unit (length-one for singles), not a batch-only wrapper."
+    },
+    {
+      "at": "2026-07-10T18:19:59.760200Z",
+      "owner_directive": "Add another user doc: a brief architecture overview for people who want to understand SciStudio but do not want to read the long architecture document.",
+      "reason": "Owner expanded the session scope: add a second user-guide page giving a brief architecture overview for readers who want to understand SciStudio without reading the long architecture doc."
+    },
+    {
+      "at": "2026-07-10T18:32:15.365716Z",
+      "owner_directive": "Revert the architecture overview page; do not write it now. Ship only the data types doc and ensure it compiles into the generated docs.",
+      "reason": "Owner reverted the architecture-overview page from this PR; deliver only the data-types page. Remove how-scistudio-works.md from scope."
+    }
+  ],
+  "docs_events": [
+    {
+      "at": "2026-07-10T18:37:53.377765Z",
+      "class": null,
+      "kind": "path",
+      "path": "src/scistudio/_user_guide/data-types.md",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": false,
+  "guard_events": [
+    {
+      "at": "2026-07-10T18:37:14.528637Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T18:37:14.541974Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {
+            "governed_files": [
+              "src/scistudio/_user_guide/README.md",
+              "src/scistudio/_user_guide/data-types.md"
+            ]
+          },
+          "expected": null,
+          "file": "",
+          "finding_class": "docs_landing",
+          "git_evidence": null,
+          "id": "docs_landing.missing-landing",
+          "line": null,
+          "message": "governed change requires docs/changelog/checklist landing evidence or an explicit N/A rationale",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "docs_landing.missing-landing",
+          "severity": "error",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "docs_landing",
+      "status": "fail"
+    },
+    {
+      "at": "2026-07-10T18:37:14.554000Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T18:37:14.565945Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T18:37:14.577378Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T18:37:14.589004Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T18:37:14.600217Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T18:37:14.612439Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T18:37:14.623771Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T18:37:14.636769Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T18:38:02.492729Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T18:38:02.505164Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T18:38:02.521957Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T18:38:02.535111Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T18:38:02.548938Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T18:38:02.561679Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T18:38:02.573258Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T18:38:02.584793Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T18:38:02.596413Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T18:38:02.608840Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1941,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": {
+    "base": "origin/main",
+    "base_sha": "300ffc65",
+    "changed_files": [
+      ".workflow/records/1941-guided-1941-data-types-doc.json",
+      "src/scistudio/_user_guide/README.md",
+      "src/scistudio/_user_guide/data-types.md"
+    ],
+    "diff_fingerprint": "sha256:df3648e62cb916205daddd82eb1f91c002429e886cddc9effa23340fe3a06946",
+    "head": "HEAD",
+    "head_sha": "12868883",
+    "surfaces": {
+      "docs": 0,
+      "frontend": 0,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 2,
+      "packaging": 0,
+      "protected_core": 0,
+      "sentrux": 2,
+      "test": 0,
+      "workflow_ci": 0
+    }
+  },
+  "owner_directive": "Add a one-page Data Types concept page to the user guide. Table-driven, concept-first for bench scientists. Cover the core container types + Collection; introduce the two-layer model (core containers vs plugin domain types) using Image and Spectrum only as illustrative examples (no exhaustive list, no SRSImage). Register it in the user-guide README ahead of custom-types.md.",
+  "persona": "live_implementer",
+  "pull_request": null,
+  "reconcile_events": [
+    {
+      "at": "2026-07-10T18:37:14.636813Z",
+      "diff_fingerprint": "sha256:df3648e62cb916205daddd82eb1f91c002429e886cddc9effa23340fe3a06946",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "docs.docs_required_or_na",
+        "guard.docs_landing",
+        "tests.changed_test_required"
+      ]
+    },
+    {
+      "at": "2026-07-10T18:38:02.608879Z",
+      "diff_fingerprint": "sha256:df3648e62cb916205daddd82eb1f91c002429e886cddc9effa23340fe3a06946",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    }
+  ],
+  "record_id": "1941-guided-1941-data-types-doc",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [
+      "format_check",
+      "full_audit",
+      "lint_format",
+      "semantic_dup"
+    ],
+    "docs": [
+      "docs_required_or_na"
+    ],
+    "guards": [
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": [
+      "changed_test_required"
+    ]
+  },
+  "runtime": "claude",
+  "schema_version": 2,
+  "scope_events": [
+    {
+      "action": "add-include",
+      "at": "2026-07-10T18:19:59.760367Z",
+      "pattern": "src/scistudio/_user_guide/how-it-works.md",
+      "reason": "Owner expanded the session scope: add a second user-guide page giving a brief architecture overview for readers who want to understand SciStudio without reading the long architecture doc."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-07-10T18:23:27.021778Z",
+      "pattern": "src/scistudio/_user_guide/how-scistudio-works.md",
+      "reason": "Correct the planned filename for the architecture overview page to the owner-chosen name how-scistudio-works.md (supersedes the earlier how-it-works.md include)."
+    },
+    {
+      "action": "remove-include",
+      "at": "2026-07-10T18:23:27.021921Z",
+      "pattern": "src/scistudio/_user_guide/how-it-works.md",
+      "reason": "Correct the planned filename for the architecture overview page to the owner-chosen name how-scistudio-works.md (supersedes the earlier how-it-works.md include)."
+    },
+    {
+      "action": "remove-include",
+      "at": "2026-07-10T18:32:15.365912Z",
+      "pattern": "src/scistudio/_user_guide/how-scistudio-works.md",
+      "reason": "Owner reverted the architecture-overview page from this PR; deliver only the data-types page. Remove how-scistudio-works.md from scope."
+    }
+  ],
+  "session_id": "fb644507-0520-4c6d-b25e-831be94ec71e",
+  "strictness_tier": 2,
+  "task_kind": "guided",
+  "test_events": [
+    {
+      "at": "2026-07-10T18:37:53.377936Z",
+      "class": "docs",
+      "kind": "na",
+      "path": null,
+      "rationale": "documentation-only user-guide change; no runtime behavior changed, nothing to test",
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/.workflow/records/1941-guided-1941-data-types-doc.json
+++ b/.workflow/records/1941-guided-1941-data-types-doc.json
@@ -68,9 +68,9 @@
   ],
   "check_na": [],
   "commit": {
-    "sha": "b8723981e6ec6b9d0f78de1c7e5731b701a41d64",
+    "sha": "b26535a24c18fd69a951a15b31cc1e146059828a",
     "shas": [
-      "b8723981e6ec6b9d0f78de1c7e5731b701a41d64"
+      "b26535a24c18fd69a951a15b31cc1e146059828a"
     ],
     "trailers": []
   },
@@ -382,6 +382,252 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-07-10T18:39:30.527918Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T18:39:30.565675Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T18:39:30.586707Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T18:39:30.606202Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T18:39:30.650049Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T18:39:30.678174Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T18:39:30.726566Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T18:39:30.768514Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T18:39:30.814138Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T18:39:30.852790Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T18:40:15.613496Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T18:40:15.625175Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T18:40:15.636910Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T18:40:15.649805Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T18:40:15.661367Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T18:40:15.674263Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T18:40:15.686086Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T18:40:15.697852Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T18:40:15.709537Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T18:40:15.723948Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T18:40:29.256104Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T18:40:29.268064Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T18:40:29.279409Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T18:40:29.291956Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T18:40:29.303315Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T18:40:29.314795Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T18:40:29.326412Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T18:40:29.340059Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T18:40:29.352129Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-10T18:40:29.365935Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -394,16 +640,16 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "origin/main",
-    "base_sha": "300ffc65",
+    "base": "179fad61d1b640ca9e167cfd7e446cc68c711fb3",
+    "base_sha": "179fad61",
     "changed_files": [
       ".workflow/records/1941-guided-1941-data-types-doc.json",
       "src/scistudio/_user_guide/README.md",
       "src/scistudio/_user_guide/data-types.md"
     ],
-    "diff_fingerprint": "sha256:91a054c42985b76a4c4316c66d8339a2b0ed0ae50f6faa0c8696140bb4faac35",
+    "diff_fingerprint": "sha256:2189007527f827436ca4e07452d22adfa8dc34d10062a00c83e790c2fb8d5ac5",
     "head": "HEAD",
-    "head_sha": "b8723981",
+    "head_sha": "b26535a2",
     "surfaces": {
       "docs": 0,
       "frontend": 0,
@@ -424,7 +670,7 @@
     "closes": [
       1941
     ],
-    "number": null,
+    "number": 1943,
     "url": null
   },
   "reconcile_events": [
@@ -451,6 +697,30 @@
     {
       "at": "2026-07-10T18:39:08.255084Z",
       "diff_fingerprint": "sha256:91a054c42985b76a4c4316c66d8339a2b0ed0ae50f6faa0c8696140bb4faac35",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-07-10T18:39:30.853275Z",
+      "diff_fingerprint": "sha256:2189007527f827436ca4e07452d22adfa8dc34d10062a00c83e790c2fb8d5ac5",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-07-10T18:40:15.723995Z",
+      "diff_fingerprint": "sha256:2189007527f827436ca4e07452d22adfa8dc34d10062a00c83e790c2fb8d5ac5",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-07-10T18:40:29.365976Z",
+      "diff_fingerprint": "sha256:2189007527f827436ca4e07452d22adfa8dc34d10062a00c83e790c2fb8d5ac5",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 2,

--- a/src/scistudio/_user_guide/README.md
+++ b/src/scistudio/_user_guide/README.md
@@ -27,6 +27,7 @@ from an empty project to your first run in five steps.
 
 | Page | What it covers |
 |---|---|
+| [data-types.md](data-types.md) | The data types that flow between blocks, and which one fits your data |
 | [writing-blocks.md](writing-blocks.md) | Write a custom block from scratch |
 | [custom-types.md](custom-types.md) | Make your own data type when the built-in ones do not fit |
 | [writing-plots.md](writing-plots.md) | Write a quick preview-only plot of a result |

--- a/src/scistudio/_user_guide/data-types.md
+++ b/src/scistudio/_user_guide/data-types.md
@@ -1,0 +1,79 @@
+# Data types
+
+In SciStudio, every value that flows between blocks carries a **type** that says
+what shape the data has, where it is stored, and what metadata travels with it.
+Blocks declare which types each port accepts, so when you draw a wire the canvas
+**type-checks** it: a port that expects an image accepts an image and rejects a
+spectrum, and the check happens while you build the workflow.
+
+A value is a lightweight **data object**. It points to where the data is stored
+and carries the payload into memory only when a block asks for it, so large
+results move between blocks as references. SciStudio manages this for you; it is
+what lets a workflow move gigabyte-scale images around while loading them only
+where they are used.
+
+## The built-in types
+
+SciStudio keeps the core data model small. These types are the common **shapes**
+that domain types build on. Each one is stored in a backend chosen for how that
+shape is accessed.
+
+| Type | What it represents | Stored as | Typical use |
+|---|---|---|---|
+| `Array` | N-dimensional numeric data with named axes | Zarr (chunked, compressed) | Images, volumes, stacks, hyperspectral cubes |
+| `Series` | One-dimensional labelled data | Arrow / Parquet | Spectra, traces, time series, calibration curves |
+| `DataFrame` | Tabular rows and named columns | Arrow / Parquet | Measurements, features, peak lists, QC tables |
+| `Text` | A small textual payload | In memory or filesystem | Notes, logs, prompts, small structured text |
+| `Artifact` | A file whose format SciStudio does not parse | Filesystem (original file preserved) | Reports, PDFs, instrument files, archives |
+| `CompositeData` | A named bundle of several data objects | One backend per slot | An omics matrix kept together with its observation and coordinate tables |
+
+These six types are the core data model. When a block hands you the value in code
+you read it as the natural Python form — an `Array` as a numpy array, a
+`DataFrame` or `Series` as a table, `Text` as a string — see
+[writing-blocks.md](writing-blocks.md).
+
+## You connect blocks by type
+
+Inside a workflow, data lives in a **canonical zone**: it is typed data objects.
+File formats are handled at the **edges**: a Load block turns your instrument
+files into typed data on the way in, and a Save block turns typed data into the
+format you ask for on the way out. You connect blocks by *type*, and you choose
+an output format with an explicit Save step.
+
+## How values travel: collections
+
+Every value that moves between blocks travels as a **collection**: an ordered,
+same-type group of items. A single object is a length-one collection; a folder of
+images is a longer one. A collection carries an item type, and ports check that
+item type, so a port that accepts `Array` accepts a collection of `Array` the
+same way it accepts one. Blocks that process one item at a time loop over the
+collection for you (see [writing-blocks.md](writing-blocks.md)).
+
+## Two layers: core categories and domain types
+
+The built-in types are broad **categories**. Installed **packages** define
+**domain types** that pin down scientific meaning by subclassing a category and
+adding axis or slot rules and typed metadata:
+
+- an `Image` *is an* `Array` that requires `y` and `x` axes and carries
+  microscopy metadata such as pixel size;
+- a `Spectrum` *is a* `Series` of intensity against wavelength, with its units
+  and instrument recorded.
+
+Domain types come from packages you install, and the app discovers them
+automatically. Because a domain type is a subclass of a core category, subtypes
+flow into supertype ports: an `Image` satisfies a port that wants an `Array`,
+while a port that wants an `Image` requires that specific type.
+
+If the built-in types do not capture your data's structure or metadata, you can
+define your own domain type in a few lines — see
+[custom-types.md](custom-types.md).
+
+## Reading only what you need
+
+Because a data object points to stored data, a block can read the whole thing,
+read a single **slice**, or **iterate in chunks**. Named axes make that
+meaningful for scientific data: a block can work over the spatial axes of an
+image while stepping through time, depth, or channel. The mechanics are covered
+in [writing-blocks.md](writing-blocks.md); most of the time you ask for the data
+and SciStudio loads the minimum required.


### PR DESCRIPTION
Add a Data Types concept page to the user guide.

The user guide had no single conceptual introduction to SciStudio's data types;
the built-in types were only mentioned piecemeal across task pages. This adds
`src/scistudio/_user_guide/data-types.md`, a one-page, table-driven overview
aligned with `docs/architecture/ARCHITECTURE.md` §4:

- a data object as a lightweight, typed reference to stored data;
- the six core container types (`Array`, `Series`, `DataFrame`, `Text`,
  `Artifact`, `CompositeData`) and their storage backends;
- the canonical zone — you connect blocks by type, and file formats are handled
  at Load/Save boundaries;
- collections as the universal transport unit (a single object is a length-one
  collection);
- the two-layer model: core categories vs plugin-provided domain types
  (`Image`, `Spectrum`), with subtype-into-supertype port matching.

The page is registered in the user-guide `README.md` ahead of `custom-types.md`
and compiles into the generated docs site (verified with
`scripts/docs/build_site.py`).

Gate record: .workflow/records/1941-guided-1941-data-types-doc.json

Closes #1941
