### PR TITLE
guided(#1946): fix PTY terminal ghosting + black-screen under fullscreen; add manual refresh

### DIFF
--- a/.workflow/records/1946-guided-1946-terminal-refresh-ghosting.json
+++ b/.workflow/records/1946-guided-1946-terminal-refresh-ghosting.json
@@ -79,6 +79,162 @@
       "status": "pass",
       "summary": "clean",
       "tool_versions": {}
+    },
+    {
+      "at": "2026-07-15T17:01:22.140677Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:a361bd1781aa379b2ce6faf89f5e0c123207b27a580fa71f0e54f2a9fecafcdc",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-07-15T17:02:02.290191Z",
+      "command": "(cd frontend && npm run check:ci)",
+      "covered_surface": "frontend",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:6510bc9607df13a8e77ea79b039ae40ea3f084d577e95d61f8ea8f242a39f52f",
+      "name": "frontend",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/frontend.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-15T17:02:06.351830Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:a9b01e2035f526ab55bb18afdf988c5c607c4bf57307e6d30ffbaf56e8d06e3c",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-15T17:02:06.807976Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:ef8dedeccd73e55e5df8f8c93bcf5ef79bafff0bc10be4b36c5f41a4fa76707c",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-15T17:02:06.857973Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:7291fd097a29c51c828d7916cc2f36025df2855e195196ec41b800a1e23f509b",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-07-15T17:04:11.113686Z",
+      "command": "python -m scistudio.qa.testing.run_python_tests --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:ba0429c0e56a22ca6f349ef8ec6bdbce03c5c7f05b3559b9cd2e132ce26d0f6a",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-15T17:06:19.979833Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:f1aac68d25734f77ccc50ac995f7176a841561da9e5b24263d30677cc76b60aa",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-15T17:06:27.509860Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:49c72ef5ca8557f576f56d36d52a69c67345181f6ae3c069d47acdd6fbf0b644",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    },
+    {
+      "at": "2026-07-15T17:08:53.578938Z",
+      "command": "python -m scistudio.qa.testing.run_python_tests --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:ba0429c0e56a22ca6f349ef8ec6bdbce03c5c7f05b3559b9cd2e132ce26d0f6a",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-15T17:10:48.509646Z",
+      "command": "python -m scistudio.qa.testing.run_python_tests --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:ba0429c0e56a22ca6f349ef8ec6bdbce03c5c7f05b3559b9cd2e132ce26d0f6a",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
     }
   ],
   "check_na": [],
@@ -465,6 +621,252 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-07-15T17:06:27.561101Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T17:06:27.570350Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T17:06:27.579523Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T17:06:27.588019Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T17:06:27.596479Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T17:06:27.604933Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T17:06:27.613890Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T17:06:27.629142Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T17:06:27.640174Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T17:06:27.654762Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T17:08:53.655351Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T17:08:53.667156Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T17:08:53.696118Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T17:08:53.721952Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T17:08:53.735348Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T17:08:53.760234Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T17:08:53.777864Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T17:08:53.793139Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T17:08:53.816454Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T17:08:53.839858Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T17:10:48.559914Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T17:10:48.569219Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T17:10:48.578549Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T17:10:48.587560Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T17:10:48.596407Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T17:10:48.605544Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T17:10:48.615026Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T17:10:48.626638Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T17:10:48.636096Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T17:10:48.647584Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -477,27 +879,29 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "179fad61d1b640ca9e167cfd7e446cc68c711fb3",
-    "base_sha": "179fad61",
+    "base": "origin/main",
+    "base_sha": "6a3e563c",
     "changed_files": [
       ".workflow/records/1946-guided-1946-terminal-refresh-ghosting.json",
       "CHANGELOG.md",
       "frontend/src/components/AIChat/TerminalView.tsx",
-      "frontend/src/components/AIChat/__tests__/TerminalView.test.tsx"
+      "frontend/src/components/AIChat/__tests__/TerminalView.test.tsx",
+      "src/scistudio/ai/agent/terminal.py",
+      "tests/ai/test_terminal.py"
     ],
-    "diff_fingerprint": "sha256:d41405d0026944ad432bce308fecfb4e52dfbe9681484495c4b37e062c06ec1f",
+    "diff_fingerprint": "sha256:0e087c46389adc8718313cda9c7f4cd8febd9a5b84fcf7d985e887d90e3933ea",
     "head": "HEAD",
-    "head_sha": "37e611c2",
+    "head_sha": "56064c35",
     "surfaces": {
       "docs": 0,
       "frontend": 2,
       "governance": 0,
       "governed_docs": 0,
-      "implementation": 2,
+      "implementation": 3,
       "packaging": 0,
       "protected_core": 0,
-      "sentrux": 2,
-      "test": 1,
+      "sentrux": 4,
+      "test": 2,
       "workflow_ci": 0
     }
   },
@@ -543,6 +947,36 @@
       "result": "pass",
       "tier": 2,
       "unsatisfied": []
+    },
+    {
+      "at": "2026-07-15T17:06:27.654891Z",
+      "diff_fingerprint": "sha256:0e087c46389adc8718313cda9c7f4cd8febd9a5b84fcf7d985e887d90e3933ea",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.python_tests"
+      ]
+    },
+    {
+      "at": "2026-07-15T17:08:53.839895Z",
+      "diff_fingerprint": "sha256:0e087c46389adc8718313cda9c7f4cd8febd9a5b84fcf7d985e887d90e3933ea",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.python_tests"
+      ]
+    },
+    {
+      "at": "2026-07-15T17:10:48.647617Z",
+      "diff_fingerprint": "sha256:0e087c46389adc8718313cda9c7f4cd8febd9a5b84fcf7d985e887d90e3933ea",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.python_tests"
+      ]
     }
   ],
   "record_id": "1946-guided-1946-terminal-refresh-ghosting",
@@ -553,8 +987,11 @@
       "format_check",
       "frontend",
       "full_audit",
+      "import_contracts",
       "lint_format",
-      "semantic_dup"
+      "python_tests",
+      "semantic_dup",
+      "type_check"
     ],
     "docs": [
       "docs_required_or_na"

--- a/.workflow/records/1946-guided-1946-terminal-refresh-ghosting.json
+++ b/.workflow/records/1946-guided-1946-terminal-refresh-ghosting.json
@@ -82,7 +82,13 @@
     }
   ],
   "check_na": [],
-  "commit": null,
+  "commit": {
+    "sha": "ec74fd8e75d92c4df857d626ff2aa3603ab537c6",
+    "shas": [
+      "ec74fd8e75d92c4df857d626ff2aa3603ab537c6"
+    ],
+    "trailers": []
+  },
   "declared_scope": {
     "exclude": [],
     "include": [
@@ -198,6 +204,88 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-07-15T15:10:08.947562Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T15:10:08.959414Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T15:10:08.971275Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T15:10:08.982344Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T15:10:08.992180Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T15:10:09.002078Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T15:10:09.012075Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T15:10:09.022315Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T15:10:09.032465Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T15:10:09.043655Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -211,16 +299,16 @@
   "observed_admin_labels": [],
   "observed_diff": {
     "base": "origin/main",
-    "base_sha": "46641582",
+    "base_sha": "6a3e563c",
     "changed_files": [
       ".workflow/records/1946-guided-1946-terminal-refresh-ghosting.json",
       "CHANGELOG.md",
       "frontend/src/components/AIChat/TerminalView.tsx",
       "frontend/src/components/AIChat/__tests__/TerminalView.test.tsx"
     ],
-    "diff_fingerprint": "sha256:2ce0ded55c75a2dcabb77d6ad3d82491e42d7cccf8349414b23d4989be0af42e",
+    "diff_fingerprint": "sha256:f159e6e8af96db368aaa15babfed7a76d883a77a7204939b87dc76535dc1b5f7",
     "head": "HEAD",
-    "head_sha": "7b625ace",
+    "head_sha": "ec74fd8e",
     "surfaces": {
       "docs": 0,
       "frontend": 2,
@@ -236,11 +324,26 @@
   },
   "owner_directive": "Fix embedded PTY terminal ghosting + black-screen (regressed under Claude Code fullscreen/alt-screen mode) via Direction B: keep xterm DOM renderer, fix resize-settle + re-show repaint timing; and add a manual refresh button in the terminal GUI so users can self-unstick.",
   "persona": "live_implementer",
-  "pull_request": null,
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [
+      1946
+    ],
+    "number": null,
+    "url": null
+  },
   "reconcile_events": [
     {
       "at": "2026-07-15T15:09:53.912232Z",
       "diff_fingerprint": "sha256:2ce0ded55c75a2dcabb77d6ad3d82491e42d7cccf8349414b23d4989be0af42e",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-07-15T15:10:09.043693Z",
+      "diff_fingerprint": "sha256:f159e6e8af96db368aaa15babfed7a76d883a77a7204939b87dc76535dc1b5f7",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 2,

--- a/.workflow/records/1946-guided-1946-terminal-refresh-ghosting.json
+++ b/.workflow/records/1946-guided-1946-terminal-refresh-ghosting.json
@@ -1,6 +1,86 @@
 {
   "branch": "guided/1946-terminal-refresh-ghosting",
-  "check_events": [],
+  "check_events": [
+    {
+      "at": "2026-07-15T15:07:05.032530Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:bee0017f30f552d2df2de1173f9ac14b9aee5192ca5e5c1de574bb119512b275",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-07-15T15:07:42.580388Z",
+      "command": "(cd frontend && npm run check:ci)",
+      "covered_surface": "frontend",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:0ab38ad3fb81ce37ad712779be9ff66d04cb1db5a549a865241d0a771d30c18e",
+      "name": "frontend",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/frontend.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-15T15:07:46.611291Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:759d27e0f4650f1da720d19d779ec12649bef022fa6abca117084c304e6050f0",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-15T15:07:46.695701Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e31351abfc33f0b3c0f28bc9f2f3d59ae3bc5d4925dc1159a7f931aa932441ed",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-07-15T15:09:53.767370Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:7b36e6b6f322bba4d7aeada531b0bf58f33a0b268d6a0540b66f8d8b57bb70f0",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    }
+  ],
   "check_na": [],
   "commit": null,
   "declared_scope": {
@@ -36,7 +116,90 @@
     }
   ],
   "governance_touch": false,
-  "guard_events": [],
+  "guard_events": [
+    {
+      "at": "2026-07-15T15:09:53.816315Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T15:09:53.827289Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T15:09:53.837984Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T15:09:53.848182Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T15:09:53.858521Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T15:09:53.868838Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T15:09:53.878746Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T15:09:53.889525Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T15:09:53.899798Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T15:09:53.912197Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
   "issues": [
     {
       "close_in_pr": true,
@@ -46,19 +209,73 @@
     }
   ],
   "observed_admin_labels": [],
-  "observed_diff": null,
+  "observed_diff": {
+    "base": "origin/main",
+    "base_sha": "46641582",
+    "changed_files": [
+      ".workflow/records/1946-guided-1946-terminal-refresh-ghosting.json",
+      "CHANGELOG.md",
+      "frontend/src/components/AIChat/TerminalView.tsx",
+      "frontend/src/components/AIChat/__tests__/TerminalView.test.tsx"
+    ],
+    "diff_fingerprint": "sha256:2ce0ded55c75a2dcabb77d6ad3d82491e42d7cccf8349414b23d4989be0af42e",
+    "head": "HEAD",
+    "head_sha": "7b625ace",
+    "surfaces": {
+      "docs": 0,
+      "frontend": 2,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 2,
+      "packaging": 0,
+      "protected_core": 0,
+      "sentrux": 2,
+      "test": 1,
+      "workflow_ci": 0
+    }
+  },
   "owner_directive": "Fix embedded PTY terminal ghosting + black-screen (regressed under Claude Code fullscreen/alt-screen mode) via Direction B: keep xterm DOM renderer, fix resize-settle + re-show repaint timing; and add a manual refresh button in the terminal GUI so users can self-unstick.",
   "persona": "live_implementer",
   "pull_request": null,
-  "reconcile_events": [],
+  "reconcile_events": [
+    {
+      "at": "2026-07-15T15:09:53.912232Z",
+      "diff_fingerprint": "sha256:2ce0ded55c75a2dcabb77d6ad3d82491e42d7cccf8349414b23d4989be0af42e",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    }
+  ],
   "record_id": "1946-guided-1946-terminal-refresh-ghosting",
   "requested_admin_labels": [],
   "required_obligations": {
     "admin_labels": [],
-    "checks": [],
-    "docs": [],
-    "guards": [],
-    "tests": []
+    "checks": [
+      "format_check",
+      "frontend",
+      "full_audit",
+      "lint_format",
+      "semantic_dup"
+    ],
+    "docs": [
+      "docs_required_or_na"
+    ],
+    "guards": [
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": [
+      "changed_test_required"
+    ]
   },
   "runtime": "claude-code",
   "schema_version": 2,
@@ -71,7 +288,7 @@
     }
   ],
   "session_id": "3371b650-6ce9-4e9d-98c4-9e396a830a81",
-  "strictness_tier": null,
+  "strictness_tier": 2,
   "task_kind": "guided",
   "test_events": [
     {

--- a/.workflow/records/1946-guided-1946-terminal-refresh-ghosting.json
+++ b/.workflow/records/1946-guided-1946-terminal-refresh-ghosting.json
@@ -101,6 +101,21 @@
       "at": "2026-07-15T15:04:32.291300Z",
       "owner_directive": "Direction B implemented in TerminalView.tsx: delayed settle full-refresh after resize/re-show to clear alt-screen ghost residue; immediate last-good-frame repaint on re-show to kill the black gap; plus a manual refresh (\u21bb) button. Tests updated. CHANGELOG entry added.",
       "reason": "plan"
+    },
+    {
+      "at": "2026-07-15T15:25:52.443959Z",
+      "owner_directive": "\u5237\u65b0\u6309\u94ae\u6ca1\u53cd\u5e94\uff1b\u628a\u5237\u65b0\u6539\u6210\u771f\u6b63\u80fd\u5f3a\u5236\u91cd\u7ed8\uff08\u6296\u52a8\u89c6\u53e3/\u6a21\u62df\u62d6\u52a8\uff09\uff0c\u786e\u4fdd\u6e05\u6389\u6b8b\u5f71\u3002",
+      "reason": "Owner live-tested: manual refresh button appears to do nothing. term.refresh() re-emits identical pixels so Chromium skips re-raster of the stale compositor tile (only text selection, which forces re-raster, cleared the ghost). Strengthen the button to a 1-row viewport wobble (resize down + restore next frame, mirrors dragging the panel \u2014 the known-good fix in #1711) forcing a real xterm re-render + SIGWINCH TUI repaint."
+    },
+    {
+      "at": "2026-07-15T16:39:55.266431Z",
+      "owner_directive": "\u653e\u5927\u540e claude \u5c3a\u5bf8\u4e0d\u53d8\u3001\u5237\u65b0\u4e5f\u4e0d refit\u2014\u2014\u6392\u67e5\u5230\u540e\u7aef/PTY\uff0c\u786e\u8ba4 resize \u6709\u6ca1\u6709\u771f\u6b63\u751f\u6548\u3002",
+      "reason": "Live diagnosis: host (TerminalView) refit is proven correct via renderer logs (xterm 101x12 -> 185x22, resize frame sent); backend WS handler + pty.resize/TIOCSWINSZ path reviewed and correct. Real symptom is claude-code not reflowing to the new size. Temporarily instrumenting backend PTY resize (src/scistudio/ai/agent/terminal.py) with a winsize readback to determine whether the resize reaches the PTY (host/backend fix) or claude ignores SIGWINCH in fullscreen mode (upstream). Diagnostic logs will be reverted before merge."
+    },
+    {
+      "at": "2026-07-15T16:45:31.703085Z",
+      "owner_directive": "\u786e\u8ba4\u6839\u56e0\uff1aPTY \u5b50\u8fdb\u7a0b\u65e0\u63a7\u5236\u7ec8\u7aef\u5bfc\u81f4 SIGWINCH \u6536\u4e0d\u5230\uff1b\u4fee spawn \u8ba9 slave \u6210\u4e3a\u63a7\u5236\u7ec8\u7aef\u3002",
+      "reason": "ROOT CAUSE CONFIRMED via ps: the PTY-spawned agent (claude pid 74572) has NO controlling terminal (tty=??). start_new_session=True calls setsid() but never TIOCSCTTY, so the slave PTY is not the child's controlling terminal; the kernel has no foreground process group to deliver SIGWINCH to on TIOCSWINSZ. The agent reads the initial winsize (TIOCGWINSZ, no ctty needed) but never receives resize SIGWINCH \u2014 fullscreen/alt-screen TUIs (Claude Code) then stay stuck at spawn-time size and render ghosted at the wrong width. Fix in src/scistudio/ai/agent/terminal.py: preexec_fn does setsid() + TIOCSCTTY so SIGWINCH reaches the agent."
     }
   ],
   "docs_events": [
@@ -568,6 +583,18 @@
       "at": "2026-07-15T15:04:32.291457Z",
       "pattern": "CHANGELOG.md",
       "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-07-15T16:45:31.703225Z",
+      "pattern": "src/scistudio/ai/agent/terminal.py",
+      "reason": "ROOT CAUSE CONFIRMED via ps: the PTY-spawned agent (claude pid 74572) has NO controlling terminal (tty=??). start_new_session=True calls setsid() but never TIOCSCTTY, so the slave PTY is not the child's controlling terminal; the kernel has no foreground process group to deliver SIGWINCH to on TIOCSWINSZ. The agent reads the initial winsize (TIOCGWINSZ, no ctty needed) but never receives resize SIGWINCH \u2014 fullscreen/alt-screen TUIs (Claude Code) then stay stuck at spawn-time size and render ghosted at the wrong width. Fix in src/scistudio/ai/agent/terminal.py: preexec_fn does setsid() + TIOCSCTTY so SIGWINCH reaches the agent."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-07-15T16:59:18.174325Z",
+      "pattern": "tests/ai/test_terminal.py",
+      "reason": "Cleanup + real fix landed: removed all diagnostic instrumentation and the speculative auto-repaint tweaks (owner: keep only the manual refresh button). Real fix is the backend controlling-terminal (TIOCSCTTY) in terminal.py; added regression test tests/ai/test_terminal.py::test_pty_child_owns_controlling_terminal."
     }
   ],
   "session_id": "3371b650-6ce9-4e9d-98c4-9e396a830a81",
@@ -579,6 +606,14 @@
       "class": null,
       "kind": "path",
       "path": "frontend/src/components/AIChat/__tests__/TerminalView.test.tsx",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-07-15T16:59:18.174450Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/ai/test_terminal.py",
       "rationale": null,
       "verified_in_diff": null
     }

--- a/.workflow/records/1946-guided-1946-terminal-refresh-ghosting.json
+++ b/.workflow/records/1946-guided-1946-terminal-refresh-ghosting.json
@@ -83,9 +83,9 @@
   ],
   "check_na": [],
   "commit": {
-    "sha": "ec74fd8e75d92c4df857d626ff2aa3603ab537c6",
+    "sha": "37e611c2424f1f790386ca68ec0abd13881ee714",
     "shas": [
-      "ec74fd8e75d92c4df857d626ff2aa3603ab537c6"
+      "37e611c2424f1f790386ca68ec0abd13881ee714"
     ],
     "trailers": []
   },
@@ -286,6 +286,170 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-07-15T15:11:59.413362Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T15:11:59.422189Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T15:11:59.431082Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T15:11:59.439667Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T15:11:59.448033Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T15:11:59.456521Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T15:11:59.465014Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T15:11:59.473825Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T15:11:59.482476Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T15:11:59.492940Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T15:12:12.609571Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T15:12:12.619280Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T15:12:12.629011Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T15:12:12.638407Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T15:12:12.647348Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T15:12:12.656369Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T15:12:12.664898Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T15:12:12.674815Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T15:12:12.684541Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T15:12:12.696328Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -298,17 +462,17 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "origin/main",
-    "base_sha": "6a3e563c",
+    "base": "179fad61d1b640ca9e167cfd7e446cc68c711fb3",
+    "base_sha": "179fad61",
     "changed_files": [
       ".workflow/records/1946-guided-1946-terminal-refresh-ghosting.json",
       "CHANGELOG.md",
       "frontend/src/components/AIChat/TerminalView.tsx",
       "frontend/src/components/AIChat/__tests__/TerminalView.test.tsx"
     ],
-    "diff_fingerprint": "sha256:f159e6e8af96db368aaa15babfed7a76d883a77a7204939b87dc76535dc1b5f7",
+    "diff_fingerprint": "sha256:d41405d0026944ad432bce308fecfb4e52dfbe9681484495c4b37e062c06ec1f",
     "head": "HEAD",
-    "head_sha": "ec74fd8e",
+    "head_sha": "37e611c2",
     "surfaces": {
       "docs": 0,
       "frontend": 2,
@@ -329,8 +493,8 @@
     "closes": [
       1946
     ],
-    "number": null,
-    "url": null
+    "number": 1948,
+    "url": "https://github.com/jiazhenz026/SciStudio/pull/1948"
   },
   "reconcile_events": [
     {
@@ -344,6 +508,22 @@
     {
       "at": "2026-07-15T15:10:09.043693Z",
       "diff_fingerprint": "sha256:f159e6e8af96db368aaa15babfed7a76d883a77a7204939b87dc76535dc1b5f7",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-07-15T15:11:59.492970Z",
+      "diff_fingerprint": "sha256:d41405d0026944ad432bce308fecfb4e52dfbe9681484495c4b37e062c06ec1f",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-07-15T15:12:12.696361Z",
+      "diff_fingerprint": "sha256:d41405d0026944ad432bce308fecfb4e52dfbe9681484495c4b37e062c06ec1f",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 2,

--- a/.workflow/records/1946-guided-1946-terminal-refresh-ghosting.json
+++ b/.workflow/records/1946-guided-1946-terminal-refresh-ghosting.json
@@ -1,0 +1,86 @@
+{
+  "branch": "guided/1946-terminal-refresh-ghosting",
+  "check_events": [],
+  "check_na": [],
+  "commit": null,
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "frontend/src/components/AIChat/TerminalView.tsx",
+      "frontend/src/components/AIChat/__tests__/TerminalView.test.tsx"
+    ]
+  },
+  "directive_events": [
+    {
+      "at": "2026-07-15T15:04:32.291300Z",
+      "owner_directive": "Direction B implemented in TerminalView.tsx: delayed settle full-refresh after resize/re-show to clear alt-screen ghost residue; immediate last-good-frame repaint on re-show to kill the black gap; plus a manual refresh (\u21bb) button. Tests updated. CHANGELOG entry added.",
+      "reason": "plan"
+    }
+  ],
+  "docs_events": [
+    {
+      "at": "2026-07-15T15:04:32.291469Z",
+      "class": null,
+      "kind": "path",
+      "path": "CHANGELOG.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-07-15T15:04:32.291493Z",
+      "class": "adr",
+      "kind": "na",
+      "path": null,
+      "rationale": "Behavioural bugfix + small UI affordance in an existing component (ADR-034 terminal); no architectural decision. spec:No contract/schema/API change; the fix is host-side render timing. user-docs:No user-facing doc covers terminal internals; the \u21bb button is self-describing via its tooltip.",
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": false,
+  "guard_events": [],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1946,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": null,
+  "owner_directive": "Fix embedded PTY terminal ghosting + black-screen (regressed under Claude Code fullscreen/alt-screen mode) via Direction B: keep xterm DOM renderer, fix resize-settle + re-show repaint timing; and add a manual refresh button in the terminal GUI so users can self-unstick.",
+  "persona": "live_implementer",
+  "pull_request": null,
+  "reconcile_events": [],
+  "record_id": "1946-guided-1946-terminal-refresh-ghosting",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [],
+    "docs": [],
+    "guards": [],
+    "tests": []
+  },
+  "runtime": "claude-code",
+  "schema_version": 2,
+  "scope_events": [
+    {
+      "action": "add-include",
+      "at": "2026-07-15T15:04:32.291457Z",
+      "pattern": "CHANGELOG.md",
+      "reason": "plan"
+    }
+  ],
+  "session_id": "3371b650-6ce9-4e9d-98c4-9e396a830a81",
+  "strictness_tier": null,
+  "task_kind": "guided",
+  "test_events": [
+    {
+      "at": "2026-07-15T15:04:32.291497Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/components/AIChat/__tests__/TerminalView.test.tsx",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,18 +35,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
-- [#1946] Embedded PTY terminal (AI Chat / Terminal) no longer leaves ghosted
-  glyphs or a black gap when panel widths are dragged or the bottom panel
-  collapses and re-expands under Claude Code's fullscreen (alternate-screen)
-  mode. xterm's DOM renderer only repaints dirty cells, so the alt-screen TUI's
-  reflow left stale cells (previously cleared only by selecting the text) or an
-  unpainted frame. The view now repaints the last-good frame immediately on
-  re-show (killing the black gap) and schedules one delayed full refresh after a
-  resize/re-show settles to clear ghost residue. A manual **↻ refresh** button
-  in the terminal's upper-right corner lets users force a redraw if the screen
-  still looks garbled. WebGL (the precise renderer noted in #1711) is
-  intentionally not adopted here; this is the incremental DOM-renderer fix.
-  Tests: `frontend/src/components/AIChat/__tests__/TerminalView.test.tsx`.
+- [#1946] Embedded PTY terminal (AI Chat / Terminal) now reflows correctly when
+  a panel is resized under Claude Code's fullscreen (alternate-screen) mode.
+  Previously the agent stayed stuck at its spawn-time size and rendered ghosted
+  at the wrong width (and left a black gap on collapse/re-expand). Root cause:
+  the PTY child was spawned with `start_new_session=True`, which only calls
+  `setsid()` — it never made the slave PTY the child's **controlling terminal**.
+  Without a controlling terminal the kernel has no foreground process group to
+  deliver `SIGWINCH` to, so a resize (`TIOCSWINSZ`) never reached the agent. The
+  agent still read its initial winsize (`TIOCGWINSZ` needs no ctty) so the first
+  paint looked right, but fullscreen TUIs that repaint only on `SIGWINCH` then
+  never learned about resizes. Fix: the spawn's `preexec_fn` now does `setsid()`
+  + `TIOCSCTTY` so the agent owns the controlling terminal and receives
+  `SIGWINCH`. Also adds a manual **↻ refresh** button in the terminal's
+  upper-right corner — a host-side redraw escape hatch for the residual case
+  where the agent leaves its own paint artifacts on resize (a known upstream
+  claude-code limitation, #1711). Tests: `tests/ai/test_terminal.py`
+  (`test_pty_child_owns_controlling_terminal`),
+  `frontend/src/components/AIChat/__tests__/TerminalView.test.tsx`.
   (@claude, 2026-07-15, branch: guided/1946-terminal-refresh-ghosting)
 - [#1918] Plot preview **Save** can now produce a valid `png` / `pdf` / `svg` /
   `jpeg` file. Previously Save only ever wrote the single preferred (SVG)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- [#1946] Embedded PTY terminal (AI Chat / Terminal) no longer leaves ghosted
+  glyphs or a black gap when panel widths are dragged or the bottom panel
+  collapses and re-expands under Claude Code's fullscreen (alternate-screen)
+  mode. xterm's DOM renderer only repaints dirty cells, so the alt-screen TUI's
+  reflow left stale cells (previously cleared only by selecting the text) or an
+  unpainted frame. The view now repaints the last-good frame immediately on
+  re-show (killing the black gap) and schedules one delayed full refresh after a
+  resize/re-show settles to clear ghost residue. A manual **↻ refresh** button
+  in the terminal's upper-right corner lets users force a redraw if the screen
+  still looks garbled. WebGL (the precise renderer noted in #1711) is
+  intentionally not adopted here; this is the incremental DOM-renderer fix.
+  Tests: `frontend/src/components/AIChat/__tests__/TerminalView.test.tsx`.
+  (@claude, 2026-07-15, branch: guided/1946-terminal-refresh-ghosting)
 - [#1918] Plot preview **Save** can now produce a valid `png` / `pdf` / `svg` /
   `jpeg` file. Previously Save only ever wrote the single preferred (SVG)
   artifact, and changing the destination extension yielded a broken file because

--- a/frontend/src/components/AIChat/TerminalView.tsx
+++ b/frontend/src/components/AIChat/TerminalView.tsx
@@ -18,21 +18,38 @@
  * Resize policy: freeze the terminal during a bottom-panel drag and refit ONCE
  * when it settles (RESIZE_DEBOUNCE_MS). Refitting on every drag frame churns
  * the PTY viewport and makes the TUI repaint continuously; one fit + SIGWINCH
- * on the settled size lets it repaint cleanly a single time.
+ * on the settled size lets it repaint cleanly a single time. AFTER the reflow
+ * settles we schedule ONE delayed full refresh (SETTLE_REPAINT_MS) — not an
+ * immediate one — to clear ghost residue the dirty-cell DOM renderer leaves
+ * behind. The delay is what keeps us off a mid-update buffer: by the time it
+ * fires the SIGWINCH redraw round-trip has landed. See #1946.
+ *
+ * Alt-screen / fullscreen TUIs (#1946): claude-code's fullscreen mode owns the
+ * alternate screen buffer and only repaints on its own cadence / on SIGWINCH.
+ * Two host-side artifacts follow from that + the dirty-cell DOM renderer:
+ *   - ghosting on resize / re-show — stale cells survive the reflow until a
+ *     full repaint (which is why selecting text, an xterm full render, clears
+ *     it manually). Countered by the delayed settle refresh above and a manual
+ *     refresh button.
+ *   - a black gap when the panel is collapsed (container -> display:none, size
+ *     0) and re-expanded, until the TUI happens to repaint. Countered by
+ *     repainting the last-good frame immediately on re-show (buffer is stable
+ *     there) before the reflow.
  *
  * Known upstream limitation (NOT a SciStudio bug): claude-code leaves ghosted
  * horizontal rules and drops its "thinking" spinner when its window is resized
  * mid-stream. This reproduces in a plain macOS terminal (Terminal.app / iTerm)
  * and does NOT happen with codex in this same component — it is claude-code's
  * own SIGWINCH redraw behaviour, which we cannot fix from the host terminal.
- * See #1711.
+ * See #1711. The manual refresh button gives the user an explicit escape hatch
+ * when that upstream residue appears.
  *
  * UTF-8 strings flow over the WS in both directions (xterm.js write() and
  * onData() use strings, never Buffers — confirmed by xterm docs).
  */
 import "@xterm/xterm/css/xterm.css";
 
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import type { TerminalProvider } from "../../store/types";
 import { usePtyWebSocket } from "./hooks/usePtyWebSocket";
@@ -41,6 +58,12 @@ import { usePtyWebSocket } from "./hooks/usePtyWebSocket";
 // PTY. Long enough that dragging the bottom-panel splitter does not refit on
 // every frame, short enough to feel responsive once the drag stops.
 const RESIZE_DEBOUNCE_MS = 100;
+
+// Delay before the post-settle full refresh fires. Longer than
+// RESIZE_DEBOUNCE_MS so it lands AFTER fit() + the SIGWINCH redraw round-trip,
+// clearing the DOM renderer's ghost residue without stamping a mid-update
+// buffer. See the resize/alt-screen policy note in the file header (#1946).
+const SETTLE_REPAINT_MS = 120;
 
 export interface TerminalViewProps {
   tabId: string;
@@ -149,6 +172,9 @@ export function TerminalView({
     // is dragged and refits once the drag settles. Cleared on unmount so the
     // callback never touches a disposed terminal.
     let resizeDebounce: ReturnType<typeof setTimeout> | null = null;
+    // Delayed full-repaint handle scheduled once a resize / re-show settles.
+    // Cleared on unmount so it never touches a disposed terminal.
+    let postSettleRepaint: ReturnType<typeof setTimeout> | null = null;
 
     const rememberInitialSize = () => {
       if (!term || term.cols <= 0 || term.rows <= 0) return;
@@ -175,6 +201,23 @@ export function TerminalView({
         term.refresh(0, Math.max(0, term.rows - 1));
       } catch {
         // Ignore transient layout glitches.
+      }
+    };
+
+    // Schedule ONE delayed full repaint after a resize / re-show settles. The
+    // alt-screen TUI redraws on its own cadence (SIGWINCH); the dirty-cell DOM
+    // renderer can leave ghost residue from the reflow that no write clears.
+    // The delay (vs. an immediate refresh) lets the SIGWINCH round-trip land
+    // first so we do not stamp a mid-update buffer. See file header (#1946).
+    const scheduleSettleRepaint = () => {
+      if (postSettleRepaint) clearTimeout(postSettleRepaint);
+      if (typeof setTimeout === "function") {
+        postSettleRepaint = setTimeout(() => {
+          postSettleRepaint = null;
+          repaintVisible();
+        }, SETTLE_REPAINT_MS);
+      } else {
+        repaintVisible();
       }
     };
 
@@ -287,6 +330,9 @@ export function TerminalView({
         } catch {
           // Ignore transient zero-size layout frames.
         }
+        // Clear ghost residue the reflow left behind, once the SIGWINCH redraw
+        // has had time to land (#1946).
+        scheduleSettleRepaint();
       };
 
       // Freeze during the drag, refit once it settles.
@@ -323,13 +369,20 @@ export function TerminalView({
           if (entry.isIntersecting && !wasVisible) {
             wasVisible = true;
             if (cancelled || !term) return;
+            // Repaint the last-good frame FIRST so the user never sees the
+            // black gap while the alt-screen TUI catches up. The buffer is
+            // stable on re-show (no mid-update), so an immediate refresh here
+            // is safe (#1946, bug#8).
+            repaintVisible();
             try {
               fit.fit();
               sendResizeIfChanged();
             } catch {
               // Ignore transient layout glitches.
             }
-            repaintVisible();
+            // Then clear any ghost residue once the reflow / SIGWINCH redraw
+            // settles.
+            scheduleSettleRepaint();
           } else if (!entry.isIntersecting) {
             wasVisible = false;
           }
@@ -343,6 +396,10 @@ export function TerminalView({
       if (resizeDebounce) {
         clearTimeout(resizeDebounce);
         resizeDebounce = null;
+      }
+      if (postSettleRepaint) {
+        clearTimeout(postSettleRepaint);
+        postSettleRepaint = null;
       }
       try {
         onDataDisposable?.dispose();
@@ -377,11 +434,53 @@ export function TerminalView({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // Manual escape hatch (#1946): force a full host-side repaint of the
+  // terminal. Mirrors what selecting the text does — the user's current manual
+  // workaround for alt-screen ghost residue — so it "unsticks" a garbled
+  // screen without tearing down the PTY. Refits first in case the layout
+  // drifted while garbled, notifies the PTY only if the fitted size actually
+  // changed, then repaints every visible row.
+  const handleRefresh = useCallback(() => {
+    const term = termRef.current as {
+      refresh?: (start: number, end: number) => void;
+      cols: number;
+      rows: number;
+    } | null;
+    if (!term) return;
+    try {
+      fitRef.current?.fit();
+    } catch {
+      // Ignore zero-size layout frames.
+    }
+    if (ptyOpenRef.current && term.cols > 0 && term.rows > 0) {
+      const previous = lastSentResizeRef.current;
+      if (!previous || previous.cols !== term.cols || previous.rows !== term.rows) {
+        lastSentResizeRef.current = { cols: term.cols, rows: term.rows };
+        send({ type: "resize", cols: term.cols, rows: term.rows });
+      }
+    }
+    try {
+      term.refresh?.(0, Math.max(0, term.rows - 1));
+    } catch {
+      // Ignore transient layout glitches.
+    }
+  }, [send]);
+
   return (
     <div
-      className="flex h-full flex-col overflow-hidden rounded-2xl border border-stone-200 bg-[#1e1e1e]"
+      className="relative flex h-full flex-col overflow-hidden rounded-2xl border border-stone-200 bg-[#1e1e1e]"
       data-testid={`terminal-view-${tabId}`}
     >
+      <button
+        type="button"
+        onClick={handleRefresh}
+        title="Refresh display — redraw the terminal if the screen looks garbled or ghosted"
+        aria-label="Refresh terminal display"
+        data-testid={`terminal-refresh-${tabId}`}
+        className="absolute right-2 top-2 z-20 rounded-md border border-white/10 bg-white/5 px-2 py-1 text-xs leading-none text-stone-300 opacity-40 transition hover:bg-white/20 hover:opacity-100"
+      >
+        ↻
+      </button>
       <div
         ref={containerRef}
         className="flex-1 overflow-hidden"

--- a/frontend/src/components/AIChat/TerminalView.tsx
+++ b/frontend/src/components/AIChat/TerminalView.tsx
@@ -18,31 +18,21 @@
  * Resize policy: freeze the terminal during a bottom-panel drag and refit ONCE
  * when it settles (RESIZE_DEBOUNCE_MS). Refitting on every drag frame churns
  * the PTY viewport and makes the TUI repaint continuously; one fit + SIGWINCH
- * on the settled size lets it repaint cleanly a single time. AFTER the reflow
- * settles we schedule ONE delayed full refresh (SETTLE_REPAINT_MS) — not an
- * immediate one — to clear ghost residue the dirty-cell DOM renderer leaves
- * behind. The delay is what keeps us off a mid-update buffer: by the time it
- * fires the SIGWINCH redraw round-trip has landed. See #1946.
+ * on the settled size lets it repaint cleanly a single time.
  *
- * Alt-screen / fullscreen TUIs (#1946): claude-code's fullscreen mode owns the
- * alternate screen buffer and only repaints on its own cadence / on SIGWINCH.
- * Two host-side artifacts follow from that + the dirty-cell DOM renderer:
- *   - ghosting on resize / re-show — stale cells survive the reflow until a
- *     full repaint (which is why selecting text, an xterm full render, clears
- *     it manually). Countered by the delayed settle refresh above and a manual
- *     refresh button.
- *   - a black gap when the panel is collapsed (container -> display:none, size
- *     0) and re-expanded, until the TUI happens to repaint. Countered by
- *     repainting the last-good frame immediately on re-show (buffer is stable
- *     there) before the reflow.
+ * Resize delivery: for the TUI to actually reflow on that SIGWINCH the agent
+ * must own the slave PTY as its controlling terminal — otherwise the kernel has
+ * no foreground process group to signal and the agent stays stuck at its
+ * spawn-time size (the root cause of #1946 fullscreen-mode ghosting). That fix
+ * lives in the backend spawn (src/scistudio/ai/agent/terminal.py), not here.
  *
  * Known upstream limitation (NOT a SciStudio bug): claude-code leaves ghosted
  * horizontal rules and drops its "thinking" spinner when its window is resized
  * mid-stream. This reproduces in a plain macOS terminal (Terminal.app / iTerm)
  * and does NOT happen with codex in this same component — it is claude-code's
  * own SIGWINCH redraw behaviour, which we cannot fix from the host terminal.
- * See #1711. The manual refresh button gives the user an explicit escape hatch
- * when that upstream residue appears.
+ * See #1711. The manual refresh (↻) button gives the user an explicit escape
+ * hatch to force a host-side redraw when that upstream residue appears.
  *
  * UTF-8 strings flow over the WS in both directions (xterm.js write() and
  * onData() use strings, never Buffers — confirmed by xterm docs).
@@ -58,12 +48,6 @@ import { usePtyWebSocket } from "./hooks/usePtyWebSocket";
 // PTY. Long enough that dragging the bottom-panel splitter does not refit on
 // every frame, short enough to feel responsive once the drag stops.
 const RESIZE_DEBOUNCE_MS = 100;
-
-// Delay before the post-settle full refresh fires. Longer than
-// RESIZE_DEBOUNCE_MS so it lands AFTER fit() + the SIGWINCH redraw round-trip,
-// clearing the DOM renderer's ghost residue without stamping a mid-update
-// buffer. See the resize/alt-screen policy note in the file header (#1946).
-const SETTLE_REPAINT_MS = 120;
 
 export interface TerminalViewProps {
   tabId: string;
@@ -172,9 +156,6 @@ export function TerminalView({
     // is dragged and refits once the drag settles. Cleared on unmount so the
     // callback never touches a disposed terminal.
     let resizeDebounce: ReturnType<typeof setTimeout> | null = null;
-    // Delayed full-repaint handle scheduled once a resize / re-show settles.
-    // Cleared on unmount so it never touches a disposed terminal.
-    let postSettleRepaint: ReturnType<typeof setTimeout> | null = null;
 
     const rememberInitialSize = () => {
       if (!term || term.cols <= 0 || term.rows <= 0) return;
@@ -201,23 +182,6 @@ export function TerminalView({
         term.refresh(0, Math.max(0, term.rows - 1));
       } catch {
         // Ignore transient layout glitches.
-      }
-    };
-
-    // Schedule ONE delayed full repaint after a resize / re-show settles. The
-    // alt-screen TUI redraws on its own cadence (SIGWINCH); the dirty-cell DOM
-    // renderer can leave ghost residue from the reflow that no write clears.
-    // The delay (vs. an immediate refresh) lets the SIGWINCH round-trip land
-    // first so we do not stamp a mid-update buffer. See file header (#1946).
-    const scheduleSettleRepaint = () => {
-      if (postSettleRepaint) clearTimeout(postSettleRepaint);
-      if (typeof setTimeout === "function") {
-        postSettleRepaint = setTimeout(() => {
-          postSettleRepaint = null;
-          repaintVisible();
-        }, SETTLE_REPAINT_MS);
-      } else {
-        repaintVisible();
       }
     };
 
@@ -330,9 +294,6 @@ export function TerminalView({
         } catch {
           // Ignore transient zero-size layout frames.
         }
-        // Clear ghost residue the reflow left behind, once the SIGWINCH redraw
-        // has had time to land (#1946).
-        scheduleSettleRepaint();
       };
 
       // Freeze during the drag, refit once it settles.
@@ -369,20 +330,13 @@ export function TerminalView({
           if (entry.isIntersecting && !wasVisible) {
             wasVisible = true;
             if (cancelled || !term) return;
-            // Repaint the last-good frame FIRST so the user never sees the
-            // black gap while the alt-screen TUI catches up. The buffer is
-            // stable on re-show (no mid-update), so an immediate refresh here
-            // is safe (#1946, bug#8).
-            repaintVisible();
             try {
               fit.fit();
               sendResizeIfChanged();
             } catch {
               // Ignore transient layout glitches.
             }
-            // Then clear any ghost residue once the reflow / SIGWINCH redraw
-            // settles.
-            scheduleSettleRepaint();
+            repaintVisible();
           } else if (!entry.isIntersecting) {
             wasVisible = false;
           }
@@ -396,10 +350,6 @@ export function TerminalView({
       if (resizeDebounce) {
         clearTimeout(resizeDebounce);
         resizeDebounce = null;
-      }
-      if (postSettleRepaint) {
-        clearTimeout(postSettleRepaint);
-        postSettleRepaint = null;
       }
       try {
         onDataDisposable?.dispose();
@@ -434,37 +384,37 @@ export function TerminalView({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // Manual escape hatch (#1946): force a full host-side repaint of the
-  // terminal. Mirrors what selecting the text does — the user's current manual
-  // workaround for alt-screen ghost residue — so it "unsticks" a garbled
-  // screen without tearing down the PTY. Refits first in case the layout
-  // drifted while garbled, notifies the PTY only if the fitted size actually
-  // changed, then repaints every visible row.
+  // Manual escape hatch (#1946): "unstick" a garbled / ghosted terminal without
+  // tearing down the PTY (a full renderer reload would drop the running agent
+  // session). The stuck-size root cause is fixed in the backend PTY spawn (the
+  // agent now owns a controlling terminal, so SIGWINCH reaches it). This button
+  // is a belt-and-braces host-side redraw for the residual case where the agent
+  // leaves its own paint artifacts (a known upstream claude-code limitation,
+  // #1711): drop the container out of layout, force a synchronous reflow so its
+  // paint records are discarded, restore it, then repaint the rows from the
+  // (correct) buffer — the programmatic equivalent of selecting the text.
   const handleRefresh = useCallback(() => {
     const term = termRef.current as {
       refresh?: (start: number, end: number) => void;
-      cols: number;
       rows: number;
     } | null;
-    if (!term) return;
+    const container = containerRef.current;
+    if (container) {
+      const previousDisplay = container.style.display;
+      container.style.display = "none";
+      // Read a layout property to force the hide to flush before we restore it;
+      // toggling display in one synchronous pass would otherwise coalesce and
+      // never repaint.
+      void container.offsetHeight;
+      container.style.display = previousDisplay;
+    }
     try {
       fitRef.current?.fit();
-    } catch {
-      // Ignore zero-size layout frames.
-    }
-    if (ptyOpenRef.current && term.cols > 0 && term.rows > 0) {
-      const previous = lastSentResizeRef.current;
-      if (!previous || previous.cols !== term.cols || previous.rows !== term.rows) {
-        lastSentResizeRef.current = { cols: term.cols, rows: term.rows };
-        send({ type: "resize", cols: term.cols, rows: term.rows });
-      }
-    }
-    try {
-      term.refresh?.(0, Math.max(0, term.rows - 1));
+      term?.refresh?.(0, Math.max(0, term.rows - 1));
     } catch {
       // Ignore transient layout glitches.
     }
-  }, [send]);
+  }, []);
 
   return (
     <div
@@ -477,7 +427,7 @@ export function TerminalView({
         title="Refresh display — redraw the terminal if the screen looks garbled or ghosted"
         aria-label="Refresh terminal display"
         data-testid={`terminal-refresh-${tabId}`}
-        className="absolute right-2 top-2 z-20 rounded-md border border-white/10 bg-white/5 px-2 py-1 text-xs leading-none text-stone-300 opacity-40 transition hover:bg-white/20 hover:opacity-100"
+        className="absolute right-2 top-2 z-50 rounded-md border border-white/10 bg-white/10 px-2 py-1 text-xs leading-none text-stone-300 opacity-60 transition hover:bg-white/20 hover:opacity-100"
       >
         ↻
       </button>

--- a/frontend/src/components/AIChat/__tests__/TerminalView.test.tsx
+++ b/frontend/src/components/AIChat/__tests__/TerminalView.test.tsx
@@ -2,7 +2,7 @@
  * Tests for TerminalView. We replace @xterm/xterm and addons with vi.mock so
  * the test does not depend on canvas / DOM measurement in jsdom.
  */
-import { cleanup, render, waitFor } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { TerminalView } from "../TerminalView";
@@ -144,6 +144,13 @@ class FakeIntersectionObserver {
 const RESIZE_DEBOUNCE_WAIT_MS = 180;
 function waitForDebounce(): Promise<void> {
   return new Promise((resolve) => globalThis.setTimeout(resolve, RESIZE_DEBOUNCE_WAIT_MS));
+}
+
+// After the debounced fit runs, the component schedules ONE delayed full
+// refresh (SETTLE_REPAINT_MS=120) to clear alt-screen ghost residue (#1946).
+// Wait comfortably past that so the settle repaint has fired.
+function waitForSettleRepaint(): Promise<void> {
+  return new Promise((resolve) => globalThis.setTimeout(resolve, 200));
 }
 
 beforeEach(() => {
@@ -336,13 +343,15 @@ describe("TerminalView", () => {
   });
 
   // --- resize behaviour -----------------------------------------------------
-  // Freeze during a drag, refit ONCE when it settles. No refresh() at resize
-  // time (the buffer is mid-update); the TUI repaints itself via SIGWINCH.
+  // Freeze during a drag, refit ONCE when it settles. No IMMEDIATE refresh() at
+  // resize time (the buffer is mid-update); the TUI repaints itself via
+  // SIGWINCH. A single DELAYED full refresh then clears the DOM renderer's
+  // ghost residue once the reflow settles (#1946).
   async function waitForResizeObserver() {
     await waitFor(() => expect(FakeResizeObserver.instances.length).toBe(1));
   }
 
-  it("refits once after the drag settles, without repainting", async () => {
+  it("refits once after the drag settles, without an immediate repaint", async () => {
     render(
       <TerminalView
         tabId="t1"
@@ -364,8 +373,33 @@ describe("TerminalView", () => {
     await waitForDebounce();
 
     expect(fitState.fitCalls).toBe(fitsBeforeResize + 1);
-    // No manual repaint on resize — the TUI redraws itself via SIGWINCH.
+    // The refresh is NOT immediate at fit time (buffer mid-update); it is
+    // deferred until the reflow settles.
     expect(term.refreshCount).toBe(0);
+  });
+
+  it("clears ghost residue with a single delayed repaint after resize settles", async () => {
+    render(
+      <TerminalView
+        tabId="t1"
+        projectDir="/p"
+        provider="claude-code"
+        dangerous={false}
+        onExit={vi.fn()}
+        onError={vi.fn()}
+      />,
+    );
+    await waitForTerm();
+    await waitForResizeObserver();
+    const term = xtermState.lastInstance!;
+
+    FakeResizeObserver.instances[0].trigger();
+    await waitForDebounce(); // fit has run; delayed repaint still pending
+    expect(term.refreshCount).toBe(0);
+
+    await waitForSettleRepaint();
+    // Exactly one full repaint clears the alt-screen ghost residue.
+    expect(term.refreshCount).toBe(1);
   });
 
   it("coalesces a burst of resize callbacks into a single fit", async () => {
@@ -421,13 +455,15 @@ describe("TerminalView", () => {
 
   // --- visibility repaint ---------------------------------------------------
   // Switching the bottom panel away (display:none) and back left the DOM
-  // renderer showing a stale/blank frame (bug#8). On return-to-view we refit
-  // and force a full repaint.
+  // renderer showing a stale/blank frame (bug#8) — and under Claude Code
+  // fullscreen mode, a black gap while the alt-screen TUI caught up (#1946).
+  // On return-to-view we repaint the last-good frame IMMEDIATELY (kills the
+  // black gap), refit, then a delayed repaint clears any ghost residue.
   async function waitForIntersectionObserver() {
     await waitFor(() => expect(FakeIntersectionObserver.instances.length).toBe(1));
   }
 
-  it("repaints when the terminal returns to view", async () => {
+  it("repaints immediately when the terminal returns to view, then again after settle", async () => {
     render(
       <TerminalView
         tabId="t1"
@@ -447,7 +483,12 @@ describe("TerminalView", () => {
     io.trigger(false); // hidden (panel collapsed / tab switched away)
     io.trigger(true); // shown again
 
+    // Immediate repaint of the last-good frame — no black gap.
     expect(term.refreshCount).toBe(1);
+
+    // A second, delayed repaint clears ghost residue after the reflow settles.
+    await waitForSettleRepaint();
+    expect(term.refreshCount).toBe(2);
   });
 
   it("does not repaint on the initial visible observation", async () => {
@@ -497,6 +538,48 @@ describe("TerminalView", () => {
 
     xtermState.onScrollCb?.(5);
 
+    expect(term.refreshCount).toBe(refreshesBefore + 1);
+  });
+
+  // --- manual refresh button ------------------------------------------------
+  // Escape hatch (#1946): when the alt-screen TUI leaves ghost residue the user
+  // can force a full host-side repaint (mirrors selecting the text) without
+  // tearing down the PTY.
+  it("renders a manual refresh button for the tab", async () => {
+    render(
+      <TerminalView
+        tabId="t1"
+        projectDir="/p"
+        provider="claude-code"
+        dangerous={false}
+        onExit={vi.fn()}
+        onError={vi.fn()}
+      />,
+    );
+    await waitForTerm();
+    expect(screen.getByTestId("terminal-refresh-t1")).toBeInTheDocument();
+  });
+
+  it("refits and repaints when the manual refresh button is clicked", async () => {
+    render(
+      <TerminalView
+        tabId="t1"
+        projectDir="/p"
+        provider="claude-code"
+        dangerous={false}
+        onExit={vi.fn()}
+        onError={vi.fn()}
+      />,
+    );
+    await waitForTerm();
+    const term = xtermState.lastInstance!;
+    const fitsBefore = fitState.fitCalls;
+    const refreshesBefore = term.refreshCount;
+
+    fireEvent.click(screen.getByTestId("terminal-refresh-t1"));
+
+    // Refit (layout may have drifted while garbled) + one full host-side repaint.
+    expect(fitState.fitCalls).toBe(fitsBefore + 1);
     expect(term.refreshCount).toBe(refreshesBefore + 1);
   });
 });

--- a/frontend/src/components/AIChat/__tests__/TerminalView.test.tsx
+++ b/frontend/src/components/AIChat/__tests__/TerminalView.test.tsx
@@ -146,13 +146,6 @@ function waitForDebounce(): Promise<void> {
   return new Promise((resolve) => globalThis.setTimeout(resolve, RESIZE_DEBOUNCE_WAIT_MS));
 }
 
-// After the debounced fit runs, the component schedules ONE delayed full
-// refresh (SETTLE_REPAINT_MS=120) to clear alt-screen ghost residue (#1946).
-// Wait comfortably past that so the settle repaint has fired.
-function waitForSettleRepaint(): Promise<void> {
-  return new Promise((resolve) => globalThis.setTimeout(resolve, 200));
-}
-
 beforeEach(() => {
   xtermState.lastInstance = null;
   xtermState.loadedAddons = [];
@@ -343,15 +336,13 @@ describe("TerminalView", () => {
   });
 
   // --- resize behaviour -----------------------------------------------------
-  // Freeze during a drag, refit ONCE when it settles. No IMMEDIATE refresh() at
-  // resize time (the buffer is mid-update); the TUI repaints itself via
-  // SIGWINCH. A single DELAYED full refresh then clears the DOM renderer's
-  // ghost residue once the reflow settles (#1946).
+  // Freeze during a drag, refit ONCE when it settles. No refresh() at resize
+  // time (the buffer is mid-update); the TUI repaints itself via SIGWINCH.
   async function waitForResizeObserver() {
     await waitFor(() => expect(FakeResizeObserver.instances.length).toBe(1));
   }
 
-  it("refits once after the drag settles, without an immediate repaint", async () => {
+  it("refits once after the drag settles, without repainting", async () => {
     render(
       <TerminalView
         tabId="t1"
@@ -373,33 +364,8 @@ describe("TerminalView", () => {
     await waitForDebounce();
 
     expect(fitState.fitCalls).toBe(fitsBeforeResize + 1);
-    // The refresh is NOT immediate at fit time (buffer mid-update); it is
-    // deferred until the reflow settles.
+    // No manual repaint on resize — the TUI redraws itself via SIGWINCH.
     expect(term.refreshCount).toBe(0);
-  });
-
-  it("clears ghost residue with a single delayed repaint after resize settles", async () => {
-    render(
-      <TerminalView
-        tabId="t1"
-        projectDir="/p"
-        provider="claude-code"
-        dangerous={false}
-        onExit={vi.fn()}
-        onError={vi.fn()}
-      />,
-    );
-    await waitForTerm();
-    await waitForResizeObserver();
-    const term = xtermState.lastInstance!;
-
-    FakeResizeObserver.instances[0].trigger();
-    await waitForDebounce(); // fit has run; delayed repaint still pending
-    expect(term.refreshCount).toBe(0);
-
-    await waitForSettleRepaint();
-    // Exactly one full repaint clears the alt-screen ghost residue.
-    expect(term.refreshCount).toBe(1);
   });
 
   it("coalesces a burst of resize callbacks into a single fit", async () => {
@@ -455,15 +421,13 @@ describe("TerminalView", () => {
 
   // --- visibility repaint ---------------------------------------------------
   // Switching the bottom panel away (display:none) and back left the DOM
-  // renderer showing a stale/blank frame (bug#8) — and under Claude Code
-  // fullscreen mode, a black gap while the alt-screen TUI caught up (#1946).
-  // On return-to-view we repaint the last-good frame IMMEDIATELY (kills the
-  // black gap), refit, then a delayed repaint clears any ghost residue.
+  // renderer showing a stale/blank frame (bug#8). On return-to-view we refit
+  // and force a full repaint.
   async function waitForIntersectionObserver() {
     await waitFor(() => expect(FakeIntersectionObserver.instances.length).toBe(1));
   }
 
-  it("repaints immediately when the terminal returns to view, then again after settle", async () => {
+  it("repaints when the terminal returns to view", async () => {
     render(
       <TerminalView
         tabId="t1"
@@ -483,12 +447,7 @@ describe("TerminalView", () => {
     io.trigger(false); // hidden (panel collapsed / tab switched away)
     io.trigger(true); // shown again
 
-    // Immediate repaint of the last-good frame — no black gap.
     expect(term.refreshCount).toBe(1);
-
-    // A second, delayed repaint clears ghost residue after the reflow settles.
-    await waitForSettleRepaint();
-    expect(term.refreshCount).toBe(2);
   });
 
   it("does not repaint on the initial visible observation", async () => {

--- a/src/scistudio/ai/agent/terminal.py
+++ b/src/scistudio/ai/agent/terminal.py
@@ -248,8 +248,9 @@ class PtyProcess:
                 # the slave PTY the child's CONTROLLING terminal.
                 #
                 # #1946: without a controlling terminal the kernel has no
-                # foreground process group to deliver SIGWINCH to, so a later
-                # TIOCSWINSZ resize on the master never reaches the agent. The
+                # foreground process group to deliver SIGWINCH to, so a
+                # subsequent TIOCSWINSZ resize on the master never reaches the
+                # agent's process at all. The
                 # agent still reads the initial winsize (TIOCGWINSZ needs no
                 # ctty) so its first paint is correct, but fullscreen /
                 # alt-screen TUIs (Claude Code's fullscreen mode) that repaint

--- a/src/scistudio/ai/agent/terminal.py
+++ b/src/scistudio/ai/agent/terminal.py
@@ -240,6 +240,29 @@ class PtyProcess:
             # Set initial winsize before spawning so the TUI lays out
             # correctly on the very first paint.
             fcntl.ioctl(slave_fd, termios.TIOCSWINSZ, struct.pack("HHHH", rows, cols, 0, 0))
+
+            def _preexec() -> None:
+                # Child side (post-fork, pre-exec), async-signal-safe syscalls
+                # only. setsid() starts a fresh session/process group so
+                # kill_tree can killpg the whole subtree. TIOCSCTTY then makes
+                # the slave PTY the child's CONTROLLING terminal.
+                #
+                # #1946: without a controlling terminal the kernel has no
+                # foreground process group to deliver SIGWINCH to, so a later
+                # TIOCSWINSZ resize on the master never reaches the agent. The
+                # agent still reads the initial winsize (TIOCGWINSZ needs no
+                # ctty) so its first paint is correct, but fullscreen /
+                # alt-screen TUIs (Claude Code's fullscreen mode) that repaint
+                # only on SIGWINCH then stay stuck at the spawn-time size and
+                # render ghosted at the wrong width on every panel resize.
+                # start_new_session=True only does setsid(); it never sets the
+                # controlling terminal, which is why this regressed silently.
+                os.setsid()
+                # Best-effort: never fail the spawn over ctty acquisition
+                # (already-a-ctty / EPERM).
+                with contextlib.suppress(OSError):  # pragma: no cover
+                    fcntl.ioctl(0, termios.TIOCSCTTY, 0)
+
             popen = subprocess.Popen(
                 argv,
                 cwd=str(cwd),
@@ -247,7 +270,7 @@ class PtyProcess:
                 stdin=slave_fd,
                 stdout=slave_fd,
                 stderr=slave_fd,
-                start_new_session=True,  # fresh process group for killpg
+                preexec_fn=_preexec,  # setsid + controlling tty (see above)
                 close_fds=True,
             )
             os.close(slave_fd)

--- a/tests/ai/test_terminal.py
+++ b/tests/ai/test_terminal.py
@@ -41,6 +41,28 @@ def _python_sleep_argv(seconds: float) -> list[str]:
     return [sys.executable, "-c", f"import time; print('hi', flush=True); time.sleep({seconds})"]
 
 
+def _python_ctty_probe_argv() -> list[str]:
+    """A child that reports whether it owns a controlling terminal.
+
+    Opening ``/dev/tty`` succeeds only when the process has a controlling
+    terminal, so this prints ``CTTY_OK`` in that case and ``NO_CTTY`` otherwise.
+    """
+    return [
+        sys.executable,
+        "-c",
+        (
+            "import os, sys\n"
+            "try:\n"
+            "    fd = os.open('/dev/tty', os.O_RDWR)\n"
+            "    os.close(fd)\n"
+            "    sys.stdout.write('CTTY_OK')\n"
+            "except OSError:\n"
+            "    sys.stdout.write('NO_CTTY')\n"
+            "sys.stdout.flush()\n"
+        ),
+    ]
+
+
 def test_pty_process_lifecycle(tmp_path: Path) -> None:
     """Spawn → read banner → kill_tree leaves no live subprocess."""
     pty = PtyProcess(_python_sleep_argv(60.0), cwd=tmp_path, cols=80, rows=24)
@@ -73,6 +95,30 @@ def test_pty_process_resize_does_not_raise(tmp_path: Path) -> None:
         # Defensive clamps: zero / huge values should not raise.
         pty.resize(cols=0, rows=0)
         pty.resize(cols=99999, rows=99999)
+    finally:
+        pty.kill_tree()
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX controlling-terminal semantics")
+def test_pty_child_owns_controlling_terminal(tmp_path: Path) -> None:
+    """The spawned child must own the slave PTY as its controlling terminal.
+
+    Regression for #1946: ``start_new_session=True`` only calls ``setsid()``;
+    without a subsequent ``TIOCSCTTY`` the child has no controlling terminal,
+    so the kernel has no foreground process group to deliver ``SIGWINCH`` to
+    when the master is resized. The child then reads its initial winsize fine
+    (``TIOCGWINSZ`` needs no ctty) but never learns about later resizes —
+    fullscreen / alt-screen TUIs (Claude Code's fullscreen mode) stay stuck at
+    their spawn-time size and render ghosted at the wrong width. Opening
+    ``/dev/tty`` succeeds only when a controlling terminal exists.
+    """
+    pty = PtyProcess(_python_ctty_probe_argv(), cwd=tmp_path, cols=80, rows=24)
+    try:
+        buf = bytearray()
+        deadline = time.monotonic() + 5.0
+        while time.monotonic() < deadline and b"CTTY_OK" not in buf and b"NO_CTTY" not in buf:
+            buf.extend(pty.read(0.1))
+        assert b"CTTY_OK" in buf, f"child lacked a controlling terminal; got {bytes(buf)!r}"
     finally:
         pty.kill_tree()
 


### PR DESCRIPTION
## Summary

Fixes the embedded PTY terminal (AI Chat / Terminal) staying stuck at its
spawn-time size and rendering ghosted at the wrong width when a panel is resized
under Claude Code's **fullscreen (alternate-screen) mode**, and adds a manual
refresh button.

## Root cause (found via live diagnosis)

Renderer logs + a backend winsize readback + `ps` proved the host was already
correct: `TerminalView` refit resized xterm and sent the resize frame, and the
backend applied `TIOCSWINSZ` (the master winsize readback matched the requested
size). The real break was that the PTY-spawned agent had **no controlling
terminal** (`ps` showed `tty=??`):

- The POSIX spawn used `start_new_session=True`, which only calls `setsid()`. It
  never made the slave PTY the child's controlling terminal (`TIOCSCTTY`).
- Without a controlling terminal the kernel has no foreground process group to
  deliver `SIGWINCH` to, so a resize never reached the agent.
- The agent read its initial winsize (`TIOCGWINSZ` needs no ctty), so the first
  paint was correct — but Claude Code's fullscreen mode repaints only on
  `SIGWINCH`, so after a resize it stayed at the spawn-time size and rendered
  ghosted at the wrong width (and left a black gap on collapse/re-expand).

This regressed silently the moment Claude Code moved to the alternate-screen
fullscreen renderer; non-fullscreen TUIs re-read the size often enough to mask
the missing signal.

## Changes

- **`src/scistudio/ai/agent/terminal.py`** — the POSIX spawn's `preexec_fn` now
  does `setsid()` + `TIOCSCTTY` so the agent owns the slave PTY as its
  controlling terminal and receives `SIGWINCH` on resize. Regression test
  `tests/ai/test_terminal.py::test_pty_child_owns_controlling_terminal` opens
  `/dev/tty` in the child (succeeds only with a controlling terminal); runs on
  Linux CI + macOS.
- **`frontend/.../TerminalView.tsx`** — adds a manual **↻ refresh** button
  (upper-right overlay) that forces a host-side redraw without tearing down the
  PTY, as an escape hatch for claude-code's own upstream mid-stream resize
  residue (#1711). No functional change to the refit path (it was already
  correct).

WebGL (the precise renderer noted in #1711) is intentionally not adopted; the
real fix is the controlling-terminal one above.

Gate record: .workflow/records/1946-guided-1946-terminal-refresh-ghosting.json

Closes #1946
