### PR TITLE
guided(#1986): remember desktop runtime port so UI prefs survive restarts

### DIFF
--- a/.workflow/records/1986-guided-1986-stable-runtime-port.json
+++ b/.workflow/records/1986-guided-1986-stable-runtime-port.json
@@ -1,0 +1,654 @@
+{
+  "branch": "guided/1986-stable-runtime-port",
+  "check_events": [
+    {
+      "at": "2026-08-05T20:50:26.820500Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:bee0017f30f552d2df2de1173f9ac14b9aee5192ca5e5c1de574bb119512b275",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-05T20:50:51.543799Z",
+      "command": "(cd frontend && npm run check:ci)",
+      "covered_surface": "frontend",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:eff252d496aeeab14180c30c487f18a6f988c2dc2e60040539c63307bae6df5f",
+      "name": "frontend",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/frontend.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-05T20:50:56.580305Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:7440f8739d78b23cfbf2c6dabddff1d65525b87d4159c8a14277a6b001a3c3f1",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-05T20:50:56.653734Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e31351abfc33f0b3c0f28bc9f2f3d59ae3bc5d4925dc1159a7f931aa932441ed",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-05T20:53:51.699938Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:a59bd55e7aab9809fe30fe97b84258cfdc470ecf683a60d41dfcef1909e1476b",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-05T20:55:21.224397Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:bee0017f30f552d2df2de1173f9ac14b9aee5192ca5e5c1de574bb119512b275",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    }
+  ],
+  "check_na": [],
+  "commit": {
+    "sha": "f5ec2ca422677cdc5594263ed59d380193e1798f",
+    "shas": [
+      "f5ec2ca422677cdc5594263ed59d380193e1798f"
+    ],
+    "trailers": []
+  },
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "desktop/main.js",
+      "desktop/test/**",
+      "frontend/src/store/tutorialSlice.ts",
+      "frontend/src/store/**"
+    ]
+  },
+  "directive_events": [
+    {
+      "at": "2026-08-05T20:49:51.342609Z",
+      "owner_directive": "Owner chose option A: persist the desktop runtime port so the renderer origin is stable across launches; also stop the tutorial slice from wiping prefs.",
+      "reason": "plan"
+    }
+  ],
+  "docs_events": [
+    {
+      "at": "2026-08-05T20:49:51.342760Z",
+      "class": null,
+      "kind": "path",
+      "path": "CHANGELOG.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-05T20:49:51.342774Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/planning/adr-037-desktop-mvp-spec.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-05T20:49:51.342781Z",
+      "class": "adr",
+      "kind": "na",
+      "path": null,
+      "rationale": "no architectural decision changes; ADR-037 desktop shell contract is unchanged, only the port argument it passes",
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": false,
+  "guard_events": [
+    {
+      "at": "2026-08-05T20:53:51.813933Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T20:53:51.835995Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T20:53:51.852020Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T20:53:51.865644Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T20:53:51.879106Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T20:53:51.892885Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T20:53:51.904112Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T20:53:51.918865Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T20:53:51.930666Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T20:53:51.945499Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T20:54:03.127293Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T20:54:03.179727Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T20:54:03.213357Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T20:54:03.229867Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T20:54:03.254782Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T20:54:03.283076Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T20:54:03.303039Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T20:54:03.327512Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T20:54:03.345099Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T20:54:03.367253Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T20:55:21.293964Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T20:55:21.305556Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T20:55:21.317110Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T20:55:21.329356Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T20:55:21.340749Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T20:55:21.352200Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T20:55:21.363814Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T20:55:21.376672Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T20:55:21.389134Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T20:55:21.403456Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T20:55:41.240870Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T20:55:41.252251Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T20:55:41.263728Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T20:55:41.314608Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T20:55:41.326266Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T20:55:41.338070Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T20:55:41.349645Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T20:55:41.361413Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T20:55:41.372615Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T20:55:41.385886Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1986,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": {
+    "base": "origin/main",
+    "base_sha": "79da765b",
+    "changed_files": [
+      ".workflow/records/1986-guided-1986-stable-runtime-port.json",
+      "CHANGELOG.md",
+      "desktop/main.js",
+      "desktop/package.json",
+      "desktop/runtime-port.js",
+      "desktop/test/runtime-port.test.js",
+      "docs/planning/adr-037-desktop-mvp-spec.md",
+      "frontend/src/store/tutorialSlice.test.ts",
+      "frontend/src/store/tutorialSlice.ts"
+    ],
+    "diff_fingerprint": "sha256:23a8b613ea65425ac5b5a8f0661681e3e1670e4b3b9f338298f58c56f5df5e21",
+    "head": "HEAD",
+    "head_sha": "f5ec2ca4",
+    "surfaces": {
+      "docs": 1,
+      "frontend": 2,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 2,
+      "packaging": 0,
+      "protected_core": 0,
+      "sentrux": 2,
+      "test": 2,
+      "workflow_ci": 0
+    }
+  },
+  "owner_directive": "Owner reports the tutorial prompt reappears on every launch even after 'Don't show again' and after completing the tutorial. Owner chose fix option A: persist the desktop runtime port in userData so the renderer origin stays stable across launches, plus fix the tutorial slice wiping prefs on start and recording nothing on exit.",
+  "persona": "live_implementer",
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [
+      1986
+    ],
+    "number": null,
+    "url": null
+  },
+  "reconcile_events": [
+    {
+      "at": "2026-08-05T20:53:51.945537Z",
+      "diff_fingerprint": "sha256:23a8b613ea65425ac5b5a8f0661681e3e1670e4b3b9f338298f58c56f5df5e21",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.format_check"
+      ]
+    },
+    {
+      "at": "2026-08-05T20:54:03.367360Z",
+      "diff_fingerprint": "sha256:23a8b613ea65425ac5b5a8f0661681e3e1670e4b3b9f338298f58c56f5df5e21",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.format_check"
+      ]
+    },
+    {
+      "at": "2026-08-05T20:55:21.403506Z",
+      "diff_fingerprint": "sha256:23a8b613ea65425ac5b5a8f0661681e3e1670e4b3b9f338298f58c56f5df5e21",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-05T20:55:41.385918Z",
+      "diff_fingerprint": "sha256:23a8b613ea65425ac5b5a8f0661681e3e1670e4b3b9f338298f58c56f5df5e21",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    }
+  ],
+  "record_id": "1986-guided-1986-stable-runtime-port",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [
+      "format_check",
+      "frontend",
+      "full_audit",
+      "lint_format",
+      "semantic_dup"
+    ],
+    "docs": [
+      "docs_required_or_na"
+    ],
+    "guards": [
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": [
+      "changed_test_required"
+    ]
+  },
+  "runtime": "claude",
+  "schema_version": 2,
+  "scope_events": [
+    {
+      "action": "add-include",
+      "at": "2026-08-05T20:49:51.342742Z",
+      "pattern": "desktop/runtime-port.js",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-05T20:49:51.342747Z",
+      "pattern": "desktop/package.json",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-05T20:49:51.342749Z",
+      "pattern": "frontend/src/store/tutorialSlice.test.ts",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-05T20:49:51.342751Z",
+      "pattern": "CHANGELOG.md",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-05T20:49:51.342752Z",
+      "pattern": "docs/planning/adr-037-desktop-mvp-spec.md",
+      "reason": "plan"
+    }
+  ],
+  "session_id": "df80d4a3-c132-4bf1-b633-deb45226588b",
+  "strictness_tier": 2,
+  "task_kind": "guided",
+  "test_events": [
+    {
+      "at": "2026-08-05T20:49:51.342787Z",
+      "class": null,
+      "kind": "path",
+      "path": "desktop/test/runtime-port.test.js",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-05T20:49:51.342789Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/store/tutorialSlice.test.ts",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/.workflow/records/1986-guided-1986-stable-runtime-port.json
+++ b/.workflow/records/1986-guided-1986-stable-runtime-port.json
@@ -559,6 +559,88 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-08-05T20:56:16.408336Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T20:56:16.421590Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T20:56:16.435063Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T20:56:16.490888Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T20:56:16.503969Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T20:56:16.517580Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T20:56:16.530680Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T20:56:16.543558Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T20:56:16.555270Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T20:56:16.570881Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -584,9 +666,9 @@
       "frontend/src/store/tutorialSlice.test.ts",
       "frontend/src/store/tutorialSlice.ts"
     ],
-    "diff_fingerprint": "sha256:e4bfab71b52fa63e3e03dc812ec00943d3586b0a5ab78301c7a7261c97aff950",
+    "diff_fingerprint": "sha256:5b92144f971dadf1178046e3c98ae665223ab1ef8860c7a86867fcd8ce9cfa43",
     "head": "HEAD",
-    "head_sha": "9a8b0fe0",
+    "head_sha": "5fc8d4ed",
     "surfaces": {
       "docs": 1,
       "frontend": 2,
@@ -650,6 +732,14 @@
     {
       "at": "2026-08-05T20:56:00.233836Z",
       "diff_fingerprint": "sha256:e4bfab71b52fa63e3e03dc812ec00943d3586b0a5ab78301c7a7261c97aff950",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-05T20:56:16.570924Z",
+      "diff_fingerprint": "sha256:5b92144f971dadf1178046e3c98ae665223ab1ef8860c7a86867fcd8ce9cfa43",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 2,

--- a/.workflow/records/1986-guided-1986-stable-runtime-port.json
+++ b/.workflow/records/1986-guided-1986-stable-runtime-port.json
@@ -100,9 +100,9 @@
   ],
   "check_na": [],
   "commit": {
-    "sha": "9a8b0fe01672f1e519d39e78acfd157324696371",
+    "sha": "ae81f58581ffe642e4261560ceadfb6e8dd3e817",
     "shas": [
-      "9a8b0fe01672f1e519d39e78acfd157324696371"
+      "ae81f58581ffe642e4261560ceadfb6e8dd3e817"
     ],
     "trailers": []
   },
@@ -641,6 +641,170 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-08-05T20:56:33.134591Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T20:56:33.145524Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T20:56:33.158256Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T20:56:33.169699Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T20:56:33.181488Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T20:56:33.193988Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T20:56:33.206603Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T20:56:33.220071Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T20:56:33.231777Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T20:56:33.247431Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T20:56:41.650918Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T20:56:41.661766Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T20:56:41.672328Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T20:56:41.683424Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T20:56:41.694365Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T20:56:41.705148Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T20:56:41.715696Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T20:56:41.726362Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T20:56:41.737565Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T20:56:41.752186Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -653,7 +817,7 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "origin/main",
+    "base": "79da765b37911c4f0b070c0f972df083bfe83d7b",
     "base_sha": "79da765b",
     "changed_files": [
       ".workflow/records/1986-guided-1986-stable-runtime-port.json",
@@ -666,9 +830,9 @@
       "frontend/src/store/tutorialSlice.test.ts",
       "frontend/src/store/tutorialSlice.ts"
     ],
-    "diff_fingerprint": "sha256:5b92144f971dadf1178046e3c98ae665223ab1ef8860c7a86867fcd8ce9cfa43",
+    "diff_fingerprint": "sha256:f75fa727c8355886fa4579af10dd62799e2d6565f86fe540524db7898d776a30",
     "head": "HEAD",
-    "head_sha": "5fc8d4ed",
+    "head_sha": "ae81f585",
     "surfaces": {
       "docs": 1,
       "frontend": 2,
@@ -689,8 +853,8 @@
     "closes": [
       1986
     ],
-    "number": null,
-    "url": null
+    "number": 1987,
+    "url": "https://github.com/jiazhenz026/SciStudio/pull/1987"
   },
   "reconcile_events": [
     {
@@ -740,6 +904,22 @@
     {
       "at": "2026-08-05T20:56:16.570924Z",
       "diff_fingerprint": "sha256:5b92144f971dadf1178046e3c98ae665223ab1ef8860c7a86867fcd8ce9cfa43",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-05T20:56:33.247469Z",
+      "diff_fingerprint": "sha256:f75fa727c8355886fa4579af10dd62799e2d6565f86fe540524db7898d776a30",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-05T20:56:41.752220Z",
+      "diff_fingerprint": "sha256:f75fa727c8355886fa4579af10dd62799e2d6565f86fe540524db7898d776a30",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 2,

--- a/.workflow/records/1986-guided-1986-stable-runtime-port.json
+++ b/.workflow/records/1986-guided-1986-stable-runtime-port.json
@@ -100,9 +100,9 @@
   ],
   "check_na": [],
   "commit": {
-    "sha": "f5ec2ca422677cdc5594263ed59d380193e1798f",
+    "sha": "9a8b0fe01672f1e519d39e78acfd157324696371",
     "shas": [
-      "f5ec2ca422677cdc5594263ed59d380193e1798f"
+      "9a8b0fe01672f1e519d39e78acfd157324696371"
     ],
     "trailers": []
   },
@@ -477,6 +477,88 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-08-05T20:56:00.137509Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T20:56:00.147781Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T20:56:00.158436Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T20:56:00.169153Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T20:56:00.179703Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T20:56:00.189650Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T20:56:00.199702Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T20:56:00.210094Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T20:56:00.220141Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-05T20:56:00.233781Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -502,9 +584,9 @@
       "frontend/src/store/tutorialSlice.test.ts",
       "frontend/src/store/tutorialSlice.ts"
     ],
-    "diff_fingerprint": "sha256:23a8b613ea65425ac5b5a8f0661681e3e1670e4b3b9f338298f58c56f5df5e21",
+    "diff_fingerprint": "sha256:e4bfab71b52fa63e3e03dc812ec00943d3586b0a5ab78301c7a7261c97aff950",
     "head": "HEAD",
-    "head_sha": "f5ec2ca4",
+    "head_sha": "9a8b0fe0",
     "surfaces": {
       "docs": 1,
       "frontend": 2,
@@ -560,6 +642,14 @@
     {
       "at": "2026-08-05T20:55:41.385918Z",
       "diff_fingerprint": "sha256:23a8b613ea65425ac5b5a8f0661681e3e1670e4b3b9f338298f58c56f5df5e21",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-05T20:56:00.233836Z",
+      "diff_fingerprint": "sha256:e4bfab71b52fa63e3e03dc812ec00943d3586b0a5ab78301c7a7261c97aff950",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 2,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- [#1986] The desktop app now remembers which port its backend bound and prefers
+  that port on the next launch, so the renderer keeps a stable
+  `http://127.0.0.1:<port>` origin across restarts. Previously the backend was
+  always started with `--port 0`, so every launch produced a new origin, and
+  because `localStorage` is origin-scoped, the persisted `scistudio-studio-ui`
+  snapshot was silently unreachable each time. The user-visible symptom was the
+  "Run Your First SciStudio Workflow" prompt returning on every launch even after
+  "Don't show again" or completing the tutorial, but the same reset hit panel
+  sizes, open file tabs, terminal tabs, and the active bottom tab. The port is
+  stored in `userData/runtime-port.json`, probed for availability before reuse,
+  and the launch falls back to an ephemeral port — retrying once if the backend
+  loses a bind race — so a port taken by another process cannot stop the app from
+  starting. An explicit `SCISTUDIO_DESKTOP_RUNTIME_PORT` still wins and is never
+  written back. Separately, `startRunFirstWorkflowTutorial` no longer clears
+  `runFirstWorkflowTutorialPrefs`, which used to erase an earlier "Don't show
+  again" or completion the moment the tutorial was started, and
+  `completeRunFirstWorkflowTutorial` now merges rather than replaces those prefs.
+  Tests: `desktop/test/runtime-port.test.js`,
+  `frontend/src/store/tutorialSlice.test.ts`. Note: `desktop/main.js` is outside
+  the OTA payload, so the port half of this fix reaches users only through a new
+  installer build. (@claude, 2026-08-05, branch: guided/1986-stable-runtime-port)
+
 - [#1969] The `validate_workflow` MCP tool now resolves a CodeBlock
   `script_path` against the active project root instead of the backend process
   working directory. #1967 threaded an explicit `project_dir` through

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -4,11 +4,13 @@ const crypto = require("crypto");
 const fs = require("fs");
 const http = require("http");
 const https = require("https");
+const net = require("net");
 const os = require("os");
 const path = require("path");
 const readline = require("readline");
 
 const ota = require("./ota");
+const runtimePortModule = require("./runtime-port");
 
 // #1784: the in-app Package Manager stages a package update on disk (into the
 // scanned installed-packages dir) and then asks the main process to relaunch so
@@ -818,27 +820,91 @@ function runtimeEnv() {
   return env;
 }
 
-function runtimePort() {
-  const requested = process.env.SCISTUDIO_DESKTOP_RUNTIME_PORT;
-  if (!requested) {
-    return "0";
-  }
-  const parsed = Number.parseInt(requested, 10);
-  if (Number.isInteger(parsed) && parsed >= 0 && parsed <= 65535) {
-    return String(parsed);
-  }
-  safeError(`[scistudio] Ignoring invalid SCISTUDIO_DESKTOP_RUNTIME_PORT=${requested}`);
-  return "0";
+// #1986: the file that carries the bound port from one launch to the next, so
+// the renderer origin (and with it every localStorage-backed UI preference)
+// survives a restart. See desktop/runtime-port.js for why.
+function runtimePortPath() {
+  return path.join(app.getPath("userData"), "runtime-port.json");
 }
 
-function runtimeArgs(candidate) {
+function envRuntimePort() {
+  const requested = process.env.SCISTUDIO_DESKTOP_RUNTIME_PORT;
+  if (!requested) {
+    return null;
+  }
+  const parsed = runtimePortModule.normalizeEnvPort(requested);
+  if (parsed === null) {
+    safeError(`[scistudio] Ignoring invalid SCISTUDIO_DESKTOP_RUNTIME_PORT=${requested}`);
+  }
+  return parsed;
+}
+
+function rememberedRuntimePort() {
+  return runtimePortModule.parseRememberedPort(readJsonSafe(runtimePortPath()));
+}
+
+// Probe rather than assume: a remembered port can be taken by anything between
+// two launches, and handing the backend an occupied port would leave the app
+// unable to start at all.
+function isPortFree(port) {
+  return new Promise((resolve) => {
+    const probe = net.createServer();
+    probe.once("error", () => resolve(false));
+    probe.once("listening", () => probe.close(() => resolve(true)));
+    probe.listen(port, "127.0.0.1");
+  });
+}
+
+async function resolveRuntimePort() {
+  const envPort = envRuntimePort();
+  if (envPort !== null) {
+    return runtimePortModule.selectRuntimePort({ envPort });
+  }
+  const rememberedPort = rememberedRuntimePort();
+  const rememberedPortFree = rememberedPort !== null ? await isPortFree(rememberedPort) : false;
+  if (rememberedPort !== null && !rememberedPortFree) {
+    safeError(
+      `[scistudio] remembered runtime port ${rememberedPort} is in use; falling back to an ephemeral port`
+    );
+  }
+  return runtimePortModule.selectRuntimePort({ envPort, rememberedPort, rememberedPortFree });
+}
+
+function rememberRuntimePort(boundPort) {
+  const decision = {
+    envPort: envRuntimePort(),
+    boundPort,
+    rememberedPort: rememberedRuntimePort()
+  };
+  if (!runtimePortModule.shouldRememberPort(decision)) {
+    return;
+  }
+  try {
+    writeJsonAtomic(runtimePortPath(), { port: boundPort });
+    safeLog(`[scistudio] remembered runtime port ${boundPort}`);
+  } catch (error) {
+    // Best-effort: failing to remember the port costs the next launch its
+    // persisted UI state, which must not stop this one from running.
+    safeError(`[scistudio] failed to remember runtime port: ${error.message}`);
+  }
+}
+
+function forgetRuntimePort() {
+  try {
+    fs.rmSync(runtimePortPath(), { force: true });
+  } catch {
+    // Best-effort; a stale remembered port is re-probed on the next launch.
+  }
+}
+
+function runtimeArgs(candidate, port) {
   return [
     ...candidate.argsPrefix,
     "-m",
     "scistudio.cli.main",
     "gui",
     "--port",
-    runtimePort(),
+    port,
     "--bundled"
   ];
 }
@@ -894,8 +960,8 @@ function verifyPtyCapablePython(candidate) {
   });
 }
 
-function spawnRuntimeCandidate(candidate) {
-  return spawn(candidate.command, runtimeArgs(candidate), {
+function spawnRuntimeCandidate(candidate, port) {
+  return spawn(candidate.command, runtimeArgs(candidate, port), {
     cwd: repoRoot(),
     env: runtimeEnv(),
     windowsHide: true,
@@ -915,10 +981,35 @@ function parseReadyLine(line) {
   return null;
 }
 
-function startRuntime() {
+// #1986: prefer the port the previous launch bound so the renderer origin — and
+// therefore every localStorage-backed UI preference — stays stable. The port can
+// be lost to another process between the free-port probe and the backend's own
+// bind, so a failure on a remembered port is retried once on an ephemeral one
+// rather than being surfaced as "SciStudio failed to start".
+async function startRuntime() {
+  const port = await resolveRuntimePort();
+  try {
+    return await startRuntimeOnPort(port);
+  } catch (error) {
+    if (
+      port === "0" ||
+      envRuntimePort() !== null ||
+      !runtimePortModule.isPortUnavailableFailure(error.message)
+    ) {
+      throw error;
+    }
+    safeError(
+      `[scistudio] runtime did not start on remembered port ${port}; retrying on an ephemeral port: ${error.message}`
+    );
+    forgetRuntimePort();
+    return startRuntimeOnPort("0");
+  }
+}
+
+function startRuntimeOnPort(port) {
   const candidates = pythonCandidates();
   const stderrLines = [];
-  safeLog("[scistudio] starting runtime");
+  safeLog(`[scistudio] starting runtime on port ${port === "0" ? "auto" : port}`);
 
   return new Promise((resolve, reject) => {
     let index = 0;
@@ -958,7 +1049,7 @@ function startRuntime() {
         tryNext();
         return;
       }
-      const child = spawnRuntimeCandidate(candidate);
+      const child = spawnRuntimeCandidate(candidate, port);
       let sawOutput = false;
       runtimeProcess = child;
 
@@ -1195,6 +1286,9 @@ app.whenReady().then(async () => {
     const { ready } = await startRuntimeWithRollback();
     safeLog(`[scistudio] waiting for HTTP readiness at ${ready.url}`);
     await waitForHttpReady(ready.url);
+    // #1986: the runtime answered on this port, so it is worth reusing next
+    // launch to keep the renderer origin (and its persisted UI state) stable.
+    rememberRuntimePort(runtimePortModule.boundPortFromReady(ready));
     // #1775: the runtime reached ready, so whatever patch is active booted
     // cleanly; remember it as the rollback target for future launches.
     recordKnownGood(effectiveBuild());

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -36,6 +36,7 @@
     "files": [
       "main.js",
       "ota.js",
+      "runtime-port.js",
       "preload.js",
       "package.json",
       "assets/icon.png"

--- a/desktop/runtime-port.js
+++ b/desktop/runtime-port.js
@@ -1,0 +1,159 @@
+"use strict";
+
+// #1986: runtime port selection for the packaged desktop app.
+//
+// The backend used to bind a fresh ephemeral port on every launch, so the
+// renderer loaded `http://127.0.0.1:<random>` each time. `localStorage` is
+// origin-scoped, so a new port meant a new origin meant an empty store: the
+// zustand `scistudio-studio-ui` snapshot (tutorial prompt state, panel sizes,
+// open file tabs, terminal tabs, active bottom tab) was silently discarded at
+// every start. Remembering the bound port keeps the origin stable, which keeps
+// the preferences.
+//
+// The decision logic lives here as pure functions so it can be unit tested
+// without Electron; `main.js` gathers the on-disk and network facts and acts on
+// the verdict, mirroring how `ota.js` is used.
+
+// A remembered port must be non-privileged: ephemeral ports always are, and
+// refusing the privileged range means a corrupt or hand-edited file can never
+// send the backend at a port it has no business binding.
+const MIN_REMEMBERED_PORT = 1024;
+const MAX_PORT = 65535;
+
+/**
+ * Normalize `SCISTUDIO_DESKTOP_RUNTIME_PORT`.
+ *
+ * `0` stays meaningful here — it is how an operator asks for the historical
+ * "always pick a fresh ephemeral port" behavior. Returns null when the value is
+ * absent or unusable, which the caller reports and then ignores.
+ */
+function normalizeEnvPort(value) {
+  if (value === undefined || value === null || value === "") {
+    return null;
+  }
+  const parsed = Number.parseInt(String(value), 10);
+  if (!Number.isInteger(parsed) || parsed < 0 || parsed > MAX_PORT) {
+    return null;
+  }
+  return parsed;
+}
+
+/**
+ * Normalize a port read back from (or about to be written to) the remembered
+ * port file. Unlike the env override, `0` is not a valid remembered port: it is
+ * a request for an ephemeral port, never the result of one.
+ */
+function normalizeRememberedPort(value) {
+  if (typeof value !== "number" || !Number.isInteger(value)) {
+    return null;
+  }
+  if (value < MIN_REMEMBERED_PORT || value > MAX_PORT) {
+    return null;
+  }
+  return value;
+}
+
+/**
+ * Extract the remembered port from a parsed `runtime-port.json` record.
+ * Anything unrecognized reads as "nothing remembered".
+ */
+function parseRememberedPort(record) {
+  if (!record || typeof record !== "object") {
+    return null;
+  }
+  return normalizeRememberedPort(record.port);
+}
+
+/**
+ * Decide which `--port` value to hand the backend.
+ *
+ * An explicit env override always wins and is never second-guessed. Otherwise
+ * the remembered port is used when it is still free, and "0" (ephemeral) is the
+ * fallback.
+ */
+function selectRuntimePort({ envPort = null, rememberedPort = null, rememberedPortFree = false }) {
+  if (envPort !== null) {
+    return String(envPort);
+  }
+  if (rememberedPort !== null && rememberedPortFree) {
+    return String(rememberedPort);
+  }
+  return "0";
+}
+
+/**
+ * Decide whether the port the backend actually bound should be written back.
+ *
+ * An env override is the operator's business, not state to remember, and
+ * rewriting an unchanged value would churn the file on every launch.
+ */
+function shouldRememberPort({ envPort = null, boundPort = null, rememberedPort = null }) {
+  if (envPort !== null) {
+    return false;
+  }
+  const normalized = normalizeRememberedPort(boundPort);
+  if (normalized === null) {
+    return false;
+  }
+  return normalized !== rememberedPort;
+}
+
+/**
+ * Read the bound port out of a `scistudio.ready` message. The backend reports
+ * it as a field; the URL is the fallback for a message that predates or omits
+ * it.
+ */
+function boundPortFromReady(ready) {
+  if (!ready || typeof ready !== "object") {
+    return null;
+  }
+  const direct = normalizeRememberedPort(ready.port);
+  if (direct !== null) {
+    return direct;
+  }
+  if (typeof ready.url !== "string") {
+    return null;
+  }
+  try {
+    return normalizeRememberedPort(Number.parseInt(new URL(ready.url).port, 10));
+  } catch {
+    return null;
+  }
+}
+
+// uvicorn's own bind-failure wording, plus the raw errno name, so the check
+// holds on both POSIX ("[Errno 48] ... address already in use") and Windows
+// ("[Errno 10048] ... only one usage of each socket address"), and does not
+// depend on the localized tail of the message.
+const PORT_UNAVAILABLE_MARKERS = [
+  "error while attempting to bind on address",
+  "eaddrinuse",
+  "address already in use"
+];
+
+/**
+ * Did the runtime fail because it could not take the port we asked for?
+ *
+ * Only such a failure justifies retrying on an ephemeral port. Retrying a
+ * broken interpreter or a missing dependency would just spend the startup
+ * timeout twice before showing the same error.
+ */
+function isPortUnavailableFailure(text) {
+  if (typeof text !== "string") {
+    return false;
+  }
+  const haystack = text.toLowerCase();
+  return PORT_UNAVAILABLE_MARKERS.some((marker) => haystack.includes(marker));
+}
+
+module.exports = {
+  isPortUnavailableFailure,
+  MIN_REMEMBERED_PORT,
+  MAX_PORT,
+  normalizeEnvPort,
+  normalizeRememberedPort,
+  parseRememberedPort,
+  selectRuntimePort,
+  shouldRememberPort,
+  boundPortFromReady
+};

--- a/desktop/test/runtime-port.test.js
+++ b/desktop/test/runtime-port.test.js
@@ -1,0 +1,172 @@
+"use strict";
+
+// Unit tests for the pure runtime-port decision logic (desktop/runtime-port.js,
+// issue #1986). Run with: npm --prefix desktop test   (Node built-in runner).
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const runtimePort = require("../runtime-port");
+
+test("normalizeEnvPort: accepts 0 as an explicit ephemeral request", () => {
+  assert.equal(runtimePort.normalizeEnvPort("0"), 0);
+  assert.equal(runtimePort.normalizeEnvPort("8000"), 8000);
+  assert.equal(runtimePort.normalizeEnvPort(65535), 65535);
+});
+
+test("normalizeEnvPort: rejects absent and out-of-range values", () => {
+  assert.equal(runtimePort.normalizeEnvPort(undefined), null);
+  assert.equal(runtimePort.normalizeEnvPort(null), null);
+  assert.equal(runtimePort.normalizeEnvPort(""), null);
+  assert.equal(runtimePort.normalizeEnvPort("nope"), null);
+  assert.equal(runtimePort.normalizeEnvPort("-1"), null);
+  assert.equal(runtimePort.normalizeEnvPort("65536"), null);
+});
+
+test("normalizeRememberedPort: rejects 0 and the privileged range", () => {
+  assert.equal(runtimePort.normalizeRememberedPort(0), null);
+  assert.equal(runtimePort.normalizeRememberedPort(1023), null);
+  assert.equal(runtimePort.normalizeRememberedPort(1024), 1024);
+  assert.equal(runtimePort.normalizeRememberedPort(50123), 50123);
+  assert.equal(runtimePort.normalizeRememberedPort(65536), null);
+});
+
+test("normalizeRememberedPort: rejects non-integer values", () => {
+  assert.equal(runtimePort.normalizeRememberedPort("50123"), null);
+  assert.equal(runtimePort.normalizeRememberedPort(50123.5), null);
+  assert.equal(runtimePort.normalizeRememberedPort(null), null);
+});
+
+test("parseRememberedPort: reads the port field, tolerates junk records", () => {
+  assert.equal(runtimePort.parseRememberedPort({ port: 50123 }), 50123);
+  assert.equal(runtimePort.parseRememberedPort({ port: "50123" }), null);
+  assert.equal(runtimePort.parseRememberedPort({}), null);
+  assert.equal(runtimePort.parseRememberedPort(null), null);
+  assert.equal(runtimePort.parseRememberedPort("50123"), null);
+});
+
+test("selectRuntimePort: env override wins over a free remembered port", () => {
+  assert.equal(
+    runtimePort.selectRuntimePort({
+      envPort: 8000,
+      rememberedPort: 50123,
+      rememberedPortFree: true
+    }),
+    "8000"
+  );
+});
+
+test("selectRuntimePort: env 0 forces an ephemeral port", () => {
+  assert.equal(
+    runtimePort.selectRuntimePort({
+      envPort: 0,
+      rememberedPort: 50123,
+      rememberedPortFree: true
+    }),
+    "0"
+  );
+});
+
+test("selectRuntimePort: reuses a remembered port that is still free", () => {
+  assert.equal(
+    runtimePort.selectRuntimePort({ rememberedPort: 50123, rememberedPortFree: true }),
+    "50123"
+  );
+});
+
+test("selectRuntimePort: falls back to ephemeral when the remembered port is taken", () => {
+  assert.equal(
+    runtimePort.selectRuntimePort({ rememberedPort: 50123, rememberedPortFree: false }),
+    "0"
+  );
+});
+
+test("selectRuntimePort: first launch has nothing remembered", () => {
+  assert.equal(runtimePort.selectRuntimePort({}), "0");
+});
+
+test("shouldRememberPort: records a newly bound ephemeral port", () => {
+  assert.equal(
+    runtimePort.shouldRememberPort({ boundPort: 50123, rememberedPort: null }),
+    true
+  );
+});
+
+test("shouldRememberPort: rewrites when the bound port moved", () => {
+  assert.equal(
+    runtimePort.shouldRememberPort({ boundPort: 50124, rememberedPort: 50123 }),
+    true
+  );
+});
+
+test("shouldRememberPort: no churn when the port is unchanged", () => {
+  assert.equal(
+    runtimePort.shouldRememberPort({ boundPort: 50123, rememberedPort: 50123 }),
+    false
+  );
+});
+
+test("shouldRememberPort: an env override is never remembered", () => {
+  assert.equal(
+    runtimePort.shouldRememberPort({ envPort: 8000, boundPort: 8000, rememberedPort: 50123 }),
+    false
+  );
+  assert.equal(
+    runtimePort.shouldRememberPort({ envPort: 0, boundPort: 50124, rememberedPort: 50123 }),
+    false
+  );
+});
+
+test("shouldRememberPort: an unusable bound port is not written back", () => {
+  assert.equal(runtimePort.shouldRememberPort({ boundPort: null, rememberedPort: 50123 }), false);
+  assert.equal(runtimePort.shouldRememberPort({ boundPort: 0, rememberedPort: null }), false);
+});
+
+test("boundPortFromReady: prefers the port field", () => {
+  assert.equal(
+    runtimePort.boundPortFromReady({ port: 50123, url: "http://127.0.0.1:50123" }),
+    50123
+  );
+});
+
+test("boundPortFromReady: falls back to the url", () => {
+  assert.equal(runtimePort.boundPortFromReady({ url: "http://127.0.0.1:50123" }), 50123);
+});
+
+test("isPortUnavailableFailure: recognizes uvicorn's POSIX bind failure", () => {
+  assert.equal(
+    runtimePort.isPortUnavailableFailure(
+      "[Errno 48] error while attempting to bind on address ('127.0.0.1', 50123): address already in use"
+    ),
+    true
+  );
+});
+
+test("isPortUnavailableFailure: recognizes the Windows bind failure", () => {
+  assert.equal(
+    runtimePort.isPortUnavailableFailure(
+      "[Errno 10048] error while attempting to bind on address ('127.0.0.1', 50123): only one usage of each socket address is normally permitted"
+    ),
+    true
+  );
+});
+
+test("isPortUnavailableFailure: recognizes a raw EADDRINUSE", () => {
+  assert.equal(runtimePort.isPortUnavailableFailure("listen EADDRINUSE 127.0.0.1:50123"), true);
+});
+
+test("isPortUnavailableFailure: an unrelated failure is not retried", () => {
+  assert.equal(
+    runtimePort.isPortUnavailableFailure("ModuleNotFoundError: No module named 'scistudio'"),
+    false
+  );
+  assert.equal(runtimePort.isPortUnavailableFailure(""), false);
+  assert.equal(runtimePort.isPortUnavailableFailure(null), false);
+  assert.equal(runtimePort.isPortUnavailableFailure(undefined), false);
+});
+
+test("boundPortFromReady: rejects unusable messages", () => {
+  assert.equal(runtimePort.boundPortFromReady(null), null);
+  assert.equal(runtimePort.boundPortFromReady({}), null);
+  assert.equal(runtimePort.boundPortFromReady({ url: "not-a-url" }), null);
+  assert.equal(runtimePort.boundPortFromReady({ url: "http://127.0.0.1" }), null);
+});

--- a/docs/planning/adr-037-desktop-mvp-spec.md
+++ b/docs/planning/adr-037-desktop-mvp-spec.md
@@ -112,7 +112,12 @@ manual dependencies into a shared user-scoped dependency runtime.
   - locates a Python executable from `SCISTUDIO_DESKTOP_PYTHON`, staged
     `desktop/resources/python/python(.exe)`, or `python`/`py` fallback for
     developer MVP;
-  - launches `python -m scistudio.cli.main gui --port 0 --bundled`;
+  - launches `python -m scistudio.cli.main gui --port <port> --bundled`, where
+    `<port>` is the port remembered from the previous launch in
+    `userData/runtime-port.json` when it is still free, and `0` (ephemeral)
+    otherwise. #1986 added the remembered port: the renderer origin is
+    `http://127.0.0.1:<port>`, and an origin that changes on every launch
+    discards the whole `localStorage`-backed UI state;
   - sets `PYTHONPATH` to include `desktop/resources/app/src` or repo `src`;
   - sets `SCISTUDIO_BUNDLED=1`;
   - sets `SCISTUDIO_DESKTOP_RESOURCES=<resources dir>`;

--- a/frontend/src/store/tutorialSlice.test.ts
+++ b/frontend/src/store/tutorialSlice.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { useAppStore } from "./index";
+import type { RunFirstWorkflowTutorialInstance } from "./types";
+
+const INSTANCE: RunFirstWorkflowTutorialInstance = {
+  tutorialId: "run-first-scistudio-workflow",
+  projectId: "proj-1",
+  datasetPath: "data/raw/fluorescence.csv",
+  workflowId: "wf-1",
+  customBlockPath: "blocks/normalize_fluorescence.py",
+  customBlockType: "normalize_fluorescence",
+  customBlockName: "Normalize Fluorescence",
+  plotId: "plot-1",
+  plotTitle: "Normalized fluorescence",
+  negativeControl: "blank",
+  positiveControl: "max",
+};
+
+function resetTutorialState(): void {
+  useAppStore.setState({
+    runFirstWorkflowTutorialActive: false,
+    runFirstWorkflowTutorialStep: "inspect-data",
+    runFirstWorkflowTutorialInstance: null,
+    runFirstWorkflowTutorialPrefs: {},
+  });
+}
+
+describe("tutorial slice prefs", () => {
+  beforeEach(resetTutorialState);
+
+  it("keeps an existing suppression when the tutorial is started again (#1986)", () => {
+    useAppStore.getState().suppressRunFirstWorkflowTutorialPrompt();
+    useAppStore.getState().startRunFirstWorkflowTutorial(INSTANCE);
+
+    const state = useAppStore.getState();
+    expect(state.runFirstWorkflowTutorialActive).toBe(true);
+    expect(state.runFirstWorkflowTutorialInstance).toEqual(INSTANCE);
+    expect(state.runFirstWorkflowTutorialPrefs.suppressAutoStart).toBe(true);
+  });
+
+  it("keeps a recorded completion when the tutorial is started again (#1986)", () => {
+    useAppStore.getState().completeRunFirstWorkflowTutorial();
+    const completedAt = useAppStore.getState().runFirstWorkflowTutorialPrefs.completedAt;
+    expect(completedAt).toBeTruthy();
+
+    useAppStore.getState().startRunFirstWorkflowTutorial(INSTANCE);
+
+    expect(useAppStore.getState().runFirstWorkflowTutorialPrefs.completedAt).toBe(completedAt);
+  });
+
+  it("survives start then exit, so the welcome prompt stays suppressed (#1986)", () => {
+    useAppStore.getState().suppressRunFirstWorkflowTutorialPrompt();
+    useAppStore.getState().startRunFirstWorkflowTutorial(INSTANCE);
+    useAppStore.getState().exitRunFirstWorkflowTutorial();
+
+    const state = useAppStore.getState();
+    expect(state.runFirstWorkflowTutorialActive).toBe(false);
+    expect(state.runFirstWorkflowTutorialPrefs.suppressAutoStart).toBe(true);
+  });
+
+  it("records completion without discarding an earlier suppression", () => {
+    useAppStore.getState().suppressRunFirstWorkflowTutorialPrompt();
+    useAppStore.getState().completeRunFirstWorkflowTutorial();
+
+    const prefs = useAppStore.getState().runFirstWorkflowTutorialPrefs;
+    expect(prefs.suppressAutoStart).toBe(true);
+    expect(prefs.completedAt).toBeTruthy();
+    expect(useAppStore.getState().runFirstWorkflowTutorialStep).toBe("finish");
+  });
+});

--- a/frontend/src/store/tutorialSlice.ts
+++ b/frontend/src/store/tutorialSlice.ts
@@ -7,21 +7,26 @@ export const createTutorialSlice: StateCreator<AppStore, [], [], TutorialSlice> 
   runFirstWorkflowTutorialStep: "inspect-data",
   runFirstWorkflowTutorialInstance: null,
   runFirstWorkflowTutorialPrefs: {},
+  // #1986: prefs are deliberately left alone here. Resetting them meant that
+  // starting the tutorial erased an earlier "Don't show again" or completion,
+  // so the welcome prompt came back the moment the user closed the panel.
   startRunFirstWorkflowTutorial: (instance) =>
     set({
       runFirstWorkflowTutorialActive: true,
       runFirstWorkflowTutorialStep: "inspect-data",
       runFirstWorkflowTutorialInstance: instance,
-      runFirstWorkflowTutorialPrefs: {},
     }),
   setRunFirstWorkflowTutorialStep: (step) => set({ runFirstWorkflowTutorialStep: step }),
   exitRunFirstWorkflowTutorial: () => set({ runFirstWorkflowTutorialActive: false }),
   completeRunFirstWorkflowTutorial: () =>
-    set({
+    set((state) => ({
       runFirstWorkflowTutorialActive: false,
       runFirstWorkflowTutorialStep: "finish",
-      runFirstWorkflowTutorialPrefs: { completedAt: new Date().toISOString() },
-    }),
+      runFirstWorkflowTutorialPrefs: {
+        ...state.runFirstWorkflowTutorialPrefs,
+        completedAt: new Date().toISOString(),
+      },
+    })),
   dismissRunFirstWorkflowTutorialPrompt: () =>
     set((state) => ({
       runFirstWorkflowTutorialPrefs: {


### PR DESCRIPTION
## Problem

Users reported the "Run Your First SciStudio Workflow" tutorial prompt coming
back on every launch of the packaged desktop app — after clicking "Don't show
again", and after completing the tutorial.

The tutorial logic was not at fault. `desktop/main.js` started the backend with
`--port 0`, so `scistudio.cli.main:gui` bound a fresh ephemeral port each launch
and Electron loaded a different `http://127.0.0.1:<port>` origin every time.
`localStorage` is origin-scoped, so the zustand `scistudio-studio-ui` snapshot
was unreachable at each start and `runFirstWorkflowTutorialPrefs` was always
`{}` — `dismissedAt`, `suppressAutoStart` and `completedAt` could never survive a
restart. Panel sizes, open file tabs, terminal tabs and the active bottom tab
were reset by the same mechanism.

A second, independent defect: `startRunFirstWorkflowTutorial` reset
`runFirstWorkflowTutorialPrefs` to `{}`, so starting the tutorial erased an
earlier suppression or completion even when storage did survive.

## Change

- New `desktop/runtime-port.js` holds the port decision logic as pure functions,
  mirroring how `desktop/ota.js` is used: `main.js` gathers the on-disk and
  network facts, the module decides.
- The desktop shell remembers the bound port in `userData/runtime-port.json` and
  prefers it next launch, so the renderer origin is stable and localStorage
  persists.
- The remembered port is probed for availability before reuse, and a bind race
  lost between probe and backend startup is retried once on an ephemeral port —
  detected via uvicorn's bind-failure wording so an unrelated startup failure is
  not retried into a second startup timeout.
- `SCISTUDIO_DESKTOP_RUNTIME_PORT` still wins outright and is never written back;
  `0` remains the way to ask for the old always-ephemeral behavior.
- `runtime-port.js` is added to the electron-builder `files` list so it ships.
- `startRunFirstWorkflowTutorial` no longer clears the prefs, and
  `completeRunFirstWorkflowTutorial` merges rather than replaces them.

## Tests

- `desktop/test/runtime-port.test.js` — 22 cases over env/remembered port
  normalization, selection precedence, write-back conditions, ready-line port
  extraction, and bind-failure detection.
- `frontend/src/store/tutorialSlice.test.ts` — prefs survive start, start+exit,
  and completion.

## Note for release

`desktop/main.js` is outside the OTA payload, so the port half of this fix
reaches users only through a new installer build. The tutorial-slice half ships
with the frontend and is OTA-deliverable.

Gate record: .workflow/records/1986-guided-1986-stable-runtime-port.json

Closes #1986
