### PR TITLE
feat(#1974): elapsed-time counter beside the running node spinner

### DIFF
--- a/.workflow/records/1974-node-elapsed-timer.json
+++ b/.workflow/records/1974-node-elapsed-timer.json
@@ -177,9 +177,9 @@
   ],
   "check_na": [],
   "commit": {
-    "sha": "fb4776615602c84b475652c8027358fecc06db52",
+    "sha": "c84f717292c9856360dea1e1bc8ac08e70c551c5",
     "shas": [
-      "fb4776615602c84b475652c8027358fecc06db52"
+      "c84f717292c9856360dea1e1bc8ac08e70c551c5"
     ],
     "trailers": []
   },
@@ -482,6 +482,170 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-07-29T22:01:02.606952Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T22:01:02.618481Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T22:01:02.630307Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T22:01:02.643379Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T22:01:02.654577Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T22:01:02.666204Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T22:01:02.677284Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T22:01:02.688580Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T22:01:02.700304Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T22:01:02.715496Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T22:01:17.824113Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T22:01:17.848971Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T22:01:17.880828Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T22:01:17.924191Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T22:01:17.948593Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T22:01:17.968684Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T22:01:17.989984Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T22:01:18.013933Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T22:01:18.032025Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T22:01:18.057310Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -494,7 +658,7 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "origin/main",
+    "base": "6c00d825718e9f30017a9e73481375552d2c4a0d",
     "base_sha": "6c00d825",
     "changed_files": [
       ".workflow/records/1974-node-elapsed-timer.json",
@@ -512,9 +676,9 @@
       "frontend/src/testUtils.ts",
       "frontend/src/types/ui.ts"
     ],
-    "diff_fingerprint": "sha256:4b03232a4d0fb27fd5577fdf899d34336c91188a5241fc36c2cce314c54bebc5",
+    "diff_fingerprint": "sha256:66067e1fc7d45c898e8ce52522b1403b1a72e14a67dcbca9b42a941be0b45485",
     "head": "HEAD",
-    "head_sha": "fb477661",
+    "head_sha": "c84f7172",
     "surfaces": {
       "docs": 0,
       "frontend": 12,
@@ -535,8 +699,8 @@
     "closes": [
       1974
     ],
-    "number": null,
-    "url": null
+    "number": 1975,
+    "url": "https://github.com/jiazhenz026/SciStudio/pull/1975"
   },
   "reconcile_events": [
     {
@@ -560,6 +724,22 @@
     {
       "at": "2026-07-29T22:00:42.068405Z",
       "diff_fingerprint": "sha256:4b03232a4d0fb27fd5577fdf899d34336c91188a5241fc36c2cce314c54bebc5",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-07-29T22:01:02.715535Z",
+      "diff_fingerprint": "sha256:66067e1fc7d45c898e8ce52522b1403b1a72e14a67dcbca9b42a941be0b45485",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-07-29T22:01:18.057351Z",
+      "diff_fingerprint": "sha256:66067e1fc7d45c898e8ce52522b1403b1a72e14a67dcbca9b42a941be0b45485",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 1,

--- a/.workflow/records/1974-node-elapsed-timer.json
+++ b/.workflow/records/1974-node-elapsed-timer.json
@@ -1,8 +1,188 @@
 {
   "branch": "feature/1974-node-elapsed-timer",
-  "check_events": [],
+  "check_events": [
+    {
+      "at": "2026-07-29T21:52:52.761568Z",
+      "command": "pytest tests/architecture/ -v --no-cov",
+      "covered_surface": "architecture",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:0deac04405434cdca6d65dc3c51f5b5938ddb201f6adf484ce98451ad607e155",
+      "name": "architecture_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/architecture_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-29T21:52:53.720876Z",
+      "command": "python scripts/deferral_scan.py --check docs/audit/baselines/deferral-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e4e496551379d17f96ad86b11eaf623c68bad77cce7a68a3c8a39640cc85f197",
+      "name": "deferral_discipline",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/deferral_discipline.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-29T21:52:54.185497Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:bee0017f30f552d2df2de1173f9ac14b9aee5192ca5e5c1de574bb119512b275",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-07-29T21:53:23.553945Z",
+      "command": "(cd frontend && npm run check:ci)",
+      "covered_surface": "frontend",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e09094ea48d2caef830564c84657a5b221d6ee7131289241fccdb2e8152b627e",
+      "name": "frontend",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/frontend.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-29T21:53:28.425356Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:3a5ad7e4a2689af0801f0d1dc885639c784cc2546c1b93211dc0c9530612c3f1",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-29T21:53:29.042048Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:179b1cba851dd153ae0ab07e4f5ff8b2a735cc2c3d6d4494d3c0100847360442",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-29T21:53:29.124145Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e31351abfc33f0b3c0f28bc9f2f3d59ae3bc5d4925dc1159a7f931aa932441ed",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-07-29T21:55:52.987253Z",
+      "command": "python -m scistudio.qa.testing.run_python_tests --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:47eac75ed95c8abfde2e5868831e97df5202e82116cf9c4a1b1122e549884f6c",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-29T21:59:08.306343Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:3af535eba76ad0b412d91638425ab895d92c1c1a0c922ca52a0cce354e39cb72",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-29T21:59:16.207552Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e94394e48009cd8fbd5108426e57662cdd3e4d99e817a3b4494b7e53776b5c37",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    },
+    {
+      "at": "2026-07-29T21:59:42.448522Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:bee0017f30f552d2df2de1173f9ac14b9aee5192ca5e5c1de574bb119512b275",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    }
+  ],
   "check_na": [],
-  "commit": null,
+  "commit": {
+    "sha": "fb4776615602c84b475652c8027358fecc06db52",
+    "shas": [
+      "fb4776615602c84b475652c8027358fecc06db52"
+    ],
+    "trailers": []
+  },
   "declared_scope": {
     "exclude": [],
     "include": [
@@ -56,7 +236,254 @@
     }
   ],
   "governance_touch": false,
-  "guard_events": [],
+  "guard_events": [
+    {
+      "at": "2026-07-29T21:59:16.289860Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T21:59:16.301802Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T21:59:16.313908Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T21:59:16.325808Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T21:59:16.338539Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T21:59:16.350819Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T21:59:16.363465Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T21:59:16.375875Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T21:59:16.387698Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T21:59:16.401631Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T21:59:42.479918Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T21:59:42.491968Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T21:59:42.503966Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T21:59:42.515864Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T21:59:42.527784Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T21:59:42.540280Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T21:59:42.551742Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T21:59:42.563146Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T21:59:42.575449Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T21:59:42.599314Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T22:00:41.955076Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T22:00:41.967304Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T22:00:41.979289Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T22:00:41.991526Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T22:00:42.003941Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T22:00:42.016173Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T22:00:42.028309Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T22:00:42.041563Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T22:00:42.053884Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T22:00:42.068368Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
   "issues": [
     {
       "close_in_pr": true,
@@ -66,25 +493,119 @@
     }
   ],
   "observed_admin_labels": [],
-  "observed_diff": null,
+  "observed_diff": {
+    "base": "origin/main",
+    "base_sha": "6c00d825",
+    "changed_files": [
+      ".workflow/records/1974-node-elapsed-timer.json",
+      "CHANGELOG.md",
+      "frontend/src/components/WorkflowCanvas.parts/flowNodeBuilder.ts",
+      "frontend/src/components/WorkflowCanvas.parts/useFlowNodes.ts",
+      "frontend/src/components/WorkflowCanvas.tsx",
+      "frontend/src/components/nodes/BlockNode.parts/NodeStatusSurface.tsx",
+      "frontend/src/components/nodes/BlockNode.tsx",
+      "frontend/src/components/nodes/__tests__/BlockNode/statusSurface.test.tsx",
+      "frontend/src/store/executionSlice.parts/eventReducer.test.ts",
+      "frontend/src/store/executionSlice.parts/eventReducer.ts",
+      "frontend/src/store/executionSlice.ts",
+      "frontend/src/store/types.ts",
+      "frontend/src/testUtils.ts",
+      "frontend/src/types/ui.ts"
+    ],
+    "diff_fingerprint": "sha256:4b03232a4d0fb27fd5577fdf899d34336c91188a5241fc36c2cce314c54bebc5",
+    "head": "HEAD",
+    "head_sha": "fb477661",
+    "surfaces": {
+      "docs": 0,
+      "frontend": 12,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 12,
+      "packaging": 0,
+      "protected_core": 0,
+      "sentrux": 12,
+      "test": 2,
+      "workflow_ci": 0
+    }
+  },
   "owner_directive": "Issue #1974: while a block is running, show an elapsed-time counter next to the spinner on the block node. The counter appears when the block enters the running state, counts up, and disappears when the block finishes - no final duration left on the node, no history of previous runs. Owner-decided behaviour; do not redesign. Main file: frontend/src/components/nodes/BlockNode.parts/NodeStatusSurface.tsx. Pick a start-time source (backend block_running started_at kept in the store vs frontend-stamped transition) and justify it in the PR body.",
   "persona": "implementer",
-  "pull_request": null,
-  "reconcile_events": [],
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [
+      1974
+    ],
+    "number": null,
+    "url": null
+  },
+  "reconcile_events": [
+    {
+      "at": "2026-07-29T21:59:16.401670Z",
+      "diff_fingerprint": "sha256:4b03232a4d0fb27fd5577fdf899d34336c91188a5241fc36c2cce314c54bebc5",
+      "mode": "local",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.format_check"
+      ]
+    },
+    {
+      "at": "2026-07-29T21:59:42.599352Z",
+      "diff_fingerprint": "sha256:4b03232a4d0fb27fd5577fdf899d34336c91188a5241fc36c2cce314c54bebc5",
+      "mode": "local",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-07-29T22:00:42.068405Z",
+      "diff_fingerprint": "sha256:4b03232a4d0fb27fd5577fdf899d34336c91188a5241fc36c2cce314c54bebc5",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    }
+  ],
   "record_id": "1974-node-elapsed-timer",
   "requested_admin_labels": [],
   "required_obligations": {
     "admin_labels": [],
-    "checks": [],
-    "docs": [],
-    "guards": [],
-    "tests": []
+    "checks": [
+      "architecture_tests",
+      "deferral_discipline",
+      "format_check",
+      "frontend",
+      "full_audit",
+      "import_contracts",
+      "lint_format",
+      "python_tests",
+      "semantic_dup",
+      "type_check"
+    ],
+    "docs": [
+      "docs_required_or_na"
+    ],
+    "guards": [
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": [
+      "changed_test_required"
+    ]
   },
   "runtime": "claude-code",
   "schema_version": 2,
   "scope_events": [],
   "session_id": "ee48d89e-65b2-4b87-997b-96472eb81c92",
-  "strictness_tier": null,
+  "strictness_tier": 1,
   "task_kind": "feature",
   "test_events": [
     {

--- a/.workflow/records/1974-node-elapsed-timer.json
+++ b/.workflow/records/1974-node-elapsed-timer.json
@@ -1,0 +1,107 @@
+{
+  "branch": "feature/1974-node-elapsed-timer",
+  "check_events": [],
+  "check_na": [],
+  "commit": null,
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "frontend/src/components/nodes/BlockNode.parts/NodeStatusSurface.tsx",
+      "frontend/src/components/nodes/BlockNode.tsx",
+      "frontend/src/components/nodes/__tests__/BlockNode/statusSurface.test.tsx",
+      "frontend/src/components/WorkflowCanvas.tsx",
+      "frontend/src/components/WorkflowCanvas.parts/useFlowNodes.ts",
+      "frontend/src/components/WorkflowCanvas.parts/flowNodeBuilder.ts",
+      "frontend/src/store/executionSlice.ts",
+      "frontend/src/store/executionSlice.parts/eventReducer.ts",
+      "frontend/src/store/executionSlice.parts/eventReducer.test.ts",
+      "frontend/src/store/types.ts",
+      "frontend/src/types/ui.ts",
+      "frontend/src/testUtils.ts",
+      "CHANGELOG.md",
+      ".workflow/records/**"
+    ]
+  },
+  "directive_events": [
+    {
+      "at": "2026-07-29T21:45:58.896272Z",
+      "owner_directive": "Plan: keep the run start instant in the execution store, sourced from the backend block_running event timestamp (backend is the source of runtime truth per AGENTS 3.5; the event already carries an ISO timestamp so no backend change is needed, and a store-held start survives node/component remounts that would reset a component-local stamp). eventReducer gains nextBlockRunStarts + resolveRunStartedAt; executionSlice gains blockRunStartedAt; WorkflowCanvas reads it from the store directly (same precedent as highlightedNodeId) and threads runStartedAt through useFlowNodes -> flowNodeBuilder -> BlockNodeData -> NodeStatusSurface. NodeStatusSurface renders a transient, absolutely-positioned elapsed counter beside the running spinner (zero geometry impact, ADR-050 FR-004/FR-011) that unmounts on any non-running state; no final duration, no run history.",
+      "reason": "plan"
+    }
+  ],
+  "docs_events": [
+    {
+      "at": "2026-07-29T21:45:58.896573Z",
+      "class": null,
+      "kind": "path",
+      "path": "CHANGELOG.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-07-29T21:45:58.896597Z",
+      "class": "adr",
+      "kind": "na",
+      "path": null,
+      "rationale": "ADR-050 \u00a72.5 keeps its decision unchanged - the counter is a transient zero-geometry overlay beside the running glyph, not a status footer, inline text row, or warning chip inside the node body, and nothing is persisted after the run ends. Prior node UI additions of the same size (#1799 highlight ring, #1887 hover detail popover) were CHANGELOG-only.",
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-07-29T21:45:58.896601Z",
+      "class": "spec",
+      "kind": "na",
+      "path": null,
+      "rationale": "adr-050-canvas-node-readability FR-004/FR-011 are unchanged - node width/height are untouched and runtime state is still represented through the single NodeStatusSurface.",
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": false,
+  "guard_events": [],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1974,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": null,
+  "owner_directive": "Issue #1974: while a block is running, show an elapsed-time counter next to the spinner on the block node. The counter appears when the block enters the running state, counts up, and disappears when the block finishes - no final duration left on the node, no history of previous runs. Owner-decided behaviour; do not redesign. Main file: frontend/src/components/nodes/BlockNode.parts/NodeStatusSurface.tsx. Pick a start-time source (backend block_running started_at kept in the store vs frontend-stamped transition) and justify it in the PR body.",
+  "persona": "implementer",
+  "pull_request": null,
+  "reconcile_events": [],
+  "record_id": "1974-node-elapsed-timer",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [],
+    "docs": [],
+    "guards": [],
+    "tests": []
+  },
+  "runtime": "claude-code",
+  "schema_version": 2,
+  "scope_events": [],
+  "session_id": "ee48d89e-65b2-4b87-997b-96472eb81c92",
+  "strictness_tier": null,
+  "task_kind": "feature",
+  "test_events": [
+    {
+      "at": "2026-07-29T21:45:58.896605Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/store/executionSlice.parts/eventReducer.test.ts",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-07-29T21:45:58.896609Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/components/nodes/__tests__/BlockNode/statusSurface.test.tsx",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [#1915] Load/save native file dialogs now default to the active project root instead of the user home directory. The backend `native_file_dialog` route resolves the start directory through a new pure helper `_resolve_dialog_start_dir` (project-scope: valid `initial_dir` → `runtime.project_dir` → session last-used → home; home-scope → last-used → home). A `prefer_home` request flag is the only per-caller opt-out, used by the create/open-project dialog (picks a project *location*) and the diagnostic-bundle export (a machine artifact, not a project file); every other load/save caller now defaults to the project root with no code change. Tests: `tests/api/test_native_dialog.py` (`_resolve_dialog_start_dir` matrix), `frontend/src/lib/api/__tests__/filesystem.test.ts`, `frontend/src/lib/__tests__/logger.test.ts`. (@claude, 2026-07-02, branch: guided/1915-dialog-project-root)
 ### Added
 
+- [#1974] Canvas block nodes now show how long a block has been running: a
+  compact elapsed-time counter appears beside the spinner on the node's status
+  surface the moment the block enters the running state, counts up (`7s`,
+  `1:05`, `1:04:09`), and disappears when the block finishes — no final duration
+  is left on the node and no previous run is shown. The start instant comes from
+  the engine's `block_running` event timestamp, which the execution store keeps
+  in a new `blockRunStartedAt` map (`nextBlockRunStarts` / `resolveRunStartedAt`)
+  for exactly as long as the block runs, so the counter is anchored to when the
+  block actually started rather than to when this client rendered the
+  transition, and it survives a node re-render or remount mid-run. The counter
+  is an absolutely-positioned overlay like the status badge itself: node width
+  and height are unchanged (ADR-050 FR-004/FR-011), and it is bound to the
+  spinner, so an error or warning surface that replaces the running glyph shows
+  no timer. Tests: `frontend/src/store/executionSlice.parts/eventReducer.test.ts`,
+  `frontend/src/components/nodes/__tests__/BlockNode/statusSurface.test.tsx`.
+  (@claude, 2026-07-29, branch: feature/1974-node-elapsed-timer)
+
 - [#1912] `edit_workflow` MCP tool — a surgical partial-edit path for existing
   workflow YAML. The agent previously had to re-emit a whole workflow through
   `write_workflow` (full-file replace) for any structural change, which dropped

--- a/frontend/src/components/WorkflowCanvas.parts/flowNodeBuilder.ts
+++ b/frontend/src/components/WorkflowCanvas.parts/flowNodeBuilder.ts
@@ -183,6 +183,8 @@ interface BlockOpts {
   summary?: BlockSummary;
   schema?: BlockSchemaResponse;
   status: string;
+  /** #1974 — epoch-ms start of the current run; undefined unless running. */
+  runStartedAt?: number;
   errorMessage: string | undefined;
   errorSummary: string | undefined;
   callbacks: BlockNodeCallbacks;
@@ -201,6 +203,7 @@ export function buildBlockNode(opts: BlockOpts): Node {
     summary,
     schema,
     status,
+    runStartedAt,
     errorMessage,
     errorSummary,
     callbacks,
@@ -248,6 +251,7 @@ export function buildBlockNode(opts: BlockOpts): Node {
         schema,
       ),
       status,
+      runStartedAt,
       errorMessage,
       errorSummary,
       problemSeverity,

--- a/frontend/src/components/WorkflowCanvas.parts/useFlowNodes.ts
+++ b/frontend/src/components/WorkflowCanvas.parts/useFlowNodes.ts
@@ -67,6 +67,12 @@ export interface UseFlowNodesOpts {
   blocks: BlockSummary[];
   schemas: Record<string, BlockSchemaResponse>;
   blockStates: Record<string, string>;
+  /**
+   * #1974 — epoch-ms start instant of each block's CURRENT run, keyed like
+   * `blockStates`. Present only while the block runs; drives the node's
+   * transient elapsed-time counter. OPTIONAL so existing call sites compile.
+   */
+  blockRunStartedAt?: Record<string, number>;
   blockErrors: Record<string, string>;
   blockErrorSummaries: Record<string, string>;
   selectedNodeId: string | null;
@@ -112,6 +118,7 @@ export function useFlowNodes(opts: UseFlowNodesOpts): Node[] {
     blocks,
     schemas,
     blockStates,
+    blockRunStartedAt,
     blockErrors,
     blockErrorSummaries,
     selectedNodeId,
@@ -191,6 +198,9 @@ export function useFlowNodes(opts: UseFlowNodesOpts): Node[] {
         // ADR-044 — in an expanded child canvas the run keys carry the parent
         // prefix; runScopePrefix is "" for a top-level workflow.
         status: blockStates[`${runScopePrefix}${node.id}`] ?? "idle",
+        // #1974 — set only while this block is running; the node clears its
+        // elapsed counter as soon as the entry disappears.
+        runStartedAt: blockRunStartedAt?.[`${runScopePrefix}${node.id}`],
         errorMessage: blockErrors[`${runScopePrefix}${node.id}`],
         errorSummary: blockErrorSummaries[`${runScopePrefix}${node.id}`],
         label: resolveLabel(node, summary, schema),
@@ -212,6 +222,7 @@ export function useFlowNodes(opts: UseFlowNodesOpts): Node[] {
   }, [
     blocks,
     blockStates,
+    blockRunStartedAt,
     blockErrors,
     blockErrorSummaries,
     blockOutputs,

--- a/frontend/src/components/WorkflowCanvas.tsx
+++ b/frontend/src/components/WorkflowCanvas.tsx
@@ -217,6 +217,11 @@ export function WorkflowCanvas(props: WorkflowCanvasProps) {
   // through ProjectWorkspace. The canvas rings the node (via useFlowNodes) and
   // pans it into view above the bottom panel.
   const highlightedNodeId = useAppStore((s) => s.highlightedNodeId);
+  // #1974 — per-block run start instants (engine clock), read straight from the
+  // store for the same reason as `highlightedNodeId`: it is transient run state
+  // consumed only by the node's status surface, so it does not need to be
+  // threaded down through ProjectWorkspace.
+  const blockRunStartedAt = useAppStore((s) => s.blockRunStartedAt);
   const {
     blocks,
     schemas,
@@ -272,6 +277,7 @@ export function WorkflowCanvas(props: WorkflowCanvasProps) {
     blocks,
     schemas,
     blockStates,
+    blockRunStartedAt,
     blockErrors,
     blockErrorSummaries,
     selectedNodeId,

--- a/frontend/src/components/nodes/BlockNode.parts/NodeStatusSurface.tsx
+++ b/frontend/src/components/nodes/BlockNode.parts/NodeStatusSurface.tsx
@@ -14,6 +14,14 @@
 //     node + opens BottomPanel Config via `onWarningClick` (FR-013).
 //   - Verbose error text / lossy-save detail / warning lists live in Logs,
 //     BottomPanel, or the tooltip `title`, never in the node body.
+//
+// #1974 — while (and only while) the runtime state is `running`, a compact
+// elapsed-time counter sits immediately left of the spinner so a long-running
+// block reads as "still working, for this long". It is an absolutely-positioned
+// overlay like the badge itself: it contributes ZERO measured geometry, it is
+// not a status footer/text row inside the body (FR-004), and it is transient —
+// it unmounts on the first non-running state, leaving NO final duration and NO
+// history of previous runs on the node.
 
 import {
   AlertTriangle,
@@ -27,6 +35,7 @@ import {
   X,
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
+import { useEffect, useState } from "react";
 
 interface SurfaceStyle {
   /** Icon rendered inside the corner badge. */
@@ -44,6 +53,8 @@ interface SurfaceStyle {
 const STATUS_BADGE_BACKGROUND = "rgba(255, 255, 255, 0.86)";
 const STATUS_BADGE_BORDER = "rgba(15, 23, 42, 0.14)";
 const ERROR_STATUSES = new Set(["error", "fail", "failed", "failure"]);
+/** #1974 — the counter ticks once a second; sub-second precision is noise here. */
+const ELAPSED_TICK_MS = 1000;
 
 const RUNTIME_STYLES: Record<string, SurfaceStyle> = {
   idle: { Icon: Circle, iconName: "circle", color: "#8A94A6", label: "Idle" },
@@ -84,9 +95,47 @@ const WARNING_STYLE: SurfaceStyle = {
 
 export type ProblemSeverity = "none" | "warning" | "error";
 
+/**
+ * #1974 — render the elapsed run time compactly: `7s` under a minute, `2:05`
+ * under an hour, `1:04:09` beyond it. Seconds are floored so the counter reads
+ * `0s` the instant the block starts rather than skipping ahead.
+ */
+function formatElapsed(elapsedMs: number): string {
+  const totalSeconds = Math.max(0, Math.floor(elapsedMs / 1000));
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+  const paddedSeconds = String(seconds).padStart(2, "0");
+  if (hours > 0) return `${hours}:${String(minutes).padStart(2, "0")}:${paddedSeconds}`;
+  if (minutes > 0) return `${minutes}:${paddedSeconds}`;
+  return `${seconds}s`;
+}
+
+/**
+ * #1974 — tick once a second while `startedAt` is set. Passing `null` (any
+ * non-running state) tears the interval down, so a finished node holds no
+ * timer, no duration, and no pending work.
+ */
+function useElapsedMs(startedAt: number | null): number {
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    if (startedAt === null) return undefined;
+    setNow(Date.now());
+    const timer = setInterval(() => setNow(Date.now()), ELAPSED_TICK_MS);
+    return () => clearInterval(timer);
+  }, [startedAt]);
+  return startedAt === null ? 0 : Math.max(0, now - startedAt);
+}
+
 export interface NodeStatusSurfaceProps {
   /** Runtime state — defaults to "idle" when unset. */
   status?: string;
+  /**
+   * #1974 — epoch-ms instant this block entered the running state (engine
+   * clock, carried by the `block_running` event). Set ONLY while running; the
+   * counter renders alongside the spinner and disappears with it.
+   */
+  runStartedAt?: number;
   /** Highest-priority problem signal (ADR-050 §2.5). */
   problemSeverity?: ProblemSeverity;
   /** Concise error detail surfaced in the tooltip (never inline). */
@@ -119,6 +168,7 @@ function resolveSurface(
 
 export function NodeStatusSurface({
   status,
+  runStartedAt,
   problemSeverity = "none",
   errorSummary,
   errorMessage,
@@ -129,6 +179,15 @@ export function NodeStatusSurface({
   const { style, kind } = resolveSurface(runtime, problemSeverity);
   const Icon = style.Icon;
 
+  // #1974 — the counter is bound to the SPINNER, not to the raw status: an
+  // error/warning surface replaces the running glyph (§2.5 priority table), so
+  // it must not keep a timer next to a glyph that no longer spins.
+  const elapsedAnchor =
+    kind === "runtime" && style.spin === true && typeof runStartedAt === "number"
+      ? runStartedAt
+      : null;
+  const elapsedMs = useElapsedMs(elapsedAnchor);
+
   // Tooltip carries the verbose detail that ADR-050 forbids in the body.
   const detail =
     kind === "error"
@@ -136,6 +195,25 @@ export function NodeStatusSurface({
       : kind === "warning"
         ? "Warning — open Config for details"
         : style.label;
+
+  // Elapsed pill — absolute, pointer-events-none, sits just left of the badge.
+  // Same zero-geometry contract as the badge (FR-004/FR-011).
+  const elapsed =
+    elapsedAnchor === null ? null : (
+      <span
+        data-testid="node-status-elapsed"
+        aria-label={`Running for ${formatElapsed(elapsedMs)}`}
+        title={`Running for ${formatElapsed(elapsedMs)}`}
+        className="pointer-events-none absolute right-7 bottom-1 flex h-5 items-center rounded-full border px-1.5 font-mono text-[10px] font-semibold tabular-nums shadow-sm backdrop-blur-[1px]"
+        style={{
+          backgroundColor: STATUS_BADGE_BACKGROUND,
+          borderColor: STATUS_BADGE_BORDER,
+          color: style.color,
+        }}
+      >
+        {formatElapsed(elapsedMs)}
+      </span>
+    );
 
   const badge = (
     <span
@@ -211,5 +289,10 @@ export function NodeStatusSurface({
     );
   }
 
-  return badge;
+  return (
+    <>
+      {elapsed}
+      {badge}
+    </>
+  );
 }

--- a/frontend/src/components/nodes/BlockNode.tsx
+++ b/frontend/src/components/nodes/BlockNode.tsx
@@ -208,6 +208,7 @@ export function BlockNode({ id: nodeId, data, selected }: NodeProps<Node<BlockNo
         {/* Unified status surface — corner glyph, zero geometry impact. */}
         <NodeStatusSurface
           status={data.status}
+          runStartedAt={data.runStartedAt}
           problemSeverity={data.problemSeverity}
           errorSummary={data.errorSummary}
           errorMessage={data.errorMessage}

--- a/frontend/src/components/nodes/__tests__/BlockNode/statusSurface.test.tsx
+++ b/frontend/src/components/nodes/__tests__/BlockNode/statusSurface.test.tsx
@@ -9,7 +9,7 @@
 //     Config).
 
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
 
 import { NodeStatusSurface } from "../../BlockNode.parts/NodeStatusSurface";
 import { openNativeDialogMock, renderNode } from "./test-utils";
@@ -137,6 +137,106 @@ describe("NodeStatusSurface — activation (FR-012 / FR-013)", () => {
     expect(button.getAttribute("title")).toBe("Division by zero");
     // The detail text is not present as a standalone text node.
     expect(screen.queryByText("Division by zero")).toBeNull();
+  });
+});
+
+// #1974 — transient elapsed-time counter beside the running spinner. It is
+// owner-decided that the counter exists ONLY while the block runs: no final
+// duration is left on the node and no previous run is shown.
+describe("NodeStatusSurface — running elapsed counter (#1974)", () => {
+  const START = Date.parse("2026-05-22T00:00:00Z");
+
+  function withFakeClock(elapsedMs: number, body: () => void) {
+    vi.useFakeTimers();
+    vi.setSystemTime(START + elapsedMs);
+    try {
+      body();
+    } finally {
+      vi.useRealTimers();
+    }
+  }
+
+  it("shows an elapsed counter next to the spinner while the block is running", () => {
+    withFakeClock(7_000, () => {
+      render(<NodeStatusSurface status="running" runStartedAt={START} />);
+      expect(screen.getByTestId("node-status-elapsed").textContent).toBe("7s");
+    });
+  });
+
+  it("counts up once a second while running", () => {
+    withFakeClock(0, () => {
+      render(<NodeStatusSurface status="running" runStartedAt={START} />);
+      expect(screen.getByTestId("node-status-elapsed").textContent).toBe("0s");
+      act(() => {
+        vi.advanceTimersByTime(3_000);
+      });
+      expect(screen.getByTestId("node-status-elapsed").textContent).toBe("3s");
+    });
+  });
+
+  it("switches to m:ss and h:mm:ss as the run gets longer", () => {
+    withFakeClock(65_000, () => {
+      const { unmount } = render(<NodeStatusSurface status="running" runStartedAt={START} />);
+      expect(screen.getByTestId("node-status-elapsed").textContent).toBe("1:05");
+      unmount();
+    });
+    withFakeClock(3_849_000, () => {
+      render(<NodeStatusSurface status="running" runStartedAt={START} />);
+      expect(screen.getByTestId("node-status-elapsed").textContent).toBe("1:04:09");
+    });
+  });
+
+  it("removes the counter when the block finishes, leaving no final duration", () => {
+    withFakeClock(9_000, () => {
+      const { rerender } = render(<NodeStatusSurface status="running" runStartedAt={START} />);
+      expect(screen.getByTestId("node-status-elapsed")).toBeInTheDocument();
+      // The store drops `runStartedAt` with the running state (see
+      // `nextBlockRunStarts`), so the done node carries no timer at all.
+      rerender(<NodeStatusSurface status="done" />);
+      expect(screen.queryByTestId("node-status-elapsed")).toBeNull();
+      expect(screen.getByTestId("node-status-surface").getAttribute("data-icon")).toBe("check");
+    });
+  });
+
+  it("shows no counter for non-running states or when no start time is known", () => {
+    withFakeClock(5_000, () => {
+      const { unmount } = render(<NodeStatusSurface status="idle" runStartedAt={START} />);
+      expect(screen.queryByTestId("node-status-elapsed")).toBeNull();
+      unmount();
+      render(<NodeStatusSurface status="running" />);
+      expect(screen.queryByTestId("node-status-elapsed")).toBeNull();
+    });
+  });
+
+  it("shows no counter when an error or warning replaces the running glyph", () => {
+    withFakeClock(5_000, () => {
+      const { unmount } = render(
+        <NodeStatusSurface status="running" problemSeverity="error" runStartedAt={START} />,
+      );
+      expect(screen.queryByTestId("node-status-elapsed")).toBeNull();
+      unmount();
+      render(<NodeStatusSurface status="running" problemSeverity="warning" runStartedAt={START} />);
+      expect(screen.queryByTestId("node-status-elapsed")).toBeNull();
+    });
+  });
+
+  it("renders the counter as a zero-geometry overlay, not a body text row", () => {
+    withFakeClock(2_000, () => {
+      render(<NodeStatusSurface status="running" runStartedAt={START} />);
+      const pill = screen.getByTestId("node-status-elapsed");
+      expect(pill.className).toContain("absolute");
+      expect(pill.className).toContain("pointer-events-none");
+    });
+  });
+
+  it("renders the counter on a running BlockNode and drops it when done", () => {
+    withFakeClock(4_000, () => {
+      const { unmount } = renderNode({ status: "running", runStartedAt: START });
+      expect(screen.getByTestId("node-status-elapsed").textContent).toBe("4s");
+      unmount();
+      renderNode({ status: "done" });
+      expect(screen.queryByTestId("node-status-elapsed")).toBeNull();
+    });
   });
 });
 

--- a/frontend/src/store/executionSlice.parts/eventReducer.test.ts
+++ b/frontend/src/store/executionSlice.parts/eventReducer.test.ts
@@ -10,9 +10,11 @@ import {
   extractBlockError,
   maybeAppendErrorLog,
   nextBlockOutputs,
+  nextBlockRunStarts,
   nextBlockStates,
   nextErrorMaps,
   nextIsRunning,
+  resolveRunStartedAt,
   summarizeErrorText,
 } from "./eventReducer";
 
@@ -101,6 +103,75 @@ describe("eventReducer helpers", () => {
     it("returns current when no block_id", () => {
       const current = { existing: "running" };
       expect(nextBlockStates(makeEvent({ block_id: null }), current)).toBe(current);
+    });
+  });
+
+  // #1974 — the node's elapsed counter is anchored to the engine's
+  // block_running timestamp and must vanish the moment the block stops.
+  describe("resolveRunStartedAt", () => {
+    it("uses the engine event timestamp as the run start", () => {
+      const now = Date.parse("2026-05-22T00:00:30Z");
+      expect(resolveRunStartedAt("2026-05-22T00:00:00Z", now)).toBe(
+        Date.parse("2026-05-22T00:00:00Z"),
+      );
+    });
+
+    it("falls back to the client clock when the timestamp is missing or unparsable", () => {
+      const now = 1_700_000_000_000;
+      expect(resolveRunStartedAt(undefined, now)).toBe(now);
+      expect(resolveRunStartedAt("not-a-timestamp", now)).toBe(now);
+    });
+
+    it("falls back to the client clock when the engine clock reads ahead", () => {
+      const now = Date.parse("2026-05-22T00:00:00Z");
+      expect(resolveRunStartedAt("2026-05-22T01:00:00Z", now)).toBe(now);
+    });
+  });
+
+  describe("nextBlockRunStarts", () => {
+    it("stamps the run start from the block_running event timestamp", () => {
+      const now = Date.parse("2026-05-22T00:00:05Z");
+      const result = nextBlockRunStarts(makeEvent({ type: "block_running" }), {}, now);
+      expect(result).toEqual({ "block-1": Date.parse("2026-05-22T00:00:00Z") });
+    });
+
+    it("re-stamps the start when the block enters running again", () => {
+      const now = Date.parse("2026-05-22T00:10:00Z");
+      const result = nextBlockRunStarts(
+        makeEvent({ type: "block_running", timestamp: "2026-05-22T00:09:00Z" }),
+        { "block-1": Date.parse("2026-05-22T00:00:00Z") },
+        now,
+      );
+      expect(result).toEqual({ "block-1": Date.parse("2026-05-22T00:09:00Z") });
+    });
+
+    it("drops the entry when the block finishes so no duration is retained", () => {
+      const started = { "block-1": Date.parse("2026-05-22T00:00:00Z") };
+      for (const type of [
+        "block_done",
+        "block_error",
+        "block_cancelled",
+        "block_skipped",
+        "block_paused",
+      ]) {
+        expect(nextBlockRunStarts(makeEvent({ type }), started)).toEqual({});
+      }
+    });
+
+    it("leaves other blocks' run starts untouched", () => {
+      const started = { "block-2": 1_700_000_000_000 };
+      expect(nextBlockRunStarts(makeEvent({ type: "block_done" }), started)).toBe(started);
+      expect(
+        nextBlockRunStarts(makeEvent({ type: "block_done", block_id: "block-2" }), started),
+      ).toEqual({});
+    });
+
+    it("returns current when the event carries no block_id", () => {
+      const current = { "block-1": 1_700_000_000_000 };
+      expect(
+        nextBlockRunStarts(makeEvent({ type: "workflow_completed", block_id: null }), current),
+      ).toBe(current);
+      expect(nextBlockRunStarts(makeEvent({ block_id: null }), current)).toBe(current);
     });
   });
 

--- a/frontend/src/store/executionSlice.parts/eventReducer.ts
+++ b/frontend/src/store/executionSlice.parts/eventReducer.ts
@@ -67,6 +67,50 @@ export function nextBlockStates(
   };
 }
 
+/**
+ * Resolve the instant a block entered the running state (#1974).
+ *
+ * The engine stamps every event with its own clock (`EngineEvent.timestamp`,
+ * serialised by `api/ws.py`), so the backend stays the source of runtime truth
+ * and the node's elapsed counter is anchored to when the block ACTUALLY
+ * started, not to when this client happened to render the transition.
+ *
+ * Falls back to the client's receive time when the payload carries no parsable
+ * timestamp, or when the engine clock reads ahead of this client's (a remote
+ * engine with skewed clocks would otherwise produce a negative elapsed time).
+ */
+export function resolveRunStartedAt(rawTimestamp: string | undefined, now: number): number {
+  if (!rawTimestamp) return now;
+  const parsed = Date.parse(rawTimestamp);
+  if (Number.isNaN(parsed) || parsed > now) return now;
+  return parsed;
+}
+
+/**
+ * Track the start instant of the CURRENT run of each block (#1974).
+ *
+ * The map holds an entry only while a block is running: `block_running` stamps
+ * it, and any later event for that block (done / error / cancelled / skipped /
+ * paused / ready / interactive prompt) drops it. That keeps the entry in
+ * lockstep with `nextBlockStates` — an entry exists exactly while the node's
+ * status surface shows the running spinner — so no final duration and no run
+ * history survive on the node.
+ */
+export function nextBlockRunStarts(
+  event: ExecutionEvent,
+  current: Record<string, number>,
+  now: number = Date.now(),
+): Record<string, number> {
+  if (!event.block_id) return current;
+  if (event.type === "block_running") {
+    return { ...current, [event.block_id]: resolveRunStartedAt(event.timestamp, now) };
+  }
+  if (!(event.block_id in current)) return current;
+  const next = { ...current };
+  delete next[event.block_id];
+  return next;
+}
+
 /** Merge an outputs payload into the existing per-block outputs map. */
 export function nextBlockOutputs(
   event: ExecutionEvent,

--- a/frontend/src/store/executionSlice.ts
+++ b/frontend/src/store/executionSlice.ts
@@ -5,6 +5,7 @@ import {
   extractBlockError,
   maybeAppendErrorLog,
   nextBlockOutputs,
+  nextBlockRunStarts,
   nextBlockStates,
   nextErrorMaps,
   nextIsRunning,
@@ -12,6 +13,7 @@ import {
 
 export const createExecutionSlice: StateCreator<AppStore, [], [], ExecutionSlice> = (set) => ({
   blockStates: {},
+  blockRunStartedAt: {},
   blockOutputs: {},
   blockErrors: {},
   blockErrorSummaries: {},
@@ -39,6 +41,7 @@ export const createExecutionSlice: StateCreator<AppStore, [], [], ExecutionSlice
 
       return {
         blockStates: nextBlockStates(event, state.blockStates),
+        blockRunStartedAt: nextBlockRunStarts(event, state.blockRunStartedAt),
         blockOutputs: nextBlockOutputs(event, state.blockOutputs),
         blockErrors: nextErrors,
         blockErrorSummaries: nextSummaries,
@@ -66,6 +69,7 @@ export const createExecutionSlice: StateCreator<AppStore, [], [], ExecutionSlice
   resetExecution: () =>
     set({
       blockStates: {},
+      blockRunStartedAt: {},
       blockOutputs: {},
       blockErrors: {},
       blockErrorSummaries: {},

--- a/frontend/src/store/types.ts
+++ b/frontend/src/store/types.ts
@@ -227,6 +227,14 @@ export interface InteractivePrompt {
 
 export interface ExecutionSlice {
   blockStates: Record<string, string>;
+  /**
+   * #1974 — epoch-ms instant at which each block entered the running state,
+   * taken from the `block_running` event's engine timestamp. An entry exists
+   * ONLY while the block is running (any later event for that block drops it),
+   * so the node's elapsed counter vanishes when the run ends and no previous
+   * run's duration is retained.
+   */
+  blockRunStartedAt: Record<string, number>;
   blockOutputs: Record<string, Record<string, unknown>>;
   blockErrors: Record<string, string>;
   blockErrorSummaries: Record<string, string>;

--- a/frontend/src/testUtils.ts
+++ b/frontend/src/testUtils.ts
@@ -17,6 +17,7 @@ export function resetAppStore() {
     workflowHistory: [],
     workflowFuture: [],
     blockStates: {},
+    blockRunStartedAt: {},
     blockOutputs: {},
     executionMessages: [],
     logEntries: [],

--- a/frontend/src/types/ui.ts
+++ b/frontend/src/types/ui.ts
@@ -30,6 +30,14 @@ export interface BlockNodeData extends Record<string, unknown> {
   inputPorts: BlockPortResponse[];
   outputPorts: BlockPortResponse[];
   status?: string;
+  /**
+   * #1974 — epoch-ms instant at which this block entered the running state,
+   * sourced from the `block_running` engine event. Set ONLY while the block is
+   * running; `NodeStatusSurface` renders a transient elapsed-time counter
+   * beside the running spinner and drops it as soon as this is undefined.
+   * Never persisted, never a final duration, never a run history.
+   */
+  runStartedAt?: number;
   /** Short error message populated when status is 'error'. Sourced from the
    *  BLOCK_ERROR WebSocket event's \`data.error\` field. Surfaced ONLY through
    *  the unified `NodeStatusSurface` (ADR-050 §2.5); never rendered as inline


### PR DESCRIPTION
## Summary

While a block is running, the canvas node now shows how long it has been
running, next to the spinner on the ADR-050 §2.5 status surface.

- The counter appears when the block enters the running state and counts up:
  `7s` under a minute, `1:05` under an hour, `1:04:09` beyond it.
- It disappears when the block finishes. No final duration is left on the node,
  and no history of previous runs is shown (owner-decided behaviour, #1974).

## Where the start time comes from, and why

The start instant is the **engine's `block_running` event timestamp**, kept in
the execution store as a new `blockRunStartedAt` map — the first of the two
options in the issue. Reasons:

1. **Backend stays the source of runtime truth.** "When did this block start
   running" is runtime state that the engine already knows and already emits;
   `AGENTS.md` §3.5 explicitly forbids putting runtime truth in frontend state.
   A frontend-stamped transition would invent that fact locally and drift by the
   websocket delivery + React render latency.
2. **No backend change was needed.** Every event already carries an ISO
   timestamp (`EngineEvent.timestamp`, serialised in `api/ws.py`), so this
   option turned out to be as cheap as the frontend stamp — it is a reducer
   helper plus one store field, not a new event field.
3. **A store-held start survives node remounts.** A component-local stamp resets
   to `0s` whenever the node component remounts mid-run (canvas re-render, view
   switch, expanding/collapsing a subworkflow), which would read as "the block
   restarted". The store keeps the start for as long as the block runs.

Clock skew is handled defensively: `resolveRunStartedAt` falls back to the
client clock when the timestamp is missing, unparsable, or reads *ahead* of the
client (a remote engine with a skewed clock would otherwise produce a negative
elapsed time), and the rendered value is clamped at zero.

## How it stays inside ADR-050 §2.5

- The counter is an absolutely-positioned overlay beside the corner badge, like
  the badge itself: node width and height are unchanged (FR-004/FR-011). It is
  not a status footer, an inline text row, or a chip inside the node body.
- It is bound to the **spinner**, not to the raw status string: an error or
  warning surface replaces the running glyph per the §2.5 priority table, and in
  that case no timer is shown.
- It is transient. `nextBlockRunStarts` drops a block's entry on the first
  non-running event for that block, so the map holds an entry exactly while the
  node spins — no persisted duration, no run history.

## Changes

- `frontend/src/store/executionSlice.parts/eventReducer.ts` — new
  `resolveRunStartedAt` + `nextBlockRunStarts` pure helpers.
- `frontend/src/store/executionSlice.ts`, `store/types.ts`, `testUtils.ts` —
  `blockRunStartedAt` state, wired into `consumeEvent` and `resetExecution`.
- `frontend/src/components/WorkflowCanvas.tsx` — reads the map straight from the
  store (same precedent as `highlightedNodeId`, so it is not threaded through
  `ProjectWorkspace`), then `useFlowNodes` → `flowNodeBuilder` →
  `BlockNodeData.runStartedAt` → `BlockNode` → `NodeStatusSurface`.
- `frontend/src/components/nodes/BlockNode.parts/NodeStatusSurface.tsx` — the
  elapsed pill, its 1 Hz tick (torn down on any non-running state), and the
  `formatElapsed` rendering.

## Tests

`frontend/src/store/executionSlice.parts/eventReducer.test.ts`

- `resolveRunStartedAt` — uses the engine event timestamp; falls back to the
  client clock when missing/unparsable; falls back when the engine clock reads
  ahead.
- `nextBlockRunStarts` — stamps from `block_running`; re-stamps on re-entry;
  drops the entry on done/error/cancelled/skipped/paused; leaves other blocks
  untouched; passes through when there is no `block_id`.

`frontend/src/components/nodes/__tests__/BlockNode/statusSurface.test.tsx`

- shows an elapsed counter next to the spinner while the block is running
- counts up once a second while running
- switches to m:ss and h:mm:ss as the run gets longer
- removes the counter when the block finishes, leaving no final duration
- shows no counter for non-running states or when no start time is known
- shows no counter when an error or warning replaces the running glyph
- renders the counter as a zero-geometry overlay, not a body text row
- renders the counter on a running BlockNode and drops it when done

Full frontend suite: 1072 tests passing. Gate `check` (tier 1) passed the full
merge-blocking mirror, including `frontend` (`npm run check:ci`) and
`python_tests`.

## Docs

`CHANGELOG.md` under Unreleased → Added. ADR-050 and its spec are unchanged and
recorded as N/A in the gate ledger: the decision itself is untouched (the node
body grows no rows and node geometry is fixed), and comparable node-UI additions
(#1799 highlight ring, #1887 hover detail popover) were CHANGELOG-only too.

Gate record: `.workflow/records/1974-node-elapsed-timer.json`

Closes #1974

🤖 Generated with [Claude Code](https://claude.com/claude-code)
