### PR TITLE
feat(#2070): ask one last open question before the session starts

### DIFF
--- a/.workflow/records/2070-work-import-final-open-question.json
+++ b/.workflow/records/2070-work-import-final-open-question.json
@@ -213,7 +213,13 @@
       "rationale": "huggingface.co is denied by this environment's egress policy (agent proxy answers 403 to CONNECT), so fastembed cannot fetch the embedding model here; the repository's semantic-dup-scan.yml CI job runs it against this PR."
     }
   ],
-  "commit": null,
+  "commit": {
+    "sha": "6718270af1f836780111f6930564c595c460e9ab",
+    "shas": [
+      "6718270af1f836780111f6930564c595c460e9ab"
+    ],
+    "trailers": []
+  },
   "declared_scope": {
     "exclude": [],
     "include": [
@@ -563,6 +569,182 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-08-17T22:33:20.556514Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-17T22:33:20.558636Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-17T22:33:20.560795Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-17T22:33:20.562883Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-17T22:33:20.565306Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-17T22:33:20.567301Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-17T22:33:20.569406Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-17T22:33:20.571420Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-17T22:33:20.573737Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-17T22:33:20.575815Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-17T22:33:20.587812Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-17T22:35:32.988536Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-17T22:35:32.990791Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-17T22:35:32.993096Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-17T22:35:32.995482Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-17T22:35:32.997914Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-17T22:35:32.999966Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-17T22:35:33.002579Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-17T22:35:33.004745Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-17T22:35:33.006980Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-17T22:35:33.009261Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-17T22:35:33.022211Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -575,7 +757,7 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "origin/main",
+    "base": "8b9eab746f5fa9fa0de0323265debd6485754f0e",
     "base_sha": "8b9eab7",
     "changed_files": [
       ".workflow/records/2070-work-import-final-open-question.json",
@@ -598,9 +780,9 @@
       "tests/ai/test_work_import_brief.py",
       "tests/api/test_work_import_session.py"
     ],
-    "diff_fingerprint": "sha256:050d351e86cb24a2965e11fb4944d05895d0c2d1ab86330ba279706f9a314dbb",
+    "diff_fingerprint": "sha256:0c8d2298ddd9e531d024d8c4a641f7844bc9bb6c4a2ef2d79edd78b08643b6be",
     "head": "HEAD",
-    "head_sha": "d6b9704",
+    "head_sha": "6718270",
     "surfaces": {
       "docs": 2,
       "frontend": 10,
@@ -617,7 +799,14 @@
   },
   "owner_directive": "\u52a0\u4e00\u4e2a\u95ee\u7528\u6237\u7684\u95ee\u9898\u653e\u6700\u540e\uff1a\u95ee\u7528\u6237\u5728\u5f00\u59cb\u4e4b\u524d\u8fd8\u6709\u522b\u7684\u60f3\u548cagent\u8bf4\u7684\u4e1c\u897f\u5417\uff1f\u7136\u540e\u8fd9\u4e2a\u95ee\u9898\u7684\u7b54\u6848\u4e00\u8d77\u653e\u8fdbprompt\uff0c\u5141\u8bb8\u8df3\u8fc7\u8fd9\u4e2a\u95ee\u9898",
   "persona": "implementer",
-  "pull_request": null,
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [
+      2070
+    ],
+    "number": 2071,
+    "url": "https://github.com/jiazhenz026/SciStudio/pull/2071"
+  },
   "reconcile_events": [
     {
       "at": "2026-08-17T22:31:18.729273Z",
@@ -644,6 +833,26 @@
     {
       "at": "2026-08-17T22:32:51.702421Z",
       "diff_fingerprint": "sha256:050d351e86cb24a2965e11fb4944d05895d0c2d1ab86330ba279706f9a314dbb",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.semantic_dup"
+      ]
+    },
+    {
+      "at": "2026-08-17T22:33:20.587843Z",
+      "diff_fingerprint": "sha256:0c8d2298ddd9e531d024d8c4a641f7844bc9bb6c4a2ef2d79edd78b08643b6be",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.semantic_dup"
+      ]
+    },
+    {
+      "at": "2026-08-17T22:35:33.022243Z",
+      "diff_fingerprint": "sha256:0c8d2298ddd9e531d024d8c4a641f7844bc9bb6c4a2ef2d79edd78b08643b6be",
       "mode": "pre-pr",
       "result": "fail",
       "tier": 1,

--- a/.workflow/records/2070-work-import-final-open-question.json
+++ b/.workflow/records/2070-work-import-final-open-question.json
@@ -1,0 +1,119 @@
+{
+  "branch": "claude/bring-in-work-final-prompt-6ol8hj",
+  "check_events": [],
+  "check_na": [],
+  "commit": null,
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "docs/specs/adr-053-work-import.md",
+      "docs/planning/adr-053-work-import-checklist.md",
+      "src/scistudio/ai/work_import/**",
+      "src/scistudio/api/routes/work_import.py",
+      "frontend/src/components/BringInMyWorkDialog.tsx",
+      "frontend/src/components/BringInMyWorkDialog.parts/**",
+      "frontend/src/components/__tests__/**",
+      "frontend/src/lib/api/workImport.ts",
+      "tests/ai/test_work_import_brief.py",
+      "tests/api/test_work_import_session.py"
+    ]
+  },
+  "directive_events": [
+    {
+      "at": "2026-08-17T22:05:51.850547Z",
+      "owner_directive": "Question 5 (FR-019a): free text, asked last, skippable, carried to the brief as anything_else. Spec \u00a74.6 gains its question block and the template is re-transcribed from it.",
+      "reason": "plan"
+    }
+  ],
+  "docs_events": [
+    {
+      "at": "2026-08-17T22:05:51.850598Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/specs/adr-053-work-import.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-17T22:05:51.850610Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/planning/adr-053-work-import-checklist.md",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": false,
+  "guard_events": [],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 2070,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": null,
+  "owner_directive": "\u52a0\u4e00\u4e2a\u95ee\u7528\u6237\u7684\u95ee\u9898\u653e\u6700\u540e\uff1a\u95ee\u7528\u6237\u5728\u5f00\u59cb\u4e4b\u524d\u8fd8\u6709\u522b\u7684\u60f3\u548cagent\u8bf4\u7684\u4e1c\u897f\u5417\uff1f\u7136\u540e\u8fd9\u4e2a\u95ee\u9898\u7684\u7b54\u6848\u4e00\u8d77\u653e\u8fdbprompt\uff0c\u5141\u8bb8\u8df3\u8fc7\u8fd9\u4e2a\u95ee\u9898",
+  "persona": "implementer",
+  "pull_request": null,
+  "reconcile_events": [],
+  "record_id": "2070-work-import-final-open-question",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [],
+    "docs": [],
+    "guards": [],
+    "tests": []
+  },
+  "runtime": "claude",
+  "schema_version": 2,
+  "scope_events": [],
+  "session_id": "c4158111-59cb-44e5-96ba-84c3ab4ba157",
+  "strictness_tier": null,
+  "task_kind": "feature",
+  "test_events": [
+    {
+      "at": "2026-08-17T22:05:51.850618Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/ai/test_work_import_brief.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-17T22:05:51.850624Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/api/test_work_import_session.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-17T22:05:51.850631Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/components/__tests__/BringInMyWorkDialog.test.tsx",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-17T22:05:51.850634Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/components/__tests__/BringInMyWorkDialogPaging.test.tsx",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-17T22:05:51.850641Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/components/__tests__/workImport.test.ts",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/.workflow/records/2070-work-import-final-open-question.json
+++ b/.workflow/records/2070-work-import-final-open-question.json
@@ -1,7 +1,218 @@
 {
   "branch": "claude/bring-in-work-final-prompt-6ol8hj",
-  "check_events": [],
-  "check_na": [],
+  "check_events": [
+    {
+      "at": "2026-08-17T22:21:24.520137Z",
+      "command": "pytest tests/architecture/ -v --no-cov",
+      "covered_surface": "architecture",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:a8b163cdded46d1e550cec7ea356dcf428e0e320f03110fb331b26bfb7050a03",
+      "name": "architecture_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/architecture_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-17T22:21:26.667971Z",
+      "command": "python scripts/deferral_scan.py --check docs/audit/baselines/deferral-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:f31807d88c41a74fc9154c9d8c59d4487ff944ebd966a2ddb9774282445783af",
+      "name": "deferral_discipline",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/deferral_discipline.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-17T22:21:26.724923Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:2e0d195f3a24935a05d0353d3301d4a40cf31346a7032c2059814506396605b1",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-17T22:24:15.646093Z",
+      "command": "(cd frontend && npm run check:ci)",
+      "covered_surface": "frontend",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:2e8930a9a7e1cd7ef676bbc6a5edb055ab240c5afba1f29ed3d2223a704a2aeb",
+      "name": "frontend",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/frontend.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-17T22:24:26.825930Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:8da72eef4ddfe5027493fb534c735f33df64336e87c03608cafc1b62da976e6b",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-17T22:24:27.043240Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:3e53e65a9f47d8eed7a378f51afb4976383365f747669a9edbce75ac9d513f6f",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-17T22:24:27.063301Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:fd14dc157a4580c269f0d140057d64293e50533b0c502872d221fa19a5b42147",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-17T22:30:56.204644Z",
+      "command": "python -m scistudio.qa.testing.run_python_tests --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:ecb23515fea2f192381d4e5148d26fb6881bf88a33bbb003788bebcc814f0747",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-17T22:30:58.858592Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:d1309ad07ea32a9ff698436f43216a9c90d553df26fcb5e62620e0d4e36e8663",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-17T22:31:18.700469Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:8f6215c40209c245f525918ee995a0907819134b9028709fe2087a22be344f90",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    },
+    {
+      "at": "2026-08-17T22:32:06.627404Z",
+      "command": "python scripts/deferral_scan.py --check docs/audit/baselines/deferral-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:62440166fc40eb302e38424bccedacb3b927a7585669499f0f4e4e0002d79d2f",
+      "name": "deferral_discipline",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/deferral_discipline.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-17T22:32:17.700973Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:c7ca619a31dc3f362d3bedf5afbf0ae6bc32ebefd16529c46135564ec075b967",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-17T22:32:20.247084Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:d1309ad07ea32a9ff698436f43216a9c90d553df26fcb5e62620e0d4e36e8663",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    }
+  ],
+  "check_na": [
+    {
+      "name": "semantic_dup",
+      "rationale": "huggingface.co is denied by this environment's egress policy (agent proxy answers 403 to CONNECT), so fastembed cannot fetch the embedding model here. The repository's own semantic-dup-scan.yml CI job runs it against this PR."
+    },
+    {
+      "name": "semantic_dup",
+      "rationale": "huggingface.co is denied by this environment's egress policy (agent proxy answers 403 to CONNECT), so fastembed cannot fetch the embedding model here; the repository's semantic-dup-scan.yml CI job runs it against this PR."
+    }
+  ],
   "commit": null,
   "declared_scope": {
     "exclude": [],
@@ -44,7 +255,316 @@
     }
   ],
   "governance_touch": false,
-  "guard_events": [],
+  "guard_events": [
+    {
+      "at": "2026-08-17T22:19:49.007101Z",
+      "findings": [
+        {
+          "message": "AI-authored edits must happen in a dedicated worktree, not the main working tree (/tmp/pytest-of-root/pytest-4/popen-gw2/test_hook_payload_blocks_main_0/main). Create one with `git worktree add ../<name> <branch>` and run your edits there.",
+          "rule_id": "worktree.main-checkout-write"
+        }
+      ],
+      "guard": "worktree_write_guard",
+      "status": "fail"
+    },
+    {
+      "at": "2026-08-17T22:19:49.497764Z",
+      "findings": [
+        {
+          "message": "AI-authored edits must happen in a dedicated worktree, not the main working tree (/tmp/pytest-of-root/pytest-4/popen-gw2/test_hook_payload_extracts_mul0/main). Create one with `git worktree add ../<name> <branch>` and run your edits there.",
+          "rule_id": "worktree.main-checkout-write"
+        }
+      ],
+      "guard": "worktree_write_guard",
+      "status": "fail"
+    },
+    {
+      "at": "2026-08-17T22:31:18.706593Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-17T22:31:18.708990Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-17T22:31:18.711191Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-17T22:31:18.713415Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-17T22:31:18.715703Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-17T22:31:18.717791Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": ".claude/settings.local.json",
+          "finding_class": "governance",
+          "git_evidence": null,
+          "id": "governance.mod_guard.unauthorized-change",
+          "line": null,
+          "message": "governance-critical file changed without authorization; declare governance_touch in the ledger and obtain owner review",
+          "path": ".claude/settings.local.json",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "governance.mod_guard.unauthorized-change",
+          "severity": "error",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "mod_guard",
+      "status": "fail"
+    },
+    {
+      "at": "2026-08-17T22:31:18.720041Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-17T22:31:18.722714Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-17T22:31:18.725056Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-17T22:31:18.727072Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-17T22:31:18.729223Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-17T22:32:20.263733Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-17T22:32:20.266105Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-17T22:32:20.268663Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-17T22:32:20.270933Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-17T22:32:20.273387Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-17T22:32:20.275905Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-17T22:32:20.278883Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-17T22:32:20.281449Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-17T22:32:20.284145Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-17T22:32:20.286323Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-17T22:32:20.296609Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-17T22:32:51.669388Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-17T22:32:51.672100Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-17T22:32:51.674483Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-17T22:32:51.677588Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-17T22:32:51.680197Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-17T22:32:51.682296Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-17T22:32:51.685343Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-17T22:32:51.687619Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-17T22:32:51.689985Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-17T22:32:51.692154Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-17T22:32:51.702372Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
   "issues": [
     {
       "close_in_pr": true,
@@ -54,25 +574,125 @@
     }
   ],
   "observed_admin_labels": [],
-  "observed_diff": null,
+  "observed_diff": {
+    "base": "origin/main",
+    "base_sha": "8b9eab7",
+    "changed_files": [
+      ".workflow/records/2070-work-import-final-open-question.json",
+      "docs/planning/adr-053-work-import-checklist.md",
+      "docs/specs/adr-053-work-import.md",
+      "frontend/src/components/BringInMyWorkDialog.parts/PageNav.tsx",
+      "frontend/src/components/BringInMyWorkDialog.parts/copy.ts",
+      "frontend/src/components/BringInMyWorkDialog.parts/formState.ts",
+      "frontend/src/components/BringInMyWorkDialog.parts/pages.ts",
+      "frontend/src/components/BringInMyWorkDialog.tsx",
+      "frontend/src/components/__tests__/BringInMyWorkDialog.harness.tsx",
+      "frontend/src/components/__tests__/BringInMyWorkDialog.test.tsx",
+      "frontend/src/components/__tests__/BringInMyWorkDialogPaging.test.tsx",
+      "frontend/src/components/__tests__/workImport.test.ts",
+      "frontend/src/lib/api/workImport.ts",
+      "src/scistudio/ai/work_import/brief.py",
+      "src/scistudio/ai/work_import/brief_template.md",
+      "src/scistudio/ai/work_import/context.py",
+      "src/scistudio/api/routes/work_import.py",
+      "tests/ai/test_work_import_brief.py",
+      "tests/api/test_work_import_session.py"
+    ],
+    "diff_fingerprint": "sha256:050d351e86cb24a2965e11fb4944d05895d0c2d1ab86330ba279706f9a314dbb",
+    "head": "HEAD",
+    "head_sha": "d6b9704",
+    "surfaces": {
+      "docs": 2,
+      "frontend": 10,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 14,
+      "packaging": 0,
+      "protected_architecture": 0,
+      "protected_core": 0,
+      "sentrux": 17,
+      "test": 6,
+      "workflow_ci": 0
+    }
+  },
   "owner_directive": "\u52a0\u4e00\u4e2a\u95ee\u7528\u6237\u7684\u95ee\u9898\u653e\u6700\u540e\uff1a\u95ee\u7528\u6237\u5728\u5f00\u59cb\u4e4b\u524d\u8fd8\u6709\u522b\u7684\u60f3\u548cagent\u8bf4\u7684\u4e1c\u897f\u5417\uff1f\u7136\u540e\u8fd9\u4e2a\u95ee\u9898\u7684\u7b54\u6848\u4e00\u8d77\u653e\u8fdbprompt\uff0c\u5141\u8bb8\u8df3\u8fc7\u8fd9\u4e2a\u95ee\u9898",
   "persona": "implementer",
   "pull_request": null,
-  "reconcile_events": [],
+  "reconcile_events": [
+    {
+      "at": "2026-08-17T22:31:18.729273Z",
+      "diff_fingerprint": "sha256:9c83b9e2eb86ce49ac8de754d23a8f12c7cadc61543ec1cf3cd38c5de655ac8c",
+      "mode": "local",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.semantic_dup",
+        "guard.mod_guard",
+        "scope.out-of-scope"
+      ]
+    },
+    {
+      "at": "2026-08-17T22:32:20.296669Z",
+      "diff_fingerprint": "sha256:050d351e86cb24a2965e11fb4944d05895d0c2d1ab86330ba279706f9a314dbb",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.semantic_dup"
+      ]
+    },
+    {
+      "at": "2026-08-17T22:32:51.702421Z",
+      "diff_fingerprint": "sha256:050d351e86cb24a2965e11fb4944d05895d0c2d1ab86330ba279706f9a314dbb",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.semantic_dup"
+      ]
+    }
+  ],
   "record_id": "2070-work-import-final-open-question",
   "requested_admin_labels": [],
   "required_obligations": {
     "admin_labels": [],
-    "checks": [],
-    "docs": [],
-    "guards": [],
-    "tests": []
+    "checks": [
+      "architecture_tests",
+      "deferral_discipline",
+      "format_check",
+      "frontend",
+      "full_audit",
+      "import_contracts",
+      "lint_format",
+      "python_tests",
+      "semantic_dup",
+      "type_check"
+    ],
+    "docs": [
+      "docs_required_or_na"
+    ],
+    "guards": [
+      "architecture_doc_guard",
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": [
+      "changed_test_required"
+    ]
   },
   "runtime": "claude",
   "schema_version": 2,
   "scope_events": [],
   "session_id": "c4158111-59cb-44e5-96ba-84c3ab4ba157",
-  "strictness_tier": null,
+  "strictness_tier": 1,
   "task_kind": "feature",
   "test_events": [
     {

--- a/docs/planning/adr-053-work-import-checklist.md
+++ b/docs/planning/adr-053-work-import-checklist.md
@@ -274,7 +274,8 @@ report rather than diverge from it.
   | `workflow_description` | `str \| None` |
   | `interaction_wishes` | `str \| None` |
   | `other_software` | `str \| None` |
-  | `skipped` | `frozenset[str]` over `{"workflow_description", "interaction_wishes", "other_software"}` |
+  | `anything_else` | `str \| None` |
+  | `skipped` | `frozenset[str]` over `{"workflow_description", "interaction_wishes", "other_software", "anything_else"}` |
   | `provider` | `str` (provider-registry key) |
   | `permission_mode` | `Literal["safe", "bypass"]` |
 
@@ -1070,6 +1071,7 @@ Append only.
 | 2026-08-07 | manager | Owner drove the live desktop build and found the dialog too long to fill in: "一个长问卷用户看着很难受，也懒得填". | Paged it, one question per page, page 1 for setup — which is also the shape #2001 already describes, separating "dialog, page one" from "the four questions". The single scrolling page was A4's own reading. §11.6. | `#2001` |
 | 2026-08-08 | manager | Owner's copy pass on the paged build: nine strings were prose explaining the control beside them, the required-field message read as condescending and was too quiet to see, and the unusable-agent list was filler. | Cut all nine. Required fields say `Required: …` in the red banner `CommitDialog` already uses, on every blocking page. Unusable agents moved into the one dropdown, greyed with a short suffix — the pattern the AI chat already uses, which the owner named. §11.7. | `#2001` |
 | 2026-08-08 | manager | Lifting `ProviderPicker.tsx` out of scope was mine to authorise and I did. FR-042 forbids a second provider implementation. | Extending the shared component serves FR-042's purpose better than a fork: one optional prop, absent for the AI chat, whose behaviour is pinned by a new regression test fixing the whole option list as data. `SetupScreen.tsx` has zero diff lines, verified independently. | `#2001` |
+| 2026-08-17 | implementer | Owner directive after the feature shipped: *"加一个问用户的问题放最后：问用户在开始之前还有别的想和 agent 说的东西吗？然后这个问题的答案一起放进 prompt，允许跳过这个问题"* — the four questions each ask about one specific thing, so a user whose most important fact is none of those four has nowhere to put it. | Added question 5 as FR-019a: free text, asked last, skippable like questions 3 and 4, carried to the brief as `anything_else` through the same skipped/answered machinery. Contract C2's field table above is updated with it; nothing about the existing four questions changed. | `#2070` |
 | 2026-08-08 | manager | The dialog agent declined to fix `Install the Qoder CLI CLI` because it lives in `availability.py`, outside the scope I gave it. That was correct. | Fixed by the manager. My first attempt wrote a literal backspace byte into the source — a regex escape eaten between the heredoc and Python — which `grep` showed as fine and `cat -A` showed as `^H`. Rewritten without a regex. The test walks the whole registry rather than the two known offenders. | `#2000` |
 
 ## 13.1 Dormant Preconditions

--- a/docs/specs/adr-053-work-import.md
+++ b/docs/specs/adr-053-work-import.md
@@ -149,7 +149,7 @@ in that repository.
 
 1. **Given** a project is open and an agent is ready, **when** the user activates
    the toolbar entry, **then** the dialog opens with the source, destination, and
-   four questions.
+   five questions.
 2. **Given** the user supplies a repository directory and answers question 1,
    **when** they start the session, **then** a brief file is written under
    `.scistudio/` carrying the source location and every answer given, and the
@@ -352,7 +352,7 @@ control stays visible so the user can see which agent will run.
 (FR-022). A choice the dialog collects but does not apply is worse than not
 offering it.
 
-#### The four questions
+#### The five questions
 
 Each question serves two purposes at once, and the second is easy to lose.
 
@@ -411,9 +411,17 @@ regularly?* — MUST be free text and MUST be skippable. It informs app-block
 integration and tells the user that integrating external applications is possible
 at all.
 
-**FR-020.** Questions 3 and 4, and question 2 in codebase mode, MUST each offer an
-explicit skip that reads as a legitimate choice — the user is telling the agent to
-work it out — rather than as an abandoned field. The source or the no-codebase
+**FR-019a.** Question 5 — *anything else you want to tell the agent before it
+starts?* — MUST be free text, MUST be skippable, and MUST be asked last, after
+question 4. Questions 1 to 4 each ask about one specific thing, so a user whose
+most important fact is not one of those four has nowhere to put it and the
+session starts without it. This one is deliberately open: it is the only question
+that does not tell the user what to say, which is also why it cannot substitute
+for any of the others and MUST NOT be used to justify dropping them.
+
+**FR-020.** Questions 3, 4 and 5, and question 2 in codebase mode, MUST each offer
+an explicit skip that reads as a legitimate choice — the user is telling the agent
+to work it out — rather than as an abandoned field. The source or the no-codebase
 option, the destination, and question 1 are required.
 
 **FR-021.** Every collected answer MUST reach the brief, and skipped questions
@@ -525,7 +533,7 @@ block without a test would produce an empty one.
 
 | Entity | Description | Attributes | Relationships |
 |---|---|---|---|
-| `ImportSessionContext` | Everything the dialog collects, composed into the brief before the session is spawned | `source_location` (nullable), `has_no_codebase` (bool), `destination_tier` (`project` \| `user_library`), `data_kinds` (preset selections + free text), `workflow_description`, `interaction_wishes`, `other_software`, a skipped/answered marker per optional question, plus `provider` and `permission_mode` | Written into the brief file before spawn (FR-023, FR-024, FR-027); per-session, gitignored, not product state |
+| `ImportSessionContext` | Everything the dialog collects, composed into the brief before the session is spawned | `source_location` (nullable), `has_no_codebase` (bool), `destination_tier` (`project` \| `user_library`), `data_kinds` (preset selections + free text), `workflow_description`, `interaction_wishes`, `other_software`, `anything_else`, a skipped/answered marker per optional question, plus `provider` and `permission_mode` | Written into the brief file before spawn (FR-023, FR-024, FR-027); per-session, gitignored, not product state |
 | `AgentAvailability` | The graded result of probing a provider | `state` (`not_installed` \| `not_authenticated` \| `call_failed` \| `ready`), `cause` (populated for `call_failed`), `providers` (populated for `ready`) | Derived from the #1994 provider registry rows plus a live call (FR-032, FR-033); consumed by this dialog and by any other agent-dependent surface (FR-036) |
 
 ## 4. Implementation Plan
@@ -585,7 +593,7 @@ feature adds a brief file rather than a second prompt-assembly path.
 |---|---|---|
 | `docs/adr/ADR-053.md` | modify | Revise §4.1 and §5; generalise §4 to users without code; synchronise §1.1, §6, §7, §8, §9.5 |
 | `docs/specs/adr-053-work-import.md` | create | This spec |
-| `frontend/src/components/BringInMyWorkDialog.tsx` | create | The framing dialog and its four questions (FR-003 – FR-021), the provider and permission-mode controls (FR-040 – FR-044), the caveat copy (FR-037, FR-038), and per-state availability guidance shown in place of a start action (FR-005, FR-031, FR-034) |
+| `frontend/src/components/BringInMyWorkDialog.tsx` | create | The framing dialog and its five questions (FR-003 – FR-021), the provider and permission-mode controls (FR-040 – FR-044), the caveat copy (FR-037, FR-038), and per-state availability guidance shown in place of a start action (FR-005, FR-031, FR-034) |
 | `frontend/src/components/AIChat/SetupScreen.parts/ProviderPicker.tsx` | reuse | Provider selection, unchanged (FR-042) |
 | `frontend/src/components/AIChat/SetupScreen.parts/PermissionModePicker.tsx` | reuse | Permission mode, unchanged (FR-042) |
 | Toolbar component | modify | The entry and its enablement rule (FR-001, FR-002) |
@@ -605,7 +613,7 @@ unresolved rather than guessed.
 | T-003 | Toolbar entry and enablement | US1, US2 | — | Enabled with a project open, disabled without |
 | T-004 | Dialog shell, source/destination page, caveat copy | US1, US2, US4 | T-003 | Caveat present and not bypassable; directory picker accepts a directory |
 | T-005 | No-codebase option and its conditional field behaviour | US2 | T-004 | Source field disabled; question 2 becomes required |
-| T-006 | The four questions, presets, grouping, and skip semantics | US1, US2 | T-004 | Preset grouping renders; skips are distinguishable from answers |
+| T-006 | The five questions, presets, grouping, and skip semantics | US1, US2 | T-004 | Preset grouping renders; skips are distinguishable from answers |
 | T-007 | Prompt composition from the collected context | US1, US2 | T-004, T-006 | Every answer and the mode appear in the composed brief |
 | T-008 | Session spawn wired to the composed brief | US1, US2 | T-007 | A session opens carrying the brief |
 | T-009 | Availability guidance surfaced in the dialog | US3 | T-002, T-004 | Each state shows its own guidance in place of a start action |
@@ -629,7 +637,7 @@ settled by a single review (see §4.5).
 | Library-mode constraint | In personal-library mode the composed brief carries the project-local-type warning (FR-026) |
 | Preset grouping | Generic shapes and domain options are visually grouped so both can be selected (FR-014) |
 | Question 2 conditionality | Skippable with a source location, required without one (FR-016, FR-017) |
-| Required vs skippable | Source-or-no-codebase, destination, and question 1 required; questions 3 and 4 each offer an explicit skip (FR-020) |
+| Required vs skippable | Source-or-no-codebase, destination, and question 1 required; questions 3, 4 and 5 each offer an explicit skip (FR-019a, FR-020) |
 | Skip is conveyed | A skipped question reaches the brief marked as skipped rather than being omitted (FR-021) |
 | Brief composition | Every dialog answer and the source location appear in the composed brief (FR-023) |
 | Brief location | The brief is written under `.scistudio/` and is not picked up by git in a project using the default ignore file (FR-027) |
@@ -1041,6 +1049,19 @@ is being made, and propose it."}
 
 **They said:** {answer, or "Skipped. They did not answer this."}
 
+---
+
+**We asked:** *Is there anything else you want to tell the agent before it
+starts? Anything the questions above did not ask for — something about your
+data, a constraint you work under, a preference, or how you would like it to
+work with you.*
+
+**They said:** {answer, or "Skipped. They did not answer this."}
+
+This one was open, so read what is there and do not read anything into what is
+not: they were given no list to answer against, and a blank means only that
+nothing came to mind.
+
 # When things come up
 
 You already know what SciStudio is and that `mcp__scistudio__*` is how you reach
@@ -1135,6 +1156,7 @@ are already provisioned as skills. Measured by review at each prompt change.
 | The feature is a permanently available toolbar entry, enabled with a project open | owner |
 | The flow is a preconfigured agent session, not a scan-then-select pipeline | owner |
 | The dialog collects a fixed question set that becomes part of the system prompt | owner |
+| The last question is an open one — anything else the user wants to tell the agent before it starts — and it is skippable like the other optional questions | owner |
 | Verification is prompt-driven and not system-enforced | owner |
 | Checks are saved in the project directory | owner |
 | The import surface states plainly that correctness is not guaranteed | owner |

--- a/frontend/src/components/BringInMyWorkDialog.parts/PageNav.tsx
+++ b/frontend/src/components/BringInMyWorkDialog.parts/PageNav.tsx
@@ -3,7 +3,7 @@
  * you move.
  *
  * The owner's complaint about the single scrolling page was that it is
- * unpleasant and users will not bother. Five pages of unknown length is its own
+ * unpleasant and users will not bother. A run of pages of unknown length is its own
  * version of that, so the progress indicator is not decoration: it is the thing
  * that makes a paged form bearable. The user can see how many steps there are,
  * which one they are on, and — because completed steps are clickable — that

--- a/frontend/src/components/BringInMyWorkDialog.parts/copy.ts
+++ b/frontend/src/components/BringInMyWorkDialog.parts/copy.ts
@@ -32,6 +32,11 @@
  * is a discovery surface as well as a form. A future editor optimising these
  * purely as data collection would remove that second effect without noticing
  * it — please do not be that editor (spec §3, preamble to FR-013).
+ *
+ * Question 5 is the exception that proves the rule: it names nothing, because
+ * its job is to catch whatever the four named questions filtered out (FR-019a).
+ * It is not a replacement for any of them — an open question collects far less
+ * than a specific one — so it may not be used as grounds for dropping one.
  */
 
 /** The toolbar entry's label (FR-001). Never say "code" here — FR-009 users have none. */
@@ -234,6 +239,34 @@ export const Q4_HELP =
 export const Q4_PLACEHOLDER = "e.g. Fiji for the segmentation, Prism for the final figures";
 
 /**
+ * FR-019a — question 5, and the last thing the dialog asks.
+ *
+ * The four questions above it each ask about one specific thing, which is what
+ * makes them answerable — and also what makes them a filter. A user whose most
+ * important fact is not their data, their workflow, an interactive step or
+ * another program has, until this question, nowhere to put it, and the session
+ * starts without it.
+ *
+ * SO THIS ONE NAMES NOTHING AND ASKS FOR EVERYTHING. The help line lists kinds
+ * of things rather than an example answer, because an example here would narrow
+ * exactly the question that exists not to. It is skippable for the same reason
+ * questions 3 and 4 are: having nothing to add to four specific questions is an
+ * ordinary answer to an open one, not a field the user gave up on.
+ *
+ * Both strings are reproduced in the brief (spec §4.6) as the user saw them —
+ * the label and the help line together form the question the agent is shown,
+ * so an edit to either without the matching edit to §4.6 makes the brief
+ * misreport what was asked.
+ */
+export const Q5_LABEL = "Is there anything else you want to tell the agent before it starts?";
+export const Q5_HELP =
+  "Anything the questions above did not ask for — something about your data, a constraint " +
+  "you work under, a preference, or how you would like it to work with you.";
+export const Q5_PLACEHOLDER =
+  "e.g. the instrument writes one folder per run and the folder names matter, and I would " +
+  "rather be asked than have it guess.";
+
+/**
  * FR-020 — the skip affordance.
  *
  * A skip must read as a legitimate choice — the user telling the agent to work
@@ -423,11 +456,12 @@ export const Q1_STEP_TITLE = "Your data";
 export const Q2_STEP_TITLE = "Your workflow";
 export const Q3_STEP_TITLE = "Stepping in";
 export const Q4_STEP_TITLE = "Other software";
+export const Q5_STEP_TITLE = "Anything else";
 
 export const PROGRESS_LABEL = "Progress";
 
 /**
- * "Five pages of unknown length is its own kind of unpleasant." The user can
+ * "A run of pages of unknown length is its own kind of unpleasant." The user can
  * see where they are and how much is left at every step, which is the whole
  * reason a paged form is bearable at all.
  */

--- a/frontend/src/components/BringInMyWorkDialog.parts/formState.ts
+++ b/frontend/src/components/BringInMyWorkDialog.parts/formState.ts
@@ -37,6 +37,8 @@ export interface WorkImportFormState {
   workflowDescription: OptionalAnswer;
   interactionWishes: OptionalAnswer;
   otherSoftware: OptionalAnswer;
+  /** FR-019a — the open question, asked last and skippable. */
+  anythingElse: OptionalAnswer;
   /** FR-040 / FR-043 — null until a usable provider is chosen or preselected. */
   provider: string | null;
   /** FR-041 — the safe mode is the default; the user opts out of it. */
@@ -52,6 +54,7 @@ export const INITIAL_FORM_STATE: WorkImportFormState = {
   workflowDescription: { ...EMPTY_ANSWER },
   interactionWishes: { ...EMPTY_ANSWER },
   otherSoftware: { ...EMPTY_ANSWER },
+  anythingElse: { ...EMPTY_ANSWER },
   provider: null,
   permissionMode: "safe",
 };
@@ -72,7 +75,7 @@ function trimmedOrNull(value: string): string | null {
  */
 export function markSkipped(
   state: WorkImportFormState,
-  key: "workflowDescription" | "interactionWishes" | "otherSoftware",
+  key: "workflowDescription" | "interactionWishes" | "otherSoftware" | "anythingElse",
 ): WorkImportFormState {
   const next: WorkImportFormState = { ...state };
   next[key] = { ...state[key], skipped: true };
@@ -199,6 +202,7 @@ export function buildRequest(
   );
   const interactionWishes = resolve("interaction_wishes", state.interactionWishes, false);
   const otherSoftware = resolve("other_software", state.otherSoftware, false);
+  const anythingElse = resolve("anything_else", state.anythingElse, false);
 
   return {
     project_dir: projectDir,
@@ -210,6 +214,7 @@ export function buildRequest(
     workflow_description: workflowDescription,
     interaction_wishes: interactionWishes,
     other_software: otherSoftware,
+    anything_else: anythingElse,
     skipped,
     // `canStart` guarantees a provider before this runs; the fallback keeps the
     // function total without inventing a default provider (ADR-034 FR-020c).

--- a/frontend/src/components/BringInMyWorkDialog.parts/pages.ts
+++ b/frontend/src/components/BringInMyWorkDialog.parts/pages.ts
@@ -14,11 +14,11 @@
  * four requirements at risk, which is what this module exists to keep true.
  *
  * FR-020 — REQUIRED VS SKIPPABLE IS NOW A NAVIGATION RULE. On one page, a
- * missing required answer disabled the start action. On five pages, the start
- * action is not even rendered until page five, so a user could answer nothing
- * and page straight past it. `pageGate` is therefore what enforces FR-020: a
- * page whose answer is required cannot be left, and the reason is the same
- * sentence the whole-form check would have given.
+ * missing required answer disabled the start action. Paged, the start action is
+ * not even rendered until the last page, so a user could answer nothing and page
+ * straight past it. `pageGate` is therefore what enforces FR-020: a page whose
+ * answer is required cannot be left, and the reason is the same sentence the
+ * whole-form check would have given.
  *
  * FR-016 / FR-017 — QUESTION 2'S REQUIREMENT IS DECIDED ON A DIFFERENT PAGE
  * FROM WHERE IT IS ENFORCED. "I don't have a codebase" is ticked on page one;
@@ -28,7 +28,7 @@
  *
  * FR-005 — AVAILABILITY HAS TO SURFACE EARLY. On one page the guidance replaced
  * the start action and the user saw it immediately. Paged, that guidance would
- * sit on the last page, and a user with no usable agent would answer five pages
+ * sit on the last page, and a user with no usable agent would answer every page
  * before finding out none of it can run. The provider is chosen on page one, so
  * page one is where "no agent can run this" blocks — the user meets it before
  * the questions rather than after them.
@@ -43,6 +43,7 @@ import {
   Q2_STEP_TITLE,
   Q3_STEP_TITLE,
   Q4_STEP_TITLE,
+  Q5_STEP_TITLE,
   SETUP_STEP_TITLE,
 } from "./copy";
 import {
@@ -56,10 +57,14 @@ import {
   type WorkImportFormState,
 } from "./formState";
 
-export type WorkImportPageId = "setup" | "q1" | "q2" | "q3" | "q4";
+export type WorkImportPageId = "setup" | "q1" | "q2" | "q3" | "q4" | "q5";
 
-/** The form-state keys holding an answer a user may skip (FR-020). */
-export type SkippableAnswerKey = "workflowDescription" | "interactionWishes" | "otherSoftware";
+/** The form-state keys holding an answer a user may skip (FR-020, FR-019a). */
+export type SkippableAnswerKey =
+  | "workflowDescription"
+  | "interactionWishes"
+  | "otherSoftware"
+  | "anythingElse";
 
 export interface WorkImportPage {
   id: WorkImportPageId;
@@ -77,8 +82,10 @@ export interface WorkImportPage {
 
 /**
  * Page one is the setup the owner asked for — browse, the no-codebase option,
- * destination, provider, permission mode — and the four questions then get a
- * page each, in the order spec §4.6 reproduces them to the agent.
+ * destination, provider, permission mode — and the five questions then get a
+ * page each, in the order spec §4.6 reproduces them to the agent. Question 5 is
+ * last because it is the open one (FR-019a): asked before the specific
+ * questions it would collect what they collect, and worse.
  */
 export const WORK_IMPORT_PAGES: readonly WorkImportPage[] = [
   { id: "setup", title: SETUP_STEP_TITLE, skips: null },
@@ -86,6 +93,7 @@ export const WORK_IMPORT_PAGES: readonly WorkImportPage[] = [
   { id: "q2", title: Q2_STEP_TITLE, skips: "workflowDescription" },
   { id: "q3", title: Q3_STEP_TITLE, skips: "interactionWishes" },
   { id: "q4", title: Q4_STEP_TITLE, skips: "otherSoftware" },
+  { id: "q5", title: Q5_STEP_TITLE, skips: "anythingElse" },
 ];
 
 export const LAST_PAGE_INDEX = WORK_IMPORT_PAGES.length - 1;
@@ -140,7 +148,7 @@ export function pageGate(
         focusId = "work-import-source";
       }
       // FR-005 — the agent is chosen here, so this is where a user learns that
-      // none can run the session, rather than five pages later.
+      // none can run the session, rather than at the end of the questions.
       if (!opts.probing) {
         if (!opts.agentUsable) {
           reasons.push(REASON_NO_AGENT);
@@ -163,8 +171,9 @@ export function pageGate(
       }
       return { reasons: [REASON_NO_WORKFLOW_DESCRIPTION], focusId: "work-import-q2-input" };
     default:
-      // FR-018 / FR-019 — questions 3 and 4 are skippable, so paging past them
-      // without answering is a legitimate choice and never blocked.
+      // FR-018 / FR-019 / FR-019a — questions 3, 4 and 5 are skippable, so
+      // paging past them without answering is a legitimate choice, never
+      // blocked.
       return NO_BLOCK;
   }
 }

--- a/frontend/src/components/BringInMyWorkDialog.tsx
+++ b/frontend/src/components/BringInMyWorkDialog.tsx
@@ -7,9 +7,10 @@
  * with the most to gain from SciStudio and the highest cost of entry. This
  * dialog is everything the product does before handing that user to an agent:
  * it collects where their work is, where the results should go, which agent
- * runs, how much that agent may do without asking, and four questions about
- * their own world. Then it says plainly that the result is not verified, and
- * starts an ordinary chat session (FR-025) with all of it already loaded.
+ * runs, how much that agent may do without asking, and five questions about
+ * their own world — the last of which asks for anything the other four did not
+ * (FR-019a). Then it says plainly that the result is not verified, and starts an
+ * ordinary chat session (FR-025) with all of it already loaded.
  *
  * IT IS PAGED, AND THE REASON IS THE USER, NOT THE CODE. Owner directive,
  * 2026-08-07: a long questionnaire is unpleasant to look at and users will not
@@ -34,7 +35,7 @@
  * why questions 3 and 4 are also a discovery surface. Because only one page is
  * on screen at a time, the guard test for those two FRs walks EVERY page — a
  * test that rendered the dialog and searched it once would now be checking page
- * one and reporting on five.
+ * one and reporting on all of them.
  */
 import { useCallback, useEffect, useState, type ReactNode } from "react";
 
@@ -75,6 +76,9 @@ import {
   Q4_HELP,
   Q4_LABEL,
   Q4_PLACEHOLDER,
+  Q5_HELP,
+  Q5_LABEL,
+  Q5_PLACEHOLDER,
   START_LABEL,
   STARTING_LABEL,
 } from "./BringInMyWorkDialog.parts/copy";
@@ -248,7 +252,7 @@ export function BringInMyWorkDialog({
     const request = buildRequest(state, projectDir);
     /*
      * A2's `ImportSessionContext` rejects a body that breaks any of its rules,
-     * and a 422 at this point is a dead end: the user has answered five pages
+     * and a 422 at this point is a dead end: the user has answered every page
      * and gets an HTTP status back. The page rules and `blockingReasons` should
      * already have made every violation unreachable, so this is a backstop that
      * turns a regression in the form's own rules into a readable sentence
@@ -432,6 +436,21 @@ export function BringInMyWorkDialog({
             placeholder={Q4_PLACEHOLDER}
             value={state.otherSoftware}
             onChange={(otherSoftware) => patch({ otherSoftware })}
+          />
+        );
+      // FR-019a — the open question, and the last one asked. It shares the
+      // free-text shape of questions 2 to 4 deliberately: it is another question
+      // about the user's own world, not a different kind of control, and the
+      // only thing that makes it the last word is where it sits.
+      case "q5":
+        return (
+          <FreeTextQuestion
+            id="q5"
+            label={Q5_LABEL}
+            help={Q5_HELP}
+            placeholder={Q5_PLACEHOLDER}
+            value={state.anythingElse}
+            onChange={(anythingElse) => patch({ anythingElse })}
           />
         );
     }

--- a/frontend/src/components/__tests__/BringInMyWorkDialog.harness.tsx
+++ b/frontend/src/components/__tests__/BringInMyWorkDialog.harness.tsx
@@ -6,7 +6,7 @@
  * the dialog is paged, so almost every assertion about it now needs the dialog
  * driven to a particular page first. Two files each carrying their own idea of
  * how to page forward would drift, and a drifted walker is the failure mode this
- * whole exercise is trying to avoid — a test that thinks it exercised five pages
+ * whole exercise is trying to avoid — a test that thinks it exercised every page
  * while exercising one.
  *
  * `walkTo` is therefore the only way these tests move between pages, and it
@@ -110,7 +110,7 @@ export async function settled(): Promise<void> {
  * imported the page list from the implementation would agree with it by
  * construction, including about a page that went missing.
  */
-export const PAGE_IDS = ["setup", "q1", "q2", "q3", "q4"] as const;
+export const PAGE_IDS = ["setup", "q1", "q2", "q3", "q4", "q5"] as const;
 export type PageId = (typeof PAGE_IDS)[number];
 
 export const LAST_PAGE: PageId = PAGE_IDS[PAGE_IDS.length - 1];
@@ -127,8 +127,8 @@ export function currentPage(): PageId {
 export type PageAnswers = Partial<Record<PageId, () => void>>;
 
 /**
- * FR-020's required answers, and nothing else. Questions 2 (with a source), 3
- * and 4 are skippable, so the default walk pages straight past them — which is
+ * FR-020's required answers, and nothing else. Questions 2 (with a source), 3,
+ * 4 and 5 are skippable, so the default walk pages straight past them — which is
  * also the state FR-021 has to survive.
  *
  * Both are IDEMPOTENT, because a walk may cross a page more than once: a test
@@ -158,7 +158,7 @@ const REQUIRED_ANSWERS: PageAnswers = {
  *
  * THROWS RATHER THAN GIVING UP QUIETLY, naming the page that refused and the
  * reason it gave. A walker that silently stayed put would let a test assert
- * against page one in the belief it was on page five — which is the whole
+ * against page one in the belief it was on the last page — which is the whole
  * failure mode paging introduces to this suite.
  */
 export function walkTo(target: PageId, answers: PageAnswers = {}): void {

--- a/frontend/src/components/__tests__/BringInMyWorkDialog.test.tsx
+++ b/frontend/src/components/__tests__/BringInMyWorkDialog.test.tsx
@@ -33,6 +33,7 @@ import {
   Q2_LABEL,
   Q3_LABEL,
   Q4_LABEL,
+  Q5_LABEL,
   SOURCE_LABEL,
 } from "../BringInMyWorkDialog.parts/copy";
 import { validateWorkImportRequest } from "../../lib/api/workImport";
@@ -305,6 +306,9 @@ describe("FR-006 / FR-007 — who the questions are written for", () => {
     /\bschema\b/i,
   ];
 
+  /** What the walk below must have actually read, or it read nothing. */
+  const MUST_READ = [SOURCE_LABEL, Q1_LABEL, Q2_LABEL, Q3_LABEL, Q4_LABEL, Q5_LABEL, CAVEAT_BODY];
+
   /**
    * Everything the user can read on the page currently rendered.
    *
@@ -325,10 +329,10 @@ describe("FR-006 / FR-007 — who the questions are written for", () => {
    *
    * THIS IS THE POINT OF THE TEST AND IT IS EASY TO LOSE. Before paging, one
    * render put the whole dialog on screen and one search covered it. Paged, a
-   * search after a single render reads page one and reports on five — the guard
-   * would keep passing while guarding almost nothing. So the walk visits each
-   * page in turn, and then asserts BOTH that it reached all five and that what
-   * it read contains the actual questions: an empty page, or a page that
+   * search after a single render reads page one and reports on all of them — the
+   * guard would keep passing while guarding almost nothing. So the walk visits
+   * each page in turn, and then asserts BOTH that it reached every page and that
+   * what it read contains the actual questions: an empty page, or a page that
    * silently stopped rendering, must fail here rather than pass by vacuity.
    */
   function everyPageIsAnswerableByAScientist(answers: PageAnswers = {}): void {
@@ -343,10 +347,8 @@ describe("FR-006 / FR-007 — who the questions are written for", () => {
     }
 
     expect(visited).toEqual([...PAGE_IDS]);
-    // The walk read real content, not five blanks.
-    for (const label of [SOURCE_LABEL, Q1_LABEL, Q2_LABEL, Q3_LABEL, Q4_LABEL, CAVEAT_BODY]) {
-      expect(everything).toContain(label);
-    }
+    // The walk read real content, not a run of blanks.
+    for (const label of MUST_READ) expect(everything).toContain(label);
   }
 
   it("asks nothing that needs SciStudio or software-development knowledge", async () => {
@@ -824,8 +826,9 @@ describe("starting the session (FR-021 – FR-025)", () => {
         fireEvent.change(screen.getByTestId("work-import-q2-input"), {
           target: { value: "Load the export, drop blanks, normalise to the control." },
         }),
-      // Question 3 is skipped by the control that says so; question 4 is simply
-      // paged past. FR-021 makes those the same claim, and the payload agrees.
+      // Question 3 is skipped by the control that says so; questions 4 and 5
+      // are simply paged past. FR-021 makes those the same claim, and the
+      // payload agrees.
       q3: () => fireEvent.click(screen.getByTestId("work-import-q3-skip")),
     });
     fireEvent.click(screen.getByTestId("work-import-start"));
@@ -841,7 +844,8 @@ describe("starting the session (FR-021 – FR-025)", () => {
       workflow_description: "Load the export, drop blanks, normalise to the control.",
       interaction_wishes: null,
       other_software: null,
-      skipped: ["interaction_wishes", "other_software"],
+      anything_else: null,
+      skipped: ["interaction_wishes", "other_software", "anything_else"],
       provider: "claude-code",
       permission_mode: "safe",
     });
@@ -864,7 +868,8 @@ describe("starting the session (FR-021 – FR-025)", () => {
     await settled();
 
     // FR-020 under paging: the block is on the page that asks, not on a start
-    // action five pages away that the user would otherwise never have reached.
+    // action several pages away that the user would otherwise never have
+    // reached.
     walkTo("q2", { setup: () => fireEvent.click(screen.getByTestId("work-import-no-codebase")) });
     fireEvent.click(screen.getByTestId("work-import-next"));
     expect(currentPage()).toBe("q2");
@@ -896,9 +901,11 @@ describe("starting the session (FR-021 – FR-025)", () => {
         fireEvent.change(screen.getByTestId("work-import-q3-input"), {
           target: { value: "Let me pick the background patch." },
         }),
+      q4: () =>
+        fireEvent.change(screen.getByTestId("work-import-q4-input"), { target: { value: "Fiji" } }),
     });
     // The last page is where the walk stops, so its answer is typed in place.
-    fireEvent.change(screen.getByTestId("work-import-q4-input"), { target: { value: "Fiji" } });
+    fireEvent.change(screen.getByTestId("work-import-q5-input"), { target: { value: "Nothing." } });
     fireEvent.click(screen.getByTestId("work-import-start"));
     await waitFor(() => expect(withSource).toHaveBeenCalledTimes(1));
     expect(validateWorkImportRequest(withSource.mock.calls[0][0])).toEqual([]);

--- a/frontend/src/components/__tests__/BringInMyWorkDialogPaging.test.tsx
+++ b/frontend/src/components/__tests__/BringInMyWorkDialogPaging.test.tsx
@@ -17,6 +17,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { BringInMyWorkDialog } from "../BringInMyWorkDialog";
 import {
+  Q5_HELP,
+  Q5_LABEL,
   SETUP_STEP_TITLE,
   SKIP_LABEL,
   SKIPPED_MARKER,
@@ -46,6 +48,7 @@ const QUESTION_TESTIDS = {
   q2: "work-import-q2",
   q3: "work-import-q3",
   q4: "work-import-q4",
+  q5: "work-import-q5",
 } as const;
 
 beforeEach(() => {
@@ -91,7 +94,7 @@ describe("the page layout the owner asked for", () => {
     renderDialog();
     await settled();
 
-    for (const page of ["q1", "q2", "q3", "q4"] as const) {
+    for (const page of ["q1", "q2", "q3", "q4", "q5"] as const) {
       walkTo(page);
       expect(currentPage()).toBe(page);
       // Exactly one question is on screen: the point of the change.
@@ -106,7 +109,7 @@ describe("the page layout the owner asked for", () => {
   });
 
   it("says where the user is and how much is left, on every page", async () => {
-    // Five pages of unknown length is its own kind of unpleasant.
+    // A run of pages of unknown length is its own kind of unpleasant.
     renderDialog();
     await settled();
     expect(screen.getByTestId("work-import-step-status").textContent).toBe(
@@ -396,10 +399,16 @@ describe("FR-020 / FR-021 — a skip is a choice, and it reaches the request", (
 
     await waitFor(() => expect(startSession).toHaveBeenCalledTimes(1));
     const body = startSession.mock.calls[0][0];
-    expect(body.skipped).toEqual(["workflow_description", "interaction_wishes", "other_software"]);
+    expect(body.skipped).toEqual([
+      "workflow_description",
+      "interaction_wishes",
+      "other_software",
+      "anything_else",
+    ]);
     expect(body.workflow_description).toBeNull();
     expect(body.interaction_wishes).toBeNull();
     expect(body.other_software).toBeNull();
+    expect(body.anything_else).toBeNull();
   });
 
   it("offers no skip on a question that is required", async () => {
@@ -526,5 +535,50 @@ describe("FR-005 — a user learns there is no usable agent on page one, not pag
     fireEvent.change(screen.getByTestId("setup-provider-select"), { target: { value: "codex" } });
     walkTo(LAST_PAGE);
     expect(screen.getByTestId("work-import-start")).toBeTruthy();
+  });
+});
+
+/**
+ * FR-019a — question 5, added after the feature shipped (owner, 2026-08-17).
+ *
+ * It lives here rather than with the other questions because what is new about
+ * it is where it sits: it is the page the start action is now on, and the last
+ * thing the dialog asks. What it collects is asserted the same way every other
+ * answer is.
+ */
+describe("FR-019a — the last question is the open one", () => {
+  it("is asked last, names no subject, and offers a skip", async () => {
+    renderDialog();
+    await settled();
+
+    walkTo("q5");
+    // Last, and last for a reason: asked earlier, an open question collects the
+    // answers the specific questions were going to collect, and worse ones.
+    expect(currentPage()).toBe(LAST_PAGE);
+    expect(screen.getByTestId("work-import-q5-skip")).toBeTruthy();
+
+    // It names no subject — that is the whole of what makes it question 5
+    // rather than a sixth specific question. Its help line offers kinds of
+    // thing to say, and deliberately not an example answer, which would narrow
+    // exactly the question that exists not to be narrow.
+    expect(screen.getByTestId("work-import-q5").textContent).toContain(Q5_LABEL);
+    expect(screen.getByTestId("work-import-q5-help").textContent).toBe(Q5_HELP);
+  });
+
+  it("FR-023: its answer reaches the request like any other", async () => {
+    const startSession = vi.fn<StartSession>(async () => sessionResponse());
+    renderDialog(ready(CLAUDE), { startSession });
+    await settled();
+
+    walkTo(LAST_PAGE);
+    fireEvent.change(screen.getByTestId("work-import-q5-input"), {
+      target: { value: "Ask me before you touch anything under raw/." },
+    });
+    fireEvent.click(screen.getByTestId("work-import-start"));
+
+    await waitFor(() => expect(startSession).toHaveBeenCalledTimes(1));
+    const body = startSession.mock.calls[0][0];
+    expect(body.anything_else).toBe("Ask me before you touch anything under raw/.");
+    expect(body.skipped).not.toContain("anything_else");
   });
 });

--- a/frontend/src/components/__tests__/workImport.test.ts
+++ b/frontend/src/components/__tests__/workImport.test.ts
@@ -42,7 +42,8 @@ function validRequest(overrides: Partial<WorkImportSessionRequest> = {}): WorkIm
     workflow_description: null,
     interaction_wishes: null,
     other_software: null,
-    skipped: ["workflow_description", "interaction_wishes", "other_software"],
+    anything_else: null,
+    skipped: ["workflow_description", "interaction_wishes", "other_software", "anything_else"],
     provider: "claude-code",
     permission_mode: "safe",
     ...overrides,
@@ -78,6 +79,7 @@ describe("buildRequest (FR-021, FR-023)", () => {
         workflowDescription: { text: "Load the export, drop blanks, normalise.", skipped: false },
         interactionWishes: { text: "", skipped: true },
         otherSoftware: { text: "", skipped: false },
+        anythingElse: { text: " Ask before touching raw/. ", skipped: false },
       }),
       "/projects/demo",
     );
@@ -92,6 +94,7 @@ describe("buildRequest (FR-021, FR-023)", () => {
       workflow_description: "Load the export, drop blanks, normalise.",
       interaction_wishes: null,
       other_software: null,
+      anything_else: "Ask before touching raw/.",
       // An explicit skip and a box the user walked past are the same claim —
       // "they did not say" — and both must reach the agent as skipped.
       skipped: ["interaction_wishes", "other_software"],
@@ -107,12 +110,14 @@ describe("buildRequest (FR-021, FR-023)", () => {
         workflowDescription: { text: "", skipped: true },
         interactionWishes: { text: "Let me pick the background patch.", skipped: false },
         otherSoftware: { text: "Fiji", skipped: false },
+        anythingElse: { text: "", skipped: true },
       }),
       "/p",
     );
-    expect(request.skipped).toEqual(["workflow_description"]);
+    expect(request.skipped).toEqual(["workflow_description", "anything_else"]);
     expect(request.interaction_wishes).toBe("Let me pick the background patch.");
     expect(request.other_software).toBe("Fiji");
+    expect(request.anything_else).toBeNull();
   });
 
   it("FR-010: no-codebase mode sends a null source and leaves the destination in effect", () => {
@@ -140,7 +145,7 @@ describe("blockingReasons (FR-017, FR-020)", () => {
     expect(reasons.some((r) => /at least one kind of data/.test(r))).toBe(true);
   });
 
-  it("questions 3 and 4 never block", () => {
+  it("questions 3, 4 and 5 never block", () => {
     const reasons = blockingReasons(form({ sourceLocation: "/repo", dataKinds: ["Array"] }), {
       projectDir: "/p",
       agentUsable: true,
@@ -224,6 +229,7 @@ describe("validateWorkImportRequest — A2's ImportSessionContext rules", () => 
           "workflow_description",
           "interaction_wishes",
           "other_software",
+          "anything_else",
         ],
       }),
     );
@@ -239,7 +245,7 @@ describe("validateWorkImportRequest — A2's ImportSessionContext rules", () => 
 
   it("rejects a blank answer that is not marked as skipped", () => {
     const problems = validateWorkImportRequest(
-      validRequest({ skipped: ["workflow_description", "interaction_wishes"] }),
+      validRequest({ skipped: ["workflow_description", "interaction_wishes", "anything_else"] }),
     );
     expect(problems).toContain('"other_software" has no answer and is not marked as skipped.');
   });
@@ -248,7 +254,7 @@ describe("validateWorkImportRequest — A2's ImportSessionContext rules", () => 
     const problems = validateWorkImportRequest(
       validRequest({
         other_software: "   ",
-        skipped: ["workflow_description", "interaction_wishes"],
+        skipped: ["workflow_description", "interaction_wishes", "anything_else"],
       }),
     );
     expect(problems).toContain('"other_software" has no answer and is not marked as skipped.');
@@ -266,6 +272,7 @@ describe("buildRequest always satisfies A2's rules", () => {
         workflowDescription: { text: "in, out", skipped: false },
         interactionWishes: { text: "background patch", skipped: false },
         otherSoftware: { text: "Fiji", skipped: false },
+        anythingElse: { text: "ask before touching raw/", skipped: false },
       }),
     ],
     [

--- a/frontend/src/lib/api/workImport.ts
+++ b/frontend/src/lib/api/workImport.ts
@@ -31,11 +31,12 @@ export type WorkImportDestinationTier = "project" | "user_library";
  */
 export type BackendPermissionMode = "safe" | "bypass";
 
-/** C2 — the three questions that may be skipped rather than answered. */
+/** C2 — the four questions that may be skipped rather than answered. */
 export type WorkImportSkippableQuestion =
   | "workflow_description"
   | "interaction_wishes"
-  | "other_software";
+  | "other_software"
+  | "anything_else";
 
 /**
  * The request body: `ImportSessionContext` in snake_case plus `project_dir`.
@@ -58,6 +59,8 @@ export interface WorkImportSessionRequest {
   workflow_description: string | null;
   interaction_wishes: string | null;
   other_software: string | null;
+  /** FR-019a — the open question asked last, or null when it was skipped. */
+  anything_else: string | null;
   /**
    * FR-021 — questions the user did not answer, conveyed as skipped rather
    * than omitted, so the agent can tell "the user did not say" from "the user
@@ -93,11 +96,12 @@ export function fromBackendPermissionMode(mode: BackendPermissionMode): Permissi
   return mode === "bypass" ? "dangerous" : "safe";
 }
 
-/** C2 — the only three questions the backend accepts in `skipped`. */
+/** C2 — the only four questions the backend accepts in `skipped`. */
 export const WORK_IMPORT_SKIPPABLE_QUESTIONS: readonly WorkImportSkippableQuestion[] = [
   "workflow_description",
   "interaction_wishes",
   "other_software",
+  "anything_else",
 ];
 
 /**
@@ -170,6 +174,7 @@ export function validateWorkImportRequest(request: WorkImportSessionRequest): st
     workflow_description: request.workflow_description,
     interaction_wishes: request.interaction_wishes,
     other_software: request.other_software,
+    anything_else: request.anything_else,
   };
   for (const key of WORK_IMPORT_SKIPPABLE_QUESTIONS) {
     const answer = answers[key];

--- a/src/scistudio/ai/work_import/brief.py
+++ b/src/scistudio/ai/work_import/brief.py
@@ -57,11 +57,12 @@ _ANSWER_SLOTS: Final[tuple[str, ...]] = (
     "workflow_description",
     "interaction_wishes",
     "other_software",
+    "anything_else",
 )
 """The template's answer substitution points, in the order §4.6 presents them.
 
-Two of them — question 2's and question 4's — carry identical text, so slots are
-matched positionally rather than by their contents.
+Three of them — question 2's, question 4's and question 5's — carry identical
+text, so slots are matched positionally rather than by their contents.
 """
 
 _MARKER_RE: Final = re.compile(r"\{[^{}]*\}", re.DOTALL)

--- a/src/scistudio/ai/work_import/brief_template.md
+++ b/src/scistudio/ai/work_import/brief_template.md
@@ -337,6 +337,19 @@ is being made, and propose it."}
 
 **They said:** {answer, or "Skipped. They did not answer this."}
 
+---
+
+**We asked:** *Is there anything else you want to tell the agent before it
+starts? Anything the questions above did not ask for — something about your
+data, a constraint you work under, a preference, or how you would like it to
+work with you.*
+
+**They said:** {answer, or "Skipped. They did not answer this."}
+
+This one was open, so read what is there and do not read anything into what is
+not: they were given no list to answer against, and a blank means only that
+nothing came to mind.
+
 # When things come up
 
 You already know what SciStudio is and that `mcp__scistudio__*` is how you reach

--- a/src/scistudio/ai/work_import/context.py
+++ b/src/scistudio/ai/work_import/context.py
@@ -43,6 +43,7 @@ SKIPPABLE_QUESTIONS: Final[tuple[str, ...]] = (
     "workflow_description",
     "interaction_wishes",
     "other_software",
+    "anything_else",
 )
 """The questions FR-020 allows the user to skip.
 
@@ -50,7 +51,9 @@ Question 1 (``data_kinds``), the destination tier, and the source-or-no-codebase
 choice are required, so they are not members here. Question 2
 (``workflow_description``) is skippable only in codebase mode (FR-016, FR-017);
 that conditionality is enforced by the dialog, not by this dataclass, which
-records what the user actually did.
+records what the user actually did. Question 5 (``anything_else``) is skippable
+unconditionally (FR-019a): it is the open question, and having nothing to add to
+four specific ones is an ordinary answer to it.
 """
 
 
@@ -81,6 +84,7 @@ class ImportSessionContext:
     workflow_description: str | None
     interaction_wishes: str | None
     other_software: str | None
+    anything_else: str | None
     skipped: frozenset[str]
     provider: str
     permission_mode: PermissionMode

--- a/src/scistudio/api/routes/work_import.py
+++ b/src/scistudio/api/routes/work_import.py
@@ -137,6 +137,10 @@ class WorkImportSessionRequest(BaseModel):
         default=None,
         description="Other software the work has to fit alongside.",
     )
+    anything_else: str | None = Field(
+        default=None,
+        description="Anything else the user wanted the agent to know before it starts (FR-019a).",
+    )
     skipped: list[str] = Field(
         default_factory=list,
         description="Optional questions the user explicitly skipped.",
@@ -268,6 +272,7 @@ def create_work_import_session(request: WorkImportSessionRequest) -> WorkImportS
             workflow_description=request.workflow_description,
             interaction_wishes=request.interaction_wishes,
             other_software=request.other_software,
+            anything_else=request.anything_else,
             skipped=frozenset(request.skipped),
             provider=request.provider,
             permission_mode=request.permission_mode,

--- a/tests/ai/test_work_import_brief.py
+++ b/tests/ai/test_work_import_brief.py
@@ -76,6 +76,7 @@ def make_context(**overrides: object) -> ImportSessionContext:
         "workflow_description": "Load TIFFs, subtract background, segment, then measure per-cell intensity.",
         "interaction_wishes": "Picking the background region by eye.",
         "other_software": "Fiji and CellProfiler",
+        "anything_else": "The folder names carry the plate id, so please keep them.",
         "skipped": frozenset(),
         "provider": "claude-code",
         "permission_mode": "safe",
@@ -88,6 +89,7 @@ ALL_SKIPPED: dict[str, object] = {
     "workflow_description": None,
     "interaction_wishes": None,
     "other_software": None,
+    "anything_else": None,
     "skipped": frozenset(SKIPPABLE_QUESTIONS),
 }
 """Overrides for the user who skipped every skippable question (SC-006)."""
@@ -109,9 +111,9 @@ def test_loaded_template_is_the_transcribed_file() -> None:
 
 
 def test_template_answers_section_carries_exactly_the_expected_placeholders() -> None:
-    """§4.6 defines seven substitution points, all inside "What they told us"."""
+    """§4.6 defines eight substitution points, all inside "What they told us"."""
     template = load_brief_template()
-    assert len(PLACEHOLDER_RE.findall(_answers_section(template))) == 7
+    assert len(PLACEHOLDER_RE.findall(_answers_section(template))) == 8
 
     before, after = _outside_answers_section(template)
     # The only braces elsewhere are the literal ``{project}`` destination paths
@@ -136,7 +138,8 @@ def test_template_answers_section_carries_exactly_the_expected_placeholders() ->
                 data_kinds_other=None,
                 interaction_wishes=None,
                 other_software=None,
-                skipped=frozenset({"interaction_wishes", "other_software"}),
+                anything_else=None,
+                skipped=frozenset({"interaction_wishes", "other_software", "anything_else"}),
                 provider="codex",
                 permission_mode="bypass",
             ),
@@ -174,6 +177,7 @@ def test_no_placeholder_survives_composition(context: ImportSessionContext) -> N
         "*Briefly describe your analysis workflow",
         "*Which steps would you like to be able to interact with, or see the",
         "*Which other data analysis software do you use regularly?*",
+        "*Is there anything else you want to tell the agent before it",
     ],
 )
 def test_each_question_is_reproduced_as_the_user_saw_it(question_text: str) -> None:
@@ -260,6 +264,46 @@ def test_the_dialogs_preset_labels_are_the_ones_the_brief_reproduces() -> None:
     assert _dialog_preset_labels() == DATA_KIND_PRESETS
 
 
+def _dialog_string_constant(name: str) -> str:
+    """The value of a single ``export const <name> = "…" + "…";`` in ``copy.ts``.
+
+    Read out of the TypeScript source for the same reason
+    :func:`_dialog_preset_labels` is: the property being pinned spans the two
+    languages, and this side is the one that can read a ``.ts`` file with no
+    toolchain. The copy module wraps its longer strings across lines with ``+``,
+    so the segments are concatenated back together here.
+    """
+    source = COPY_TS_PATH.read_text(encoding="utf-8")
+    start = source.index(f"export const {name} =")
+    declaration = source[start : source.index(";", start)]
+    segments = re.findall(r'"((?:[^"\\]|\\.)*)"', declaration)
+    assert segments, f"{name} not found as a string constant in {COPY_TS_PATH}"
+    return "".join(segments)
+
+
+def _unwrapped(text: str) -> str:
+    """Collapse the template's soft line wrapping, as the dialog's copy has none."""
+    return re.sub(r"\s+", " ", text)
+
+
+@pytest.mark.parametrize("constant", ["Q5_LABEL", "Q5_HELP"])
+def test_question_5_reaches_the_agent_in_the_dialogs_own_words(constant: str) -> None:
+    """FR-019a: question 5 is open, so its wording is the whole of what was asked.
+
+    The other four questions each name a subject, and an agent reading a short
+    answer to one of them can tell what it is an answer to. Question 5 names
+    nothing: without the prompt the user actually saw — the question and the
+    line under it listing the kinds of thing it wanted — an answer like "the
+    plate ids matter" arrives with no indication of what it was a reply to.
+
+    So both strings are pinned, and they are pinned in the direction that can
+    silently go wrong: the dialog is what the user read, and §4.6 is what the
+    agent is told they read.
+    """
+    answers = _unwrapped(_answers_section(compose_brief(make_context())))
+    assert _unwrapped(_dialog_string_constant(constant)) in answers
+
+
 @pytest.mark.parametrize("preset", DATA_KIND_PRESETS)
 def test_each_preset_label_appears_in_spec_section_4_6(preset: str) -> None:
     """The third copy — the spec's own prose list — agrees with the other two.
@@ -293,6 +337,7 @@ SKIP_WORDING = {
         "Work out for yourself where a human judgement is being made, and propose it."
     ),
     "other_software": "Skipped. They did not answer this.",
+    "anything_else": "Skipped. They did not answer this.",
 }
 
 
@@ -328,10 +373,10 @@ def test_interaction_skip_tells_the_agent_to_work_it_out_itself() -> None:
     assert "Work out for yourself where a human judgement is being made" in answers
 
 
-def test_all_three_optional_questions_can_be_skipped_at_once() -> None:
+def test_every_optional_question_can_be_skipped_at_once() -> None:
     """SC-006: skipping everything still produces a brief that distinguishes skips."""
     answers = _answers_section(compose_brief(make_context(**ALL_SKIPPED)))
-    assert answers.count("Skipped. They did not answer this.") == 2
+    assert answers.count("Skipped. They did not answer this.") == 3
     assert SKIP_WORDING["interaction_wishes"] in answers
 
 
@@ -395,6 +440,7 @@ def test_both_tiers_carry_the_full_destination_guidance(tier: str) -> None:
         "Load TIFFs, subtract background, segment, then measure per-cell intensity.",
         "Picking the background region by eye.",
         "Fiji and CellProfiler",
+        "The folder names carry the plate id, so please keep them.",
     ],
 )
 def test_every_collected_answer_reaches_the_brief(answer: str) -> None:
@@ -438,6 +484,7 @@ def test_context_matches_contract_c2_field_names_and_order() -> None:
         "workflow_description",
         "interaction_wishes",
         "other_software",
+        "anything_else",
         "skipped",
         "provider",
         "permission_mode",

--- a/tests/api/test_work_import_session.py
+++ b/tests/api/test_work_import_session.py
@@ -163,6 +163,7 @@ def _payload(project_root: Path, **overrides: Any) -> dict[str, Any]:
         "workflow_description": "I run a MATLAB script over every folder, then paste the numbers into Excel.",
         "interaction_wishes": "I want to change the baseline window and see the fit update.",
         "other_software": None,
+        "anything_else": "Please ask before you touch anything under raw/.",
         "skipped": ["other_software"],
         "provider": "claude-code",
         "permission_mode": "safe",
@@ -182,6 +183,7 @@ def _expected_brief(body: dict[str, Any]) -> str:
         workflow_description=body["workflow_description"],
         interaction_wishes=body["interaction_wishes"],
         other_software=body["other_software"],
+        anything_else=body["anything_else"],
         skipped=frozenset(body["skipped"]),
         provider=body["provider"],
         permission_mode=body["permission_mode"],
@@ -684,11 +686,45 @@ def test_a_blank_answer_is_a_valid_session_not_an_error(
         opened_project,
         interaction_wishes="   ",
         other_software=None,
+        anything_else="   ",
         skipped=[],
     )
 
     assert spawn.calls[0]["brief_text_at_spawn"] == _expected_brief(body)
     assert (opened_project / data["brief_path"]).is_file()
+
+
+def test_the_final_open_answer_reaches_the_brief_the_agent_reads(
+    client: TestClient, opened_project: Path, spawn: _SpawnRecorder
+) -> None:
+    """FR-019a with FR-023: question 5 is an answer like any other, not a note.
+
+    It is the one question the user was not told what to say to, so it is also
+    the one most likely to carry the fact that changes how the session should go
+    — asserted against the file on disk rather than the composed string, because
+    the file is what the agent opens.
+    """
+    body, data = _start(client, opened_project, anything_else="Please ask before you touch anything under raw/.")
+
+    written = (opened_project / data["brief_path"]).read_text(encoding="utf-8")
+    assert body["anything_else"] in written
+    assert written == _expected_brief(body)
+
+
+def test_the_final_open_question_can_be_skipped(
+    client: TestClient, opened_project: Path, spawn: _SpawnRecorder
+) -> None:
+    """FR-019a: having nothing to add is an answer, and the brief says so."""
+    body, data = _start(
+        client,
+        opened_project,
+        anything_else=None,
+        skipped=["other_software", "anything_else"],
+    )
+
+    written = (opened_project / data["brief_path"]).read_text(encoding="utf-8")
+    assert written == _expected_brief(body)
+    assert written.count("Skipped. They did not answer this.") == 2
 
 
 def test_no_codebase_session_is_a_first_class_path(


### PR DESCRIPTION
## Summary

The Bring In My Work dialog asked four questions, each about one specific thing:
the user's data, their workflow, the steps they want to step into, and the other
software they use. Each one is answerable *because* it is specific — and each one
is also a filter. A user whose most important fact was none of those four had
nowhere to put it, and the session started without it.

This adds question 5, the last thing the dialog asks: **is there anything else
you want to tell the agent before it starts?** Free text, skippable like
questions 3 and 4, and carried into the brief with every other answer.

**Why it is last, and why it is open.** Asked earlier, an open question collects
the answers the specific questions were going to collect, in a vaguer form. Asked
last, it collects only what the four named questions filtered out. Its help line
lists *kinds* of thing rather than an example answer, because an example would
narrow exactly the question that exists not to be narrow — and it is skippable
because having nothing to add to four specific questions is an ordinary answer to
an open one, not a field somebody gave up on.

| Area | Change |
|---|---|
| Spec | `FR-019a` records question 5, its position and its skip; `FR-020` now covers it; §4.6's brief text gains the question block, and `brief_template.md` is re-transcribed from §4.6 mechanically (FR-026 fidelity is asserted by an existing test) |
| Backend | `ImportSessionContext.anything_else`, the new member of `SKIPPABLE_QUESTIONS`, the template's eighth answer slot, and the request field on `POST /api/work-import/sessions` |
| Frontend | `Q5_*` copy, `anythingElse` form state, the `q5` page and its skip control, and `anything_else` in the request body and its client-side validation |
| Docs | Contract C2's field table in the work-import checklist, plus a decision-log row for the owner directive |

Nothing about the existing four questions changed — not their wording, their
order, their help text, or their skip semantics.

## Related Issues

Closes #2070

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI / tooling
- [ ] Breaking change

## Checklist

- [x] Linked to an issue
- [x] Tests added or updated
- [x] Docs updated (if applicable)
- [x] Spec/ADR updated (if applicable)
- [x] Self-reviewed
- [x] No unrelated changes

### Tests

- `tests/ai/test_work_import_brief.py` — question 5's label and help line are
  pinned as the same strings on both sides of the language boundary (the dialog
  is what the user read; §4.6 is what the agent is told they read), the answer
  count and skip wording follow, and the template-vs-spec fidelity test carries
  the new block for free.
- `tests/api/test_work_import_session.py` — the answer reaches the brief file the
  agent opens, and the question can be skipped.
- `BringInMyWorkDialogPaging.test.tsx` — question 5 is the last page, names no
  subject, offers a skip, and its answer reaches the request.
- The existing paged walk, the FR-006/FR-007 guard, and the skipped-not-omitted
  assertions all extend over the new page.

### Verification

| Check | Result |
|---|---|
| `pytest tests/ai/test_work_import_brief.py tests/api/test_work_import_session.py` | 132 passed |
| `pytest tests/architecture/` | 485 passed, 1 skipped |
| `ruff check .` / `ruff format --check .` | clean |
| `mypy src/scistudio/ --ignore-missing-imports` | no issues in 368 files |
| `npx vitest run` (full frontend suite) | 156 files / 1735 tests passed |
| `npm run lint`, `tsc --noEmit`, `prettier --check` | 0 errors |

`gate_record check --mode pre-pr` (tier 1) holds current passing evidence for
every selected check — `architecture_tests`, `deferral_discipline`,
`format_check`, `frontend`, `full_audit`, `import_contracts`, `lint_format`,
`python_tests`, `type_check` — with one exception, stated rather than waived:

- **`semantic_dup` could not run in this session.** `scripts/semantic_dup_scan.py`
  loads its embedding model through fastembed from `huggingface.co`, and this
  environment's egress policy answers 403 to that CONNECT, so the model cannot be
  fetched. The gate CLI records the reason and says plainly that the N/A does not
  waive the obligation; `semantic-dup-scan.yml` runs the scan on this PR, which is
  where the result should be read. The diff adds no new Python functions — only
  fields, a slot, and comments — so it has no new candidates for that ratchet.
- **This PR was opened through the GitHub API rather than
  `scripts/scistudio_pr_create.py`.** That wrapper shells out to `gh pr create`,
  and the `gh` CLI is not available in this remote session.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GhhyGHu65UDLx7FEkta3un)_