### PR TITLE
guided(#1957): strip variadic port keys before CodeBlockConfig

### DIFF
--- a/.workflow/records/1957-guided-1957-codeblock-port-keys.json
+++ b/.workflow/records/1957-guided-1957-codeblock-port-keys.json
@@ -145,9 +145,9 @@
   ],
   "check_na": [],
   "commit": {
-    "sha": "10b7f70856fd653489136d76d0ee3c46860f67d8",
+    "sha": "59b522ead2c3c2070379881e7872aa4a51419c5b",
     "shas": [
-      "10b7f70856fd653489136d76d0ee3c46860f67d8"
+      "59b522ead2c3c2070379881e7872aa4a51419c5b"
     ],
     "trailers": []
   },
@@ -573,6 +573,506 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:52:14.972863Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/code/code_block.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/code/code_block.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/code/validation.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/code/validation.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:52:14.982274Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:52:14.991413Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:52:15.001130Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:52:15.011071Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:52:15.020738Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:52:15.030087Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:52:15.039361Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:52:15.049044Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:52:15.061219Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:52:34.146716Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/code/code_block.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/code/code_block.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/code/validation.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/code/validation.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:52:34.156665Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:52:34.166996Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:52:34.176892Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:52:34.187188Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:52:34.196888Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:52:34.207081Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:52:34.216608Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:52:34.226726Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:52:34.238252Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:52:47.409119Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/code/code_block.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/code/code_block.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/code/validation.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/code/validation.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:52:47.418987Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:52:47.429387Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:52:47.439314Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:52:47.449264Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:52:47.459855Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:52:47.470228Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:52:47.480399Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:52:47.490960Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:52:47.503622Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:52:56.233427Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/code/code_block.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/code/code_block.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/code/validation.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/code/validation.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:52:56.244985Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:52:56.255381Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:52:56.265511Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:52:56.274921Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:52:56.285182Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:52:56.294920Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:52:56.305313Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:52:56.314782Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:52:56.327210Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -585,8 +1085,8 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "origin/main",
-    "base_sha": "d9797e08",
+    "base": "302fe419fd6f6ae6d3115ea4b4c115149f3b21a7",
+    "base_sha": "302fe419",
     "changed_files": [
       ".workflow/records/1957-guided-1957-codeblock-port-keys.json",
       "src/scistudio/blocks/code/code_block.py",
@@ -594,9 +1094,9 @@
       "tests/blocks/code/test_codeblock_execution.py",
       "tests/blocks/code/test_codeblock_validation.py"
     ],
-    "diff_fingerprint": "sha256:8fc4630f87b98bcd8a9cd97ca4aa1dd96bc50c547eab45344db587e1c879d7ea",
+    "diff_fingerprint": "sha256:6da2b584c23af7e35b338c7d5ff1a60754f70583d38ef1ce8d651eb01ba9ceb3",
     "head": "HEAD",
-    "head_sha": "10b7f708",
+    "head_sha": "59b522ea",
     "surfaces": {
       "docs": 0,
       "frontend": 0,
@@ -617,8 +1117,8 @@
     "closes": [
       1957
     ],
-    "number": null,
-    "url": null
+    "number": 1958,
+    "url": "https://github.com/jiazhenz026/SciStudio/pull/1958"
   },
   "reconcile_events": [
     {
@@ -642,6 +1142,38 @@
     {
       "at": "2026-07-16T19:51:32.401782Z",
       "diff_fingerprint": "sha256:8fc4630f87b98bcd8a9cd97ca4aa1dd96bc50c547eab45344db587e1c879d7ea",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-07-16T19:52:15.061272Z",
+      "diff_fingerprint": "sha256:6da2b584c23af7e35b338c7d5ff1a60754f70583d38ef1ce8d651eb01ba9ceb3",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-07-16T19:52:34.238298Z",
+      "diff_fingerprint": "sha256:6da2b584c23af7e35b338c7d5ff1a60754f70583d38ef1ce8d651eb01ba9ceb3",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-07-16T19:52:47.503656Z",
+      "diff_fingerprint": "sha256:6da2b584c23af7e35b338c7d5ff1a60754f70583d38ef1ce8d651eb01ba9ceb3",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-07-16T19:52:56.327238Z",
+      "diff_fingerprint": "sha256:6da2b584c23af7e35b338c7d5ff1a60754f70583d38ef1ce8d651eb01ba9ceb3",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 1,

--- a/.workflow/records/1957-guided-1957-codeblock-port-keys.json
+++ b/.workflow/records/1957-guided-1957-codeblock-port-keys.json
@@ -1,0 +1,743 @@
+{
+  "branch": "guided/1957-codeblock-port-keys",
+  "check_events": [
+    {
+      "at": "2026-07-16T19:46:27.894313Z",
+      "command": "pytest tests/architecture/ -v --no-cov",
+      "covered_surface": "architecture",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:7939ff3d5820b300889ea1cc41135ef91845f040ccd849f67b597561736930d2",
+      "name": "architecture_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/architecture_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-16T19:46:28.704801Z",
+      "command": "python scripts/deferral_scan.py --check docs/audit/baselines/deferral-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:3de2d1d5e47dc099af3fd471fe9d363af71cf3506274a0f9551abee606191deb",
+      "name": "deferral_discipline",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/deferral_discipline.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-16T19:46:28.741510Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:dff986d079e5666a55e27f3a1aa68e818d0a5debcddee902eb0d32f299cea7f0",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-07-16T19:46:32.348081Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:f18baf8fc1fcb0da213af8aceab33acdac8738e898427d266c3fe20dc7b89ce8",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-16T19:46:32.459882Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:b8859fa7e7149ed822c3465f9b269b10a972375a3176f57fdaf95771bacc762b",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-16T19:46:32.477917Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:9a1d7924804933b72c0ccb8f28e4f852816156da1ca12c11800e9b479945ed20",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-07-16T19:48:00.804382Z",
+      "command": "python -m scistudio.qa.testing.run_python_tests --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:b5e7913e974f69e1ddd5ea1371d9d35198d414f2f19fb92a45edd4c30ba0aa3c",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-16T19:50:27.158646Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cab431169af307352273246c718bb3997775380275192d23a2fe19ff5adf5aed",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-16T19:50:34.722505Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:5fac5ce8fff70b1748a9d8cadede70081dfb059ce5bf963b851796405e9b955a",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    }
+  ],
+  "check_na": [],
+  "commit": {
+    "sha": "10b7f70856fd653489136d76d0ee3c46860f67d8",
+    "shas": [
+      "10b7f70856fd653489136d76d0ee3c46860f67d8"
+    ],
+    "trailers": []
+  },
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "src/scistudio/blocks/code/code_block.py",
+      "src/scistudio/blocks/code/validation.py"
+    ]
+  },
+  "directive_events": [
+    {
+      "at": "2026-07-16T19:43:38.841440Z",
+      "owner_directive": "Approved fix approach A: strip input_ports/output_ports (ADR-029 variadic canvas-port keys) in both CodeBlockConfig strip-sets, like #1308 for workflow_id. No schema/variadic change. Owner authorized admin-approved:core-change for src/scistudio/blocks/code/**.",
+      "reason": "plan"
+    }
+  ],
+  "docs_events": [
+    {
+      "at": "2026-07-16T19:43:38.841629Z",
+      "class": "changelog",
+      "kind": "na",
+      "path": null,
+      "rationale": "bugfix restoring intended behavior \u2014 strips non-script variadic-port keys before the internal CodeBlockConfig model; no public contract, schema, or behavior-surface change; codeblock_config_payload docstring updated inline.",
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": false,
+  "guard_events": [
+    {
+      "at": "2026-07-16T19:46:09.589363Z",
+      "findings": [
+        {
+          "message": "AI-authored edits must happen in a dedicated worktree, not the main working tree (/private/var/folders/mk/xk0dqvn934l5425gwb19rsqc0000gn/T/pytest-of-jiazhenz/pytest-1247/popen-gw5/test_hook_payload_blocks_main_0/main). Create one with `git worktree add ../<name> <branch>` and run your edits there.",
+          "rule_id": "worktree.main-checkout-write"
+        }
+      ],
+      "guard": "worktree_write_guard",
+      "status": "fail"
+    },
+    {
+      "at": "2026-07-16T19:46:10.375161Z",
+      "findings": [
+        {
+          "message": "AI-authored edits must happen in a dedicated worktree, not the main working tree (/private/var/folders/mk/xk0dqvn934l5425gwb19rsqc0000gn/T/pytest-of-jiazhenz/pytest-1247/popen-gw5/test_hook_payload_extracts_mul0/main). Create one with `git worktree add ../<name> <branch>` and run your edits there.",
+          "rule_id": "worktree.main-checkout-write"
+        }
+      ],
+      "guard": "worktree_write_guard",
+      "status": "fail"
+    },
+    {
+      "at": "2026-07-16T19:50:34.784641Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/code/code_block.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/code/code_block.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/code/validation.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/code/validation.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:50:34.796531Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:50:34.809212Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:50:34.822129Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:50:34.834470Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:50:34.846931Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:50:34.860323Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:50:34.876173Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:50:34.888664Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:50:34.901994Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:51:03.452955Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/code/code_block.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/code/code_block.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/code/validation.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/code/validation.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:51:03.462064Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:51:03.471179Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:51:03.480407Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:51:03.489770Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:51:03.499013Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:51:03.508256Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:51:03.517636Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:51:03.526908Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:51:03.537388Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:51:32.317015Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/code/code_block.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/code/code_block.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/code/validation.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/code/validation.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:51:32.326180Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:51:32.335360Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:51:32.344911Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:51:32.354050Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:51:32.363132Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:51:32.372124Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:51:32.381307Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:51:32.390606Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-16T19:51:32.401743Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1957,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": {
+    "base": "origin/main",
+    "base_sha": "d9797e08",
+    "changed_files": [
+      ".workflow/records/1957-guided-1957-codeblock-port-keys.json",
+      "src/scistudio/blocks/code/code_block.py",
+      "src/scistudio/blocks/code/validation.py",
+      "tests/blocks/code/test_codeblock_execution.py",
+      "tests/blocks/code/test_codeblock_validation.py"
+    ],
+    "diff_fingerprint": "sha256:8fc4630f87b98bcd8a9cd97ca4aa1dd96bc50c547eab45344db587e1c879d7ea",
+    "head": "HEAD",
+    "head_sha": "10b7f708",
+    "surfaces": {
+      "docs": 0,
+      "frontend": 0,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 2,
+      "packaging": 0,
+      "protected_core": 2,
+      "sentrux": 4,
+      "test": 2,
+      "workflow_ci": 0
+    }
+  },
+  "owner_directive": "Fix CodeBlock config rejecting variadic port keys input_ports/output_ports (Extra inputs not permitted), which blocks validate/run of the whole workflow. Strip them in both CodeBlockConfig strip-sets like #1308 did for workflow_id.",
+  "persona": "live_implementer",
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [
+      1957
+    ],
+    "number": null,
+    "url": null
+  },
+  "reconcile_events": [
+    {
+      "at": "2026-07-16T19:50:34.902055Z",
+      "diff_fingerprint": "sha256:2dd351ae8101ccd51ee9081f6e82ca8346db102e832eee35835ec21b6edc5c56",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "scope.out-of-scope"
+      ]
+    },
+    {
+      "at": "2026-07-16T19:51:03.537420Z",
+      "diff_fingerprint": "sha256:2dd351ae8101ccd51ee9081f6e82ca8346db102e832eee35835ec21b6edc5c56",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-07-16T19:51:32.401782Z",
+      "diff_fingerprint": "sha256:8fc4630f87b98bcd8a9cd97ca4aa1dd96bc50c547eab45344db587e1c879d7ea",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    }
+  ],
+  "record_id": "1957-guided-1957-codeblock-port-keys",
+  "requested_admin_labels": [
+    {
+      "actor_permission": null,
+      "applied_at": null,
+      "applied_by": null,
+      "name": "admin-approved:core-change"
+    }
+  ],
+  "required_obligations": {
+    "admin_labels": [
+      "admin-approved:core-change"
+    ],
+    "checks": [
+      "architecture_tests",
+      "deferral_discipline",
+      "format_check",
+      "full_audit",
+      "import_contracts",
+      "lint_format",
+      "python_tests",
+      "semantic_dup",
+      "type_check"
+    ],
+    "docs": [
+      "docs_required_or_na"
+    ],
+    "guards": [
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": [
+      "changed_test_required"
+    ]
+  },
+  "runtime": "claude",
+  "schema_version": 2,
+  "scope_events": [
+    {
+      "action": "add-include",
+      "at": "2026-07-16T19:43:38.841603Z",
+      "pattern": "src/scistudio/blocks/code/code_block.py",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-07-16T19:43:38.841609Z",
+      "pattern": "src/scistudio/blocks/code/validation.py",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-07-16T19:50:50.947272Z",
+      "pattern": "tests/blocks/code/test_codeblock_execution.py",
+      "reason": "Regression tests for the fix live in these files; declare them in scope alongside the touched source."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-07-16T19:50:50.947428Z",
+      "pattern": "tests/blocks/code/test_codeblock_validation.py",
+      "reason": "Regression tests for the fix live in these files; declare them in scope alongside the touched source."
+    }
+  ],
+  "session_id": "7ffd378f-f2a5-4ec2-802f-f7ce323eeca6",
+  "strictness_tier": 1,
+  "task_kind": "guided",
+  "test_events": [
+    {
+      "at": "2026-07-16T19:43:38.841802Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/blocks/code/test_codeblock_execution.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-07-16T19:43:38.841806Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/blocks/code/test_codeblock_validation.py",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/src/scistudio/blocks/code/code_block.py
+++ b/src/scistudio/blocks/code/code_block.py
@@ -474,6 +474,14 @@ def _persisted_codeblock_config(raw_config: Mapping[str, Any]) -> dict[str, Any]
     # ``subprocess.run(timeout=None)``) and the project root as the script cwd
     # ("."), even if a legacy workflow persisted other values.
     dropped = runtime_only | {"timeout_seconds", "working_directory"}
+    # Fix #1957: ``input_ports`` / ``output_ports`` are the ADR-029 variadic
+    # canvas-port definitions (CodeBlock is variadic, so its effective ports come
+    # from these via ``Block.get_effective_input_ports``). They are persisted by
+    # the frontend port editor into the same node config blob but are NOT
+    # script-config fields, so ``CodeBlockConfig(extra="forbid")`` rejects them
+    # and the whole workflow fails validate/run. Strip them here, exactly like
+    # the runtime-injected keys above.
+    dropped |= {"input_ports", "output_ports"}
     return {key: value for key, value in raw_config.items() if key not in dropped}
 
 

--- a/src/scistudio/blocks/code/validation.py
+++ b/src/scistudio/blocks/code/validation.py
@@ -44,6 +44,15 @@ _RUNTIME_ONLY_CONFIG_KEYS = {
     "materialise_adapter",
     "reconstruct_adapter",
 }
+# Fix #1957: ``input_ports`` / ``output_ports`` are the ADR-029 variadic
+# canvas-port definitions (CodeBlock is variadic, so its effective ports come
+# from these via ``Block.get_effective_input_ports``). The frontend port editor
+# persists them into the same node config blob, but they are NOT script-config
+# fields, so ``CodeBlockConfig(extra="forbid")`` rejects them and validation
+# fails the whole workflow. Strip them alongside the runtime-only keys before
+# building ``CodeBlockConfig``. Mirrors ``code_block._persisted_codeblock_config``.
+_GRAPH_PORT_CONFIG_KEYS = {"input_ports", "output_ports"}
+_NON_SCRIPT_CONFIG_KEYS = _RUNTIME_ONLY_CONFIG_KEYS | _GRAPH_PORT_CONFIG_KEYS
 
 
 @provisional(since="0.3.1")
@@ -85,9 +94,11 @@ def codeblock_config_payload(config: Mapping[str, Any]) -> dict[str, Any]:
     """Extract just the saved Code Block settings from a raw config mapping.
 
     A config may arrive with its fields at the top level or nested under a
-    ``params`` key, and may carry runtime-only keys the runtime injects (such as
-    the project directory). This returns the script settings only, flattened and
-    with those runtime-only keys removed.
+    ``params`` key, and may carry keys that are not part of the script config:
+    runtime-only keys the runtime injects (such as the project directory) and
+    the ADR-029 variadic canvas-port keys (``input_ports`` / ``output_ports``)
+    the port editor persists. This returns the script settings only, flattened
+    and with those non-script keys removed.
 
     Args:
         config: The raw configuration mapping.
@@ -104,7 +115,7 @@ def codeblock_config_payload(config: Mapping[str, Any]) -> dict[str, Any]:
                 raw[key] = value
     else:
         raw = dict(config)
-    return {key: value for key, value in raw.items() if key not in _RUNTIME_ONLY_CONFIG_KEYS}
+    return {key: value for key, value in raw.items() if key not in _NON_SCRIPT_CONFIG_KEYS}
 
 
 @provisional(since="0.3.1")

--- a/tests/blocks/code/test_codeblock_execution.py
+++ b/tests/blocks/code/test_codeblock_execution.py
@@ -272,3 +272,29 @@ def test_persisted_codeblock_config_strips_engine_enrichment_fields() -> None:
     # falls back to the CodeBlockConfig defaults (project root, no timeout).
     assert "working_directory" not in cleaned
     assert "timeout_seconds" not in cleaned
+
+
+def test_persisted_codeblock_config_strips_variadic_port_keys() -> None:
+    """Fix #1957 regression guard: ``_persisted_codeblock_config`` MUST strip the
+    ADR-029 variadic canvas-port keys ``input_ports`` / ``output_ports``. The
+    port editor persists them into the same node config blob, but they are not
+    script-config fields, so ``CodeBlockConfig(extra='forbid')`` would reject
+    them and fail validate/run of the whole workflow."""
+    from scistudio.blocks.code.code_block import _persisted_codeblock_config
+    from scistudio.blocks.code.config import CodeBlockConfig
+
+    raw = {
+        "script_path": "script.py",
+        "inputs": [],
+        "outputs": [],
+        # ADR-029 variadic canvas-port definitions written by the port editor:
+        "input_ports": [{"name": "data", "types": ["DataObject"]}],
+        "output_ports": [{"name": "result", "types": ["DataObject"]}],
+    }
+    cleaned = _persisted_codeblock_config(raw)
+    assert "input_ports" not in cleaned, "must strip input_ports (fix #1957)"
+    assert "output_ports" not in cleaned, "must strip output_ports (fix #1957)"
+    # User-authored script-config fields must survive.
+    assert cleaned["script_path"] == "script.py"
+    # The cleaned mapping must construct a CodeBlockConfig without extra_forbidden.
+    assert CodeBlockConfig(**cleaned).script_path == "script.py"

--- a/tests/blocks/code/test_codeblock_validation.py
+++ b/tests/blocks/code/test_codeblock_validation.py
@@ -99,6 +99,25 @@ def test_valid_codeblock_v2_config_has_no_diagnostics(tmp_path: Path) -> None:
     assert _messages(_config("scripts/script.py"), tmp_path) == []
 
 
+def test_variadic_port_keys_do_not_trigger_extra_forbidden(tmp_path: Path) -> None:
+    """Fix #1957 regression guard: a CodeBlock config carrying the ADR-029
+    variadic canvas-port keys (``input_ports`` / ``output_ports``, persisted by
+    the port editor) must validate cleanly. Before the fix, ``codeblock_config_payload``
+    left them in and ``CodeBlockConfig(extra='forbid')`` reported
+    ``input_ports: Extra inputs are not permitted``, failing the whole workflow."""
+    _script(tmp_path)
+    config = _config(
+        "scripts/script.py",
+        input_ports=[{"name": "data", "types": ["DataObject"]}],
+        output_ports=[{"name": "result", "types": ["DataObject"]}],
+    )
+
+    messages = _messages(config, tmp_path)
+
+    assert messages == []
+    assert not any("Extra inputs are not permitted" in message for message in messages)
+
+
 def test_rejects_script_path_outside_project(tmp_path: Path) -> None:
     outside = tmp_path.parent / "outside.py"
     outside.write_text("print('outside')\n", encoding="utf-8")


### PR DESCRIPTION
## Summary

Any CodeBlock node whose persisted config carried `input_ports` and/or `output_ports` failed strict validation with `Extra inputs are not permitted`, blocking `validate_workflow` and `run_workflow` for the **entire** workflow (not just the offending node).

`input_ports` / `output_ports` are the ADR-029 **variadic canvas-port** definitions. Because CodeBlock is variadic, its effective canvas ports come from these keys via `Block.get_effective_input_ports()`; the frontend port editor persists them into the node config blob. They are legitimate per-instance port defs — not runtime-injected, not unused.

But CodeBlock funnels the same config blob through `CodeBlockConfig(extra="forbid")`, which models only the **file-exchange** ports (`inputs`/`outputs`). Both strip-sets that remove non-script keys before constructing `CodeBlockConfig` (`code_block._persisted_codeblock_config` and `validation._RUNTIME_ONLY_CONFIG_KEYS`, added in #1308 for `workflow_id`) forgot these graph-layer keys, so they leaked into the strict model and tripped `extra_forbidden`.

## Fix

Strip `input_ports` / `output_ports` in both strip-sets before building `CodeBlockConfig`, exactly as #1308 strips runtime-injected keys. No schema change, no variadic change — CodeBlock's variadic canvas ports are correct and preserved. App block is unaffected: it consumes these keys from a loose dict and has no `extra="forbid"` model.

## Tests

- `test_persisted_codeblock_config_strips_variadic_port_keys` — run-path strip + `CodeBlockConfig` constructs cleanly.
- `test_variadic_port_keys_do_not_trigger_extra_forbidden` — validation path yields no diagnostics for a config carrying the port-editor keys.

## Protected path

Touches `src/scistudio/blocks/code/**`; owner authorized `admin-approved:core-change`.

Gate record: .workflow/records/1957-guided-1957-codeblock-port-keys.json

Closes #1957
