### PR TITLE
fix(#1980): request zarr auto-chunking with chunks=None

### DIFF
--- a/.workflow/records/1980-guided-1980-zarr-auto-chunks.json
+++ b/.workflow/records/1980-guided-1980-zarr-auto-chunks.json
@@ -1,0 +1,118 @@
+{
+  "branch": "guided/1980-zarr-auto-chunks",
+  "check_events": [],
+  "check_na": [],
+  "commit": null,
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "src/scistudio/blocks/base/block.py",
+      "tests/blocks/**"
+    ]
+  },
+  "directive_events": [
+    {
+      "at": "2026-08-05T15:08:08.816671Z",
+      "owner_directive": "\u6388\u6743 admin-approved:core-change\uff08\u8303\u56f4\u4ec5\u9650 persist_array \u7684 chunk \u53c2\u6570\u4fee\u590d\uff09\uff0c\u76f4\u63a5\u505a\u5230\u6700\u540e PR",
+      "reason": "owner authorized the protected-core fix and directed the session through to PR"
+    },
+    {
+      "at": "2026-08-05T15:10:12.291272Z",
+      "owner_directive": "\u4fee\u6389\u6240\u6709 PR \u5728 Python 3.13 \u4e0a\u7684 CI \u5931\u8d25",
+      "reason": "plan"
+    }
+  ],
+  "docs_events": [
+    {
+      "at": "2026-08-05T15:10:12.291767Z",
+      "class": null,
+      "kind": "path",
+      "path": "CHANGELOG.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-05T15:10:12.291799Z",
+      "class": "adr",
+      "kind": "na",
+      "path": null,
+      "rationale": "no architectural decision changes; the persist_array signature, docstring, and chunk-grid behavior are all unchanged",
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-05T15:10:12.291807Z",
+      "class": "spec",
+      "kind": "na",
+      "path": null,
+      "rationale": "internal call-site correction to a zarr argument spelling; no contract, schema, storage, or API behavior change",
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": false,
+  "guard_events": [],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1980,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": null,
+  "owner_directive": "\u5f53\u524d\u6240\u6709\u7684PR\u90fd\u5728python3.13 fail\uff0c\u6211\u6000\u7591\u662f\u4e3b\u4ed3\u5e93\u7684\u95ee\u9898\u3002\u8c03\u67e5\u4e00\u4e0b\u7136\u540e\u4fee\u6389\u3002",
+  "persona": "live_implementer",
+  "pull_request": null,
+  "reconcile_events": [],
+  "record_id": "1980-guided-1980-zarr-auto-chunks",
+  "requested_admin_labels": [
+    {
+      "actor_permission": null,
+      "applied_at": null,
+      "applied_by": null,
+      "name": "admin-approved:core-change"
+    }
+  ],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [],
+    "docs": [],
+    "guards": [],
+    "tests": []
+  },
+  "runtime": "claude",
+  "schema_version": 2,
+  "scope_events": [
+    {
+      "action": "add-include",
+      "at": "2026-08-05T15:10:12.291544Z",
+      "pattern": "src/scistudio/blocks/base/block.py",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-05T15:10:12.291577Z",
+      "pattern": "tests/blocks/test_block_base.py",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-05T15:10:12.291581Z",
+      "pattern": "CHANGELOG.md",
+      "reason": "plan"
+    }
+  ],
+  "session_id": "ce934bf4-df5e-4898-a0af-54ae8801327b",
+  "strictness_tier": null,
+  "task_kind": "guided",
+  "test_events": [
+    {
+      "at": "2026-08-05T15:10:12.291813Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/blocks/test_block_base.py",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/.workflow/records/1980-guided-1980-zarr-auto-chunks.json
+++ b/.workflow/records/1980-guided-1980-zarr-auto-chunks.json
@@ -319,7 +319,13 @@
     }
   ],
   "check_na": [],
-  "commit": null,
+  "commit": {
+    "sha": "a62bf2ee575c2b6005f8fa0f135b3da8197fdcef",
+    "shas": [
+      "a62bf2ee575c2b6005f8fa0f135b3da8197fdcef"
+    ],
+    "trailers": []
+  },
   "declared_scope": {
     "exclude": [],
     "include": [
@@ -705,6 +711,214 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-08-05T16:12:34.515668Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/base/block.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/base/block.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T16:12:34.526664Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T16:12:34.537920Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T16:12:34.550431Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T16:12:34.560724Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T16:12:34.571300Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T16:12:34.582078Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T16:12:34.592625Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T16:12:34.603061Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T16:12:34.616511Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T16:13:08.455477Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/base/block.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/base/block.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T16:13:08.467610Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T16:13:08.479754Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T16:13:08.491774Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T16:13:08.503892Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T16:13:08.515657Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T16:13:08.528185Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T16:13:08.542247Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T16:13:08.554391Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T16:13:08.568661Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -717,7 +931,7 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "origin/main",
+    "base": "7fe4f65f7015ce2fa97bb475a8e9ed2841a1c3c4",
     "base_sha": "7fe4f65f",
     "changed_files": [
       ".workflow/records/1980-guided-1980-zarr-auto-chunks.json",
@@ -725,9 +939,9 @@
       "src/scistudio/blocks/base/block.py",
       "tests/blocks/test_block_base.py"
     ],
-    "diff_fingerprint": "sha256:53cac95725517643e67ff05297c9474ca891a083959251f17b8b8061b0741a1c",
+    "diff_fingerprint": "sha256:a03b43504bd0cde4146a2da83dba57c657757643164198511cd92952bb0ab308",
     "head": "HEAD",
-    "head_sha": "c2a115a1",
+    "head_sha": "a62bf2ee",
     "surfaces": {
       "docs": 0,
       "frontend": 0,
@@ -743,7 +957,14 @@
   },
   "owner_directive": "\u5f53\u524d\u6240\u6709\u7684PR\u90fd\u5728python3.13 fail\uff0c\u6211\u6000\u7591\u662f\u4e3b\u4ed3\u5e93\u7684\u95ee\u9898\u3002\u8c03\u67e5\u4e00\u4e0b\u7136\u540e\u4fee\u6389\u3002",
   "persona": "live_implementer",
-  "pull_request": null,
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [
+      1980
+    ],
+    "number": 1982,
+    "url": null
+  },
   "reconcile_events": [
     {
       "at": "2026-08-05T15:20:41.708177Z",
@@ -770,6 +991,26 @@
     {
       "at": "2026-08-05T15:51:07.441169Z",
       "diff_fingerprint": "sha256:53cac95725517643e67ff05297c9474ca891a083959251f17b8b8061b0741a1c",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.format_check"
+      ]
+    },
+    {
+      "at": "2026-08-05T16:12:34.616555Z",
+      "diff_fingerprint": "sha256:a03b43504bd0cde4146a2da83dba57c657757643164198511cd92952bb0ab308",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.format_check"
+      ]
+    },
+    {
+      "at": "2026-08-05T16:13:08.568710Z",
+      "diff_fingerprint": "sha256:a03b43504bd0cde4146a2da83dba57c657757643164198511cd92952bb0ab308",
       "mode": "pre-pr",
       "result": "fail",
       "tier": 1,

--- a/.workflow/records/1980-guided-1980-zarr-auto-chunks.json
+++ b/.workflow/records/1980-guided-1980-zarr-auto-chunks.json
@@ -141,6 +141,181 @@
       "tool_versions": {
         "mypy": "2.1.0"
       }
+    },
+    {
+      "at": "2026-08-05T15:36:25.970481Z",
+      "command": "python scripts/deferral_scan.py --check docs/audit/baselines/deferral-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:036fd60df9398916ef528bde38177d2c81a9e64927e1c03a4eff0245a68e8e5d",
+      "name": "deferral_discipline",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/deferral_discipline.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-05T15:36:26.154403Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:2a3954937702acf801c844566ae58e89a4d7c1fc51fc355095a3f05b6c547bb0",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-05T15:36:32.278834Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:c36031ac19218556c709caec446e372d0bb0932ccf700a243411f471cdcf7e0e",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-05T15:36:32.528080Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:a9ff44ca0a05d21db8b65f4588c18f4a392755a399dfd1e970195b107bafcca3",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-05T15:36:32.553740Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:24b0837ea29befadc97546b4569841bafd21de49ad23c79e74a22865f68fdda0",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-05T15:40:28.992108Z",
+      "command": "python -m scistudio.qa.testing.run_python_tests --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:aa0a177e6146935613ba7560c0e04edcb8c058f3234f7f33a081c6d1a60e087e",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-05T15:44:23.724531Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:a12ab9db5a9fdeff4e6d9743683fd05262ecd3b0f42c279dab4e96090271845d",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-05T15:44:47.908670Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:829f5b2c51efc06b3792767d8feec11c989e9879a1036797fc29848ce00bffb9",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    },
+    {
+      "at": "2026-08-05T15:47:04.164959Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:2a3954937702acf801c844566ae58e89a4d7c1fc51fc355095a3f05b6c547bb0",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-05T15:50:56.665910Z",
+      "command": "python -m scistudio.qa.testing.run_python_tests --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:aa0a177e6146935613ba7560c0e04edcb8c058f3234f7f33a081c6d1a60e087e",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-05T15:51:06.980323Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:829f5b2c51efc06b3792767d8feec11c989e9879a1036797fc29848ce00bffb9",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
     }
   ],
   "check_na": [],
@@ -162,6 +337,11 @@
       "at": "2026-08-05T15:10:12.291272Z",
       "owner_directive": "\u4fee\u6389\u6240\u6709 PR \u5728 Python 3.13 \u4e0a\u7684 CI \u5931\u8d25",
       "reason": "plan"
+    },
+    {
+      "at": "2026-08-05T16:12:03.973631Z",
+      "owner_directive": "B \u2014 \u53ea\u4fee zarr\uff0cruff pin \u6f02\u79fb\u53e6\u5f00 issue\uff08#1981\uff09\uff0c\u8fd9\u4e2a PR \u7528 SCISTUDIO_SKIP_PREFLIGHT=1 \u8fc7\u672c\u5730 preflight \u5e76\u5728 PR body \u5199\u660e",
+      "reason": "owner chose option B: keep this PR scoped to the zarr fix; the local format_check blocker is gate-environment drift tracked separately"
     }
   ],
   "docs_events": [
@@ -295,6 +475,236 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-08-05T15:27:45.101588Z",
+      "findings": [
+        {
+          "message": "AI-authored edits must happen in a dedicated worktree, not the main working tree (/private/tmp/pytest-of-jiazhenz/pytest-13/popen-gw10/test_hook_payload_blocks_main_0/main). Create one with `git worktree add ../<name> <branch>` and run your edits there.",
+          "rule_id": "worktree.main-checkout-write"
+        }
+      ],
+      "guard": "worktree_write_guard",
+      "status": "fail"
+    },
+    {
+      "at": "2026-08-05T15:27:50.373085Z",
+      "findings": [
+        {
+          "message": "AI-authored edits must happen in a dedicated worktree, not the main working tree (/private/tmp/pytest-of-jiazhenz/pytest-13/popen-gw3/test_hook_payload_extracts_mul0/main). Create one with `git worktree add ../<name> <branch>` and run your edits there.",
+          "rule_id": "worktree.main-checkout-write"
+        }
+      ],
+      "guard": "worktree_write_guard",
+      "status": "fail"
+    },
+    {
+      "at": "2026-08-05T15:44:48.020959Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/base/block.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/base/block.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T15:44:48.033045Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T15:44:48.046988Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T15:44:48.059428Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T15:44:48.071165Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T15:44:48.083853Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T15:44:48.095646Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T15:44:48.107766Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T15:44:48.119312Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T15:44:48.133990Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T15:51:07.285886Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/base/block.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/base/block.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T15:51:07.301345Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T15:51:07.315455Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T15:51:07.335226Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T15:51:07.349448Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T15:51:07.365917Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T15:51:07.381716Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T15:51:07.397294Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T15:51:07.411357Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T15:51:07.441126Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -308,16 +718,16 @@
   "observed_admin_labels": [],
   "observed_diff": {
     "base": "origin/main",
-    "base_sha": "6c00d825",
+    "base_sha": "7fe4f65f",
     "changed_files": [
       ".workflow/records/1980-guided-1980-zarr-auto-chunks.json",
       "CHANGELOG.md",
       "src/scistudio/blocks/base/block.py",
       "tests/blocks/test_block_base.py"
     ],
-    "diff_fingerprint": "sha256:2878264f965ccd6a108bc8121630cccc37f7e3ddabe70429e92a6a49ff88a0cc",
+    "diff_fingerprint": "sha256:53cac95725517643e67ff05297c9474ca891a083959251f17b8b8061b0741a1c",
     "head": "HEAD",
-    "head_sha": "c98dc4c0",
+    "head_sha": "c2a115a1",
     "surfaces": {
       "docs": 0,
       "frontend": 0,
@@ -338,6 +748,28 @@
     {
       "at": "2026-08-05T15:20:41.708177Z",
       "diff_fingerprint": "sha256:2878264f965ccd6a108bc8121630cccc37f7e3ddabe70429e92a6a49ff88a0cc",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.format_check"
+      ]
+    },
+    {
+      "at": "2026-08-05T15:44:48.134256Z",
+      "diff_fingerprint": "sha256:53cac95725517643e67ff05297c9474ca891a083959251f17b8b8061b0741a1c",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.format_check",
+        "checks.python_tests",
+        "checks.type_check"
+      ]
+    },
+    {
+      "at": "2026-08-05T15:51:07.441169Z",
+      "diff_fingerprint": "sha256:53cac95725517643e67ff05297c9474ca891a083959251f17b8b8061b0741a1c",
       "mode": "pre-pr",
       "result": "fail",
       "tier": 1,

--- a/.workflow/records/1980-guided-1980-zarr-auto-chunks.json
+++ b/.workflow/records/1980-guided-1980-zarr-auto-chunks.json
@@ -1,6 +1,148 @@
 {
   "branch": "guided/1980-zarr-auto-chunks",
-  "check_events": [],
+  "check_events": [
+    {
+      "at": "2026-08-05T15:11:54.295126Z",
+      "command": "pytest tests/architecture/ -v --no-cov",
+      "covered_surface": "architecture",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:24473ce915fcfcf934bc9ac5b88f2226512c2ccc11bb20738e39f5636f818a7a",
+      "name": "architecture_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/architecture_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-05T15:11:55.233835Z",
+      "command": "python scripts/deferral_scan.py --check docs/audit/baselines/deferral-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:90dd4f2a0aab011010a76225a16bb8a76316e44dd9548ddf3842d3da74370964",
+      "name": "deferral_discipline",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/deferral_discipline.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-05T15:11:55.662896Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:247d117c2167292c766183fc2c2c7fbc62c9ca8df108a47d8837a1d3221645fd",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-05T15:12:00.670738Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:f2efdf11bf2a088117c0a4a3b82e9c0ae7967a19f6ac03f4cd310b0351e05e10",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-05T15:12:01.235029Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:a03d0ab400d687d69d936bf168778c2a7746490a10691f35b496e8907a393eac",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-05T15:12:01.282427Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:315605c9c5d2be7ae63f45a7998ab7f60167d994fd84e86ac2aea7c7bbcb63a2",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-05T15:15:56.008143Z",
+      "command": "python -m scistudio.qa.testing.run_python_tests --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:84edb42d7fd27cd6a61759f894813eec733206be8ded42769b02a31e8d5994c0",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-05T15:20:19.157019Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:a5af0bb0d48b0aaee0974bb80a8c2c7a5da6fc5e477f0f077b5399a393baa796",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-05T15:20:41.426154Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:09b21e87b5506e0942e5d0bb188f5895e66b474d4551958f13442a156786b367",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    }
+  ],
   "check_na": [],
   "commit": null,
   "declared_scope": {
@@ -49,7 +191,112 @@
     }
   ],
   "governance_touch": false,
-  "guard_events": [],
+  "guard_events": [
+    {
+      "at": "2026-08-05T15:20:41.546776Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/base/block.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/base/block.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T15:20:41.564163Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T15:20:41.581396Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T15:20:41.601068Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T15:20:41.619427Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T15:20:41.636260Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T15:20:41.652930Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T15:20:41.669698Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T15:20:41.685223Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T15:20:41.707868Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
   "issues": [
     {
       "close_in_pr": true,
@@ -59,11 +306,46 @@
     }
   ],
   "observed_admin_labels": [],
-  "observed_diff": null,
+  "observed_diff": {
+    "base": "origin/main",
+    "base_sha": "6c00d825",
+    "changed_files": [
+      ".workflow/records/1980-guided-1980-zarr-auto-chunks.json",
+      "CHANGELOG.md",
+      "src/scistudio/blocks/base/block.py",
+      "tests/blocks/test_block_base.py"
+    ],
+    "diff_fingerprint": "sha256:2878264f965ccd6a108bc8121630cccc37f7e3ddabe70429e92a6a49ff88a0cc",
+    "head": "HEAD",
+    "head_sha": "c98dc4c0",
+    "surfaces": {
+      "docs": 0,
+      "frontend": 0,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 1,
+      "packaging": 0,
+      "protected_core": 1,
+      "sentrux": 2,
+      "test": 1,
+      "workflow_ci": 0
+    }
+  },
   "owner_directive": "\u5f53\u524d\u6240\u6709\u7684PR\u90fd\u5728python3.13 fail\uff0c\u6211\u6000\u7591\u662f\u4e3b\u4ed3\u5e93\u7684\u95ee\u9898\u3002\u8c03\u67e5\u4e00\u4e0b\u7136\u540e\u4fee\u6389\u3002",
   "persona": "live_implementer",
   "pull_request": null,
-  "reconcile_events": [],
+  "reconcile_events": [
+    {
+      "at": "2026-08-05T15:20:41.708177Z",
+      "diff_fingerprint": "sha256:2878264f965ccd6a108bc8121630cccc37f7e3ddabe70429e92a6a49ff88a0cc",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.format_check"
+      ]
+    }
+  ],
   "record_id": "1980-guided-1980-zarr-auto-chunks",
   "requested_admin_labels": [
     {
@@ -74,11 +356,38 @@
     }
   ],
   "required_obligations": {
-    "admin_labels": [],
-    "checks": [],
-    "docs": [],
-    "guards": [],
-    "tests": []
+    "admin_labels": [
+      "admin-approved:core-change"
+    ],
+    "checks": [
+      "architecture_tests",
+      "deferral_discipline",
+      "format_check",
+      "full_audit",
+      "import_contracts",
+      "lint_format",
+      "python_tests",
+      "semantic_dup",
+      "type_check"
+    ],
+    "docs": [
+      "docs_required_or_na"
+    ],
+    "guards": [
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": [
+      "changed_test_required"
+    ]
   },
   "runtime": "claude",
   "schema_version": 2,
@@ -103,7 +412,7 @@
     }
   ],
   "session_id": "ce934bf4-df5e-4898-a0af-54ae8801327b",
-  "strictness_tier": null,
+  "strictness_tier": 1,
   "task_kind": "guided",
   "test_events": [
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   `tests/blocks/test_block_config_schema.py`. (@claude, 2026-07-29, branch:
   guided/1967-codeblock-script-path)
 
+- [#1980] `Block.persist_array` now requests zarr auto-chunking with
+  `chunks=None` instead of `chunks=True`, restoring the CI `Test (Python 3.13)`
+  job. zarr accepted `True` up to 3.1 and rejects it from 3.2 on
+  (`ValueError: True is not a valid chunk input`); because zarr 3.2 also raised
+  its floor to Python 3.12, the 3.11 matrix leg stayed pinned to zarr 3.1.6 and
+  kept passing while every 3.13 run — on `main` and on every open PR — failed
+  `tests/blocks/io/test_load_data_capabilities.py::TestBackwardCompatLoadRoundtrip::test_array_npy_load_round_trip`.
+  `None` is the one auto-chunk input valid across the supported zarr range
+  (`zarr>=3.0`); both versions route it to the same `guess_chunks()` heuristic,
+  so the chunk grid, streaming-write path, and existing `.zarr` artifacts are
+  unchanged. The `"auto"` spelling suggested by zarr 3.3's own error message
+  does not work through `open_array` on either version. Tests:
+  `tests/blocks/test_block_base.py` (`TestPersistArrayChunking`).
+  (@claude, 2026-08-05, branch: guided/1980-zarr-auto-chunks)
 - [#1946] Embedded PTY terminal (AI Chat / Terminal) now reflows correctly when
   a panel is resized under Claude Code's fullscreen (alternate-screen) mode.
   Previously the agent stayed stuck at its spawn-time size and rendered ghosted

--- a/src/scistudio/blocks/base/block.py
+++ b/src/scistudio/blocks/base/block.py
@@ -587,12 +587,13 @@ class Block(ABC):
         Path(store_path).parent.mkdir(parents=True, exist_ok=True)
 
         np_dtype = np.dtype(dtype)
-        if chunks is None:
-            zarr_chunks: tuple[int, ...] | bool = True  # let zarr auto-chunk
-        else:
-            zarr_chunks = chunks
-
-        z = zarr.open_array(store_path, mode="w", shape=shape, dtype=np_dtype, chunks=zarr_chunks)
+        # ``chunks=None`` is the auto-chunking input that holds across the
+        # supported zarr range (#1980). zarr <=3.1 also accepted ``True`` and
+        # zarr >=3.2 rejects it; both route ``None`` to the same
+        # ``guess_chunks()`` heuristic, so the chunk grid is unchanged. The
+        # ``"auto"`` spelling the zarr 3.3 error message suggests does not work
+        # through ``open_array`` on either version.
+        z = zarr.open_array(store_path, mode="w", shape=shape, dtype=np_dtype, chunks=chunks)
 
         if isinstance(data_or_iterator, np.ndarray):
             z[:] = data_or_iterator

--- a/tests/blocks/test_block_base.py
+++ b/tests/blocks/test_block_base.py
@@ -627,9 +627,7 @@ class TestPersistArrayChunking:
         data = np.arange(400 * 500, dtype="float64").reshape(400, 500)
         block = _DummyBlock()
 
-        ref = block.persist_array(
-            data, shape=data.shape, dtype=data.dtype, output_dir=str(tmp_path), chunks=(100, 125)
-        )
+        ref = block.persist_array(data, shape=data.shape, dtype=data.dtype, output_dir=str(tmp_path), chunks=(100, 125))
 
         z = zarr.open_array(ref.path, mode="r")
         assert z.chunks == (100, 125)

--- a/tests/blocks/test_block_base.py
+++ b/tests/blocks/test_block_base.py
@@ -587,3 +587,68 @@ class TestVariadicPortCountLimits:
             }
         )
         assert block.validate(inputs) is True
+
+
+class TestPersistArrayChunking:
+    """Block.persist_array — the zarr chunk argument it forwards (#1980).
+
+    ``persist_array`` used to request auto-chunking with ``chunks=True``, which
+    zarr accepted up to 3.1 and rejects from 3.2 on. Because zarr 3.2 raised its
+    floor to Python 3.12, the CI 3.11 job stayed pinned to the old API and only
+    the 3.13 job broke. These tests pin the auto-chunk call so a chunk input
+    that any supported zarr version rejects fails here directly, on every
+    interpreter in the matrix.
+    """
+
+    def test_auto_chunks_round_trip(self, tmp_path: Path) -> None:
+        """Omitting ``chunks`` writes a readable store with a real chunk grid."""
+        import numpy as np
+        import zarr
+
+        data = np.arange(400 * 500, dtype="float64").reshape(400, 500)
+        block = _DummyBlock()
+
+        ref = block.persist_array(data, shape=data.shape, dtype=data.dtype, output_dir=str(tmp_path))
+
+        z = zarr.open_array(ref.path, mode="r")
+        assert z.chunks is not None
+        assert len(z.chunks) == data.ndim
+        # zarr's guess_chunks subdivides an array this size, so an auto-chunked
+        # store is distinguishable from a single-chunk one.
+        assert z.chunks != data.shape
+        assert all(c <= s for c, s in zip(z.chunks, data.shape, strict=True))
+        np.testing.assert_array_equal(z[:], data)
+
+    def test_explicit_chunks_are_honored(self, tmp_path: Path) -> None:
+        """An explicit chunk shape reaches zarr unchanged."""
+        import numpy as np
+        import zarr
+
+        data = np.arange(400 * 500, dtype="float64").reshape(400, 500)
+        block = _DummyBlock()
+
+        ref = block.persist_array(
+            data, shape=data.shape, dtype=data.dtype, output_dir=str(tmp_path), chunks=(100, 125)
+        )
+
+        z = zarr.open_array(ref.path, mode="r")
+        assert z.chunks == (100, 125)
+        np.testing.assert_array_equal(z[:], data)
+
+    def test_auto_chunks_streaming_write(self, tmp_path: Path) -> None:
+        """The streaming ``(index, chunk)`` path also auto-chunks."""
+        import numpy as np
+        import zarr
+
+        pages = [np.full((8, 8), i, dtype="uint16") for i in range(4)]
+        block = _DummyBlock()
+
+        ref = block.persist_array(
+            ((i, page) for i, page in enumerate(pages)),
+            shape=(4, 8, 8),
+            dtype="uint16",
+            output_dir=str(tmp_path),
+        )
+
+        z = zarr.open_array(ref.path, mode="r")
+        np.testing.assert_array_equal(z[:], np.stack(pages))


### PR DESCRIPTION
## Problem

`main` and every open PR failed the CI `Test (Python 3.13)` job on one test:

```
FAILED tests/blocks/io/test_load_data_capabilities.py::TestBackwardCompatLoadRoundtrip::test_array_npy_load_round_trip
ValueError: True is not a valid chunk input. Use chunks=None or chunks="auto" from the top-level API
for auto-chunking, or pass an int / tuple of ints.
```

`Test (Python 3.11)` kept passing, which is what made it look branch-specific.

## Root cause

`Block.persist_array` asked zarr for auto-chunking by passing `chunks=True`. zarr accepted
that up to 3.1 and rejects it from 3.2 on.

The matrix split is a dependency-resolution artefact rather than a Python-version behaviour
difference. zarr 3.2.0 raised its `requires-python` floor to 3.12, so the two legs resolve
different zarr versions against the repository's `zarr>=3.0` floor:

| Python | resolved zarr | `chunks=True` |
|---|---|---|
| 3.11 | 3.1.6 (last release allowing 3.11) | accepted |
| 3.13 | 3.3.0 | rejected |

No PR introduced this; it expired on its own when zarr 3.2 was released.

## Fix

Pass `chunks` straight through, so the auto-chunk path sends `chunks=None`.

`None` is the only auto-chunk input valid across the supported zarr range. Verified against
both ends of that range over seven shape/dtype cases:

| `chunks=` | zarr 3.1.5 | zarr 3.3.0 |
|---|---|---|
| `True` | OK | **ValueError** |
| `"auto"` | ValueError | ValueError |
| `None` | OK | OK |
| tuple | OK | OK |

Both versions route `None` to the same `guess_chunks()` heuristic and produced **identical
chunk grids** in all seven cases, so the chunk grid, the streaming `z[idx] = chunk` write
path, `iter_chunks` read granularity, and existing `.zarr` artifacts are all unchanged. The
`"auto"` spelling that zarr 3.3's own error message suggests does not work through
`open_array` on either version.

`persist_array`'s signature and docstring are unchanged; callers that pass an explicit chunk
tuple (`utils/axis_iter.py`) never used this branch.

## Tests

`tests/blocks/test_block_base.py::TestPersistArrayChunking` — auto-chunk round trip (asserts
a real subdivided chunk grid, not just "it didn't raise"), explicit-chunks pass-through, and
the streaming-iterator write path. The break previously surfaced only indirectly, through one
loader round-trip test on a single matrix leg.

## Notes

- `src/scistudio/blocks/**` is a protected core path; this PR carries
  `admin-approved:core-change`, owner-authorized for this one chunk-argument fix.
- The branch is rebased onto current `origin/main`.

### Local gate state

`gate_record check --mode pre-pr` (tier 1, escalated by the protected-core path) passes 8 of
its 9 checks: `architecture_tests`, `deferral_discipline`, `full_audit`, `import_contracts`,
`lint_format`, `python_tests`, `semantic_dup`, `type_check`.

The 9th, `format_check`, fails on ~54 pre-existing files that this diff does not touch. That
is gate-environment drift, not a defect in this branch: the parity venv installs `ruff>=0.11`
from the dev extra and resolves 0.16.1, while CI and `.pre-commit-config.yaml` both pin
0.15.15. Run with the pinned 0.15.15, the tree is clean (`775 files already formatted`) and
`ruff check .` passes. Tracked in #1981; kept out of this PR's scope by owner decision, so
the PR was opened with `SCISTUDIO_SKIP_PREFLIGHT=1`. CI runs the full evaluator with its own
pinned ruff.

Gate record: .workflow/records/1980-guided-1980-zarr-auto-chunks.json

Closes #1980
