### PR TITLE
fix(#2045,#2014): correct Kimi Code's hook facts and stop advertising it for AI Blocks

### DIFF
--- a/.workflow/records/2014-fix-2014-kimi-ai-block-provider.json
+++ b/.workflow/records/2014-fix-2014-kimi-ai-block-provider.json
@@ -49,6 +49,177 @@
       "tool_versions": {
         "ruff": "0.15.15"
       }
+    },
+    {
+      "at": "2026-08-08T08:05:40.114510Z",
+      "command": "pytest tests/architecture/ -v --no-cov",
+      "covered_surface": "architecture",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:96434b2ac1d9ff7ad59dc86aa777ab83c8bf0fc425b3fb55299c1ea69ceae68a",
+      "name": "architecture_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/architecture_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-08T08:05:41.260100Z",
+      "command": "python scripts/deferral_scan.py --check docs/audit/baselines/deferral-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:68250349cae2261f3a52634effd35391da6b440f7b9dea7f56a83cd48e11c488",
+      "name": "deferral_discipline",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/deferral_discipline.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-08T08:05:41.297468Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:1b76a3fb1ed537bae9ad402e0b3d6b9f8f953e4615b2cd42975198101e53b2df",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-08T08:06:35.522724Z",
+      "command": "(cd frontend && npm run check:ci)",
+      "covered_surface": "frontend",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:16a44822f2b10e0729b9a80eb9680ce67a4f66019c3699d93e727d32d60f0337",
+      "name": "frontend",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/frontend.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-08T08:06:44.950850Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:89497be32fec325be9b928b46c741589717fd0bcb9bc34d4bf02803042f30136",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-08T08:06:45.204442Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:75ee5ed63bf5097546a8572f470e281047f7b5f896519f6630dabded886ae717",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-08T08:06:45.237425Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:3b9487d2f96795fc517fc5e6762c93a551160f799fac7f797db19ab9459dd261",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-08T08:08:49.018539Z",
+      "command": "python -m scistudio.qa.testing.run_python_tests --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:cbbd5ae99722d0a6c033d78f2ce5b931741ecb0d2a16c1808878e8392cb59f2a",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-08T08:09:57.946465Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:412a6ba833815468335ffe758a42669624146faeab7aeffa3e00e4dcf495ddd4",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-08T08:10:01.113171Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:9e3a64c59c427aa7323bcce437550ab10a7776961f2d83fb1a55b2f169c6f155",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    },
+    {
+      "at": "2026-08-08T08:30:23.433611Z",
+      "command": "python -m scistudio.qa.testing.run_python_tests --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cbbd5ae99722d0a6c033d78f2ce5b931741ecb0d2a16c1808878e8392cb59f2a",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
     }
   ],
   "check_na": [],
@@ -247,6 +418,214 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-08-08T08:10:01.163130Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/ai/ai_block.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/ai/ai_block.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-08T08:10:01.175935Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-08T08:10:01.189012Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-08T08:10:01.201733Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-08T08:10:01.215330Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-08T08:10:01.228346Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-08T08:10:01.241140Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-08T08:10:01.253971Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-08T08:10:01.266824Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-08T08:10:01.285662Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-08T08:30:23.483568Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/ai/ai_block.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/ai/ai_block.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-08T08:30:23.497681Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-08T08:30:23.510622Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-08T08:30:23.523540Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-08T08:30:23.536704Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-08T08:30:23.551013Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-08T08:30:23.564727Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-08T08:30:23.593160Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-08T08:30:23.605892Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-08T08:30:23.623691Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -267,20 +646,37 @@
   "observed_diff": {
     "base": "origin/main",
     "base_sha": "1844cc43",
-    "changed_files": [],
-    "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "changed_files": [
+      ".workflow/records/2014-fix-2014-kimi-ai-block-provider.json",
+      "docs/agent-provisioning.md",
+      "docs/specs/adr-034-multi-provider-agent-chat.md",
+      "frontend/src/components/AIChat/SetupScreen.tsx",
+      "frontend/src/components/AIChat/__tests__/ProviderExtensibility.test.tsx",
+      "frontend/src/components/AIChat/__tests__/SetupScreen.test.tsx",
+      "src/scistudio/_skills/scistudio/scistudio-build-workflow/SKILL.md",
+      "src/scistudio/_user_guide/ai-assistant.md",
+      "src/scistudio/ai/agent/availability.py",
+      "src/scistudio/ai/agent/providers_registry.py",
+      "src/scistudio/api/routes/ai_pty/_state.py",
+      "src/scistudio/blocks/ai/ai_block.py",
+      "tests/agent_provisioning/test_hooks.py",
+      "tests/api/test_provider_registry_extensibility.py",
+      "tests/architecture/test_adr_034_provider_single_source.py",
+      "tests/blocks/ai/test_ai_block_skeleton.py"
+    ],
+    "diff_fingerprint": "sha256:6bcb4b732108055e3b150253ea003f4953862c2373cf73f3a6bec756aa50d4c0",
     "head": "HEAD",
-    "head_sha": "2c916133",
+    "head_sha": "2706e353",
     "surfaces": {
-      "docs": 0,
-      "frontend": 0,
+      "docs": 2,
+      "frontend": 3,
       "governance": 0,
       "governed_docs": 0,
-      "implementation": 0,
+      "implementation": 9,
       "packaging": 0,
-      "protected_core": 0,
-      "sentrux": 0,
-      "test": 0,
+      "protected_core": 1,
+      "sentrux": 14,
+      "test": 6,
       "workflow_ci": 0
     }
   },
@@ -303,6 +699,24 @@
       "result": "pass",
       "tier": 2,
       "unsatisfied": []
+    },
+    {
+      "at": "2026-08-08T08:10:01.285688Z",
+      "diff_fingerprint": "sha256:6bcb4b732108055e3b150253ea003f4953862c2373cf73f3a6bec756aa50d4c0",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.python_tests"
+      ]
+    },
+    {
+      "at": "2026-08-08T08:30:23.623722Z",
+      "diff_fingerprint": "sha256:6bcb4b732108055e3b150253ea003f4953862c2373cf73f3a6bec756aa50d4c0",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
     }
   ],
   "record_id": "2014-fix-2014-kimi-ai-block-provider",
@@ -315,13 +729,24 @@
     }
   ],
   "required_obligations": {
-    "admin_labels": [],
-    "checks": [
-      "format_check",
-      "full_audit",
-      "lint_format"
+    "admin_labels": [
+      "admin-approved:core-change"
     ],
-    "docs": [],
+    "checks": [
+      "architecture_tests",
+      "deferral_discipline",
+      "format_check",
+      "frontend",
+      "full_audit",
+      "import_contracts",
+      "lint_format",
+      "python_tests",
+      "semantic_dup",
+      "type_check"
+    ],
+    "docs": [
+      "docs_required_or_na"
+    ],
     "guards": [
       "core_change_guard",
       "docs_landing",
@@ -334,7 +759,9 @@
       "test_engineer_scope_guard",
       "weakened_ci_check"
     ],
-    "tests": []
+    "tests": [
+      "changed_test_required"
+    ]
   },
   "runtime": "agents:kimi-code",
   "schema_version": 2,
@@ -431,7 +858,7 @@
     }
   ],
   "session_id": "724dc80e-a55d-46c2-86a7-8a599c0986eb",
-  "strictness_tier": 2,
+  "strictness_tier": 1,
   "task_kind": "guided",
   "test_events": [
     {

--- a/.workflow/records/2014-fix-2014-kimi-ai-block-provider.json
+++ b/.workflow/records/2014-fix-2014-kimi-ai-block-provider.json
@@ -1,0 +1,486 @@
+{
+  "branch": "fix/2014-kimi-ai-block-provider",
+  "check_events": [
+    {
+      "at": "2026-08-08T07:54:35.417829Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:bee0017f30f552d2df2de1173f9ac14b9aee5192ca5e5c1de574bb119512b275",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-08T07:54:44.775053Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:d2016153ffe72f6d9588cf72b647d8f545261ca64eb63f312f104e3c66e7d074",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-08T07:54:44.814803Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e31351abfc33f0b3c0f28bc9f2f3d59ae3bc5d4925dc1159a7f931aa932441ed",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    }
+  ],
+  "check_na": [],
+  "commit": null,
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "src/scistudio/**"
+    ]
+  },
+  "directive_events": [
+    {
+      "at": "2026-08-08T07:42:36.484362Z",
+      "owner_directive": "\u65b9\u6848\uff1aAI Block provider enum \u6539\u4e3a\u6309\u80fd\u529b\u8fc7\u6ee4\u2014\u2014\u7528 availability.session_unsupported_reason \u6392\u9664\u65e0\u4f4d\u7f6e\u63d0\u793a\u8bcd\u53c2\u6570\u7684 provider\uff08kimi-code\uff09\uff1bvalidate_config \u4fdd\u7559\u5168\u90e8 agent key \u7684\u8bc6\u522b\u4e0e\u53cb\u597d\u62a5\u9519\u3002\u540c\u6b65\u6ce8\u91ca\u3001SKILL.md\u3001adr-034 spec \u52d8\u8bef\u6bb5\u3001\u56de\u5f52\u6d4b\u8bd5\u3002",
+      "reason": "plan"
+    },
+    {
+      "at": "2026-08-08T07:45:52.273731Z",
+      "owner_directive": "\u4eca\u5929\u4fee\u4e00\u4e2abug\uff1akimi\u5185\u90e8agent\u62a5\u544a\u5b89\u5168hook\u4e0d\u751f\u6548\u3002\u8c03\u67e5\u786e\u8ba4 Kimi Code 0.33.0 \u6709\u5b8c\u6574 hook \u7cfb\u7edf\uff08\u5951\u7ea6\u4e0e Claude Code \u4e00\u81f4\uff09\uff0c\u4f46\u53ea\u652f\u6301\u7528\u6237\u7ea7 <KIMI_CODE_HOME>/config.toml\uff0c\u6ca1\u6709\u9879\u76ee\u7ea7\u58f0\u660e\u4f4d\u7f6e\u3002Owner \u51b3\u5b9a\uff1a\u4e0d\u5199\u7528\u6237\u5168\u5c40\u914d\u7f6e\uff0c\u53ea\u628a spec \u91cc 'no hook system' \u7684\u9519\u8bef\u8bb0\u8f7d\u6539\u5bf9\uff0c\u5e76\u5728 AI Chat \u7684 Kimi \u4e0b\u52a0\u4e00\u6761\u50cf Codex trust \u63d0\u9192\u90a3\u6837\u7684\u63d0\u793a\uff0c\u544a\u8bc9\u7528\u6237 hook \u53ea\u80fd\u5168\u5c40\u751f\u6548\u3001\u53ef\u4ee5\u624b\u52a8\u914d\u7f6e\u6216\u8ba9 kimi \u81ea\u5df1\u5e2e\u5fd9\u914d\u7f6e\u3002",
+      "reason": "owner switched this branch to an owner-directed guided session and widened it to also fix the Kimi hook-coverage bug (#2045); the original bugfix ledger also omitted the protected-core authorization its own diff needs"
+    },
+    {
+      "at": "2026-08-08T07:46:05.274948Z",
+      "owner_directive": "\u63d0\u793a\u673a\u5236\uff1a\u524d\u7aef\u518d\u5199\u4e00\u4e2a\u786c\u7f16\u7801\u5206\u652f\uff08\u7167\u642c Codex trust \u63d0\u793a\u7684\u5199\u6cd5\uff09\uff0c\u5e76\u628a\u67b6\u6784\u6d4b\u8bd5 _FRONTEND_KEY_ALLOWLIST \u4ece 1 \u6761\u6269\u5230 2 \u6761\u3002#2014 \u4e00\u8d77\u505a\uff0cowner \u4f1a\u7ed9 PR \u6253 admin-approved:core-change label\u3002",
+      "reason": "owner chose the placement mechanism for the Kimi notice and confirmed the two-issue PR scope"
+    }
+  ],
+  "docs_events": [
+    {
+      "at": "2026-08-08T07:42:36.484406Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/specs/adr-034-multi-provider-agent-chat.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-08T07:42:36.484412Z",
+      "class": null,
+      "kind": "path",
+      "path": "src/scistudio/_skills/scistudio/scistudio-build-workflow/SKILL.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-08T07:42:36.484423Z",
+      "class": "user-docs",
+      "kind": "na",
+      "path": null,
+      "rationale": "docs/user \u65e0 AI Block provider \u76f8\u5173\u9875\u9762\uff08\u5df2\u68c0\u7d22\u786e\u8ba4\uff09\uff0c\u65e0\u7528\u6237\u6587\u6863\u53ef\u66f4\u65b0",
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-08T07:46:05.274981Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/specs/adr-034-multi-provider-agent-chat.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-08T07:54:17.184212Z",
+      "class": null,
+      "kind": "path",
+      "path": "src/scistudio/_user_guide/ai-assistant.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-08T07:54:17.184216Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/agent-provisioning.md",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": false,
+  "guard_events": [
+    {
+      "at": "2026-08-08T07:54:44.857251Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-08T07:54:44.872422Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-08T07:54:44.886578Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-08T07:54:44.900073Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-08T07:54:44.913651Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-08T07:54:44.927294Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-08T07:54:44.940857Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-08T07:54:44.954876Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-08T07:54:44.968407Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-08T07:54:44.981236Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-08T07:55:00.275591Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-08T07:55:00.288452Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-08T07:55:00.301457Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-08T07:55:00.314424Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-08T07:55:00.327165Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-08T07:55:00.340953Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-08T07:55:00.354398Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-08T07:55:00.368409Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-08T07:55:00.382303Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-08T07:55:00.396379Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 2014,
+      "url": null
+    },
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 2045,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": {
+    "base": "origin/main",
+    "base_sha": "1844cc43",
+    "changed_files": [],
+    "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "head": "HEAD",
+    "head_sha": "2c916133",
+    "surfaces": {
+      "docs": 0,
+      "frontend": 0,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 0,
+      "packaging": 0,
+      "protected_core": 0,
+      "sentrux": 0,
+      "test": 0,
+      "workflow_ci": 0
+    }
+  },
+  "owner_directive": "\u4fee\u590d issue #2014\uff1aAI Block provider enum \u4e0d\u5e94\u66b4\u9732\u65e0\u6cd5\u8fd0\u884c AI Block \u4efb\u52a1\u7684 kimi-code\uff1b\u6309 issue \u65b9\u6848 1 \u7528\u5171\u4eab\u80fd\u529b\u5224\u5b9a\u6d3e\u751f enum\uff0c\u6700\u540e\u63d0\u4ea4 PR",
+  "persona": "live_implementer",
+  "pull_request": null,
+  "reconcile_events": [
+    {
+      "at": "2026-08-08T07:54:44.981289Z",
+      "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "mode": "local",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-08T07:55:00.396434Z",
+      "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "mode": "local",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    }
+  ],
+  "record_id": "2014-fix-2014-kimi-ai-block-provider",
+  "requested_admin_labels": [
+    {
+      "actor_permission": null,
+      "applied_at": null,
+      "applied_by": null,
+      "name": "admin-approved:core-change"
+    }
+  ],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [
+      "format_check",
+      "full_audit",
+      "lint_format"
+    ],
+    "docs": [],
+    "guards": [
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": []
+  },
+  "runtime": "agents:kimi-code",
+  "schema_version": 2,
+  "scope_events": [
+    {
+      "action": "add-include",
+      "at": "2026-08-08T07:42:36.484382Z",
+      "pattern": "src/scistudio/blocks/ai/ai_block.py",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-08T07:42:36.484390Z",
+      "pattern": "src/scistudio/ai/agent/availability.py",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-08T07:42:36.484392Z",
+      "pattern": "src/scistudio/api/routes/ai_pty/_state.py",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-08T07:42:36.484394Z",
+      "pattern": "src/scistudio/ai/agent/providers_registry.py",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-08T07:42:36.484395Z",
+      "pattern": "src/scistudio/_skills/scistudio/scistudio-build-workflow/SKILL.md",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-08T07:42:36.484397Z",
+      "pattern": "tests/blocks/ai/test_ai_block_skeleton.py",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-08T07:42:36.484398Z",
+      "pattern": "tests/api/test_provider_registry_extensibility.py",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-08T07:42:36.484400Z",
+      "pattern": "docs/specs/adr-034-multi-provider-agent-chat.md",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-08T07:46:05.274966Z",
+      "pattern": "frontend/src/components/AIChat/SetupScreen.tsx",
+      "reason": "owner chose the placement mechanism for the Kimi notice and confirmed the two-issue PR scope"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-08T07:46:05.274972Z",
+      "pattern": "frontend/src/components/AIChat/__tests__/**",
+      "reason": "owner chose the placement mechanism for the Kimi notice and confirmed the two-issue PR scope"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-08T07:46:05.274974Z",
+      "pattern": "tests/architecture/test_adr_034_provider_single_source.py",
+      "reason": "owner chose the placement mechanism for the Kimi notice and confirmed the two-issue PR scope"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-08T07:46:05.274975Z",
+      "pattern": "docs/specs/adr-034-multi-provider-agent-chat.md",
+      "reason": "owner chose the placement mechanism for the Kimi notice and confirmed the two-issue PR scope"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-08T07:54:17.184171Z",
+      "pattern": "src/scistudio/_user_guide/ai-assistant.md",
+      "reason": "record the docs and test surfaces the Kimi hook work actually landed on"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-08T07:54:17.184199Z",
+      "pattern": "docs/agent-provisioning.md",
+      "reason": "record the docs and test surfaces the Kimi hook work actually landed on"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-08T07:54:17.184204Z",
+      "pattern": "tests/agent_provisioning/test_hooks.py",
+      "reason": "record the docs and test surfaces the Kimi hook work actually landed on"
+    }
+  ],
+  "session_id": "724dc80e-a55d-46c2-86a7-8a599c0986eb",
+  "strictness_tier": 2,
+  "task_kind": "guided",
+  "test_events": [
+    {
+      "at": "2026-08-08T07:42:36.484427Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/blocks/ai/test_ai_block_skeleton.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-08T07:42:36.484431Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/api/test_provider_registry_extensibility.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-08T07:46:05.274986Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/architecture/test_adr_034_provider_single_source.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-08T07:54:17.184220Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/agent_provisioning/test_hooks.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-08T07:54:17.184223Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/components/AIChat/__tests__/SetupScreen.test.tsx",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-08T07:54:17.184224Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/components/AIChat/__tests__/ProviderExtensibility.test.tsx",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/.workflow/records/2014-fix-2014-kimi-ai-block-provider.json
+++ b/.workflow/records/2014-fix-2014-kimi-ai-block-provider.json
@@ -224,9 +224,9 @@
   ],
   "check_na": [],
   "commit": {
-    "sha": "579b097d3d2014805c8efe1b0c44d32ff9b6f5ab",
+    "sha": "42cb1b7d64e67a617213c8ad03520f482e7c1ce5",
     "shas": [
-      "579b097d3d2014805c8efe1b0c44d32ff9b6f5ab"
+      "42cb1b7d64e67a617213c8ad03520f482e7c1ce5"
     ],
     "trailers": []
   },
@@ -736,6 +736,214 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-08-08T08:31:09.739326Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/ai/ai_block.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/ai/ai_block.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-08T08:31:09.751784Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-08T08:31:09.764189Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-08T08:31:09.780978Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-08T08:31:09.793515Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-08T08:31:09.806577Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-08T08:31:09.818639Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-08T08:31:09.830719Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-08T08:31:09.848278Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-08T08:31:09.864666Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-08T08:31:17.853807Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/ai/ai_block.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/ai/ai_block.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-08T08:31:17.866185Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-08T08:31:17.878430Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-08T08:31:17.890936Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-08T08:31:17.903382Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-08T08:31:17.916359Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-08T08:31:17.928713Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-08T08:31:17.940747Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-08T08:31:17.952621Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-08T08:31:17.971484Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -754,8 +962,8 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "origin/main",
-    "base_sha": "1844cc43",
+    "base": "2c916133c7454af685c6564aa6960b02cbedaf76",
+    "base_sha": "2c916133",
     "changed_files": [
       ".workflow/records/2014-fix-2014-kimi-ai-block-provider.json",
       "docs/agent-provisioning.md",
@@ -774,9 +982,9 @@
       "tests/architecture/test_adr_034_provider_single_source.py",
       "tests/blocks/ai/test_ai_block_skeleton.py"
     ],
-    "diff_fingerprint": "sha256:4819fde6fb48c6d8a05aaa278897542a9ae830c7086c15e908929fa88649bcdd",
+    "diff_fingerprint": "sha256:de5e9c11d91a8bbecb171312fa91a9223cc385eba3297d5948ec7523b340b58f",
     "head": "HEAD",
-    "head_sha": "579b097d",
+    "head_sha": "42cb1b7d",
     "surfaces": {
       "docs": 2,
       "frontend": 3,
@@ -798,7 +1006,7 @@
       2045,
       2014
     ],
-    "number": null,
+    "number": 2048,
     "url": null
   },
   "reconcile_events": [
@@ -839,6 +1047,22 @@
     {
       "at": "2026-08-08T08:30:49.021150Z",
       "diff_fingerprint": "sha256:4819fde6fb48c6d8a05aaa278897542a9ae830c7086c15e908929fa88649bcdd",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-08T08:31:09.864697Z",
+      "diff_fingerprint": "sha256:de5e9c11d91a8bbecb171312fa91a9223cc385eba3297d5948ec7523b340b58f",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-08T08:31:17.971516Z",
+      "diff_fingerprint": "sha256:de5e9c11d91a8bbecb171312fa91a9223cc385eba3297d5948ec7523b340b58f",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 1,

--- a/.workflow/records/2014-fix-2014-kimi-ai-block-provider.json
+++ b/.workflow/records/2014-fix-2014-kimi-ai-block-provider.json
@@ -223,7 +223,13 @@
     }
   ],
   "check_na": [],
-  "commit": null,
+  "commit": {
+    "sha": "579b097d3d2014805c8efe1b0c44d32ff9b6f5ab",
+    "shas": [
+      "579b097d3d2014805c8efe1b0c44d32ff9b6f5ab"
+    ],
+    "trailers": []
+  },
   "declared_scope": {
     "exclude": [],
     "include": [
@@ -626,6 +632,110 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-08-08T08:30:48.891526Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/ai/ai_block.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/ai/ai_block.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-08T08:30:48.904469Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-08T08:30:48.920421Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-08T08:30:48.933292Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-08T08:30:48.946293Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-08T08:30:48.960401Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-08T08:30:48.974116Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-08T08:30:48.991612Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-08T08:30:49.004601Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-08T08:30:49.021120Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -664,9 +774,9 @@
       "tests/architecture/test_adr_034_provider_single_source.py",
       "tests/blocks/ai/test_ai_block_skeleton.py"
     ],
-    "diff_fingerprint": "sha256:6bcb4b732108055e3b150253ea003f4953862c2373cf73f3a6bec756aa50d4c0",
+    "diff_fingerprint": "sha256:4819fde6fb48c6d8a05aaa278897542a9ae830c7086c15e908929fa88649bcdd",
     "head": "HEAD",
-    "head_sha": "2706e353",
+    "head_sha": "579b097d",
     "surfaces": {
       "docs": 2,
       "frontend": 3,
@@ -682,7 +792,15 @@
   },
   "owner_directive": "\u4fee\u590d issue #2014\uff1aAI Block provider enum \u4e0d\u5e94\u66b4\u9732\u65e0\u6cd5\u8fd0\u884c AI Block \u4efb\u52a1\u7684 kimi-code\uff1b\u6309 issue \u65b9\u6848 1 \u7528\u5171\u4eab\u80fd\u529b\u5224\u5b9a\u6d3e\u751f enum\uff0c\u6700\u540e\u63d0\u4ea4 PR",
   "persona": "live_implementer",
-  "pull_request": null,
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [
+      2045,
+      2014
+    ],
+    "number": null,
+    "url": null
+  },
   "reconcile_events": [
     {
       "at": "2026-08-08T07:54:44.981289Z",
@@ -713,6 +831,14 @@
     {
       "at": "2026-08-08T08:30:23.623722Z",
       "diff_fingerprint": "sha256:6bcb4b732108055e3b150253ea003f4953862c2373cf73f3a6bec756aa50d4c0",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-08T08:30:49.021150Z",
+      "diff_fingerprint": "sha256:4819fde6fb48c6d8a05aaa278897542a9ae830c7086c15e908929fa88649bcdd",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 1,

--- a/docs/agent-provisioning.md
+++ b/docs/agent-provisioning.md
@@ -163,10 +163,17 @@ wins inside a SciStudio project tree.
 
 ## Known limitations
 
-- **Codex hook system** has documented gaps (ADR-040 §3.10) — the 7
-  hooks govern Claude Code only. The `AGENTS.md` file gives Codex the
-  same prose-level guidance, but matcher-driven blocking is
-  Claude-Code-specific until Codex hooks mature.
+- **Hook coverage is four providers out of five.** This bullet used to say
+  the 7 hooks govern Claude Code only; #1994 provisioned Codex
+  (`.codex/config.toml`) and both Qoder channels (`.qoder/settings.json`)
+  as well, and Codex hooks still carry the documented `apply_patch` and
+  MCP-call gaps of ADR-040 §3.10 plus a first-launch trust review the user
+  answers in the terminal. **Kimi Code is not provisioned at all** (#2045):
+  it has a hook system whose contract matches ours exactly, but it reads
+  hook declarations only from the user's own `<KIMI_CODE_HOME>/config.toml`,
+  and SciStudio does not write user-scope CLI configuration. A Kimi Code
+  chat therefore runs unguarded, and the AI Chat setup screen says so. Every
+  provider still receives the same prose-level guidance through `AGENTS.md`.
 - **Layer 7 ACL on `<project>/blocks/`** (`#1015`) — hook-layer
   enforcement has known blind spots (exotic Bash writes, `python -c`,
   `mv`). True bulletproof enforcement requires filesystem ACLs and is

--- a/docs/specs/adr-034-multi-provider-agent-chat.md
+++ b/docs/specs/adr-034-multi-provider-agent-chat.md
@@ -21,7 +21,7 @@ scope:
     - Add per-provider MCP injection strategies so the existing provider-agnostic MCP payload reaches every CLI.
     - Replace `AIBlock._build_spawn_argv` with an explicit `provider` field on the worker to engine PTY tab request.
     - Extend `GET /api/ai/status` and the PTY WebSocket provider whitelist to the full registry-derived provider set.
-    - Extend the AI Block `provider` config enum to the full agent provider set.
+    - Extend the AI Block `provider` config enum to the full agent provider set. AMENDED 2026-08-08 by #2014 - the enum covers the capability-filtered agent set (providers that can carry a positional prompt), so chat-only `kimi-code` is not advertised; see the corrections section.
     - Replace the SetupScreen provider radio list with a registry-driven dropdown that lists every supported agent and enables only the installed ones.
     - Add a zero-install guidance state that tells the user to install an agent CLI when none is detected.
     - Reword the permission-mode picker to plain user language with no CLI flag names.
@@ -276,6 +276,18 @@ meaningless because there is no session in which to approve anything. Adopting
 it would change what an AI Block *is* for one provider, which is an owner
 decision and not one to take silently inside a bug fix.
 
+**The AI Block enum no longer advertises Kimi Code (#2014).** The correction
+above made the AI Block *refuse* Kimi Code at config time, but the schema's
+`provider` enum was still derived from every registry agent key, so the block
+editor offered a choice the validator was guaranteed to reject. The enum is
+now derived from the capability-filtered agent set — the same
+`session_unsupported_reason` check the work-import surface uses — so the
+schema, the UI, and runtime validation cannot disagree. User Story 2's first
+acceptance scenario and Success Criterion 2 are amended accordingly: the AI
+Block provider set is "every agent CLI that can carry a positional prompt",
+which today means all five registry agents except `kimi-code`. Kimi Code
+remains a fully supported chat-tab provider.
+
 **A batch-launcher install truncates the AI Block prompt.** Codex installs from
 npm as `codex.cmd` with no `codex.exe` on PATH — the real binary sits under a
 hashed `node_modules` path — so `CreateProcess` runs it through `cmd.exe`, whose
@@ -293,10 +305,16 @@ separate per-CLI mechanism the tables never covered:
 
 | Fact | `claude-code` | `codex` | `kimi-code` | `qoder` / `qoder-cn` |
 |---|---|---|---|---|
-| Hook config location | `<project>/.claude/settings.json` | `<project>/.codex/config.toml` | **no hook system** | `<project>/.qoder/settings.json` |
-| Project-dir variable | `$CLAUDE_PROJECT_DIR` | `$(git rev-parse --show-toplevel)` | n/a | `$QODER_PROJECT_DIR` |
-| Provisioned before #1994 | yes | yes | n/a | **no** |
-| Extra gate | none | **trust review (answered in PTY) + POSIX-only command, now fixed** | n/a | none |
+| Hook config location | `<project>/.claude/settings.json` | `<project>/.codex/config.toml` | `<KIMI_CODE_HOME>/config.toml` — **user scope only**, corrected by #2045 | `<project>/.qoder/settings.json` |
+| Project-dir variable | `$CLAUDE_PROJECT_DIR` | `$(git rev-parse --show-toplevel)` | none — hooks run with the session cwd | `$QODER_PROJECT_DIR` |
+| Provisioned before #1994 | yes | yes | no | **no** |
+| Provisioned after #2045 | yes | yes | **no — deliberately, see below** | yes |
+| Extra gate | none | **trust review (answered in PTY) + POSIX-only command, now fixed** | none | none |
+
+The `kimi-code` column of this table originally read **"no hook system"** in
+every row. That was wrong when it was written, and #2045 corrects it; the
+paragraph below records what is actually true and why the conclusion — SciStudio
+does not provision Kimi hooks — nonetheless stands.
 
 Qoder's location and format were established by running
 `qoderclicn hooks migrate --from-claude` at 1.1.15 against a SciStudio-
@@ -388,6 +406,78 @@ Bash call, with the agent relaying SciStudio's own hook text. Claude Code is
 only a POSIX shell executes, so its hooks depend on Git Bash being present on
 Windows. That is a latent exposure for a Windows user without Git for Windows,
 recorded here rather than fixed because no such failure has been observed.
+
+**Kimi Code does have a hook system, and SciStudio still does not provision it
+(#2045).** The table above originally wrote Kimi off with *no hook system*, and
+every downstream row followed with `n/a`. A Kimi agent working inside a
+provisioned SciStudio project reported the consequence: it wrote
+`workflows/hook-test.yaml`, edited `workflows/main.yaml`, wrote into `data/`
+through Bash, and called `scaffold_block` without a prior `list_blocks` — four
+operations every other provider blocks — and nothing stopped any of them. It
+then attributed that to Kimi lacking hooks, which is the same wrong conclusion
+the table had already recorded.
+
+Reading the shipped 0.33.0 binary — the same build the rest of §1's provider
+table was verified against — shows the opposite. Kimi implements sixteen hook
+events including `PreToolUse` and `PostToolUse`; a blocking `PreToolUse` result
+is converted into a `deny` permission decision, so it genuinely gates tool
+calls; the runner spawns the command through a shell, writes the payload to
+stdin as JSON, and **treats exit code 2 as a block with stderr as the reason**;
+payload keys are emitted snake_case (`tool_name`, `tool_input`, `cwd`,
+`session_id`); and `matcher` is a regular expression tested against the tool
+name, so `Edit|Write|MultiEdit` is already a valid matcher. That is SciStudio's
+existing hook contract in every particular. **The seven scripts would run
+unmodified.**
+
+The reading is confirmed against the running binary, and the check is cheap to
+repeat. Point `KIMI_CODE_HOME` at a scratch directory holding a `config.toml`
+with SciStudio's hook entries and run `kimi doctor`: it reports `OK config.toml`.
+Add one bogus key to the same entry and it fails with
+`hooks[0]: Unrecognized key: "notARealField"` — so the `hooks` section is parsed
+and schema-checked rather than tolerated and ignored, and the snake_case TOML
+spelling is what the strict schema expects.
+
+The real obstacle is one row down: *where* a hook may be declared. Kimi reads
+hooks from a `[[hooks]]` array of `{event, matcher?, command, timeout?}` in
+`<KIMI_CODE_HOME>/config.toml`, and from plugins registered in
+`<KIMI_CODE_HOME>/plugins/installed.json`. Both are user scope. A project-scope
+file does exist — `<project>/.kimi-code/local.toml` — but its schema is a strict
+`{workspace: {additional_dir: [string]}}` and rejects anything else. The only
+knob that redirects the config is `KIMI_CODE_HOME`, which relocates
+credentials, sessions, and provider settings along with it. Confirmed the same
+way: with the cwd set to a project holding a `.kimi-code/config.toml`,
+`kimi doctor` still resolves its config from `KIMI_CODE_HOME` alone and reports
+the project file's location as *does not exist*. So the move that
+covers the other four CLIs — drop one file into the project — has no Kimi
+analogue, and the only mechanism that would work is writing the user's global
+configuration.
+
+**Decision: disclose the gap rather than write a user-scope config.** Three
+routes were considered. Merging entries into `<KIMI_CODE_HOME>/config.toml`
+works — Kimi runs hooks with the session cwd, so a cwd-relative command would
+bite only inside a provisioned project — but it makes SciStudio the first thing
+in this codebase to edit a user's global CLI configuration, and every entry
+fires in every unrelated project that user opens, failing to spawn seven times
+per tool call. Registering absolute per-project paths in that same global file
+is worse: Kimi matches on tool name, not on cwd, so project A's hook scripts
+would receive project B's payloads unless each script grew a project-root
+guard. A per-project `KIMI_CODE_HOME` would take the user's login with it.
+
+What ships instead is the truth, in the two places a reader can act on it: this
+table, and a note in the AI Chat setup screen shown when Kimi Code is selected.
+The note says the safety hooks do not apply to that tab, that the user can add
+them by hand — or ask Kimi in that very tab to do it — and that doing so takes
+effect for every Kimi session on the machine rather than this project alone.
+That note is the second and, by intent, last entry in the frontend
+provider-literal allowlist in
+`tests/architecture/test_adr_034_provider_single_source.py`; a third would mean
+the notice text belongs in the registry and the allowlist should empty out.
+
+This changes no success criterion. Kimi Code remains a fully supported chat
+provider; what changes is that its one unguarded surface is now stated rather
+than mislabelled, and revisiting is cheap — if Kimi Code gains a project-scope
+hook file, provisioning it is a `write_hooks` addition and nothing else, because
+the scripts and matchers already fit.
 
 **With the command line fixed, Codex invoked the hooks — and all three exited
 1.** Two further causes, and the first is not the one the error text suggests.
@@ -627,7 +717,9 @@ Acceptance Scenarios:
 
 - Given an AI Block configured with `provider: kimi-code`, when the block runs,
   then the engine receives `provider="kimi-code"` on the tab request and spawns
-  the Kimi factory.
+  the Kimi factory. AMENDED by #1994 and #2014 - Kimi Code has no positional
+  prompt argument, so it is refused at config time with that explanation and is
+  not advertised in the `provider` enum at all; see the corrections section.
 - Given an AI Block run completes, when the run directory is inspected, then
   `<project>/.scistudio/.tmp/` contains no orphaned system-prompt file.
 - Given a provider binary is absent, when `validate_config` runs, then the error
@@ -1428,8 +1520,9 @@ say so, because the change reads as a stylistic regression and will otherwise be
 
 - All five agent providers launch a chat tab and reach a working SciStudio MCP
   tool call in the manual smoke launch.
-- All five agent providers are selectable as an AI Block provider and complete a
-  block run.
+- Every AI-Block-capable agent provider — all registry agents except chat-only
+  `kimi-code` (#1994, #2014) — is selectable as an AI Block provider and
+  completes a block run.
 - Kimi Code and both Qoder channels are discovered when installed only in their
   well-known directories and absent from PATH.
 - Both Qoder channels are independently selectable when both are installed, and

--- a/frontend/src/components/AIChat/SetupScreen.tsx
+++ b/frontend/src/components/AIChat/SetupScreen.tsx
@@ -173,6 +173,31 @@ export function SetupScreen({ tabId, onLaunch, onCancel }: SetupScreenProps) {
           </div>
         ) : null}
 
+        {/* #2045: Kimi Code does have a hook system, and its contract is the
+            one SciStudio's scripts already speak — JSON on stdin, exit code 2
+            blocks, regex matchers on the tool name. What it has no equivalent
+            of is a *project-scope* place to declare hooks: the only location it
+            reads is the user-level config file, and `.kimi-code/local.toml`
+            accepts nothing but `[workspace] additional_dir`. So there is no
+            file SciStudio can drop into the project the way it does for the
+            other four CLIs, and this tab runs unguarded. Writing the user's
+            global config on their behalf was rejected — SciStudio has never
+            written a user-scope CLI config — which leaves saying so plainly. */}
+        {provider === "kimi-code" ? (
+          <div
+            className="rounded-2xl border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800"
+            data-testid="setup-kimi-hooks-note"
+          >
+            <strong className="font-medium">Heads up:</strong> Kimi Code reads hooks only from its
+            own user-level <span className="font-mono">config.toml</span>, so SciStudio&rsquo;s
+            safety hooks — the ones that keep your <span className="font-mono">data/</span> folder
+            and workflow files from being edited by accident — do not apply to this tab. You can add
+            them by hand, or simply ask Kimi in this tab to set them up for you. They would then
+            apply to <strong className="font-medium">every</strong> Kimi Code session on this
+            machine, not just this project.
+          </div>
+        ) : null}
+
         <PermissionModePicker
           tabId={tabId}
           permissionMode={permissionMode}

--- a/frontend/src/components/AIChat/__tests__/ProviderExtensibility.test.tsx
+++ b/frontend/src/components/AIChat/__tests__/ProviderExtensibility.test.tsx
@@ -204,15 +204,20 @@ describe("ADR-034 User Story 7 — a provider the frontend has never heard of", 
   });
 
   it("shows no provider-specific UI note for an unknown provider", async () => {
-    // The one surviving provider-specific branch in SetupScreen is the #1859
-    // Codex trust-hooks note, allowlisted by name in
-    // `tests/architecture/test_adr_034_provider_single_source.py`. It must be
-    // the *only* one: a second branch would mean the picker had started
-    // accumulating per-provider knowledge again.
+    // Two provider-specific branches survive in SetupScreen — the #1859 Codex
+    // trust-hooks note and the #2045 Kimi user-scope-hooks note — both
+    // allowlisted by name in
+    // `tests/architecture/test_adr_034_provider_single_source.py`. Each exists
+    // because that CLI imposes a hook gap SciStudio cannot close from inside
+    // the project. What must stay true is that a provider the frontend has
+    // never seen gets *neither*: a note appearing for an unknown key would mean
+    // the branches had stopped being about two named CLIs and started being
+    // per-provider knowledge the picker maintains.
     await renderWith(PAYLOAD_WITH_UNKNOWN_PROVIDERS);
 
     selectProvider("fixture-agent");
     expect(screen.queryByTestId("setup-codex-trust-note")).toBeNull();
+    expect(screen.queryByTestId("setup-kimi-hooks-note")).toBeNull();
   });
 });
 

--- a/frontend/src/components/AIChat/__tests__/SetupScreen.test.tsx
+++ b/frontend/src/components/AIChat/__tests__/SetupScreen.test.tsx
@@ -253,6 +253,33 @@ describe("SetupScreen provider select (FR-021)", () => {
     expect(note.textContent).toMatch(/trust/i);
     expect(note.textContent).toMatch(/data\//);
   });
+
+  it("shows the Kimi user-scope-hooks note only when Kimi Code is selected (#2045)", async () => {
+    mockStatusOnce({
+      providers: [
+        ALL_PROVIDERS[0],
+        { ...ALL_PROVIDERS[2], available: true, version: "0.33.0", logged_in: true },
+      ],
+    });
+    render(<SetupScreen tabId="t1" onLaunch={vi.fn()} onCancel={vi.fn()} />);
+    await screen.findByTestId("setup-provider-select");
+
+    expect(screen.queryByTestId("setup-kimi-hooks-note")).not.toBeInTheDocument();
+
+    selectProvider("claude-code");
+    expect(screen.queryByTestId("setup-kimi-hooks-note")).not.toBeInTheDocument();
+
+    selectProvider("kimi-code");
+    const note = screen.getByTestId("setup-kimi-hooks-note");
+    // The three things the user needs from this note: which hooks are missing,
+    // that they can turn them on themselves, and that doing so is global. A
+    // note that only said "hooks are off" would leave them stuck.
+    expect(note.textContent).toMatch(/data\//);
+    expect(note.textContent).toMatch(/config\.toml/);
+    expect(note.textContent).toMatch(/every Kimi Code session/i);
+    // The two notes are about different CLIs and must never co-render.
+    expect(screen.queryByTestId("setup-codex-trust-note")).not.toBeInTheDocument();
+  });
 });
 
 describe("SetupScreen zero-install notice (FR-021c / FR-021d)", () => {

--- a/src/scistudio/_skills/scistudio/scistudio-build-workflow/SKILL.md
+++ b/src/scistudio/_skills/scistudio/scistudio-build-workflow/SKILL.md
@@ -271,22 +271,26 @@ terminates cleanly via
 `scistudio-debug-run` for the full `finish_ai_block` operational
 contract.
 
-The `provider` config accepts any agent CLI SciStudio supports:
+The `provider` config accepts any agent CLI that can run an AI Block task:
 
 | Value | Label | Binary |
 |---|---|---|
 | `claude-code` | Claude Code (default) | `claude` |
 | `codex` | Codex | `codex` |
-| `kimi-code` | Kimi Code | `kimi` |
 | `qoder` | Qoder CLI — international channel | `qodercli` |
 | `qoder-cn` | Qoder CLI (China) — China channel | `qoderclicn` |
+
+`kimi-code` is deliberately absent (#2014): Kimi Code has no positional
+prompt argument, so it cannot receive an AI Block task and the block refuses
+it at config time. It remains available for hand-launched chat tabs.
 
 The two Qoder channels are separate providers, not aliases: they have
 separate binaries, config roots, and credentials, and a user may have
 both installed. Picking one never falls back to the other.
 
 Do not treat this table as the authority. The enum is generated from
-`scistudio.ai.agent.providers_registry`, so
+`scistudio.ai.agent.providers_registry` (filtered to providers that can
+carry an AI Block prompt), so
 `get_block_schema("ai.assisted_segmenter")` is always current and this
 table may lag a newly added provider. Existing workflows using
 `provider: claude-code` are unaffected — the enum only widened.

--- a/src/scistudio/_user_guide/ai-assistant.md
+++ b/src/scistudio/_user_guide/ai-assistant.md
@@ -20,6 +20,10 @@ to. Five are supported:
 | **Qoder CLI** | Qoder (international) | yes | yes |
 | **Qoder CLI (China)** | Qoder (China) | yes | yes |
 
+Kimi Code has one further difference worth knowing before you pick it: SciStudio's
+safety hooks cannot be installed into a Kimi Code chat. See
+[Kimi Code chats run without SciStudio's hooks](#kimi-code-chats-run-without-scistudios-hooks).
+
 You only need **one** to get going, but you can install several and choose per
 chat or per AI Agent block. Install whichever you have an account for:
 
@@ -102,6 +106,30 @@ Until you answer, SciStudio's hooks are inactive — that is what option 3's
 "hooks won't run" means. If you picked option 3 and later wonder why the
 protections seem silent, that is the cause; the prompt returns when the hook
 configuration next changes.
+
+### Kimi Code chats run without SciStudio's hooks
+
+The hooks described just above are installed **into your project**, and every
+provider except Kimi Code picks them up from there. Kimi Code reads hooks only
+from its own settings file in your home directory, so there is nowhere in the
+project for SciStudio to put them. A Kimi Code chat therefore runs without
+them: the guard that stops accidental edits to your `data/` folder and your
+workflow files is simply not active in that tab.
+
+SciStudio does not edit that file for you. It is your personal settings file,
+shared by every project you open with Kimi Code, and changing it on your behalf
+would reach far outside the project you are working in.
+
+You can add the hooks yourself if you want them. The easiest way is to ask Kimi
+in the chat itself — something like *"add the hook scripts in this project's
+`.claude/hooks/` folder to my Kimi config as PreToolUse and PostToolUse hooks"* —
+since it can read the scripts and edit its own configuration. The scripts work
+with Kimi Code as-is; nothing needs to be rewritten. Remember that hooks added
+this way apply to **every** Kimi Code session on your computer, not only this
+project.
+
+Everything else — the SciStudio tools, the skills, and the project knowledge the
+assistant works from — is unaffected and works normally in a Kimi Code chat.
 
 ## The chat assistant
 

--- a/src/scistudio/ai/agent/availability.py
+++ b/src/scistudio/ai/agent/availability.py
@@ -109,7 +109,12 @@ from enum import StrEnum
 from pathlib import Path
 from typing import Any
 
-from scistudio.ai.agent.providers_registry import CONFIG_ROOT, ProviderDescriptor, resolve_binary
+from scistudio.ai.agent.providers_registry import (
+    CONFIG_ROOT,
+    ProviderDescriptor,
+    resolve_binary,
+    session_unsupported_reason,
+)
 from scistudio.ai.agent.providers_registry import get as get_descriptor
 
 logger = logging.getLogger(__name__)
@@ -709,38 +714,19 @@ def login_hint(descriptor: ProviderDescriptor) -> str:
     return f"Start `{binary}` in a terminal and complete its sign-in; SciStudio reads {where} to confirm it."
 
 
-def session_unsupported_reason(descriptor: ProviderDescriptor) -> str | None:
-    """Why a SciStudio-started session cannot use *descriptor*, or ``None``.
-
-    The single place this question is answered. Every SciStudio-started session
-    — an AI Block run, a Bring In My Work session — hands its agent an opening
-    instruction as a positional command-line argument, because four of the five
-    registry agents have no per-session prompt channel at all. A CLI that parses
-    its first positional as a *subcommand* cannot be reached that way, and the
-    registry records exactly that with ``prompt_argv_prefix is None`` plus a
-    sentence explaining it.
-
-    Consumers ask here rather than reading ``prompt_argv_prefix`` themselves so
-    the meaning of that field is interpreted once. Availability carries the
-    answer because availability is already the shared report every
-    agent-dependent surface reads (FR-036), and a surface that must not offer a
-    provider it cannot launch needs this at the same moment it needs the grade.
-
-    **The AI Block has the same defect and is not fixed here.** ``#2014`` (open,
-    P2) records that ``AIBlock.config_schema`` derives its ``provider`` enum
-    from ``agent_keys()`` and therefore advertises a provider that
-    ``AIBlock.validate_config`` will reject — the identical shape of bug this
-    function exists to close on the work-import surface, from the identical
-    cause. Its own first suggested fix is a shared provider capability, which is
-    what this is; adopting it there is out of scope for this change and stays
-    tracked on that issue.
-    """
-    if descriptor.prompt_argv_prefix is not None:
-        return None
-    return descriptor.prompt_unsupported_reason or (
-        f"{descriptor.label} has no positional prompt argument, so a SciStudio-started session "
-        f"cannot hand it the instructions it needs."
-    )
+# ``session_unsupported_reason`` is defined in ``providers_registry`` and
+# re-exported here (it stays in this module's ``__all__``). It lived here first,
+# because availability is the shared report every agent-dependent surface reads
+# and a surface that must not offer a provider it cannot launch needs the answer
+# at the same moment it needs the grade. #2014 gave it a second consumer,
+# ``AIBlock.config_schema``, and that is what moved it: ``blocks`` may not
+# import ``scistudio.ai`` except for one carved-out lazy edge to the registry,
+# and this module runs subprocesses to probe auth — far more than a block layer
+# should be able to reach for a question that reads three descriptor fields and
+# calls nothing. The registry is where per-CLI facts already live and is the
+# leaf both layers may depend on, so the predicate moved there and every caller
+# here, in ``api``, and in the tests keeps importing it from wherever it was
+# already importing it.
 
 
 def _next_step(descriptor: ProviderDescriptor, state: AvailabilityState) -> str | None:

--- a/src/scistudio/ai/agent/providers_registry.py
+++ b/src/scistudio/ai/agent/providers_registry.py
@@ -83,6 +83,7 @@ __all__ = [
     "provider_keys",
     "resolve_binary",
     "resolve_executable",
+    "session_unsupported_reason",
 ]
 
 #: Sentinel first segment marking a path as relative to the provider's resolved
@@ -656,6 +657,36 @@ _KIMI_CODE = ProviderDescriptor(
         "seed the interactive session an AI Block needs. Kimi Code works as a "
         "hand-launched chat tab; pick another provider for an AI Block."
     ),
+    # #2045. Kimi Code is the one provider SciStudio does not provision hooks
+    # for, and the reason is not the one previously recorded. The ADR-034 spec
+    # said Kimi has "no hook system"; that is wrong, and was already wrong at
+    # the same 0.33.0 the rest of this table was verified against.
+    #
+    # Kimi has a full external-hook system whose contract is the one
+    # SciStudio's seven scripts already speak, verified by reading the shipped
+    # binary: ``PreToolUse``/``PostToolUse`` among sixteen events, the payload
+    # delivered as JSON on stdin with snake_case keys (``tool_name``,
+    # ``tool_input``, ``cwd``, ``session_id``), **exit code 2 blocks** with
+    # stderr carried back as the denial reason, and ``matcher`` a regular
+    # expression tested against the tool name — so ``Edit|Write|MultiEdit`` is
+    # already valid. Dropped in unchanged, the scripts would run.
+    #
+    # What Kimi has no equivalent of is a *project-scope* declaration site.
+    # Hooks are read from a ``[[hooks]]`` array in
+    # ``<KIMI_CODE_HOME>/config.toml`` and from user-scope plugins, and nowhere
+    # else: ``<project>/.kimi-code/local.toml`` exists but its schema is a
+    # strict ``{workspace: {additional_dir: [str]}}``, and the only relocation
+    # knob is ``KIMI_CODE_HOME``, which moves credentials and sessions with it.
+    #
+    # So the per-project file drop that covers Claude Code, both Qoder
+    # channels, and Codex has no Kimi analogue, and the only way to install
+    # these hooks is to write the user's global config. That was rejected on
+    # owner decision: SciStudio has never written a user-scope CLI config, and
+    # entries added there would fire in every unrelated project the user opens.
+    # The gap is disclosed to the user instead, by the ``kimi-code`` note in
+    # ``SetupScreen.tsx``. If a future Kimi Code release gains a project-scope
+    # hook file, provisioning it is an addition to ``write_hooks`` and nothing
+    # more, because the scripts and the matchers already fit.
 )
 
 _QODER = _qoder_channel(
@@ -691,7 +722,8 @@ _USER_TERMINAL = ProviderDescriptor(
 #: Ordered registry. Order is the frozen cross-agent contract:
 #: ``claude-code``, ``codex``, ``kimi-code``, ``qoder``, ``qoder-cn``, then the
 #: ``user-terminal`` TERMINAL-kind entry. It drives the status endpoint order,
-#: the WS whitelist, and the AI Block enum.
+#: the WS whitelist, and — after the AI Block's capability filter (#2014) —
+#: the AI Block enum.
 REGISTRY = ProviderRegistry(
     (
         _CLAUDE_CODE,
@@ -727,6 +759,38 @@ def agent_keys() -> tuple[str, ...]:
 def provider_keys() -> tuple[str, ...]:
     """Every provider key in registry order, including ``user-terminal``."""
     return REGISTRY.keys()
+
+
+def session_unsupported_reason(descriptor: ProviderDescriptor) -> str | None:
+    """Why a SciStudio-started session cannot use *descriptor*, or ``None``.
+
+    The single place this question is answered. Every SciStudio-started session
+    — an AI Block run, a Bring In My Work session — hands its agent an opening
+    instruction as a positional command-line argument, because four of the five
+    registry agents have no per-session prompt channel at all. A CLI that parses
+    its first positional as a *subcommand* cannot be reached that way, and
+    :attr:`ProviderDescriptor.prompt_argv_prefix` records exactly that, with
+    :attr:`ProviderDescriptor.prompt_unsupported_reason` explaining it in the
+    user's terms.
+
+    Consumers ask here rather than reading ``prompt_argv_prefix`` themselves so
+    the meaning of that field is interpreted once. It sits in the registry
+    beside the field it interprets, and not in ``availability`` where it began,
+    because #2014 gave it a second consumer in the block layer:
+    ``AIBlock.config_schema`` derives its ``provider`` enum from it, and
+    ``blocks`` may reach into ``scistudio.ai`` only through the one carved-out
+    lazy edge to this module (see the import-linter contracts in
+    ``pyproject.toml``). ``availability`` probes auth by running subprocesses;
+    a question that reads three descriptor fields and calls nothing should not
+    drag that into the block layer. ``availability`` re-exports it, so its own
+    callers and the API layer are unaffected.
+    """
+    if descriptor.prompt_argv_prefix is not None:
+        return None
+    return descriptor.prompt_unsupported_reason or (
+        f"{descriptor.label} has no positional prompt argument, so a SciStudio-started session "
+        f"cannot hand it the instructions it needs."
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/src/scistudio/api/routes/ai_pty/_state.py
+++ b/src/scistudio/api/routes/ai_pty/_state.py
@@ -55,7 +55,9 @@ _ProviderSpawner = Callable[..., PtyProcess]
 #
 # ``_VALID_PROVIDERS`` is the WebSocket query whitelist (FR-023), so it spans the
 # *whole* registry including the ``user-terminal`` pseudo-provider; the agent-only
-# view (``agent_keys()``) is what ``GET /api/ai/status`` and the AI Block enum use.
+# view (``agent_keys()``) is what ``GET /api/ai/status`` uses. The AI Block enum
+# is narrower still: it filters the agent keys down to the providers that can
+# carry an AI Block task (#2014).
 _VALID_PROVIDERS: tuple[str, ...] = REGISTRY.keys()
 
 # ``functools.partial`` binds the descriptor, leaving the uniform keyword-only

--- a/src/scistudio/blocks/ai/ai_block.py
+++ b/src/scistudio/blocks/ai/ai_block.py
@@ -79,6 +79,30 @@ def _agent_provider_keys() -> list[str]:
     return list(agent_keys())
 
 
+def _ai_block_provider_keys() -> list[str]:
+    """Agent keys the AI Block may advertise, in registry order (#2014).
+
+    The chat surface offers every registry agent; the AI Block surface must
+    not. An AI Block hands its task to the agent as a positional prompt
+    argument, and a CLI with no positional prompt — Kimi Code parses its
+    first positional as a subcommand — exits 1 before painting anything.
+    Advertising such a provider in the config enum offered the user a choice
+    that ``validate_config`` was guaranteed to reject, so the enum is
+    filtered through :func:`session_unsupported_reason`, the shared
+    capability check the work-import surface already uses, rather than
+    reading ``prompt_argv_prefix`` here and interpreting that field twice.
+
+    That check is imported from the registry, not from ``ai.agent.availability``
+    where it was first written. The lazy block-to-agent edge carved out in the
+    import-linter contracts terminates at the registry and nowhere else, and
+    ``availability`` runs subprocesses to probe auth state — a dependency this
+    layer has no business acquiring for a pure descriptor question.
+    """
+    from scistudio.ai.agent.providers_registry import agent_descriptors, session_unsupported_reason
+
+    return [d.key for d in agent_descriptors() if session_unsupported_reason(d) is None]
+
+
 def _resolve_provider_descriptor(provider: str) -> ProviderDescriptor:
     """Return the registry descriptor for *provider* or raise ``ValueError``.
 
@@ -143,8 +167,10 @@ class AIBlock(Block):
 
     Config:
         ``user_prompt`` (required) is the natural-language task. ``provider``
-        selects any agent CLI in the provider registry — ``"claude-code"`` is
-        the default. ``permission_mode`` is ``"safe"`` (the agent asks before
+        selects any agent CLI in the provider registry that can carry an AI
+        Block task — ``"claude-code"`` is the default, and chat-only CLIs
+        with no positional prompt argument (Kimi Code) are not offered
+        (#2014). ``permission_mode`` is ``"safe"`` (the agent asks before
         sensitive tool use, default) or ``"bypass"`` (full filesystem access).
         ``input_ports`` / ``output_ports`` declare the named ports and, for
         outputs, the file path where each result is expected.
@@ -254,14 +280,17 @@ class AIBlock(Block):
                 "ui_priority": 1,
             },
             # ADR-034 FR-015: the enum is derived from the provider
-            # registry's agent keys rather than a hand-maintained literal,
-            # so adding a sixth provider is a registry-only change. Enum
+            # registry rather than a hand-maintained literal, so adding a
+            # sixth provider is a registry-only change. #2014 narrowed the
+            # derivation from every agent key to the agents that can carry
+            # an AI Block task (``_ai_block_provider_keys``), so a chat-only
+            # provider such as Kimi Code is never advertised here. Enum
             # widening is backward compatible: a workflow saved with
             # ``provider: claude-code`` still validates, and the default is
             # deliberately unchanged.
             "provider": {
                 "type": "string",
-                "enum": _agent_provider_keys(),
+                "enum": _ai_block_provider_keys(),
                 "default": "claude-code",
                 "title": "Provider",
                 "ui_priority": 2,

--- a/tests/agent_provisioning/test_hooks.py
+++ b/tests/agent_provisioning/test_hooks.py
@@ -90,6 +90,36 @@ def test_write_hooks_excludes_worktree_write_guard(tmp_project_dir: Path) -> Non
     assert not any("worktree_write_guard" in command for command in commands)
 
 
+def test_write_hooks_writes_nothing_for_kimi_code(tmp_project_dir: Path) -> None:
+    """#2045: Kimi hooks are user scope, so provisioning must stay out of the project.
+
+    Kimi Code *does* have a hook system, and its contract is ours exactly —
+    JSON on stdin, exit 2 blocks, regex matchers on the tool name — so the
+    seven scripts above would run under it unchanged. That similarity is the
+    trap: it makes "just provision Kimi too" look like a one-line addition.
+    It is not, because the only place Kimi reads hook declarations from is
+    ``<KIMI_CODE_HOME>/config.toml``. There is no project-scope file to write,
+    and the owner decision is that SciStudio does not edit a user's global CLI
+    configuration — entries there would fire in every unrelated project the
+    user opens. The AI Chat setup screen discloses the gap instead.
+
+    This test exists so that decision fails loudly if it is ever quietly
+    reversed by a provisioning change rather than by amending the spec.
+    """
+    written = write_hooks(tmp_project_dir, force=True)
+
+    assert not any("kimi" in path.lower() for path in written), (
+        f"write_hooks reported a Kimi path: {written}. Kimi reads hook "
+        "declarations only from <KIMI_CODE_HOME>/config.toml."
+    )
+    # ``<project>/.kimi-code/`` is a legitimate directory — the chat spawn path
+    # writes Kimi's MCP config there — so the assertion is about hook *config*
+    # landing in it, not about the directory existing.
+    assert not (tmp_project_dir / ".kimi-code" / "config.toml").exists()
+    assert not (tmp_project_dir / ".kimi-code" / "local.toml").exists()
+    assert not (tmp_project_dir / ".kimi-code" / "settings.json").exists()
+
+
 def test_write_hooks_idempotent_when_all_canonical_present(tmp_project_dir: Path) -> None:
     """force=False does not rewrite settings.json when nothing is missing."""
     settings = _build_settings_json(".claude/hooks")

--- a/tests/api/test_provider_registry_extensibility.py
+++ b/tests/api/test_provider_registry_extensibility.py
@@ -173,10 +173,19 @@ def test_ws_whitelist_and_spawner_map_pick_up_the_sixth_provider(sixth_provider:
 
 
 def test_ai_block_config_enum_picks_up_the_sixth_provider(sixth_provider: dict[str, ModuleType]) -> None:
-    """FR-015: the enum widens and the default does not move."""
+    """FR-015: the enum widens and the default does not move.
+
+    #2014: the enum is the *capability-filtered* agent set, not every agent
+    key — chat-only providers such as ``kimi-code`` are excluded. The fixture
+    descriptor keeps the default ``prompt_argv_prefix``, so it is capable and
+    still appears with no edit here.
+    """
+    from scistudio.ai.agent.availability import session_unsupported_reason
+
     ai_block = sixth_provider["scistudio.blocks.ai.ai_block"]
     provider_schema = ai_block.AIBlock.config_schema["properties"]["provider"]
-    assert provider_schema["enum"] == list(registry.agent_keys())
+    capable = [d.key for d in registry.agent_descriptors() if session_unsupported_reason(d) is None]
+    assert provider_schema["enum"] == capable
     assert "fixture-agent" in provider_schema["enum"]
     assert provider_schema["default"] == "claude-code"
 

--- a/tests/architecture/test_adr_034_provider_single_source.py
+++ b/tests/architecture/test_adr_034_provider_single_source.py
@@ -237,18 +237,35 @@ def test_the_registry_is_the_only_module_declaring_provider_labels() -> None:
 # SC: the frontend has no hand-maintained provider key or label list
 # ---------------------------------------------------------------------------
 
-#: ``{frontend file: {literal: reason}}`` — the single sanctioned survivor.
+#: ``{frontend file: {literal: reason}}`` — the sanctioned survivors.
 #:
-#: ``SetupScreen`` keeps a ``provider === "codex"`` branch that shows Codex's
-#: trust-hooks note (#1859). A5 retained it deliberately and flagged it. It is
-#: one provider-specific *UI warning*, not a key list and not a label map, so
-#: it does not reintroduce the duplication FR-020a/FR-020b remove: adding a
-#: sixth provider still requires no edit to this file. It is permitted here by
-#: exact file, exact literal, and stated count — a loose "SetupScreen may
+#: ``SetupScreen`` keeps two ``provider === "<key>"`` branches, each showing one
+#: warning about a hook gap that provider's own CLI design creates and that
+#: SciStudio cannot close from inside the project:
+#:
+#: - ``codex`` (#1859): Codex gates hook execution behind a trust review the
+#:   user answers in the PTY; declining it silently disables every provisioned
+#:   hook.
+#: - ``kimi-code`` (#2045): Kimi Code reads hook declarations only from its
+#:   user-level ``config.toml``. There is no project-scope location to
+#:   provision, so the tab runs with none of SciStudio's hooks and the note is
+#:   what tells the user.
+#:
+#: Both are provider-specific *UI warnings*, not a key list and not a label map,
+#: so neither reintroduces the duplication FR-020a/FR-020b remove: adding a
+#: sixth provider still requires no edit to this file. They are permitted here
+#: by exact file, exact literal, and stated count — a loose "SetupScreen may
 #: mention providers" rule would also let a real regression through.
+#:
+#: Growth here is the thing to watch. Two entries, each an unavoidable
+#: CLI-imposed gap with an issue behind it, is not the branch chain FR-020a
+#: deleted; a third arriving for an ordinary per-provider difference would be,
+#: and is the point at which the notice text belongs in the registry and this
+#: allowlist should shrink back to nothing.
 _FRONTEND_KEY_ALLOWLIST: dict[str, dict[str, str]] = {
     "components/AIChat/SetupScreen.tsx": {
         "codex": "#1859 Codex trust-hooks warning: one UI note, not a key or label list",
+        "kimi-code": "#2045 Kimi user-scope-hooks warning: one UI note, not a key or label list",
     },
 }
 
@@ -410,11 +427,21 @@ def test_the_guards_above_are_not_vacuous() -> None:
         assert (SRC_ROOT / relpath).is_file(), relpath
     sources = _frontend_sources()
     assert len(sources) > 50, f"frontend scan found only {len(sources)} files"
-    # The allowlisted survivor must actually be there: if #1859's warning is
-    # ever removed, this test fails and the allowlist entry is deleted with it
-    # rather than quietly becoming a hole.
-    setup_screen = FRONTEND_SRC / "components" / "AIChat" / "SetupScreen.tsx"
-    assert '"codex"' in _strip_ts_comments(setup_screen.read_text(encoding="utf-8"))
+    # Every allowlisted survivor must actually be there: if #1859's or #2045's
+    # warning is ever removed, this test fails and the allowlist entry is
+    # deleted with it rather than quietly becoming a hole. Derived from the
+    # allowlist rather than spelled out, so a third entry cannot be added
+    # without also being held to this rule.
+    for relpath, allowed in _FRONTEND_KEY_ALLOWLIST.items():
+        path = FRONTEND_SRC / relpath
+        assert path.is_file(), f"allowlisted frontend file moved or was deleted: {relpath}"
+        source = _strip_ts_comments(path.read_text(encoding="utf-8"))
+        stale = sorted(value for value in allowed if f'"{value}"' not in source)
+        assert stale == [], (
+            f"_FRONTEND_KEY_ALLOWLIST[{relpath!r}] still permits {stale}, but the "
+            "literal is gone. Delete the entry so the guard tightens instead of "
+            "keeping an unused exception open."
+        )
 
     # Same rule for the backend allowlist, added when the ``terminal.py`` entry
     # outlived the ``spawn_claude`` / ``spawn_codex`` shims it existed for

--- a/tests/blocks/ai/test_ai_block_skeleton.py
+++ b/tests/blocks/ai/test_ai_block_skeleton.py
@@ -12,7 +12,8 @@ from pathlib import Path
 import pytest
 
 from scistudio.ai.agent import providers_registry
-from scistudio.ai.agent.providers_registry import agent_keys
+from scistudio.ai.agent.availability import session_unsupported_reason
+from scistudio.ai.agent.providers_registry import agent_descriptors, agent_keys
 from scistudio.blocks.ai.ai_block import (
     REUSE_LAST_OUTPUT_KEY,
     AIBlock,
@@ -495,27 +496,58 @@ def test_output_path_overrides_extracts_correctly() -> None:
 
 
 # ---------------------------------------------------------------------------
-# T-009 / FR-015 — registry-derived provider enum
+# T-009 / FR-015 — registry-derived, capability-filtered provider enum
 # ---------------------------------------------------------------------------
 
 
+def _capable_agent_keys() -> list[str]:
+    """Registry agent keys that can carry an AI Block task, in order."""
+    return [d.key for d in agent_descriptors() if session_unsupported_reason(d) is None]
+
+
 def test_config_schema_provider_enum_is_registry_derived() -> None:
-    """FR-015: the enum is exactly the registry's agent keys, in order.
+    """FR-015 + #2014: the enum is exactly the registry's AI-Block-capable
+    agent keys, in order.
 
     Equality rather than containment: a hand-maintained literal that
-    happened to include the registry keys plus a stale extra would pass a
+    happened to include the capable keys plus a stale extra would pass a
     containment check, and User Story 7 requires that adding a sixth
-    provider needs no edit here.
+    provider needs no edit here. #2014 narrowed the derivation from every
+    agent key to the capability-filtered set, so a chat-only provider can
+    never leak into the enum.
     """
     enum = AIBlock.config_schema["properties"]["provider"]["enum"]
-    assert enum == list(agent_keys())
+    assert enum == _capable_agent_keys()
 
 
-def test_config_schema_provider_enum_lists_all_five_agents() -> None:
-    """The three added providers are selectable on the block, not just in chat."""
+def test_config_schema_provider_enum_lists_only_capable_agents() -> None:
+    """The prompt-capable providers are selectable on the block; #2014:
+    ``kimi-code`` is chat-only and must not appear."""
     enum = AIBlock.config_schema["properties"]["provider"]["enum"]
-    assert set(enum) == {"claude-code", "codex", "kimi-code", "qoder", "qoder-cn"}
+    assert set(enum) == {"claude-code", "codex", "qoder", "qoder-cn"}
+    assert "kimi-code" not in enum
     assert "user-terminal" not in enum
+
+
+def test_config_schema_enum_never_advertises_a_provider_validation_rejects(
+    _provider_installed: None,
+) -> None:
+    """#2014 regression: the schema enum and ``validate_config`` agree.
+
+    The bug was a one-way disagreement — the enum advertised ``kimi-code``
+    while validation refused it — so pin both directions: every enum member
+    validates, and every registry agent *absent* from the enum is refused
+    with the chat-only explanation rather than spawned into a PTY that
+    exits 1.
+    """
+    enum = AIBlock.config_schema["properties"]["provider"]["enum"]
+    for provider in enum:
+        AIBlock().validate_config(_config(provider=provider, user_prompt="hi"))
+    for descriptor in agent_descriptors():
+        if descriptor.key in enum:
+            continue
+        with pytest.raises(ValueError, match="cannot run as an AI Block"):
+            AIBlock().validate_config(_config(provider=descriptor.key, user_prompt="hi"))
 
 
 def test_config_schema_provider_default_is_still_claude_code() -> None:


### PR DESCRIPTION
## What this fixes

A Kimi Code agent working inside a provisioned SciStudio project reported that
none of SciStudio's safety hooks fired: it wrote `workflows/hook-test.yaml`,
edited `workflows/main.yaml`, wrote into `data/` through Bash, and called
`scaffold_block` with no prior `list_blocks` — four operations every other
provider blocks — and nothing stopped any of them. It attributed that to Kimi
having no hook system, which is what the ADR-034 spec's hook-parity table also
said.

**The spec was wrong.** Kimi Code 0.33.0 — the same build the rest of the
provider table was verified against — has a full external-hook system, and its
contract is SciStudio's contract in every particular. Verified by reading the
shipped binary:

- sixteen hook events including `PreToolUse` and `PostToolUse`, with a blocking
  `PreToolUse` result converted into a `deny` permission decision;
- payload delivered as JSON on stdin with snake_case keys (`tool_name`,
  `tool_input`, `cwd`, `session_id`);
- **exit code 2 blocks**, stderr carried back as the denial reason;
- `matcher` is a regular expression over the tool name, so `Edit|Write|MultiEdit`
  is already valid.

The seven hook scripts would run under Kimi unmodified.

**The real obstacle is scope.** Kimi reads hooks only from a `[[hooks]]` array
in `<KIMI_CODE_HOME>/config.toml` and from user-scope plugins.
`<project>/.kimi-code/local.toml` exists but its schema is a strict
`{workspace: {additional_dir: [string]}}`, and `KIMI_CODE_HOME` relocates
credentials and sessions along with the config. Confirmed against the binary:
`kimi doctor` accepts SciStudio's hook entries, rejects a bogus key inside them
(`hooks[0]: Unrecognized key`), and ignores a project-scope `config.toml`
entirely. So the per-project file drop that covers Claude Code, Codex, and both
Qoder channels has no Kimi analogue.

## Decision

Installing these hooks would mean writing the user's global CLI configuration,
where they would fire in every unrelated project the user opens. **Owner
decision: disclose the gap rather than write a user-scope config.** SciStudio
has never written user-scope CLI configuration and does not start here.

## What changed

- **Spec** — the hook-parity table's `kimi-code` column is corrected, and a
  new section records the verified contract, the scope limitation, the three
  provisioning routes considered and why each was rejected, and the
  reproducible `kimi doctor` checks.
- **Registry** — the `_KIMI_CODE` descriptor carries the verified hook facts,
  so the next reader finds them where per-CLI facts already live.
- **AI Chat setup screen** — selecting Kimi Code now shows a note saying the
  safety hooks do not apply to that tab, that the user can add them by hand or
  ask Kimi in that tab to do it, and that doing so is machine-wide. This is the
  second and, by intent, last entry in the frontend provider-literal allowlist;
  the allowlist docstring says what a third entry would mean.
- **User guide and provisioning docs** — matching plain-language sections, and
  the stale "the 7 hooks govern Claude Code only" limitation is corrected to
  the actual four-of-five coverage.
- **Tests** — a provisioning test that fails if Kimi hook files ever start
  landing in a project, frontend tests pinning the note to Kimi Code and to no
  other provider, and the architecture allowlist pin generalised so a third
  entry cannot be added without being held to the same rule.

## Also closes #2014

Same misfit on the AI Block surface: `AIBlock.config_schema` derived its
`provider` enum from every registry agent key while `validate_config` was
guaranteed to reject Kimi, so the block editor offered a choice that could not
work. The enum now filters through `session_unsupported_reason`, the shared
capability check the work-import surface already uses.

That predicate moves from `ai.agent.availability` into the provider registry.
`blocks` may reach the agent layer only through the one carved-out lazy edge to
the registry, and `availability` runs subprocesses to probe auth state — not a
dependency the block layer should acquire to answer a question that reads three
descriptor fields. `availability` re-exports it, so its own callers, the API
layer, and existing tests are untouched, and no import-linter carve-out widens.

## Authorization

This PR touches `src/scistudio/blocks/ai/ai_block.py`, a protected core path.
The owner authorized `admin-approved:core-change` for the #2014 scope and will
apply the label.

Gate record: .workflow/records/2014-fix-2014-kimi-ai-block-provider.json

Closes #2045
Closes #2014
