### PR TITLE
fix(#1969): pass the active project root from the MCP validate_workflow tool

### DIFF
--- a/.workflow/records/1969-mcp-validate-project-dir.json
+++ b/.workflow/records/1969-mcp-validate-project-dir.json
@@ -1,8 +1,143 @@
 {
   "branch": "guided/1969-mcp-validate-project-dir",
-  "check_events": [],
+  "check_events": [
+    {
+      "at": "2026-07-29T21:01:30.732614Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:fe5f47a3fc25ad0a16405dbbedf93625f17295b751109822312906b9b38a7f8d",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-07-29T21:01:35.810190Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:4d8f92f3e3cf63864606b74a44705213d9720dabdabf28ff1d3c9a42d9745532",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-29T21:01:36.339053Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:38f0576d4fedba6220cdd8ebc38ea5201140d29e6ff2d775e0dd865573567379",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-29T21:01:36.399328Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:58724d8ddcea416e3c194a555d244a0909ad7fe7500e9c10dc04e3dda11c21b5",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-07-29T21:04:01.878975Z",
+      "command": "python -m scistudio.qa.testing.run_python_tests --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:547e7d53f900c405eb7b1cf67310dd49148be177f82f3cf2604796057ab74fa3",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-29T21:06:20.533019Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:2e6dc77a5ce0c8e2cf14fe0c268c7a56afbfb135f81bbe2b0b2cef7b21eb7640",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-29T21:06:28.303197Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:75b3bda3b6cf3e7f17e935a38018c559174e60f8e205c1659255d1a4bee0f55c",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    },
+    {
+      "at": "2026-07-29T21:06:56.346749Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:fe5f47a3fc25ad0a16405dbbedf93625f17295b751109822312906b9b38a7f8d",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    }
+  ],
   "check_na": [],
-  "commit": null,
+  "commit": {
+    "sha": "40c4727e9b47a1ad4d378384488239a8821aa912",
+    "shas": [
+      "40c4727e9b47a1ad4d378384488239a8821aa912"
+    ],
+    "trailers": []
+  },
   "declared_scope": {
     "exclude": [],
     "include": [
@@ -29,7 +164,254 @@
     }
   ],
   "governance_touch": false,
-  "guard_events": [],
+  "guard_events": [
+    {
+      "at": "2026-07-29T21:06:28.358443Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T21:06:28.368757Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T21:06:28.379120Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T21:06:28.390390Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T21:06:28.400471Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T21:06:28.411903Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T21:06:28.422255Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T21:06:28.433580Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T21:06:28.444164Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T21:06:28.456168Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T21:06:56.375893Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T21:06:56.388264Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T21:06:56.400670Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T21:06:56.413176Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T21:06:56.425710Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T21:06:56.438478Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T21:06:56.450660Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T21:06:56.463246Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T21:06:56.475493Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T21:06:56.488582Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T21:07:21.189733Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T21:07:21.202031Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T21:07:21.214400Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T21:07:21.226866Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T21:07:21.240136Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T21:07:21.252830Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T21:07:21.264973Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T21:07:21.279437Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T21:07:21.291992Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T21:07:21.305093Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
   "issues": [
     {
       "close_in_pr": true,
@@ -39,19 +421,100 @@
     }
   ],
   "observed_admin_labels": [],
-  "observed_diff": null,
+  "observed_diff": {
+    "base": "origin/main",
+    "base_sha": "6c00d825",
+    "changed_files": [
+      ".workflow/records/1969-mcp-validate-project-dir.json",
+      "CHANGELOG.md",
+      "src/scistudio/ai/agent/mcp/tools_workflow/read.py",
+      "tests/ai/test_mcp_tools_disk_integration.py"
+    ],
+    "diff_fingerprint": "sha256:27c68ab152d7bae16114633850d0b38ea5fa1868773e3b9f7d7d3cb4d5f0a4c7",
+    "head": "HEAD",
+    "head_sha": "40c4727e",
+    "surfaces": {
+      "docs": 0,
+      "frontend": 0,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 1,
+      "packaging": 0,
+      "protected_core": 0,
+      "sentrux": 2,
+      "test": 1,
+      "workflow_ci": 0
+    }
+  },
   "owner_directive": "\u5f00 \u2014 land the Codex P1 fix that missed the #1968 merge: pass ctx.project_dir from the MCP validate_workflow tool",
   "persona": "live_implementer",
-  "pull_request": null,
-  "reconcile_events": [],
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [
+      1969
+    ],
+    "number": null,
+    "url": null
+  },
+  "reconcile_events": [
+    {
+      "at": "2026-07-29T21:06:28.456413Z",
+      "diff_fingerprint": "sha256:27c68ab152d7bae16114633850d0b38ea5fa1868773e3b9f7d7d3cb4d5f0a4c7",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.format_check"
+      ]
+    },
+    {
+      "at": "2026-07-29T21:06:56.488625Z",
+      "diff_fingerprint": "sha256:27c68ab152d7bae16114633850d0b38ea5fa1868773e3b9f7d7d3cb4d5f0a4c7",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-07-29T21:07:21.305135Z",
+      "diff_fingerprint": "sha256:27c68ab152d7bae16114633850d0b38ea5fa1868773e3b9f7d7d3cb4d5f0a4c7",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    }
+  ],
   "record_id": "1969-mcp-validate-project-dir",
   "requested_admin_labels": [],
   "required_obligations": {
     "admin_labels": [],
-    "checks": [],
-    "docs": [],
-    "guards": [],
-    "tests": []
+    "checks": [
+      "format_check",
+      "full_audit",
+      "import_contracts",
+      "lint_format",
+      "python_tests",
+      "semantic_dup",
+      "type_check"
+    ],
+    "docs": [
+      "docs_required_or_na"
+    ],
+    "guards": [
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": [
+      "changed_test_required"
+    ]
   },
   "runtime": "claude-code",
   "schema_version": 2,
@@ -76,7 +539,7 @@
     }
   ],
   "session_id": "4fef6690-bbac-4e60-83e6-db3989ba74ce",
-  "strictness_tier": null,
+  "strictness_tier": 2,
   "task_kind": "guided",
   "test_events": [
     {

--- a/.workflow/records/1969-mcp-validate-project-dir.json
+++ b/.workflow/records/1969-mcp-validate-project-dir.json
@@ -1,0 +1,91 @@
+{
+  "branch": "guided/1969-mcp-validate-project-dir",
+  "check_events": [],
+  "check_na": [],
+  "commit": null,
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "src/scistudio/ai/agent/mcp/tools_workflow/read.py",
+      "tests/ai/test_mcp_tools_disk_integration.py",
+      "CHANGELOG.md"
+    ]
+  },
+  "directive_events": [
+    {
+      "at": "2026-07-29T20:58:32.124376Z",
+      "owner_directive": "\u5f00 \u2014 land the Codex P1 fix that missed the #1968 merge",
+      "reason": "plan"
+    }
+  ],
+  "docs_events": [
+    {
+      "at": "2026-07-29T20:58:32.124652Z",
+      "class": null,
+      "kind": "path",
+      "path": "CHANGELOG.md",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": false,
+  "guard_events": [],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1969,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": null,
+  "owner_directive": "\u5f00 \u2014 land the Codex P1 fix that missed the #1968 merge: pass ctx.project_dir from the MCP validate_workflow tool",
+  "persona": "live_implementer",
+  "pull_request": null,
+  "reconcile_events": [],
+  "record_id": "1969-mcp-validate-project-dir",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [],
+    "docs": [],
+    "guards": [],
+    "tests": []
+  },
+  "runtime": "claude-code",
+  "schema_version": 2,
+  "scope_events": [
+    {
+      "action": "add-include",
+      "at": "2026-07-29T20:58:32.124528Z",
+      "pattern": "src/scistudio/ai/agent/mcp/tools_workflow/read.py",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-07-29T20:58:32.124535Z",
+      "pattern": "tests/ai/test_mcp_tools_disk_integration.py",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-07-29T20:58:32.124537Z",
+      "pattern": "CHANGELOG.md",
+      "reason": "plan"
+    }
+  ],
+  "session_id": "4fef6690-bbac-4e60-83e6-db3989ba74ce",
+  "strictness_tier": null,
+  "task_kind": "guided",
+  "test_events": [
+    {
+      "at": "2026-07-29T20:58:32.124669Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/ai/test_mcp_tools_disk_integration.py",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/.workflow/records/1969-mcp-validate-project-dir.json
+++ b/.workflow/records/1969-mcp-validate-project-dir.json
@@ -132,9 +132,9 @@
   ],
   "check_na": [],
   "commit": {
-    "sha": "40c4727e9b47a1ad4d378384488239a8821aa912",
+    "sha": "e707bc606853ddaeaf69ce11db95b9c0d9daca3e",
     "shas": [
-      "40c4727e9b47a1ad4d378384488239a8821aa912"
+      "e707bc606853ddaeaf69ce11db95b9c0d9daca3e"
     ],
     "trailers": []
   },
@@ -410,6 +410,170 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-07-29T21:08:41.903997Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T21:08:41.917211Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T21:08:41.929869Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T21:08:41.942267Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T21:08:41.954655Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T21:08:41.967005Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T21:08:41.992930Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T21:08:42.005383Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T21:08:42.017915Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T21:08:42.032261Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T21:08:54.603694Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T21:08:54.615923Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T21:08:54.628388Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T21:08:54.640672Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T21:08:54.652806Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T21:08:54.665028Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T21:08:54.677136Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T21:08:54.689704Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T21:08:54.701260Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T21:08:54.715163Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -422,7 +586,7 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "origin/main",
+    "base": "6c00d825718e9f30017a9e73481375552d2c4a0d",
     "base_sha": "6c00d825",
     "changed_files": [
       ".workflow/records/1969-mcp-validate-project-dir.json",
@@ -430,9 +594,9 @@
       "src/scistudio/ai/agent/mcp/tools_workflow/read.py",
       "tests/ai/test_mcp_tools_disk_integration.py"
     ],
-    "diff_fingerprint": "sha256:27c68ab152d7bae16114633850d0b38ea5fa1868773e3b9f7d7d3cb4d5f0a4c7",
+    "diff_fingerprint": "sha256:2ebc268cea236c0af0bf2ed808a847bca2b5e0cfb66a584c2c0e028b0b3ec94a",
     "head": "HEAD",
-    "head_sha": "40c4727e",
+    "head_sha": "e707bc60",
     "surfaces": {
       "docs": 0,
       "frontend": 0,
@@ -453,8 +617,8 @@
     "closes": [
       1969
     ],
-    "number": null,
-    "url": null
+    "number": 1970,
+    "url": "https://github.com/jiazhenz026/SciStudio/pull/1970"
   },
   "reconcile_events": [
     {
@@ -478,6 +642,22 @@
     {
       "at": "2026-07-29T21:07:21.305135Z",
       "diff_fingerprint": "sha256:27c68ab152d7bae16114633850d0b38ea5fa1868773e3b9f7d7d3cb4d5f0a4c7",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-07-29T21:08:42.032295Z",
+      "diff_fingerprint": "sha256:2ebc268cea236c0af0bf2ed808a847bca2b5e0cfb66a584c2c0e028b0b3ec94a",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-07-29T21:08:54.715221Z",
+      "diff_fingerprint": "sha256:2ebc268cea236c0af0bf2ed808a847bca2b5e0cfb66a584c2c0e028b0b3ec94a",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 2,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- [#1969] The `validate_workflow` MCP tool now resolves a CodeBlock
+  `script_path` against the active project root instead of the backend process
+  working directory. #1967 threaded an explicit `project_dir` through
+  `validate_workflow` and pinned FR-035 — every caller that knows the active
+  project must pass its root — but missed this third caller, which loads the
+  YAML itself and so never sees the runtime's load-time path absolutification.
+  Users were unaffected (run start already passed the project root); the agent
+  was not: the dry-run self-check it is told to run after writing a workflow
+  falsely reported a valid project-relative script as invalid. Tests:
+  `tests/ai/test_mcp_tools_disk_integration.py` covers both branches of the tool
+  (file path and inline YAML) with the working directory outside the project.
+  (@claude, 2026-07-29, branch: guided/1969-mcp-validate-project-dir)
+
 - [#1967] CodeBlock: a project-relative `script_path` no longer fails workflow
   validation at run start. The persisted graph carries no project root — the
   scheduler injects one at dispatch, after validation — so

--- a/src/scistudio/ai/agent/mcp/tools_workflow/read.py
+++ b/src/scistudio/ai/agent/mcp/tools_workflow/read.py
@@ -238,7 +238,13 @@ async def validate_workflow(
     except Exception as exc:
         return ValidateWorkflowResult(valid=False, errors=[f"parse failure: {exc}"])
 
-    errors = _validate(definition, registry=ctx.block_registry)
+    # ``project_dir`` (#1967 FR-035, landed here by #1969): this tool reads the
+    # YAML through ``load_yaml`` (or parses inline text), so it never sees the
+    # runtime's load-time path absolutification. Without the active project root
+    # the validator falls back to the backend process's working directory and
+    # falsely rejects a valid project-relative CodeBlock ``script_path`` that run
+    # start accepts.
+    errors = _validate(definition, registry=ctx.block_registry, project_dir=ctx.project_dir)
     return ValidateWorkflowResult(valid=not errors, errors=list(errors))
 
 

--- a/tests/ai/test_mcp_tools_disk_integration.py
+++ b/tests/ai/test_mcp_tools_disk_integration.py
@@ -531,3 +531,71 @@ def test_resolved_path_uses_realpath_not_string_compare(
     assert expected.is_file()
     # ``..`` should NOT have escaped (still inside workflows/).
     assert os.path.commonpath([str(expected), str(project_root)]) == str(project_root)
+
+
+# ---------------------------------------------------------------------------
+# Case 12: validate_workflow resolves a CodeBlock script_path against
+# project_dir, not the backend CWD (#1969).
+# ---------------------------------------------------------------------------
+
+
+_CODEBLOCK_WF_YAML = """\
+workflow:
+  id: codeblock_wf
+  version: 1.0.0
+  nodes:
+    - id: code1
+      block_type: code_block
+      config:
+        script_path: scripts/analyse.py
+  edges: []
+"""
+
+
+def test_validate_workflow_resolves_codeblock_script_path_against_project_dir(
+    ctx_with_project: _StubRuntime,
+    project_root: Path,
+    other_cwd: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#1969: a project-relative ``script_path`` validates through the MCP tool
+    even when the backend CWD is elsewhere.
+
+    This tool reads the YAML directly, so it never benefits from the runtime's
+    load-time path absolutification — it has to pass ``ctx.project_dir`` to the
+    validator itself. Otherwise the agent's own dry-run check rejects a workflow
+    that run start accepts.
+    """
+    script = project_root / "scripts" / "analyse.py"
+    script.parent.mkdir(parents=True, exist_ok=True)
+    script.write_text("print('ok')\n", encoding="utf-8")
+    (project_root / "workflows").mkdir(parents=True, exist_ok=True)
+    (project_root / "workflows" / "codeblock_wf.yaml").write_text(_CODEBLOCK_WF_YAML, encoding="utf-8")
+
+    monkeypatch.chdir(other_cwd)
+    assert Path.cwd().resolve() == other_cwd  # sanity
+
+    result = _run(tools_workflow.validate_workflow(yaml_or_path="workflows/codeblock_wf.yaml"))
+
+    assert [error for error in result.errors if "script_path" in error] == []
+    assert result.valid is True
+
+
+def test_validate_workflow_inline_yaml_also_resolves_against_project_dir(
+    ctx_with_project: _StubRuntime,
+    project_root: Path,
+    other_cwd: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#1969: the inline-YAML branch carries no project root of its own either,
+    so it depends on the same ``ctx.project_dir`` hand-off."""
+    script = project_root / "scripts" / "analyse.py"
+    script.parent.mkdir(parents=True, exist_ok=True)
+    script.write_text("print('ok')\n", encoding="utf-8")
+
+    monkeypatch.chdir(other_cwd)
+
+    result = _run(tools_workflow.validate_workflow(yaml_or_path=_CODEBLOCK_WF_YAML))
+
+    assert [error for error in result.errors if "script_path" in error] == []
+    assert result.valid is True


### PR DESCRIPTION
## Summary

Follow-up to #1967 / PR #1968. Codex raised this as a P1 on that PR, but the fix
landed after the merge, so `origin/main` still has the gap.

`validate_workflow` gained an explicit `project_dir` in #1967, and FR-035 in
`docs/specs/adr-041-codeblock-v2.md` requires every caller that knows the active
project to pass its root. Two of the three callers were updated. The MCP
`validate_workflow` tool was not:

```python
# src/scistudio/ai/agent/mcp/tools_workflow/read.py:241 (on main)
errors = _validate(definition, registry=ctx.block_registry)
```

`ctx.project_dir` is available (`_context.py:53`), and `_context.py:152` already
documents that paths must resolve against it rather than the backend cwd.

## Why this caller in particular

The two runtime callers receive a definition that the loader has already been
through, so its paths are absolute by the time the validator sees them. This tool
loads the YAML itself (`load_yaml`) or parses inline text, so it never sees that
pass — it has to supply the project root explicitly or the validator falls back
to `Path.cwd()`.

## Impact

Users are unaffected: clicking Run works, because run-start validation passes the
project root as of #1968. The victim is the agent. It is guided to call
`validate_workflow` as a dry-run self-check after writing a workflow; in the
packaged app the backend cwd is `SciStudio.app/Contents/Resources`, so the check
falsely rejects a valid project-relative CodeBlock `script_path` and the agent
goes off to "fix" a workflow that is not broken.

## Changes

- `read.py`: pass `project_dir=ctx.project_dir`.
- `tests/ai/test_mcp_tools_disk_integration.py`: both branches of the tool (file
  path and inline YAML) validated with the working directory outside the project.
- `CHANGELOG.md`.

## Testing

Both new tests fail without the one-line change and pass with it.

Gate record: .workflow/records/1969-mcp-validate-project-dir.json

Closes #1969
