### PR TITLE
guided(#1967): resolve CodeBlock script_path against the project, not cwd

### DIFF
--- a/.workflow/records/1967-guided-1967-codeblock-script-path.json
+++ b/.workflow/records/1967-guided-1967-codeblock-script-path.json
@@ -286,9 +286,9 @@
   ],
   "check_na": [],
   "commit": {
-    "sha": "2a182fa584f4e61705e6c1ee53585b675ddd84db",
+    "sha": "3b1d18f8636ac5102fdc5a2c1542665bab8c18fb",
     "shas": [
-      "2a182fa584f4e61705e6c1ee53585b675ddd84db"
+      "3b1d18f8636ac5102fdc5a2c1542665bab8c18fb"
     ],
     "trailers": []
   },
@@ -843,6 +843,381 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-07-29T20:10:50.682794Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/code/code_block.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/code/code_block.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/workflow/validator.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/workflow/validator.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T20:10:50.695478Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T20:10:50.708158Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T20:10:50.721991Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T20:10:50.735728Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T20:10:50.748966Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T20:10:50.761487Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T20:10:50.774611Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T20:10:50.788384Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T20:10:50.804870Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T20:10:58.376649Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/code/code_block.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/code/code_block.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/workflow/validator.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/workflow/validator.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T20:10:58.388639Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T20:10:58.400711Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T20:10:58.413192Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T20:10:58.425813Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T20:10:58.438279Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T20:10:58.450144Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T20:10:58.461839Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T20:10:58.473705Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T20:10:58.489705Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T20:11:07.577448Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/code/code_block.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/code/code_block.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/workflow/validator.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/workflow/validator.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T20:11:07.590620Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T20:11:07.603168Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T20:11:07.615169Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T20:11:07.627407Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T20:11:07.639744Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T20:11:07.651628Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T20:11:07.663926Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T20:11:07.676009Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T20:11:07.692140Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -855,7 +1230,7 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "origin/main",
+    "base": "f5938dce0347c48e1e79133776ac486655682d5a",
     "base_sha": "f5938dce",
     "changed_files": [
       ".workflow/records/1967-guided-1967-codeblock-script-path.json",
@@ -871,9 +1246,9 @@
       "tests/workflow/test_path_portability.py",
       "tests/workflow/test_validator_codeblock_v2.py"
     ],
-    "diff_fingerprint": "sha256:fef1673579f779e81932a23e216dd57921fd119dd7da897d468ab95bde0e70bd",
+    "diff_fingerprint": "sha256:bd0dbe9d84bd6d36eb2f43d69c95220e5ef76a63dff783b828004b425d77cf51",
     "head": "HEAD",
-    "head_sha": "2a182fa5",
+    "head_sha": "3b1d18f8",
     "surfaces": {
       "docs": 2,
       "frontend": 0,
@@ -894,7 +1269,7 @@
     "closes": [
       1967
     ],
-    "number": null,
+    "number": 1968,
     "url": null
   },
   "reconcile_events": [
@@ -932,6 +1307,30 @@
     {
       "at": "2026-07-29T20:10:26.801479Z",
       "diff_fingerprint": "sha256:fef1673579f779e81932a23e216dd57921fd119dd7da897d468ab95bde0e70bd",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-07-29T20:10:50.804983Z",
+      "diff_fingerprint": "sha256:bd0dbe9d84bd6d36eb2f43d69c95220e5ef76a63dff783b828004b425d77cf51",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-07-29T20:10:58.489752Z",
+      "diff_fingerprint": "sha256:bd0dbe9d84bd6d36eb2f43d69c95220e5ef76a63dff783b828004b425d77cf51",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-07-29T20:11:07.692180Z",
+      "diff_fingerprint": "sha256:bd0dbe9d84bd6d36eb2f43d69c95220e5ef76a63dff783b828004b425d77cf51",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 1,

--- a/.workflow/records/1967-guided-1967-codeblock-script-path.json
+++ b/.workflow/records/1967-guided-1967-codeblock-script-path.json
@@ -1,0 +1,788 @@
+{
+  "branch": "guided/1967-codeblock-script-path",
+  "check_events": [
+    {
+      "at": "2026-07-29T19:28:52.805932Z",
+      "command": "pytest tests/architecture/ -v --no-cov",
+      "covered_surface": "architecture",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:f8636da2bb61aec4dc9db17523128b90af678edebd459309363457da9c30ad5d",
+      "name": "architecture_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/architecture_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-29T19:28:53.642544Z",
+      "command": "python scripts/deferral_scan.py --check docs/audit/baselines/deferral-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:1c2c44c060dcaa424b6881c4429b43a7bb3a2179df19cb447e03656eb45a3e95",
+      "name": "deferral_discipline",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/deferral_discipline.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-29T19:28:54.026056Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:44d5769982e0fbbdfe7c1a60e34db2269c814873e9fed828a3e8279c41642b32",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-07-29T19:28:58.319909Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:ba6b03cab5830ab73f442ffe8a178cc9ded8fc7db425cabf4f72b279de8d863e",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-29T19:28:58.806259Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:93fd17eb0b3d7575e7b9edff7932279291337968f7e2ece0bc30e4c8224aecd1",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-29T19:28:58.848184Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:0bbab892589b87c5a963fbf7ec6d33f0e6b7b6dfab6175d61fafe885b8c9a8ea",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-07-29T19:31:07.542137Z",
+      "command": "python -m scistudio.qa.testing.run_python_tests --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:9ef7fdf823dda9a0c81bc6a5fd447faa22c6981f97667232d18718c2f3a40f72",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-29T19:33:25.726616Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:36679abd66c4c7db916de1bce97f09bf15e93a328b8deabeac1489243017904e",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-29T19:33:33.126543Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:67192b1e99dffb51a101533f7b115f3dd15c2f4727471da572e53ef741a66223",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    },
+    {
+      "at": "2026-07-29T19:36:39.353916Z",
+      "command": "pytest tests/architecture/ -v --no-cov",
+      "covered_surface": "architecture",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:b6f10a0ee8e7b1ab90232dfcbd80f69a9427e6525687d6e8c8fb13265a887f12",
+      "name": "architecture_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/architecture_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-29T19:36:40.334418Z",
+      "command": "python scripts/deferral_scan.py --check docs/audit/baselines/deferral-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:94a83ba1efc2363c8d06dd1abbcca2b080de60f72db82c13f7a391829badcb44",
+      "name": "deferral_discipline",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/deferral_discipline.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-29T19:36:40.377017Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:3f0be68b143aaf260a960b8400fee0c577c994971e9b52ffa03fce5f1f7be7ca",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-07-29T19:36:44.534771Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:7055e4c8f4c2a8ec4fae1dbf896ba6a9c02cad2447daa8b6eaf1576676a43d37",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-29T19:36:44.651335Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:68899b7e3d5e463a352cea5af10ba8a6e49a8d135e9637219ab6d2930f589ee7",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-29T19:36:44.664997Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:70794231faf45f613f4617602c3a53623d4441c92a4af80d05854638eaa5473b",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-07-29T19:46:18.633141Z",
+      "command": "python -m scistudio.qa.testing.run_python_tests --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:5a9928731d406f50c67d22dcec18406945f089a9a427c598fc06cb2c096360eb",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-29T19:48:45.187637Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e77f05881e759395d02b7dbae592e51ef83b87f716a84359ebaacfcb6243c087",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-29T19:48:45.768737Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e406430a7fdd9de4be165d9cade50d23489e8fd6c86913a3fb7927d01bae2104",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    }
+  ],
+  "check_na": [],
+  "commit": null,
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "src/scistudio/workflow/validator.py",
+      "src/scistudio/api/runtime/_runs.py",
+      "src/scistudio/blocks/code/code_block.py",
+      "tests/workflow/test_validator_codeblock_v2.py"
+    ]
+  },
+  "directive_events": [
+    {
+      "at": "2026-07-29T19:26:30.418197Z",
+      "owner_directive": "\u4e24\u5904\u4e00\u8d77\u505a\uff1arun-start \u6821\u9a8c\u663e\u5f0f\u4f20 project_dir\uff1bscript_path \u8865 ui_widget \u8ba9\u5b58\u76d8\u76f8\u5bf9\u5316/\u52a0\u8f7d\u7edd\u5bf9\u5316\u3002\u5df2\u6709\u5de5\u4f5c\u6d41\u88ab\u6539\u5199\u6210\u76f8\u5bf9\u8def\u5f84 owner \u5df2\u6279\u51c6\u3002",
+      "reason": "plan"
+    }
+  ],
+  "docs_events": [
+    {
+      "at": "2026-07-29T19:26:30.418365Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/specs/adr-041-codeblock-v2.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-07-29T19:26:30.418380Z",
+      "class": null,
+      "kind": "path",
+      "path": "CHANGELOG.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-07-29T19:26:30.418388Z",
+      "class": "adr",
+      "kind": "na",
+      "path": null,
+      "rationale": "no architectural decision changes; ADR-041 contract is unchanged, only its implementation spec gains FR-035/AC-015",
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-07-29T19:35:39.962142Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/adr/ADR-011.md",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": false,
+  "guard_events": [
+    {
+      "at": "2026-07-29T19:33:33.200558Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/code/code_block.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/code/code_block.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/workflow/validator.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/workflow/validator.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T19:33:33.212058Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T19:33:33.223412Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T19:33:33.233891Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T19:33:33.245011Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T19:33:33.256534Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T19:33:33.267285Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T19:33:33.278595Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T19:33:33.289074Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T19:33:33.302106Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T19:48:45.847384Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/code/code_block.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/code/code_block.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/workflow/validator.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/workflow/validator.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T19:48:45.858465Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T19:48:45.869038Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T19:48:45.880366Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T19:48:45.890981Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T19:48:45.901483Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T19:48:45.912460Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T19:48:45.922350Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T19:48:45.932910Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T19:48:45.946253Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1967,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": {
+    "base": "origin/main",
+    "base_sha": "f5938dce",
+    "changed_files": [
+      ".workflow/records/1967-guided-1967-codeblock-script-path.json",
+      "CHANGELOG.md",
+      "docs/adr/ADR-011.md",
+      "docs/specs/adr-041-codeblock-v2.md",
+      "src/scistudio/api/runtime/_runs.py",
+      "src/scistudio/api/runtime/_workflows.py",
+      "src/scistudio/blocks/code/code_block.py",
+      "src/scistudio/workflow/validator.py",
+      "tests/api/test_runtime_workflow_validation_gate.py",
+      "tests/blocks/test_block_config_schema.py",
+      "tests/workflow/test_path_portability.py",
+      "tests/workflow/test_validator_codeblock_v2.py"
+    ],
+    "diff_fingerprint": "sha256:bdd3865bd0b06ab5536cc0fae575e7920ee19e66643ff3dc150e5e4b72d432c0",
+    "head": "HEAD",
+    "head_sha": "1ce491d6",
+    "surfaces": {
+      "docs": 2,
+      "frontend": 0,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 4,
+      "packaging": 0,
+      "protected_core": 2,
+      "sentrux": 10,
+      "test": 4,
+      "workflow_ci": 0
+    }
+  },
+  "owner_directive": "\u8c03\u67e5\u7528\u6237 codeblock \u62a5 workflow validation error \u7684\u539f\u56e0\uff1b\u786e\u8ba4\u6839\u56e0\u540e owner \u6279\u51c6\uff1a\u6821\u9a8c\u4fee\u590d + script_path \u5b58\u76d8\u76f8\u5bf9\u5316\u4e00\u8d77\u505a\uff0c\u6539\u5199\u5df2\u6709\u5de5\u4f5c\u6d41\u7684\u76f8\u5bf9\u8def\u5f84\u6ca1\u95ee\u9898\uff0c\u6700\u540e\u63d0\u4ea4 PR",
+  "persona": "live_implementer",
+  "pull_request": null,
+  "reconcile_events": [
+    {
+      "at": "2026-07-29T19:33:33.302161Z",
+      "diff_fingerprint": "sha256:5ce85b536beb0c62c3f92535ac821f0d07baa61b67f20c762787a40fa78bb475",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.format_check",
+        "checks.full_audit",
+        "checks.lint_format",
+        "scope.out-of-scope"
+      ]
+    },
+    {
+      "at": "2026-07-29T19:48:45.946294Z",
+      "diff_fingerprint": "sha256:bdd3865bd0b06ab5536cc0fae575e7920ee19e66643ff3dc150e5e4b72d432c0",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "scope.out-of-scope"
+      ]
+    }
+  ],
+  "record_id": "1967-guided-1967-codeblock-script-path",
+  "requested_admin_labels": [
+    {
+      "actor_permission": null,
+      "applied_at": null,
+      "applied_by": null,
+      "name": "admin-approved:core-change"
+    }
+  ],
+  "required_obligations": {
+    "admin_labels": [
+      "admin-approved:core-change"
+    ],
+    "checks": [
+      "architecture_tests",
+      "deferral_discipline",
+      "format_check",
+      "full_audit",
+      "import_contracts",
+      "lint_format",
+      "python_tests",
+      "semantic_dup",
+      "type_check"
+    ],
+    "docs": [
+      "docs_required_or_na"
+    ],
+    "guards": [
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": [
+      "changed_test_required"
+    ]
+  },
+  "runtime": "claude-code",
+  "schema_version": 2,
+  "scope_events": [
+    {
+      "action": "add-include",
+      "at": "2026-07-29T19:26:30.418346Z",
+      "pattern": "docs/specs/adr-041-codeblock-v2.md",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-07-29T19:26:30.418352Z",
+      "pattern": "CHANGELOG.md",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-07-29T19:26:30.418354Z",
+      "pattern": "tests/api/test_runtime_workflow_validation_gate.py",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-07-29T19:26:30.418356Z",
+      "pattern": "tests/workflow/test_path_portability.py",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-07-29T19:26:30.418357Z",
+      "pattern": "tests/blocks/test_block_config_schema.py",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-07-29T19:35:39.961995Z",
+      "pattern": "docs/adr/ADR-011.md",
+      "reason": "signature_drift: ADR-011 pins the validate_workflow signature, which gained the project_dir parameter"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-07-29T20:09:52.955884Z",
+      "pattern": "src/scistudio/api/runtime/_workflows.py",
+      "reason": "save_workflow is the second validate_workflow call site; it must pass the active project root for the same reason start_workflow does"
+    }
+  ],
+  "session_id": "e0f7c002-951a-4108-89f2-a6b7e0564c77",
+  "strictness_tier": 1,
+  "task_kind": "guided",
+  "test_events": [
+    {
+      "at": "2026-07-29T19:26:30.418392Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/api/test_runtime_workflow_validation_gate.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-07-29T19:26:30.418394Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/workflow/test_validator_codeblock_v2.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-07-29T19:26:30.418395Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/workflow/test_path_portability.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-07-29T19:26:30.418396Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/blocks/test_block_config_schema.py",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/.workflow/records/1967-guided-1967-codeblock-script-path.json
+++ b/.workflow/records/1967-guided-1967-codeblock-script-path.json
@@ -285,7 +285,13 @@
     }
   ],
   "check_na": [],
-  "commit": null,
+  "commit": {
+    "sha": "2a182fa584f4e61705e6c1ee53585b675ddd84db",
+    "shas": [
+      "2a182fa584f4e61705e6c1ee53585b675ddd84db"
+    ],
+    "trailers": []
+  },
   "declared_scope": {
     "exclude": [],
     "include": [
@@ -587,6 +593,256 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-07-29T20:10:11.622967Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/code/code_block.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/code/code_block.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/workflow/validator.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/workflow/validator.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T20:10:11.634511Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T20:10:11.646149Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T20:10:11.657949Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T20:10:11.669694Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T20:10:11.681535Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T20:10:11.692349Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T20:10:11.703929Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T20:10:11.714808Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T20:10:11.728483Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T20:10:26.668944Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/code/code_block.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/code/code_block.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/workflow/validator.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/workflow/validator.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T20:10:26.683041Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T20:10:26.696451Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T20:10:26.712096Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T20:10:26.725672Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T20:10:26.740259Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T20:10:26.754275Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T20:10:26.767710Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T20:10:26.783051Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T20:10:26.801438Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -615,9 +871,9 @@
       "tests/workflow/test_path_portability.py",
       "tests/workflow/test_validator_codeblock_v2.py"
     ],
-    "diff_fingerprint": "sha256:bdd3865bd0b06ab5536cc0fae575e7920ee19e66643ff3dc150e5e4b72d432c0",
+    "diff_fingerprint": "sha256:fef1673579f779e81932a23e216dd57921fd119dd7da897d468ab95bde0e70bd",
     "head": "HEAD",
-    "head_sha": "1ce491d6",
+    "head_sha": "2a182fa5",
     "surfaces": {
       "docs": 2,
       "frontend": 0,
@@ -633,7 +889,14 @@
   },
   "owner_directive": "\u8c03\u67e5\u7528\u6237 codeblock \u62a5 workflow validation error \u7684\u539f\u56e0\uff1b\u786e\u8ba4\u6839\u56e0\u540e owner \u6279\u51c6\uff1a\u6821\u9a8c\u4fee\u590d + script_path \u5b58\u76d8\u76f8\u5bf9\u5316\u4e00\u8d77\u505a\uff0c\u6539\u5199\u5df2\u6709\u5de5\u4f5c\u6d41\u7684\u76f8\u5bf9\u8def\u5f84\u6ca1\u95ee\u9898\uff0c\u6700\u540e\u63d0\u4ea4 PR",
   "persona": "live_implementer",
-  "pull_request": null,
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [
+      1967
+    ],
+    "number": null,
+    "url": null
+  },
   "reconcile_events": [
     {
       "at": "2026-07-29T19:33:33.302161Z",
@@ -657,6 +920,22 @@
       "unsatisfied": [
         "scope.out-of-scope"
       ]
+    },
+    {
+      "at": "2026-07-29T20:10:11.728520Z",
+      "diff_fingerprint": "sha256:fef1673579f779e81932a23e216dd57921fd119dd7da897d468ab95bde0e70bd",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-07-29T20:10:26.801479Z",
+      "diff_fingerprint": "sha256:fef1673579f779e81932a23e216dd57921fd119dd7da897d468ab95bde0e70bd",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
     }
   ],
   "record_id": "1967-guided-1967-codeblock-script-path",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- [#1967] CodeBlock: a project-relative `script_path` no longer fails workflow
+  validation at run start. The persisted graph carries no project root — the
+  scheduler injects one at dispatch, after validation — so
+  `_project_dir_for_workflow` fell back to the process working directory, which
+  in the packaged desktop app is `SciStudio.app/Contents/Resources`. Every run
+  of an agent-authored CodeBlock (`script_path: scripts/foo.py`) was rejected
+  with `CodeBlock script_path: [Errno 2] No such file or directory`, while the
+  editor save that produced it passed (Check 9 is skipped in draft mode).
+  `validate_workflow` now takes an explicit `project_dir`, which
+  `start_workflow` and `save_workflow` pass from the active project. Separately,
+  `script_path` was missing `ui_widget: "file_browser"` in the backend config
+  schema, so it was excluded from the #506 path-portability pass that the
+  frontend editor already assumed: a GUI-picked absolute path was persisted
+  verbatim and broke on any other machine. It is now relativised on save and
+  absolutised on load, so existing workflows storing an absolute `script_path`
+  are rewritten to a project-relative one on their next editor save. Tests:
+  `tests/api/test_runtime_workflow_validation_gate.py`,
+  `tests/workflow/test_validator_codeblock_v2.py`,
+  `tests/workflow/test_path_portability.py`,
+  `tests/blocks/test_block_config_schema.py`. (@claude, 2026-07-29, branch:
+  guided/1967-codeblock-script-path)
+
 - [#1946] Embedded PTY terminal (AI Chat / Terminal) now reflows correctly when
   a panel is resized under Claude Code's fullscreen (alternate-screen) mode.
   Previously the agent stayed stuck at its spawn-time size and rendered ghosted

--- a/docs/adr/ADR-011.md
+++ b/docs/adr/ADR-011.md
@@ -85,10 +85,15 @@ def validate_workflow(
     registry: BlockRegistry | None = None,
     *,
     mode: str = "strict",
+    project_dir: str | Path | None = None,
 ) -> list[str]:
     # mode="draft" defers dangling-required-port (Check 6) and CodeBlock
     # config (Check 9) checks to run start, so editor autosave does not throw
     # "Field required" on an incomplete graph (#1711).
+    # project_dir resolves project-relative config paths (the CodeBlock
+    # script_path of Check 9). Node/workflow project_dir metadata still wins;
+    # the process working directory is the last resort for callers with no
+    # project context (#1967).
     ...
 ```
 

--- a/docs/specs/adr-041-codeblock-v2.md
+++ b/docs/specs/adr-041-codeblock-v2.md
@@ -324,6 +324,12 @@ Acceptance Scenarios:
 - FR-034: CodeBlock v2 MUST preserve AppBlock's file-exchange security
   posture, including project-root path validation and controlled process
   command construction.
+- FR-035: `script_path` MUST persist as a project-relative path and MUST be
+  resolved against the active project root, never against the process working
+  directory. The block config schema declares `script_path` as a path field
+  (`ui_widget: file_browser`) so the #506 portability pass relativises it on
+  save and absolutises it on load, and every validation caller that knows the
+  active project MUST pass it to `validate_workflow(project_dir=...)` (#1967).
 
 ### Non-Functional Requirements
 
@@ -618,6 +624,10 @@ reviewers can distinguish intentional removals from accidental regressions.
 - AC-013: Block-development documentation includes CodeBlock v2 script usage,
   path adaptation examples, and migration guidance.
 - AC-014: Existing AppBlock capability and materialisation tests remain green.
+- AC-015: A workflow whose `script_path` is project-relative validates and runs
+  when the process working directory is not the project directory, and a
+  GUI-picked absolute `script_path` inside the project persists as a relative
+  path, so the workflow stays portable across machines.
 
 ## 6. Risks And Rollback
 

--- a/src/scistudio/api/runtime/_runs.py
+++ b/src/scistudio/api/runtime/_runs.py
@@ -373,7 +373,16 @@ def start_workflow(
     # any ``subworkflow_broken`` marker left by an unresolved reference.
     from scistudio.workflow.validator import validate_workflow
 
-    diagnostics = validate_workflow(workflow, registry=self.block_registry)
+    # ``project_dir`` (#1967): the persisted graph never carries a project root —
+    # the scheduler injects one at dispatch, well after this call — so without it
+    # the validator resolved a project-relative CodeBlock ``script_path`` against
+    # the process working directory (the app's ``Resources`` directory in the
+    # packaged desktop build) and rejected every run.
+    diagnostics = validate_workflow(
+        workflow,
+        registry=self.block_registry,
+        project_dir=str(self.active_project.path) if self.active_project else None,
+    )
     hard_errors = [d for d in diagnostics if not str(d).startswith("Warning:")]
     if hard_errors:
         raise ValueError("Cannot start workflow; validation failed: " + "; ".join(str(e) for e in hard_errors))

--- a/src/scistudio/api/runtime/_workflows.py
+++ b/src/scistudio/api/runtime/_workflows.py
@@ -140,7 +140,17 @@ def save_workflow(self: ApiRuntime, payload: dict[str, Any]) -> WorkflowDefiniti
     # the editor from throwing "Field required" while the user is still wiring up
     # a freshly dropped node. The route layer maps raised ``ValueError`` to HTTP
     # 422 (api/routes/workflows.py create/update handlers).
-    diagnostics = validate_workflow(definition, registry=self.block_registry, mode="draft")
+    # ``project_dir`` (#1967): node configs were just relativified above, so any
+    # project-relative path in them (CodeBlock ``script_path``) needs the active
+    # project root to resolve. Passing it keeps the validator off its
+    # process-working-directory fallback, which in the packaged desktop app is
+    # the app's ``Resources`` directory rather than the user's project.
+    diagnostics = validate_workflow(
+        definition,
+        registry=self.block_registry,
+        mode="draft",
+        project_dir=project_dir,
+    )
     warnings = [d for d in diagnostics if str(d).startswith("Warning:")]
     hard_errors = [d for d in diagnostics if not str(d).startswith("Warning:")]
     if warnings:

--- a/src/scistudio/blocks/code/code_block.py
+++ b/src/scistudio/blocks/code/code_block.py
@@ -198,7 +198,19 @@ class CodeBlock(Block):
     config_schema: ClassVar[dict[str, Any]] = {
         "type": "object",
         "properties": {
-            "script_path": {"type": "string", "title": "Project Script", "ui_priority": 1},
+            # ``ui_widget: file_browser`` (#1967) is what opts ``script_path`` into
+            # the #506 path-portability pass: ``relativify_paths`` rewrites it to a
+            # project-relative path on save and ``absolutify_paths`` restores an
+            # absolute one on load. Without it a GUI-picked absolute path was
+            # persisted verbatim (breaking the workflow on any other machine) while
+            # an authored project-relative path was never resolved. The frontend
+            # CodeBlock editor already renders this field as a file browser.
+            "script_path": {
+                "type": "string",
+                "title": "Project Script",
+                "ui_widget": "file_browser",
+                "ui_priority": 1,
+            },
             "language": {
                 "type": "string",
                 "enum": ["python", "r", "julia"],

--- a/src/scistudio/workflow/validator.py
+++ b/src/scistudio/workflow/validator.py
@@ -91,8 +91,22 @@ def _is_codeblock_spec(spec: BlockSpec) -> bool:
     )
 
 
-def _project_dir_for_workflow(workflow: WorkflowDefinition, node: NodeDef) -> Path:
-    """Resolve workflow/node project directory metadata for CodeBlock validation."""
+def _project_dir_for_workflow(
+    workflow: WorkflowDefinition,
+    node: NodeDef,
+    project_dir: str | Path | None = None,
+) -> Path:
+    """Resolve workflow/node project directory metadata for CodeBlock validation.
+
+    *project_dir* is the caller-supplied project root. It ranks below the
+    per-node and per-workflow metadata (a flattened subworkflow node may carry
+    its own) and above the ``Path.cwd()`` fallback. Passing it matters
+    (#1967): a persisted workflow never carries ``project_dir`` — the scheduler
+    injects it at dispatch, which is *after* run-start validation — so without
+    it a project-relative ``script_path`` resolved against the process working
+    directory. In the packaged desktop app that is the app's ``Resources``
+    directory, so every relative ``script_path`` failed to validate.
+    """
 
     params = node.config.get("params")
     if isinstance(params, dict) and params.get("project_dir"):
@@ -101,6 +115,8 @@ def _project_dir_for_workflow(workflow: WorkflowDefinition, node: NodeDef) -> Pa
         return Path(str(node.config["project_dir"])).resolve()
     if workflow.metadata.get("project_dir"):
         return Path(str(workflow.metadata["project_dir"])).resolve()
+    if project_dir:
+        return Path(str(project_dir)).resolve()
     return Path.cwd().resolve()
 
 
@@ -173,6 +189,7 @@ def validate_workflow(  # noqa: C901 — grandfathered (#1602): mccabe 60 > 30; 
     registry: BlockRegistry | None = None,
     *,
     mode: str = "strict",
+    project_dir: str | Path | None = None,
 ) -> list[str]:
     """Validate a workflow definition and return a list of diagnostic messages.
 
@@ -213,6 +230,12 @@ def validate_workflow(  # noqa: C901 — grandfathered (#1602): mccabe 60 > 30; 
         spurious errors. Structural, edge, cycle, type, cardinality, extension,
         and boundary checks still run. Run start re-validates in strict mode,
         so an incomplete graph still cannot execute.
+    project_dir:
+        Project root used to resolve project-relative config paths (currently
+        the CodeBlock ``script_path`` of Check 9). Callers that know the active
+        project MUST pass it; node/workflow ``project_dir`` metadata still wins
+        when present, and the process working directory remains the last-resort
+        fallback for callers with no project context (#1967).
 
     Returns
     -------
@@ -489,7 +512,7 @@ def validate_workflow(  # noqa: C901 — grandfathered (#1602): mccabe 60 > 30; 
             continue
         diagnostics = validate_codeblock_config(
             node.config,
-            project_dir=_project_dir_for_workflow(workflow, node),
+            project_dir=_project_dir_for_workflow(workflow, node, project_dir),
             registry=registry,
         )
         errors.extend(

--- a/tests/api/test_runtime_workflow_validation_gate.py
+++ b/tests/api/test_runtime_workflow_validation_gate.py
@@ -102,3 +102,65 @@ def test_start_workflow_rejects_cycle_on_disk(runtime: ApiRuntime, opened_projec
 
     with pytest.raises(ValueError, match="validation failed"):
         runtime.start_workflow("sneaky_wf")
+
+
+class _StopBeforeDispatchError(Exception):
+    """Sentinel raised by the validation spy to halt ``start_workflow``."""
+
+
+def test_start_workflow_validates_relative_script_path_against_the_project(
+    runtime: ApiRuntime,
+    opened_project: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#1967: a CodeBlock whose ``script_path`` is project-relative must validate
+    at run start even when the process working directory is not the project.
+
+    This is the packaged-desktop shape: the backend runs with its working
+    directory inside ``SciStudio.app/Contents/Resources``, and the persisted
+    graph carries no ``project_dir`` (the scheduler injects one at dispatch,
+    after validation). The agent's ``write_workflow`` tool writes exactly this
+    graph, so before #1967 every such run was rejected with
+    ``CodeBlock script_path: [Errno 2] No such file or directory``.
+    """
+    import scistudio.workflow.validator as validator_module
+
+    script = opened_project / "scripts" / "analyse.py"
+    script.parent.mkdir(parents=True, exist_ok=True)
+    script.write_text("print('ok')\n", encoding="utf-8")
+
+    runtime.workflow_path("codeblock_wf").parent.mkdir(parents=True, exist_ok=True)
+    runtime.workflow_path("codeblock_wf").write_text(
+        "workflow:\n"
+        "  id: codeblock_wf\n"
+        "  nodes:\n"
+        "    - id: code1\n"
+        "      block_type: code_block\n"
+        "      config:\n"
+        "        script_path: scripts/analyse.py\n"
+        "  edges: []\n",
+        encoding="utf-8",
+    )
+
+    elsewhere = tmp_path / "not-the-project"
+    elsewhere.mkdir()
+    monkeypatch.chdir(elsewhere)
+
+    # Run the real validator, capture its verdict, and stop before dispatch so
+    # the test never schedules an actual run.
+    captured: list[list[str]] = []
+    real_validate = validator_module.validate_workflow
+
+    def _spy(*args: object, **kwargs: object) -> list[str]:
+        diagnostics = real_validate(*args, **kwargs)  # type: ignore[arg-type]
+        captured.append(list(diagnostics))
+        raise _StopBeforeDispatchError
+
+    monkeypatch.setattr(validator_module, "validate_workflow", _spy)
+
+    with pytest.raises(_StopBeforeDispatchError):
+        runtime.start_workflow("codeblock_wf")
+
+    assert captured, "start_workflow did not run workflow validation"
+    assert not [d for d in captured[-1] if "script_path" in d]

--- a/tests/blocks/test_block_config_schema.py
+++ b/tests/blocks/test_block_config_schema.py
@@ -37,6 +37,16 @@ class TestBlockConfigSchema:
         assert "language" in schema["properties"]
         assert "python" in schema["properties"]["language"]["enum"]
 
+    def test_code_block_script_path_is_a_file_browser_path_field(self) -> None:
+        """#1967: ``ui_widget`` is what opts ``script_path`` into the #506
+        relativify-on-save / absolutify-on-load pass. Without it a GUI-picked
+        absolute path is persisted verbatim and an authored project-relative
+        path is never resolved against the project root."""
+        from scistudio.blocks.code.code_block import CodeBlock
+
+        props = CodeBlock.config_schema["properties"]
+        assert props["script_path"]["ui_widget"] == "file_browser"
+
     def test_spec_from_class_includes_config_schema(self) -> None:
         class MyBlock(Block):
             name: ClassVar[str] = "Test Block"

--- a/tests/workflow/test_path_portability.py
+++ b/tests/workflow/test_path_portability.py
@@ -132,3 +132,35 @@ class TestAbsolutifyPaths:
 
         assert Path(restored["path"]).resolve() == data_file.resolve()
         assert Path(restored["output_dir"]).resolve() == (project_dir / "results").resolve()
+
+
+class TestCodeBlockScriptPathPortability:
+    """#1967: ``script_path`` participates in the #506 portability pass.
+
+    The real ``CodeBlock.config_schema`` is used rather than the sample
+    ``SCHEMA`` above, so the test fails if the ``ui_widget`` marker is dropped.
+    """
+
+    def test_save_relativises_script_path(self, tmp_path: Path) -> None:
+        from scistudio.blocks.code.code_block import CodeBlock
+
+        project_dir = tmp_path / "project"
+        script = project_dir / "scripts" / "analyse.py"
+        script.parent.mkdir(parents=True)
+        script.touch()
+
+        config = {"script_path": str(script.resolve())}
+        result = relativify_paths(config, str(project_dir), CodeBlock.config_schema)
+
+        assert result["script_path"] == "scripts/analyse.py"
+
+    def test_load_absolutises_script_path(self, tmp_path: Path) -> None:
+        from scistudio.blocks.code.code_block import CodeBlock
+
+        project_dir = tmp_path / "project"
+        (project_dir / "scripts").mkdir(parents=True)
+
+        config = {"script_path": "scripts/analyse.py"}
+        result = absolutify_paths(config, str(project_dir), CodeBlock.config_schema)
+
+        assert result["script_path"] == str((project_dir / "scripts" / "analyse.py").resolve())

--- a/tests/workflow/test_validator_codeblock_v2.py
+++ b/tests/workflow/test_validator_codeblock_v2.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from scistudio.blocks.code.code_block import CodeBlock
 from scistudio.blocks.registry import BlockRegistry, _spec_from_class
 from scistudio.workflow.definition import EdgeDef, NodeDef, WorkflowDefinition
@@ -164,3 +166,102 @@ def test_validate_workflow_preserves_unknown_block_warning() -> None:
 
     assert any("Warning: block type 'not_registered_source' not in registry" in error for error in errors)
     assert not any("CodeBlock" in error for error in errors)
+
+
+def _persisted_node_config(script_path: str) -> dict[str, object]:
+    """A node config in its persisted shape: no runtime-injected ``project_dir``.
+
+    The scheduler injects ``project_dir`` at dispatch, so the graph the
+    validator sees at run start never carries one (#1967).
+    """
+
+    return {
+        "script_path": script_path,
+        "inputs": [],
+        "outputs": [],
+    }
+
+
+def test_validate_workflow_resolves_script_path_against_caller_project_dir(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#1967: a project-relative ``script_path`` validates when the caller
+    supplies the project root, even though the process working directory is
+    somewhere else entirely (the app's ``Resources`` directory in the packaged
+    desktop build)."""
+
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    _script(project_dir)
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    monkeypatch.chdir(elsewhere)
+
+    registry = _CodeBlockValidationRegistry()
+    workflow = WorkflowDefinition(
+        nodes=[
+            NodeDef(
+                id="code1",
+                block_type="code_block",
+                config=_persisted_node_config("scripts/script.py"),
+            )
+        ],
+    )
+
+    assert validate_workflow(workflow, registry=registry, project_dir=str(project_dir)) == []
+
+
+def test_validate_workflow_script_path_falls_back_to_cwd_without_project_dir(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without a caller-supplied project root the validator still falls back to
+    the working directory — the documented last resort for callers with no
+    project context, and the #1967 failure mode when the API forgot to pass one."""
+
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    _script(project_dir)
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    monkeypatch.chdir(elsewhere)
+
+    registry = _CodeBlockValidationRegistry()
+    workflow = WorkflowDefinition(
+        nodes=[
+            NodeDef(
+                id="code1",
+                block_type="code_block",
+                config=_persisted_node_config("scripts/script.py"),
+            )
+        ],
+    )
+
+    errors = validate_workflow(workflow, registry=registry)
+
+    assert any("CodeBlock script_path" in error for error in errors)
+
+
+def test_validate_workflow_node_project_dir_outranks_caller_project_dir(tmp_path: Path) -> None:
+    """Node-level ``project_dir`` still wins: a flattened subworkflow node may
+    carry its own root that differs from the parent's."""
+
+    node_project = tmp_path / "node-project"
+    node_project.mkdir()
+    _script(node_project)
+    caller_project = tmp_path / "caller-project"
+    caller_project.mkdir()
+
+    registry = _CodeBlockValidationRegistry()
+    workflow = WorkflowDefinition(
+        nodes=[
+            NodeDef(
+                id="code1",
+                block_type="code_block",
+                config=_node_config(node_project, "scripts/script.py"),
+            )
+        ],
+    )
+
+    assert validate_workflow(workflow, registry=registry, project_dir=str(caller_project)) == []


### PR DESCRIPTION
## Summary

A CodeBlock whose `script_path` is project-relative failed workflow validation at
run start in the packaged desktop app, so the run never started:

```
Cannot start workflow; validation failed: Node 'code_block-...':
CodeBlock script_path: [Errno 2] No such file or directory:
'/Applications/SciStudio.app/Contents/Resources/scripts'
```

Reported from a user diagnostics bundle (0.3.3-alpha-build0020, macOS). In the GUI
it surfaces as `POST /api/workflows/<id>/execute` → 422; the editor save that
produced the workflow passes, because Check 9 is skipped in draft mode.

## Root cause

Two independent gaps compound.

**1. Validation resolved the script against the process working directory.**
`_project_dir_for_workflow` falls back to `Path.cwd()` when neither the node config
nor `workflow.metadata` carries `project_dir`. The persisted graph never carries it
— the scheduler injects it at dispatch (`engine/scheduler/_dispatch.py`), which is
*after* `validate_workflow()` in `start_workflow`. In the packaged app the backend
cwd is `SciStudio.app/Contents/Resources`.

**2. `script_path` was excluded from the #506 path-portability pass.**
`relativify_paths` (save) and `absolutify_paths` (load) act only on schema fields
whose `ui_widget` is `file_browser`/`directory_browser`. The backend
`CodeBlock.config_schema` declared `script_path` without one, while the frontend
`CodeBlockConfigEditor` hardcodes `ui_widget: "file_browser"` for the same field.
So neither direction normalised it.

The two together mean the stored value's shape decided the outcome: a GUI-picked
absolute path validated but was not portable across machines, while a
project-relative path (what the agent's `write_workflow` writes, and the portable
form) always failed. `tests/workflow/test_validator_codeblock_v2.py` never caught
this because every case injects `project_dir` into the node config manually.

## Changes

- `validate_workflow` takes an explicit `project_dir`; `start_workflow` and
  `save_workflow` pass it from the active project. Node- and workflow-level
  `project_dir` metadata still outranks it, and cwd remains the last resort for
  callers with no project context (the CLI).
- `script_path` declares `ui_widget: "file_browser"` in the backend config schema,
  so it is relativised on save and absolutised on load like every other path field.
- Regression tests for the "cwd is not the project directory" shape at both the
  validator and the `start_workflow` level, plus schema and round-trip coverage.
- `docs/adr/ADR-011.md` (pinned `validate_workflow` signature),
  `docs/specs/adr-041-codeblock-v2.md` (FR-035 / AC-015), `CHANGELOG.md`.

## Behaviour change

Existing workflows that store an absolute `script_path` are rewritten to a
project-relative path on their next editor save. Owner-approved.

## Testing

- `tests/api/test_runtime_workflow_validation_gate.py` — run-start validation with
  the working directory outside the project (the packaged-app shape).
- `tests/workflow/test_validator_codeblock_v2.py` — caller-supplied project root,
  cwd fallback, and node metadata precedence.
- `tests/workflow/test_path_portability.py` — `script_path` relativify/absolutify
  against the real `CodeBlock.config_schema`.
- `tests/blocks/test_block_config_schema.py` — the `ui_widget` marker itself.

Every new test fails on `origin/main` and passes here.

Gate record: .workflow/records/1967-guided-1967-codeblock-script-path.json

Closes #1967
