### PR TITLE
docs(#2005): ADR-053 — the Learning Center and bringing existing work into SciStudio

### DIFF
--- a/.workflow/records/2005-docs-2005-adr-053-learning-center.json
+++ b/.workflow/records/2005-docs-2005-adr-053-learning-center.json
@@ -15,10 +15,76 @@
       "status": "pass",
       "summary": "clean",
       "tool_versions": {}
+    },
+    {
+      "at": "2026-08-06T07:04:31.152424Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:b977486afaabd48850bd52dd6d98628a2cbc5fd9386b874090c4aa14eabe091e",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-06T07:05:42.784760Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e202154f7b795177fc44503554dc45ff3de4b68fd365987065eebe6235f2b9dc",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-06T07:08:27.639010Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:747cee0bb37f646f262ef4e4ce861d4f469905b525133687e32ba77307681cca",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-06T07:09:38.655889Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:00186355234e39c5bd678a55c44022d62f745fbc717fe2c2a56a54686a3960cf",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
     }
   ],
   "check_na": [],
-  "commit": null,
+  "commit": {
+    "sha": "d274f5b63d4860f957832fa0f74f3d2663aff66f",
+    "shas": [
+      "d274f5b63d4860f957832fa0f74f3d2663aff66f"
+    ],
+    "trailers": []
+  },
   "declared_scope": {
     "exclude": [],
     "include": [
@@ -128,6 +194,334 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-08-06T07:04:16.173419Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-06T07:04:16.188002Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-06T07:04:16.202074Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-06T07:04:16.216369Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-06T07:04:16.229988Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-06T07:04:16.245092Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-06T07:04:16.260478Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-06T07:04:16.276271Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-06T07:04:16.290829Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-06T07:04:16.307854Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-06T07:05:42.819374Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-06T07:05:42.832243Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-06T07:05:42.845476Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-06T07:05:42.858020Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-06T07:05:42.870849Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-06T07:05:42.884212Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-06T07:05:42.896762Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-06T07:05:42.909747Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-06T07:05:42.922742Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-06T07:05:42.937446Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-06T07:09:38.689495Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-06T07:09:38.702378Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-06T07:09:38.714952Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-06T07:09:38.727576Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-06T07:09:38.740477Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-06T07:09:38.753443Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-06T07:09:38.766176Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-06T07:09:38.778825Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-06T07:09:38.793011Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-06T07:09:38.808235Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-06T07:09:44.453504Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-06T07:09:44.466185Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-06T07:09:44.479464Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-06T07:09:44.493013Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-06T07:09:44.506123Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-06T07:09:44.519698Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-06T07:09:44.533514Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-06T07:09:44.546175Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-06T07:09:44.558431Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-06T07:09:44.573359Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -142,31 +536,79 @@
   "observed_diff": {
     "base": "origin/main",
     "base_sha": "5c7775b3",
-    "changed_files": [],
-    "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "changed_files": [
+      ".workflow/records/2005-docs-2005-adr-053-learning-center.json",
+      "docs/adr/ADR-037.md",
+      "docs/adr/ADR-053.md"
+    ],
+    "diff_fingerprint": "sha256:5d7616730390654558bac8fac5346cc67f0f9e72df0db272ea95586d30e466b3",
     "head": "HEAD",
-    "head_sha": "5c7775b3",
+    "head_sha": "d274f5b6",
     "surfaces": {
-      "docs": 0,
+      "docs": 2,
       "frontend": 0,
       "governance": 0,
       "governed_docs": 0,
       "implementation": 0,
       "packaging": 0,
       "protected_core": 0,
-      "sentrux": 0,
+      "sentrux": 2,
       "test": 0,
       "workflow_ci": 0
     }
   },
   "owner_directive": "Owner approved authoring ADR-053 for the Learning Center and pipeline-import track (issues #1995-#2002) after a design discussion. Owner decisions: name the surface 'Learning Center' in both architecture and UI; record supersession of ADR-037 section 3.7 D23 inside ADR-053 with a back-pointer in ADR-037 rather than an ADR-037 addendum; write the ADR as a feature narrative in the ADR-050/ADR-051 house style rather than an enumerated list of decisions.",
   "persona": "adr_author",
-  "pull_request": null,
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [
+      2005
+    ],
+    "number": null,
+    "url": null
+  },
   "reconcile_events": [
     {
       "at": "2026-08-06T07:03:21.449245Z",
       "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
       "mode": "local",
+      "result": "pass",
+      "tier": 3,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-06T07:04:16.307878Z",
+      "diff_fingerprint": "sha256:7498ed723a5b56470996a34c7c13ac239c461b5a9685999aeca1c322d5f9814c",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 3,
+      "unsatisfied": [
+        "checks.full_audit",
+        "checks.semantic_dup"
+      ]
+    },
+    {
+      "at": "2026-08-06T07:05:42.937469Z",
+      "diff_fingerprint": "sha256:7498ed723a5b56470996a34c7c13ac239c461b5a9685999aeca1c322d5f9814c",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 3,
+      "unsatisfied": [
+        "checks.full_audit"
+      ]
+    },
+    {
+      "at": "2026-08-06T07:09:38.808265Z",
+      "diff_fingerprint": "sha256:5d7616730390654558bac8fac5346cc67f0f9e72df0db272ea95586d30e466b3",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 3,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-06T07:09:44.573388Z",
+      "diff_fingerprint": "sha256:5d7616730390654558bac8fac5346cc67f0f9e72df0db272ea95586d30e466b3",
+      "mode": "pre-pr",
       "result": "pass",
       "tier": 3,
       "unsatisfied": []
@@ -177,7 +619,8 @@
   "required_obligations": {
     "admin_labels": [],
     "checks": [
-      "full_audit"
+      "full_audit",
+      "semantic_dup"
     ],
     "docs": [],
     "guards": [

--- a/.workflow/records/2005-docs-2005-adr-053-learning-center.json
+++ b/.workflow/records/2005-docs-2005-adr-053-learning-center.json
@@ -79,9 +79,9 @@
   ],
   "check_na": [],
   "commit": {
-    "sha": "d274f5b63d4860f957832fa0f74f3d2663aff66f",
+    "sha": "0c26bb50a8b4354a1f27789c7cb6413a2d325ecd",
     "shas": [
-      "d274f5b63d4860f957832fa0f74f3d2663aff66f"
+      "0c26bb50a8b4354a1f27789c7cb6413a2d325ecd"
     ],
     "trailers": []
   },
@@ -604,6 +604,170 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-08-06T07:10:57.094071Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-06T07:10:57.106976Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-06T07:10:57.120413Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-06T07:10:57.133673Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-06T07:10:57.145922Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-06T07:10:57.158177Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-06T07:10:57.170317Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-06T07:10:57.182864Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-06T07:10:57.194977Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-06T07:10:57.210662Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-06T07:11:08.252421Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-06T07:11:08.265150Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-06T07:11:08.277639Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-06T07:11:08.290319Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-06T07:11:08.303244Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-06T07:11:08.316338Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-06T07:11:08.328873Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-06T07:11:08.344299Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-06T07:11:08.356637Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-06T07:11:08.371969Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -616,16 +780,16 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "origin/main",
+    "base": "5c7775b342f7933d7fc7adb3ab01a767e344a35e",
     "base_sha": "5c7775b3",
     "changed_files": [
       ".workflow/records/2005-docs-2005-adr-053-learning-center.json",
       "docs/adr/ADR-037.md",
       "docs/adr/ADR-053.md"
     ],
-    "diff_fingerprint": "sha256:3a49ee68938faa7c678226911e0711b85af1669ba2d9917761744cf396a0798e",
+    "diff_fingerprint": "sha256:3e3f01d4987fdbdbcb3a6e0974dd12b3b1e9eaf502915299646fd9137671bcad",
     "head": "HEAD",
-    "head_sha": "892becbf",
+    "head_sha": "0c26bb50",
     "surfaces": {
       "docs": 2,
       "frontend": 0,
@@ -646,7 +810,7 @@
     "closes": [
       2005
     ],
-    "number": null,
+    "number": 2006,
     "url": null
   },
   "reconcile_events": [
@@ -698,6 +862,22 @@
     {
       "at": "2026-08-06T07:10:08.350270Z",
       "diff_fingerprint": "sha256:3a49ee68938faa7c678226911e0711b85af1669ba2d9917761744cf396a0798e",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 3,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-06T07:10:57.210694Z",
+      "diff_fingerprint": "sha256:3e3f01d4987fdbdbcb3a6e0974dd12b3b1e9eaf502915299646fd9137671bcad",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 3,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-06T07:11:08.371998Z",
+      "diff_fingerprint": "sha256:3e3f01d4987fdbdbcb3a6e0974dd12b3b1e9eaf502915299646fd9137671bcad",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 3,

--- a/.workflow/records/2005-docs-2005-adr-053-learning-center.json
+++ b/.workflow/records/2005-docs-2005-adr-053-learning-center.json
@@ -522,6 +522,88 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-08-06T07:10:08.227691Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-06T07:10:08.240902Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-06T07:10:08.254742Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-06T07:10:08.268164Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-06T07:10:08.281537Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-06T07:10:08.294735Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-06T07:10:08.307755Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-06T07:10:08.321222Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-06T07:10:08.334056Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-06T07:10:08.350240Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -541,9 +623,9 @@
       "docs/adr/ADR-037.md",
       "docs/adr/ADR-053.md"
     ],
-    "diff_fingerprint": "sha256:5d7616730390654558bac8fac5346cc67f0f9e72df0db272ea95586d30e466b3",
+    "diff_fingerprint": "sha256:3a49ee68938faa7c678226911e0711b85af1669ba2d9917761744cf396a0798e",
     "head": "HEAD",
-    "head_sha": "d274f5b6",
+    "head_sha": "892becbf",
     "surfaces": {
       "docs": 2,
       "frontend": 0,
@@ -608,6 +690,14 @@
     {
       "at": "2026-08-06T07:09:44.573388Z",
       "diff_fingerprint": "sha256:5d7616730390654558bac8fac5346cc67f0f9e72df0db272ea95586d30e466b3",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 3,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-06T07:10:08.350270Z",
+      "diff_fingerprint": "sha256:3a49ee68938faa7c678226911e0711b85af1669ba2d9917761744cf396a0798e",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 3,

--- a/.workflow/records/2005-docs-2005-adr-053-learning-center.json
+++ b/.workflow/records/2005-docs-2005-adr-053-learning-center.json
@@ -1,0 +1,221 @@
+{
+  "branch": "docs/2005-adr-053-learning-center",
+  "check_events": [
+    {
+      "at": "2026-08-06T07:03:21.307608Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:d2016153ffe72f6d9588cf72b647d8f545261ca64eb63f312f104e3c66e7d074",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    }
+  ],
+  "check_na": [],
+  "commit": null,
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "docs/adr/ADR-053.md",
+      "docs/adr/ADR-037.md"
+    ]
+  },
+  "directive_events": [
+    {
+      "at": "2026-08-06T06:57:32.611207Z",
+      "owner_directive": "Plan: create docs/adr/ADR-053.md (status Proposed, phase planning) following the ADR-042 normative body outline with a 1.1 Problems Addressed table whose Detailed section values all resolve; body written as four narrative claims (learning by running; a tool library is a place; the way in starts from what the user already has; correctness comes from verification) plus scope, verification, consequences, alternatives. Add a back-pointer in docs/adr/ADR-037.md section 3.7 D23 recording that ADR-053 supersedes that decision.",
+      "reason": "plan"
+    }
+  ],
+  "docs_events": [
+    {
+      "at": "2026-08-06T06:57:32.611232Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/adr/ADR-053.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-06T06:57:32.611240Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/adr/ADR-037.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-06T07:02:43.572859Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/adr/ADR-053.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-06T07:02:43.572877Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/adr/ADR-037.md",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": false,
+  "guard_events": [
+    {
+      "at": "2026-08-06T07:03:21.338453Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-06T07:03:21.350761Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-06T07:03:21.362967Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-06T07:03:21.375296Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-06T07:03:21.387600Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-06T07:03:21.400364Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-06T07:03:21.412664Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-06T07:03:21.424965Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-06T07:03:21.437132Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-06T07:03:21.449200Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 2005,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": {
+    "base": "origin/main",
+    "base_sha": "5c7775b3",
+    "changed_files": [],
+    "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "head": "HEAD",
+    "head_sha": "5c7775b3",
+    "surfaces": {
+      "docs": 0,
+      "frontend": 0,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 0,
+      "packaging": 0,
+      "protected_core": 0,
+      "sentrux": 0,
+      "test": 0,
+      "workflow_ci": 0
+    }
+  },
+  "owner_directive": "Owner approved authoring ADR-053 for the Learning Center and pipeline-import track (issues #1995-#2002) after a design discussion. Owner decisions: name the surface 'Learning Center' in both architecture and UI; record supersession of ADR-037 section 3.7 D23 inside ADR-053 with a back-pointer in ADR-037 rather than an ADR-037 addendum; write the ADR as a feature narrative in the ADR-050/ADR-051 house style rather than an enumerated list of decisions.",
+  "persona": "adr_author",
+  "pull_request": null,
+  "reconcile_events": [
+    {
+      "at": "2026-08-06T07:03:21.449245Z",
+      "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "mode": "local",
+      "result": "pass",
+      "tier": 3,
+      "unsatisfied": []
+    }
+  ],
+  "record_id": "2005-docs-2005-adr-053-learning-center",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [
+      "full_audit"
+    ],
+    "docs": [],
+    "guards": [
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": []
+  },
+  "runtime": "claude-code",
+  "schema_version": 2,
+  "scope_events": [],
+  "session_id": "82fbdadb-4f4c-4f1b-a256-df869e1f7e81",
+  "strictness_tier": 3,
+  "task_kind": "docs",
+  "test_events": [
+    {
+      "at": "2026-08-06T06:57:32.611248Z",
+      "class": "implementation",
+      "kind": "na",
+      "path": null,
+      "rationale": "Docs-only ADR authoring; no runtime, API, or frontend behavior changes in this PR. Implementation and its tests are tracked by issues #1995-#2002.",
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-06T07:02:43.572885Z",
+      "class": "implementation",
+      "kind": "na",
+      "path": null,
+      "rationale": "Docs-only ADR authoring; no runtime, API, or frontend behavior changes. Implementation and its tests are tracked by issues #1995-#2002 and enumerated in ADR-053 section 7.",
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/docs/adr/ADR-037.md
+++ b/docs/adr/ADR-037.md
@@ -7,7 +7,7 @@ date_accepted: null
 date_superseded: null
 supersedes: []
 superseded_by: null
-related: [17, 19, 24, 25, 29, 31, 32, 34, 35, 36, 39, 40]
+related: [17, 19, 24, 25, 29, 31, 32, 34, 35, 36, 39, 40, 53]
 closes_issues: []
 tracking_issue: 1289
 is_code_implementation: true
@@ -409,7 +409,15 @@ All installers ship via GitHub Releases as the primary download URL. Update chan
 
 #### 3.7 First-run onboarding
 
-**D23. Same web first-screen + sample project + silent CLI detection.**
+> **Superseded by ADR-053 §2.4.** D23 below is no longer the accepted decision.
+> First launch lands on the Learning Center; the single bundled sample becomes a
+> catalogue of entries that each bootstrap their own project; and silent CLI
+> detection with a one-time notification becomes a graded availability probe
+> surfaced when an agent-dependent action is attempted. D23 is retained here as
+> the superseded record. The rest of ADR-037 is unaffected — it remains governing
+> for desktop packaging, distribution, update, uninstall, and offline behavior.
+
+**D23. Same web first-screen + sample project + silent CLI detection.** *(Superseded — see ADR-053 §2.4.)*
 
 - First launch shows the current web first-screen (no new onboarding wizard).
 - A bundled sample project is offered: "Open example project" button on the start screen. The example demonstrates 2-3 blocks producing a visible result within 30 seconds of launch.

--- a/docs/adr/ADR-053.md
+++ b/docs/adr/ADR-053.md
@@ -1,0 +1,614 @@
+---
+adr: 53
+title: "The Learning Center And Bringing Existing Work Into SciStudio"
+status: Proposed
+date_created: 2026-08-06
+date_accepted: null
+date_superseded: null
+
+supersedes: []
+superseded_by: null
+related: [33, 34, 37, 42, 43, 48, 51]
+closes_issues: [2005]
+tracking_issue: 1999
+
+is_code_implementation: true
+governs:
+  modules:
+    - scistudio.api.routes.tutorials
+    - scistudio.api._block_source
+  contracts:
+    - scistudio.api._block_source.map_block_origin
+    - scistudio.api._block_source.resolve_block_source
+  entry_points: []
+  files:
+    - docs/adr/ADR-053.md
+    - src/scistudio/api/routes/tutorials.py
+    - src/scistudio/api/_block_source.py
+    - src/scistudio/api/routes/blocks.py
+    - frontend/src/store/tutorialSlice.ts
+    - frontend/src/components/TutorialPanel.tsx
+    - frontend/src/components/WelcomeScreen.tsx
+    - frontend/src/components/BlockPalette.tsx
+    - frontend/src/components/BlockPalette.parts/paletteModel.ts
+    - frontend/src/App.parts/WelcomePane.tsx
+    - frontend/src/App.parts/useRunFirstWorkflowTutorial.ts
+    - frontend/src/tutorials/runFirstWorkflow/content.ts
+    - frontend/src/lib/api/tutorials.ts
+    - docs/specs/frontend-block-palette.md
+  excludes:
+    - docs/user/reference/**
+    - docs/user/llms.txt
+planned_governs:
+  modules: []
+  contracts: []
+  entry_points: []
+  files: []
+  excludes: []
+tests:
+  - tests/api/test_tutorials.py
+  - tests/api/test_block_origin_tiers.py
+  - frontend/src/store/tutorialSlice.test.ts
+  - frontend/src/components/BlockPalette.parts/__tests__/paletteModel.test.ts
+agent_editable: false
+assisted_by:
+  - "Claude:claude-opus-5"
+
+phase: planning
+tags:
+  - onboarding
+  - learning-center
+  - block-library
+  - discoverability
+  - agent-availability
+  - frontend-runtime
+owner: "@jiazhenz026"
+co_authors:
+  - "@claude"
+language_source: en
+translations: []
+---
+
+# ADR-053: The Learning Center And Bringing Existing Work Into SciStudio
+
+## 1. Decision Summary
+
+A scientist who opens SciStudio for the first time meets an empty canvas. They
+have an analysis to finish today, and nothing on the screen tells them what the
+graph is for. So they drag in the one block whose purpose is self-evident — an
+agent — and start a conversation. The analysis gets done. Nothing is left behind
+that another project could use.
+
+This is what our users actually do. Others get further and build five process
+blocks, each carrying out several steps of a pipeline, and none of those blocks
+ever leaves the project it was written in. None of these users had heard of
+interactive blocks, custom previewers, or custom data types. The natural reading
+is that they failed to learn the product, but that is not what happened. Coarse
+blocks and one-shot conversations are the correct choice when there is nowhere
+for a block to go afterwards: splitting a pipeline into reusable pieces only
+repays the effort if the pieces can be reused, and today they cannot be. What
+these users are missing is not knowledge. It is a place to put things, and a
+path that leads there.
+
+This ADR introduces the **Learning Center** — a catalogue of entries that are
+real, runnable workflows rather than pages to read — and a path for **bringing
+an existing codebase into SciStudio as blocks**. The two are one feature. The
+Learning Center is where a user learns that a personal tool library exists and
+what it is worth; pipeline import is how a lab that already owns hundreds of
+analysis scripts obtains that library without rebuilding it by hand.
+
+The ADR is built around four claims, each addressed by a later section: learning
+happens by **running**, so an entry is a real project (Section 2); a tool library
+is **a place in the product**, not a filesystem convention (Section 3); the way
+in starts from **what the user already has** (Section 4); and the correctness of
+an imported block comes from **verification, not from the agent writing it well**
+(Section 5).
+
+This ADR supersedes ADR-037 §3.7 D23, which decided that first launch would keep
+the existing first screen with no onboarding surface; Section 2.4 explains what
+changed and why. It extends the graceful-degradation principle of ADR-037 §3.8
+D24 from network availability to agent availability. ADR-042 remains governing
+for documentation under `docs/user/tutorials/`, which this ADR deliberately does
+not touch; Section 2.5 draws that boundary. ADR-051 remains governing for the
+interactive blocks that Learning Center entries teach, and ADR-048 for
+previewers. ADR-034 remains governing for agent provider configuration, which
+Section 5.2 reads but does not redefine.
+
+The evidence for this ADR is owner-observed usage across colleagues, early
+users, and one spatial multi-omics lab. It is qualitative observation and a
+small number of direct conversations, not instrumented telemetry. The decisions
+below are sized accordingly: they are reversible product surfaces, not schema or
+runtime commitments.
+
+### 1.1 Problems Addressed
+
+| Problem | Risk | ADR response | Detailed section |
+|---|---|---|---|
+| A new user's first screen is an empty canvas that does not say what the graph is for | The user reaches for the one self-explanatory block, an agent, and the product degrades into a chat window with extra steps | Make the Learning Center the first-run landing surface | Section 2.3 |
+| Learning material that is read rather than run leaves the user with nothing and cannot be verified as understood | Completion becomes page views; the user finishes the material and still has no working artefact | Every Learning Center entry bootstraps a real project with real data; completion is granted only for a completed run | Section 2.1, Section 2.2 |
+| ADR-037 §3.7 D23 accepted no onboarding surface at first launch | A future reader finds D23, sees the Learning Center, and cannot tell whether the product drifted or the decision changed | Record the supersession explicitly, with the observation that changed it | Section 2.4 |
+| "Tutorial" already denotes generated documentation under ADR-042 | Two unrelated things share a name; contributors and agents put content in the wrong place | Name the in-app surface Learning Center and state the boundary | Section 2.5 |
+| Process blocks stay coarse because a block has nowhere to live once the project ends | Nothing accumulates; every project starts from zero and fine-grained authoring never repays its cost | Make the personal tool library a first-class place in the product, with a promotion path into it | Section 3 |
+| The user tier of the block library exists on disk but has no product surface and no write path | A capability that already works is invisible, so no user or agent ever uses it | Distinguish the user tier from the project tier in the palette and give it write entry points | Section 3 |
+| A lab's existing codebase is their real tool library, and it cannot enter SciStudio without hand-rebuilding | The users with the most to gain face the highest entry cost and stay outside the product | Provide an import path that starts from the code they already have | Section 4 |
+| An import path that requires a configured agent before showing anything turns setup into a gate | Users abandon at the configuration step, before any value has been demonstrated | Static scanning produces the candidate list with no agent involved | Section 4.1 |
+| An agent-transcribed block cannot be trusted on the agent's word | Users accumulate blocks nobody dares run, which is worse than having none | Every transcribed block ships with a generated differential test against the original code | Section 5.1 |
+| Agent availability treated as a boolean produces misleading guidance | A user who is logged in but out of quota is told to install software they already have | Grade availability into four states, each with its own guidance | Section 5.2 |
+
+## 2. Learning Is Done By Running, Not By Reading
+
+The thing a new user needs is not an explanation of what a block is. It is one
+completed workflow that belongs to them. Until they have run something, the
+vocabulary has nothing to attach to: a typed port is an abstraction, a lineage
+record is bookkeeping, and a custom previewer solves a problem they have not yet
+had. After they have run something, all three become answers to questions they
+are already asking. The design follows from this: the unit of learning is a run,
+not a page, and everything else in this section is a consequence.
+
+### 2.1 A Learning Center Entry Is A Real Project
+
+An entry does not simulate SciStudio and does not describe it. It creates a
+project on disk, writes real input data into it, and walks the user through
+building and running a workflow over that data.
+
+This property already exists and is the foundation this ADR builds on. The
+current onboarding flow (`POST /api/tutorials/run-first-workflow/bootstrap`)
+creates a project under `~/SciStudio Tutorials`, writes a fluorescence dataset
+into it, and guides the user through authoring a custom block and producing a
+plot. The decision recorded here is that this is the standard for every entry,
+not a property of the one that happens to exist.
+
+The cost is real and is accepted deliberately. Entries create directories the
+user did not ask for, can fail partway, and leave artefacts behind that
+something must eventually clean up. A read-only lesson has none of those
+problems. It also leaves the user with nothing at the end, and gives the product
+no way to know whether they understood anything. A workflow that ran is evidence;
+a page that was scrolled is not.
+
+What must change is that the current implementation is built around exactly one
+entry. The route path, the response model, and the frontend store keys all name
+that single tutorial — `RUN_FIRST_WORKFLOW_ID`, `runFirstWorkflowTutorialActive`,
+`runFirstWorkflowTutorialStep`, `runFirstWorkflowTutorialPrefs`. A second entry
+today means copying the whole stack. This ADR requires that entries become
+registry data rather than hardcoded identity: a catalogue declares each entry's
+id, title, cover image, ordering, and prerequisites, and one generalised
+bootstrap serves all of them. This is planned work, tracked by #1998.
+
+### 2.2 Progress Is Counted In Completed Runs
+
+A user needs to know that there is more to learn and roughly how much of it they
+have. That requires a denominator, which the current single-entry structure
+cannot express — its progress state is one tutorial's `completedAt` and
+`dismissedAt`, with no notion of a set.
+
+Two rules govern how progress is counted.
+
+Completion is granted for **running an entry's workflow to the end**, never for
+opening it. Because entries are real projects (Section 2.1), this is directly
+observable rather than a proxy. Reading is not progress, and the product should
+not pretend otherwise.
+
+Progress is displayed as **completed count out of total**, not as a bare
+percentage. The two carry the same information until the catalogue grows, and
+then they diverge sharply: adding entries leaves the numerator untouched but
+reduces the percentage, so a user who did nothing is told they went backwards.
+Stated as a count, the same event reads as new material being available. This is
+a presentation rule rather than a data model rule, and it exists because the
+catalogue is expected to grow for as long as the product does.
+
+Progress state must migrate from the existing single-tutorial preferences. A user
+who has already completed or dismissed the current onboarding flow must not be
+prompted again; #1986 fixed exactly that regression and the migration must not
+reintroduce it.
+
+### 2.3 The First Thing A New User Sees
+
+First launch lands on the Learning Center rather than on an empty canvas.
+
+The empty canvas is not neutral. It is a prompt that the user must answer with
+knowledge they do not have, and the observed answer is to reach for the one block
+whose purpose needs no explanation. The agent block is a good block; it is a bad
+first block, because a conversation is a terminal state that leaves no reusable
+artefact behind. Landing on a catalogue of runnable entries replaces a question
+the user cannot answer with a choice they can.
+
+This is a rework of the existing first-run surfaces (`WelcomeScreen.tsx`,
+`WelcomePane.tsx`), not a new page in front of them. The dismissal and
+auto-start machinery those surfaces already carry — the suppression preference
+and the recorded dismissal — is preserved rather than rebuilt, because it
+encodes a fix for a real regression.
+
+Entries are presented as cards led by the artefact they produce: the finished
+plot, the spectrum, the spatial slice. The users are scientists, and one real
+result image tells them whether an entry is relevant faster than a paragraph
+does.
+
+### 2.4 Relationship To ADR-037 §3.7
+
+ADR-037 §3.7 D23 decided three things: first launch keeps the existing web first
+screen with no onboarding wizard; a bundled sample project is offered behind an
+"Open example project" button; and claude/codex detection runs silently, with a
+one-time non-modal notification when both are missing.
+
+This ADR supersedes all three. First launch lands on the Learning Center
+(Section 2.3). The single bundled sample becomes a catalogue of entries, each of
+which bootstraps its own project (Section 2.1). Silent detection with a one-time
+notification becomes a graded availability probe surfaced at the moment an
+agent-dependent action is attempted (Section 5.2).
+
+D23 was a reasonable decision on the information available when ADR-037 was
+written. It optimised for not building an onboarding wizard nobody had asked
+for, which was correct in the absence of evidence about how users behave on first
+launch. The evidence now exists, and it is that the un-onboarded first screen
+does not stay neutral — it reliably produces the single-agent-block usage pattern
+described in Section 1. That is what changed.
+
+ADR-037 is **not** superseded as a whole. It remains governing for desktop
+packaging, distribution, update, uninstall, and offline behavior. Only §3.7 D23
+is replaced. A back-pointer is recorded in ADR-037 at that decision.
+
+Section 3.8 D24 of the same ADR is not superseded but extended. D24 established
+that core functionality stays fully available offline while AI, plugin install,
+and auto-update degrade gracefully. This ADR applies the same principle to a
+different axis: agent-dependent flows degrade to their non-agent portion rather
+than becoming unavailable (Section 4.1, Section 5.2).
+
+### 2.5 Boundary With Documentation Tutorials
+
+ADR-042 uses "tutorial" for generated and hand-authored documentation under
+`docs/user/tutorials/`, rendered through the docs toolchain. That is a different
+artefact from what this ADR introduces, and the two must not be conflated.
+
+The boundary is drawn by naming rather than by qualification. The in-app surface
+is the **Learning Center**, in the architecture and in the user interface alike.
+Its contents are entries that bootstrap projects and are completed by running.
+Documentation tutorials remain documentation: they live under `docs/user/`, they
+are governed by ADR-042, and nothing in this ADR changes them.
+
+The two may reference each other. An entry may link to the documentation for a
+contract it uses, and documentation may point a reader at the Learning Center
+entry that demonstrates the same thing. Neither is generated from the other, and
+neither is the source of truth for the other.
+
+## 3. A Tool Library Is A Place, Not A Convention
+
+SciStudio already has three block tiers. Packages install blocks; a user-wide
+directory (`~/.scistudio/blocks/`, `~/.scistudio/types/`) holds blocks available
+in every project; a project-local directory (`{project}/blocks/`,
+`{project}/types/`) holds blocks belonging to one project. Discovery reads all
+three. The middle tier — the one that would constitute a personal tool library —
+works, and is invisible.
+
+It is invisible in two specific ways. The API collapses the distinction:
+`map_block_origin` maps the tier-1 registry label to a single `custom` origin,
+so the user tier and the project tier arrive at the frontend indistinguishable.
+The palette then renders them as one `Custom` section (`buildPaletteSections`
+orders sections as pinned Data I/O, then Built-in, then Custom, then plugin
+packages alphabetically). And there is no write path at all: nothing in the
+product puts a block into the user-wide directory. Reaching it requires copying
+files in a file manager, which no observed user does and which the agent never
+offers.
+
+This is the missing container, and it explains the coarse blocks. A block that
+can only ever live in the project where it was written has no reuse to repay the
+cost of a clean boundary, so authoring one large block that does five things is
+the economical choice. Granularity is downstream of destination. The decision
+recorded here is therefore not "encourage smaller blocks" — an instruction users
+have no reason to follow — but "give a block somewhere to go", after which
+smaller blocks become worth authoring on their own merits.
+
+Three things follow.
+
+The palette **names the tiers the user actually has**. The single `Custom`
+section separates into a user-tier section and a project-tier section. The user
+tier is ordered above the project tier, because it is the container the product
+is asking users to invest in and ordering it last would state the opposite. The
+underlying split is inexpensive: the registry spec already carries the concrete
+`file_path` used by `resolve_block_source`, so the tier is a path comparison and
+no data model changes.
+
+Both sections **render when empty**, carrying a one-line statement of what the
+section is for. A section that disappears when empty teaches nothing, and the
+empty state is the only moment when a user who has never heard of a personal
+library is guaranteed to be looking at the place it would live. This is the
+cheapest discovery surface in the entire ADR and is treated as load-bearing
+rather than as polish.
+
+A block is **promoted by an action in the product**. Saving a block to the user
+library is available where the user is already looking at a block — its source,
+and its node on the canvas — and the agent can perform the same promotion and
+offer it when it has just authored a block the user ran successfully. Promotion
+is a copy, not a move: the project keeps working. Name collisions prompt rather
+than overwrite. A block that references a project-local custom type is flagged,
+because promoting it alone produces a library block that fails in every other
+project.
+
+This work is planned, tracked by #1995 and #1996.
+
+## 4. The Way In Starts From What The User Already Has
+
+The spatial multi-omics lab using SciStudio has a substantial Python codebase.
+That codebase is their tool library. It is organised, it works, and it took
+years. The gap between them and a SciStudio block library is not understanding —
+it is the cost of re-authoring work they have already done.
+
+An onboarding strategy that only teaches block authoring asks precisely the users
+with the most existing assets to pay the highest entry cost. The import path
+exists to invert that: the assets they already own become the library, and the
+product's job is to carry them across rather than to ask for them again.
+
+### 4.1 Scanning Is Not An Agent Task
+
+Import splits into two operations with very different requirements. Finding the
+block-shaped units in a codebase — the functions and scripts with clear inputs,
+outputs, and a single responsibility — is static analysis. Converting one into a
+SciStudio block is a language task that needs an agent.
+
+They are separated deliberately, and the separation is the decision, not an
+implementation detail.
+
+Scanning runs with **no agent configured**. A user who has never set up an agent
+can point SciStudio at their repository and be shown a list: these twelve things
+in your code could become blocks, here is where each one lives and why it was
+suggested. That list is useful on its own, and it is produced before the product
+has asked for anything.
+
+This changes what agent setup is. Behind a gate, configuring an agent is a cost
+paid on a promise. After the candidate list, it is the next step toward something
+the user has already seen and wants. The same configuration screen sits in both
+designs; only its position relative to the demonstrated value differs, and that
+position is the part that determines whether users complete it.
+
+Transcription proceeds in **small batches**, not whole repositories. The user
+selects a few candidates, converts them, runs them, and returns for more. A
+whole-repository conversion produces a large volume of code whose correctness the
+user cannot assess, which is the fastest way to make the feature untrustworthy.
+Trust in an automated conversion is built incrementally or not at all.
+
+### 4.2 When The Offer Appears
+
+The import path is offered when the user has enough context for the offer to
+mean something. Before a user knows what a block is, "import your existing
+pipeline as blocks" is a sentence with no referent, and offering it at project
+creation puts it in front of exactly the users who cannot parse it.
+
+The trigger is therefore **learning progress**, not elapsed time or project
+count. Progress is a readiness signal: a user who has completed a share of the
+Learning Center has, by construction, run workflows and authored a block. The
+initial threshold is 40% of the catalogue and is **configuration, not a
+constant** — it is a first guess about a population we have observed informally,
+and it will need adjustment once real usage exists.
+
+Where the offer appears matters as much as when. It is surfaced on the completion
+of the entry that crosses the threshold, as an unlock alongside that completion,
+rather than as a separate notification. The same sentence arrives either way; as
+an unlock it arrives at the moment the user is most receptive, and as a
+notification it arrives as an interruption.
+
+The threshold must **not be the only entry point**. Users who never open the
+Learning Center — precisely the single-agent-block cohort this ADR is trying to
+reach — would otherwise never encounter import at all, and they are the users
+whose existing code most needs carrying across. A permanent, quiet entry point
+exists independent of progress. The threshold governs when the product
+volunteers the capability, never whether the capability can be reached.
+
+This work is planned, tracked by #1999, #2001, and #2002.
+
+## 5. Correctness Comes From Verification, Not From The Agent
+
+The obvious objection to agent-authored blocks is that the agent may convert the
+code wrongly, and the objection is correct. The response is not to make the agent
+better at the task. It is to make the result checkable independently of how the
+agent performed.
+
+### 5.1 Differential Tests
+
+Every transcribed block ships with a generated **differential test**: the same
+input through the original script and through the new block, with the outputs
+compared. The user reviews that comparison before accepting the block. A block
+whose differential test fails is presented as failing, with the difference shown,
+rather than accepted quietly.
+
+The important structural property is the split between generating the test and
+running it. **Generating** it requires the agent, because it requires reading the
+original code. **Running** it does not. So the trustworthiness of an imported
+block does not depend on the agent still being available, still being
+authenticated, or still having quota. If an agent becomes unavailable partway
+through a batch, the work already produced remains verifiable, and the user is
+never left holding blocks that nobody is willing to run.
+
+Uncertainty is surfaced rather than smoothed over. Where the agent inferred a
+port type, could not determine a configuration field, or failed to resolve a
+dependency, the draft says so. An agent that reports "I inferred this input is an
+AnnData but I am not certain" is more useful than one that guesses silently and
+presents a confident-looking result, because the first can be checked in seconds
+and the second cannot be checked at all.
+
+### 5.2 Agent Availability Is Graded, Not Boolean
+
+Several flows in this ADR depend on an agent, and each of them needs the same
+question answered: can this user run an agent right now? Answered as a boolean,
+the question produces wrong guidance, because the ways it can be false are not
+interchangeable.
+
+Availability resolves to one of four states, each with its own guidance:
+
+| State | Meaning | Guidance |
+|---|---|---|
+| Not installed | No agent CLI found | Installation instructions |
+| Not authenticated | Installed, no valid credentials | Login instructions for the detected provider |
+| Call failed | Authenticated, live call failed | The concrete cause — quota, network, provider outage |
+| Ready | Live call succeeded | Which providers are configured |
+
+The determination is a **live minimal call**, not a check for an installed
+binary. Installed is not authenticated, and authenticated is not funded; a
+presence check reports ready for users who cannot run anything, which is the
+failure mode most likely to waste a user's afternoon.
+
+The `call failed` state in particular must report its actual cause and must not
+suggest reinstalling. Telling a user who is correctly configured and out of quota
+to install the software they are already running is worse than saying nothing,
+because it sends them to fix something that is not broken.
+
+Provider configuration itself is governed by ADR-034. This ADR consumes that
+configuration to answer an availability question and does not redefine how
+providers are configured or selected.
+
+Agent setup belongs in the Learning Center, but not at its start. The first entry
+must run with **no external configuration at all** — load, process, save. A user
+who is still deciding whether the product is worth their time will not configure
+a language-model provider before they have seen it do anything, and putting that
+demand first loses exactly the users who were only browsing.
+
+This work is planned, tracked by #2000.
+
+## 6. Scope
+
+In scope for this ADR as a decision record:
+
+- The Learning Center as the in-app learning surface, its entries as real
+  runnable projects, and completion counted in runs.
+- First-run landing behavior, superseding ADR-037 §3.7 D23.
+- The naming boundary against ADR-042 documentation tutorials.
+- The personal tool library as a named product surface with a promotion path.
+- Import as a two-stage path whose first stage requires no agent.
+- Differential tests as the correctness mechanism for transcribed blocks.
+- Graded agent availability and its guidance obligations.
+
+Out of scope:
+
+- Implementation. This ADR is `Proposed` and `phase: planning`; all behavior it
+  describes beyond the facts explicitly attributed to the current codebase is
+  planned. Implementation is tracked by #1995 through #2002.
+- Spec text. `docs/specs/frontend-block-palette.md` and the tutorial API
+  contract are updated by the implementing issues, not by this ADR.
+- Documentation tutorials under `docs/user/tutorials/`, governed by ADR-042.
+- Agent provider configuration and selection, governed by ADR-034.
+- Telemetry or instrumented measurement of onboarding. The evidence base here is
+  qualitative; if measurement is wanted it is separate work.
+- Any change to block discovery, the registry, or the tier semantics themselves.
+  This ADR changes how the existing tiers are surfaced, not what they are.
+
+## 7. Verification And Tooling Impact
+
+This ADR introduces no code and no tests of its own. Verification obligations
+attach to the implementing issues, and are recorded here so those issues inherit
+them:
+
+| Claim | How it is verified | Where |
+|---|---|---|
+| The user tier and project tier are distinguishable | Backend test resolving a block in each directory to its distinct origin, plus the fallback for an unresolvable path | #1995 |
+| Palette ordering and empty states | `paletteModel` unit tests over section order and empty-section rendering | #1995 |
+| Promotion copies rather than moves, and prompts on collision | Frontend tests over the promotion action | #1996 |
+| Entries are registry data, not hardcoded identity | Adding a second entry requires no store, driver, or route change | #1998 |
+| Progress migration does not reintroduce #1986 | Explicit regression test over previously completed and dismissed state | #1998 |
+| Completion requires a run | Progress test asserting that opening an entry grants nothing | #1998, #1999 |
+| Scanning works with no agent | Test exercising the scan path with agent availability forced to not-installed | #2001 |
+| Differential tests run without an agent | Test running a generated differential test with no agent configured | #2002 |
+| Availability grading | Tests covering all four states, including authenticated-but-failing | #2000 |
+
+Documentation impact: `docs/specs/frontend-block-palette.md` is amended by
+#1995 and #1997; the tutorial API contract change is recorded by #1998. This ADR
+records a back-pointer in `docs/adr/ADR-037.md` at §3.7 D23 and adds itself to
+that ADR's `related` list.
+
+## 8. Consequences And Risks
+
+**A third place for blocks to live becomes visible.** Users currently reason
+about two categories, built-in and everything-else. This ADR makes it three.
+That is a real increase in what a user must hold in their head, accepted because
+the alternative — a container that exists but cannot be seen — has produced the
+behavior described in Section 1.
+
+**Entries write to the user's disk.** Real projects mean real directories,
+partial failures, and accumulated artefacts under a tutorials location. Cleanup
+is not designed here and will need to be, most likely as part of #1998.
+
+**Gating a capability behind progress is a bet.** If the threshold is wrong,
+users who would benefit from import do not see it offered. The permanent entry
+point limits the damage, and the threshold is configuration precisely because the
+first value is a guess.
+
+**Agent transcription can produce plausible, wrong blocks.** Differential tests
+are the mitigation, and they are only as good as the inputs they exercise. A
+transcription that passes on the sample input and fails on a real one remains
+possible. The batch discipline in Section 4.1 is what keeps that failure small
+and visible rather than large and diffuse.
+
+**The evidence base is thin.** These decisions rest on observation of a small
+number of users, not measurement. They are deliberately confined to reversible
+product surfaces: nothing here changes a schema, a runtime contract, or a stored
+format, so being wrong costs UI work rather than a migration.
+
+**ADR-037 becomes partially superseded.** A reader of ADR-037 must now follow a
+pointer to understand first-run behavior. The back-pointer at D23 is what keeps
+that navigable, and it is a required part of this change rather than a courtesy.
+
+## 9. Alternatives Considered
+
+### 9.1 Write Better Documentation Instead Of Building Product Surface
+
+The cheapest response to "users do not know about these features" is to document
+them better. It fails on its own evidence: the users had never *heard* of
+interactive blocks, custom previewers, or custom data types. Documentation
+answers questions users know to ask. It cannot reach a user who does not know the
+subject exists, because nothing prompts them to go looking. Documentation remains
+necessary and is unchanged by this ADR; it is not sufficient.
+
+### 9.2 State-Triggered Contextual Hints Instead Of A Learning Center
+
+A more sophisticated design detects the situation from the workflow graph — a
+single agent block with a long conversation, a process block with several
+internal stages, the same code appearing in two projects — and offers the
+relevant capability at the moment the user is feeling the underlying pain. This
+is very likely more effective per impression than anything in this ADR.
+
+It was deferred rather than rejected. It costs substantially more, and it is
+built on an assumption not yet tested: that users read hints in the surfaces we
+would place them in. The static tip strip in #1997 tests that assumption cheaply
+and is explicitly designed to keep the trigger mechanism pluggable, so
+condition-driven hints can be added later without rework.
+
+### 9.3 Two Separate ADRs
+
+The Learning Center and pipeline import are separable features with different
+implementation risk, and splitting them would produce two shorter documents.
+
+Rejected because the strongest argument in this ADR is the one that spans them:
+the reason users do not build reusable libraries is a missing container, and both
+features exist to fill it from opposite directions — import carries assets in,
+promotion sinks project work down, and the Learning Center is where the user
+learns the container is there. Split across two documents, that argument has no
+home and each half reads as a smaller, weaker proposal.
+
+### 9.4 Teach Block Authoring Instead Of Importing
+
+Rather than converting existing code, teach users to author blocks well and let
+libraries accumulate naturally. This is what the product does today.
+
+Rejected because it asks the users with the most existing assets to pay the most.
+A lab with years of working analysis code is being asked to re-author it as the
+price of entry, and the observed outcome is that they do not — they wrap the
+existing code in a few coarse blocks and move on, which is the behavior in
+Section 1. Teaching remains part of the design; it is not a substitute for
+carrying existing work across.
+
+### 9.5 One-Shot Whole-Repository Conversion
+
+Convert an entire codebase in a single action and present the finished library.
+
+Rejected because it produces more generated code than a user can evaluate, at the
+moment when they have the least reason to trust the generator. The user's
+realistic options become accept everything unread or discard everything, and both
+outcomes end with a library nobody uses. Batching keeps each acceptance decision
+small enough to actually be a decision.
+
+### 9.6 Presence Check Instead Of A Live Agent Probe
+
+Check whether an agent CLI is installed, which is fast, offline, and simple.
+
+Rejected because it answers a question nobody is asking. What every consuming
+flow needs to know is whether an agent call will succeed, and a present binary
+does not establish that. A presence check reports ready for a user who has never
+logged in, sends them into a flow that fails several steps later, and produces an
+error at the point where it is most expensive to recover from.

--- a/docs/adr/ADR-053.md
+++ b/docs/adr/ADR-053.md
@@ -16,10 +16,7 @@ is_code_implementation: true
 governs:
   modules:
     - scistudio.api.routes.tutorials
-    - scistudio.api._block_source
-  contracts:
-    - scistudio.api._block_source.map_block_origin
-    - scistudio.api._block_source.resolve_block_source
+  contracts: []
   entry_points: []
   files:
     - docs/adr/ADR-053.md


### PR DESCRIPTION
## What this is

ADR-053 records the decision behind the onboarding / discoverability track
(#1995 – #2002). Docs only — status `Proposed`, `phase: planning`. No runtime,
API, or frontend behavior changes.

## Why

Observed usage across colleagues, early users, and one spatial multi-omics lab
shows users are not using SciStudio as designed. Some drop in a single agent
block and converse to the end. Others build five coarse process blocks, each
carrying several pipeline steps, none of which ever leaves the project it was
written in. None had heard of interactive blocks, custom previewers, or custom
data types.

The ADR argues this is not a failure to learn the product. Coarse blocks and
one-shot conversations are the correct choice when a block has nowhere to live
afterwards — splitting a pipeline into reusable pieces only repays the effort if
the pieces can be reused. What is missing is a container and a path to it.

## What the ADR says

Four claims, each with its own section:

| Section | Claim |
|---|---|
| 2 | Learning is done by running, not by reading — an entry is a real project, completion is a completed run |
| 3 | A tool library is a place, not a convention — the user tier exists on disk and is invisible in the product |
| 4 | The way in starts from what the user already has — scanning a codebase needs no agent |
| 5 | Correctness comes from verification, not from the agent — generated differential tests; graded availability |

## ADR relationships

**Supersedes ADR-037 §3.7 D23** (existing first screen with no onboarding
surface; bundled sample project; silent CLI detection with a one-time
notification). All three are replaced. ADR-037 is **not** superseded as a whole —
it remains governing for desktop packaging, distribution, update, uninstall, and
offline behavior.

Per owner decision, this is recorded as a section in ADR-053 (§2.4) plus a
back-pointer at ADR-037 D23 and `53` added to that ADR's `related` list, rather
than as an ADR-037 addendum: D23 is a small clause in an ADR whose subject is
desktop packaging, and an addendum would be disproportionate.

**Extends ADR-037 §3.8 D24** — the graceful-degradation principle is applied to
agent availability, not just to network availability.

**Bounded against ADR-042** — `docs/user/tutorials/` remains documentation
governed by ADR-042 and is untouched. §2.5 draws the boundary; the in-app surface
is named Learning Center in both the architecture and the UI (owner decision).

## Facts asserted about the current codebase

Verified against `origin/main` at the time of writing, and cited in the ADR as
current rather than planned:

- `POST /api/tutorials/run-first-workflow/bootstrap` creates a real project with
  a real dataset — the foundation §2.1 builds on
- Tutorial identity is hardcoded to one entry (`RUN_FIRST_WORKFLOW_ID`,
  `runFirstWorkflowTutorialActive`, …), so there is no catalogue and no progress
  denominator
- `map_block_origin` maps tier-1 to a single `custom` origin, collapsing the user
  and project tiers
- `buildPaletteSections` orders sections pinned Data I/O → Built-in → Custom →
  plugin packages A→Z
- `spec.file_path` is already available, so splitting the tiers is a path
  comparison and needs no data model change

Everything else in the ADR is explicitly marked as planned.

## Review focus

The argument, not the prose. Specifically: whether §3's claim that granularity is
downstream of destination holds up, and whether §4.2's progress-gated import
offer is the right call given it deliberately hides a capability behind learning
progress (with a permanent entry point as the mitigation).

## Verification

Docs-only. `gate_record check` at Tier 3 selected `full_audit`; reconciliation
passed. Implementation tests recorded N/A with rationale — the implementing work
and its test obligations are tracked by #1995 – #2002 and enumerated in ADR-053
§7.

Gate record: .workflow/records/2005-docs-2005-adr-053-learning-center.json

Closes #2005