### PR TITLE
chore(#2018): relicense SciStudio from MIT to Apache-2.0

### DIFF
--- a/.workflow/records/2018-chore-2018-relicense-apache-2-0.json
+++ b/.workflow/records/2018-chore-2018-relicense-apache-2-0.json
@@ -49,10 +49,172 @@
       "tool_versions": {
         "ruff": "0.15.15"
       }
+    },
+    {
+      "at": "2026-08-07T04:44:37.928979Z",
+      "command": "pytest tests/architecture/ -v --no-cov",
+      "covered_surface": "architecture",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:6d41ca38e476addedf4c5bb67c43dd1612f3a27d5493800a4bb8d989d74dbeb0",
+      "name": "architecture_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/architecture_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-07T04:44:39.003374Z",
+      "command": "python scripts/deferral_scan.py --check docs/audit/baselines/deferral-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:0665fa33d7b02570300abd6d57ba380c12930441928b8eb1bf76a810aa3be8f3",
+      "name": "deferral_discipline",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/deferral_discipline.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-07T04:44:39.039806Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:1c6fb48f027e458d25700cb23eac444df7435f55c00e008e0d9c7679a323faea",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-07T04:44:47.807311Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e80410c215dc82a2d9dbc33fa59aa6daa09008f719d24d7cb0a2d784e01a79b7",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-07T04:44:48.041302Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:7c74f5f0c18cab68d6065df3c7544d65f9c3781c84cc40adc86c40640a177872",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-07T04:44:48.074298Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:0de4098671e609ed1836a9c7355fecb4a8fda6809378bdf24db98f2b6baba528",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-07T04:46:59.346083Z",
+      "command": "python -m scistudio.qa.testing.run_python_tests --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:ce152b7427ae07435bc16afa9f42985e21794c606b3818c9d43f2e7622996e13",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-07T04:48:11.818617Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:ef4c3413363a632cccda6e1bbf58f02243f0fb5603fce7882a0762432e941432",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-07T04:48:12.515766Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e9c905fcb311baa10457f65665ebd3ca6001fc1fa0fb6543c9b5782e92f31fd5",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    },
+    {
+      "at": "2026-08-07T04:48:23.638134Z",
+      "command": "python -m build --wheel",
+      "covered_surface": "packaging",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:c331e134242d5f4dc54ca91e751f46a9937b8de7289f77f1bcf9df6c472f61e0",
+      "name": "wheel_release_smoke",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/wheel_release_smoke.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
     }
   ],
   "check_na": [],
-  "commit": null,
+  "commit": {
+    "sha": "febca38fac6f28cfea196cff12f9a3edac754ef1",
+    "shas": [
+      "febca38fac6f28cfea196cff12f9a3edac754ef1"
+    ],
+    "trailers": []
+  },
   "declared_scope": {
     "exclude": [],
     "include": [
@@ -69,6 +231,11 @@
       "at": "2026-08-07T04:36:21.410339Z",
       "owner_directive": "Plan: replace LICENSE with the full Apache-2.0 text (appendix copyright: 2026 Jiazhen Zhang); set pyproject license to Apache-2.0; update both README license badges and license sections; add a CHANGELOG [Unreleased]/Changed entry; extend tests/packaging/test_version_alignment.py with a LICENSE<->pyproject license alignment guard. Deliberately unchanged and documented in the PR body: scaffold template (owner decision, stays MIT), no NOTICE (owner decision), docs/specs/phase11-lcms-block-spec.md (describes an untracked block package plus upstream AccuCor MIT), frontend/desktop package.json (no license field today, unpublished), and third-party/historical license statements in ADR-039/ADR-043/architecture docs/CHANGELOG history/npm lockfiles.",
       "reason": "plan"
+    },
+    {
+      "at": "2026-08-08T05:07:40.192027Z",
+      "owner_directive": "Owner: open the PR with SCISTUDIO_SKIP_PREFLIGHT=1 and let cloud CI be the authoritative check, since the local python_tests blocker is a pre-existing Windows environment failure unrelated to the relicense.",
+      "reason": "Owner authorized opening the PR with SCISTUDIO_SKIP_PREFLIGHT=1. The only unsatisfied pre-PR obligation is checks.python_tests, and the failures are pre-existing local-Windows failures unrelated to this diff: the same 9 tests (2 in test_mcp_transport_publish, 1 in test_filesystem_browse, 2 in test_terminal_post_rc, 1 in test_install, 3 in test_gate_record_hooks) fail identically on a clean detached origin/main worktree using the same interpreter, while origin/main's cloud CI is green. This diff changes no Python source: it adds one test module and edits LICENSE, pyproject license metadata, both READMEs, and CHANGELOG. Cloud CI remains the authoritative evaluator and will run the full check set on Linux."
     }
   ],
   "docs_events": [
@@ -234,6 +401,334 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-08-07T04:44:19.578146Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-07T04:44:19.591284Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-07T04:44:19.610664Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-07T04:44:19.624028Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-07T04:44:19.637263Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-07T04:44:19.650295Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-07T04:44:19.662322Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-07T04:44:19.674506Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-07T04:44:19.687416Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-07T04:44:19.699696Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-07T04:48:23.680125Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-07T04:48:23.694007Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-07T04:48:23.707529Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-07T04:48:23.724283Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-07T04:48:23.737896Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-07T04:48:23.751381Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-07T04:48:23.765178Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-07T04:48:23.780654Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-07T04:48:23.795002Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-07T04:48:23.808602Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-07T04:49:50.871730Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-07T04:49:50.884758Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-07T04:49:50.897798Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-07T04:49:50.910748Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-07T04:49:50.923332Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-07T04:49:50.936236Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-07T04:49:50.949674Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-07T04:49:50.963370Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-07T04:49:50.976458Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-07T04:49:50.988956Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-08T05:08:36.450780Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-08T05:08:36.465309Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-08T05:08:36.478751Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-08T05:08:36.492539Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-08T05:08:36.507081Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-08T05:08:36.522232Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-08T05:08:36.536689Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-08T05:08:36.550248Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-08T05:08:36.563998Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-08T05:08:36.577796Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -246,28 +741,43 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "origin/main",
+    "base": "5ed0dc727d0f10caf17e3d4d641f22a0ded1348b",
     "base_sha": "5ed0dc72",
-    "changed_files": [],
-    "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "changed_files": [
+      ".workflow/records/2018-chore-2018-relicense-apache-2-0.json",
+      "CHANGELOG.md",
+      "LICENSE",
+      "README.md",
+      "README.zh-CN.md",
+      "pyproject.toml",
+      "tests/packaging/test_license_alignment.py"
+    ],
+    "diff_fingerprint": "sha256:23a9b1ae8f9ec8234a05edf89dd9f1dfefb7c18f8014fadbe211e4a3a1984aae",
     "head": "HEAD",
-    "head_sha": "5ed0dc72",
+    "head_sha": "febca38f",
     "surfaces": {
       "docs": 0,
       "frontend": 0,
-      "governance": 0,
+      "governance": 1,
       "governed_docs": 0,
-      "implementation": 0,
-      "packaging": 0,
+      "implementation": 1,
+      "packaging": 1,
       "protected_core": 0,
-      "sentrux": 0,
-      "test": 0,
+      "sentrux": 1,
+      "test": 1,
       "workflow_ci": 0
     }
   },
   "owner_directive": "Owner: relicense SciStudio from MIT to Apache-2.0. Investigate every reference point, then implement and open a PR. Owner decisions: (1) the block-package scaffold template keeps license MIT because scaffolded packages are the user's own code; (2) no NOTICE file.",
   "persona": "implementer",
-  "pull_request": null,
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [
+      2018
+    ],
+    "number": 2043,
+    "url": null
+  },
   "reconcile_events": [
     {
       "at": "2026-08-07T04:40:03.213774Z",
@@ -284,6 +794,55 @@
       "result": "pass",
       "tier": 2,
       "unsatisfied": []
+    },
+    {
+      "at": "2026-08-07T04:44:19.699726Z",
+      "diff_fingerprint": "sha256:23a9b1ae8f9ec8234a05edf89dd9f1dfefb7c18f8014fadbe211e4a3a1984aae",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.architecture_tests",
+        "checks.deferral_discipline",
+        "checks.format_check",
+        "checks.full_audit",
+        "checks.import_contracts",
+        "checks.lint_format",
+        "checks.python_tests",
+        "checks.semantic_dup",
+        "checks.type_check",
+        "checks.wheel_release_smoke"
+      ]
+    },
+    {
+      "at": "2026-08-07T04:48:23.808630Z",
+      "diff_fingerprint": "sha256:23a9b1ae8f9ec8234a05edf89dd9f1dfefb7c18f8014fadbe211e4a3a1984aae",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.python_tests"
+      ]
+    },
+    {
+      "at": "2026-08-07T04:49:50.988984Z",
+      "diff_fingerprint": "sha256:23a9b1ae8f9ec8234a05edf89dd9f1dfefb7c18f8014fadbe211e4a3a1984aae",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.python_tests"
+      ]
+    },
+    {
+      "at": "2026-08-08T05:08:36.577828Z",
+      "diff_fingerprint": "sha256:23a9b1ae8f9ec8234a05edf89dd9f1dfefb7c18f8014fadbe211e4a3a1984aae",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.python_tests"
+      ]
     }
   ],
   "record_id": "2018-chore-2018-relicense-apache-2-0",
@@ -291,11 +850,20 @@
   "required_obligations": {
     "admin_labels": [],
     "checks": [
+      "architecture_tests",
+      "deferral_discipline",
       "format_check",
       "full_audit",
-      "lint_format"
+      "import_contracts",
+      "lint_format",
+      "python_tests",
+      "semantic_dup",
+      "type_check",
+      "wheel_release_smoke"
     ],
-    "docs": [],
+    "docs": [
+      "docs_required_or_na"
+    ],
     "guards": [
       "core_change_guard",
       "docs_landing",
@@ -308,7 +876,9 @@
       "test_engineer_scope_guard",
       "weakened_ci_check"
     ],
-    "tests": []
+    "tests": [
+      "changed_test_required"
+    ]
   },
   "runtime": "claude-code",
   "schema_version": 2,
@@ -321,7 +891,7 @@
     }
   ],
   "session_id": "394d6d59-c987-4083-b5b8-b320da44900b",
-  "strictness_tier": 2,
+  "strictness_tier": 1,
   "task_kind": "maintenance",
   "test_events": [
     {

--- a/.workflow/records/2018-chore-2018-relicense-apache-2-0.json
+++ b/.workflow/records/2018-chore-2018-relicense-apache-2-0.json
@@ -1,0 +1,344 @@
+{
+  "branch": "chore/2018-relicense-apache-2-0",
+  "check_events": [
+    {
+      "at": "2026-08-07T04:39:51.597835Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:bee0017f30f552d2df2de1173f9ac14b9aee5192ca5e5c1de574bb119512b275",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-07T04:40:03.006070Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:d2016153ffe72f6d9588cf72b647d8f545261ca64eb63f312f104e3c66e7d074",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-07T04:40:03.069249Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e31351abfc33f0b3c0f28bc9f2f3d59ae3bc5d4925dc1159a7f931aa932441ed",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    }
+  ],
+  "check_na": [],
+  "commit": null,
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "LICENSE",
+      "pyproject.toml",
+      "README.md",
+      "README.zh-CN.md",
+      "CHANGELOG.md",
+      "tests/packaging/test_version_alignment.py"
+    ]
+  },
+  "directive_events": [
+    {
+      "at": "2026-08-07T04:36:21.410339Z",
+      "owner_directive": "Plan: replace LICENSE with the full Apache-2.0 text (appendix copyright: 2026 Jiazhen Zhang); set pyproject license to Apache-2.0; update both README license badges and license sections; add a CHANGELOG [Unreleased]/Changed entry; extend tests/packaging/test_version_alignment.py with a LICENSE<->pyproject license alignment guard. Deliberately unchanged and documented in the PR body: scaffold template (owner decision, stays MIT), no NOTICE (owner decision), docs/specs/phase11-lcms-block-spec.md (describes an untracked block package plus upstream AccuCor MIT), frontend/desktop package.json (no license field today, unpublished), and third-party/historical license statements in ADR-039/ADR-043/architecture docs/CHANGELOG history/npm lockfiles.",
+      "reason": "plan"
+    }
+  ],
+  "docs_events": [
+    {
+      "at": "2026-08-07T04:36:21.410362Z",
+      "class": null,
+      "kind": "path",
+      "path": "README.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-07T04:36:21.410369Z",
+      "class": null,
+      "kind": "path",
+      "path": "README.zh-CN.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-07T04:36:21.410372Z",
+      "class": null,
+      "kind": "path",
+      "path": "CHANGELOG.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-07T04:36:21.410378Z",
+      "class": "adr",
+      "kind": "na",
+      "path": null,
+      "rationale": "License choice is an owner/legal decision, not an architectural decision with runtime consequences; no ADR-scope contract, schema, or behavior changes.",
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-07T04:36:21.410383Z",
+      "class": "spec",
+      "kind": "na",
+      "path": null,
+      "rationale": "No spec describes the project license; docs/specs/phase11-lcms-block-spec.md MIT references are out of scope (untracked package plus upstream AccuCor).",
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": true,
+  "guard_events": [
+    {
+      "at": "2026-08-07T04:40:03.101916Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-07T04:40:03.115408Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-07T04:40:03.128333Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-07T04:40:03.140553Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-07T04:40:03.152620Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-07T04:40:03.164986Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-07T04:40:03.176823Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-07T04:40:03.188411Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-07T04:40:03.200617Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-07T04:40:03.213729Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-07T04:43:04.429425Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-07T04:43:04.442588Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-07T04:43:04.456573Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-07T04:43:04.475569Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-07T04:43:04.487990Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-07T04:43:04.500578Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-07T04:43:04.512752Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-07T04:43:04.524884Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-07T04:43:04.537367Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-07T04:43:04.549367Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 2018,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": {
+    "base": "origin/main",
+    "base_sha": "5ed0dc72",
+    "changed_files": [],
+    "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "head": "HEAD",
+    "head_sha": "5ed0dc72",
+    "surfaces": {
+      "docs": 0,
+      "frontend": 0,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 0,
+      "packaging": 0,
+      "protected_core": 0,
+      "sentrux": 0,
+      "test": 0,
+      "workflow_ci": 0
+    }
+  },
+  "owner_directive": "Owner: relicense SciStudio from MIT to Apache-2.0. Investigate every reference point, then implement and open a PR. Owner decisions: (1) the block-package scaffold template keeps license MIT because scaffolded packages are the user's own code; (2) no NOTICE file.",
+  "persona": "implementer",
+  "pull_request": null,
+  "reconcile_events": [
+    {
+      "at": "2026-08-07T04:40:03.213774Z",
+      "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "mode": "local",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-07T04:43:04.549411Z",
+      "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "mode": "local",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    }
+  ],
+  "record_id": "2018-chore-2018-relicense-apache-2-0",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [
+      "format_check",
+      "full_audit",
+      "lint_format"
+    ],
+    "docs": [],
+    "guards": [
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": []
+  },
+  "runtime": "claude-code",
+  "schema_version": 2,
+  "scope_events": [
+    {
+      "action": "add-include",
+      "at": "2026-08-07T04:37:46.008385Z",
+      "pattern": "tests/packaging/test_license_alignment.py",
+      "reason": "License alignment belongs in its own narrow test module rather than stretching test_version_alignment.py, whose docstring scopes it to version metadata. Adding tests/packaging/test_license_alignment.py instead."
+    }
+  ],
+  "session_id": "394d6d59-c987-4083-b5b8-b320da44900b",
+  "strictness_tier": 2,
+  "task_kind": "maintenance",
+  "test_events": [
+    {
+      "at": "2026-08-07T04:36:21.410387Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/packaging/test_version_alignment.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-07T04:37:46.008407Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/packaging/test_license_alignment.py",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- [#2018] SciStudio is now licensed under the **Apache License 2.0** instead of
+  the MIT License. Apache-2.0 keeps the same permissive shape (use, modify,
+  redistribute, commercial use, no copyleft) and adds an explicit patent grant
+  from contributors, a patent-retaliation termination clause, and a requirement
+  that modified files be marked and the license/attribution notices carried
+  forward — the terms scientific institutions and companies most often ask for
+  before adopting a runtime. `LICENSE` now carries the verbatim Apache-2.0 text
+  with the appendix copyright line filled in; `pyproject.toml` declares
+  `Apache-2.0`; both READMEs were updated. The change is **prospective only**:
+  every existing tag, published artifact, and clone taken before this commit
+  keeps its MIT grant permanently, so nothing already released is withdrawn.
+  Two things deliberately did *not* change: the block-package scaffold
+  (`scistudio new-block-package`) still writes `license = {text = "MIT"}`
+  because the package it generates is the user's own code and gets the most
+  permissive default rather than inheriting the runtime's choice, and no
+  `NOTICE` file was added since Apache-2.0 does not require one and there is no
+  third-party attribution to propagate yet.
 - [#1983] Persisted block artifacts are now reclaimed instead of accumulating
   forever. Every block output is written as a full-size store under
   `data/zarr/<workflow_id>/<block_id>/`, and nothing ever removed one: a real

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,202 @@
-MIT License
 
-Copyright (c) 2026 Jiazhen Zhang
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+   1. Definitions.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Jiazhen Zhang
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 **For your great science: every data, every tool, one workflow.**
 
 [![Status: alpha](https://img.shields.io/badge/status-alpha-orange.svg)]()
-[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-green.svg)](LICENSE)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11%2B-blue.svg)](https://www.python.org/downloads/)
 [![CI](https://github.com/jiazhenz026/SciStudio/actions/workflows/ci.yml/badge.svg)](https://github.com/jiazhenz026/SciStudio/actions/workflows/ci.yml)
 [![Docs](https://img.shields.io/badge/docs-online-blue.svg)](https://jiazhenz026.github.io/SciStudio/)
@@ -115,5 +115,5 @@ marks the stability tier of each public symbol.
 
 ## License
 
-SciStudio is released under the MIT License. See [LICENSE](LICENSE) for the full
-text.
+SciStudio is released under the Apache License 2.0. See [LICENSE](LICENSE) for
+the full text.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -7,7 +7,7 @@
 **为你的科研而生:每一份数据,每一个工具,汇于同一条工作流。**
 
 [![Status: alpha](https://img.shields.io/badge/status-alpha-orange.svg)]()
-[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-green.svg)](LICENSE)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11%2B-blue.svg)](https://www.python.org/downloads/)
 [![CI](https://github.com/jiazhenz026/SciStudio/actions/workflows/ci.yml/badge.svg)](https://github.com/jiazhenz026/SciStudio/actions/workflows/ci.yml)
 [![Docs](https://img.shields.io/badge/docs-online-blue.svg)](https://jiazhenz026.github.io/SciStudio/)
@@ -114,4 +114,4 @@ SciStudio 目前处于 **alpha** 阶段,正在积极开发中。各版本之间�
 
 ## 许可证
 
-SciStudio 以 MIT 许可证发布。完整条款见 [LICENSE](LICENSE)。
+SciStudio 以 Apache License 2.0 发布。完整条款见 [LICENSE](LICENSE)。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "scistudio"
 version = "0.3.3a0"
 description = "AI-native, inclusive workflow runtime for multimodal scientific data"
 readme = "README.md"
-license = {text = "MIT"}
+license = {text = "Apache-2.0"}
 requires-python = ">=3.11"
 authors = [
     {name = "Jiazhen Zhang"},

--- a/tests/packaging/test_license_alignment.py
+++ b/tests/packaging/test_license_alignment.py
@@ -1,0 +1,76 @@
+"""Regression tests pinning the project's declared license to the LICENSE file.
+
+SciStudio relicensed from MIT to Apache-2.0 (#2018). The license is stated in
+four independent places -- ``LICENSE``, the ``pyproject.toml`` metadata that
+lands on PyPI, and the badge plus license section of each README -- with
+nothing linking them. These tests make the four agree by construction so a
+future edit to one cannot silently leave the others advertising a license the
+project no longer grants.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+EXPECTED_LICENSE = "Apache-2.0"
+
+
+def _read(rel: str) -> str:
+    return (REPO_ROOT / rel).read_text(encoding="utf-8")
+
+
+def test_license_file_is_the_apache_2_0_text() -> None:
+    """``LICENSE`` must carry the Apache-2.0 body, not just a name."""
+    license_text = _read("LICENSE")
+
+    assert "Apache License" in license_text
+    assert "Version 2.0, January 2004" in license_text
+    assert "http://www.apache.org/licenses/" in license_text
+    # Clauses unique to Apache-2.0 (absent from MIT): patent grant and the
+    # redistribution conditions that make it more than a permissive one-liner.
+    assert "Grant of Patent License" in license_text
+    assert "TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION" in license_text
+
+    # The appendix placeholder must be filled in, or the copyright line is void.
+    assert "[yyyy] [name of copyright owner]" not in license_text
+    assert "Copyright 2026 Jiazhen Zhang" in license_text
+
+
+def test_pyproject_declares_the_same_license() -> None:
+    """Package metadata (and therefore PyPI) must match ``LICENSE``."""
+    with (REPO_ROOT / "pyproject.toml").open("rb") as fh:
+        pyproject = tomllib.load(fh)
+
+    assert pyproject["project"]["license"] == {"text": EXPECTED_LICENSE}
+
+
+def test_readmes_advertise_the_same_license() -> None:
+    """Both READMEs must name Apache-2.0 and must not still claim MIT.
+
+    The badge and the license section are separate strings in each file, so a
+    partial edit is the realistic failure mode; both are checked.
+    """
+    for rel in ("README.md", "README.zh-CN.md"):
+        readme = _read(rel)
+
+        assert "badge/License-Apache_2.0" in readme, f"{rel} license badge is stale"
+        assert "Apache License 2.0" in readme, f"{rel} license section is stale"
+        assert "MIT" not in readme, f"{rel} still claims MIT somewhere"
+
+
+def test_block_package_scaffold_keeps_the_permissive_default() -> None:
+    """Scaffolded user packages stay MIT; the relicense is deliberately not propagated.
+
+    ``scistudio new-block-package`` writes this template into a package that
+    belongs to the *user*, not to SciStudio. Per the owner decision on #2018 the
+    default there stays MIT -- the most permissive choice -- rather than
+    inheriting whatever license the runtime happens to ship under. This test
+    exists so that decision has to be revisited explicitly rather than swept
+    along by a future project-wide relicense.
+    """
+    template = _read("src/scistudio/cli/templates/block_package/pyproject.toml.tpl")
+
+    assert 'license = {{text = "MIT"}}' in template


### PR DESCRIPTION
## What

Relicenses SciStudio from the **MIT License** to the **Apache License 2.0**.

Apache-2.0 keeps the same permissive shape as MIT — use, modify, redistribute,
commercial use, no copyleft — and adds an explicit patent grant from
contributors, a patent-retaliation termination clause, and a requirement that
modified files be marked and license/attribution notices carried forward.

## Why this was safe to do

Relicensing normally stalls on consent from every copyright holder.
`git shortlog -sne --all` lists only the owner's three identities plus bot
identities (dependabot, test accounts) and AI co-author trailers — there is no
third-party human copyright holder, so no contributor consent was required.

## Changed

| File | Change |
|---|---|
| `LICENSE` | Byte-exact Apache-2.0 text (verified against three independent canonical copies, md5 `3b83ef96387f14655fc854ddc3c6bd57`), appendix copyright filled in as `Copyright 2026 Jiazhen Zhang` |
| `pyproject.toml` | `license = {text = "Apache-2.0"}` — the metadata that lands on PyPI. Declared as a `governance_touch` in the ledger; the license field is the only key changed |
| `README.md` | License badge + `## License` section |
| `README.zh-CN.md` | License badge + `## 许可证` section |
| `CHANGELOG.md` | `[Unreleased] / Changed` entry |
| `tests/packaging/test_license_alignment.py` | **New.** Pins `LICENSE`, `pyproject.toml`, and both READMEs to one license so the four independent statements cannot drift apart |

## Deliberately NOT changed

Both are owner decisions recorded on #2018, and the first is now pinned by a
test so a future relicense has to revisit it explicitly:

- **`src/scistudio/cli/templates/block_package/pyproject.toml.tpl` stays MIT.**
  `scistudio new-block-package` writes this template into a package that
  belongs to the *user*. It keeps the most permissive default rather than
  inheriting whatever license the runtime happens to ship under.
- **No `NOTICE` file.** Apache-2.0 does not require one, and there is no
  third-party attribution to propagate yet.

Also left alone, with reasons:

- `docs/specs/phase11-lcms-block-spec.md` — its `license = { text = "MIT" }`
  describes a block package under `packages/` (untracked), consistent with the
  scaffold decision above; its other MIT references describe **upstream
  AccuCor's** own license and must not change.
- `frontend/package.json`, `desktop/package.json` — declare no `license` field
  today and are not published; left unchanged rather than newly asserting one.
- Third-party and historical license statements: `docs/adr/ADR-039.md` (git's
  GPLv2, `vscode-git-graph`'s custom license), `docs/adr/ADR-043.md`,
  `docs/architecture/*`, `CHANGELOG.md` history, npm lockfile metadata.
- `src/scistudio/cli/_scaffold.py` and `tests/cli/test_new_block_package.py`
  mention `MIT` only as an arbitrary string in brace-escaping examples for the
  template renderer, not as a license declaration.

## Note on scope of effect

The relicense is **prospective only**. Every existing tag, published artifact,
and clone taken before this commit keeps its MIT grant permanently — nothing
already released is withdrawn.

## Verification

- `gate_record check` — reconciliation passed (`format_check`, `full_audit`,
  `lint_format`).
- Full pre-commit hook set passed: gate record pre-commit, ruff, ruff-format,
  mypy, commitizen, and the file-hygiene hooks.
- `pytest tests/packaging tests/cli/test_new_block_package.py` — passed
  (1 pre-existing skip needing `npm run stage`).

### Local `python_tests` blocker (why the wrapper preflight was skipped)

This PR was opened with `SCISTUDIO_SKIP_PREFLIGHT=1`, authorized by the owner
and recorded as a directive event in the gate ledger. **Cloud CI is the
authoritative evaluator here and runs the full check set on Linux.**

The local pre-PR check reported one unsatisfied obligation, `checks.python_tests`
(9 failed, 5563 passed). All 9 are pre-existing local-Windows failures unrelated
to this diff — they fail identically on a clean detached `origin/main` worktree
using the same interpreter, while `origin/main`'s cloud CI is green:

- `tests/api/test_mcp_transport_publish.py` — 2 (POSIX socket)
- `tests/api/test_filesystem_browse.py` — 1 (overlength path)
- `tests/desktop/test_terminal_post_rc.py` — 2 (zsh/bash rc)
- `tests/cli/test_install.py` — 1 (MCP env parity)
- `tests/qa/test_gate_record_hooks.py` — 3 (`ModuleNotFoundError: No module
  named 'scistudio'` when the gate venv spawns the hook subprocess)

This diff changes no Python source: it adds one test module and edits `LICENSE`,
`pyproject.toml` license metadata, both READMEs, and `CHANGELOG.md`.

Two local defects surfaced while running this task. Neither is caused by this
change and neither is fixed here; both need their own issue:

1. The gate-parity venv does not make `scistudio` importable to subprocesses,
   which is what the 3 `test_gate_record_hooks` failures actually report.
2. The pre-commit-generated hooks in `.git/hooks/` carry a `#!/bin/sh` line
   ahead of `#!/usr/bin/env bash` while the script body uses bash array syntax,
   so pre-commit cannot resolve `/bin/sh` on Windows. It only triggers when the
   worktree has unstaged changes (pre-commit then runs `git checkout -- .`,
   which fires the equally broken `post-checkout` hook). Related to #2011 but a
   different root cause.

Gate record: `.workflow/records/2018-chore-2018-relicense-apache-2-0.json`

Closes #2018
