### PR TITLE
fix(#2068): stop the package repair loop, move it off the startup path, add a splash window

### DIFF
--- a/.workflow/records/2068-2068-startup-repair-and-splash.json
+++ b/.workflow/records/2068-2068-startup-repair-and-splash.json
@@ -160,9 +160,9 @@
   ],
   "check_na": [],
   "commit": {
-    "sha": "64b52a1307b974e59242a5446eda35fbe73a64e4",
+    "sha": "9c08a062fae7a6fb2e183181ed7ff46830080de8",
     "shas": [
-      "64b52a1307b974e59242a5446eda35fbe73a64e4"
+      "9c08a062fae7a6fb2e183181ed7ff46830080de8"
     ],
     "trailers": []
   },
@@ -534,6 +534,182 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-08-10T20:28:11.530061Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-10T20:28:11.540873Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-10T20:28:11.551152Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-10T20:28:11.561573Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-10T20:28:11.572793Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-10T20:28:11.583291Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-10T20:28:11.594175Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-10T20:28:11.604781Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-10T20:28:11.618048Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-10T20:28:11.629294Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-10T20:28:11.643211Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-10T20:28:22.180453Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-10T20:28:22.190969Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-10T20:28:22.201845Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-10T20:28:22.211979Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-10T20:28:22.223273Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-10T20:28:22.234060Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-10T20:28:22.243671Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-10T20:28:22.253251Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-10T20:28:22.263344Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-10T20:28:22.272961Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-10T20:28:22.287013Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -546,9 +722,10 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "origin/main",
+    "base": "c8f308c11529641806822902bd175d768399cb10",
     "base_sha": "c8f308c1",
     "changed_files": [
+      ".workflow/records/2068-2068-startup-repair-and-splash.json",
       "desktop/main.js",
       "desktop/ota.js",
       "desktop/package.json",
@@ -560,9 +737,9 @@
       "tests/api/test_runtime_package_repair.py",
       "tests/desktop/test_package_installer.py"
     ],
-    "diff_fingerprint": "sha256:b75fc3961f566bad3fc387aa55bf9b0123b31b825ce74b3493fe9d7bdb1c9e55",
+    "diff_fingerprint": "sha256:c67e519e0517df61cabc49bcf4822e80d57b4231a478a22629da37e746dd3004",
     "head": "HEAD",
-    "head_sha": "64b52a13",
+    "head_sha": "9c08a062",
     "surfaces": {
       "docs": 1,
       "frontend": 0,
@@ -584,8 +761,8 @@
     "closes": [
       2068
     ],
-    "number": null,
-    "url": null
+    "number": 2069,
+    "url": "https://github.com/jiazhenz026/SciStudio/pull/2069"
   },
   "reconcile_events": [
     {
@@ -620,6 +797,22 @@
     {
       "at": "2026-08-10T20:27:36.867912Z",
       "diff_fingerprint": "sha256:b75fc3961f566bad3fc387aa55bf9b0123b31b825ce74b3493fe9d7bdb1c9e55",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-10T20:28:11.643247Z",
+      "diff_fingerprint": "sha256:c67e519e0517df61cabc49bcf4822e80d57b4231a478a22629da37e746dd3004",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-10T20:28:22.287044Z",
+      "diff_fingerprint": "sha256:c67e519e0517df61cabc49bcf4822e80d57b4231a478a22629da37e746dd3004",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 1,

--- a/.workflow/records/2068-2068-startup-repair-and-splash.json
+++ b/.workflow/records/2068-2068-startup-repair-and-splash.json
@@ -1,0 +1,757 @@
+{
+  "branch": "feature/2068-startup-repair-and-splash",
+  "check_events": [
+    {
+      "at": "2026-08-10T20:18:18.144924Z",
+      "command": "pytest tests/architecture/ -v --no-cov",
+      "covered_surface": "architecture",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:6e1b3fd5c40a22de33dc963e1de3ebf1344f0f9be09c1548e9810dfc1d987b2d",
+      "name": "architecture_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/architecture_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-10T20:18:19.010774Z",
+      "command": "python scripts/deferral_scan.py --check docs/audit/baselines/deferral-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:d195411c017130f3e84515d0162ca8bf45711ab7a128da0ab75165a68f69c283",
+      "name": "deferral_discipline",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/deferral_discipline.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-10T20:18:19.374126Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:67aabbba05e9b894e6e329e7687f2e35d1b85c965d1a3ffedcbbb7a31cc6c2c6",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-10T20:18:23.619271Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:59d32a17e19eaacb6a6ce0c1ea4f54d7f74ce8d7edc4ff86e9fbac94628f191c",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-10T20:18:24.083401Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:99cb3b50c4840bbcd8e3cda901a6ab3382e2420af940f63f57e64818befc9626",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-10T20:18:24.134451Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:2c7f6cc79ffccddf172b317a0787644b351bcfdc5236778dd01b16114f1b6261",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-10T20:20:31.275987Z",
+      "command": "python -m scistudio.qa.testing.run_python_tests --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:3ce600ad8b2aafa063a078a98073155c9f3fc57c36a0f5879080e38832f7c3c1",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-10T20:23:01.263734Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:f317e007428e1390acfb026d8433e7054a1ddeec27077e4b4007db4187f56c2b",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-10T20:23:08.208036Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:1437e09668775f207bd3341748d775ddc1fbdecc3882a2f85bdf15faf09f6911",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    },
+    {
+      "at": "2026-08-10T20:26:28.138278Z",
+      "command": "python -m scistudio.qa.testing.run_python_tests --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:3ce600ad8b2aafa063a078a98073155c9f3fc57c36a0f5879080e38832f7c3c1",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    }
+  ],
+  "check_na": [],
+  "commit": {
+    "sha": "64b52a1307b974e59242a5446eda35fbe73a64e4",
+    "shas": [
+      "64b52a1307b974e59242a5446eda35fbe73a64e4"
+    ],
+    "trailers": []
+  },
+  "declared_scope": {
+    "exclude": [],
+    "include": []
+  },
+  "directive_events": [],
+  "docs_events": [
+    {
+      "at": "2026-08-10T20:01:35.841986Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/specs/desktop-package-ota-hot-update.md",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": false,
+  "guard_events": [
+    {
+      "at": "2026-08-10T20:23:08.247282Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-10T20:23:08.258616Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-10T20:23:08.269637Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-10T20:23:08.281068Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-10T20:23:08.292790Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-10T20:23:08.304020Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-10T20:23:08.314983Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-10T20:23:08.325654Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-10T20:23:08.337136Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-10T20:23:08.347723Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-10T20:23:08.360052Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-10T20:26:28.175825Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-10T20:26:28.186535Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-10T20:26:28.197057Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-10T20:26:28.207132Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-10T20:26:28.217027Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-10T20:26:28.227673Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-10T20:26:28.238486Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-10T20:26:28.248953Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-10T20:26:28.259500Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-10T20:26:28.269382Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-10T20:26:28.281406Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-10T20:26:52.093672Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-10T20:26:52.104402Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-10T20:26:52.116338Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-10T20:26:52.127122Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-10T20:26:52.139503Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-10T20:26:52.150628Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-10T20:26:52.161068Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-10T20:26:52.171705Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-10T20:26:52.184117Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-10T20:26:52.195923Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-10T20:26:52.208720Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-10T20:27:36.764566Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-10T20:27:36.774719Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-10T20:27:36.785579Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-10T20:27:36.795682Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-10T20:27:36.806536Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-10T20:27:36.816276Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-10T20:27:36.826238Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-10T20:27:36.836374Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-10T20:27:36.846504Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-10T20:27:36.856182Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-10T20:27:36.867884Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 2068,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": {
+    "base": "origin/main",
+    "base_sha": "c8f308c1",
+    "changed_files": [
+      "desktop/main.js",
+      "desktop/ota.js",
+      "desktop/package.json",
+      "desktop/splash.html",
+      "desktop/test/ota.test.js",
+      "docs/specs/desktop-package-ota-hot-update.md",
+      "src/scistudio/api/runtime/__init__.py",
+      "src/scistudio/desktop/package_installer.py",
+      "tests/api/test_runtime_package_repair.py",
+      "tests/desktop/test_package_installer.py"
+    ],
+    "diff_fingerprint": "sha256:b75fc3961f566bad3fc387aa55bf9b0123b31b825ce74b3493fe9d7bdb1c9e55",
+    "head": "HEAD",
+    "head_sha": "64b52a13",
+    "surfaces": {
+      "docs": 1,
+      "frontend": 0,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 2,
+      "packaging": 0,
+      "protected_architecture": 0,
+      "protected_core": 0,
+      "sentrux": 5,
+      "test": 3,
+      "workflow_ci": 0
+    }
+  },
+  "owner_directive": "\u8c03\u67e5\u684c\u9762\u7248\u542f\u52a8\u6162\u7684\u539f\u56e0\u5e76\u4f18\u5316\uff1b\u4fee\u6b7b\u5faa\u73af+\u79fb\u51fa\u5173\u952e\u8def\u5f84+\u542f\u52a8\u7a97\u53e3\u4e00\u5171\u63d0\u4ea41\u4e2aPR",
+  "persona": "implementer",
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [
+      2068
+    ],
+    "number": null,
+    "url": null
+  },
+  "reconcile_events": [
+    {
+      "at": "2026-08-10T20:23:08.360108Z",
+      "diff_fingerprint": "sha256:b75fc3961f566bad3fc387aa55bf9b0123b31b825ce74b3493fe9d7bdb1c9e55",
+      "mode": "local",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.python_tests",
+        "scope.out-of-scope"
+      ]
+    },
+    {
+      "at": "2026-08-10T20:26:28.281496Z",
+      "diff_fingerprint": "sha256:b75fc3961f566bad3fc387aa55bf9b0123b31b825ce74b3493fe9d7bdb1c9e55",
+      "mode": "local",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "scope.out-of-scope"
+      ]
+    },
+    {
+      "at": "2026-08-10T20:26:52.208757Z",
+      "diff_fingerprint": "sha256:b75fc3961f566bad3fc387aa55bf9b0123b31b825ce74b3493fe9d7bdb1c9e55",
+      "mode": "local",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-10T20:27:36.867912Z",
+      "diff_fingerprint": "sha256:b75fc3961f566bad3fc387aa55bf9b0123b31b825ce74b3493fe9d7bdb1c9e55",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    }
+  ],
+  "record_id": "2068-2068-startup-repair-and-splash",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [
+      "architecture_tests",
+      "deferral_discipline",
+      "format_check",
+      "full_audit",
+      "import_contracts",
+      "lint_format",
+      "python_tests",
+      "semantic_dup",
+      "type_check"
+    ],
+    "docs": [
+      "docs_required_or_na"
+    ],
+    "guards": [
+      "architecture_doc_guard",
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": [
+      "changed_test_required"
+    ]
+  },
+  "runtime": "claude",
+  "schema_version": 2,
+  "scope_events": [
+    {
+      "action": "add-include",
+      "at": "2026-08-10T20:01:35.841593Z",
+      "pattern": "src/scistudio/desktop/package_installer.py",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-10T20:01:35.841966Z",
+      "pattern": "src/scistudio/api/runtime/__init__.py",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-10T20:01:35.841975Z",
+      "pattern": "desktop/main.js",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-10T20:01:35.841977Z",
+      "pattern": "desktop/splash.html",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-10T20:15:44.709592Z",
+      "pattern": "desktop/package.json",
+      "reason": "splash needs electron-builder file inclusion; cache-clear predicate extracted to the testable ota module per the runtime-port precedent"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-10T20:15:44.709797Z",
+      "pattern": "desktop/ota.js",
+      "reason": "splash needs electron-builder file inclusion; cache-clear predicate extracted to the testable ota module per the runtime-port precedent"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-10T20:26:42.454311Z",
+      "pattern": "tests/desktop/test_package_installer.py",
+      "reason": "declare the test and docs paths as scope includes; they were recorded only as --test-path/--docs-updated evidence at plan time"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-10T20:26:42.454516Z",
+      "pattern": "tests/api/test_runtime_package_repair.py",
+      "reason": "declare the test and docs paths as scope includes; they were recorded only as --test-path/--docs-updated evidence at plan time"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-10T20:26:42.454518Z",
+      "pattern": "desktop/test/ota.test.js",
+      "reason": "declare the test and docs paths as scope includes; they were recorded only as --test-path/--docs-updated evidence at plan time"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-10T20:26:42.454519Z",
+      "pattern": "docs/specs/desktop-package-ota-hot-update.md",
+      "reason": "declare the test and docs paths as scope includes; they were recorded only as --test-path/--docs-updated evidence at plan time"
+    }
+  ],
+  "session_id": "5692fea9-0f50-4451-9cd4-de562713c5fc",
+  "strictness_tier": 1,
+  "task_kind": "feature",
+  "test_events": [
+    {
+      "at": "2026-08-10T20:01:35.841993Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/desktop/test_package_installer.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-10T20:01:35.841996Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/api/test_runtime_package_repair.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-10T20:15:44.709802Z",
+      "class": null,
+      "kind": "path",
+      "path": "desktop/test/ota.test.js",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -1,4 +1,4 @@
-const { app, BrowserWindow, dialog, ipcMain, session } = require("electron");
+const { app, BrowserWindow, dialog, ipcMain, nativeTheme, session } = require("electron");
 const { spawn, spawnSync } = require("child_process");
 const crypto = require("crypto");
 const fs = require("fs");
@@ -39,6 +39,7 @@ const OTA_DOWNLOAD_TIMEOUT_MS = 120000;
 const OTA_MAX_REDIRECTS = 5;
 
 let mainWindow = null;
+let splashWindow = null;
 let runtimeProcess = null;
 let isQuitting = false;
 let cachedMacLoginShellEnv = null;
@@ -1106,6 +1107,31 @@ function startRuntimeOnPort(port) {
   });
 }
 
+function cacheBuildPath() {
+  return path.join(app.getPath("userData"), "cache-build.json");
+}
+
+// #2068: this used to be an unconditional clearCache() on every launch, which
+// threw away the frontend bundle each time and made every start pay a full
+// re-download and re-parse. The served assets only change when the effective
+// build changes (a new baseline or a newly applied OTA patch), so that is the
+// only moment the cache has to be dropped — which is what e538c071 was after.
+async function clearCacheOnBuildChange() {
+  const build = effectiveBuild();
+  if (!ota.shouldClearCache(readJsonSafe(cacheBuildPath()), build)) {
+    return;
+  }
+  safeLog(`[scistudio] clearing HTTP cache for build ${build}`);
+  await session.defaultSession.clearCache();
+  try {
+    writeJsonAtomic(cacheBuildPath(), { build });
+  } catch (error) {
+    // Best-effort: failing to record it only costs the next launch one more
+    // cache clear, which must not stop this one from starting.
+    safeError(`[scistudio] failed to record cache build: ${error.message}`);
+  }
+}
+
 function launchUrl(runtimeUrl) {
   const frontendUrl = process.env.SCISTUDIO_DESKTOP_FRONTEND_URL;
   const url = frontendUrl && frontendUrl.trim() ? frontendUrl.trim() : runtimeUrl;
@@ -1184,6 +1210,9 @@ function loadBeforeShowing(window, url, attempt = 0) {
     if (!window.isDestroyed() && !window.isVisible()) {
       window.show();
     }
+    // #2068: hand over only once the real window is up, so the two are never
+    // both absent and the user sees no gap.
+    closeSplash();
   };
 
   window.webContents.once("did-finish-load", async () => {
@@ -1207,6 +1236,78 @@ function loadBeforeShowing(window, url, attempt = 0) {
   });
 
   window.loadURL(url);
+}
+
+// #2068: the main window is deliberately hidden until the SPA has painted, and
+// everything before that — mandatory-update check, interpreter start, import
+// chain, registry scans — is silent. Measured at ~16s on a healthy launch, all
+// of it with nothing on screen. The splash owns that window of time and reports
+// the phase the main process is already in.
+function createSplashWindow() {
+  const splash = new BrowserWindow({
+    width: 380,
+    height: 260,
+    resizable: false,
+    maximizable: false,
+    minimizable: false,
+    fullscreenable: false,
+    frame: false,
+    show: false,
+    center: true,
+    skipTaskbar: true,
+    title: "SciStudio",
+    backgroundColor: nativeTheme.shouldUseDarkColors ? "#171a21" : "#f7f8fb",
+    webPreferences: {
+      contextIsolation: true,
+      nodeIntegration: false,
+      sandbox: true
+    }
+  });
+
+  splash.once("ready-to-show", () => {
+    if (!splash.isDestroyed()) {
+      splash.show();
+    }
+  });
+  // The status set before the page finished loading would have been dropped by
+  // executeJavaScript, so replay the latest one once the function exists.
+  splash.webContents.on("did-finish-load", () => {
+    applySplashStatus(splash);
+  });
+  splash.loadFile(path.join(__dirname, "splash.html"));
+  return splash;
+}
+
+let splashStatusText = "Starting…";
+
+function applySplashStatus(splash) {
+  if (!splash || splash.isDestroyed()) {
+    return;
+  }
+  splash.webContents
+    .executeJavaScript(
+      `window.__scistudioSplashStatus && window.__scistudioSplashStatus(${JSON.stringify(splashStatusText)})`,
+      true
+    )
+    .catch(() => {
+      // The splash is cosmetic; a failed status update must never break startup.
+    });
+}
+
+function splashStatus(message) {
+  splashStatusText = message;
+  safeLog(`[scistudio] splash: ${message}`);
+  applySplashStatus(splashWindow);
+}
+
+function closeSplash() {
+  if (!splashWindow || splashWindow.isDestroyed()) {
+    splashWindow = null;
+    return;
+  }
+  const splash = splashWindow;
+  splashWindow = null;
+  splash.close();
 }
 
 function createWindow(url) {
@@ -1276,15 +1377,20 @@ app.whenReady().then(async () => {
   }
   try {
     safeLog("[scistudio] electron ready");
+    splashWindow = createSplashWindow();
     // #1868: enforce a mandatory OTA update before starting the runtime/window.
     // Fail-open: returns true (continue) unless a fetched manifest marks the
     // update mandatory and the user declines or it cannot be applied.
+    splashStatus("Checking for updates…");
     const proceed = await maybeEnforceMandatoryUpdate();
     if (!proceed) {
+      closeSplash();
       return;
     }
+    splashStatus("Starting the SciStudio runtime…");
     const { ready } = await startRuntimeWithRollback();
     safeLog(`[scistudio] waiting for HTTP readiness at ${ready.url}`);
+    splashStatus("Loading blocks and data types…");
     await waitForHttpReady(ready.url);
     // #1986: the runtime answered on this port, so it is worth reusing next
     // launch to keep the renderer origin (and its persisted UI state) stable.
@@ -1292,9 +1398,10 @@ app.whenReady().then(async () => {
     // #1775: the runtime reached ready, so whatever patch is active booted
     // cleanly; remember it as the rollback target for future launches.
     recordKnownGood(effectiveBuild());
-    await session.defaultSession.clearCache();
+    await clearCacheOnBuildChange();
     const url = launchUrl(ready.url);
     safeLog(`[scistudio] creating window for ${url}`);
+    splashStatus("Loading the interface…");
     createWindow(url);
     // #1775: check for an OTA update after the window is up so startup is never
     // blocked on the network. Fire-and-forget; failures are logged, not fatal.
@@ -1303,6 +1410,7 @@ app.whenReady().then(async () => {
     });
   } catch (error) {
     safeError(`[scistudio] startup failed: ${error instanceof Error ? error.stack : String(error)}`);
+    closeSplash();
     await dialog.showMessageBox({
       type: "error",
       title: "SciStudio failed to start",

--- a/desktop/ota.js
+++ b/desktop/ota.js
@@ -142,6 +142,20 @@ function pythonPathFor({ isPackaged, patchSrc, stagedSrc, checkoutSrc }) {
   return [patchSrc, stagedSrc, checkoutSrc].filter(Boolean);
 }
 
+// #2068: the renderer's HTTP cache used to be cleared on every launch, so each
+// start re-downloaded and re-parsed the whole frontend bundle. The served assets
+// only change when the effective build changes — a new baseline or a newly
+// applied OTA patch — which is the case e538c071 was actually guarding against.
+//
+// An unreadable or missing record clears, so a first run after this lands (and
+// any corrupted pointer) still starts from a known-clean cache.
+function shouldClearCache(recorded, build) {
+  if (!recorded || typeof recorded.build !== "number") {
+    return true;
+  }
+  return recorded.build !== build;
+}
+
 module.exports = {
   VERSION_RE,
   parseVersion,
@@ -151,5 +165,6 @@ module.exports = {
   evaluateUpdate,
   resolveActivePatch,
   pythonPathFor,
+  shouldClearCache,
   displayBuildVersion
 };

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -38,6 +38,7 @@
       "ota.js",
       "runtime-port.js",
       "preload.js",
+      "splash.html",
       "package.json",
       "assets/icon.png"
     ],

--- a/desktop/splash.html
+++ b/desktop/splash.html
@@ -1,0 +1,112 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src 'self'; style-src 'unsafe-inline'; script-src 'unsafe-inline'" />
+    <title>Starting SciStudio</title>
+    <style>
+      :root {
+        --splash-bg: #f7f8fb;
+        --splash-fg: #1c2333;
+        --splash-muted: #6b7488;
+        --splash-track: #e2e6ef;
+        --splash-accent: #3b6ef5;
+      }
+
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --splash-bg: #171a21;
+          --splash-fg: #eef1f7;
+          --splash-muted: #98a1b5;
+          --splash-track: #2a2f3a;
+          --splash-accent: #6d94ff;
+        }
+      }
+
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+
+      body {
+        width: 100vw;
+        height: 100vh;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 14px;
+        background: var(--splash-bg);
+        color: var(--splash-fg);
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+        user-select: none;
+        cursor: default;
+        -webkit-app-region: drag;
+      }
+
+      img {
+        width: 64px;
+        height: 64px;
+        border-radius: 14px;
+      }
+
+      h1 {
+        font-size: 17px;
+        font-weight: 600;
+        letter-spacing: 0.01em;
+      }
+
+      #status {
+        font-size: 12.5px;
+        color: var(--splash-muted);
+        min-height: 16px;
+        text-align: center;
+        padding: 0 24px;
+      }
+
+      #track {
+        width: 190px;
+        height: 3px;
+        border-radius: 999px;
+        background: var(--splash-track);
+        overflow: hidden;
+      }
+
+      #bar {
+        width: 40%;
+        height: 100%;
+        border-radius: 999px;
+        background: var(--splash-accent);
+        animation: slide 1.35s ease-in-out infinite;
+      }
+
+      @keyframes slide {
+        0% { transform: translateX(-105%); }
+        100% { transform: translateX(255%); }
+      }
+
+      @media (prefers-reduced-motion: reduce) {
+        #bar {
+          animation: none;
+          width: 100%;
+          opacity: 0.55;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <img src="assets/icon.png" alt="" />
+    <h1>SciStudio</h1>
+    <div id="status">Starting&#8230;</div>
+    <div id="track"><div id="bar"></div></div>
+    <script>
+      // Issue #2068: the main process drives this via executeJavaScript rather
+      // than IPC, so the splash needs no preload script and can stay sandboxed
+      // with scripting limited to this one function.
+      window.__scistudioSplashStatus = (text) => {
+        document.getElementById("status").textContent = text;
+      };
+    </script>
+  </body>
+</html>

--- a/desktop/test/ota.test.js
+++ b/desktop/test/ota.test.js
@@ -190,3 +190,21 @@ test("pythonPathFor: dev uses only the worktree checkout src", () => {
     ["/repo/src"]
   );
 });
+
+// #2068: the HTTP cache was cleared on every launch, so each start threw away
+// the frontend bundle and paid a full re-download and re-parse. It only has to
+// be dropped when the served assets change, which is a build change.
+test("shouldClearCache: only when the effective build changed", () => {
+  assert.equal(ota.shouldClearCache({ build: 22 }, 22), false);
+  assert.equal(ota.shouldClearCache({ build: 21 }, 22), true);
+  assert.equal(ota.shouldClearCache({ build: 22 }, 0), true);
+});
+
+test("shouldClearCache: a missing or unusable record clears", () => {
+  // First launch after this lands, and any corrupted pointer, must still start
+  // from a known-clean cache rather than trusting an unreadable record.
+  assert.equal(ota.shouldClearCache(null, 22), true);
+  assert.equal(ota.shouldClearCache(undefined, 22), true);
+  assert.equal(ota.shouldClearCache({}, 22), true);
+  assert.equal(ota.shouldClearCache({ build: "22" }, 22), true);
+});

--- a/docs/specs/desktop-package-ota-hot-update.md
+++ b/docs/specs/desktop-package-ota-hot-update.md
@@ -135,6 +135,33 @@ new code requires a fresh interpreter. The Package Manager prompts a restart and
 calls the `scistudio:relaunch` IPC (`app.relaunch(); app.exit(0)`). Rollback
 restores the backup and discards the current version; delete removes both.
 
+### 5.1 Dependency cache is output, never input
+
+Because `source_path` is repointed at the install dir, the "source" handed to
+`install_local_package` is routinely a previous install of the same package. The
+staging copy therefore excludes `site-packages`, and the dependency target is
+rebuilt from empty before pip runs. Both are load-bearing rather than tidiness:
+pip's `--target` overwrites same-named files and leaves everything else in place,
+so a cache that is copied forward accumulates every prior generation of wheels.
+
+That accumulation was self-sustaining (#2068). A `.so` compiled for a retired
+Python ABI is exactly what `repair_installed_package_dependencies` looks for, and
+the repair used to carry that file into staging and back out again — so the
+repair re-created its own trigger and re-ran on every launch, costing a measured
+11.7s-36s each time. Rebuilding the cache from scratch means a repair clears the
+condition that caused it, and the next launch finds nothing to do.
+
+### 5.2 Repair runs off the startup path
+
+`ApiRuntime` scans its registries first and hands the repair to a background
+thread, refreshing the registries again only if a cache was actually rebuilt. A
+package whose compiled dependencies target a dead ABI is already unusable, so
+blocking every launch on the fix buys nothing — and at 36s it exceeded the
+desktop's 30s HTTP readiness timeout, turning a slow launch into a failed one.
+
+A package repaired mid-session reaches the frontend on the next reload, the same
+limitation tracked in #1791.
+
 ## 6. API and UI
 
 - `GET /api/packages/installed` — on-disk install records.

--- a/src/scistudio/api/runtime/__init__.py
+++ b/src/scistudio/api/runtime/__init__.py
@@ -95,18 +95,31 @@ def _desktop_package_dependency_repair_enabled() -> bool:
     return raw not in {"0", "false", "no", "off"}
 
 
-def _repair_desktop_package_dependencies() -> None:
+def _repair_desktop_package_dependencies() -> bool:
+    """Rebuild package dependency caches whose compiled artefacts target another ABI.
+
+    Returns ``True`` when at least one cache was rebuilt, so the caller knows the
+    registries it already scanned are now stale.
+
+    Issue #2068: this ends in ``pip install`` subprocesses and has been measured
+    at 11.7s-36s, so it must never run on the startup critical path — 36s alone
+    exceeds the desktop's 30s HTTP readiness timeout and turns a slow launch into
+    a failed one. :meth:`ApiRuntime._configure_static_registries` therefore hands
+    it to a background thread and refreshes the registries again once it lands.
+    """
     if not _is_bundled_desktop_run() or not _desktop_package_dependency_repair_enabled():
-        return
+        return False
     try:
         from scistudio.desktop.package_installer import repair_installed_package_dependencies
 
         results = repair_installed_package_dependencies()
     except Exception:
-        logger.warning("desktop package dependency repair failed before registry refresh", exc_info=True)
-        return
+        logger.warning("desktop package dependency repair failed", exc_info=True)
+        return False
+    repaired_any = False
     for result in results:
         if result.repaired:
+            repaired_any = True
             logger.info(
                 "desktop package dependency cache repaired for %s %s: %s",
                 result.package_name,
@@ -121,6 +134,7 @@ def _repair_desktop_package_dependencies() -> None:
                 result.reason,
                 f" ({result.error})" if result.error else "",
             )
+    return repaired_any
 
 
 # #1551 / DSN-12: the per-session ``data_catalog`` and ``workflow_runs`` registries
@@ -414,9 +428,42 @@ class ApiRuntime:
         self._workflow_runs = registry
 
     def _configure_static_registries(self) -> None:
-        _repair_desktop_package_dependencies()
         self.refresh_type_registry()
         self.refresh_block_registry()
+        self._start_background_package_repair()
+
+    def _start_background_package_repair(self) -> None:
+        """Repair desktop package dependency caches without blocking startup.
+
+        Issue #2068: this used to be the first statement of this method, which
+        put a ``pip install`` on the path between ``Waiting for application
+        startup.`` and ``Application startup complete.`` — measured at 11.7s in
+        the common case and 36s at worst, against a 30s desktop HTTP readiness
+        timeout. A package whose compiled dependencies target a dead ABI is
+        already unusable, so nothing is gained by making every launch wait for
+        the fix; the registries are scanned immediately and rebuilt afterwards
+        only if a repair actually changed something.
+
+        The frontend is not told about the second refresh, so a package repaired
+        mid-session appears after the next reload — same limitation as #1791.
+        """
+        if not _is_bundled_desktop_run() or not _desktop_package_dependency_repair_enabled():
+            return
+
+        def _repair_then_refresh() -> None:
+            if not _repair_desktop_package_dependencies():
+                return
+            try:
+                self.refresh_type_registry()
+                self.refresh_block_registry()
+            except Exception:
+                logger.warning("registry refresh after package dependency repair failed", exc_info=True)
+
+        threading.Thread(
+            target=_repair_then_refresh,
+            name="scistudio-package-repair",
+            daemon=True,
+        ).start()
 
     def _bind_event_logging(self) -> None:
         async def _emit_log(event: Any) -> None:

--- a/src/scistudio/desktop/package_installer.py
+++ b/src/scistudio/desktop/package_installer.py
@@ -23,6 +23,16 @@ from scistudio.desktop import paths
 _MANIFEST_NAME = "scistudio-local-package.json"
 _SUPPORTED_ARCHIVE_SUFFIXES = {".zip", ".tar", ".tgz", ".tar.gz", ".tar.bz2", ".tar.xz"}
 
+# Issue #2068: the dependency cache is pip's output, never installer input. An
+# OTA install repoints ``source_path`` at the install dir itself
+# (``package_manager._repoint_install_source``), so a source tree handed to this
+# module can *be* a previous install — copying its ``site-packages`` forward
+# would carry every prior generation of wheels along with it, including files
+# compiled for a Python ABI that no longer runs. That is what made
+# ``_first_mismatched_binary_tag`` fire on every launch: the repair kept
+# re-importing the very files that triggered it.
+_STAGE_IGNORE = shutil.ignore_patterns("__pycache__", "*.pyc", paths.PACKAGE_SITE_DIR_NAME)
+
 
 class PackageInstallError(ValueError):
     """Raised when a local package cannot be installed."""
@@ -91,7 +101,7 @@ def install_local_package(
                 raise PackageInstallError(f"No SciStudio block package found in {resolved_source}")
             metadata = _source_metadata(package_root)
             dependencies = _source_dependencies(package_root)
-            shutil.copytree(package_root, prepared_dir, ignore=shutil.ignore_patterns("__pycache__", "*.pyc"))
+            shutil.copytree(package_root, prepared_dir, ignore=_STAGE_IGNORE)
             install_source = prepared_dir
         elif _is_wheel(resolved_source):
             metadata = _wheel_metadata(resolved_source)
@@ -111,7 +121,7 @@ def install_local_package(
                 raise PackageInstallError(f"No SciStudio block package found in {resolved_source}")
             metadata = _source_metadata(package_root)
             dependencies = _source_dependencies(package_root)
-            shutil.copytree(package_root, prepared_dir, ignore=shutil.ignore_patterns("__pycache__", "*.pyc"))
+            shutil.copytree(package_root, prepared_dir, ignore=_STAGE_IGNORE)
             install_source = prepared_dir
         else:
             suffixes = "".join(resolved_source.suffixes) or resolved_source.suffix
@@ -410,6 +420,14 @@ def _install_runtime_package(
     target_dir: Path,
     python_executable: str,
 ) -> None:
+    # Issue #2068: pip's ``--target`` overwrites same-named files and leaves
+    # every other file in place, so installing into a populated directory
+    # accumulates generations of wheels instead of replacing them. Rebuilding
+    # from empty keeps the cache the output of exactly one dependency resolve.
+    # ``_STAGE_IGNORE`` already keeps an inherited cache out of the staging dir;
+    # this is the second line of defence for callers that stage differently.
+    if target_dir.exists():
+        shutil.rmtree(target_dir)
     target_dir.mkdir(parents=True, exist_ok=True)
     _run_pip(
         [

--- a/tests/api/test_runtime_package_repair.py
+++ b/tests/api/test_runtime_package_repair.py
@@ -1,0 +1,109 @@
+"""Scheduling tests for the desktop package dependency repair (#2068).
+
+The repair ends in ``pip install`` subprocesses and was measured at 11.7s in the
+common case and 36s at worst. It used to be the first statement of
+``ApiRuntime._configure_static_registries``, which put that cost between
+uvicorn's "Waiting for application startup." and readiness — against the
+desktop's 30s HTTP readiness timeout, so the slow case did not merely feel slow,
+it failed the launch outright.
+"""
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+from scistudio.api import runtime as runtime_module
+from scistudio.api.runtime import ApiRuntime
+
+pytestmark = pytest.mark.serial
+
+
+class _RegistryStub:
+    """Minimal object carrying the real method under test.
+
+    A full ``ApiRuntime`` would scan the block and type registries, which is what
+    this test is trying to observe rather than perform.
+    """
+
+    _start_background_package_repair = ApiRuntime._start_background_package_repair
+
+    def __init__(self) -> None:
+        self.refreshed: list[str] = []
+
+    def refresh_type_registry(self) -> None:
+        self.refreshed.append("type")
+
+    def refresh_block_registry(self) -> None:
+        self.refreshed.append("block")
+
+
+def _capture_threads(monkeypatch: pytest.MonkeyPatch) -> list[threading.Thread]:
+    created: list[threading.Thread] = []
+    real_thread = threading.Thread
+
+    def capture(*args: object, **kwargs: object) -> threading.Thread:
+        thread = real_thread(*args, **kwargs)  # type: ignore[arg-type]
+        created.append(thread)
+        return thread
+
+    monkeypatch.setattr(runtime_module.threading, "Thread", capture)
+    return created
+
+
+def test_package_repair_runs_off_the_startup_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    entered = threading.Event()
+    release = threading.Event()
+
+    def fake_repair() -> bool:
+        entered.set()
+        assert release.wait(5)
+        return True
+
+    monkeypatch.setattr(runtime_module, "_is_bundled_desktop_run", lambda: True)
+    monkeypatch.setattr(runtime_module, "_repair_desktop_package_dependencies", fake_repair)
+    created = _capture_threads(monkeypatch)
+
+    stub = _RegistryStub()
+    stub._start_background_package_repair()
+
+    # Startup has already moved on while the repair is still mid-flight.
+    assert entered.wait(5)
+    assert stub.refreshed == []
+
+    release.set()
+    created[0].join(5)
+    # A repair rewrites the dependency cache the registries were scanned against,
+    # so they are rebuilt once it lands.
+    assert stub.refreshed == ["type", "block"]
+
+
+def test_package_repair_skips_registry_refresh_when_nothing_changed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(runtime_module, "_is_bundled_desktop_run", lambda: True)
+    monkeypatch.setattr(runtime_module, "_repair_desktop_package_dependencies", lambda: False)
+    created = _capture_threads(monkeypatch)
+
+    stub = _RegistryStub()
+    stub._start_background_package_repair()
+    created[0].join(5)
+
+    assert stub.refreshed == []
+
+
+def test_package_repair_is_skipped_outside_a_bundled_desktop_run(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(runtime_module, "_is_bundled_desktop_run", lambda: False)
+    monkeypatch.setattr(
+        runtime_module,
+        "_repair_desktop_package_dependencies",
+        lambda: pytest.fail("repair must not run outside a bundled desktop run"),
+    )
+    created = _capture_threads(monkeypatch)
+
+    _RegistryStub()._start_background_package_repair()
+
+    assert created == []

--- a/tests/desktop/test_package_installer.py
+++ b/tests/desktop/test_package_installer.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import sys
 import zipfile
 from pathlib import Path
@@ -242,6 +243,148 @@ def test_install_archive_rejects_path_traversal(tmp_path: Path) -> None:
 
     with pytest.raises(PackageInstallError, match="outside its install root"):
         install_local_package(archive_path, install_root=tmp_path / "installed")
+
+
+def test_install_source_directory_does_not_inherit_dependency_cache(tmp_path: Path) -> None:
+    """#2068: a source tree's ``site-packages`` must never be copied forward.
+
+    ``package_manager._repoint_install_source`` points every OTA-installed
+    package's ``source_path`` at its own install directory, so the "source" handed
+    to the installer is routinely a previous install. Copying its dependency cache
+    into the staging dir carried every prior generation of wheels along with it —
+    including files compiled for a Python ABI that no longer runs, which is what
+    made the ABI check fire on every launch forever.
+    """
+    source_root = _write_source_package(
+        tmp_path / "source",
+        dist_name="scistudio-blocks-inheritprobe",
+        module_name="scistudio_blocks_inheritprobe",
+        block_name="InheritProbeBlock",
+        package_name="Inherit Probe",
+    )
+    stale_cache = source_root / desktop_paths.PACKAGE_SITE_DIR_NAME / "numpy"
+    stale_cache.mkdir(parents=True)
+    (stale_cache / "_multiarray_umath.cpython-311-darwin.so").write_bytes(b"")
+    install_root = tmp_path / "installed"
+
+    result = install_local_package(source_root, install_root=install_root)
+
+    assert not (result.install_path / desktop_paths.PACKAGE_SITE_DIR_NAME).exists()
+
+
+def test_install_runtime_package_rebuilds_target_from_empty(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """#2068: pip ``--target`` overwrites same-named files and keeps the rest.
+
+    Installing into a populated directory therefore accumulates generations of
+    wheels rather than replacing them, so the cache must start empty.
+    """
+    target = tmp_path / desktop_paths.PACKAGE_SITE_DIR_NAME
+    target.mkdir()
+    (target / "stale.cpython-311-darwin.so").write_bytes(b"")
+    (target / "numpy-2.4.6.dist-info").mkdir()
+
+    def fake_run_pip(command: list[str]) -> None:
+        installed_into = Path(command[command.index("--target") + 1])
+        installed_into.mkdir(parents=True, exist_ok=True)
+        (installed_into / "fresh.cpython-312-darwin.so").write_bytes(b"")
+
+    monkeypatch.setattr(package_installer, "_run_pip", fake_run_pip)
+
+    package_installer._install_runtime_package(
+        tmp_path / "source",
+        runtime_dependencies=("numpy>=1.24",),
+        target_dir=target,
+        python_executable="python",
+    )
+
+    assert not (target / "stale.cpython-311-darwin.so").exists()
+    assert not (target / "numpy-2.4.6.dist-info").exists()
+    assert (target / "fresh.cpython-312-darwin.so").exists()
+
+
+def test_repair_of_self_sourced_install_drops_stale_abi_files(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """#2068: the repair has to clear the condition that triggered it.
+
+    An OTA-installed package's ``source_path`` is its own install directory, so
+    repair used to copy the stale cache into staging, layer pip's output on top,
+    and move the whole thing back — leaving the mismatched ``.so`` in place to
+    trigger the identical repair on the next launch, forever.
+    """
+    staged = _write_source_package(
+        tmp_path / "staging",
+        dist_name="scistudio-blocks-selfprobe",
+        module_name="scistudio_blocks_selfprobe",
+        block_name="SelfProbeBlock",
+        package_name="Self Probe",
+        dependencies=("numpy>=1.24",),
+    )
+    install_root = tmp_path / "installed"
+    install_path = install_root / "scistudio-blocks-selfprobe-0.1.0"
+    install_root.mkdir()
+    shutil.copytree(staged, install_path)
+
+    site_dir = install_path / desktop_paths.PACKAGE_SITE_DIR_NAME
+    (site_dir / "numpy").mkdir(parents=True)
+    (site_dir / "numpy" / "_multiarray_umath.cpython-311-darwin.so").write_bytes(b"")
+    (install_path / "scistudio-local-package.json").write_text(
+        json.dumps(
+            {
+                "format": "source-directory",
+                "installed_at": "2026-06-27T00:00:00+00:00",
+                "modules": ["scistudio_blocks_selfprobe"],
+                "package_name": "scistudio-blocks-selfprobe",
+                # The self-referential source_path that OTA installs record.
+                "source_path": str(install_path),
+                "version": "0.1.0",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    def fake_run_pip(command: list[str]) -> None:
+        installed_into = Path(command[command.index("--target") + 1])
+        installed_into.mkdir(parents=True, exist_ok=True)
+        (installed_into / "numpy").mkdir(exist_ok=True)
+        (installed_into / "numpy" / "_multiarray_umath.cpython-312-darwin.so").write_bytes(b"")
+
+    monkeypatch.setattr(package_installer, "_run_pip", fake_run_pip)
+    monkeypatch.setattr(
+        package_installer,
+        "_python_runtime_info",
+        lambda python: package_installer._PythonRuntimeInfo(
+            executable=str(Path(python)),
+            version="3.12.13",
+            cache_tag="cpython-312",
+        ),
+    )
+
+    results = package_installer.repair_installed_package_dependencies(
+        install_root=install_root,
+        python_executable=tmp_path / "python",
+    )
+
+    assert [(r.package_name, r.repaired) for r in results] == [("scistudio-blocks-selfprobe", True)]
+    assert results[0].reason == "compiled dependency targets cpython-311-darwin"
+
+    repaired_site = install_path / desktop_paths.PACKAGE_SITE_DIR_NAME
+    surviving = sorted(p.name for p in repaired_site.rglob("*.so"))
+    assert surviving == ["_multiarray_umath.cpython-312-darwin.so"]
+
+    # The trigger is now gone, so a second launch finds nothing to repair --
+    # without this the loop re-arms itself every time.
+    assert (
+        package_installer.repair_installed_package_dependencies(
+            install_root=install_root,
+            python_executable=tmp_path / "python",
+        )
+        == []
+    )
 
 
 def test_repair_installed_package_dependencies_reinstalls_mismatched_abi(


### PR DESCRIPTION
## Problem

Desktop launch showed nothing for 12-20 seconds and then the main window appeared. On slower runs the backend crossed the 30s `HTTP_READY_TIMEOUT_MS` and startup failed outright with "SciStudio runtime did not start" (2026-08-05 16:06 and 2026-08-09 02:07 in the desktop log).

Measured breakdown of one healthy launch:

| stage | cost |
|---|---|
| OTA mandatory-update manifest fetch | 0.27s |
| login shell env probe | ~0.00s |
| interpreter start + import chain (`cli.main` 0.11s, `api.app` 1.29s) | ~2s |
| **lifespan: package dependency repair** | **11.72s** |
| lifespan: pint unit registry | 0.26s |
| lifespan: entry-point + drop-in types | 0.24s |
| lifespan: block registry scan | 1.17s |
| **total to backend ready** | **~16s** |

`Waiting for application startup.` → `Application startup complete.` is 13.40s, 87% of it the repair.

## Root cause: the repair re-created its own trigger

`package_manager._repoint_install_source` points every OTA-installed package's `source_path` at its own install directory — deliberately, because the temp-dir snapshot an OTA install is fed would otherwise dangle. So the "source" handed to `install_local_package` is routinely a previous install of the same package, and the staging `copytree` carried that install's `site-packages` forward. pip's `--target` then layered a new resolve on top without removing anything.

Filesystem evidence on the reporting machine:

```
package dir mtime:     06-27 22:51   <- never actually replaced
site-packages mtime:   08-10 15:49   <- rewritten every launch
numpy 311 .so mtime:   07-07 16:40   <- carried forward for a month
numpy 312 .so:         none exist
dist-info generations: 06-27 / 07-07 / 07-14 / 07-27 / 08-10
co-resident versions:  numpy 2.4.6+2.5.1+2.5.2, pyarrow 24.0.0+25.0.0+25.0.1
```

`_first_mismatched_binary_tag` fires on a `.so` built for a retired Python ABI — which is exactly the file the repair kept copying forward. The loop could not converge: 19 stale numpy `.so` files re-triggered a full `pip install` on every launch for a month.

The install-source manifests confirm the causal link. Only the package whose `source_path` points at itself is in the loop:

| package | `source_path` | result |
|---|---|---|
| imaging | external source dir | 215 `.so`, all 312, never repaired |
| lcms | external wheel | 191 `.so`, all 312, never repaired |
| spectroscopy | **its own install dir** | 19 stale 311 `.so`, repaired every launch |

## Blast radius

The bundled runtime has always been 3.12, so a user who only installs through the app has no stale-ABI files today. The defect is still universal and is a time bomb:

- Every Package Manager / OTA install gets `source_path` repointed at itself, so version pile-up already affects anyone who has updated a package.
- The next bundled-Python bump hands every package user a permanent stale-ABI set — a 12-36s penalty on every launch, forever, with no self-heal path.
- 36s exceeds the readiness timeout, so the tail of that distribution is a failed launch rather than a slow one.

## Changes

**1. Rebuild dependency caches instead of inheriting them** (`package_installer.py`)
Exclude `site-packages` from the staging copy and rebuild the dependency target from empty before pip runs. The cache is pip's output and must never be its input. A repair now clears the condition that caused it, which also makes affected installs self-heal on their next launch.

**2. Run the repair off the startup path** (`api/runtime/__init__.py`)
Scan the registries first, hand the repair to a background thread, refresh again only if a cache was actually rebuilt. A package whose compiled dependencies target a dead ABI is already unusable, so making every launch wait for the fix buys nothing. A package repaired mid-session reaches the frontend on the next reload — same limitation as #1791.

**3. Splash window + build-scoped cache clear** (`desktop/main.js`, `desktop/splash.html`, `desktop/ota.js`)
The main window is created with `show: false` and only shown after `did-finish-load` plus a rendered check, so the whole startup was invisible. The splash covers that gap and reports the phase the main process is in. ADR-037 §5.1 already reserved `desktop/splash.html` for "splash during cold start"; this fills it in.

`clearCache()` also ran unconditionally on every launch, discarding the frontend bundle each time. Scoped to an effective-build change, which is what e538c071 was guarding against. The predicate lives in `ota.js` so it is testable without Electron, following the `runtime-port.js` precedent from #1986.

## Not done, deliberately

The issue also proposed short-circuiting the ABI scan on a matching `dependency_runtime.cache_tag`. The scan measures 25-66ms, so it saves nothing worth having, and skipping it would forfeit the self-heal in change 1 — an affected machine's manifest already records the correct tag while its files disagree.

## Testing

- `tests/desktop/test_package_installer.py` — three new tests: staging does not inherit a source tree's `site-packages`; the dependency target is rebuilt from empty; and a self-sourced install's repair drops the stale ABI files and leaves nothing to repair on the second pass. All three fail without the fix (verified by stashing `package_installer.py`).
- `tests/api/test_runtime_package_repair.py` — the repair runs off the startup path, refreshes registries only when something changed, and stays skipped outside a bundled desktop run.
- `desktop/test/ota.test.js` — `shouldClearCache` for build change, no change, and unusable records. 58 JS tests pass.
- Gate check tier 1: `reconciliation passed` across all nine checks.

Closes #2068
