### PR TITLE
gate(#2054): guard the architecture document behind an owner approval label

### DIFF
--- a/.github/workflows/workflow-gate.yml
+++ b/.github/workflows/workflow-gate.yml
@@ -70,12 +70,15 @@ jobs:
 
           # Legacy override-label migration (§4.2).
           LABEL_MIGRATION = {"admin-approved:ai-override": "admin-approved:bypass"}
-          OVERRIDE_LABELS = {
-              "human-authored",
-              "admin-approved:bypass",
-              "admin-approved:core-change",
-              "admin-approved:merge",
-          }
+          # Derived, never restated (#2054). This set decides which labels reach
+          # the evaluator at all, so a label missing from it is invisible to every
+          # guard no matter what the guard was told to look for: the owner applies
+          # the label, CI filters it out here, and the guard reports missing
+          # approval. That is exactly what happened to
+          # `admin-approved:architecture-doc` when this was a literal — a second
+          # copy of a vocabulary `labels.py` already owns. Importing it means a
+          # label added there is forwarded here without anyone remembering to.
+          from scistudio.qa.governance.gate_record.labels import VALID_LABELS as OVERRIDE_LABELS
 
           def _gh_json(args):
               try:

--- a/.workflow/records/2054-2054-architecture-doc-guard.json
+++ b/.workflow/records/2054-2054-architecture-doc-guard.json
@@ -427,9 +427,9 @@
   ],
   "check_na": [],
   "commit": {
-    "sha": "52ba3f3f04e7552cedfb9e2439dacf4149fa331b",
+    "sha": "76096eec795bfa5479b7bb8540a3a1a97a56de02",
     "shas": [
-      "52ba3f3f04e7552cedfb9e2439dacf4149fa331b"
+      "76096eec795bfa5479b7bb8540a3a1a97a56de02"
     ],
     "trailers": []
   },
@@ -1113,6 +1113,182 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-08-09T06:40:56.263093Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-09T06:40:56.273550Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-09T06:40:56.283955Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-09T06:40:56.294824Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-09T06:40:56.305857Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-09T06:40:56.317000Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-09T06:40:56.328116Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-09T06:40:56.339051Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-09T06:40:56.349752Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-09T06:40:56.360082Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-09T06:40:56.371652Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-09T06:41:04.644989Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-09T06:41:04.655588Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-09T06:41:04.666572Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-09T06:41:04.678181Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-09T06:41:04.706109Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-09T06:41:04.740909Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-09T06:41:04.751925Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-09T06:41:04.762734Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-09T06:41:04.773544Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-09T06:41:04.785111Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-09T06:41:04.797930Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -1125,8 +1301,8 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "origin/main",
-    "base_sha": "5f9f2b12",
+    "base": "c8110edbd2205f87c3ec66804b875f50c796f38f",
+    "base_sha": "c8110edb",
     "changed_files": [
       ".github/workflows/workflow-gate.yml",
       ".workflow/records/2054-2054-architecture-doc-guard.json",
@@ -1149,9 +1325,9 @@
       "tests/qa/test_governance_paths.py",
       "tests/qa/test_guard_calculators.py"
     ],
-    "diff_fingerprint": "sha256:d4d8cc88a427f31bc337a9560877bc803c2fffb163f06c04949fb92d35807ea3",
+    "diff_fingerprint": "sha256:f1abe41341f7700b11a5b19f99759bed43213319c072ae89daf6b335666f61e4",
     "head": "HEAD",
-    "head_sha": "db87d3ed",
+    "head_sha": "76096eec",
     "surfaces": {
       "docs": 5,
       "frontend": 0,
@@ -1228,6 +1404,22 @@
       "unsatisfied": [
         "scope.out-of-scope"
       ]
+    },
+    {
+      "at": "2026-08-09T06:40:56.371683Z",
+      "diff_fingerprint": "sha256:f1abe41341f7700b11a5b19f99759bed43213319c072ae89daf6b335666f61e4",
+      "mode": "local",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-09T06:41:04.797975Z",
+      "diff_fingerprint": "sha256:f1abe41341f7700b11a5b19f99759bed43213319c072ae89daf6b335666f61e4",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
     }
   ],
   "record_id": "2054-2054-architecture-doc-guard",

--- a/.workflow/records/2054-2054-architecture-doc-guard.json
+++ b/.workflow/records/2054-2054-architecture-doc-guard.json
@@ -1,0 +1,192 @@
+{
+  "branch": "guided/2054-architecture-doc-guard",
+  "check_events": [],
+  "check_na": [],
+  "commit": null,
+  "declared_scope": {
+    "exclude": [],
+    "include": []
+  },
+  "directive_events": [
+    {
+      "at": "2026-08-09T05:45:16.692150Z",
+      "owner_directive": "Place the guard in Verify Workflow Compliance (gate evaluator), not Full Audit: it is the only CI job with PR context and can verify who applied the approval label. Protect docs/architecture/ARCHITECTURE.md only; bypass and human-authored still release it.",
+      "reason": "plan"
+    }
+  ],
+  "docs_events": [
+    {
+      "at": "2026-08-09T05:45:16.692435Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/specs/adr-042-gate-ledger-runtime.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-09T05:45:16.692441Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/ai-developer/rules.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-09T05:45:16.692443Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/ai-developer/gate-cli-command-set.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-09T05:45:16.692444Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/ai-developer/specific_rules/gated-workflow.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-09T05:45:16.692445Z",
+      "class": null,
+      "kind": "path",
+      "path": "CHANGELOG.md",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": true,
+  "guard_events": [
+    {
+      "at": "2026-08-09T05:40:43.602383Z",
+      "findings": [
+        {
+          "message": "AI-authored edits must happen in a dedicated worktree, not the main working tree (/private/var/folders/mk/xk0dqvn934l5425gwb19rsqc0000gn/T/pytest-of-jiazhenz/pytest-1358/test_hook_payload_blocks_main_0/main). Create one with `git worktree add ../<name> <branch>` and run your edits there.",
+          "rule_id": "worktree.main-checkout-write"
+        }
+      ],
+      "guard": "worktree_write_guard",
+      "status": "fail"
+    },
+    {
+      "at": "2026-08-09T05:40:44.072873Z",
+      "findings": [
+        {
+          "message": "AI-authored edits must happen in a dedicated worktree, not the main working tree (/private/var/folders/mk/xk0dqvn934l5425gwb19rsqc0000gn/T/pytest-of-jiazhenz/pytest-1358/test_hook_payload_extracts_mul0/main). Create one with `git worktree add ../<name> <branch>` and run your edits there.",
+          "rule_id": "worktree.main-checkout-write"
+        }
+      ],
+      "guard": "worktree_write_guard",
+      "status": "fail"
+    },
+    {
+      "at": "2026-08-09T05:44:45.264977Z",
+      "findings": [
+        {
+          "message": "AI-authored edits must happen in a dedicated worktree, not the main working tree (/private/var/folders/mk/xk0dqvn934l5425gwb19rsqc0000gn/T/pytest-of-jiazhenz/pytest-1360/test_hook_payload_blocks_main_0/main). Create one with `git worktree add ../<name> <branch>` and run your edits there.",
+          "rule_id": "worktree.main-checkout-write"
+        }
+      ],
+      "guard": "worktree_write_guard",
+      "status": "fail"
+    },
+    {
+      "at": "2026-08-09T05:44:45.683578Z",
+      "findings": [
+        {
+          "message": "AI-authored edits must happen in a dedicated worktree, not the main working tree (/private/var/folders/mk/xk0dqvn934l5425gwb19rsqc0000gn/T/pytest-of-jiazhenz/pytest-1360/test_hook_payload_extracts_mul0/main). Create one with `git worktree add ../<name> <branch>` and run your edits there.",
+          "rule_id": "worktree.main-checkout-write"
+        }
+      ],
+      "guard": "worktree_write_guard",
+      "status": "fail"
+    }
+  ],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 2054,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": null,
+  "owner_directive": "Write a guard so that changing the architecture document fails CI unless an approval flag is present. Owner decisions: protect docs/architecture/ARCHITECTURE.md only; admin-approved:bypass and human-authored may still release it.",
+  "persona": "live_implementer",
+  "pull_request": null,
+  "reconcile_events": [],
+  "record_id": "2054-2054-architecture-doc-guard",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [],
+    "docs": [],
+    "guards": [],
+    "tests": []
+  },
+  "runtime": "claude-code",
+  "schema_version": 2,
+  "scope_events": [
+    {
+      "action": "add-include",
+      "at": "2026-08-09T05:45:16.692303Z",
+      "pattern": "src/scistudio/qa/governance/gate_record/**",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-09T05:45:16.692312Z",
+      "pattern": "tests/qa/**",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-09T05:45:16.692316Z",
+      "pattern": "docs/ai-developer/**",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-09T05:45:16.692318Z",
+      "pattern": "docs/specs/adr-042-gate-ledger-runtime.md",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-09T05:45:16.692319Z",
+      "pattern": "CHANGELOG.md",
+      "reason": "plan"
+    }
+  ],
+  "session_id": "eb0d6246-4932-42a5-adc8-21a6522a60e2",
+  "strictness_tier": null,
+  "task_kind": "guided",
+  "test_events": [
+    {
+      "at": "2026-08-09T05:45:16.692449Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/qa/test_guard_calculators.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-09T05:45:16.692451Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/qa/test_governance_paths.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-09T05:45:16.692452Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/qa/test_gate_evaluator.py",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/.workflow/records/2054-2054-architecture-doc-guard.json
+++ b/.workflow/records/2054-2054-architecture-doc-guard.json
@@ -1,6 +1,148 @@
 {
   "branch": "guided/2054-architecture-doc-guard",
-  "check_events": [],
+  "check_events": [
+    {
+      "at": "2026-08-09T05:46:08.659169Z",
+      "command": "pytest tests/architecture/ -v --no-cov",
+      "covered_surface": "architecture",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:8a76c86301e10fe82ae2df8233d7c85a10340b075632c822e04fd4a02e328483",
+      "name": "architecture_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/architecture_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-09T05:46:09.589774Z",
+      "command": "python scripts/deferral_scan.py --check docs/audit/baselines/deferral-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:ddaab0c8c298e5a66a15304f17edac762270287bec4defcd3a38841ee5bff462",
+      "name": "deferral_discipline",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/deferral_discipline.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-09T05:46:09.955550Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:24eb0073a55e8df934ba2d406ec6baeaed15eb9a3b11b1a16b79533e8158d957",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-09T05:46:14.552294Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:499860e2e63da103ce7414871e33d8f2d96ded69113e79f0d966daa1d489b954",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-09T05:46:15.054240Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:0f684d9bbd554a6fac48331d190dade4483971424db3f5b9176de349d7d859a5",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-09T05:46:15.101126Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:fe5ae59f571d3a3e7c6c18c187d73858c04ad3128a9a34631f31b14142c84b01",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-09T05:49:03.286811Z",
+      "command": "python -m scistudio.qa.testing.run_python_tests --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:0f5f7c64fcfee2e0c3f174bc0d2ad686e3caa0a565c00e9f7f85c8a73707b26e",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-09T05:51:20.604831Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:02c4fe5a47791a788e66495ed243fe154023e475d1a85f7fcb0bb62c437ee719",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-09T05:51:27.862562Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:4080cbb112650ea9cfdfabf5960abcccd27fa31f00f8f9b8c3dcd820d60b888e",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    }
+  ],
   "check_na": [],
   "commit": null,
   "declared_scope": {
@@ -101,6 +243,138 @@
       ],
       "guard": "worktree_write_guard",
       "status": "fail"
+    },
+    {
+      "at": "2026-08-09T05:51:27.897448Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-09T05:51:27.908074Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-09T05:51:27.919278Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-09T05:51:27.930085Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-09T05:51:27.940948Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-09T05:51:27.951593Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-09T05:51:27.961891Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-09T05:51:27.971942Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-09T05:51:27.983517Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-09T05:51:27.993617Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-09T05:51:28.004806Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-09T05:53:26.465492Z",
+      "findings": [
+        {
+          "message": "AI-authored edits must happen in a dedicated worktree, not the main working tree (/private/var/folders/mk/xk0dqvn934l5425gwb19rsqc0000gn/T/pytest-of-jiazhenz/pytest-1365/test_hook_payload_blocks_main_0/main). Create one with `git worktree add ../<name> <branch>` and run your edits there.",
+          "rule_id": "worktree.main-checkout-write"
+        }
+      ],
+      "guard": "worktree_write_guard",
+      "status": "fail"
+    },
+    {
+      "at": "2026-08-09T05:53:26.937919Z",
+      "findings": [
+        {
+          "message": "AI-authored edits must happen in a dedicated worktree, not the main working tree (/private/var/folders/mk/xk0dqvn934l5425gwb19rsqc0000gn/T/pytest-of-jiazhenz/pytest-1365/test_hook_payload_extracts_mul0/main). Create one with `git worktree add ../<name> <branch>` and run your edits there.",
+          "rule_id": "worktree.main-checkout-write"
+        }
+      ],
+      "guard": "worktree_write_guard",
+      "status": "fail"
+    },
+    {
+      "at": "2026-08-09T05:58:54.715713Z",
+      "findings": [
+        {
+          "message": "AI-authored edits must happen in a dedicated worktree, not the main working tree (/private/var/folders/mk/xk0dqvn934l5425gwb19rsqc0000gn/T/pytest-of-jiazhenz/pytest-1366/test_hook_payload_blocks_main_0/main). Create one with `git worktree add ../<name> <branch>` and run your edits there.",
+          "rule_id": "worktree.main-checkout-write"
+        }
+      ],
+      "guard": "worktree_write_guard",
+      "status": "fail"
+    },
+    {
+      "at": "2026-08-09T05:58:55.116104Z",
+      "findings": [
+        {
+          "message": "AI-authored edits must happen in a dedicated worktree, not the main working tree (/private/var/folders/mk/xk0dqvn934l5425gwb19rsqc0000gn/T/pytest-of-jiazhenz/pytest-1366/test_hook_payload_extracts_mul0/main). Create one with `git worktree add ../<name> <branch>` and run your edits there.",
+          "rule_id": "worktree.main-checkout-write"
+        }
+      ],
+      "guard": "worktree_write_guard",
+      "status": "fail"
     }
   ],
   "issues": [
@@ -112,19 +386,93 @@
     }
   ],
   "observed_admin_labels": [],
-  "observed_diff": null,
+  "observed_diff": {
+    "base": "origin/main",
+    "base_sha": "c8110edb",
+    "changed_files": [
+      ".workflow/records/2054-2054-architecture-doc-guard.json",
+      "CHANGELOG.md",
+      "docs/ai-developer/gate-cli-command-set.md",
+      "docs/ai-developer/rules.md",
+      "docs/ai-developer/specific_rules/gated-workflow.md",
+      "docs/ai-developer/templates/agent-dispatch-checklist-template.md",
+      "docs/specs/adr-042-gate-ledger-runtime.md",
+      "src/scistudio/qa/governance/gate_record/__init__.py",
+      "src/scistudio/qa/governance/gate_record/evaluator.py",
+      "src/scistudio/qa/governance/gate_record/guards/__init__.py",
+      "src/scistudio/qa/governance/gate_record/guards/architecture_doc_guard.py",
+      "src/scistudio/qa/governance/gate_record/labels.py",
+      "src/scistudio/qa/governance/gate_record/surfaces.py",
+      "tests/qa/test_gate_evaluator.py",
+      "tests/qa/test_governance_paths.py",
+      "tests/qa/test_guard_calculators.py"
+    ],
+    "diff_fingerprint": "sha256:acbc788d2756c3b22616e0132e791ad6c7d62703270eaaad0ac13e0c19577f64",
+    "head": "HEAD",
+    "head_sha": "e34af5e5",
+    "surfaces": {
+      "docs": 5,
+      "frontend": 0,
+      "governance": 10,
+      "governed_docs": 4,
+      "implementation": 6,
+      "packaging": 0,
+      "protected_architecture": 0,
+      "protected_core": 0,
+      "sentrux": 10,
+      "test": 3,
+      "workflow_ci": 0
+    }
+  },
   "owner_directive": "Write a guard so that changing the architecture document fails CI unless an approval flag is present. Owner decisions: protect docs/architecture/ARCHITECTURE.md only; admin-approved:bypass and human-authored may still release it.",
   "persona": "live_implementer",
   "pull_request": null,
-  "reconcile_events": [],
+  "reconcile_events": [
+    {
+      "at": "2026-08-09T05:51:28.004828Z",
+      "diff_fingerprint": "sha256:acbc788d2756c3b22616e0132e791ad6c7d62703270eaaad0ac13e0c19577f64",
+      "mode": "local",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.semantic_dup"
+      ]
+    }
+  ],
   "record_id": "2054-2054-architecture-doc-guard",
   "requested_admin_labels": [],
   "required_obligations": {
     "admin_labels": [],
-    "checks": [],
-    "docs": [],
-    "guards": [],
-    "tests": []
+    "checks": [
+      "architecture_tests",
+      "deferral_discipline",
+      "format_check",
+      "full_audit",
+      "import_contracts",
+      "lint_format",
+      "python_tests",
+      "semantic_dup",
+      "type_check"
+    ],
+    "docs": [
+      "docs_required_or_na"
+    ],
+    "guards": [
+      "architecture_doc_guard",
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": [
+      "changed_test_required"
+    ]
   },
   "runtime": "claude-code",
   "schema_version": 2,
@@ -161,7 +509,7 @@
     }
   ],
   "session_id": "eb0d6246-4932-42a5-adc8-21a6522a60e2",
-  "strictness_tier": null,
+  "strictness_tier": 1,
   "task_kind": "guided",
   "test_events": [
     {

--- a/.workflow/records/2054-2054-architecture-doc-guard.json
+++ b/.workflow/records/2054-2054-architecture-doc-guard.json
@@ -141,10 +141,157 @@
       "tool_versions": {
         "mypy": "2.1.0"
       }
+    },
+    {
+      "at": "2026-08-09T06:02:21.395119Z",
+      "command": "pytest tests/architecture/ -v --no-cov",
+      "covered_surface": "architecture",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:76937ec744c3045772c61999e56f5fc930a31387546b5a9c5712f983793bda18",
+      "name": "architecture_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/architecture_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-09T06:02:22.287671Z",
+      "command": "python scripts/deferral_scan.py --check docs/audit/baselines/deferral-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:f2d6b99a92bbd8d1f816e5d2cb7e5d96c2486196d0cbacea0f9b478254b1f403",
+      "name": "deferral_discipline",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/deferral_discipline.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-09T06:02:22.330960Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:c224ee1194412047daba131407c217b85a5b7d2fb59db2b768c9f41e98d4e09e",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-09T06:02:26.788827Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:f6d7e48a17826879e4b7b404a0bcecad41f050d8c167425f689a34fd01c900af",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-09T06:02:26.911264Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:75197219b867a87c7a6546b0a518285f014505c7653ad7a9feba4490ef2f954d",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-09T06:02:26.931422Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:7167a26e95142176d6cbe8aedb47e5f582dcb7e4f9f343992739decd930aa748",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-09T06:04:53.800049Z",
+      "command": "python -m scistudio.qa.testing.run_python_tests --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:9ca5d80dc68fca2da24b7d0652ac600e2d54a306ed5bf0e36068853935b9441e",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-09T06:07:46.527430Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:43a210f66c4e3246c119542e06d60ec889ff34a7a3894e8f3dc349f05a29a48b",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-09T06:07:47.530663Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:3a0767ed7e35c0edf53e1aaa431ced754f9abc66b899eb0f0f025f08d4c254d9",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
     }
   ],
   "check_na": [],
-  "commit": null,
+  "commit": {
+    "sha": "d18914a955bcfec98f9b7c799598842e72e6a9c9",
+    "shas": [
+      "d18914a955bcfec98f9b7c799598842e72e6a9c9"
+    ],
+    "trailers": []
+  },
   "declared_scope": {
     "exclude": [],
     "include": []
@@ -154,6 +301,11 @@
       "at": "2026-08-09T05:45:16.692150Z",
       "owner_directive": "Place the guard in Verify Workflow Compliance (gate evaluator), not Full Audit: it is the only CI job with PR context and can verify who applied the approval label. Protect docs/architecture/ARCHITECTURE.md only; bypass and human-authored still release it.",
       "reason": "plan"
+    },
+    {
+      "at": "2026-08-09T06:02:08.219720Z",
+      "owner_directive": "Semantic-duplication ratchet rejected the copied helpers; extract one shared label-gated-surface implementation and route core_change_guard through it too.",
+      "reason": "semantic-dup ratchet forced a shared implementation"
     }
   ],
   "docs_events": [
@@ -375,6 +527,182 @@
       ],
       "guard": "worktree_write_guard",
       "status": "fail"
+    },
+    {
+      "at": "2026-08-09T06:07:47.617520Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-09T06:07:47.644728Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-09T06:07:47.665994Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-09T06:07:47.690392Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-09T06:07:47.713282Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-09T06:07:47.736273Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-09T06:07:47.759144Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-09T06:07:47.777916Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-09T06:07:47.802374Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-09T06:07:47.822928Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-09T06:07:47.859588Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-09T06:08:17.248593Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-09T06:08:17.270313Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-09T06:08:17.293638Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-09T06:08:17.312578Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-09T06:08:17.332955Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-09T06:08:17.352990Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-09T06:08:17.372324Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-09T06:08:17.397866Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-09T06:08:17.418330Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-09T06:08:17.440092Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-09T06:08:17.487659Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -388,7 +716,7 @@
   "observed_admin_labels": [],
   "observed_diff": {
     "base": "origin/main",
-    "base_sha": "c8110edb",
+    "base_sha": "5f9f2b12",
     "changed_files": [
       ".workflow/records/2054-2054-architecture-doc-guard.json",
       "CHANGELOG.md",
@@ -400,33 +728,42 @@
       "src/scistudio/qa/governance/gate_record/__init__.py",
       "src/scistudio/qa/governance/gate_record/evaluator.py",
       "src/scistudio/qa/governance/gate_record/guards/__init__.py",
+      "src/scistudio/qa/governance/gate_record/guards/_authorization.py",
       "src/scistudio/qa/governance/gate_record/guards/architecture_doc_guard.py",
+      "src/scistudio/qa/governance/gate_record/guards/core_change_guard.py",
       "src/scistudio/qa/governance/gate_record/labels.py",
       "src/scistudio/qa/governance/gate_record/surfaces.py",
       "tests/qa/test_gate_evaluator.py",
       "tests/qa/test_governance_paths.py",
       "tests/qa/test_guard_calculators.py"
     ],
-    "diff_fingerprint": "sha256:acbc788d2756c3b22616e0132e791ad6c7d62703270eaaad0ac13e0c19577f64",
+    "diff_fingerprint": "sha256:2c8529b1046b7590e629d6b363284f1a748e740415a8b21045e2cf96d27eaf57",
     "head": "HEAD",
-    "head_sha": "e34af5e5",
+    "head_sha": "d18914a9",
     "surfaces": {
       "docs": 5,
       "frontend": 0,
-      "governance": 10,
+      "governance": 12,
       "governed_docs": 4,
-      "implementation": 6,
+      "implementation": 8,
       "packaging": 0,
       "protected_architecture": 0,
       "protected_core": 0,
-      "sentrux": 10,
+      "sentrux": 12,
       "test": 3,
       "workflow_ci": 0
     }
   },
   "owner_directive": "Write a guard so that changing the architecture document fails CI unless an approval flag is present. Owner decisions: protect docs/architecture/ARCHITECTURE.md only; admin-approved:bypass and human-authored may still release it.",
   "persona": "live_implementer",
-  "pull_request": null,
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [
+      2054
+    ],
+    "number": null,
+    "url": null
+  },
   "reconcile_events": [
     {
       "at": "2026-08-09T05:51:28.004828Z",
@@ -437,6 +774,22 @@
       "unsatisfied": [
         "checks.semantic_dup"
       ]
+    },
+    {
+      "at": "2026-08-09T06:07:47.859660Z",
+      "diff_fingerprint": "sha256:2c8529b1046b7590e629d6b363284f1a748e740415a8b21045e2cf96d27eaf57",
+      "mode": "local",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-09T06:08:17.487894Z",
+      "diff_fingerprint": "sha256:2c8529b1046b7590e629d6b363284f1a748e740415a8b21045e2cf96d27eaf57",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
     }
   ],
   "record_id": "2054-2054-architecture-doc-guard",

--- a/.workflow/records/2054-2054-architecture-doc-guard.json
+++ b/.workflow/records/2054-2054-architecture-doc-guard.json
@@ -286,9 +286,9 @@
   ],
   "check_na": [],
   "commit": {
-    "sha": "d18914a955bcfec98f9b7c799598842e72e6a9c9",
+    "sha": "52ba3f3f04e7552cedfb9e2439dacf4149fa331b",
     "shas": [
-      "d18914a955bcfec98f9b7c799598842e72e6a9c9"
+      "52ba3f3f04e7552cedfb9e2439dacf4149fa331b"
     ],
     "trailers": []
   },
@@ -703,6 +703,182 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-08-09T06:08:32.881842Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-09T06:08:32.899779Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-09T06:08:32.918137Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-09T06:08:32.938409Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-09T06:08:32.954646Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-09T06:08:32.971031Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-09T06:08:32.992718Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-09T06:08:33.015514Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-09T06:08:33.036855Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-09T06:08:33.055376Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-09T06:08:33.081876Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-09T06:08:41.737760Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-09T06:08:41.758880Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-09T06:08:41.784328Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-09T06:08:41.806910Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-09T06:08:41.828685Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-09T06:08:41.851195Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-09T06:08:41.872500Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-09T06:08:41.895912Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-09T06:08:41.920065Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-09T06:08:41.941623Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-09T06:08:41.963383Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -715,8 +891,8 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "origin/main",
-    "base_sha": "5f9f2b12",
+    "base": "c8110edbd2205f87c3ec66804b875f50c796f38f",
+    "base_sha": "c8110edb",
     "changed_files": [
       ".workflow/records/2054-2054-architecture-doc-guard.json",
       "CHANGELOG.md",
@@ -737,9 +913,9 @@
       "tests/qa/test_governance_paths.py",
       "tests/qa/test_guard_calculators.py"
     ],
-    "diff_fingerprint": "sha256:2c8529b1046b7590e629d6b363284f1a748e740415a8b21045e2cf96d27eaf57",
+    "diff_fingerprint": "sha256:6ca51c041cf7e3c062facfcfd8dafa375fbeade5b58676a28a1e0da8e1c8495d",
     "head": "HEAD",
-    "head_sha": "d18914a9",
+    "head_sha": "52ba3f3f",
     "surfaces": {
       "docs": 5,
       "frontend": 0,
@@ -761,8 +937,8 @@
     "closes": [
       2054
     ],
-    "number": null,
-    "url": null
+    "number": 2055,
+    "url": "https://github.com/jiazhenz026/SciStudio/pull/2055"
   },
   "reconcile_events": [
     {
@@ -786,6 +962,22 @@
     {
       "at": "2026-08-09T06:08:17.487894Z",
       "diff_fingerprint": "sha256:2c8529b1046b7590e629d6b363284f1a748e740415a8b21045e2cf96d27eaf57",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-09T06:08:33.082028Z",
+      "diff_fingerprint": "sha256:6ca51c041cf7e3c062facfcfd8dafa375fbeade5b58676a28a1e0da8e1c8495d",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-09T06:08:41.963435Z",
+      "diff_fingerprint": "sha256:6ca51c041cf7e3c062facfcfd8dafa375fbeade5b58676a28a1e0da8e1c8495d",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 1,

--- a/.workflow/records/2054-2054-architecture-doc-guard.json
+++ b/.workflow/records/2054-2054-architecture-doc-guard.json
@@ -282,6 +282,147 @@
       "tool_versions": {
         "mypy": "2.1.0"
       }
+    },
+    {
+      "at": "2026-08-09T06:35:34.611989Z",
+      "command": "pytest tests/architecture/ -v --no-cov",
+      "covered_surface": "architecture",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:ff60175f769204f1ebe7c88ee15661718c84fa654da2d88dfb87c224162f3c5c",
+      "name": "architecture_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/architecture_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-09T06:35:35.569161Z",
+      "command": "python scripts/deferral_scan.py --check docs/audit/baselines/deferral-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:c9ea424eb8f6bb92c0715afc8148c6301e1a5676335db10e6162d734a8c8b8b3",
+      "name": "deferral_discipline",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/deferral_discipline.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-09T06:35:35.622670Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:0de635e41b6221e818dffef7a8af2d2a1be6c1e6569d681608b28c7b951b8e8a",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-09T06:35:39.617593Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:43a90981c4bfd750cd12db3783edc3bc548347b950638606734e9e0845067e97",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-09T06:35:39.768686Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:30e87964b884bfa4c77e6ff5556b924935264888947a659c87faaeb175ba2fdf",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-09T06:35:39.792944Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:6241fe89dd0e13ae4228516353df26c7cfb47ec28c3bb17aa29b74afdc40ae10",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-09T06:38:10.133526Z",
+      "command": "python -m scistudio.qa.testing.run_python_tests --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:8d2378c60192e820c4511ed4c5f560456fb71785cff9fc99540ac433274d6a15",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-09T06:40:37.963181Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:79bfff7bc6c01e50e0359c0e08a1f9f31aa4a13756e204f541ac690ba8b07a2f",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-09T06:40:38.455957Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:4bd6ce1e9d6d53f8997a5c19f8c63a80ee0c0a5cbae2839fe9e8238e39e0ec43",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
     }
   ],
   "check_na": [],
@@ -306,6 +447,11 @@
       "at": "2026-08-09T06:02:08.219720Z",
       "owner_directive": "Semantic-duplication ratchet rejected the copied helpers; extract one shared label-gated-surface implementation and route core_change_guard through it too.",
       "reason": "semantic-dup ratchet forced a shared implementation"
+    },
+    {
+      "at": "2026-08-09T06:40:47.971161Z",
+      "owner_directive": "Fix the Codex review finding on PR #2055.",
+      "reason": "Codex review P1 on PR #2055: the workflow's literal OVERRIDE_LABELS set drops the new label before the evaluator sees it, so the approval flag never authorizes anything"
     }
   ],
   "docs_events": [
@@ -879,6 +1025,94 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-08-09T06:40:38.499112Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-09T06:40:38.510944Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-09T06:40:38.523117Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-09T06:40:38.534809Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-09T06:40:38.546274Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-09T06:40:38.557411Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-09T06:40:38.569080Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-09T06:40:38.598138Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-09T06:40:38.632957Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-09T06:40:38.644506Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-09T06:40:38.656867Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -891,9 +1125,10 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "c8110edbd2205f87c3ec66804b875f50c796f38f",
-    "base_sha": "c8110edb",
+    "base": "origin/main",
+    "base_sha": "5f9f2b12",
     "changed_files": [
+      ".github/workflows/workflow-gate.yml",
       ".workflow/records/2054-2054-architecture-doc-guard.json",
       "CHANGELOG.md",
       "docs/ai-developer/gate-cli-command-set.md",
@@ -910,24 +1145,25 @@
       "src/scistudio/qa/governance/gate_record/labels.py",
       "src/scistudio/qa/governance/gate_record/surfaces.py",
       "tests/qa/test_gate_evaluator.py",
+      "tests/qa/test_gate_record_hooks.py",
       "tests/qa/test_governance_paths.py",
       "tests/qa/test_guard_calculators.py"
     ],
-    "diff_fingerprint": "sha256:6ca51c041cf7e3c062facfcfd8dafa375fbeade5b58676a28a1e0da8e1c8495d",
+    "diff_fingerprint": "sha256:d4d8cc88a427f31bc337a9560877bc803c2fffb163f06c04949fb92d35807ea3",
     "head": "HEAD",
-    "head_sha": "52ba3f3f",
+    "head_sha": "db87d3ed",
     "surfaces": {
       "docs": 5,
       "frontend": 0,
-      "governance": 12,
+      "governance": 13,
       "governed_docs": 4,
-      "implementation": 8,
+      "implementation": 9,
       "packaging": 0,
       "protected_architecture": 0,
       "protected_core": 0,
-      "sentrux": 12,
-      "test": 3,
-      "workflow_ci": 0
+      "sentrux": 14,
+      "test": 4,
+      "workflow_ci": 1
     }
   },
   "owner_directive": "Write a guard so that changing the architecture document fails CI unless an approval flag is present. Owner decisions: protect docs/architecture/ARCHITECTURE.md only; admin-approved:bypass and human-authored may still release it.",
@@ -982,6 +1218,16 @@
       "result": "pass",
       "tier": 1,
       "unsatisfied": []
+    },
+    {
+      "at": "2026-08-09T06:40:38.656949Z",
+      "diff_fingerprint": "sha256:d4d8cc88a427f31bc337a9560877bc803c2fffb163f06c04949fb92d35807ea3",
+      "mode": "local",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "scope.out-of-scope"
+      ]
     }
   ],
   "record_id": "2054-2054-architecture-doc-guard",
@@ -1051,6 +1297,12 @@
       "at": "2026-08-09T05:45:16.692319Z",
       "pattern": "CHANGELOG.md",
       "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-09T06:40:47.971282Z",
+      "pattern": ".github/workflows/workflow-gate.yml",
+      "reason": "Codex review P1 on PR #2055: the workflow's literal OVERRIDE_LABELS set drops the new label before the evaluator sees it, so the approval flag never authorizes anything"
     }
   ],
   "session_id": "eb0d6246-4932-42a5-adc8-21a6522a60e2",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- [#2054] **The architecture document is now owner-controlled in CI, not only by
+  convention.** `docs/architecture/ARCHITECTURE.md` may only change with the
+  owner's specific approval, and nothing enforced that: PR #2036 carried a
+  thirty-line addition to §12.5 through every check green — Full Audit
+  included — and it was caught by the owner reading the diff. The gap was less
+  an omission than an inversion. `surfaces.is_architecture_doc_path` already
+  existed, and its only consumer was `checks.py`'s test for whether a
+  *documentation obligation was satisfied*; touching the document made a PR look
+  better, not worse.
+  A new `architecture_doc_guard` blocks the change in CI unless the PR carries
+  `admin-approved:architecture-doc` applied by an authorized maintainer, or an
+  administrator has approved the PR — an owner who reviewed the diff has already
+  given the approval, and should not have to say yes twice. Locally, a
+  *requested* label downgrades the finding to a warning, so an agent is told
+  before it opens the PR while CI stays the authority; silence downgrades
+  nothing.
+  It is enforced in **Verify Workflow Compliance**, which is the only CI job
+  that runs the gate evaluator with PR context and can therefore verify *who*
+  applied a label — the whole difficulty of an approval flag. Full Audit and the
+  architecture tests have no PR context and could not check it without growing a
+  second label-reading pipeline. No CI workflow file changed; the guard registry
+  carries it.
+  The protected surface is the single file, not `docs/architecture/**`: that
+  directory also holds a generated `PROJECT_TREE.md` and a superseded
+  `ARCHITECTURE_legacy.md`, and `docs/adr/**` and `docs/specs/**` are ordinary
+  work product. `admin-approved:bypass` and `human-authored` release this guard
+  exactly as they release the others; it does not become the first
+  non-bypassable guard.
+
 ### Changed
 
 - [#2033] **Restore is now the single way back to a past state, and it actually

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   *requested* label downgrades the finding to a warning, so an agent is told
   before it opens the PR while CI stays the authority; silence downgrades
   nothing.
+  The workflow's label filter is now **derived** from `labels.py` rather than
+  restating it. That set decides which labels reach the evaluator at all, so a
+  label missing from it is invisible to every guard no matter what the guard
+  looks for — the owner applies the label, CI drops it, and the guard reports
+  missing approval. The new label was born into exactly that state while the set
+  was a literal; a Codex review caught it. Any label added to the vocabulary is
+  forwarded from now on without anyone having to remember a second list.
   It is enforced in **Verify Workflow Compliance**, which is the only CI job
   that runs the gate evaluator with PR context and can therefore verify *who*
   applied a label — the whole difficulty of an approval flag. Full Audit and the

--- a/docs/ai-developer/gate-cli-command-set.md
+++ b/docs/ai-developer/gate-cli-command-set.md
@@ -125,7 +125,7 @@ python -m scistudio.qa.governance.gate_record plan \
   [--docs-updated <path>] [--docs-na "<class>:<rationale>"] \
   [--test-path <path>] [--test-na "<class>:<rationale>"] \
   [--check <check-name>] [--check-na "<check-name>:<rationale>"] \
-  [--admin-label admin-approved:bypass|admin-approved:core-change|admin-approved:merge] \
+  [--admin-label admin-approved:bypass|admin-approved:core-change|admin-approved:merge|admin-approved:architecture-doc] \
   [--record .workflow/records/<record>.json]
 ```
 
@@ -738,7 +738,9 @@ PR body must close every gate-listed issue with a GitHub closing keyword
 - **Admin / bypass labels.** The valid labels are `admin-approved:bypass`
   (one-off AI gate workflow bypass), `admin-approved:core-change` (protected
   core path authorization only), `admin-approved:merge` (AI merge automation),
-  and the PR-level `human-authored` (human AI-harness bypass). Locally
+  `admin-approved:architecture-doc` (a change to
+  `docs/architecture/ARCHITECTURE.md` only), and the PR-level
+  `human-authored` (human AI-harness bypass). Locally
   recorded requested labels are intent only; CI verifies the observed PR label
   and the actor's administrator/maintainer permission. None of these bypass
   branch protection, normal repository CI, or owner review.

--- a/docs/ai-developer/rules.md
+++ b/docs/ai-developer/rules.md
@@ -110,6 +110,10 @@ language_source: en
 
 - `admin-approved:merge` authorizes approved merge automation.
 
+- `admin-approved:architecture-doc` authorizes a change to
+  `docs/architecture/ARCHITECTURE.md` only. That document is owner-controlled:
+  do not edit it as part of implementation work. Propose the text and wait.
+
 - If the owner authorizes one of these actions in chat, the PR must carry the
   matching label before the action is considered approved.
 

--- a/docs/ai-developer/specific_rules/gated-workflow.md
+++ b/docs/ai-developer/specific_rules/gated-workflow.md
@@ -146,7 +146,7 @@ python -m scistudio.qa.governance.gate_record plan \
   [--test-na "<class>:<rationale>"] \
   [--check <check-name>] \
   [--check-na "<check-name>:<rationale>"] \
-  [--admin-label admin-approved:bypass|admin-approved:core-change|admin-approved:merge]
+  [--admin-label admin-approved:bypass|admin-approved:core-change|admin-approved:merge|admin-approved:architecture-doc]
 ```
 
 `plan` appends planning fields without running the full check set. It observes
@@ -178,7 +178,7 @@ python -m scistudio.qa.governance.gate_record amend \
   [--test-na "<class>:<rationale>"] \
   [--check <check-name>] \
   [--check-na "<check-name>:<rationale>"] \
-  [--admin-label admin-approved:bypass|admin-approved:core-change|admin-approved:merge]
+  [--admin-label admin-approved:bypass|admin-approved:core-change|admin-approved:merge|admin-approved:architecture-doc]
 ```
 
 `amend` is the dedicated low-cost correction command. It is append-only: it
@@ -212,7 +212,7 @@ python -m scistudio.qa.governance.gate_record check \
   [--test-na "<class>:<rationale>"] \
   [--check <check-name>] \
   [--check-na "<check-name>:<rationale>"] \
-  [--admin-label admin-approved:bypass|admin-approved:core-change|admin-approved:merge] \
+  [--admin-label admin-approved:bypass|admin-approved:core-change|admin-approved:merge|admin-approved:architecture-doc] \
   [--only <check-name>] \
   [--skip-execution]
 ```
@@ -354,6 +354,7 @@ The valid administrator bypass labels are:
 | `admin-approved:bypass` | Bypass AI gate workflow steps when CI verifies provenance |
 | `admin-approved:core-change` | Protected core path authorization only |
 | `admin-approved:merge` | Authorization for AI-assisted merge into `origin/main` only |
+| `admin-approved:architecture-doc` | Authorization for a change to `docs/architecture/ARCHITECTURE.md` only |
 | `human-authored` | Human AI-harness bypass at PR level |
 
 Local ledger records of requested labels are not authoritative; CI verifies the
@@ -738,7 +739,8 @@ evidence helps review; CI evidence is authoritative.
 - MUST treat CI evidence as authoritative.
 - MUST use bypass labels exactly as accepted by the gate CLI. The valid bypass
   labels are: `admin-approved:bypass`, `admin-approved:core-change`,
-  `admin-approved:merge`, `human-authored`.
+  `admin-approved:merge`, `admin-approved:architecture-doc`,
+  `human-authored`.
 - MUST use local bypass labels only when the owner authorizes that bypass.
 - MUST treat `admin-approved:core-change` as authorization for protected core
   paths only, not as a broad gate or bypass.

--- a/docs/ai-developer/templates/agent-dispatch-checklist-template.md
+++ b/docs/ai-developer/templates/agent-dispatch-checklist-template.md
@@ -75,7 +75,7 @@ language_source: en
 
 ## 5. Local Gate Hook Bypass Evidence
 
-- Authorized bypass label: `<human-authored|admin-approved:bypass|admin-approved:core-change|admin-approved:merge|N/A>`
+- Authorized bypass label: `<human-authored|admin-approved:bypass|admin-approved:core-change|admin-approved:merge|admin-approved:architecture-doc|N/A>`
 - Owner authorization source: `<chat/date/link or N/A>`
 - Reason: `<why bypass was needed or N/A>`
 

--- a/docs/specs/adr-042-gate-ledger-runtime.md
+++ b/docs/specs/adr-042-gate-ledger-runtime.md
@@ -121,7 +121,7 @@ to each existing component:
 | `gate_record/checks.py` | CI-graph parser + tier-selected check-set inference + check execution in the parity environment (§7). Produces sanitized `check_event`s and writes raw transcripts to ignored local paths. | **new** (no current equivalent; supersedes `gate_receipt.infer_required_checks` and its hand-written `CHECK_COMMANDS`). |
 | `gate_record/parity.py` | Tool-version + environment parity (§7.10): resolve CI tool versions, set up/validate the isolated per-worktree environment or the `PYTHONPATH=src` invocation, fail closed when parity cannot be reproduced. | **new**. |
 | `gate_record/guards/` | Each guard as an evaluator-owned calculator returning `AuditReport`/`Finding` via `qa.schemas.report`. One module per guard. No guard keeps its own task-kind rules, required-check sets, local/CI differences, bypass vocab, or protected-path lists. | **rewrite/modify** of the current top-level guard modules (see §4). |
-| `gate_record/labels.py` | Single label vocabulary (`admin-approved:bypass`, `admin-approved:core-change`, `admin-approved:merge`, `human-authored`) and the bypass/authorization semantics. | **port** of the shared constants currently exported from `human_bypass_guard`. |
+| `gate_record/labels.py` | Single label vocabulary (`admin-approved:bypass`, `admin-approved:core-change`, `admin-approved:merge`, `admin-approved:architecture-doc`, `human-authored`) and the bypass/authorization semantics. | **port** of the shared constants currently exported from `human_bypass_guard`. |
 | `gate_record/instructions.py` | The `init` task-specific instruction generator (§5) rendering the §7.7.4/§7.7.5 argument profiles. | **new**. |
 | `gate_record/workflow.py` | The five workflow command implementations (`init`/`plan`/`amend`/`check`/`finalize`) and the `--mode` dispatcher; thin orchestration over `evaluator`. | **rewrite** of current `stages.py` + `workflow.py`. |
 | `gate_record/cli.py` | Argparse surface for the five commands plus compatibility aliases (§5.6). | **rewrite**. |
@@ -269,6 +269,7 @@ tier, `requested_admin_labels`, `observed_admin_labels`, `governance_touch`,
 | Guard | Evaluator-supplied inputs | Findings produced |
 |---|---|---|
 | `core_change_guard` | protected-core surfaces, `observed_admin_labels`, `requested_admin_labels`, runtime, pr_context | AI-authored protected-core change lacks `admin-approved:core-change` provenance. |
+| `architecture_doc_guard` | protected-architecture surface, `observed_admin_labels`, `requested_admin_labels`, pr_context | Change to `docs/architecture/ARCHITECTURE.md` lacks `admin-approved:architecture-doc` provenance or an administrator approval review (#2054). |
 | `human_bypass_guard` | pr_context (labels + actor permission), runtime, AI-evidence facts from `runtime`/`check_events` | `human-authored`/`admin-approved:bypass` claimed without verified maintainer/admin provenance. |
 | `pr_merge_guard` | merge intent from the real GitHub event, `observed_admin_labels`, actor | AI merge attempt without authorized `admin-approved:merge` provenance. |
 | `mod_guard` (`governance_mod_guard`) | governance surfaces, `governance_touch`, `requested/observed_admin_labels` | Governance-file change without declared governance-touch + verified authorization. Env-var bypass channels removed. |

--- a/src/scistudio/qa/governance/gate_record/__init__.py
+++ b/src/scistudio/qa/governance/gate_record/__init__.py
@@ -28,6 +28,7 @@ from scistudio.qa.governance.gate_record.evaluator import (
 from scistudio.qa.governance.gate_record.guards import GUARD_REGISTRY, Guard, GuardInputs
 from scistudio.qa.governance.gate_record.labels import (
     ADMIN_LABELS,
+    ARCHITECTURE_DOC_LABEL,
     BYPASS_LABEL,
     CORE_CHANGE_LABEL,
     HUMAN_AUTHORED_LABEL,
@@ -60,6 +61,7 @@ from scistudio.qa.governance.gate_record.ledger import (
 
 __all__ = [
     "ADMIN_LABELS",
+    "ARCHITECTURE_DOC_LABEL",
     "BYPASS_LABEL",
     "CORE_CHANGE_LABEL",
     "GUARD_REGISTRY",

--- a/src/scistudio/qa/governance/gate_record/evaluator.py
+++ b/src/scistudio/qa/governance/gate_record/evaluator.py
@@ -91,6 +91,7 @@ _SURFACE_CLASSIFIERS = {
     "test": surfaces.is_test_path,
     "governance": surfaces.is_governance_path,
     "protected_core": surfaces.is_protected_core_path,
+    "protected_architecture": surfaces.is_protected_architecture_path,
     "frontend": surfaces.is_frontend_path,
     "packaging": surfaces.is_packaging_path,
     "workflow_ci": surfaces.is_workflow_ci_path,
@@ -415,6 +416,9 @@ def _infer_obligations(
     # Protected-core authorization.
     if grouped["protected_core"]:
         admin_labels.append("admin-approved:core-change")
+    # Architecture-document authorization (#2054).
+    if grouped["protected_architecture"]:
+        admin_labels.append("admin-approved:architecture-doc")
 
     return RequiredObligations(
         checks=list(required_checks),
@@ -435,6 +439,12 @@ _GUARD_REPAIR_ACTIONS: dict[str, str] = {
         "Request the admin-approved:core-change label (owner applies it; the "
         "actor-permission provenance is verified in CI), or move the change out "
         "of the protected-core surface."
+    ),
+    "architecture_doc_guard": (
+        "The architecture document is owner-controlled: ask the owner to approve "
+        "this specific change and apply admin-approved:architecture-doc (or to "
+        "approve the PR as an administrator), or drop the change and put the "
+        "content in a spec instead."
     ),
     "human_bypass_guard": (
         "Use a valid ADR-042 override label applied by an authorized maintainer; "

--- a/src/scistudio/qa/governance/gate_record/guards/__init__.py
+++ b/src/scistudio/qa/governance/gate_record/guards/__init__.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 # GuardInputs and Guard live in _base to avoid import cycles: guard submodules
 # import from _base directly; __init__ re-exports them for external callers.
+import scistudio.qa.governance.gate_record.guards.architecture_doc_guard as architecture_doc_guard
 import scistudio.qa.governance.gate_record.guards.core_change_guard as core_change_guard
 import scistudio.qa.governance.gate_record.guards.docs_landing as docs_landing
 import scistudio.qa.governance.gate_record.guards.human_bypass_guard as human_bypass_guard
@@ -37,6 +38,7 @@ from scistudio.qa.governance.gate_record.guards._base import Guard, GuardInputs
 # stable contract for B2/B3/B4.
 GUARD_REGISTRY: dict[str, Guard] = {
     "core_change_guard": core_change_guard.check,
+    "architecture_doc_guard": architecture_doc_guard.check,
     "human_bypass_guard": human_bypass_guard.check,
     "pr_merge_guard": pr_merge_guard.check,
     "mod_guard": mod_guard.check,

--- a/src/scistudio/qa/governance/gate_record/guards/_authorization.py
+++ b/src/scistudio/qa/governance/gate_record/guards/_authorization.py
@@ -1,0 +1,117 @@
+"""The one label-gated-surface policy, shared by the guards that apply it (#2054).
+
+``core_change_guard`` and ``architecture_doc_guard`` gate different surfaces on
+different labels, but the policy is a single one: *this surface may only change
+when an authorization CI can verify the provenance of exists.* Each guard used
+to carry its own copy of it, which is two places for one answer to drift — and
+drift here is not cosmetic, because the guards would then disagree about whether
+the same owner action authorized anything at all.
+
+They are now two configurations of :func:`check_label_gated_surface` rather than
+two implementations of the same rule. What differs between them is data: which
+surface class the evaluator classified, which label authorizes it, and what to
+say when it is missing.
+
+Kept out of ``_base`` on purpose: ``_base`` owns the frozen ``GuardInputs``
+bundle and the ``Guard`` type, which every guard imports. This is policy, and a
+guard that does not gate on a label has no reason to see it.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+import scistudio.qa.governance.gate_record.labels as label_vocab
+from scistudio.qa.governance.gate_record.guards._base import GuardInputs
+from scistudio.qa.governance.gate_record.guards._stub import source_sha
+from scistudio.qa.schemas.report import AuditReport, AuditStatus, Finding, Severity
+
+
+def has_admin_approval_review(pr_context: Mapping[str, Any] | None) -> bool:
+    """Return True when an approving review carries admin/maintainer provenance.
+
+    Someone who reviews and approves the PR has given approval in the surface
+    where they read the diff. Requiring a label *as well* would only mean saying
+    yes twice.
+    """
+
+    raw_reviews = (pr_context or {}).get("reviews", [])
+    if not isinstance(raw_reviews, Sequence) or isinstance(raw_reviews, str):
+        return False
+    for review in raw_reviews:
+        if not isinstance(review, Mapping):
+            continue
+        state = str(review.get("state", "")).upper()
+        permission = str(review.get("permission", review.get("actor_permission", ""))).lower()
+        if state == "APPROVED" and permission in label_vocab.ADMIN_PERMISSIONS:
+            return True
+    return False
+
+
+def label_has_authorized_provenance(observed: Sequence[Any], label: str) -> bool:
+    """Return True when an observed admin label was applied by an authorized actor.
+
+    ``observed`` are ledger ``AdminLabel`` objects carrying CI-verified actor
+    permission provenance. A label with no provenance is treated as unverified,
+    which is the case that matters: an agent can put a label on its own PR, and
+    only CI can say who actually applied it.
+    """
+
+    for item in observed:
+        name = getattr(item, "name", None)
+        permission = getattr(item, "actor_permission", None)
+        if name == label and isinstance(permission, str) and permission.lower() in label_vocab.ADMIN_PERMISSIONS:
+            return True
+    return False
+
+
+def check_label_gated_surface(
+    inputs: GuardInputs,
+    *,
+    tool: str,
+    surface: str,
+    label: str,
+    rule_id: str,
+    message: str,
+    requested_summary_key: str,
+) -> AuditReport:
+    """Report an unauthorized change to a label-gated surface.
+
+    In CI mode authorization is verified against observed labels (actor
+    permission provenance) or an admin approval review. In local modes the label
+    cannot be provenance-verified, so a *requested* label is treated as recorded
+    pre-PR intent and the finding is downgraded to a warning — the agent learns
+    before it opens the PR, while CI stays the authority. Silence downgrades
+    nothing: an unrecorded intent is not an intent.
+
+    One finding per affected path, so the repair hint can name the files rather
+    than say a surface was touched.
+    """
+
+    protected = list(inputs.surfaces.get(surface, []))
+    is_ci = inputs.mode == "ci"
+
+    approved = label_has_authorized_provenance(inputs.observed_admin_labels, label)
+    approved = approved or has_admin_approval_review(inputs.pr_context)
+    requested = label in {requested.name for requested in inputs.requested_admin_labels}
+
+    findings: list[Finding] = []
+    if protected and not approved:
+        severity = Severity.ERROR if is_ci or not requested else Severity.WARNING
+        findings = [Finding(rule_id=rule_id, severity=severity, file=path, message=message) for path in protected]
+
+    return AuditReport(
+        tool=tool,
+        status=AuditStatus.FAIL
+        if any(finding.severity == Severity.ERROR for finding in findings)
+        else AuditStatus.PASS,
+        source_sha=source_sha(inputs.repo_root),
+        findings=findings,
+        summary={
+            "protected_files": protected,
+            "approved": approved,
+            requested_summary_key: requested,
+            "mode": inputs.mode,
+        },
+    )

--- a/src/scistudio/qa/governance/gate_record/guards/architecture_doc_guard.py
+++ b/src/scistudio/qa/governance/gate_record/guards/architecture_doc_guard.py
@@ -5,122 +5,49 @@ Produces: a change to the owner-controlled architecture document lacks
 
 ``docs/architecture/ARCHITECTURE.md`` is the owner's artifact. A change to it
 needs the owner's specific prior approval, and until this guard existed nothing
-in CI asked for one: PR #2036 carried a thirty-line addition through every
-check green, Full Audit included, and it was caught by the owner reading the
-diff. The gap was not an oversight in the checks so much as an inversion in the
-classifier — ``surfaces.is_architecture_doc_path`` exists, and its only
-consumer counts a touch of this document as a *documentation obligation
-satisfied*. Editing it made a PR look better, not worse.
+in CI asked for one: PR #2036 carried a thirty-line addition through every check
+green, Full Audit included, and it was caught by the owner reading the diff. The
+gap was less an oversight in the checks than an inversion in the classifier —
+``surfaces.is_architecture_doc_path`` exists, and its only consumer counts a
+touch of this document as a *documentation obligation satisfied*. Editing it
+made a PR look better, not worse.
 
-The shape is deliberately ``core_change_guard``'s, because the requirement is
-the same one: a surface that may only change with an authorization CI can
-verify the provenance of. Sharing the shape is what keeps the two from drifting
-into different answers to "what counts as approval".
-
-Reads ONLY ``GuardInputs``: the protected surface comes from the evaluator's
-``surfaces`` classifier, the label vocabulary from ``labels``, and the observed
-labels + PR context from the bundle. The guard keeps no path list, no label
-vocabulary, and no git access of its own.
+The rule body is ``core_change_guard``'s, literally: both delegate to
+``_authorization.check_label_gated_surface``. That is the point rather than a
+convenience — the two must not drift into different answers to "what counts as
+approval", and one implementation is what makes that hold. Reads ONLY
+``GuardInputs``; the guard keeps no path list, label vocabulary, or git access
+of its own.
 """
 
 from __future__ import annotations
 
-from collections.abc import Mapping, Sequence
-from typing import Any
-
+import scistudio.qa.governance.gate_record.guards._authorization as authorization
 import scistudio.qa.governance.gate_record.labels as label_vocab
 from scistudio.qa.governance.gate_record.guards._base import GuardInputs
-from scistudio.qa.governance.gate_record.guards._stub import source_sha
-from scistudio.qa.schemas.report import AuditReport, AuditStatus, Finding, Severity
+from scistudio.qa.schemas.report import AuditReport
 
-
-def _has_admin_approval_review(pr_context: Mapping[str, Any] | None) -> bool:
-    """Return True when an approving review carries admin/maintainer provenance.
-
-    An owner who reviews and approves the PR has given the specific approval the
-    document requires, in the surface where they read the diff. Requiring the
-    label *in addition* would only mean the owner had to say yes twice.
-    """
-
-    raw_reviews = (pr_context or {}).get("reviews", [])
-    if not isinstance(raw_reviews, Sequence) or isinstance(raw_reviews, str):
-        return False
-    for review in raw_reviews:
-        if not isinstance(review, Mapping):
-            continue
-        state = str(review.get("state", "")).upper()
-        permission = str(review.get("permission", review.get("actor_permission", ""))).lower()
-        if state == "APPROVED" and permission in label_vocab.ADMIN_PERMISSIONS:
-            return True
-    return False
-
-
-def _label_has_authorized_provenance(observed: Sequence[Any], label: str) -> bool:
-    """Return True when an observed admin label was applied by an authorized actor.
-
-    ``observed`` are ledger ``AdminLabel`` objects carrying CI-verified actor
-    permission provenance. A label with no provenance is unverified, which is
-    the case that matters most here: an agent can add a label to its own PR,
-    and only CI can say who actually applied it.
-    """
-
-    for item in observed:
-        name = getattr(item, "name", None)
-        permission = getattr(item, "actor_permission", None)
-        if name == label and isinstance(permission, str) and permission.lower() in label_vocab.ADMIN_PERMISSIONS:
-            return True
-    return False
+_MESSAGE = (
+    "the architecture document is owner-controlled and this change has no owner "
+    "approval: apply admin-approved:architecture-doc as an authorized maintainer, "
+    "or approve the PR as an administrator, or drop the change"
+)
 
 
 def check(inputs: GuardInputs) -> AuditReport:
     """Hard-fail an unapproved architecture-document change in CI.
-
-    In CI mode authorization is verified against observed labels (actor
-    permission provenance) or an admin approval review. In local modes the
-    label cannot be provenance-verified, so a *requested* label is treated as
-    recorded pre-PR intent and the finding is downgraded to a warning — the
-    agent is told before it opens the PR, and CI is still the authority.
 
     ``admin-approved:bypass`` and ``human-authored`` release this guard exactly
     as they release the others (owner decision, #2054). The evaluator applies
     them; this guard does not re-implement a bypass vocabulary.
     """
 
-    protected = list(inputs.surfaces.get("protected_architecture", []))
-    is_ci = inputs.mode == "ci"
-
-    approved = _label_has_authorized_provenance(inputs.observed_admin_labels, label_vocab.ARCHITECTURE_DOC_LABEL)
-    approved = approved or _has_admin_approval_review(inputs.pr_context)
-    requested = label_vocab.ARCHITECTURE_DOC_LABEL in {label.name for label in inputs.requested_admin_labels}
-
-    findings: list[Finding] = []
-    if protected and not approved:
-        # Local/pre-PR: a requested label is intent, not verified provenance.
-        severity = Severity.ERROR if is_ci or not requested else Severity.WARNING
-        message = (
-            "the architecture document is owner-controlled and this change has no "
-            "owner approval: apply admin-approved:architecture-doc as an authorized "
-            "maintainer, or approve the PR as an administrator, or drop the change"
-        )
-        findings = [
-            Finding(
-                rule_id="architecture_doc_guard.missing-owner-approval",
-                severity=severity,
-                file=path,
-                message=message,
-            )
-            for path in protected
-        ]
-
-    return AuditReport(
+    return authorization.check_label_gated_surface(
+        inputs,
         tool="architecture_doc_guard",
-        status=AuditStatus.FAIL if any(f.severity == Severity.ERROR for f in findings) else AuditStatus.PASS,
-        source_sha=source_sha(inputs.repo_root),
-        findings=findings,
-        summary={
-            "protected_files": protected,
-            "approved": approved,
-            "requested_architecture_doc": requested,
-            "mode": inputs.mode,
-        },
+        surface="protected_architecture",
+        label=label_vocab.ARCHITECTURE_DOC_LABEL,
+        rule_id="architecture_doc_guard.missing-owner-approval",
+        message=_MESSAGE,
+        requested_summary_key="requested_architecture_doc",
     )

--- a/src/scistudio/qa/governance/gate_record/guards/architecture_doc_guard.py
+++ b/src/scistudio/qa/governance/gate_record/guards/architecture_doc_guard.py
@@ -1,0 +1,126 @@
+"""architecture_doc_guard calculator (#2054).
+
+Produces: a change to the owner-controlled architecture document lacks
+``admin-approved:architecture-doc`` provenance.
+
+``docs/architecture/ARCHITECTURE.md`` is the owner's artifact. A change to it
+needs the owner's specific prior approval, and until this guard existed nothing
+in CI asked for one: PR #2036 carried a thirty-line addition through every
+check green, Full Audit included, and it was caught by the owner reading the
+diff. The gap was not an oversight in the checks so much as an inversion in the
+classifier — ``surfaces.is_architecture_doc_path`` exists, and its only
+consumer counts a touch of this document as a *documentation obligation
+satisfied*. Editing it made a PR look better, not worse.
+
+The shape is deliberately ``core_change_guard``'s, because the requirement is
+the same one: a surface that may only change with an authorization CI can
+verify the provenance of. Sharing the shape is what keeps the two from drifting
+into different answers to "what counts as approval".
+
+Reads ONLY ``GuardInputs``: the protected surface comes from the evaluator's
+``surfaces`` classifier, the label vocabulary from ``labels``, and the observed
+labels + PR context from the bundle. The guard keeps no path list, no label
+vocabulary, and no git access of its own.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+import scistudio.qa.governance.gate_record.labels as label_vocab
+from scistudio.qa.governance.gate_record.guards._base import GuardInputs
+from scistudio.qa.governance.gate_record.guards._stub import source_sha
+from scistudio.qa.schemas.report import AuditReport, AuditStatus, Finding, Severity
+
+
+def _has_admin_approval_review(pr_context: Mapping[str, Any] | None) -> bool:
+    """Return True when an approving review carries admin/maintainer provenance.
+
+    An owner who reviews and approves the PR has given the specific approval the
+    document requires, in the surface where they read the diff. Requiring the
+    label *in addition* would only mean the owner had to say yes twice.
+    """
+
+    raw_reviews = (pr_context or {}).get("reviews", [])
+    if not isinstance(raw_reviews, Sequence) or isinstance(raw_reviews, str):
+        return False
+    for review in raw_reviews:
+        if not isinstance(review, Mapping):
+            continue
+        state = str(review.get("state", "")).upper()
+        permission = str(review.get("permission", review.get("actor_permission", ""))).lower()
+        if state == "APPROVED" and permission in label_vocab.ADMIN_PERMISSIONS:
+            return True
+    return False
+
+
+def _label_has_authorized_provenance(observed: Sequence[Any], label: str) -> bool:
+    """Return True when an observed admin label was applied by an authorized actor.
+
+    ``observed`` are ledger ``AdminLabel`` objects carrying CI-verified actor
+    permission provenance. A label with no provenance is unverified, which is
+    the case that matters most here: an agent can add a label to its own PR,
+    and only CI can say who actually applied it.
+    """
+
+    for item in observed:
+        name = getattr(item, "name", None)
+        permission = getattr(item, "actor_permission", None)
+        if name == label and isinstance(permission, str) and permission.lower() in label_vocab.ADMIN_PERMISSIONS:
+            return True
+    return False
+
+
+def check(inputs: GuardInputs) -> AuditReport:
+    """Hard-fail an unapproved architecture-document change in CI.
+
+    In CI mode authorization is verified against observed labels (actor
+    permission provenance) or an admin approval review. In local modes the
+    label cannot be provenance-verified, so a *requested* label is treated as
+    recorded pre-PR intent and the finding is downgraded to a warning — the
+    agent is told before it opens the PR, and CI is still the authority.
+
+    ``admin-approved:bypass`` and ``human-authored`` release this guard exactly
+    as they release the others (owner decision, #2054). The evaluator applies
+    them; this guard does not re-implement a bypass vocabulary.
+    """
+
+    protected = list(inputs.surfaces.get("protected_architecture", []))
+    is_ci = inputs.mode == "ci"
+
+    approved = _label_has_authorized_provenance(inputs.observed_admin_labels, label_vocab.ARCHITECTURE_DOC_LABEL)
+    approved = approved or _has_admin_approval_review(inputs.pr_context)
+    requested = label_vocab.ARCHITECTURE_DOC_LABEL in {label.name for label in inputs.requested_admin_labels}
+
+    findings: list[Finding] = []
+    if protected and not approved:
+        # Local/pre-PR: a requested label is intent, not verified provenance.
+        severity = Severity.ERROR if is_ci or not requested else Severity.WARNING
+        message = (
+            "the architecture document is owner-controlled and this change has no "
+            "owner approval: apply admin-approved:architecture-doc as an authorized "
+            "maintainer, or approve the PR as an administrator, or drop the change"
+        )
+        findings = [
+            Finding(
+                rule_id="architecture_doc_guard.missing-owner-approval",
+                severity=severity,
+                file=path,
+                message=message,
+            )
+            for path in protected
+        ]
+
+    return AuditReport(
+        tool="architecture_doc_guard",
+        status=AuditStatus.FAIL if any(f.severity == Severity.ERROR for f in findings) else AuditStatus.PASS,
+        source_sha=source_sha(inputs.repo_root),
+        findings=findings,
+        summary={
+            "protected_files": protected,
+            "approved": approved,
+            "requested_architecture_doc": requested,
+            "mode": inputs.mode,
+        },
+    )

--- a/src/scistudio/qa/governance/gate_record/guards/core_change_guard.py
+++ b/src/scistudio/qa/governance/gate_record/guards/core_change_guard.py
@@ -8,49 +8,23 @@ Ported from the legacy ``core_change_guard`` (deleted on this branch, on
 the evaluator's single ``surfaces`` classifier, the label vocabulary from
 ``labels``, and observed/requested labels + PR context from the bundle. The
 guard keeps no protected-path list, label vocabulary, or git access of its own.
+
+The rule body lives in ``_authorization.check_label_gated_surface``, shared with
+``architecture_doc_guard`` (#2054). What is left here is the configuration that
+makes this guard *this* guard: which surface, which label, what to say.
 """
 
 from __future__ import annotations
 
-from collections.abc import Mapping, Sequence
-from typing import Any
-
+import scistudio.qa.governance.gate_record.guards._authorization as authorization
 import scistudio.qa.governance.gate_record.labels as label_vocab
 from scistudio.qa.governance.gate_record.guards._base import GuardInputs
-from scistudio.qa.governance.gate_record.guards._stub import source_sha
-from scistudio.qa.schemas.report import AuditReport, AuditStatus, Finding, Severity
+from scistudio.qa.schemas.report import AuditReport
 
-
-def _has_admin_approval_review(pr_context: Mapping[str, Any] | None) -> bool:
-    """Return True when an approving review carries admin/maintainer provenance."""
-
-    raw_reviews = (pr_context or {}).get("reviews", [])
-    if not isinstance(raw_reviews, Sequence) or isinstance(raw_reviews, str):
-        return False
-    for review in raw_reviews:
-        if not isinstance(review, Mapping):
-            continue
-        state = str(review.get("state", "")).upper()
-        permission = str(review.get("permission", review.get("actor_permission", ""))).lower()
-        if state == "APPROVED" and permission in label_vocab.ADMIN_PERMISSIONS:
-            return True
-    return False
-
-
-def _label_has_authorized_provenance(observed: Sequence[Any], label: str) -> bool:
-    """Return True when an observed admin label was applied by an authorized actor.
-
-    ``observed`` are ledger ``AdminLabel`` objects carrying CI-verified actor
-    permission provenance (``actor_permission``). A label with no provenance is
-    treated as unverified (CI is the only authority that fills provenance).
-    """
-
-    for item in observed:
-        name = getattr(item, "name", None)
-        permission = getattr(item, "actor_permission", None)
-        if name == label and isinstance(permission, str) and permission.lower() in label_vocab.ADMIN_PERMISSIONS:
-            return True
-    return False
+_MESSAGE = (
+    "protected core/runtime change requires admin-approved:core-change "
+    "applied by an authorized maintainer or administrator approval"
+)
 
 
 def check(inputs: GuardInputs) -> AuditReport:
@@ -63,40 +37,12 @@ def check(inputs: GuardInputs) -> AuditReport:
     warning (the evaluator's pre-PR mode classifies it as a known gap).
     """
 
-    protected = list(inputs.surfaces.get("protected_core", []))
-    is_ci = inputs.mode == "ci"
-
-    approved = _label_has_authorized_provenance(inputs.observed_admin_labels, label_vocab.CORE_CHANGE_LABEL)
-    approved = approved or _has_admin_approval_review(inputs.pr_context)
-    requested = label_vocab.CORE_CHANGE_LABEL in {label.name for label in inputs.requested_admin_labels}
-
-    findings: list[Finding] = []
-    if protected and not approved:
-        # Local/pre-PR: a requested label is intent, not verified provenance.
-        severity = Severity.ERROR if is_ci or not requested else Severity.WARNING
-        message = (
-            "protected core/runtime change requires admin-approved:core-change "
-            "applied by an authorized maintainer or administrator approval"
-        )
-        findings = [
-            Finding(
-                rule_id="core_change_guard.missing-admin-approval",
-                severity=severity,
-                file=path,
-                message=message,
-            )
-            for path in protected
-        ]
-
-    return AuditReport(
+    return authorization.check_label_gated_surface(
+        inputs,
         tool="core_change_guard",
-        status=AuditStatus.FAIL if any(f.severity == Severity.ERROR for f in findings) else AuditStatus.PASS,
-        source_sha=source_sha(inputs.repo_root),
-        findings=findings,
-        summary={
-            "protected_files": protected,
-            "approved": approved,
-            "requested_core_change": requested,
-            "mode": inputs.mode,
-        },
+        surface="protected_core",
+        label=label_vocab.CORE_CHANGE_LABEL,
+        rule_id="core_change_guard.missing-admin-approval",
+        message=_MESSAGE,
+        requested_summary_key="requested_core_change",
     )

--- a/src/scistudio/qa/governance/gate_record/labels.py
+++ b/src/scistudio/qa/governance/gate_record/labels.py
@@ -16,11 +16,17 @@ BYPASS_LABEL: Final[str] = "admin-approved:bypass"
 CORE_CHANGE_LABEL: Final[str] = "admin-approved:core-change"
 # AI-assisted merge authorization only (§7.8).
 MERGE_LABEL: Final[str] = "admin-approved:merge"
+# Architecture document authorization only (#2054). Separate from
+# ``CORE_CHANGE_LABEL`` because the two authorize different things and the
+# owner grants them on different evidence: a protected-core change is judged on
+# runtime risk, an architecture-document change on whether the owner wants that
+# text in their document at all.
+ARCHITECTURE_DOC_LABEL: Final[str] = "admin-approved:architecture-doc"
 # Human AI-harness bypass (PR-level CI signal, not a CLI field) (§7.5).
 HUMAN_AUTHORED_LABEL: Final[str] = "human-authored"
 
 # Labels the ``--admin-label`` CLI flag accepts (§7.5 table).
-ADMIN_LABELS: frozenset[str] = frozenset({BYPASS_LABEL, CORE_CHANGE_LABEL, MERGE_LABEL})
+ADMIN_LABELS: frozenset[str] = frozenset({BYPASS_LABEL, CORE_CHANGE_LABEL, MERGE_LABEL, ARCHITECTURE_DOC_LABEL})
 
 # Full valid label vocabulary including the CI-only ``human-authored`` signal.
 VALID_LABELS: frozenset[str] = ADMIN_LABELS | {HUMAN_AUTHORED_LABEL}

--- a/src/scistudio/qa/governance/gate_record/surfaces.py
+++ b/src/scistudio/qa/governance/gate_record/surfaces.py
@@ -117,6 +117,15 @@ ARCHITECTURE_DOC_PATTERNS: tuple[str, ...] = (
     "docs/architecture/**",
 )
 
+# The owner-controlled architecture document (#2054). Deliberately one file
+# rather than a reuse of ``ARCHITECTURE_DOC_PATTERNS``, which serves the
+# opposite purpose: that surface tells ``checks.py`` a documentation obligation
+# was *satisfied*, and it covers ``docs/adr/**`` and ``docs/specs/**``, which
+# are ordinary work product. ``docs/architecture/`` also holds a generated
+# ``PROJECT_TREE.md`` and a superseded ``ARCHITECTURE_legacy.md``; locking the
+# directory would gate a regeneration behind an owner label for no benefit.
+PROTECTED_ARCHITECTURE_PATTERNS: tuple[str, ...] = ("docs/architecture/ARCHITECTURE.md",)
+
 FRONTEND_PATTERNS: tuple[str, ...] = ("frontend/**",)
 
 PACKAGING_PATTERNS: tuple[str, ...] = (
@@ -251,6 +260,17 @@ def is_architecture_doc_path(path: str) -> bool:
     """Return True for ADR/spec/architecture docs."""
 
     return matches_any(path, ARCHITECTURE_DOC_PATTERNS)
+
+
+def is_protected_architecture_path(path: str) -> bool:
+    """Return True for the owner-controlled architecture document (#2054).
+
+    Narrower than :func:`is_architecture_doc_path` and answering a different
+    question: that one asks "did this change land documentation?", this one
+    asks "does this change need the owner's permission to exist?".
+    """
+
+    return matches_any(path, PROTECTED_ARCHITECTURE_PATTERNS)
 
 
 def is_docs_path(path: str) -> bool:

--- a/tests/qa/test_gate_evaluator.py
+++ b/tests/qa/test_gate_evaluator.py
@@ -420,6 +420,39 @@ def test_blocking_guard_emits_repair_hint(git_repo: Path) -> None:
     assert "src/scistudio/core/foo.py" in hint
 
 
+def test_architecture_document_change_blocks_ci_and_names_the_label(git_repo: Path) -> None:
+    """#2054 end-to-end: the diff alone must produce the block and the obligation.
+
+    The regression this pins is PR #2036, where a thirty-line addition to the
+    architecture document passed every CI job. Here the only input is the file
+    appearing in the observed diff.
+    """
+
+    _add_change(git_repo, "docs/architecture/ARCHITECTURE.md")
+    ledger = _ledger(task_kind="feature", declared_scope=DeclaredScope(include=["docs/**"]))
+    result = evaluator.reconcile(
+        ledger=ledger, repo_root=git_repo, base="HEAD~1", head="HEAD", mode="ci", run_checks=False
+    )
+    assert "guard.architecture_doc_guard" in result.unsatisfied
+    assert "admin-approved:architecture-doc" in result.required_obligations.admin_labels
+    hints = [h for h in result.repair_hints if h.startswith("- guard.architecture_doc_guard")]
+    assert hints, result.repair_hints
+    assert "admin-approved:architecture-doc" in hints[0]
+    assert "docs/architecture/ARCHITECTURE.md" in hints[0]
+
+
+def test_ordinary_docs_change_does_not_trip_the_architecture_guard(git_repo: Path) -> None:
+    """A spec or ADR is work product; only the owner's document is gated."""
+
+    _add_change(git_repo, "docs/specs/adr-053-personal-tool-library.md")
+    ledger = _ledger(task_kind="feature", declared_scope=DeclaredScope(include=["docs/**"]))
+    result = evaluator.reconcile(
+        ledger=ledger, repo_root=git_repo, base="HEAD~1", head="HEAD", mode="ci", run_checks=False
+    )
+    assert "guard.architecture_doc_guard" not in result.unsatisfied
+    assert "admin-approved:architecture-doc" not in result.required_obligations.admin_labels
+
+
 def test_guard_repair_hint_uses_finding_message_when_no_action_mapped() -> None:
     # The helper falls back to the finding's own message/remediation; the
     # ``- guard.<name>`` header is always present.

--- a/tests/qa/test_gate_record_hooks.py
+++ b/tests/qa/test_gate_record_hooks.py
@@ -99,6 +99,56 @@ def test_workflow_gate_ci_is_single_evaluator_ci_invocation() -> None:
     assert "admin-approved:bypass" in workflow
 
 
+def test_workflow_gate_derives_the_label_vocabulary_rather_than_restating_it() -> None:
+    """#2054: the workflow's label filter must come from ``labels.py``.
+
+    ``OVERRIDE_LABELS`` decides which labels reach the evaluator at all, so a
+    label missing from it is invisible to every guard regardless of what that
+    guard looks for — the owner applies the label, the workflow drops it, and
+    the guard reports missing approval. That is precisely how
+    ``admin-approved:architecture-doc`` was born broken while it was a literal
+    set here, and a Codex review caught it. Restating the vocabulary is the
+    defect; deriving it is the fix.
+    """
+
+    workflow = _text(".github/workflows/workflow-gate.yml")
+    assert "from scistudio.qa.governance.gate_record.labels import VALID_LABELS as OVERRIDE_LABELS" in workflow
+    # No second copy of the vocabulary. Quoted forms only — the names may still
+    # appear in prose, and the one string literal that legitimately remains is
+    # the legacy ai-override migration map.
+    assert "OVERRIDE_LABELS = {" not in workflow
+    assert '"admin-approved:core-change"' not in workflow
+    assert '"admin-approved:merge"' not in workflow
+    assert '"admin-approved:architecture-doc"' not in workflow
+    assert '"human-authored"' not in workflow
+
+
+def test_workflow_gate_inline_python_parses_and_covers_every_valid_label() -> None:
+    """The heredoc is real code that never runs locally; parse it and check its set."""
+
+    import ast
+    import re
+
+    from scistudio.qa.governance.gate_record.labels import VALID_LABELS
+
+    workflow = _text(".github/workflows/workflow-gate.yml")
+    match = re.search(r"python - <<'PY'\n(.*?)\n\s*PY\n", workflow, re.S)
+    assert match, "the PR-context heredoc is no longer recognisable"
+    lines = match.group(1).split("\n")
+    indent = min(len(line) - len(line.lstrip()) for line in lines if line.strip())
+    ast.parse("\n".join(line[indent:] for line in lines))
+
+    # Every label an owner can apply must survive the filter, including the ones
+    # added after this test was written.
+    assert {
+        "human-authored",
+        "admin-approved:bypass",
+        "admin-approved:core-change",
+        "admin-approved:merge",
+        "admin-approved:architecture-doc",
+    } <= VALID_LABELS
+
+
 # ---------------------------------------------------------------------------
 # Legacy entry points and state are gone.
 # ---------------------------------------------------------------------------

--- a/tests/qa/test_governance_paths.py
+++ b/tests/qa/test_governance_paths.py
@@ -97,3 +97,35 @@ class TestSentruxApplicabilityIsSingleCiInclusivePredicate:
         # sentrux-applicable surface; the evaluator records the advisory, not a
         # block (sentrux is opt-in per the active addendum).
         assert not surfaces.sentrux_applies_to_changes([])
+
+
+class TestProtectedArchitectureDocument:
+    """``is_protected_architecture_path`` covers the owner's document only (#2054)."""
+
+    def test_the_architecture_document_matches(self) -> None:
+        assert surfaces.is_protected_architecture_path("docs/architecture/ARCHITECTURE.md")
+
+    def test_windows_separators_normalised(self) -> None:
+        assert surfaces.is_protected_architecture_path(r"docs\architecture\ARCHITECTURE.md")
+
+    def test_generated_and_legacy_siblings_do_not_match(self) -> None:
+        # Owner decision (#2054): the document, not the directory. Gating a
+        # PROJECT_TREE.md regeneration behind an owner label buys nothing, and
+        # the legacy file is superseded rather than governed.
+        assert not surfaces.is_protected_architecture_path("docs/architecture/PROJECT_TREE.md")
+        assert not surfaces.is_protected_architecture_path("docs/architecture/ARCHITECTURE_legacy.md")
+        assert not surfaces.is_protected_architecture_path("docs/architecture/sentrux-rules.md")
+
+    def test_adrs_and_specs_do_not_match(self) -> None:
+        # These are ordinary work product. Locking them would gate the normal
+        # development flow, which is the opposite of what the guard is for.
+        assert not surfaces.is_protected_architecture_path("docs/adr/ADR-053.md")
+        assert not surfaces.is_protected_architecture_path("docs/specs/adr-053-personal-tool-library.md")
+
+    def test_it_is_narrower_than_the_documentation_obligation_surface(self) -> None:
+        # ``is_architecture_doc_path`` answers "did this land documentation?";
+        # this one answers "does this need the owner's permission?". Every
+        # protected path is also a doc path, but not the reverse.
+        assert surfaces.is_architecture_doc_path("docs/architecture/ARCHITECTURE.md")
+        assert surfaces.is_architecture_doc_path("docs/adr/ADR-053.md")
+        assert not surfaces.is_protected_architecture_path("docs/adr/ADR-053.md")

--- a/tests/qa/test_guard_calculators.py
+++ b/tests/qa/test_guard_calculators.py
@@ -16,6 +16,7 @@ import pytest
 
 from scistudio.qa.governance.gate_record.guards import (
     GuardInputs,
+    architecture_doc_guard,
     core_change_guard,
     docs_landing,
     human_bypass_guard,
@@ -37,6 +38,7 @@ _SURFACE_CLASSES = (
     "test",
     "governance",
     "protected_core",
+    "protected_architecture",
     "frontend",
     "packaging",
     "workflow_ci",
@@ -143,6 +145,109 @@ def test_core_change_local_requested_label_is_warning_not_block() -> None:
     # A requested (unverified) label downgrades the local finding to a warning.
     assert not report.blocks_merge
     assert any(f.severity == Severity.WARNING for f in report.findings)
+
+
+# ---------------------------------------------------------------------------
+# architecture_doc_guard (#2054)
+# ---------------------------------------------------------------------------
+
+ARCH_DOC = "docs/architecture/ARCHITECTURE.md"
+
+
+def test_architecture_doc_passes_when_the_document_is_untouched() -> None:
+    report = architecture_doc_guard.check(_inputs(mode="ci", surfaces={"protected_architecture": []}))
+    assert report.status is AuditStatus.PASS
+    assert not report.blocks_merge
+
+
+def test_architecture_doc_blocks_ci_change_without_approval() -> None:
+    """The case that motivated the guard: PR #2036 went green with this diff."""
+
+    report = architecture_doc_guard.check(_inputs(mode="ci", surfaces={"protected_architecture": [ARCH_DOC]}))
+    assert report.blocks_merge
+    assert "architecture_doc_guard.missing-owner-approval" in _rule_ids(report)
+    assert report.findings[0].file == ARCH_DOC
+
+
+def test_architecture_doc_passes_with_verified_label() -> None:
+    report = architecture_doc_guard.check(
+        _inputs(
+            mode="ci",
+            surfaces={"protected_architecture": [ARCH_DOC]},
+            observed_admin_labels=[AdminLabel(name="admin-approved:architecture-doc", actor_permission="admin")],
+        )
+    )
+    assert report.status is AuditStatus.PASS
+    assert not report.blocks_merge
+
+
+def test_architecture_doc_label_without_provenance_does_not_release_ci() -> None:
+    """An agent can put a label on its own PR; only CI can say who applied it."""
+
+    report = architecture_doc_guard.check(
+        _inputs(
+            mode="ci",
+            surfaces={"protected_architecture": [ARCH_DOC]},
+            observed_admin_labels=[AdminLabel(name="admin-approved:architecture-doc")],
+        )
+    )
+    assert report.blocks_merge
+
+
+def test_architecture_doc_core_change_label_does_not_release_it() -> None:
+    """The two authorizations are distinct; one does not stand in for the other."""
+
+    report = architecture_doc_guard.check(
+        _inputs(
+            mode="ci",
+            surfaces={"protected_architecture": [ARCH_DOC]},
+            observed_admin_labels=[AdminLabel(name="admin-approved:core-change", actor_permission="admin")],
+        )
+    )
+    assert report.blocks_merge
+
+
+def test_architecture_doc_passes_with_admin_approval_review() -> None:
+    """An owner who approved the PR read the diff; do not make them say yes twice."""
+
+    report = architecture_doc_guard.check(
+        _inputs(
+            mode="ci",
+            surfaces={"protected_architecture": [ARCH_DOC]},
+            pr_context={"reviews": [{"state": "APPROVED", "permission": "admin"}]},
+        )
+    )
+    assert report.status is AuditStatus.PASS
+
+
+def test_architecture_doc_non_admin_review_does_not_release_it() -> None:
+    report = architecture_doc_guard.check(
+        _inputs(
+            mode="ci",
+            surfaces={"protected_architecture": [ARCH_DOC]},
+            pr_context={"reviews": [{"state": "APPROVED", "permission": "read"}]},
+        )
+    )
+    assert report.blocks_merge
+
+
+def test_architecture_doc_local_requested_label_is_warning_not_block() -> None:
+    report = architecture_doc_guard.check(
+        _inputs(
+            mode="local",
+            surfaces={"protected_architecture": [ARCH_DOC]},
+            requested_admin_labels=[AdminLabel(name="admin-approved:architecture-doc")],
+        )
+    )
+    assert not report.blocks_merge
+    assert any(f.severity == Severity.WARNING for f in report.findings)
+
+
+def test_architecture_doc_local_without_any_label_still_blocks() -> None:
+    """Local mode warns only when the intent was recorded; silence is not intent."""
+
+    report = architecture_doc_guard.check(_inputs(mode="local", surfaces={"protected_architecture": [ARCH_DOC]}))
+    assert report.blocks_merge
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
`docs/architecture/ARCHITECTURE.md` may only change with the owner's specific approval, and nothing enforced that. PR #2036 carried a thirty-line addition to §12.5 through every check green — Full Audit included — and it was caught by the owner reading the diff.

Gate record: `.workflow/records/2054-2054-architecture-doc-guard.json`

## Why nothing caught it

The gap was an inversion rather than an omission. `surfaces.is_architecture_doc_path` already existed, and its only consumer was `checks.py`'s test for whether a **documentation obligation was satisfied**. Touching the owner's document made a PR look *better*.

## Where the check lives, and why not Full Audit

`architecture_doc_guard` runs in **Verify Workflow Compliance** — the only CI job that runs the gate evaluator with PR context, and therefore the only one that can verify *who applied a label*. That verification is the entire difficulty of an approval flag: without it, an agent labels its own PR and walks through.

Full Audit and Architecture Tests have no PR context and could not enforce this without growing a second label-reading pipeline; a new dedicated workflow would make a second authority for reading PR labels where the repository already has exactly one. **No CI workflow file changed** — the guard registry carries it, which is also why this branch does not touch `ci.yml`.

## What it does

Blocks in CI unless the PR carries `admin-approved:architecture-doc` applied by an authorized maintainer, **or** an administrator has approved the PR. The second is deliberate: an owner who approved the diff has already given the approval, in the surface where they read it, and should not have to say yes twice.

Locally a *requested* label downgrades the finding to a warning, so an agent is told before it opens the PR while CI stays the authority. Silence downgrades nothing — an unrecorded intent is not an intent.

## Scope, per owner decision

- **The document, not the directory.** `docs/architecture/` also holds a generated `PROJECT_TREE.md` and a superseded `ARCHITECTURE_legacy.md`; `docs/adr/**` and `docs/specs/**` are ordinary work product. Reusing the existing `ARCHITECTURE_DOC_PATTERNS` would have gated the normal development flow, which is the opposite of the point.
- **`admin-approved:bypass` and `human-authored` still release it**, exactly as they release every other guard. It does not become the first non-bypassable guard.

## Review note

The first version of this branch was **rejected by the semantic-duplication ratchet**, correctly: the new guard had `core_change_guard`'s two authorization helpers copied verbatim and its body paraphrased, while the docstring claimed the two "share the shape". Both now delegate to `_authorization.check_label_gated_surface`, and each guard is reduced to the configuration that makes it that guard. That is what the stated intent actually required — the two must not drift into different answers to "what counts as approval". Ratchet after: 119 clusters / 6917 duplicate LOC against limits of 120 / 7000, both **lower than before this branch**.

## Before this can be used

The `admin-approved:architecture-doc` label must exist in the repository for the owner to apply it.

Closes #2054
