### PR TITLE
guided(#1953): fix "Workflow changed elsewhere" false alarm on canvas save

### DIFF
--- a/.workflow/records/1953-guided-1953-workflow-selfwrite-race.json
+++ b/.workflow/records/1953-guided-1953-workflow-selfwrite-race.json
@@ -1,0 +1,920 @@
+{
+  "branch": "guided/1953-workflow-selfwrite-race",
+  "check_events": [
+    {
+      "at": "2026-07-16T18:56:06.082544Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:b94760357fa0369e3a103e4fdb83a5277f149efde3c1a9e582275ca3d66c3955",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-07-16T18:56:10.537442Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:986038762c857da247eed20042aaf12b1730bba488837f841542ff950831ddcc",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-16T18:56:11.053920Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:94c43231b931a7009f7017bc3d1ddff42157c487e01d2a583e936a5ce7b93209",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-16T18:56:11.102851Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:0c06d0faca6dbdc2814a45b8a59986d83af2e239c2a7f28bd3b27ab342a01d89",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-07-16T18:58:22.044370Z",
+      "command": "python -m scistudio.qa.testing.run_python_tests --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:5b5faa9888333b2133cb0cc9a67bde38c684369c7118230574397ff958cb3db6",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-16T19:00:48.902555Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:7967548600c9ac432d271fff91966e50efccb5b49b3eecc606a908f78eb6b9f1",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-16T19:00:55.908098Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e139b7a0bb7216e7dce09e1cf7638c6821cd962c15608723baea429eb9ca1bd8",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    },
+    {
+      "at": "2026-07-16T19:15:28.498396Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:2c337a74ddde46268e79b43775cfa736303ab9cc3eea1f80ae44395ae33803ec",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-07-16T19:15:32.672519Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:1057f2d19bcb55978729647660eb59462d697c490c1ff0259d2aeb5a28da2400",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-16T19:15:32.814706Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:971985816622a7ad343de6f719999a507a3bd7815e07131e940d6df491cc66e5",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-16T19:15:32.837130Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:f2120d0e65e282a6cf5b8ccd29ea9f961424836adbee8491be36b507c94b8bb5",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-07-16T19:17:21.563917Z",
+      "command": "python -m scistudio.qa.testing.run_python_tests --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:1a3ea765dc2a46eddbc64187f9cd96422fa6f2f178691840cf0104e749340a5c",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-16T19:19:53.802814Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:ede0479bbc3834c1992d177a6c7346e9bd10b172dea30d1adff4f8b4059c148e",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-16T19:19:54.586000Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:3f3128c5953437def8c80e86e986f00a141e8a333ca61491523961b7e9e8c06f",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    }
+  ],
+  "check_na": [],
+  "commit": {
+    "sha": "d106552772b3e9f2fc56d271b44a37d80df65827",
+    "shas": [
+      "d106552772b3e9f2fc56d271b44a37d80df65827"
+    ],
+    "trailers": []
+  },
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "src/scistudio/api/routes/workflows.py",
+      "src/scistudio/api/runtime/_workflows.py"
+    ]
+  },
+  "directive_events": [
+    {
+      "at": "2026-07-16T18:54:48.474063Z",
+      "owner_directive": "Fix Bug 1 only this session (Bug 2 resolved by re-download); backend fix, push OTA hot update after merge.",
+      "reason": "plan"
+    }
+  ],
+  "docs_events": [
+    {
+      "at": "2026-07-16T18:54:48.474239Z",
+      "class": "adr",
+      "kind": "na",
+      "path": null,
+      "rationale": "Internal race-condition bug fix restoring the intended ADR-045 \u00a75.1 self-write suppression; no public contract, schema, API, UI, or storage change. Mirrors the already-established pending-before-rename pattern in routes/projects.py and the agent MCP write tool.",
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-07-16T18:54:48.474422Z",
+      "class": "changelog",
+      "kind": "na",
+      "path": null,
+      "rationale": "Alpha-stage bug fix; no user-facing changelog maintained for alpha OTA builds (release note carried on the OTA manifest at publish time).",
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": false,
+  "guard_events": [
+    {
+      "at": "2026-07-16T19:00:55.946994Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:00:55.956699Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:00:55.966561Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:00:55.976178Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:00:55.985305Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:00:55.994570Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:00:56.003360Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:00:56.013177Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:00:56.022465Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:00:56.033301Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:19:54.633354Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:19:54.644512Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:19:54.655570Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:19:54.667022Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:19:54.678101Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:19:54.688674Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:19:54.698857Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:19:54.715337Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:19:54.725423Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:19:54.737904Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:20:23.121126Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:20:23.130367Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:20:23.139521Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:20:23.148740Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:20:23.157955Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:20:23.167095Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:20:23.176722Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:20:23.185900Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:20:23.195246Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:20:23.210683Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:20:50.674377Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:20:50.684264Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:20:50.693934Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:20:50.704313Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:20:50.713666Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:20:50.723409Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:20:50.732573Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:20:50.742100Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:20:50.751210Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:20:50.763241Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:21:28.034293Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:21:28.043573Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:21:28.052912Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:21:28.062302Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:21:28.072000Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:21:28.081940Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:21:28.091122Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:21:28.100440Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:21:28.109886Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:21:28.121538Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:21:35.930395Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:21:35.939423Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:21:35.949013Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:21:35.958473Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:21:35.967730Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:21:35.977031Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:21:35.986425Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:21:35.995713Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:21:36.004659Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:21:36.015788Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1953,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": {
+    "base": "302fe419fd6f6ae6d3115ea4b4c115149f3b21a7",
+    "base_sha": "302fe419",
+    "changed_files": [
+      ".workflow/records/1953-guided-1953-workflow-selfwrite-race.json",
+      "src/scistudio/api/runtime/_workflows.py",
+      "tests/api/test_workflow_watcher.py"
+    ],
+    "diff_fingerprint": "sha256:5e86c8f07ae60a7844eb6d1893d16db2ce93220ffa1230aabec502c49200cb54",
+    "head": "HEAD",
+    "head_sha": "d1065527",
+    "surfaces": {
+      "docs": 0,
+      "frontend": 0,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 1,
+      "packaging": 0,
+      "protected_core": 0,
+      "sentrux": 2,
+      "test": 1,
+      "workflow_ci": 0
+    }
+  },
+  "owner_directive": "Fix Bug 1 from Yufan Chen's 2026-07-16 report: 'Workflow changed elsewhere' false alarm on every canvas save (Linux/inotify). Root cause is a race: canvas save registers the workflow first-party write signature AFTER os.replace, so the inotify observer thread wins and emits a phantom external event. Fix by registering pending=True first-party signature BEFORE the atomic rename, mirroring projects.py and the agent MCP write path. Backend-only, OTA-hot-patchable. Bug 2 (AppImage relaunch) is out of scope this session.",
+  "persona": "live_implementer",
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [
+      1953
+    ],
+    "number": 1955,
+    "url": null
+  },
+  "reconcile_events": [
+    {
+      "at": "2026-07-16T19:00:56.033334Z",
+      "diff_fingerprint": "sha256:2718b8424eb93fa74276f8437dbf2ad92f756a1ff62f324d7990ee37a669a492",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.format_check",
+        "checks.lint_format",
+        "checks.semantic_dup"
+      ]
+    },
+    {
+      "at": "2026-07-16T19:19:54.737942Z",
+      "diff_fingerprint": "sha256:e685a6d0d6fdd0ae4a0b32b39a3a282f2d1f71d74c8e60ef4d0b3a34f2428791",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-07-16T19:20:23.210736Z",
+      "diff_fingerprint": "sha256:2c8a127e36592ce066de0be14a778e7a7597857c83f9fc06fe766affff891479",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-07-16T19:20:50.763279Z",
+      "diff_fingerprint": "sha256:8c6e0fe96f2cc3da8e218de0599e7f5bf817ec7ac67014be16eb1aae94b1b9eb",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-07-16T19:21:28.121581Z",
+      "diff_fingerprint": "sha256:5e86c8f07ae60a7844eb6d1893d16db2ce93220ffa1230aabec502c49200cb54",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-07-16T19:21:36.015815Z",
+      "diff_fingerprint": "sha256:5e86c8f07ae60a7844eb6d1893d16db2ce93220ffa1230aabec502c49200cb54",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    }
+  ],
+  "record_id": "1953-guided-1953-workflow-selfwrite-race",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [
+      "format_check",
+      "full_audit",
+      "import_contracts",
+      "lint_format",
+      "python_tests",
+      "semantic_dup",
+      "type_check"
+    ],
+    "docs": [
+      "docs_required_or_na"
+    ],
+    "guards": [
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": [
+      "changed_test_required"
+    ]
+  },
+  "runtime": "claude",
+  "schema_version": 2,
+  "scope_events": [
+    {
+      "action": "add-include",
+      "at": "2026-07-16T18:48:58.717958Z",
+      "pattern": "src/scistudio/api/runtime/__init__.py",
+      "reason": "Fix requires forwarding pending= through the workflow first-party convenience wrapper; add runtime/__init__.py and the watcher test file to scope."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-07-16T18:48:58.718108Z",
+      "pattern": "tests/**/test_workflow_watcher*.py",
+      "reason": "Fix requires forwarding pending= through the workflow first-party convenience wrapper; add runtime/__init__.py and the watcher test file to scope."
+    }
+  ],
+  "session_id": "be082f35-2aca-420f-86c0-1d9224327974",
+  "strictness_tier": 2,
+  "task_kind": "guided",
+  "test_events": [
+    {
+      "at": "2026-07-16T18:54:48.474426Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/api/test_workflow_watcher.py",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/src/scistudio/api/runtime/_workflows.py
+++ b/src/scistudio/api/runtime/_workflows.py
@@ -154,6 +154,31 @@ def save_workflow(self: ApiRuntime, payload: dict[str, Any]) -> WorkflowDefiniti
         raise WorkflowIdConflictError(definition.id, conflict)
 
     path = self.workflow_path(definition.id)
+    # #1953: register a *pending* first-party write signature BEFORE the atomic
+    # rename inside ``save_yaml``. ``save_yaml`` writes a tempfile then
+    # ``os.replace``s it onto ``path``; on Linux/inotify that rename surfaces to
+    # the watchdog observer thread immediately, before the route layer's
+    # ``_emit_workflow_changed`` runs its post-write ``mark_workflow_first_party_write``.
+    # The observer thread then races ahead of the signature and emits a phantom
+    # ``source=external`` event, which the canvas surfaces as a spurious
+    # "Workflow changed elsewhere" dialog. A pending signature is path-only
+    # matched (``exists is None`` -> match) so it suppresses the echo regardless
+    # of the race, mtime, or event kind. This mirrors the already-correct pattern
+    # in ``routes/projects.py`` (file write) and the agent MCP ``write_workflow``
+    # tool.
+    kind = "modified" if path.exists() else "created"
+    # Import the entity-class constant lazily: ``runtime/__init__`` imports this
+    # module during its own initialisation, so a top-level import would cycle.
+    from scistudio.api.runtime import WORKFLOW_ENTITY_CLASS
+
+    self.mark_entity_first_party_write(
+        WORKFLOW_ENTITY_CLASS,
+        definition.id,
+        self.current_workflow_version(definition.id),
+        path=path,
+        kind=kind,
+        pending=True,
+    )
     save_yaml(definition, path)
     # ADR-034 Phase 2: tell the FS watcher this write came from us so it
     # does not echo a workflow.changed event back to the canvas.

--- a/tests/api/test_workflow_watcher.py
+++ b/tests/api/test_workflow_watcher.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 import threading
 import time
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock
 
 import pytest
@@ -38,6 +38,9 @@ from scistudio.api.routes.workflow_watcher import (
     WorkflowWatcher,
     _WorkflowFileHandler,
 )
+
+if TYPE_CHECKING:
+    from scistudio.api.runtime import ApiRuntime
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -382,3 +385,135 @@ def _isolate_module_singleton() -> Any:
     watcher_module.set_active_watcher(None)
     yield
     watcher_module.set_active_watcher(None)
+
+
+# ---------------------------------------------------------------------------
+# #1953: canvas-save atomic-rename race — pending first-party signature
+# ---------------------------------------------------------------------------
+#
+# Prior coverage tested post-write ``FileModifiedEvent`` suppression and a plain
+# (un-suppressed) ``FileMovedEvent`` separately, but never the canvas save's
+# atomic rename: ``save_yaml`` writes a tempfile then ``os.replace``s it, which
+# on Linux/inotify surfaces to the watchdog observer thread *the instant the
+# rename lands* — before the route layer's post-write ``mark_workflow_first_party_write``
+# runs. The observer thread then won the race and emitted a phantom
+# ``source=external`` event, surfaced by the canvas as a spurious "Workflow
+# changed elsewhere" dialog (Bug 1, 2026-07-16 Linux report). The fix registers a
+# *pending* first-party signature BEFORE the rename inside ``save_workflow``.
+
+
+def test_save_workflow_registers_pending_signature_before_atomic_rename(
+    runtime: ApiRuntime, opened_project: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The first-party signature must exist BEFORE ``save_yaml`` renames.
+
+    We spy on ``save_yaml`` (which performs the ``os.replace``) and assert that,
+    at the moment the rename happens, the runtime already reports a pending
+    first-party write for the workflow — the exact ordering guarantee that
+    lets the FS watcher suppress the atomic-rename echo. The check uses
+    ``kind="created"`` because the watcher relabels a ``FileMovedEvent`` on the
+    destination to ``created``.
+    """
+    from scistudio.api.runtime import _workflows as workflows_mod
+
+    payload = {
+        "id": "race_wf",
+        "nodes": [
+            {"id": "A", "block_type": "loader"},
+            {"id": "B", "block_type": "writer"},
+        ],
+        "edges": [{"source": "A:out", "target": "B:in"}],
+    }
+    wf_path = runtime.workflow_path("race_wf")
+    real_save_yaml = workflows_mod.save_yaml
+    observed: dict[str, bool] = {}
+
+    def spy_save_yaml(definition: Any, path: Any) -> Any:
+        observed["pending_before_rename"] = runtime.is_recent_workflow_first_party_write(
+            "race_wf", path=Path(path), kind="created"
+        )
+        return real_save_yaml(definition, path)
+
+    monkeypatch.setattr(workflows_mod, "save_yaml", spy_save_yaml)
+    runtime.save_workflow(payload)
+
+    assert observed.get("pending_before_rename") is True
+    assert wf_path.exists()
+
+
+def test_pending_signature_suppresses_relabeled_move_created(runtime: ApiRuntime, opened_project: Path) -> None:
+    """A relabeled-``created`` move is suppressed by a ``modified`` pending mark.
+
+    The canvas save registers the first-party write with ``kind="modified"``, but
+    the atomic rename surfaces to the watcher as a ``FileMovedEvent`` relabeled to
+    ``kind="created"``. A pending signature is path-only matched, so it suppresses
+    the echo regardless of the kind or mtime mismatch — the race-proof property
+    the fix relies on.
+    """
+    project = opened_project
+    wf_path = runtime.workflow_path("demo")
+    wf_path.parent.mkdir(parents=True, exist_ok=True)
+    wf_path.write_text("id: demo\nnodes: []\nedges: []\n", encoding="utf-8")
+    # Seed the cached disk version then advance the file, so ADR-045's
+    # delayed-echo guard would *pass* the event through — isolating the pending
+    # first-party signature as the only thing that can suppress it.
+    version = runtime.current_workflow_version("demo")
+    time.sleep(0.02)
+    wf_path.write_text("id: demo\nnodes: []\nedges: []\n# saved\n", encoding="utf-8")
+
+    captured: list[dict[str, Any]] = []
+    handler = _WorkflowFileHandler(
+        project_dir=project,
+        broadcast=captured.append,
+        loop=None,
+        runtime=runtime,
+    )
+    runtime.mark_entity_first_party_write(
+        "workflow",
+        "demo",
+        version,
+        path=wf_path,
+        kind="modified",
+        pending=True,
+    )
+
+    tmp = wf_path.with_name(".demo.yaml.tmp")
+    handler.on_any_event(FileMovedEvent(str(tmp), str(wf_path)))
+
+    assert captured == []
+
+
+def test_move_created_emits_without_pending_signature(runtime: ApiRuntime, opened_project: Path) -> None:
+    """Contrast: with no pending signature, a genuinely external move still emits.
+
+    Guards against the pending suppression becoming unconditional — a real
+    external atomic rename (no first-party mark) must still reach the canvas.
+    We seed the runtime's cached disk version at the file's original mtime and
+    then advance the file, so ADR-045's delayed-echo guard passes and the
+    *only* thing that could silence the event is a first-party signature (which
+    this test deliberately does not register).
+    """
+    project = opened_project
+    wf_path = runtime.workflow_path("ext")
+    wf_path.parent.mkdir(parents=True, exist_ok=True)
+    wf_path.write_text("id: ext\nnodes: []\nedges: []\n", encoding="utf-8")
+    # Seed the cached disk version at the current (older) mtime.
+    runtime.current_workflow_version("ext")
+    # Advance the file so the upcoming event is newer than the cached version.
+    time.sleep(0.02)
+    wf_path.write_text("id: ext\nnodes: []\nedges: []\n# external edit\n", encoding="utf-8")
+
+    captured: list[dict[str, Any]] = []
+    handler = _WorkflowFileHandler(
+        project_dir=project,
+        broadcast=captured.append,
+        loop=None,
+        runtime=runtime,
+    )
+
+    tmp = wf_path.with_name(".ext.yaml.tmp")
+    handler.on_any_event(FileMovedEvent(str(tmp), str(wf_path)))
+
+    assert len(captured) == 1
+    assert captured[0]["kind"] == "created"
+    assert captured[0]["source"] == "external"


### PR DESCRIPTION
## Summary

Fixes the Linux-only "**Workflow changed elsewhere**" false-alarm dialog (Bug 1
of Yufan Chen's 2026-07-16 v0.3.3-alpha report): while editing on the canvas with
a single editor open, the conflict dialog appeared every 1–2 minutes, and
dismissing it triggered another save that re-triggered the alarm.

## Root cause (corrected from the report)

The report guessed a `kind`-signature mismatch, but `_entity_write_path_matches`
does not compare `kind` for existing files — the real cause is an **ordering
race**:

1. `save_workflow` → `save_yaml` → `atomic_write_text` performs a tempfile +
   `os.replace`. On Linux/inotify that rename surfaces to the watchdog observer
   thread the instant it lands.
2. The route layer only registers the first-party write signature **afterwards**,
   in `_emit_workflow_changed`. The observer thread wins the race, finds no
   signature, and emits a phantom `source=external kind=created` event → the
   spurious dialog. On the frontend the phantom event (`source_id=None`) cannot
   be confirmed as an own-echo, and the workflow is dirty → conflict dialog.

macOS never reproduced because FSEvents coalescing latency lets the route
register the signature first. Full-log stats corroborate a race: 27 phantom
events across 103 saves (~26%), each paired with an adjacent canvas save.

## Fix

Register a `pending=True` first-party write signature **before** the atomic
rename inside `save_workflow` (via `mark_entity_first_party_write`). A pending
signature is path-only matched (`exists is None`), so it is race-, mtime-, and
kind-proof. This mirrors the already-correct pattern in `routes/projects.py`
(file write) and the agent MCP `write_workflow` tool.

Backend-only and OTA-hot-patchable.

## Tests

Three regression tests in `test_workflow_watcher.py` covering the previously
un-covered canvas atomic-rename case: the pending signature is registered before
the rename; a relabeled-`created` move is suppressed despite a `modified`-kind
mark; and a genuinely external move (no signature) still emits.

Gate record: .workflow/records/1953-guided-1953-workflow-selfwrite-race.json

Closes #1953
