### PR TITLE
fix(#1971,#1972,#1973): make block output reach the people debugging it

### DIFF
--- a/.workflow/records/1971-block-log-observability.json
+++ b/.workflow/records/1971-block-log-observability.json
@@ -1,8 +1,173 @@
 {
   "branch": "guided/1971-block-log-observability",
-  "check_events": [],
+  "check_events": [
+    {
+      "at": "2026-07-29T22:01:32.263213Z",
+      "command": "pytest tests/architecture/ -v --no-cov",
+      "covered_surface": "architecture",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:f26522bb0229e21c6e1558e89fd3728d57a98b7dfd2c8d7789b78d415da2a8f4",
+      "name": "architecture_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/architecture_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-29T22:01:33.166857Z",
+      "command": "python scripts/deferral_scan.py --check docs/audit/baselines/deferral-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:eae0c9272b2d138f30ea14117017ed8fa4f4a09eebf5e4383ed3a0a17febf867",
+      "name": "deferral_discipline",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/deferral_discipline.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-29T22:01:33.581090Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:6a3cfea0f54989161035f7f77db32068f9665c13e79cb4166dbfa6be50b8cf3a",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-07-29T22:01:38.603565Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:7129f855c84841e2b25a678f50da871aff25073dbb3709051d46c76737d073f5",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-29T22:01:39.667358Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:c6587ef8b1e97fbda0b36983cc6119e0e9740629812bb1b45264e0b554ab50ae",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-29T22:01:39.731656Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:15d21fea87e3415235c4d9a8635f0db6e272a12751d028cecbee816b6c10db2c",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-07-29T22:03:49.559410Z",
+      "command": "python -m scistudio.qa.testing.run_python_tests --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:a8f2d9a8312b673b6adc9f47180437a1409e23ef12b5b59c78f25ee06ac8bbed",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-29T22:06:00.675396Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:f022e5bc87ee0bbce942812fce55dc33dc88296d0a9cefb04ee96925ae4b0044",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-07-29T22:06:08.523103Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:f3c549887a43eaf5373c7a34aba17a39ba4b84a29c487d36ecd617770520099e",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    },
+    {
+      "at": "2026-07-29T22:06:29.879867Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:6a3cfea0f54989161035f7f77db32068f9665c13e79cb4166dbfa6be50b8cf3a",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    }
+  ],
   "check_na": [],
-  "commit": null,
+  "commit": {
+    "sha": "ad6dc39b58a02656ff4b156cdd5b923e7f884646",
+    "shas": [
+      "ad6dc39b58a02656ff4b156cdd5b923e7f884646"
+    ],
+    "trailers": []
+  },
   "declared_scope": {
     "exclude": [],
     "include": [
@@ -39,7 +204,446 @@
     }
   ],
   "governance_touch": false,
-  "guard_events": [],
+  "guard_events": [
+    {
+      "at": "2026-07-29T22:06:08.611526Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/code/code_block.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/code/code_block.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "error",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/engine/run_logging.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/engine/run_logging.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "error",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/engine/runners/worker.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/engine/runners/worker.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "error",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "fail"
+    },
+    {
+      "at": "2026-07-29T22:06:08.622448Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T22:06:08.633980Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T22:06:08.645263Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T22:06:08.656337Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T22:06:08.667240Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T22:06:08.677875Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T22:06:08.689023Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T22:06:08.699951Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T22:06:08.713484Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T22:06:29.911436Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/code/code_block.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/code/code_block.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "error",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/engine/run_logging.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/engine/run_logging.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "error",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/engine/runners/worker.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/engine/runners/worker.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "error",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "fail"
+    },
+    {
+      "at": "2026-07-29T22:06:29.923397Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T22:06:29.935807Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T22:06:29.948168Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T22:06:29.960410Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T22:06:29.972721Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T22:06:29.984704Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T22:06:29.996570Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T22:06:30.008439Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T22:06:30.022611Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T22:06:49.262056Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/code/code_block.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/code/code_block.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/engine/run_logging.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/engine/run_logging.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/engine/runners/worker.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/engine/runners/worker.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T22:06:49.273746Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T22:06:49.285789Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T22:06:49.297568Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T22:06:49.308815Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T22:06:49.320384Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T22:06:49.332116Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T22:06:49.343540Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T22:06:49.355160Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T22:06:49.369390Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
   "issues": [
     {
       "close_in_pr": true,
@@ -61,19 +665,124 @@
     }
   ],
   "observed_admin_labels": [],
-  "observed_diff": null,
+  "observed_diff": {
+    "base": "origin/main",
+    "base_sha": "6c00d825",
+    "changed_files": [
+      ".workflow/records/1971-block-log-observability.json",
+      "CHANGELOG.md",
+      "docs/specs/alpha-observability-logging.md",
+      "src/scistudio/_skills/scistudio/scistudio-debug-run/SKILL.md",
+      "src/scistudio/ai/agent/mcp/tools_inspection/_models.py",
+      "src/scistudio/ai/agent/mcp/tools_inspection/read.py",
+      "src/scistudio/blocks/code/code_block.py",
+      "src/scistudio/engine/run_logging.py",
+      "src/scistudio/engine/runners/worker.py",
+      "tests/ai/test_mcp_tools_inspection.py",
+      "tests/blocks/code/test_codeblock_execution.py",
+      "tests/engine/test_worker.py"
+    ],
+    "diff_fingerprint": "sha256:288a0aa49f4dc0582c3076a3de571a96fbf8b5addc28d656231ed74d516b6d8d",
+    "head": "HEAD",
+    "head_sha": "ad6dc39b",
+    "surfaces": {
+      "docs": 1,
+      "frontend": 0,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 6,
+      "packaging": 0,
+      "protected_core": 3,
+      "sentrux": 10,
+      "test": 3,
+      "workflow_ci": 0
+    }
+  },
   "owner_directive": "\u540c\u610f \u2014 fix the three chained block-observability defects (print breaks the run, CodeBlock discards script output, get_block_logs reads a layout nothing writes) in one PR",
   "persona": "live_implementer",
-  "pull_request": null,
-  "reconcile_events": [],
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [
+      1971,
+      1972,
+      1973
+    ],
+    "number": null,
+    "url": null
+  },
+  "reconcile_events": [
+    {
+      "at": "2026-07-29T22:06:08.713537Z",
+      "diff_fingerprint": "sha256:288a0aa49f4dc0582c3076a3de571a96fbf8b5addc28d656231ed74d516b6d8d",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.format_check",
+        "guard.core_change_guard"
+      ]
+    },
+    {
+      "at": "2026-07-29T22:06:30.022653Z",
+      "diff_fingerprint": "sha256:288a0aa49f4dc0582c3076a3de571a96fbf8b5addc28d656231ed74d516b6d8d",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "guard.core_change_guard"
+      ]
+    },
+    {
+      "at": "2026-07-29T22:06:49.369432Z",
+      "diff_fingerprint": "sha256:288a0aa49f4dc0582c3076a3de571a96fbf8b5addc28d656231ed74d516b6d8d",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    }
+  ],
   "record_id": "1971-block-log-observability",
-  "requested_admin_labels": [],
+  "requested_admin_labels": [
+    {
+      "actor_permission": null,
+      "applied_at": null,
+      "applied_by": null,
+      "name": "admin-approved:core-change"
+    }
+  ],
   "required_obligations": {
-    "admin_labels": [],
-    "checks": [],
-    "docs": [],
-    "guards": [],
-    "tests": []
+    "admin_labels": [
+      "admin-approved:core-change"
+    ],
+    "checks": [
+      "architecture_tests",
+      "deferral_discipline",
+      "format_check",
+      "full_audit",
+      "import_contracts",
+      "lint_format",
+      "python_tests",
+      "semantic_dup",
+      "type_check"
+    ],
+    "docs": [
+      "docs_required_or_na"
+    ],
+    "guards": [
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": [
+      "changed_test_required"
+    ]
   },
   "runtime": "claude-code",
   "schema_version": 2,
@@ -104,7 +813,7 @@
     }
   ],
   "session_id": "1c2e7898-ace7-45dd-8ab9-b1014ce8c142",
-  "strictness_tier": null,
+  "strictness_tier": 1,
   "task_kind": "guided",
   "test_events": [
     {

--- a/.workflow/records/1971-block-log-observability.json
+++ b/.workflow/records/1971-block-log-observability.json
@@ -162,9 +162,9 @@
   ],
   "check_na": [],
   "commit": {
-    "sha": "ad6dc39b58a02656ff4b156cdd5b923e7f884646",
+    "sha": "cdef2de3e54a7da251516fc4ba37b5b9d2fc59f6",
     "shas": [
-      "ad6dc39b58a02656ff4b156cdd5b923e7f884646"
+      "cdef2de3e54a7da251516fc4ba37b5b9d2fc59f6"
     ],
     "trailers": []
   },
@@ -642,6 +642,298 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-07-29T22:07:13.740511Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/code/code_block.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/code/code_block.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/engine/run_logging.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/engine/run_logging.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/engine/runners/worker.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/engine/runners/worker.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T22:07:13.760216Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T22:07:13.775895Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T22:07:13.791816Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T22:07:13.807719Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T22:07:13.822546Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T22:07:13.837734Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T22:07:13.852851Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T22:07:13.869045Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T22:07:13.891281Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T22:07:23.898090Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/code/code_block.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/code/code_block.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/engine/run_logging.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/engine/run_logging.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/engine/runners/worker.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/engine/runners/worker.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T22:07:23.909910Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T22:07:23.922468Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T22:07:23.935647Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T22:07:23.947874Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T22:07:23.959303Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T22:07:23.970453Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T22:07:23.981891Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T22:07:23.994284Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-07-29T22:07:24.011214Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -666,7 +958,7 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "origin/main",
+    "base": "6c00d825718e9f30017a9e73481375552d2c4a0d",
     "base_sha": "6c00d825",
     "changed_files": [
       ".workflow/records/1971-block-log-observability.json",
@@ -682,9 +974,9 @@
       "tests/blocks/code/test_codeblock_execution.py",
       "tests/engine/test_worker.py"
     ],
-    "diff_fingerprint": "sha256:288a0aa49f4dc0582c3076a3de571a96fbf8b5addc28d656231ed74d516b6d8d",
+    "diff_fingerprint": "sha256:92e3c627eb07f98404cd9de072c6c59aa3f8356cb0f4c970b20bf039aa5e8c6e",
     "head": "HEAD",
-    "head_sha": "ad6dc39b",
+    "head_sha": "cdef2de3",
     "surfaces": {
       "docs": 1,
       "frontend": 0,
@@ -707,8 +999,8 @@
       1972,
       1973
     ],
-    "number": null,
-    "url": null
+    "number": 1976,
+    "url": "https://github.com/jiazhenz026/SciStudio/pull/1976"
   },
   "reconcile_events": [
     {
@@ -735,6 +1027,22 @@
     {
       "at": "2026-07-29T22:06:49.369432Z",
       "diff_fingerprint": "sha256:288a0aa49f4dc0582c3076a3de571a96fbf8b5addc28d656231ed74d516b6d8d",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-07-29T22:07:13.891331Z",
+      "diff_fingerprint": "sha256:92e3c627eb07f98404cd9de072c6c59aa3f8356cb0f4c970b20bf039aa5e8c6e",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-07-29T22:07:24.011253Z",
+      "diff_fingerprint": "sha256:92e3c627eb07f98404cd9de072c6c59aa3f8356cb0f4c970b20bf039aa5e8c6e",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 1,

--- a/.workflow/records/1971-block-log-observability.json
+++ b/.workflow/records/1971-block-log-observability.json
@@ -1,0 +1,135 @@
+{
+  "branch": "guided/1971-block-log-observability",
+  "check_events": [],
+  "check_na": [],
+  "commit": null,
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "src/scistudio/engine/runners/worker.py",
+      "src/scistudio/blocks/code/code_block.py",
+      "src/scistudio/ai/agent/mcp/tools_inspection/read.py",
+      "tests/**",
+      "CHANGELOG.md"
+    ]
+  },
+  "directive_events": [
+    {
+      "at": "2026-07-29T21:55:48.467567Z",
+      "owner_directive": "\u8c03\u67e5\u7ed3\u8bba\u786e\u8ba4\u540e\u5b9e\u73b0\uff1a\u4e09\u4e2a\u7f3a\u9677\u4e00\u6761\u94fe\uff0c\u5408\u6210\u4e00\u4e2a PR",
+      "reason": "The fix chain reaches past the three files planned at init: the run-log naming rule is shared with the reader, the tool result gains a source field, and the debug skill plus the observability spec document the new behaviour."
+    }
+  ],
+  "docs_events": [
+    {
+      "at": "2026-07-29T21:55:48.467766Z",
+      "class": null,
+      "kind": "path",
+      "path": "CHANGELOG.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-07-29T21:55:48.467980Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/specs/alpha-observability-logging.md",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": false,
+  "guard_events": [],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1971,
+      "url": null
+    },
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1972,
+      "url": null
+    },
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1973,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": null,
+  "owner_directive": "\u540c\u610f \u2014 fix the three chained block-observability defects (print breaks the run, CodeBlock discards script output, get_block_logs reads a layout nothing writes) in one PR",
+  "persona": "live_implementer",
+  "pull_request": null,
+  "reconcile_events": [],
+  "record_id": "1971-block-log-observability",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [],
+    "docs": [],
+    "guards": [],
+    "tests": []
+  },
+  "runtime": "claude-code",
+  "schema_version": 2,
+  "scope_events": [
+    {
+      "action": "add-include",
+      "at": "2026-07-29T21:55:48.467746Z",
+      "pattern": "src/scistudio/engine/run_logging.py",
+      "reason": "The fix chain reaches past the three files planned at init: the run-log naming rule is shared with the reader, the tool result gains a source field, and the debug skill plus the observability spec document the new behaviour."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-07-29T21:55:48.467753Z",
+      "pattern": "src/scistudio/ai/agent/mcp/tools_inspection/_models.py",
+      "reason": "The fix chain reaches past the three files planned at init: the run-log naming rule is shared with the reader, the tool result gains a source field, and the debug skill plus the observability spec document the new behaviour."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-07-29T21:55:48.467754Z",
+      "pattern": "src/scistudio/_skills/scistudio/scistudio-debug-run/SKILL.md",
+      "reason": "The fix chain reaches past the three files planned at init: the run-log naming rule is shared with the reader, the tool result gains a source field, and the debug skill plus the observability spec document the new behaviour."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-07-29T21:55:48.467756Z",
+      "pattern": "docs/specs/alpha-observability-logging.md",
+      "reason": "The fix chain reaches past the three files planned at init: the run-log naming rule is shared with the reader, the tool result gains a source field, and the debug skill plus the observability spec document the new behaviour."
+    }
+  ],
+  "session_id": "1c2e7898-ace7-45dd-8ab9-b1014ce8c142",
+  "strictness_tier": null,
+  "task_kind": "guided",
+  "test_events": [
+    {
+      "at": "2026-07-29T21:55:48.467989Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/engine/test_worker.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-07-29T21:55:48.467993Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/blocks/code/test_codeblock_execution.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-07-29T21:55:48.467994Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/ai/test_mcp_tools_inspection.py",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- [#1971] A `print()` inside a block's `run()` no longer breaks the run. The
+  worker writes its JSON result envelope to stdout and the engine parses that
+  stream, so anything a block printed landed in front of the envelope and the
+  run failed with `Failed to parse worker output` — pointing at the transport
+  rather than at the print. The worker now claims a private duplicate of stdout
+  for the envelope and redirects its own fd 1 to stderr before running anything
+  block-controlled, which covers `print`, native extensions writing to fd 1, and
+  inherited child processes alike. Block output joins the worker stderr the
+  engine already forwards, so it lands in `run-<run_id>.log` as
+  `worker[<block_id>] ...`. Tests:
+  `tests/engine/test_worker.py::TestWorkerBlockOutputIsolation`.
+  (@claude, 2026-07-29, branch: guided/1971-block-log-observability)
+
+- [#1972] A failing CodeBlock script now reports its own error. The script's
+  captured stdout/stderr were attached to `CodeBlockExecutionError` and read by
+  nothing, so a `ZeroDivisionError` at a known file and line surfaced as
+  `CodeBlock script exited with status 1.` — the only string that reaches
+  `get_run_status().errors` and the GUI. The failure message now carries a tail
+  of the script's stderr, and both streams are persisted to the per-run exchange
+  `logs/` folder (allocated since ADR-041 and empty until now) on success as
+  well as failure. Tests: `tests/blocks/code/test_codeblock_execution.py`.
+  (@claude, 2026-07-29, branch: guided/1971-block-log-observability)
+
+- [#1973] `get_block_logs` returns logs instead of always raising. It read
+  `<project>/logs/<run_id>/<block_id>.stdout`, a layout no code has ever
+  written, so every call raised `KeyError` — while the debug skill instructs the
+  agent to call it for any failed block. Its test wrote the files itself, which
+  is why CI stayed green. It now reads the real artifacts: a Code Block's
+  per-run script logs, or the per-run engine log filtered to the block, with a
+  new `source` field naming which one answered. `run_log_path` is exported from
+  `scistudio.engine.run_logging` so reader and writer share one naming rule.
+  Tests: `tests/ai/test_mcp_tools_inspection.py` now runs a real block and reads
+  its logs back. Docs: the `scistudio-debug-run` skill and
+  `docs/specs/alpha-observability-logging.md` (FR-016 to FR-018).
+  (@claude, 2026-07-29, branch: guided/1971-block-log-observability)
+
 - [#1967] CodeBlock: a project-relative `script_path` no longer fails workflow
   validation at run start. The persisted graph carries no project root — the
   scheduler injects one at dispatch, after validation — so

--- a/docs/specs/alpha-observability-logging.md
+++ b/docs/specs/alpha-observability-logging.md
@@ -200,6 +200,22 @@ containing log files and an environment manifest.
   the file handler persists them (no separate sink).
 - **FR-015**: Logs MUST record metadata only (path/type/size/hash) for scientific
   payloads and MUST support redaction of configured sensitive config fields.
+- **FR-016** (#1971): The block worker's stdout is reserved for the JSON result
+  envelope. The worker MUST claim a private duplicate of it and redirect its own
+  fd 1 to stderr before running anything block-controlled, so a block that
+  writes to stdout — via `print`, a native extension, or an inherited child
+  process — cannot corrupt the envelope. That output MUST reach the per-run log
+  through the stderr the engine already forwards, satisfying FR-008's "worker
+  output" for the stdout half.
+- **FR-017** (#1972): A Code Block MUST persist its script's captured stdout and
+  stderr into the per-run exchange `logs/` folder on success and on failure, and
+  a non-zero exit MUST carry a tail of the script's stderr in the raised error
+  message. Only the message reaches `get_run_status().errors` and the GUI, so an
+  exit status alone is not a reportable failure.
+- **FR-018** (#1973): `get_block_logs` MUST read artifacts the runtime actually
+  produces — the Code Block exchange logs, or the per-run log filtered to the
+  block — and MUST report which one answered. Tests for it MUST exercise a real
+  producer rather than writing the expected files themselves.
 
 ### Key Entities
 

--- a/src/scistudio/_skills/scistudio/scistudio-debug-run/SKILL.md
+++ b/src/scistudio/_skills/scistudio/scistudio-debug-run/SKILL.md
@@ -53,8 +53,17 @@ locate its matching `BlockErrorEntry` in `errors`.
 
 ## 3. `get_block_logs` patterns
 
-`get_block_logs(run_id, block_id)` returns `{stdout: str, stderr: str}`.
-Read both. Common signatures:
+`get_block_logs(run_id, block_id)` returns `{stdout: str, stderr: str,
+source: str}`. Read both streams and check `source`, which says which
+artifact answered:
+
+- `codeblock_exchange` — a Code Block's per-run script logs. A true
+  stdout/stderr split; `stdout` holds whatever the script printed.
+- `run_log` — the per-run engine log filtered to this block. Everything
+  the block wrote arrives in `stderr`; `stdout` is empty by design,
+  because the engine routes block output onto one stream.
+
+Common signatures:
 
 - **`Traceback (most recent call last):`** — Python exception. Find
   the bottom-most line; that names the exception and the offending

--- a/src/scistudio/ai/agent/mcp/tools_inspection/_models.py
+++ b/src/scistudio/ai/agent/mcp/tools_inspection/_models.py
@@ -102,6 +102,14 @@ class GetBlockLogsResult(BaseModel):
     truncated: bool = Field(description="True if either stream was truncated.")
     started_at: str = Field(default="", description="ISO timestamp when the block started.")
     finished_at: str | None = Field(default=None, description="ISO timestamp when the block finished.")
+    source: str = Field(
+        default="",
+        description=(
+            "Which artifact was read: 'codeblock_exchange' for a Code Block's per-run "
+            "script logs (a true stdout/stderr split), or 'run_log' for the per-run "
+            "engine log filtered to this block (delivered in stderr)."
+        ),
+    )
 
 
 __all__ = [

--- a/src/scistudio/ai/agent/mcp/tools_inspection/read.py
+++ b/src/scistudio/ai/agent/mcp/tools_inspection/read.py
@@ -346,21 +346,55 @@ async def get_block_config(
 # ---------------------------------------------------------------------------
 
 
+def _read_tail(path: Path) -> str:
+    """Return the last ``_BLOCK_LOG_TRUNCATE_BYTES`` of *path* as text."""
+    if not path.exists():
+        return ""
+    size = path.stat().st_size
+    if size <= _BLOCK_LOG_TRUNCATE_BYTES:
+        return path.read_text(encoding="utf-8", errors="replace")
+    with path.open("rb") as fh:
+        fh.seek(size - _BLOCK_LOG_TRUNCATE_BYTES)
+        tail = fh.read()
+    return "...\n" + tail.decode("utf-8", errors="replace")
+
+
+def _codeblock_script_logs(project_dir: Path, run_id: str, block_id: str) -> Path | None:
+    """Locate a Code Block's per-run script log folder, if this block is one.
+
+    The exchange layout is ``<exchange_root>/<slug>-<block_id>/<run_id>/logs``
+    (``scistudio.blocks.code.exchange``). ``exchange_root`` defaults to
+    ``<project>/exchange`` and is per-block configurable, so we match any root
+    one level under the project rather than reading every block's config back.
+    """
+    from scistudio.blocks.code.exchange import safe_exchange_name
+
+    safe_block = safe_exchange_name(block_id, fallback="block")
+    safe_run = safe_exchange_name(run_id, fallback="run")
+    for candidate in project_dir.glob(f"*/*-{safe_block}/{safe_run}/logs"):
+        if candidate.is_dir():
+            return candidate
+    return None
+
+
 @mcp.tool(name="get_block_logs", tags={"category:inspection", "read"})
 async def get_block_logs(
     run_id: str = Field(description="Run identifier from run_workflow."),
     block_id: str = Field(description="Block id within the workflow."),
 ) -> GetBlockLogsResult:
-    """Return captured stdout/stderr from a block's execution.
+    """Return captured output from a block's execution.
 
     Use when:
       - A run has failed and the ``errors`` list in ``get_run_status``
         is not enough — you need the block's print/log output.
       - You're diagnosing slow blocks via their stderr.
 
-    Do NOT use to:
-      - Get tracebacks — ``get_run_status`` carries the full traceback
-        in its ``errors`` list.
+    Two artifacts back this, and ``source`` says which one you got. A Code
+    Block's script output is captured per run under the exchange folder and
+    comes back as a true stdout/stderr split (``codeblock_exchange``). Every
+    other block writes into the per-run engine log, which is filtered to this
+    block and returned in ``stderr`` (``run_log``) — the engine routes block
+    output there, so there is no separate stdout stream to report.
 
     Tails are truncated to 16 KiB per stream to keep MCP frames small.
     """
@@ -369,34 +403,45 @@ async def get_block_logs(
     if project_dir is None:
         raise RuntimeError("No project is currently open")
 
-    log_root = project_dir / "logs" / run_id
-    stdout_path = log_root / f"{block_id}.stdout"
-    stderr_path = log_root / f"{block_id}.stderr"
-    if not log_root.exists():
-        raise KeyError(f"No log directory for run '{run_id}'")
+    script_logs = _codeblock_script_logs(project_dir, run_id, block_id)
+    if script_logs is not None:
+        from scistudio.blocks.code.code_block import (
+            SCRIPT_STDERR_LOG_NAME,
+            SCRIPT_STDOUT_LOG_NAME,
+        )
 
-    def _read_tail(p: Path) -> str:
-        if not p.exists():
-            return ""
-        size = p.stat().st_size
-        if size <= _BLOCK_LOG_TRUNCATE_BYTES:
-            return p.read_text(encoding="utf-8", errors="replace")
-        with p.open("rb") as fh:
-            fh.seek(size - _BLOCK_LOG_TRUNCATE_BYTES)
-            tail = fh.read()
-        return "...\n" + tail.decode("utf-8", errors="replace")
+        stdout_path = script_logs / SCRIPT_STDOUT_LOG_NAME
+        stderr_path = script_logs / SCRIPT_STDERR_LOG_NAME
+        truncated = any(
+            path.exists() and path.stat().st_size > _BLOCK_LOG_TRUNCATE_BYTES for path in (stdout_path, stderr_path)
+        )
+        return GetBlockLogsResult(
+            stdout=_read_tail(stdout_path),
+            stderr=_read_tail(stderr_path),
+            truncated=truncated,
+            source="codeblock_exchange",
+        )
 
-    truncated = (stdout_path.exists() and stdout_path.stat().st_size > _BLOCK_LOG_TRUNCATE_BYTES) or (
-        stderr_path.exists() and stderr_path.stat().st_size > _BLOCK_LOG_TRUNCATE_BYTES
-    )
+    from scistudio.engine.run_logging import run_log_path
 
-    return GetBlockLogsResult(
-        stdout=_read_tail(stdout_path),
-        stderr=_read_tail(stderr_path),
-        truncated=truncated,
-        started_at="",
-        finished_at=None,
-    )
+    log_path = run_log_path(run_id, project_root=project_dir)
+    if not log_path.exists():
+        raise KeyError(
+            f"No log found for run '{run_id}'. The run log is written while the run "
+            f"executes; check the run id from run_workflow, or use get_run_status "
+            f"for the failure itself."
+        )
+
+    lines = [line for line in log_path.read_text(encoding="utf-8", errors="replace").splitlines() if block_id in line]
+    if not lines:
+        raise KeyError(f"Run '{run_id}' has no log lines for block '{block_id}'")
+
+    text = "\n".join(lines)
+    truncated = len(text.encode("utf-8")) > _BLOCK_LOG_TRUNCATE_BYTES
+    if truncated:
+        text = "...\n" + text.encode("utf-8")[-_BLOCK_LOG_TRUNCATE_BYTES:].decode("utf-8", errors="replace")
+
+    return GetBlockLogsResult(stdout="", stderr=text, truncated=truncated, source="run_log")
 
 
 __all__ = [

--- a/src/scistudio/blocks/code/code_block.py
+++ b/src/scistudio/blocks/code/code_block.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import importlib
 import inspect
 import json
+import logging
 import subprocess
 import uuid
 from collections.abc import Mapping
@@ -94,6 +95,45 @@ from scistudio.core.types.dataframe import DataFrame
 from scistudio.core.types.series import Series
 from scistudio.core.types.text import Text
 from scistudio.stability import provisional
+
+logger = logging.getLogger(__name__)
+
+# #1972: file names for the script's captured output inside the per-run
+# exchange ``logs/`` folder, and how much of stderr is quoted back in the
+# failure message before the reader is pointed at the file.
+SCRIPT_STDOUT_LOG_NAME = "stdout.log"
+SCRIPT_STDERR_LOG_NAME = "stderr.log"
+_SCRIPT_ERROR_TAIL_CHARS = 4000
+
+
+def _write_script_logs(logs_dir: Path, *, stdout: str | None, stderr: str | None) -> None:
+    """Persist a script run's captured output into the exchange ``logs/`` folder.
+
+    Written on success as well as failure: a script that "succeeds wrongly"
+    needs its output just as much as one that crashes. Best-effort — a logging
+    failure never fails a run that otherwise worked.
+    """
+    try:
+        logs_dir.mkdir(parents=True, exist_ok=True)
+        (logs_dir / SCRIPT_STDOUT_LOG_NAME).write_text(stdout or "", encoding="utf-8")
+        (logs_dir / SCRIPT_STDERR_LOG_NAME).write_text(stderr or "", encoding="utf-8")
+    except OSError:
+        logger.warning("Could not write CodeBlock script logs to %s", logs_dir, exc_info=True)
+
+
+def _script_error_tail(stderr: str | None) -> str:
+    """Return the tail of *stderr*, formatted for a failure message.
+
+    #1972: the exit status alone says nothing. The script's traceback — file,
+    line, exception type — is the one thing a reader needs, so it travels with
+    the error instead of waiting in a file nobody knows to open.
+    """
+    text = (stderr or "").strip()
+    if not text:
+        return ""
+    if len(text) > _SCRIPT_ERROR_TAIL_CHARS:
+        text = "...\n" + text[-_SCRIPT_ERROR_TAIL_CHARS:]
+    return f"\n--- script stderr ---\n{text}"
 
 
 @provisional(since="0.3.1")
@@ -391,11 +431,27 @@ class CodeBlock(Block):
         completed_at: str | None = None
 
         try:
-            completed = backend.run(runtime_context, resolved_interpreter)
+            try:
+                completed = backend.run(runtime_context, resolved_interpreter)
+            except CodeBlockTimeoutError as timeout_exc:
+                # #1972: a timed-out script produced output right up to the
+                # deadline, and that output is usually where the hang shows.
+                _write_script_logs(
+                    manifest.layout.logs_dir,
+                    stdout=timeout_exc.stdout,
+                    stderr=timeout_exc.stderr,
+                )
+                raise
             self.last_process = completed
+            _write_script_logs(
+                manifest.layout.logs_dir,
+                stdout=completed.stdout,
+                stderr=completed.stderr,
+            )
             if completed.returncode != 0:
                 raise CodeBlockExecutionError(
-                    f"CodeBlock script exited with status {completed.returncode}.",
+                    f"CodeBlock script exited with status {completed.returncode}."
+                    f"{_script_error_tail(completed.stderr)}",
                     returncode=completed.returncode,
                     stdout=completed.stdout,
                     stderr=completed.stderr,

--- a/src/scistudio/engine/run_logging.py
+++ b/src/scistudio/engine/run_logging.py
@@ -42,6 +42,15 @@ class _RunFilter(logging.Filter):
         return current == self._run_id
 
 
+def run_log_path(run_id: object, *, project_root: str | Path | None = None) -> Path:
+    """Return the per-run log file for *run_id* (whether or not it exists yet).
+
+    #1973: readers need the same answer the writer uses, so the naming rule
+    lives here rather than being restated at every call site.
+    """
+    return resolve_log_dir(project_root=project_root) / f"run-{_safe_run_id(run_id)}.log"
+
+
 def attach_run_logger(
     run_id: object,
     *,
@@ -50,9 +59,8 @@ def attach_run_logger(
 ) -> logging.Handler | None:
     """Install a per-run file handler on the root logger; return it (or None)."""
     try:
-        log_dir = resolve_log_dir(project_root=project_root)
-        log_dir.mkdir(parents=True, exist_ok=True)
-        path = log_dir / f"run-{_safe_run_id(run_id)}.log"
+        path = run_log_path(run_id, project_root=project_root)
+        path.parent.mkdir(parents=True, exist_ok=True)
         handler = logging.FileHandler(path, encoding="utf-8")
         handler.setLevel(level)
         handler.setFormatter(HumanFormatter())
@@ -99,4 +107,4 @@ def run_log_context(
         run_id_var.reset(token)
 
 
-__all__ = ["attach_run_logger", "detach_run_logger", "run_log_context"]
+__all__ = ["attach_run_logger", "detach_run_logger", "run_log_context", "run_log_path"]

--- a/src/scistudio/engine/runners/worker.py
+++ b/src/scistudio/engine/runners/worker.py
@@ -26,6 +26,11 @@ Protocol:
     4. Import block class, instantiate, call block.run(inputs, config).
     5. Serialize outputs to wire format and write JSON result to stdout.
     6. On error: serialize traceback, return error payload, exit with code 1.
+
+Stdout is reserved for that JSON envelope, so :func:`main` claims a private
+duplicate of it and redirects the process's own fd 1 to stderr before running
+anything block-controlled (#1971). A block is free to ``print()``; its output
+joins the worker's stderr, which the engine forwards into the per-run log.
 """
 
 from __future__ import annotations
@@ -34,10 +39,11 @@ import importlib
 import importlib.util
 import json
 import logging
+import os
 import sys
 import traceback
 from pathlib import Path
-from typing import Any
+from typing import Any, TextIO
 
 from scistudio.blocks.base.exceptions import BlockCancelledByAppError
 from scistudio.core.storage.errors import StorageReferenceInvalidError
@@ -49,6 +55,42 @@ logger = logging.getLogger(__name__)
 # Bump on a non-backward-compatible change to the engine<->worker JSON contract
 # and pair it with a migration/compat step; stamping is the cheap half done now.
 WIRE_FORMAT_VERSION = 1
+
+# #1971: the private duplicate of the real stdout the envelope is written to.
+# ``main`` installs it; helpers fall back to ``sys.__stdout__`` so a direct
+# in-process call (unit tests) still writes somewhere sensible.
+_ENVELOPE_STREAM: TextIO | None = None
+
+
+def _claim_result_channel() -> TextIO:
+    """Take stdout private for the envelope and point block output at stderr.
+
+    The engine parses this process's stdout as one JSON document
+    (``LocalRunner._spawn_worker``), so anything a block prints lands in front
+    of the envelope and fails the parse — a ``print()`` in ``run()`` used to
+    fail the whole run with ``Failed to parse worker output`` (#1971).
+
+    We duplicate fd 1 for our own use and then point fd 1 itself at fd 2, so
+    output escapes to stderr no matter which layer produced it: Python
+    ``print``, a C extension writing to fd 1, or a child process that inherited
+    it. ``sys.stdout`` is rebound as well so Python-level writes share stderr's
+    buffering instead of racing it. The engine already forwards worker stderr
+    into the per-run log, so block output becomes visible for free.
+    """
+    envelope_fd = os.dup(1)
+    os.dup2(2, 1)
+    sys.stdout = sys.stderr
+    return os.fdopen(envelope_fd, "w", encoding="utf-8")
+
+
+def _emit_envelope(payload: dict[str, Any]) -> None:
+    """Write one JSON envelope to the engine on the private result channel."""
+    stream = _ENVELOPE_STREAM if _ENVELOPE_STREAM is not None else sys.__stdout__
+    if stream is None:  # pragma: no cover - only when the process has no stdout at all
+        raise RuntimeError("worker has no stdout to write its result envelope to")
+    stream.write(json.dumps(payload))
+    stream.write("\n")
+    stream.flush()
 
 
 def _prepend_runtime_import_roots(raw_roots: Any) -> tuple[str, ...]:
@@ -121,13 +163,11 @@ def _emit_storage_error(
     block_id: str | None,
 ) -> None:
     port_name, upstream_block = _storage_error_context(inputs or {}, exc.ref)
-    print(
-        json.dumps(
-            exc.to_payload(
-                block_id=block_id,
-                port_name=port_name,
-                upstream_block=upstream_block,
-            )
+    _emit_envelope(
+        exc.to_payload(
+            block_id=block_id,
+            port_name=port_name,
+            upstream_block=upstream_block,
         )
     )
 
@@ -435,6 +475,13 @@ def main() -> None:
         7. Serialize outputs via the typed wire format.
         8. On exception: write {"error": traceback_str} to stdout, exit 1.
     """
+    global _ENVELOPE_STREAM
+
+    # #1971: claim the result channel before anything the block controls can
+    # run. Everything after this line — imports of block modules included —
+    # writes to stderr if it writes to "stdout" at all.
+    _ENVELOPE_STREAM = _claim_result_channel()
+
     payload: dict[str, Any] = {}
     inputs: dict[str, Any] = {}
     block_id: str | None = None
@@ -543,7 +590,7 @@ def main() -> None:
                 # replayed (skipping the dialog) on a subsequent run.
                 "input_signature": interactive_input_signature(inputs),
             }
-            print(json.dumps(prompt_envelope))
+            _emit_envelope(prompt_envelope)
             return
 
         # #1518 (DSN-2): enforce the documented Block.validate() contract on
@@ -578,7 +625,7 @@ def main() -> None:
                 "environment": env_snapshot.to_dict(),
                 "final_state": "cancelled",
             }
-            print(json.dumps(envelope))
+            _emit_envelope(envelope)
             return
 
         # #1330/#1811: enforce ADR-020 §3 transport contract — wrap bare
@@ -610,12 +657,12 @@ def main() -> None:
         result = serialise_outputs(outputs, output_dir) if isinstance(outputs, dict) else {"_result": str(outputs)}
 
         envelope = {"wire_version": WIRE_FORMAT_VERSION, "outputs": result, "environment": env_snapshot.to_dict()}
-        print(json.dumps(envelope))
+        _emit_envelope(envelope)
     except StorageReferenceInvalidError as exc:
         _emit_storage_error(exc, inputs=inputs, block_id=block_id)
         sys.exit(1)
     except Exception:
-        print(json.dumps({"error": traceback.format_exc()}))
+        _emit_envelope({"error": traceback.format_exc()})
         sys.exit(1)
 
 

--- a/tests/ai/test_mcp_tools_inspection.py
+++ b/tests/ai/test_mcp_tools_inspection.py
@@ -316,12 +316,60 @@ def test_get_block_logs_no_logs_raises(ctx: _StubRuntime, tmp_path: Path) -> Non
         _run(tools_inspection.get_block_logs(run_id="run-x", block_id="block-y"))
 
 
-def test_get_block_logs_happy(ctx: _StubRuntime, tmp_path: Path) -> None:
-    logs = tmp_path / "logs" / "run-1"
-    logs.mkdir(parents=True)
-    (logs / "b1.stdout").write_text("hello\n", encoding="utf-8")
-    (logs / "b1.stderr").write_text("warn\n", encoding="utf-8")
-    out = _run(tools_inspection.get_block_logs(run_id="run-1", block_id="b1"))
-    # out is a GetBlockLogsResult Pydantic model.
-    assert "hello" in out.stdout
-    assert "warn" in out.stderr
+def test_get_block_logs_reads_what_a_code_block_actually_wrote(ctx: _StubRuntime, tmp_path: Path) -> None:
+    """#1973: producer and reader must agree.
+
+    The previous version of this test wrote ``<project>/logs/<run>/<block>.stdout``
+    itself — a layout nothing in the runtime has ever produced — so the tool
+    passed here while raising ``KeyError`` on every real call. This runs a real
+    Code Block and reads its logs back through the tool.
+    """
+    from scistudio.blocks.base.config import BlockConfig
+    from scistudio.blocks.code.code_block import CodeBlock
+
+    scripts = tmp_path / "scripts"
+    scripts.mkdir()
+    (scripts / "chatty.py").write_text(
+        "import sys\nprint('rows: 12')\nprint('a warning', file=sys.stderr)\n",
+        encoding="utf-8",
+    )
+    config = BlockConfig(
+        params={"script_path": "scripts/chatty.py", "project_dir": str(tmp_path)},
+        block_id="code_block-1",
+        workflow_id="main",
+    )
+    CodeBlock().run({}, config)
+
+    run_id = next((tmp_path / "exchange" / "codeblock-code_block-1").iterdir()).name
+    out = _run(tools_inspection.get_block_logs(run_id=run_id, block_id="code_block-1"))
+
+    assert out.source == "codeblock_exchange"
+    assert "rows: 12" in out.stdout
+    assert "a warning" in out.stderr
+
+
+def test_get_block_logs_falls_back_to_the_per_run_engine_log(ctx: _StubRuntime, tmp_path: Path) -> None:
+    """A non-Code block's output reaches the reader through the run log."""
+    import logging
+
+    from scistudio.engine.run_logging import run_log_context
+
+    with run_log_context("run-77", project_root=tmp_path):
+        logging.getLogger("scistudio.test").warning("worker[%s] %s", "segment-1", "loaded 12 rows")
+
+    out = _run(tools_inspection.get_block_logs(run_id="run-77", block_id="segment-1"))
+
+    assert out.source == "run_log"
+    assert "loaded 12 rows" in out.stderr
+
+
+def test_get_block_logs_unknown_block_in_a_real_run_raises(ctx: _StubRuntime, tmp_path: Path) -> None:
+    import logging
+
+    from scistudio.engine.run_logging import run_log_context
+
+    with run_log_context("run-78", project_root=tmp_path):
+        logging.getLogger("scistudio.test").warning("worker[%s] %s", "segment-1", "hello")
+
+    with pytest.raises(KeyError, match="no log lines for block"):
+        _run(tools_inspection.get_block_logs(run_id="run-78", block_id="not-a-block"))

--- a/tests/blocks/code/test_codeblock_execution.py
+++ b/tests/blocks/code/test_codeblock_execution.py
@@ -159,6 +159,54 @@ raise SystemExit(3)
     assert "boom" in exc_info.value.stderr
 
 
+def test_codeblock_failure_message_carries_the_script_error(tmp_path: Path) -> None:
+    """#1972: the exit status alone tells a reader nothing.
+
+    Only the exception *message* survives into ``get_run_status().errors`` and
+    the GUI, so the script's own traceback has to be in it — otherwise the file
+    and line that failed are unreachable without opening a log by hand.
+    """
+    _write_script(tmp_path, "x = 1 / 0\n")
+    block = CodeBlock(config=_block_config(tmp_path, "scripts/script.py"))
+
+    with pytest.raises(CodeBlockExecutionError) as exc_info:
+        block.run({}, block.config)
+
+    message = str(exc_info.value)
+    assert "exited with status 1" in message
+    assert "ZeroDivisionError: division by zero" in message
+    assert "script.py" in message
+
+
+def test_codeblock_writes_script_logs_into_the_exchange_folder(tmp_path: Path) -> None:
+    """#1972: the exchange layout already allocates ``logs/``; fill it."""
+    _write_script(
+        tmp_path,
+        "import sys\nprint('rows: 12')\nprint('a warning', file=sys.stderr)\n",
+    )
+    block = CodeBlock(config=_block_config(tmp_path, "scripts/script.py"))
+
+    block.run({}, block.config)
+
+    assert block.last_exchange_manifest is not None
+    logs_dir = block.last_exchange_manifest.layout.logs_dir
+    assert (logs_dir / "stdout.log").read_text(encoding="utf-8").strip() == "rows: 12"
+    assert "a warning" in (logs_dir / "stderr.log").read_text(encoding="utf-8")
+
+
+def test_codeblock_writes_script_logs_even_when_the_script_fails(tmp_path: Path) -> None:
+    """A failed run is exactly when the output matters most."""
+    _write_script(tmp_path, "import sys\nprint('got here')\nsys.exit(2)\n")
+    block = CodeBlock(config=_block_config(tmp_path, "scripts/script.py"))
+
+    with pytest.raises(CodeBlockExecutionError):
+        block.run({}, block.config)
+
+    assert block.last_exchange_manifest is not None
+    logs_dir = block.last_exchange_manifest.layout.logs_dir
+    assert "got here" in (logs_dir / "stdout.log").read_text(encoding="utf-8")
+
+
 # NOTE: ``test_codeblock_timeout_raises_structured_error`` removed — CodeBlock
 # no longer enforces a wall-clock timeout (``timeout_seconds`` is stripped in
 # ``_persisted_codeblock_config`` so the run always uses ``timeout=None``).

--- a/tests/engine/test_worker.py
+++ b/tests/engine/test_worker.py
@@ -352,6 +352,78 @@ class TestWorkerFinalState:
         assert "final_state" not in parsed
 
 
+class _PrintingStubBlock:
+    """Block that debug-prints from ``run()``, the way a block author would.
+
+    #1971: stdout is the engine's result channel, so an unguarded ``print``
+    used to land in front of the JSON envelope and fail the whole run.
+    """
+
+    def __init__(self, config: object = None) -> None:
+        pass
+
+    def run(self, inputs: dict, config: object) -> dict:
+        import sys
+
+        print("loaded 12 rows")
+        print("about to finish", file=sys.stderr)
+        return {"result": "ok"}
+
+
+class TestWorkerBlockOutputIsolation:
+    """#1971: a block may print; the envelope stays parseable."""
+
+    def _run_worker(self, block_class_path: str) -> tuple[str, str]:
+        """Return ``(stdout, stderr)`` from a real worker subprocess."""
+        import json
+        import os
+        import subprocess
+        import sys
+        from pathlib import Path
+
+        payload = json.dumps(
+            {
+                "block_class": block_class_path,
+                "inputs": {},
+                "config": {},
+                "output_dir": "",
+            }
+        )
+        env = os.environ.copy()
+        repo_src = Path(__file__).resolve().parents[2] / "src"
+        if repo_src.is_dir():
+            env["PYTHONPATH"] = str(repo_src) + os.pathsep + env.get("PYTHONPATH", "")
+        result = subprocess.run(
+            [sys.executable, "-m", "scistudio.engine.runners.worker"],
+            input=payload,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            env=env,
+        )
+        return result.stdout, result.stderr
+
+    def test_printing_block_still_produces_a_parseable_envelope(self) -> None:
+        import json
+
+        stdout, _stderr = self._run_worker("tests.engine.test_worker._PrintingStubBlock")
+        parsed = dict(json.loads(stdout))
+        assert "error" not in parsed, parsed
+        assert parsed["outputs"] == {"result": "ok"}
+
+    def test_block_stdout_is_diverted_to_stderr(self) -> None:
+        """The print is not lost — it joins the stream the engine forwards.
+
+        ``LocalRunner._spawn_worker`` logs every worker stderr line as
+        ``worker[<block_id>] ...``, which is what lands in ``run-<run_id>.log``.
+        """
+        stdout, stderr = self._run_worker("tests.engine.test_worker._PrintingStubBlock")
+        assert "loaded 12 rows" not in stdout, "block output must not pollute the result channel"
+        assert "loaded 12 rows" in stderr
+        # A block writing to stderr directly keeps working as before.
+        assert "about to finish" in stderr
+
+
 class TestWorkerStorageErrors:
     def test_missing_storage_ref_emits_structured_payload(self, tmp_path: Path) -> None:
         import json


### PR DESCRIPTION
## Summary

Three defects in one causal chain, found while investigating a report that
agents debugging a workflow cannot get run logs and have to ask the user to
paste the error by hand.

## 1. A `print()` inside a block's `run()` broke the run (#1971)

The worker writes its JSON result envelope to raw stdout
(`worker.py:print(json.dumps(envelope))`) and the engine parses that stream
(`local.py: json.loads(stdout)`). Nothing redirected `sys.stdout` while
`block.run()` executed, so anything a block printed was prepended to the
envelope. Reproduced through `LocalRunner` — same block, one line difference:

```
with    print("loaded 12 rows")  -> RuntimeError: Failed to parse worker output:
                                    Expecting value: line 1 column 1 (char 0)
without print()                  -> succeeds
```

Print debugging is the first thing a scientist writing a custom block reaches
for, and the error named the worker transport rather than the print.

The worker now duplicates fd 1 for its own envelope use and points fd 1 itself
at fd 2 before running anything block-controlled. Redirecting the file
descriptor rather than just `sys.stdout` also covers a native extension writing
to fd 1 and a child process that inherited it. Block output joins the worker
stderr the engine already forwards, so it reaches `run-<run_id>.log` as
`worker[<block_id>] ...` — which is what FR-008 of the observability spec always
claimed the run log captured.

## 2. CodeBlock discarded the script's error (#1972)

`code_block.py` attached the script's captured output to
`CodeBlockExecutionError` and nothing read it back out:

```
str(exc):    'CodeBlock script exited with status 1.'
exc.stderr:  '...ZeroDivisionError: division by zero' at a named file and line
```

Only the exception message reaches `get_run_status().errors` and the GUI, so
neither a user nor an agent ever saw the file, the line, or the exception type.
The exchange layout has allocated a per-run `logs/` folder since ADR-041 and
published it in the manifest; nothing ever wrote to it.

The failure message now carries a tail of the script's stderr, and both streams
are persisted into that `logs/` folder — on success as well as failure, since a
run that succeeds wrongly needs its output too, and on timeout, where the output
right before the deadline is usually where the hang shows.

## 3. `get_block_logs` read a layout nothing writes (#1973)

```python
log_root = project_dir / "logs" / run_id          # no producer, anywhere
raise KeyError(f"No log directory for run '{run_id}'")
```

Every call raised `KeyError`, while `scistudio-debug-run/SKILL.md` instructs the
agent to always call this tool before diagnosing a failed block. CI stayed green
because the test wrote the `.stdout`/`.stderr` files itself before reading them
— it pinned the reader against a layout with no writer.

It now reads the artifacts the runtime actually produces, and a new `source`
field says which one answered: `codeblock_exchange` for a Code Block's script
logs (a true stdout/stderr split), or `run_log` for the per-run engine log
filtered to the block. `run_log_path` is exported from
`scistudio.engine.run_logging` so the reader and the writer share one naming
rule instead of restating it.

## Testing

- `tests/engine/test_worker.py::TestWorkerBlockOutputIsolation` — a printing
  block through a real worker subprocess: the envelope still parses, and the
  print is found in stderr rather than stdout.
- `tests/blocks/code/test_codeblock_execution.py` — the failure message carries
  the script traceback; the script logs land in the exchange folder on success
  and on failure.
- `tests/ai/test_mcp_tools_inspection.py` — the replacement for the blind spot:
  it runs a real Code Block and reads its logs back through the tool, and covers
  the run-log fallback and the unknown-block error.

Every new test fails on `origin/main` and passes here. The #1971 failure on
`origin/main` was verified separately through `LocalRunner`, since the worker
test resolves its own `src` from the checkout under test.

## Docs

`docs/specs/alpha-observability-logging.md` gains FR-016 to FR-018 pinning all
three behaviours, and the `scistudio-debug-run` skill documents the new result
shape.

Gate record: .workflow/records/1971-block-log-observability.json

Closes #1971
Closes #1972
Closes #1973
