### PR TITLE
feat(#1947): open_gui MCP tool for browser-based GUI self-debugging

### DIFF
--- a/.workflow/records/1947-open-gui.json
+++ b/.workflow/records/1947-open-gui.json
@@ -1,0 +1,689 @@
+{
+  "branch": "guided/1947-open-gui",
+  "check_events": [
+    {
+      "at": "2026-07-15T15:20:48.593179Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:891729ae5359f67b039f9a0723664b0881b4df389fd9173dd9bd93c8a1febfbc",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-07-15T15:20:52.896727Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cb2c3f3728df81636ef1d4ed5ec16615db07837b1aa7f1e69505451369d12c67",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-15T15:20:53.397481Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:40610c1584aa65ab1bcfaac63ba9dfa55325485a36d351967b213dc44709bb69",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-15T15:20:53.441844Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:76a53699f33a6816c98d7c56d6be3c9ad58891582a409b6f64eeb5df354c6c5c",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-07-15T15:22:57.641616Z",
+      "command": "python -m scistudio.qa.testing.run_python_tests --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:c1621fa5319183a5c496c0036bd9d5c1dcb5c6aa9ea25ae4c3f67de755d018fa",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-15T15:24:56.651146Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:5e5635e55075bd714039194a95ba67b9438cefc42891a617ce3f65fd15b6fdd0",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-15T15:25:03.407549Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:4608e05c0ddcd10a0a2d95efb62cbf53bbb0a4e069b09b21a638a0caa1f5d6fb",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    }
+  ],
+  "check_na": [],
+  "commit": {
+    "sha": "95c58a8816de7f8f3a812ebf0e8ce2479d48b338",
+    "shas": [
+      "95c58a8816de7f8f3a812ebf0e8ce2479d48b338"
+    ],
+    "trailers": []
+  },
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "src/scistudio/ai/agent/mcp/tools_qa.py",
+      "src/scistudio/_skills/scistudio/SKILL.md",
+      "docs/architecture/ARCHITECTURE.md",
+      "tests/ai/test_mcp_fastmcp.py",
+      "tests/integration/test_phase2_mcp_end_to_end.py",
+      "tests/cli/test_mcp_bridge.py"
+    ]
+  },
+  "directive_events": [
+    {
+      "at": "2026-07-15T15:12:45.678024Z",
+      "owner_directive": "Implement open_gui in tools_qa.py (category:qa, read). Source the GUI URL from the canonical SCISTUDIO_ENGINE_API_URL env var; raise a clear error when no GUI server is running (MCP bridge standalone mode). Update the two live tool catalogs (ARCHITECTURE.md table+count, SKILL.md static fallback+counts) and the three tool-count contract tests 34->35. Add happy+error tests. Leave frozen historical baselines (ADR-040 26, embedded-coding-agent-spec 25) unchanged.",
+      "reason": "plan"
+    }
+  ],
+  "docs_events": [
+    {
+      "at": "2026-07-15T15:12:45.678191Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/architecture/ARCHITECTURE.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-07-15T15:12:45.678207Z",
+      "class": null,
+      "kind": "path",
+      "path": "src/scistudio/_skills/scistudio/SKILL.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-07-15T15:12:45.678216Z",
+      "class": "adr",
+      "kind": "na",
+      "path": null,
+      "rationale": "one read-only MCP tool addition is covered by the two live tool catalogs (ARCHITECTURE.md + SKILL.md); no architectural decision reversal warrants a new ADR",
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-07-15T15:12:45.678221Z",
+      "class": "changelog",
+      "kind": "na",
+      "path": null,
+      "rationale": "no user-facing changelog maintained for internal agent MCP tool surface",
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-07-15T15:19:19.015874Z",
+      "class": null,
+      "kind": "path",
+      "path": "src/scistudio/_user_guide/how-scistudio-works.md",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": false,
+  "guard_events": [
+    {
+      "at": "2026-07-15T15:25:03.442534Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T15:25:03.452415Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T15:25:03.462186Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T15:25:03.472415Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T15:25:03.482213Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T15:25:03.492998Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T15:25:03.503270Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T15:25:03.514924Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T15:25:03.524580Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T15:25:03.535553Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T15:26:58.210758Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T15:26:58.222220Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T15:26:58.233221Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T15:26:58.244680Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T15:26:58.256174Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T15:26:58.267008Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T15:26:58.277856Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T15:26:58.290030Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T15:26:58.299993Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T15:26:58.312617Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T15:27:52.389776Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T15:27:52.399474Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T15:27:52.410405Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T15:27:52.421654Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T15:27:52.432696Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T15:27:52.443562Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T15:27:52.454206Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T15:27:52.466445Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T15:27:52.477263Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T15:27:52.490781Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T15:28:07.769413Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T15:28:07.780936Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T15:28:07.792621Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T15:28:07.804262Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T15:28:07.816027Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T15:28:07.840248Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T15:28:07.875316Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T15:28:07.888404Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T15:28:07.900853Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-15T15:28:07.919947Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1947,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": {
+    "base": "6a3e563cb04ef3db7f7df415c56232d597eaec29",
+    "base_sha": "6a3e563c",
+    "changed_files": [
+      ".workflow/records/1947-open-gui.json",
+      "docs/architecture/ARCHITECTURE.md",
+      "src/scistudio/_skills/scistudio/SKILL.md",
+      "src/scistudio/_user_guide/how-scistudio-works.md",
+      "src/scistudio/ai/agent/mcp/tools_qa.py",
+      "tests/ai/test_finish_ai_block_skeleton.py",
+      "tests/ai/test_mcp_fastmcp.py",
+      "tests/ai/test_mcp_tools_qa.py",
+      "tests/cli/test_mcp_bridge.py",
+      "tests/contracts/test_runtime_import_contract.py",
+      "tests/integration/test_phase2_mcp_end_to_end.py"
+    ],
+    "diff_fingerprint": "sha256:e3291ef06b46305b8b6de035547dd2a19bc4f5a98f9a32f8f8db2ad04ae20417",
+    "head": "HEAD",
+    "head_sha": "95c58a88",
+    "surfaces": {
+      "docs": 1,
+      "frontend": 0,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 3,
+      "packaging": 0,
+      "protected_core": 0,
+      "sentrux": 10,
+      "test": 6,
+      "workflow_ci": 0
+    }
+  },
+  "owner_directive": "Add a single read-only open_gui MCP tool (category qa) returning the frontend URL so the agent can open SciStudio in a Chrome tab and self-debug plots/previewers/interactive blocks. Plan A: no GUI-control tool suite, no Electron CDP work. Make the change complete across all current contract surfaces; do not pick placement to dodge tests.",
+  "persona": "live_implementer",
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [
+      1947
+    ],
+    "number": 1949,
+    "url": "https://github.com/jiazhenz026/SciStudio/pull/1949"
+  },
+  "reconcile_events": [
+    {
+      "at": "2026-07-15T15:25:03.535593Z",
+      "diff_fingerprint": "sha256:873fe4c94652b231e816107eff7bfbe5ae5c1e0930577d8b394185a37dbf19c6",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-07-15T15:26:58.312655Z",
+      "diff_fingerprint": "sha256:1c64fcd247fac7cdd63e6869f489e1fa86f11a311e4a6576205d286d12886140",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-07-15T15:27:52.490829Z",
+      "diff_fingerprint": "sha256:e3291ef06b46305b8b6de035547dd2a19bc4f5a98f9a32f8f8db2ad04ae20417",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-07-15T15:28:07.920005Z",
+      "diff_fingerprint": "sha256:e3291ef06b46305b8b6de035547dd2a19bc4f5a98f9a32f8f8db2ad04ae20417",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    }
+  ],
+  "record_id": "1947-open-gui",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [
+      "format_check",
+      "full_audit",
+      "import_contracts",
+      "lint_format",
+      "python_tests",
+      "semantic_dup",
+      "type_check"
+    ],
+    "docs": [
+      "docs_required_or_na"
+    ],
+    "guards": [
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": [
+      "changed_test_required"
+    ]
+  },
+  "runtime": "claude-code",
+  "schema_version": 2,
+  "scope_events": [
+    {
+      "action": "add-include",
+      "at": "2026-07-15T15:12:45.678179Z",
+      "pattern": "tests/ai/test_mcp_tools_qa.py",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-07-15T15:19:19.015730Z",
+      "pattern": "tests/ai/test_finish_ai_block_skeleton.py",
+      "reason": "Discovered additional tool-count contract surfaces during implementation (broad test sweep found two more count assertions + one more live user-guide catalog beyond the initial six declared surfaces). Same open_gui change must update them for completeness per owner directive 'touch whatever needs touching'."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-07-15T15:19:19.015864Z",
+      "pattern": "tests/contracts/test_runtime_import_contract.py",
+      "reason": "Discovered additional tool-count contract surfaces during implementation (broad test sweep found two more count assertions + one more live user-guide catalog beyond the initial six declared surfaces). Same open_gui change must update them for completeness per owner directive 'touch whatever needs touching'."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-07-15T15:19:19.015867Z",
+      "pattern": "src/scistudio/_user_guide/how-scistudio-works.md",
+      "reason": "Discovered additional tool-count contract surfaces during implementation (broad test sweep found two more count assertions + one more live user-guide catalog beyond the initial six declared surfaces). Same open_gui change must update them for completeness per owner directive 'touch whatever needs touching'."
+    }
+  ],
+  "session_id": "afbf3fb4-48fa-4f70-bb98-3f652f9974fd",
+  "strictness_tier": 2,
+  "task_kind": "guided",
+  "test_events": [
+    {
+      "at": "2026-07-15T15:12:45.678224Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/ai/test_mcp_tools_qa.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-07-15T15:19:19.015887Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/ai/test_finish_ai_block_skeleton.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-07-15T15:19:19.015889Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/contracts/test_runtime_import_contract.py",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -1321,7 +1321,7 @@ state, and event bus context that the backend uses. This is why MCP calls can
 validate workflows, reload blocks, start runs, inspect lineage, and reflect live
 runtime state instead of operating as disconnected file edits.
 
-The production MCP surface contains 34 tools:
+The production MCP surface contains 35 tools:
 
 | Area | MCP tool | Purpose | Access |
 |---|---|---|---|
@@ -1359,6 +1359,7 @@ The production MCP surface contains 34 tools:
 | Project QA | <code>mcp&#95;&#95;scistudio&#95;&#95;get_doc</code> | Read a selected documentation page or section. | Read |
 | Project QA | <code>mcp&#95;&#95;scistudio&#95;&#95;list_data</code> | List project data files and references. | Read |
 | Project QA | <code>mcp&#95;&#95;scistudio&#95;&#95;get_project_info</code> | Read project metadata, paths, and high-level state. | Read |
+| Project QA | <code>mcp&#95;&#95;scistudio&#95;&#95;open_gui</code> | Return the running GUI's URL so the agent can open the live frontend in a browser and self-debug plots, previewers, and interactive block panels. | Read |
 
 The important architectural rule is not the exact tool list. The rule is that
 agent actions touching **blocks**, **workflows**, **runs**, **data**, or

--- a/src/scistudio/_skills/scistudio/SKILL.md
+++ b/src/scistudio/_skills/scistudio/SKILL.md
@@ -98,7 +98,7 @@ plugins). Trust the rendered values; do not invent project metadata.
 ## Tool catalog
 
 The injected block below is replaced at prompt-composition time with
-the live MCP tool catalog (34 tools across workflow / authoring /
+the live MCP tool catalog (35 tools across workflow / authoring /
 inspection / qa / plot). Use tool names and descriptions from the rendered
 catalog; do not type from memory if uncertain.
 
@@ -114,7 +114,7 @@ skill (`scistudio-build-workflow`, `scistudio-write-block`,
 `scistudio-write-plot`) for the documented call sequence.
 
 <!-- tool_catalog:begin -->
-**Static fallback (34 tools — Codex sees this; Claude sees the live
+**Static fallback (35 tools — Codex sees this; Claude sees the live
 catalog re-spliced from FastMCP at compose time).**
 
 - **Workflow (12)** — `list_blocks`, `get_block_schema`, `list_types`,
@@ -131,9 +131,11 @@ catalog re-spliced from FastMCP at compose time).**
   `get_block_output`, `get_lineage`, `get_block_logs`,
   `get_block_config`, `update_block_config`. Walk data refs, logs,
   block configuration, and lineage without materialising arrays.
-- **QA / project (4)** — `get_project_info`, `list_data`,
-  `search_docs`, `get_doc`. Project structure, raw-asset listing,
-  doc search.
+- **QA / project (5)** — `get_project_info`, `list_data`,
+  `search_docs`, `get_doc`, `open_gui`. Project structure, raw-asset
+  listing, doc search; `open_gui` returns the running GUI's URL so you
+  can open the live frontend in a browser and self-debug plots,
+  previewers, and interactive block panels.
 - **Plot (6)** — `list_plot_targets`, `scaffold_plot`,
   `list_plot_examples`, `read_plot_source`, `validate_plot`,
   `run_plot_job`. Author and run PREVIEW-ONLY plots (matplotlib /

--- a/src/scistudio/_user_guide/how-scistudio-works.md
+++ b/src/scistudio/_user_guide/how-scistudio-works.md
@@ -68,7 +68,7 @@ Four project agent surfaces:
 | Surface | Role |
 |---|---|
 | Agent session | Interactive project help in Claude Code or Codex |
-| MCP server | 34 tools for blocks, types, workflows, runs, data, lineage, plots, and project information |
+| MCP server | 35 tools for blocks, types, workflows, runs, data, lineage, plots, project information, and opening the live GUI in a browser |
 | Skills | Task guidance for workflows, block authoring, debugging, data inspection, and project QA |
 | `AIBlock` | Bounded graph node with typed inputs, outputs, and completion |
 

--- a/src/scistudio/ai/agent/mcp/tools_qa.py
+++ b/src/scistudio/ai/agent/mcp/tools_qa.py
@@ -1,15 +1,18 @@
-"""Category (d) MCP tools — documentation and project Q&A (4 tools).
+"""Category (d) MCP tools — documentation and project Q&A (5 tools).
 
 ADR-040 §3.1 FastMCP migration, I40a Phase 2a implementation.
 
-The 4 tools (all read-class) are:
+The 5 tools (all read-class) are:
 
-``search_docs``, ``get_doc``, ``list_data``, ``get_project_info``.
+``search_docs``, ``get_doc``, ``list_data``, ``get_project_info``,
+``open_gui`` (the last added for #1947 so the agent can open the running
+GUI in a browser and self-debug plots / previewers / interactive blocks).
 """
 
 from __future__ import annotations
 
 import logging
+import os
 import warnings
 from pathlib import Path
 from typing import Any
@@ -85,6 +88,17 @@ class GetProjectInfoResult(BaseModel):
     recent_runs: list[RecentRunEntry] = Field(
         default_factory=list,
         description="Best-effort recent run listing via MetadataStore.",
+    )
+
+
+class OpenGuiResult(BaseModel):
+    """Result envelope for ``open_gui`` (#1947)."""
+
+    url: str = Field(
+        description="Base URL of the running SciStudio GUI. Open this in a browser tab.",
+    )
+    hint: str = Field(
+        description="How to use the URL to inspect the live GUI.",
     )
 
 
@@ -381,4 +395,50 @@ async def get_project_info() -> GetProjectInfoResult:
         path=str(root),
         workflows=workflows,
         recent_runs=recent_runs,
+    )
+
+
+# ---------------------------------------------------------------------------
+# (d.5) open_gui  (#1947)
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool(name="open_gui", tags={"category:qa", "read"})
+async def open_gui() -> OpenGuiResult:
+    """Return the URL of the running SciStudio GUI so you can open it in a browser.
+
+    Use when:
+      - You need to SEE the live rendered frontend — a plot, a previewer,
+        or an interactive block panel — to debug how it renders or behaves.
+      - You want to drive the GUI yourself with your own browser tooling.
+
+    Do NOT use to:
+      - Read a data payload — use ``inspect_data`` / ``preview_data``.
+      - Render a plot artifact headlessly — use ``run_plot_job``.
+
+    Open the returned URL in a browser tab (the frontend renders the same
+    in a plain browser as in the desktop app) and use your own browser
+    tools from there. SciStudio does not drive the browser for you.
+
+    The URL is read from the ``SCISTUDIO_ENGINE_API_URL`` the backend
+    publishes on startup (ADR-035 §3.10); the SciStudio SPA is served at
+    that server's root. Raises ``RuntimeError`` when no GUI server is
+    running for this session — for example when the MCP bridge is in
+    standalone mode with no backend behind it.
+    """
+    url = os.environ.get("SCISTUDIO_ENGINE_API_URL", "").strip()
+    if not url:
+        raise RuntimeError(
+            "No running SciStudio GUI is available for this session. The GUI "
+            "URL is published only while the backend/API server is running "
+            "(via `scistudio gui` / `scistudio serve`). If you are connected "
+            "through the MCP bridge in standalone mode, start the GUI first."
+        )
+    return OpenGuiResult(
+        url=url.rstrip("/"),
+        hint=(
+            "Open this URL in a browser tab and use your own browser tools to "
+            "inspect plots, previewers, and interactive block panels. "
+            "SciStudio does not control the browser for you."
+        ),
     )

--- a/tests/ai/test_finish_ai_block_skeleton.py
+++ b/tests/ai/test_finish_ai_block_skeleton.py
@@ -32,12 +32,12 @@ def test_finish_ai_block_is_registered() -> None:
     assert "write" in tags
 
 
-def test_registry_now_has_34_tools() -> None:
-    """ADR-035 §3.5 + ADR-040 §3.1 + Addendum 5 + ADR-048 SPEC 2 + edit_workflow (#1912): FastMCP exposes 34 tools."""
+def test_registry_now_has_35_tools() -> None:
+    """ADR-035 §3.5 + ADR-040 §3.1 + Addendum 5 + ADR-048 SPEC 2 + edit_workflow (#1912) + open_gui (#1947): FastMCP exposes 35 tools."""
     from scistudio.ai.agent.mcp.server import mcp
 
     tools = _run(mcp.list_tools())
-    assert len(tools) == 34
+    assert len(tools) == 35
 
 
 def test_finish_ai_block_handler_has_docstring() -> None:

--- a/tests/ai/test_mcp_fastmcp.py
+++ b/tests/ai/test_mcp_fastmcp.py
@@ -2,9 +2,9 @@
 
 Asserts the FastMCP-backed MCP server matches the ADR-040 contract:
 
-* 34 tools discoverable via ``await mcp.list_tools()``
+* 35 tools discoverable via ``await mcp.list_tools()``
   (26 from ADR-040 §3.1 + 1 from Addendum 5 / #1488 + 6 plot tools
-  from ADR-048 SPEC 2).
+  from ADR-048 SPEC 2 + 1 qa tool ``open_gui`` from #1947).
 * Every write-class tool's result model has ``next_step: str``.
 * ``scaffold_block`` has the widened §3.2a signature with
   ``input_ports`` + ``output_ports`` dict args and a ``warnings`` field.
@@ -66,6 +66,8 @@ _EXPECTED_TOOL_NAMES = {
     "get_doc",
     "list_data",
     "get_project_info",
+    # #1947: open the running GUI in a browser for self-debugging
+    "open_gui",
     # category (e) plot (ADR-048 SPEC 2)
     "list_plot_targets",
     "scaffold_plot",
@@ -85,10 +87,10 @@ def _run(coro):
 # ---------------------------------------------------------------------------
 
 
-def test_fastmcp_lists_34_tools() -> None:
-    """ADR-040 §3.1 + Addendum 5 + ADR-048 SPEC 2 + edit_workflow (#1912): 34 tools (28 + 6 plot)."""
+def test_fastmcp_lists_35_tools() -> None:
+    """ADR-040 §3.1 + Addendum 5 + ADR-048 SPEC 2 + edit_workflow (#1912) + open_gui (#1947): 35 tools (28 + 6 plot + open_gui)."""
     tools = _run(mcp.list_tools())
-    assert len(tools) == 34
+    assert len(tools) == 35
     names = {t.name for t in tools}
     assert names == _EXPECTED_TOOL_NAMES, (
         f"missing: {_EXPECTED_TOOL_NAMES - names}; extra: {names - _EXPECTED_TOOL_NAMES}"

--- a/tests/ai/test_mcp_tools_qa.py
+++ b/tests/ai/test_mcp_tools_qa.py
@@ -7,7 +7,7 @@ use ``asyncio.run()`` directly against the async-decorated callables, which
 is the same pattern used by ``test_mcp_fastmcp.py``.
 
 Tools under test: ``search_docs``, ``get_doc``, ``list_data``,
-``get_project_info``.
+``get_project_info``, ``open_gui`` (#1947).
 """
 
 from __future__ import annotations
@@ -154,3 +154,30 @@ def test_get_project_info_no_project_raises(tmp_path: Path) -> None:
             _run(tools_qa.get_project_info())
     finally:
         _context.set_context(None)
+
+
+# --- open_gui (#1947) ------------------------------------------------------
+
+
+def test_open_gui_happy(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Returns the running GUI URL published by the backend on startup.
+
+    open_gui reads the canonical ``SCISTUDIO_ENGINE_API_URL`` (ADR-035 §3.10);
+    it needs no project context. A trailing slash is stripped so the agent
+    gets a clean base URL to open in a browser.
+    """
+    monkeypatch.setenv("SCISTUDIO_ENGINE_API_URL", "http://127.0.0.1:54321/")
+    out = _run(tools_qa.open_gui())
+    assert out.url == "http://127.0.0.1:54321"
+    assert out.hint  # non-empty usage guidance
+
+
+def test_open_gui_no_server_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Raises when no GUI server is running (e.g. MCP bridge standalone mode).
+
+    With ``SCISTUDIO_ENGINE_API_URL`` unset there is no live frontend URL to
+    hand back, so the tool must fail loudly rather than return a bogus URL.
+    """
+    monkeypatch.delenv("SCISTUDIO_ENGINE_API_URL", raising=False)
+    with pytest.raises(RuntimeError, match="No running SciStudio GUI"):
+        _run(tools_qa.open_gui())

--- a/tests/cli/test_mcp_bridge.py
+++ b/tests/cli/test_mcp_bridge.py
@@ -129,9 +129,10 @@ def test_run_standalone_mode_returns_tools_list(tmp_path: Path, monkeypatch: pyt
     Verifies:
 
     * Bridge exits 0 (clean EOF).
-    * Stdout contains a JSON-RPC response with ``result.tools`` of 26
-      entries — the registered tool count (25 pre-ADR-035 +
-      ``finish_ai_block`` added by PR #861 / ADR-035 §3.5 path a).
+    * Stdout contains a JSON-RPC response with ``result.tools`` of 35
+      entries — the full registered tool count (26 baseline +
+      get_active_workflow_context + 6 ADR-048 plot tools + edit_workflow
+      #1912 + open_gui #1947).
     """
     project = _make_project(tmp_path)
     request = {"jsonrpc": "2.0", "id": 1, "method": "tools/list"}
@@ -148,9 +149,9 @@ def test_run_standalone_mode_returns_tools_list(tmp_path: Path, monkeypatch: pyt
     assert response.get("id") == 1
     tools = response.get("result", {}).get("tools")
     assert isinstance(tools, list), response
-    assert len(tools) == 34, (
-        f"expected 34 tools (26 baseline + get_active_workflow_context per ADR-040 Addendum 5 "
-        f"+ 6 ADR-048 SPEC 2 plot tools + edit_workflow #1912), got {len(tools)}"
+    assert len(tools) == 35, (
+        f"expected 35 tools (26 baseline + get_active_workflow_context per ADR-040 Addendum 5 "
+        f"+ 6 ADR-048 SPEC 2 plot tools + edit_workflow #1912 + open_gui #1947), got {len(tools)}"
     )
 
 
@@ -219,8 +220,8 @@ def test_run_attached_mode_proxies_to_backend(tmp_path: Path, monkeypatch: pytes
         assert response.get("id") == 99
         tools = response.get("result", {}).get("tools")
         assert (
-            isinstance(tools, list) and len(tools) == 34
-        )  # ADR-040 Addendum 5 + ADR-048 SPEC 2 plot + edit_workflow #1912
+            isinstance(tools, list) and len(tools) == 35
+        )  # ADR-040 Addendum 5 + ADR-048 SPEC 2 plot + edit_workflow #1912 + open_gui #1947
     finally:
         _shutdown.set()
         if server_thread is not None:

--- a/tests/contracts/test_runtime_import_contract.py
+++ b/tests/contracts/test_runtime_import_contract.py
@@ -15,8 +15,8 @@ the other contract files in tests/contracts/:
    contract break.
 
 3. **MCP tool registry contract**: The MCP server must always expose
-   exactly 34 tools (ADR-040 §3.1 + Addendum 5 + ADR-048 SPEC 2 plot + edit_workflow #1912
-   tools). This is a separate
+   exactly 35 tools (ADR-040 §3.1 + Addendum 5 + ADR-048 SPEC 2 plot + edit_workflow #1912
+   + open_gui #1947 tools). This is a separate
    invariant from the parity test in test_mcp_fastmcp.py — it ensures
    the contract is also enforced from the contracts test suite so that
    CI failure is clearly labelled as an architecture regression.
@@ -202,7 +202,7 @@ def test_api_ai_routes_are_registered(app_routes: set[str]) -> None:
 # 3. MCP tool registry contract.
 # ---------------------------------------------------------------------------
 
-# ADR-040 §3.1 + Addendum 5 (#1488) + ADR-048 SPEC 2 + edit_workflow (#1912): 34 tools total.
+# ADR-040 §3.1 + Addendum 5 (#1488) + ADR-048 SPEC 2 + edit_workflow (#1912) + open_gui (#1947): 35 tools total.
 _MCP_EXPECTED_TOOL_NAMES = {
     # category (a) workflow (11 + 1 addendum5)
     "list_blocks",
@@ -231,11 +231,12 @@ _MCP_EXPECTED_TOOL_NAMES = {
     "get_block_config",
     "update_block_config",
     "get_block_logs",
-    # category (d) qa (4)
+    # category (d) qa (5)
     "search_docs",
     "get_doc",
     "list_data",
     "get_project_info",
+    "open_gui",  # #1947
     # category (e) plot (6) — ADR-048 SPEC 2
     "list_plot_targets",
     "scaffold_plot",
@@ -244,11 +245,11 @@ _MCP_EXPECTED_TOOL_NAMES = {
     "validate_plot",
     "run_plot_job",
 }
-_MCP_EXPECTED_COUNT = 34
+_MCP_EXPECTED_COUNT = 35
 
 
-def test_mcp_server_exposes_34_tools() -> None:
-    """ADR-040 §3.1 + Addendum 5 + ADR-048 SPEC 2 + edit_workflow (#1912): MCP server must expose 34 tools.
+def test_mcp_server_exposes_35_tools() -> None:
+    """ADR-040 §3.1 + Addendum 5 + ADR-048 SPEC 2 + edit_workflow (#1912) + open_gui (#1947): MCP server must expose 35 tools.
 
     This contract test mirrors the parity check in test_mcp_fastmcp.py but
     lives in the contracts suite so a regression is flagged as an

--- a/tests/integration/test_phase2_mcp_end_to_end.py
+++ b/tests/integration/test_phase2_mcp_end_to_end.py
@@ -4,7 +4,7 @@ Drives the JSON-RPC dispatcher over the actual transport (Unix socket
 on POSIX, TCP loopback on Windows). Verifies:
 
 * ``initialize`` handshake returns server info.
-* ``tools/list`` enumerates all 34 tools (25 baseline + finish_ai_block + ADR-040 Addendum 5 get_active_workflow_context + 6 ADR-048 SPEC 2 plot tools).
+* ``tools/list`` enumerates all 35 tools (25 baseline + finish_ai_block + ADR-040 Addendum 5 get_active_workflow_context + 6 ADR-048 SPEC 2 plot tools + open_gui #1947).
 * ``tools/call`` for a read-only tool (``list_types``) round-trips.
 * Graceful start / stop, no orphan socket files on POSIX.
 """
@@ -76,12 +76,13 @@ async def _test_mcp_server_initialize_tools_list_and_call(tmp_path: Path) -> Non
         assert "result" in init
         assert init["result"]["serverInfo"]["name"] == "scistudio-mcp"
 
-        # tools/list — expect all 34 (25 baseline + finish_ai_block from ADR-035
+        # tools/list — expect all 35 (25 baseline + finish_ai_block from ADR-035
         # + get_active_workflow_context from ADR-040 Addendum 5
-        # + 6 plot tools from ADR-048 SPEC 2 + edit_workflow from #1912).
+        # + 6 plot tools from ADR-048 SPEC 2 + edit_workflow from #1912
+        # + open_gui from #1947).
         listed = await _connect_and_call(server, {"jsonrpc": "2.0", "id": 2, "method": "tools/list"})
         tools = listed["result"]["tools"]
-        assert len(tools) == 34
+        assert len(tools) == 35
         names = {t["name"] for t in tools}
         assert "list_blocks" in names and "preview_data" in names and "search_docs" in names
         assert "edit_workflow" in names


### PR DESCRIPTION
## What

Adds a single read-only MCP tool **`open_gui`** (category `qa`) so the SciStudio
agent can open the live frontend in a browser (e.g. Chrome) and self-debug
plots, previewers, and interactive block panels using its own browser tooling.

This is **Plan A**: the agent drives a real browser tab with its own browser
capability. SciStudio only hands it the URL — no GUI-control tool suite, no
Electron `remote-debugging-port` / CDP work.

## How

- `open_gui` returns the running GUI's base URL, sourced from the canonical
  `SCISTUDIO_ENGINE_API_URL` the backend publishes on startup (ADR-035 §3.10);
  the SPA is served at that server's root. This is the same signal engine
  workers already use to call back, so the tool discovers the (possibly random,
  `--port 0`) bundled-app port without guessing.
- Raises a clear `RuntimeError` when no GUI server is running for the session
  (e.g. the MCP bridge in standalone mode) — exercised as the error-path test.

The frontend renders faithfully in a plain browser tab: the only Electron-bridge
dependency (`window.scistudioDesktop` in `PackageManagerDialog`) already degrades
gracefully, so plots / previewers / interactive block panels look the same in
Chrome as in the desktop app.

## Contract surfaces updated (34 → 35)

Adding an MCP tool touches the public tool-count contract in several places; all
current surfaces are updated:

- Live catalogs: `docs/architecture/ARCHITECTURE.md` table, the SKILL.md static
  fallback catalog (what Codex sees), and the `how-scistudio-works` user guide.
- Count/set assertions: `test_mcp_fastmcp`, `test_phase2_mcp_end_to_end`,
  `test_mcp_bridge`, `test_finish_ai_block_skeleton`, `test_runtime_import_contract`.
- New happy + error tests in `test_mcp_tools_qa`.

Frozen historical baselines (ADR-040 "26", embedded-coding-agent-spec "25") are
left unchanged by design.

## Testing

- Affected suites green locally (`tests/ai/`, `tests/cli/test_mcp_bridge.py`,
  `tests/integration/test_phase2_mcp_end_to_end.py`, `tests/contracts/test_runtime_import_contract.py`).
- `gate_record check --mode pre-pr` (Tier 2) passed: format_check, full_audit,
  import_contracts, lint_format, python_tests, semantic_dup, type_check.

Gate record: .workflow/records/1947-open-gui.json

Closes #1947
