### PR TITLE
guided(#1954): exclude annotations from canvas Tidy layout

### DIFF
--- a/.workflow/records/1954-guided-1954-tidy-preserve-annotations.json
+++ b/.workflow/records/1954-guided-1954-tidy-preserve-annotations.json
@@ -83,9 +83,9 @@
   ],
   "check_na": [],
   "commit": {
-    "sha": "89d5a714889408533356fd9aec14f6458fc45d07",
+    "sha": "c7b011a43155f7f1d2e470f82367b27054e6e034",
     "shas": [
-      "89d5a714889408533356fd9aec14f6458fc45d07"
+      "c7b011a43155f7f1d2e470f82367b27054e6e034"
     ],
     "trailers": []
   },
@@ -362,6 +362,88 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:28:41.010858Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:28:41.020512Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:28:41.029802Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:28:41.039352Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:28:41.048601Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:28:41.057695Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:28:41.066977Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:28:41.076798Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:28:41.086131Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:28:41.097472Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -374,7 +456,7 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "origin/main",
+    "base": "d9797e08cb02f6ca4f5a4817e4c29c381829658c",
     "base_sha": "d9797e08",
     "changed_files": [
       ".workflow/records/1954-guided-1954-tidy-preserve-annotations.json",
@@ -383,9 +465,9 @@
       "frontend/src/components/WorkflowCanvas.parts/__tests__/autoLayout.test.ts",
       "frontend/src/components/WorkflowCanvas.parts/autoLayout.ts"
     ],
-    "diff_fingerprint": "sha256:633b26790a8c8a8a73e18c454ab9ca9536ca17e6d6697794758377b19ae4faae",
+    "diff_fingerprint": "sha256:aeea1ad9b178f84a0329c4ee887b80f7f38ad30ff33ea9143945b72876a65cfd",
     "head": "HEAD",
-    "head_sha": "4c4fcc36",
+    "head_sha": "c7b011a4",
     "surfaces": {
       "docs": 2,
       "frontend": 2,
@@ -406,7 +488,7 @@
     "closes": [
       1954
     ],
-    "number": null,
+    "number": 1956,
     "url": null
   },
   "reconcile_events": [
@@ -429,6 +511,14 @@
     {
       "at": "2026-07-16T19:28:00.959224Z",
       "diff_fingerprint": "sha256:633b26790a8c8a8a73e18c454ab9ca9536ca17e6d6697794758377b19ae4faae",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-07-16T19:28:41.097505Z",
+      "diff_fingerprint": "sha256:aeea1ad9b178f84a0329c4ee887b80f7f38ad30ff33ea9143945b72876a65cfd",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 2,

--- a/.workflow/records/1954-guided-1954-tidy-preserve-annotations.json
+++ b/.workflow/records/1954-guided-1954-tidy-preserve-annotations.json
@@ -1,0 +1,503 @@
+{
+  "branch": "guided/1954-tidy-preserve-annotations",
+  "check_events": [
+    {
+      "at": "2026-07-16T19:24:03.774242Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:bee0017f30f552d2df2de1173f9ac14b9aee5192ca5e5c1de574bb119512b275",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-07-16T19:24:43.891168Z",
+      "command": "(cd frontend && npm run check:ci)",
+      "covered_surface": "frontend",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:64a54cca0a7c27a612ea11ef24d7ced2517eb9206f897a9aa2714eb616cf6ddc",
+      "name": "frontend",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/frontend.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-16T19:24:48.485261Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:66fcce56acd756c025e5fc336a462968c4fff58e0fc6a25d44efcda846b49fdf",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-16T19:24:48.554072Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e31351abfc33f0b3c0f28bc9f2f3d59ae3bc5d4925dc1159a7f931aa932441ed",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-07-16T19:27:17.072223Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:5f1c4640316a04ba314eb640d12d22c074ba1169d14a8ab0970ab4ff6dedc71b",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    }
+  ],
+  "check_na": [],
+  "commit": {
+    "sha": "89d5a714889408533356fd9aec14f6458fc45d07",
+    "shas": [
+      "89d5a714889408533356fd9aec14f6458fc45d07"
+    ],
+    "trailers": []
+  },
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "frontend/src/components/WorkflowCanvas.parts/autoLayout.ts",
+      "frontend/src/components/WorkflowCanvas.tsx"
+    ]
+  },
+  "directive_events": [],
+  "docs_events": [
+    {
+      "at": "2026-07-16T19:19:55.362165Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/specs/adr-050-canvas-node-readability.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-07-16T19:19:55.362171Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/adr/ADR-050.md",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": false,
+  "guard_events": [
+    {
+      "at": "2026-07-16T19:27:17.112680Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:27:17.122061Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:27:17.131504Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:27:17.141021Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:27:17.151003Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:27:17.160421Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:27:17.169565Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:27:17.181848Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:27:17.191128Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:27:17.201431Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:27:24.958420Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:27:24.968959Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:27:24.978995Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:27:24.988935Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:27:24.998762Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:27:25.008956Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:27:25.019182Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:27:25.029273Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:27:25.039284Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:27:25.050633Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:28:00.871559Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:28:00.880768Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:28:00.889825Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:28:00.900866Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:28:00.912434Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:28:00.921724Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:28:00.930636Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:28:00.939895Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:28:00.948918Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:28:00.959188Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1954,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": {
+    "base": "origin/main",
+    "base_sha": "d9797e08",
+    "changed_files": [
+      ".workflow/records/1954-guided-1954-tidy-preserve-annotations.json",
+      "docs/adr/ADR-050.md",
+      "docs/specs/adr-050-canvas-node-readability.md",
+      "frontend/src/components/WorkflowCanvas.parts/__tests__/autoLayout.test.ts",
+      "frontend/src/components/WorkflowCanvas.parts/autoLayout.ts"
+    ],
+    "diff_fingerprint": "sha256:633b26790a8c8a8a73e18c454ab9ca9536ca17e6d6697794758377b19ae4faae",
+    "head": "HEAD",
+    "head_sha": "4c4fcc36",
+    "surfaces": {
+      "docs": 2,
+      "frontend": 2,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 2,
+      "packaging": 0,
+      "protected_core": 0,
+      "sentrux": 4,
+      "test": 1,
+      "workflow_ci": 0
+    }
+  },
+  "owner_directive": "Fix canvas Tidy button reshuffling user annotations. Approach A: exclude _annotation nodes from auto-layout so notes stay pinned in place.",
+  "persona": "live_implementer",
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [
+      1954
+    ],
+    "number": null,
+    "url": null
+  },
+  "reconcile_events": [
+    {
+      "at": "2026-07-16T19:27:17.201668Z",
+      "diff_fingerprint": "sha256:fb6f0aacd2dd44311c83243ab94d8599d689680464d2858cc413c81a33bf6286",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-07-16T19:27:25.050663Z",
+      "diff_fingerprint": "sha256:fb6f0aacd2dd44311c83243ab94d8599d689680464d2858cc413c81a33bf6286",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-07-16T19:28:00.959224Z",
+      "diff_fingerprint": "sha256:633b26790a8c8a8a73e18c454ab9ca9536ca17e6d6697794758377b19ae4faae",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    }
+  ],
+  "record_id": "1954-guided-1954-tidy-preserve-annotations",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [
+      "format_check",
+      "frontend",
+      "full_audit",
+      "lint_format",
+      "semantic_dup"
+    ],
+    "docs": [
+      "docs_required_or_na"
+    ],
+    "guards": [
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": [
+      "changed_test_required"
+    ]
+  },
+  "runtime": "claude-code",
+  "schema_version": 2,
+  "scope_events": [
+    {
+      "action": "add-include",
+      "at": "2026-07-16T19:19:55.361981Z",
+      "pattern": "frontend/src/components/WorkflowCanvas.parts/__tests__/autoLayout.test.ts",
+      "reason": "Record implemented scope: annotation exclusion in autoLayout adapter, its unit tests, and the ADR-050 spec/ADR invariant for tidy"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-07-16T19:19:55.362154Z",
+      "pattern": "docs/specs/adr-050-canvas-node-readability.md",
+      "reason": "Record implemented scope: annotation exclusion in autoLayout adapter, its unit tests, and the ADR-050 spec/ADR invariant for tidy"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-07-16T19:19:55.362157Z",
+      "pattern": "docs/adr/ADR-050.md",
+      "reason": "Record implemented scope: annotation exclusion in autoLayout adapter, its unit tests, and the ADR-050 spec/ADR invariant for tidy"
+    }
+  ],
+  "session_id": "e119e3d3-5a34-4449-80af-21ba74cc4e86",
+  "strictness_tier": 2,
+  "task_kind": "guided",
+  "test_events": [
+    {
+      "at": "2026-07-16T19:19:55.362175Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/components/WorkflowCanvas.parts/__tests__/autoLayout.test.ts",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/docs/adr/ADR-050.md
+++ b/docs/adr/ADR-050.md
@@ -401,6 +401,10 @@ Requirements:
 - Tidy writes positions through the existing `node.layout` metadata path.
 - Tidy MUST NOT change node ids, block types, config, ports, edges, execution
   state, lineage, or runtime data.
+- Tidy MUST NOT reposition annotation notes (`block_type === "_annotation"`).
+  These are free-floating, user-placed canvas pseudo-nodes with no ports or
+  edges; the layout adapter excludes them so a note keeps its position and its
+  spatial relationship to the block it describes.
 - Tidy MUST be explicit user action. It is not automatic on every graph edit.
 - Tidy SHOULD preserve manual layout when the user does not invoke it.
 - Dragging a node after tidy remains the normal manual override.

--- a/docs/specs/adr-050-canvas-node-readability.md
+++ b/docs/specs/adr-050-canvas-node-readability.md
@@ -341,6 +341,11 @@ Acceptance Scenarios:
   package-provided blocks carry the same metadata shape as core blocks, the
   frontend node/config tests that exercise that metadata cover package blocks by
   construction; this frontend ADR adds no backend or package contract tests.
+- FR-034: Tidy layout MUST NOT reposition annotation notes
+  (`block_type === "_annotation"`). Annotation notes are free-floating,
+  user-placed canvas pseudo-nodes with no ports or edges; the layout adapter
+  MUST exclude them so their `node.layout` stays where the user put it and the
+  note keeps its spatial relationship to the block it describes.
 
 ### Key Entities
 

--- a/frontend/src/components/WorkflowCanvas.parts/__tests__/autoLayout.test.ts
+++ b/frontend/src/components/WorkflowCanvas.parts/__tests__/autoLayout.test.ts
@@ -135,3 +135,52 @@ describe("computeAutoLayout — scope (focus-scoped tidy, ADR-050 §3.2)", () =>
     expect(Object.keys(positions)).toEqual(["b"]);
   });
 });
+
+describe("computeAutoLayout — annotations are not laid out (#1954)", () => {
+  function annotation(id: string): WorkflowNode {
+    return {
+      id,
+      block_type: "_annotation",
+      config: { params: { text: "Note" }, style: { width: 240, height: 120 } },
+      layout: { x: 111, y: 222 },
+    };
+  }
+
+  it("omits annotation nodes from the output so their positions stay pinned", async () => {
+    const positions = await computeAutoLayout({
+      nodes: [...LINEAR_NODES, annotation("note-1")],
+      edges: LINEAR_EDGES,
+    });
+    // The note is never assigned a layout position; the caller leaves its
+    // persisted `layout` untouched.
+    expect(positions["note-1"]).toBeUndefined();
+    expect(Object.keys(positions).sort()).toEqual(["a", "b", "c", "d"]);
+  });
+
+  it("does not let an annotation perturb the layout of real nodes", async () => {
+    const withoutNote = await computeAutoLayout({ nodes: LINEAR_NODES, edges: LINEAR_EDGES });
+    const withNote = await computeAutoLayout({
+      nodes: [...LINEAR_NODES, annotation("note-1")],
+      edges: LINEAR_EDGES,
+    });
+    expect(withNote).toEqual(withoutNote);
+  });
+
+  it("returns an empty map when the graph is annotations only", async () => {
+    const positions = await computeAutoLayout({
+      nodes: [annotation("note-1"), annotation("note-2")],
+      edges: [],
+    });
+    expect(positions).toEqual({});
+  });
+
+  it("excludes an annotation even when it is inside the focus scope", async () => {
+    const positions = await computeAutoLayout({
+      nodes: [...LINEAR_NODES, annotation("note-1")],
+      edges: LINEAR_EDGES,
+      scopeNodeIds: new Set(["b", "note-1"]),
+    });
+    expect(Object.keys(positions).sort()).toEqual(["b"]);
+    expect(positions["note-1"]).toBeUndefined();
+  });
+});

--- a/frontend/src/components/WorkflowCanvas.parts/autoLayout.ts
+++ b/frontend/src/components/WorkflowCanvas.parts/autoLayout.ts
@@ -102,8 +102,15 @@ export async function computeAutoLayout(input: AutoLayoutInput): Promise<LayoutP
   const nodeSize = input.nodeSize ?? NODE_SIZE;
   const scope = input.scopeNodeIds;
 
+  // Annotation notes (`block_type === "_annotation"`) are free-floating canvas
+  // pseudo-nodes with no ports or edges. ELK would treat each as a disconnected
+  // component and reflow it into the layered grid, tearing the note away from
+  // the block it describes (#1954). Tidy lays out real workflow nodes only and
+  // leaves annotation positions untouched.
+  //
   // Filter + sort nodes by id for a stable ELK input order (SC-006).
   const scopedNodes = input.nodes
+    .filter((node) => node.block_type !== "_annotation")
     .filter((node) => (scope ? scope.has(node.id) : true))
     .slice()
     .sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));


### PR DESCRIPTION
## Problem

On the workflow canvas, the **Tidy** (auto-layout) button repositioned user-written annotation notes, so the spatial correspondence between a note and the workflow node it describes was lost.

## Root cause

Annotations are modeled as ordinary `WorkflowNode`s with `block_type === "_annotation"` and free-floating absolute `layout:{x,y}` (no anchor to any node). `runTidy` passed the **entire** node array — including `_annotation` nodes — into ELK (`computeAutoLayout`), which had no annotation filter. Since annotations have no edges, ELK treated each as a disconnected component and slotted it into the layered grid, flinging notes away from where the user placed them.

## Fix (approach A — pin annotations)

Exclude `_annotation` nodes from `computeAutoLayout` so Tidy lays out real workflow nodes only; annotations keep their absolute positions (the common sticky-note-stays-put behavior, e.g. n8n).

## Changes

- `frontend/src/components/WorkflowCanvas.parts/autoLayout.ts` — filter `_annotation` nodes out of the layout input.
- `frontend/src/components/WorkflowCanvas.parts/__tests__/autoLayout.test.ts` — +4 tests: annotations excluded from output, annotations do not perturb real-node layout, annotations-only graph → empty map, annotation excluded even inside focus scope.
- `docs/adr/ADR-050.md` §3.2 and `docs/specs/adr-050-canvas-node-readability.md` FR-034 — record the "Tidy MUST NOT reposition annotation notes" invariant.

## Testing

`npx vitest run autoLayout.test.ts` → 15/15 pass.

Gate record: .workflow/records/1954-guided-1954-tidy-preserve-annotations.json

Closes #1954
