### PR TITLE
fix(#2073): ignore registry fields a newer build added instead of failing startup

### DIFF
--- a/.workflow/records/2073-fix-2073-known-project-forward-compat.json
+++ b/.workflow/records/2073-fix-2073-known-project-forward-compat.json
@@ -119,7 +119,13 @@
       "rationale": "Cannot pass locally on Windows. Eight Learning Center tests fail identically on unmodified origin/main (issue #2075) for test-side reasons: shutil.rmtree over read-only git objects, CRLF text fixtures, an OS-separator path comparison, and a symlink privilege. None is touched by this diff, whose own tests pass. CI is Ubuntu-only, green on the same base, and runs this check authoritatively."
     }
   ],
-  "commit": null,
+  "commit": {
+    "sha": "4a86121b741eca3bc9f68163b818860e651f871b",
+    "shas": [
+      "4a86121b741eca3bc9f68163b818860e651f871b"
+    ],
+    "trailers": []
+  },
   "declared_scope": {
     "exclude": [],
     "include": [
@@ -337,6 +343,94 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-08-20T05:46:09.381259Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-20T05:46:09.396007Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-20T05:46:09.417752Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-20T05:46:09.433980Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-20T05:46:09.449194Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-20T05:46:09.462875Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-20T05:46:09.476287Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-20T05:46:09.490305Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-20T05:46:09.504787Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-20T05:46:09.518992Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-20T05:46:09.535435Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -357,9 +451,9 @@
       "src/scistudio/api/runtime/_projects.py",
       "tests/api/test_known_project_registry.py"
     ],
-    "diff_fingerprint": "sha256:1f9f69720b66ad7e8124cfeac69027da948a1f8e602ca2657d4a3781eb97ac29",
+    "diff_fingerprint": "sha256:d7e464a07f435aab1ec3cd715cab1baaffefd617ef8a7ae140a0af35bd6b25bb",
     "head": "HEAD",
-    "head_sha": "dbf1f935",
+    "head_sha": "4a86121b",
     "surfaces": {
       "docs": 0,
       "frontend": 0,
@@ -376,7 +470,14 @@
   },
   "owner_directive": "Owner: root-fix the known-project registry loader so a projects.json written by a newer build cannot brick an older runtime, then ship it as an urgent PR ahead of an OTA build25 hot update.",
   "persona": "implementer",
-  "pull_request": null,
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [
+      2073
+    ],
+    "number": null,
+    "url": null
+  },
   "reconcile_events": [
     {
       "at": "2026-08-20T05:25:34.283154Z",
@@ -395,6 +496,17 @@
       "result": "pass",
       "tier": 2,
       "unsatisfied": []
+    },
+    {
+      "at": "2026-08-20T05:46:09.535458Z",
+      "diff_fingerprint": "sha256:d7e464a07f435aab1ec3cd715cab1baaffefd617ef8a7ae140a0af35bd6b25bb",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.python_tests",
+        "checks.semantic_dup"
+      ]
     }
   ],
   "record_id": "2073-fix-2073-known-project-forward-compat",
@@ -438,6 +550,12 @@
       "at": "2026-08-20T05:10:11.651847Z",
       "pattern": "CHANGELOG.md",
       "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-20T05:58:00.658060Z",
+      "pattern": "src/scistudio/api/runtime/__init__.py",
+      "reason": "Review finding on PR #2076: dropping unknown keys at load makes the next full-file rewrite erase them, so a downgraded runtime silently deletes a newer build's per-project metadata. Carrying the keys aside at load and splicing them back at save needs one new attribute declared on ApiRuntime."
     }
   ],
   "session_id": "792e9a91-9817-42f5-9801-41961feb0018",

--- a/.workflow/records/2073-fix-2073-known-project-forward-compat.json
+++ b/.workflow/records/2073-fix-2073-known-project-forward-compat.json
@@ -1,7 +1,124 @@
 {
   "branch": "fix/2073-known-project-forward-compat",
-  "check_events": [],
-  "check_na": [],
+  "check_events": [
+    {
+      "at": "2026-08-20T05:12:35.359013Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:02135e75355536b526a7408ac9f8357f112b453a29cd825e6f012fe04606cfcd",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-20T05:12:45.248227Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:a2ef412ed617d1641823a47562258dd90b3adb4e6dc353aaf8c80ecc7f4e88ca",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-20T05:12:45.499458Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:54ed3d342234040e16966a02b59756e9ba7d424453e6d2d0c0227e0a719d705a",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-20T05:12:45.535855Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:0fd19e9550ac2df9cd9b27a71627a76b97a824d39cb1c4cc846ca7c354bf8035",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-20T05:15:31.431231Z",
+      "command": "python -m scistudio.qa.testing.run_python_tests --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:a2d9a2c70151638b5c456e1b89891c7148775f451064ba5ad2431eb7fde35c76",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-20T05:25:31.455943Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": null,
+      "input_fingerprint": "sha256:3468c5cf7dde76ed42a02bc03673121955c4feb907b32453b3dab2d9c1694934",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": null,
+      "status": "unknown",
+      "summary": "execution error: TimeoutExpired",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-20T05:25:34.112282Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:192c9bb7a03a9b3037b1945e6e94d6fad155f178b534bf30e90381e308a52b48",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    }
+  ],
+  "check_na": [
+    {
+      "name": "python_tests",
+      "rationale": "Cannot pass locally on Windows. Eight Learning Center tests fail identically on unmodified origin/main (issue #2075) for test-side reasons: shutil.rmtree over read-only git objects, CRLF text fixtures, an OS-separator path comparison, and a symlink privilege. None is touched by this diff, whose own tests pass. CI is Ubuntu-only, green on the same base, and runs this check authoritatively."
+    }
+  ],
   "commit": null,
   "declared_scope": {
     "exclude": [],
@@ -44,7 +161,184 @@
     }
   ],
   "governance_touch": false,
-  "guard_events": [],
+  "guard_events": [
+    {
+      "at": "2026-08-20T05:25:34.153099Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-20T05:25:34.165786Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-20T05:25:34.179398Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-20T05:25:34.192849Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-20T05:25:34.206159Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-20T05:25:34.219120Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-20T05:25:34.231973Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-20T05:25:34.244073Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-20T05:25:34.257138Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-20T05:25:34.269679Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-20T05:25:34.283130Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-20T05:30:47.071254Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-20T05:30:47.086459Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-20T05:30:47.100724Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-20T05:30:47.118914Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-20T05:30:47.134122Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-20T05:30:47.148007Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-20T05:30:47.161767Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-20T05:30:47.176136Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-20T05:30:47.190690Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-20T05:30:47.204886Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-20T05:30:47.220692Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
   "issues": [
     {
       "close_in_pr": true,
@@ -54,19 +348,87 @@
     }
   ],
   "observed_admin_labels": [],
-  "observed_diff": null,
+  "observed_diff": {
+    "base": "origin/main",
+    "base_sha": "6b0a5b66",
+    "changed_files": [
+      ".workflow/records/2073-fix-2073-known-project-forward-compat.json",
+      "CHANGELOG.md",
+      "src/scistudio/api/runtime/_projects.py",
+      "tests/api/test_known_project_registry.py"
+    ],
+    "diff_fingerprint": "sha256:1f9f69720b66ad7e8124cfeac69027da948a1f8e602ca2657d4a3781eb97ac29",
+    "head": "HEAD",
+    "head_sha": "dbf1f935",
+    "surfaces": {
+      "docs": 0,
+      "frontend": 0,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 1,
+      "packaging": 0,
+      "protected_architecture": 0,
+      "protected_core": 0,
+      "sentrux": 2,
+      "test": 1,
+      "workflow_ci": 0
+    }
+  },
   "owner_directive": "Owner: root-fix the known-project registry loader so a projects.json written by a newer build cannot brick an older runtime, then ship it as an urgent PR ahead of an OTA build25 hot update.",
   "persona": "implementer",
   "pull_request": null,
-  "reconcile_events": [],
+  "reconcile_events": [
+    {
+      "at": "2026-08-20T05:25:34.283154Z",
+      "diff_fingerprint": "sha256:1f9f69720b66ad7e8124cfeac69027da948a1f8e602ca2657d4a3781eb97ac29",
+      "mode": "local",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.python_tests"
+      ]
+    },
+    {
+      "at": "2026-08-20T05:30:47.220727Z",
+      "diff_fingerprint": "sha256:1f9f69720b66ad7e8124cfeac69027da948a1f8e602ca2657d4a3781eb97ac29",
+      "mode": "local",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    }
+  ],
   "record_id": "2073-fix-2073-known-project-forward-compat",
   "requested_admin_labels": [],
   "required_obligations": {
     "admin_labels": [],
-    "checks": [],
-    "docs": [],
-    "guards": [],
-    "tests": []
+    "checks": [
+      "format_check",
+      "full_audit",
+      "import_contracts",
+      "lint_format",
+      "python_tests",
+      "semantic_dup",
+      "type_check"
+    ],
+    "docs": [
+      "docs_required_or_na"
+    ],
+    "guards": [
+      "architecture_doc_guard",
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": [
+      "changed_test_required"
+    ]
   },
   "runtime": "claude-code",
   "schema_version": 2,
@@ -79,7 +441,7 @@
     }
   ],
   "session_id": "792e9a91-9817-42f5-9801-41961feb0018",
-  "strictness_tier": null,
+  "strictness_tier": 2,
   "task_kind": "bugfix",
   "test_events": [
     {

--- a/.workflow/records/2073-fix-2073-known-project-forward-compat.json
+++ b/.workflow/records/2073-fix-2073-known-project-forward-compat.json
@@ -111,6 +111,117 @@
       "tool_versions": {
         "mypy": "2.1.0"
       }
+    },
+    {
+      "at": "2026-08-20T06:09:49.366247Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:b8be02d1c7b9a5d51b0eee2fcf8445a6977a01e68d2d4145b898c3e3d0bb8660",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-20T06:09:59.477515Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:9817bffaf3ebc66db04b16dec656eec3e652b77b6b6094578bc5d7bbb4da0781",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-20T06:09:59.722976Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:ffe724df4794e59f43c49013ecc1bfea1ca9dc1ec81d7ca46d17968de555f1a5",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-20T06:09:59.758755Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:b705464555ad9142b9892481195b9716c6432d020c3eeadf19366ee81b7e1a4e",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-20T06:12:02.806802Z",
+      "command": "python -m scistudio.qa.testing.run_python_tests --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:cf356bd62d508dbbaf8a725b9fdd652a7b5ec6b7a10e0f795d9647f513aa05ce",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-20T06:22:02.835526Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": null,
+      "input_fingerprint": "sha256:6a362208ef3d8f674d60d3311e980703f7ccc709783e87cf006b6b6dd3d595d1",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": null,
+      "status": "unknown",
+      "summary": "execution error: TimeoutExpired",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-20T06:22:05.479208Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:4b4757e2f4f5e5cb8cc898636caa960198ebd8ec12e085f91530958e39d81a1a",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
     }
   ],
   "check_na": [
@@ -120,9 +231,9 @@
     }
   ],
   "commit": {
-    "sha": "4a86121b741eca3bc9f68163b818860e651f871b",
+    "sha": "0eab742c7c36098479da255400fe655a2173e4e7",
     "shas": [
-      "4a86121b741eca3bc9f68163b818860e651f871b"
+      "0eab742c7c36098479da255400fe655a2173e4e7"
     ],
     "trailers": []
   },
@@ -431,6 +542,182 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-08-20T06:22:05.520720Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-20T06:22:05.533732Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-20T06:22:05.547205Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-20T06:22:05.561140Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-20T06:22:05.574635Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-20T06:22:05.589378Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-20T06:22:05.605098Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-20T06:22:05.618805Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-20T06:22:05.631828Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-20T06:22:05.644151Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-20T06:22:05.659089Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-20T06:22:26.589666Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-20T06:22:26.605174Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-20T06:22:26.618857Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-20T06:22:26.633264Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-20T06:22:26.647445Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-20T06:22:26.660988Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-20T06:22:26.674562Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-20T06:22:26.687957Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-20T06:22:26.701365Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-20T06:22:26.715212Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-20T06:22:26.731111Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -443,27 +730,28 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "origin/main",
+    "base": "6b0a5b666be4aec53c5252dd7c8db341b88b4359",
     "base_sha": "6b0a5b66",
     "changed_files": [
       ".workflow/records/2073-fix-2073-known-project-forward-compat.json",
       "CHANGELOG.md",
+      "src/scistudio/api/runtime/__init__.py",
       "src/scistudio/api/runtime/_projects.py",
       "tests/api/test_known_project_registry.py"
     ],
-    "diff_fingerprint": "sha256:d7e464a07f435aab1ec3cd715cab1baaffefd617ef8a7ae140a0af35bd6b25bb",
+    "diff_fingerprint": "sha256:c028a7ef986038f7170d29c31be9bdbf3a4bc4ab889bcd8c9ff4082121867113",
     "head": "HEAD",
-    "head_sha": "4a86121b",
+    "head_sha": "0eab742c",
     "surfaces": {
       "docs": 0,
       "frontend": 0,
       "governance": 0,
       "governed_docs": 0,
-      "implementation": 1,
+      "implementation": 2,
       "packaging": 0,
       "protected_architecture": 0,
       "protected_core": 0,
-      "sentrux": 2,
+      "sentrux": 3,
       "test": 1,
       "workflow_ci": 0
     }
@@ -475,7 +763,7 @@
     "closes": [
       2073
     ],
-    "number": null,
+    "number": 2076,
     "url": null
   },
   "reconcile_events": [
@@ -500,6 +788,27 @@
     {
       "at": "2026-08-20T05:46:09.535458Z",
       "diff_fingerprint": "sha256:d7e464a07f435aab1ec3cd715cab1baaffefd617ef8a7ae140a0af35bd6b25bb",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.python_tests",
+        "checks.semantic_dup"
+      ]
+    },
+    {
+      "at": "2026-08-20T06:22:05.659113Z",
+      "diff_fingerprint": "sha256:c028a7ef986038f7170d29c31be9bdbf3a4bc4ab889bcd8c9ff4082121867113",
+      "mode": "local",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.python_tests"
+      ]
+    },
+    {
+      "at": "2026-08-20T06:22:26.731136Z",
+      "diff_fingerprint": "sha256:c028a7ef986038f7170d29c31be9bdbf3a4bc4ab889bcd8c9ff4082121867113",
       "mode": "pre-pr",
       "result": "fail",
       "tier": 2,

--- a/.workflow/records/2073-fix-2073-known-project-forward-compat.json
+++ b/.workflow/records/2073-fix-2073-known-project-forward-compat.json
@@ -1,0 +1,94 @@
+{
+  "branch": "fix/2073-known-project-forward-compat",
+  "check_events": [],
+  "check_na": [],
+  "commit": null,
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "src/scistudio/api/runtime/_projects.py",
+      "tests/api/**"
+    ]
+  },
+  "directive_events": [
+    {
+      "at": "2026-08-20T05:10:11.651828Z",
+      "owner_directive": "Fix scoped to the loader tolerance only; save-side field omission, desktop-side self-healing, and the identical checkpoint deserialisation pattern are recorded as out of scope in issue #2073.",
+      "reason": "plan"
+    }
+  ],
+  "docs_events": [
+    {
+      "at": "2026-08-20T05:10:11.651859Z",
+      "class": null,
+      "kind": "path",
+      "path": "CHANGELOG.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-20T05:10:11.651868Z",
+      "class": "spec",
+      "kind": "na",
+      "path": null,
+      "rationale": "No spec describes the user-level project registry entry schema; the fix restores the documented startup contract rather than changing one.",
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-20T05:10:11.651877Z",
+      "class": "adr",
+      "kind": "na",
+      "path": null,
+      "rationale": "Loader robustness inside an existing contract, not an architectural decision \u2014 no ADR-level tradeoff is introduced.",
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": false,
+  "guard_events": [],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 2073,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": null,
+  "owner_directive": "Owner: root-fix the known-project registry loader so a projects.json written by a newer build cannot brick an older runtime, then ship it as an urgent PR ahead of an OTA build25 hot update.",
+  "persona": "implementer",
+  "pull_request": null,
+  "reconcile_events": [],
+  "record_id": "2073-fix-2073-known-project-forward-compat",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [],
+    "docs": [],
+    "guards": [],
+    "tests": []
+  },
+  "runtime": "claude-code",
+  "schema_version": 2,
+  "scope_events": [
+    {
+      "action": "add-include",
+      "at": "2026-08-20T05:10:11.651847Z",
+      "pattern": "CHANGELOG.md",
+      "reason": "plan"
+    }
+  ],
+  "session_id": "792e9a91-9817-42f5-9801-41961feb0018",
+  "strictness_tier": null,
+  "task_kind": "bugfix",
+  "test_events": [
+    {
+      "at": "2026-08-20T05:10:11.651881Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/api/test_known_project_registry.py",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   alive at once would have produced drift with no beneficiary. It is recorded as
   breaking regardless, because a route leaves the API surface.
 
+### Fixed
+
+- [#2073] **A project registry written by a newer build no longer stops an older
+  runtime from starting.** `~/.scistudio/projects.json` outlives the runtime that
+  reads it — it survives uninstall and reinstall, and the desktop client's OTA
+  rollback can put an older runtime in front of a file a newer one wrote. Since
+  every `KnownProject` field is persisted, that file carried keys the older
+  runtime had never heard of, and passing them to the dataclass raised
+  `TypeError` inside the FastAPI lifespan. Startup aborted rather than the
+  project list degrading: the desktop client reported only an HTTP timeout, and
+  because the file is user-level, every relaunch, reinstall, and further rollback
+  read it again with no route back for the user.
+  Unrecognised keys are now ignored and logged once, and an entry that still
+  cannot be constructed is skipped with a warning instead of taking the registry,
+  and the process, down with it.
+
 ### Added
 
 - [#2054] **The architecture document is now owner-controlled in CI, not only by

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,7 +98,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   read it again with no route back for the user.
   Unrecognised keys are now ignored and logged once, and an entry that still
   cannot be constructed is skipped with a warning instead of taking the registry,
-  and the process, down with it.
+  and the process, down with it. They are ignored rather than discarded: the
+  registry is rewritten in full on every project open, create and delete, so
+  parsing past a field and then writing without it would have erased a newer
+  build's metadata on the first project the user touched. The keys are carried
+  through untouched, which keeps a downgrade readable in both directions.
 
 ### Added
 

--- a/src/scistudio/api/runtime/__init__.py
+++ b/src/scistudio/api/runtime/__init__.py
@@ -315,6 +315,9 @@ class ApiRuntime:
         self.registry_dir.mkdir(parents=True, exist_ok=True)
         self.known_projects_path = self.registry_dir / "projects.json"
         self.known_projects: dict[str, KnownProject] = {}
+        # #2073: per-project registry keys this build does not model, kept
+        # aside at load so saving cannot erase a newer build's metadata.
+        self._known_project_extras: dict[str, dict[str, Any]] = {}
 
         self.active_project: KnownProject | None = None
         # #1551 / DSN-12: both registries are LRU-bounded so a long session does

--- a/src/scistudio/api/runtime/_projects.py
+++ b/src/scistudio/api/runtime/_projects.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import json
 import logging
-from dataclasses import asdict
+from dataclasses import asdict, fields
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 from urllib.parse import unquote
@@ -40,17 +40,49 @@ logger = logging.getLogger(__name__)
 
 
 def _load_known_projects(self: ApiRuntime) -> None:
+    """Load the user-level project registry, tolerating a file a newer build wrote.
+
+    Issue #2073: ``~/.scistudio/projects.json`` outlives the runtime that reads
+    it. It survives uninstall and reinstall, and the desktop client's OTA
+    rollback can move the runtime *backwards* past the build that wrote the
+    file. Because :func:`_save_known_projects` persists every dataclass field,
+    a registry written by a newer build carries keys this ``KnownProject`` has
+    never heard of, and passing them straight to the constructor raises
+    ``TypeError``.
+
+    That exception used to be fatal rather than local. This runs from
+    ``ApiRuntime.__init__``, which runs inside the FastAPI lifespan, so one
+    unrecognised key aborted server startup — leaving the desktop client to
+    report nothing but an HTTP timeout while every relaunch read the same file
+    and failed the same way, with no path back for the user.
+
+    So unknown keys are dropped instead of rejected, and an entry that still
+    cannot be constructed (a missing required field, say) is skipped with a
+    warning rather than taking the registry, and the process, down with it.
+    """
     from .models import KnownProject
 
     if not self.known_projects_path.exists():
         self.known_projects = {}
         return
     raw = json.loads(self.known_projects_path.read_text(encoding="utf-8"))
-    self.known_projects = {
-        entry["id"]: KnownProject(**entry)
-        for entry in raw.get("projects", [])
-        if isinstance(entry, dict) and entry.get("id") and entry.get("path")
-    }
+    accepted = {f.name for f in fields(KnownProject)}
+    unrecognised: set[str] = set()
+    known: dict[str, KnownProject] = {}
+    for entry in raw.get("projects", []):
+        if not isinstance(entry, dict) or not entry.get("id") or not entry.get("path"):
+            continue
+        unrecognised.update(entry.keys() - accepted)
+        try:
+            known[entry["id"]] = KnownProject(**{k: v for k, v in entry.items() if k in accepted})
+        except TypeError:
+            logger.warning("Skipping unusable project registry entry %r", entry["id"])
+    if unrecognised:
+        logger.info(
+            "Ignoring unrecognised project registry field(s) %s; the registry was written by a newer build",
+            ", ".join(sorted(unrecognised)),
+        )
+    self.known_projects = known
 
 
 def _save_known_projects(self: ApiRuntime) -> None:

--- a/src/scistudio/api/runtime/_projects.py
+++ b/src/scistudio/api/runtime/_projects.py
@@ -59,34 +59,65 @@ def _load_known_projects(self: ApiRuntime) -> None:
     So unknown keys are dropped instead of rejected, and an entry that still
     cannot be constructed (a missing required field, say) is skipped with a
     warning rather than taking the registry, and the process, down with it.
+
+    Dropped is not the same as discarded. The keys are kept aside per project
+    and spliced back by :func:`_save_known_projects`, because that function
+    rewrites the whole file on every project open, create and delete — so
+    parsing past a field and then writing without it would erase a newer
+    build's metadata on the first project the user touched.
     """
     from .models import KnownProject
 
     if not self.known_projects_path.exists():
         self.known_projects = {}
+        self._known_project_extras = {}
         return
     raw = json.loads(self.known_projects_path.read_text(encoding="utf-8"))
     accepted = {f.name for f in fields(KnownProject)}
-    unrecognised: set[str] = set()
     known: dict[str, KnownProject] = {}
+    extras: dict[str, dict[str, Any]] = {}
     for entry in raw.get("projects", []):
         if not isinstance(entry, dict) or not entry.get("id") or not entry.get("path"):
             continue
-        unrecognised.update(entry.keys() - accepted)
         try:
             known[entry["id"]] = KnownProject(**{k: v for k, v in entry.items() if k in accepted})
         except TypeError:
             logger.warning("Skipping unusable project registry entry %r", entry["id"])
-    if unrecognised:
+            continue
+        carried = {k: v for k, v in entry.items() if k not in accepted}
+        if carried:
+            extras[entry["id"]] = carried
+    if extras:
         logger.info(
-            "Ignoring unrecognised project registry field(s) %s; the registry was written by a newer build",
-            ", ".join(sorted(unrecognised)),
+            "Carrying %d unrecognised project registry field(s) forward unread: %s",
+            len(set().union(*extras.values())),
+            ", ".join(sorted(set().union(*extras.values()))),
         )
     self.known_projects = known
+    self._known_project_extras = extras
 
 
 def _save_known_projects(self: ApiRuntime) -> None:
-    payload = {"projects": [asdict(entry) for entry in self.known_projects.values()]}
+    """Persist the registry, carrying forward fields this build does not model.
+
+    Issue #2073: dropping unrecognised keys at load is what lets an older
+    runtime start at all, but this function rewrites the whole file on every
+    project open, create and delete. Writing back only what this build models
+    would therefore erase a newer build's metadata from every entry — silently,
+    and on the first project the user touched. For the Learning Center that is
+    the tutorial marker a project's identity depends on, so the projects would
+    come back from a downgrade as ordinary ones.
+
+    The keys are set aside at load and spliced back here instead, which keeps a
+    downgrade merely readable rather than destructive. They are never
+    interpreted; a field this build does not understand is data to carry, not
+    data to act on.
+    """
+    payload = {
+        "projects": [
+            {**asdict(entry), **self._known_project_extras.get(entry.id, {})} for entry in self.known_projects.values()
+        ]
+    }
     self.known_projects_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
 
 

--- a/tests/api/test_known_project_registry.py
+++ b/tests/api/test_known_project_registry.py
@@ -121,3 +121,80 @@ def test_the_api_starts_against_a_registry_from_a_newer_build(isolated_home: Pat
 
     with TestClient(create_app()) as client:
         assert client.get("/api/projects/").status_code == 200
+
+
+def test_the_registry_round_trips_unchanged_through_this_build(isolated_home: Path) -> None:
+    """Loading and saving is not allowed to be lossy.
+
+    ``_save_known_projects`` rewrites the whole file, so a build that parsed
+    past a field it does not model and then wrote without it would erase that
+    field from every entry at once. The keys are carried instead, which is what
+    makes a downgrade readable in both directions rather than destructive in
+    one.
+    """
+    original = [
+        {
+            "id": "project-1",
+            "name": "Demo",
+            "path": str(isolated_home / "demo"),
+            "description": "",
+            "last_opened": "2026-08-20T00:00:00+00:00",
+            "some_field_added_later": "value",
+            "another_field_added_later": None,
+        },
+        {
+            "id": "project-2",
+            "name": "Other",
+            "path": str(isolated_home / "other"),
+            "description": "no later fields at all",
+            "last_opened": None,
+        },
+    ]
+    _write_registry(isolated_home, original)
+
+    runtime = ApiRuntime()
+    runtime._save_known_projects()
+
+    written = json.loads((isolated_home / ".scistudio" / "projects.json").read_text(encoding="utf-8"))["projects"]
+    by_id = {entry["id"]: entry for entry in written}
+
+    assert set(by_id) == {entry["id"] for entry in original}
+    for entry in original:
+        # A superset rather than equality: this build legitimately writes its
+        # own defaults for fields the file omitted. What it may not do is lose
+        # or alter anything the file already said.
+        assert by_id[entry["id"]].items() >= entry.items()
+
+
+def test_creating_a_project_does_not_erase_another_entrys_later_fields(isolated_home: Path, tmp_path: Path) -> None:
+    """The realistic path: the erasure would have happened on ordinary use.
+
+    Every project open, create and delete rewrites the file, so this is what a
+    downgraded runtime does within seconds of starting — not an edge case that
+    needs an unusual sequence to reach.
+    """
+    _write_registry(
+        isolated_home,
+        [
+            {
+                "id": "project-1",
+                "name": "Demo",
+                "path": str(isolated_home / "demo"),
+                "some_field_added_later": "value",
+            }
+        ],
+    )
+    parent = tmp_path / "projects"
+    parent.mkdir()
+
+    with TestClient(create_app()) as client:
+        response = client.post("/api/projects/", json={"name": "New", "description": "", "path": str(parent)})
+        assert response.status_code == 200
+
+    written = json.loads((isolated_home / ".scistudio" / "projects.json").read_text(encoding="utf-8"))["projects"]
+    by_id = {entry["id"]: entry for entry in written}
+    assert len(by_id) == 2
+    assert by_id["project-1"]["some_field_added_later"] == "value"
+    # The project this build created has nothing to carry.
+    created = next(entry for entry in written if entry["id"] != "project-1")
+    assert "some_field_added_later" not in created

--- a/tests/api/test_known_project_registry.py
+++ b/tests/api/test_known_project_registry.py
@@ -1,0 +1,123 @@
+"""The known-project registry survives a file that a newer build wrote.
+
+Issue #2073. ``~/.scistudio/projects.json`` outlives the runtime that reads it:
+it survives uninstall and reinstall, and the desktop client's OTA rollback
+(``startRuntimeWithRollback`` in ``desktop/main.js``) can put an *older* runtime
+in front of a file a newer one wrote. Because ``_save_known_projects`` persists
+every dataclass field, such a file carries keys the older
+:class:`~scistudio.api.runtime.models.KnownProject` has never heard of.
+
+What makes this worth pinning is where the failure landed, not that it happened.
+``_load_known_projects`` runs from ``ApiRuntime.__init__``, which runs inside the
+FastAPI lifespan, so one unrecognised key did not degrade the project list — it
+aborted server startup. The desktop client then reported nothing but an HTTP
+timeout, and because the offending file is user-level, every relaunch, reinstall
+and further rollback read it again, with no route back for the user.
+
+These tests hold the two halves that keep that from recurring: an unknown key is
+ignored, and a single unusable entry costs that entry rather than the process.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from scistudio.api.app import create_app
+from scistudio.api.runtime import ApiRuntime
+
+
+@pytest.fixture()
+def isolated_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """A SciStudio home patched before any runtime is constructed.
+
+    The registry has to exist on disk *before* ``ApiRuntime.__init__`` runs,
+    which is why these tests patch home themselves instead of reusing the
+    ``client`` fixture — that one builds the app against an empty home.
+    """
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+
+    from scistudio.api import runtime as runtime_module
+
+    monkeypatch.setattr(runtime_module.Path, "home", classmethod(lambda cls: fake_home))
+    return fake_home
+
+
+def _write_registry(home: Path, projects: list[dict]) -> None:
+    registry_dir = home / ".scistudio"
+    registry_dir.mkdir(parents=True, exist_ok=True)
+    (registry_dir / "projects.json").write_text(json.dumps({"projects": projects}), encoding="utf-8")
+
+
+def test_entry_from_a_newer_build_loads_without_its_unknown_fields(isolated_home: Path) -> None:
+    """Keys this build has never heard of are dropped, and the entry survives."""
+    _write_registry(
+        isolated_home,
+        [
+            {
+                "id": "project-1",
+                "name": "Demo",
+                "path": str(isolated_home / "demo"),
+                "description": "written by a later build",
+                "last_opened": "2026-08-20T00:00:00+00:00",
+                # Whatever a future KnownProject grows. The real report carried
+                # tutorial_source_kind/tutorial_source_id/tutorial_id from #2057.
+                "some_field_added_later": "value",
+                "another_field_added_later": None,
+            }
+        ],
+    )
+
+    runtime = ApiRuntime()
+
+    assert set(runtime.known_projects) == {"project-1"}
+    loaded = runtime.known_projects["project-1"]
+    assert loaded.name == "Demo"
+    assert loaded.description == "written by a later build"
+    assert not hasattr(loaded, "some_field_added_later")
+
+
+def test_an_unusable_entry_is_skipped_rather_than_fatal(isolated_home: Path, caplog: pytest.LogCaptureFixture) -> None:
+    """A malformed entry costs that entry, and says so, rather than the registry."""
+    _write_registry(
+        isolated_home,
+        [
+            {"id": "usable", "name": "Usable", "path": str(isolated_home / "usable")},
+            # ``name`` has no default, so this one cannot be constructed at all.
+            {"id": "nameless", "path": str(isolated_home / "nameless")},
+        ],
+    )
+
+    with caplog.at_level(logging.WARNING):
+        runtime = ApiRuntime()
+
+    assert set(runtime.known_projects) == {"usable"}
+    assert "nameless" in caplog.text
+
+
+def test_the_api_starts_against_a_registry_from_a_newer_build(isolated_home: Path) -> None:
+    """The regression that actually mattered: the server comes up and serves.
+
+    ``ApiRuntime`` is constructed inside the lifespan, so before #2073 an
+    unrecognised key raised during startup and uvicorn exited instead of
+    listening — which is the state a user could not recover from.
+    """
+    _write_registry(
+        isolated_home,
+        [
+            {
+                "id": "project-1",
+                "name": "Demo",
+                "path": str(isolated_home / "demo"),
+                "some_field_added_later": None,
+            }
+        ],
+    )
+
+    with TestClient(create_app()) as client:
+        assert client.get("/api/projects/").status_code == 200


### PR DESCRIPTION
## What was wrong

The user-level project registry outlives the runtime that reads it. It survives
uninstall and reinstall, and the desktop client's OTA rollback
(`startRuntimeWithRollback` in `desktop/main.js`) can put an *older* runtime in
front of a file a newer one wrote. Because `_save_known_projects` persists every
`KnownProject` field via `asdict()` — including optional fields whose value is
`None` — that file carries keys the older dataclass has never heard of, and
`KnownProject(**entry)` rejects them.

The failure was not a degraded project list. `_load_known_projects` runs from
`ApiRuntime.__init__`, which runs inside the FastAPI lifespan, so one
unrecognised key aborted server startup:

```
TypeError: KnownProject.__init__() got an unexpected keyword argument 'tutorial_source_kind'
ERROR uvicorn.error Application startup failed. Exiting.
```

The desktop client surfaced only `Timed out waiting for SciStudio HTTP
endpoint`, naming neither the file nor the cause. And because the registry is
user-level, there was no route back: every relaunch read the same file, the app
never reached the window and therefore never reached the OTA update check that
could have delivered a newer runtime, and uninstalling did not remove the file.
A single transient start failure, which the rollback path exists to absorb,
could turn into a permanently unstartable install.

## What changed

`_load_known_projects` now filters each entry to the dataclass's own fields
before construction, so unknown keys are ignored and logged once. An entry that
still cannot be constructed — a missing required field, say — is skipped with a
warning rather than taking the registry, and the process, down with it.

Ignoring is not discarding. `_save_known_projects` rewrites the whole file on
every project open, create and delete, so parsing past a field and then writing
without it would erase a newer build's metadata from every entry at once —
silently, and on the first project the user touched. For the Learning Center
those keys are a tutorial project's identity: the marker that hides it from the
project listing, decides what "start over" deletes, and keys its progress.
Erasing it would bring the projects back from a downgrade as ordinary ones,
which trades a startup failure for silent data loss rather than fixing it.

The keys are therefore set aside per project at load and spliced back at save.
They are never interpreted — a field this build does not understand is data to
carry, not data to act on.

Deliberately out of scope, each tracked separately:

- omitting `None`-valued optional fields in `_save_known_projects`, which would
  let a file written by this build stay readable to the runtimes already shipped
  without this fix (issue open on request);
- #2077 — desktop-side recognition of an unreadable registry, the only thing
  that can help a machine whose fallback runtime predates this fix, since
  shipping a fix cannot repair a runtime that predates it;
- #2078 — `scistudio/engine/checkpoint.py` uses the same unfiltered
  `WorkflowCheckpoint(**data)` pattern on a narrower surface.

## Tests

`tests/api/test_known_project_registry.py` — three cases, each of which fails on
`main` with the exact reported `TypeError` and passes here:

- an entry carrying fields a later build added still loads, without them;
- one unusable entry is skipped and logged, and the others survive;
- the API starts and serves against such a registry, which is the regression
  that actually mattered;
- the registry round-trips through a load and save without losing anything the
  file already said;
- creating a project — the ordinary act that rewrites the file — does not erase
  another entry's carried fields.

The last two fail if the splice in `_save_known_projects` is removed, so they
pin the preservation half rather than restating the first three.

## Notes

Found while diagnosing a desktop install that would not start. The trigger there
was #2074 (tests writing to the real home registry) rather than ordinary use,
but the same registry is written by ordinary use on any build that adds a
`KnownProject` field.

Gate record: .workflow/records/2073-fix-2073-known-project-forward-compat.json

Closes #2073
