### PR TITLE
fix(#2079): a finished tutorial no longer reopens the Learning Center on every launch

### DIFF
--- a/.workflow/records/2079-guided-2079-learning-center-auto-open.json
+++ b/.workflow/records/2079-guided-2079-learning-center-auto-open.json
@@ -109,13 +109,43 @@
       "status": "unknown",
       "summary": "execution error: TimeoutExpired",
       "tool_versions": {}
+    },
+    {
+      "at": "2026-08-21T20:20:23.831553Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": null,
+      "input_fingerprint": "sha256:4a8652db8f4c7d27e9069455a43fb3deeba62392f6b7d4478fd81ff4e3508ffd",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": null,
+      "status": "unknown",
+      "summary": "execution error: TimeoutExpired",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-21T20:43:25.645691Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:4a8652db8f4c7d27e9069455a43fb3deeba62392f6b7d4478fd81ff4e3508ffd",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
     }
   ],
   "check_na": [],
   "commit": {
-    "sha": "478662d0",
+    "sha": "2cea225e",
     "shas": [
-      "478662d0"
+      "2cea225e"
     ],
     "trailers": []
   },
@@ -509,6 +539,358 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:06:22.667280Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:06:22.682131Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:06:22.700263Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:06:22.714897Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:06:22.730122Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:06:22.745094Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:06:22.760319Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:06:22.775089Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:06:22.790240Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:06:22.806965Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:06:22.825682Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:20:23.879491Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:20:23.893468Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:20:23.907511Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:20:23.921761Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:20:23.936500Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:20:23.951263Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:20:23.965963Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:20:23.987231Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:20:24.007243Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:20:24.021440Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:20:24.038358Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:43:25.696234Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:43:25.712326Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:43:25.729775Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:43:25.745906Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:43:25.763740Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:43:25.779878Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:43:25.796353Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:43:25.812662Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:43:25.829494Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:43:25.845460Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:43:25.863336Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:43:50.573153Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:43:50.589540Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:43:50.605233Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:43:50.621082Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:43:50.636383Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:43:50.654673Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:43:50.670540Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:43:50.687957Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:43:50.703732Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:43:50.722253Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:43:50.739206Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -530,9 +912,9 @@
       "frontend/src/components/__tests__/WorkImportOffer.test.tsx",
       "frontend/src/components/__tests__/tutorialProjectOpens.test.tsx"
     ],
-    "diff_fingerprint": "sha256:b046e344e4a61dec6c4494e8865062df38e22255b81d85c3c5c97004fe9c4108",
+    "diff_fingerprint": "sha256:80b3d87ab75177e5025d435adadb7b8512539b3bb49fa77b1820761c5afc90ee",
     "head": "HEAD",
-    "head_sha": "c81151b1",
+    "head_sha": "2cea225e",
     "surfaces": {
       "docs": 0,
       "frontend": 3,
@@ -587,6 +969,40 @@
     {
       "at": "2026-08-21T20:05:25.549374Z",
       "diff_fingerprint": "sha256:b046e344e4a61dec6c4494e8865062df38e22255b81d85c3c5c97004fe9c4108",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-21T20:06:22.825712Z",
+      "diff_fingerprint": "sha256:80b3d87ab75177e5025d435adadb7b8512539b3bb49fa77b1820761c5afc90ee",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.semantic_dup"
+      ]
+    },
+    {
+      "at": "2026-08-21T20:20:24.038396Z",
+      "diff_fingerprint": "sha256:80b3d87ab75177e5025d435adadb7b8512539b3bb49fa77b1820761c5afc90ee",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-21T20:43:25.863379Z",
+      "diff_fingerprint": "sha256:80b3d87ab75177e5025d435adadb7b8512539b3bb49fa77b1820761c5afc90ee",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-21T20:43:50.739240Z",
+      "diff_fingerprint": "sha256:80b3d87ab75177e5025d435adadb7b8512539b3bb49fa77b1820761c5afc90ee",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 2,

--- a/.workflow/records/2079-guided-2079-learning-center-auto-open.json
+++ b/.workflow/records/2079-guided-2079-learning-center-auto-open.json
@@ -139,13 +139,152 @@
       "status": "pass",
       "summary": "clean",
       "tool_versions": {}
+    },
+    {
+      "at": "2026-08-21T21:56:14.819043Z",
+      "command": "(cd frontend && npm run check:ci)",
+      "covered_surface": "frontend",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:ad27a77833e33fa9a080850a5dff46b63f83655353eb71337b931eb3a59b24ed",
+      "name": "frontend",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/frontend.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-21T21:56:35.501379Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:1563b7331277f7cd7a4d65f1721169d53af8c6196f4c998d43cc5d678049e4f8",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-21T22:06:35.529164Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": null,
+      "input_fingerprint": "sha256:0f49de5feb9bc4b2735c1a3a46237c97b24d6aa243d281ab01fcca85e718f03e",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": null,
+      "status": "unknown",
+      "summary": "execution error: TimeoutExpired",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-21T22:36:27.942577Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:8779ef8bddae9da1f346141ac3fae42945359bcaeed41686b3ef8dcf3bdae414",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-21T22:39:11.253511Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:bee0017f30f552d2df2de1173f9ac14b9aee5192ca5e5c1de574bb119512b275",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-21T22:41:18.021402Z",
+      "command": "(cd frontend && npm run check:ci)",
+      "covered_surface": "frontend",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:91c75ea976d1024687045862a2f6183a0f9600a45ee016c27917baa7b2c7102c",
+      "name": "frontend",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/frontend.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-21T22:41:36.232532Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:11c7ded02784a4ff8239916ac7559cc52a03105a81e25bd4958f5200aa15c7e7",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-21T22:41:36.276530Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e31351abfc33f0b3c0f28bc9f2f3d59ae3bc5d4925dc1159a7f931aa932441ed",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-21T22:43:23.803334Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:8779ef8bddae9da1f346141ac3fae42945359bcaeed41686b3ef8dcf3bdae414",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/semantic_dup.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
     }
   ],
   "check_na": [],
   "commit": {
-    "sha": "ee30b834",
+    "sha": "26c72033",
     "shas": [
-      "ee30b834"
+      "26c72033"
     ],
     "trailers": []
   },
@@ -1336,6 +1475,622 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:54:16.207533Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:54:16.227024Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:54:16.241766Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:54:16.257037Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:54:16.272461Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:54:16.286780Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:54:16.314336Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:54:16.333335Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:54:16.348981Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:54:16.384899Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:54:16.417324Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:06:35.625197Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:06:35.652062Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:06:35.693887Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:06:35.719747Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:06:35.768364Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:06:35.814432Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:06:35.842571Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:06:35.871314Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:06:35.897631Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:06:35.919941Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:06:35.947349Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:06:39.199987Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:06:39.227572Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:06:39.262418Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:06:39.289126Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:06:39.343302Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:06:39.398456Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:06:39.431357Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:06:39.468442Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:06:39.499109Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:06:39.525614Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:06:39.565192Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:07:27.222066Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:07:27.239867Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:07:27.255106Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:07:27.269475Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:07:27.283540Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:07:27.298124Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:07:27.313280Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:07:27.329554Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:07:27.358661Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:07:27.375299Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:07:27.395470Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:36:27.991441Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:36:28.006547Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:36:28.022773Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:36:28.038323Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:36:28.055146Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:36:28.071292Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:36:28.088873Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:36:28.104499Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:36:28.121383Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:36:28.138412Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:36:28.158685Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:36:50.479900Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:36:50.496902Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:36:50.513450Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:36:50.531700Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:36:50.548589Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:36:50.565199Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:36:50.582261Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:36:50.598489Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:36:50.615908Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:36:50.632371Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:36:50.653497Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:43:23.857516Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:43:23.889787Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:43:23.909653Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:43:23.925557Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:43:23.940701Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:43:23.957286Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:43:23.974049Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:43:23.990680Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:43:24.008427Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:43:24.025380Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:43:24.046291Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -1349,7 +2104,7 @@
   "observed_admin_labels": [],
   "observed_diff": {
     "base": "origin/main",
-    "base_sha": "4105e165",
+    "base_sha": "4105e1654",
     "changed_files": [
       ".workflow/records/2079-guided-2079-learning-center-auto-open.json",
       "CHANGELOG.md",
@@ -1357,9 +2112,9 @@
       "frontend/src/components/__tests__/WorkImportOffer.test.tsx",
       "frontend/src/components/__tests__/tutorialProjectOpens.test.tsx"
     ],
-    "diff_fingerprint": "sha256:3fed2b0198cf2b7ea90d8028ec29d21f14f3fb511619c62803062464f5a99384",
+    "diff_fingerprint": "sha256:775287a4ae6e5aa7ec059acad38ee5a6615268da3031bd0323bca8016110d56b",
     "head": "HEAD",
-    "head_sha": "60a39527",
+    "head_sha": "26c72033b",
     "surfaces": {
       "docs": 0,
       "frontend": 3,
@@ -1488,6 +2243,73 @@
     {
       "at": "2026-08-21T21:51:23.966467Z",
       "diff_fingerprint": "sha256:3fed2b0198cf2b7ea90d8028ec29d21f14f3fb511619c62803062464f5a99384",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-21T21:54:16.417354Z",
+      "diff_fingerprint": "sha256:c525aab7c7c6618f0cee45029312223c79721933cd45a33c8a8b2189bf9c4c81",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.frontend",
+        "checks.full_audit",
+        "checks.semantic_dup"
+      ]
+    },
+    {
+      "at": "2026-08-21T22:06:35.947431Z",
+      "diff_fingerprint": "sha256:c525aab7c7c6618f0cee45029312223c79721933cd45a33c8a8b2189bf9c4c81",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-21T22:06:39.565328Z",
+      "diff_fingerprint": "sha256:c525aab7c7c6618f0cee45029312223c79721933cd45a33c8a8b2189bf9c4c81",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.semantic_dup"
+      ]
+    },
+    {
+      "at": "2026-08-21T22:07:27.395498Z",
+      "diff_fingerprint": "sha256:c525aab7c7c6618f0cee45029312223c79721933cd45a33c8a8b2189bf9c4c81",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.semantic_dup"
+      ]
+    },
+    {
+      "at": "2026-08-21T22:36:28.158721Z",
+      "diff_fingerprint": "sha256:775287a4ae6e5aa7ec059acad38ee5a6615268da3031bd0323bca8016110d56b",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-21T22:36:50.653521Z",
+      "diff_fingerprint": "sha256:775287a4ae6e5aa7ec059acad38ee5a6615268da3031bd0323bca8016110d56b",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.frontend",
+        "checks.full_audit"
+      ]
+    },
+    {
+      "at": "2026-08-21T22:43:24.046329Z",
+      "diff_fingerprint": "sha256:775287a4ae6e5aa7ec059acad38ee5a6615268da3031bd0323bca8016110d56b",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 2,

--- a/.workflow/records/2079-guided-2079-learning-center-auto-open.json
+++ b/.workflow/records/2079-guided-2079-learning-center-auto-open.json
@@ -143,9 +143,9 @@
   ],
   "check_na": [],
   "commit": {
-    "sha": "ef78052d",
+    "sha": "ee30b834",
     "shas": [
-      "ef78052d"
+      "ee30b834"
     ],
     "trailers": []
   },
@@ -979,6 +979,182 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:45:37.534034Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:45:37.554098Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:45:37.571580Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:45:37.587545Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:45:37.603248Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:45:37.618509Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:45:37.634594Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:45:37.653150Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:45:37.671868Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:45:37.688212Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:45:37.707980Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:45:57.778831Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:45:57.801905Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:45:57.834792Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:45:57.867203Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:45:57.890963Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:45:57.911265Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:45:57.937307Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:45:57.959247Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:45:57.981036Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:45:58.000658Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:45:58.025276Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -991,8 +1167,8 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "origin/main",
-    "base_sha": "4105e165",
+    "base": "bca9e5f2325b43768b74d14b256815b9b34bc528",
+    "base_sha": "bca9e5f2",
     "changed_files": [
       ".workflow/records/2079-guided-2079-learning-center-auto-open.json",
       "CHANGELOG.md",
@@ -1000,9 +1176,9 @@
       "frontend/src/components/__tests__/WorkImportOffer.test.tsx",
       "frontend/src/components/__tests__/tutorialProjectOpens.test.tsx"
     ],
-    "diff_fingerprint": "sha256:432170b71f35e62bbef160f09085d8e9d0b32f7005b5ba2215f478ec6779d87d",
+    "diff_fingerprint": "sha256:9c1fb3ac7ff30cbff752c667abf3e1aa3553ba33f12cc72f65e9d314be0d7a95",
     "head": "HEAD",
-    "head_sha": "ef78052d",
+    "head_sha": "ee30b834",
     "surfaces": {
       "docs": 0,
       "frontend": 3,
@@ -1024,7 +1200,7 @@
     "closes": [
       2079
     ],
-    "number": null,
+    "number": 2092,
     "url": null
   },
   "reconcile_events": [
@@ -1099,6 +1275,22 @@
     {
       "at": "2026-08-21T20:44:40.314415Z",
       "diff_fingerprint": "sha256:432170b71f35e62bbef160f09085d8e9d0b32f7005b5ba2215f478ec6779d87d",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-21T20:45:37.708015Z",
+      "diff_fingerprint": "sha256:9c1fb3ac7ff30cbff752c667abf3e1aa3553ba33f12cc72f65e9d314be0d7a95",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-21T20:45:58.025313Z",
+      "diff_fingerprint": "sha256:9c1fb3ac7ff30cbff752c667abf3e1aa3553ba33f12cc72f65e9d314be0d7a95",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 2,

--- a/.workflow/records/2079-guided-2079-learning-center-auto-open.json
+++ b/.workflow/records/2079-guided-2079-learning-center-auto-open.json
@@ -49,10 +49,61 @@
       "tool_versions": {
         "ruff": "0.15.15"
       }
+    },
+    {
+      "at": "2026-08-21T19:44:08.489565Z",
+      "command": "(cd frontend && npm run check:ci)",
+      "covered_surface": "frontend",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:37898e6f7092c58873ad775503eee1ea3ed01af35c468ceaeef2dc89698d2340",
+      "name": "frontend",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/frontend.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-21T19:44:18.233193Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:8564283276b162ebf207dca2a377a3ca8753ed8048161b8b559ece71d797386f",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-21T19:54:18.242442Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": null,
+      "input_fingerprint": "sha256:4a8652db8f4c7d27e9069455a43fb3deeba62392f6b7d4478fd81ff4e3508ffd",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": null,
+      "status": "unknown",
+      "summary": "execution error: TimeoutExpired",
+      "tool_versions": {}
     }
   ],
   "check_na": [],
-  "commit": null,
+  "commit": {
+    "sha": "478662d0",
+    "shas": [
+      "478662d0"
+    ],
+    "trailers": []
+  },
   "declared_scope": {
     "exclude": [],
     "include": [
@@ -179,6 +230,182 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-08-21T19:54:18.288253Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T19:54:18.303082Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T19:54:18.315331Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T19:54:18.328600Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T19:54:18.341880Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T19:54:18.354539Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T19:54:18.367639Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T19:54:18.380021Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T19:54:18.392829Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T19:54:18.406015Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T19:54:18.419983Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T19:54:48.583730Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T19:54:48.597439Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T19:54:48.611639Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T19:54:48.624944Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T19:54:48.637866Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T19:54:48.651005Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T19:54:48.664300Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T19:54:48.678184Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T19:54:48.692321Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T19:54:48.707755Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T19:54:48.723702Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -192,28 +419,41 @@
   "observed_admin_labels": [],
   "observed_diff": {
     "base": "origin/main",
-    "base_sha": "bca9e5f2",
-    "changed_files": [],
-    "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "base_sha": "4105e165",
+    "changed_files": [
+      ".workflow/records/2079-guided-2079-learning-center-auto-open.json",
+      "CHANGELOG.md",
+      "frontend/src/App.parts/useLearningCenter.ts",
+      "frontend/src/components/__tests__/WorkImportOffer.test.tsx",
+      "frontend/src/components/__tests__/tutorialProjectOpens.test.tsx"
+    ],
+    "diff_fingerprint": "sha256:507b838db8e7086919632a8d3c1522a7e3e816c388d63305f6798b7a23059137",
     "head": "HEAD",
-    "head_sha": "bca9e5f2",
+    "head_sha": "478662d0",
     "surfaces": {
       "docs": 0,
-      "frontend": 0,
+      "frontend": 3,
       "governance": 0,
       "governed_docs": 0,
-      "implementation": 0,
+      "implementation": 3,
       "packaging": 0,
       "protected_architecture": 0,
       "protected_core": 0,
-      "sentrux": 0,
-      "test": 0,
+      "sentrux": 3,
+      "test": 2,
       "workflow_ci": 0
     }
   },
   "owner_directive": "\u4fee\u590d Learning Center \u7a97\u53e3\u5f00\u542f\u903b\u8f91\uff1a\u6bcf\u6b21\u91cd\u542f scistudio \u90fd\u4f1a\u81ea\u52a8\u5f00\u542f\uff1b\u6b63\u786e\u903b\u8f91\u5e94\u4e3a\u5b58\u5728\u672a\u5b8c\u6210 learning \u65f6\u624d\u5f00\u542f\uff0c\u4e0e\u5c0f\u7ea2\u70b9\u51fa\u73b0\u903b\u8f91\u4e00\u81f4\u3002\u4fee\u597d\u540e\u63a8\u4e00\u4e2a PR\u3002",
   "persona": "live_implementer",
-  "pull_request": null,
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [
+      2079
+    ],
+    "number": null,
+    "url": null
+  },
   "reconcile_events": [
     {
       "at": "2026-08-21T19:37:33.114498Z",
@@ -222,6 +462,24 @@
       "result": "pass",
       "tier": 2,
       "unsatisfied": []
+    },
+    {
+      "at": "2026-08-21T19:54:18.420014Z",
+      "diff_fingerprint": "sha256:507b838db8e7086919632a8d3c1522a7e3e816c388d63305f6798b7a23059137",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-21T19:54:48.723727Z",
+      "diff_fingerprint": "sha256:507b838db8e7086919632a8d3c1522a7e3e816c388d63305f6798b7a23059137",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.semantic_dup"
+      ]
     }
   ],
   "record_id": "2079-guided-2079-learning-center-auto-open",
@@ -230,10 +488,14 @@
     "admin_labels": [],
     "checks": [
       "format_check",
+      "frontend",
       "full_audit",
-      "lint_format"
+      "lint_format",
+      "semantic_dup"
     ],
-    "docs": [],
+    "docs": [
+      "docs_required_or_na"
+    ],
     "guards": [
       "architecture_doc_guard",
       "core_change_guard",
@@ -247,7 +509,9 @@
       "test_engineer_scope_guard",
       "weakened_ci_check"
     ],
-    "tests": []
+    "tests": [
+      "changed_test_required"
+    ]
   },
   "runtime": "agents",
   "schema_version": 2,

--- a/.workflow/records/2079-guided-2079-learning-center-auto-open.json
+++ b/.workflow/records/2079-guided-2079-learning-center-auto-open.json
@@ -164,6 +164,11 @@
       "at": "2026-08-21T19:37:09.818108Z",
       "owner_directive": "\u4fee\u590d\uff1a\u542f\u52a8\u65f6\u91c7\u7eb3\u7684\u5df2\u5b8c\u6210 session \u4e0d\u5e94\u89e6\u53d1\u5b8c\u6210\u53cd\u5e94\uff08\u5f00 Learning Center\u3001\u5173\u9879\u76ee\u3001\u95ee work-import offer\uff09\uff1b\u53ea\u6709\u672c app run \u89c1\u8bc1\u8fc7\u7684\u5b8c\u6210\u624d\u53cd\u5e94\uff1b\u4ec5 active session \u53ef\u79fb\u52a8\u7a97\u53e3\u5230 tutorial \u9879\u76ee",
       "reason": "plan"
+    },
+    {
+      "at": "2026-08-21T21:34:49.192561Z",
+      "owner_directive": "Wait for startup classification before reacting \u2014 the stale-complete session adopted via the active-session request before the catalogue arrives still triggers the completion reaction; make the guard independent of request ordering",
+      "reason": "review finding on PR #2092: startup classification raced the catalogue request; simplifying the guard to witnessed-only removes the timing dependence"
     }
   ],
   "docs_events": [
@@ -1155,6 +1160,182 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:43:53.982807Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:43:53.999929Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:43:54.020216Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:43:54.038241Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:43:54.058420Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:43:54.079824Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:43:54.102321Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:43:54.119653Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:43:54.137234Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:43:54.154056Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:43:54.177474Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:51:23.723446Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:51:23.743789Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:51:23.784392Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:51:23.805595Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:51:23.824358Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:51:23.842154Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:51:23.881085Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:51:23.908632Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:51:23.927786Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:51:23.945215Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:51:23.966430Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -1167,8 +1348,8 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "bca9e5f2325b43768b74d14b256815b9b34bc528",
-    "base_sha": "bca9e5f2",
+    "base": "origin/main",
+    "base_sha": "4105e165",
     "changed_files": [
       ".workflow/records/2079-guided-2079-learning-center-auto-open.json",
       "CHANGELOG.md",
@@ -1176,9 +1357,9 @@
       "frontend/src/components/__tests__/WorkImportOffer.test.tsx",
       "frontend/src/components/__tests__/tutorialProjectOpens.test.tsx"
     ],
-    "diff_fingerprint": "sha256:9c1fb3ac7ff30cbff752c667abf3e1aa3553ba33f12cc72f65e9d314be0d7a95",
+    "diff_fingerprint": "sha256:3fed2b0198cf2b7ea90d8028ec29d21f14f3fb511619c62803062464f5a99384",
     "head": "HEAD",
-    "head_sha": "ee30b834",
+    "head_sha": "60a39527",
     "surfaces": {
       "docs": 0,
       "frontend": 3,
@@ -1291,6 +1472,22 @@
     {
       "at": "2026-08-21T20:45:58.025313Z",
       "diff_fingerprint": "sha256:9c1fb3ac7ff30cbff752c667abf3e1aa3553ba33f12cc72f65e9d314be0d7a95",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-21T21:43:54.177512Z",
+      "diff_fingerprint": "sha256:3fed2b0198cf2b7ea90d8028ec29d21f14f3fb511619c62803062464f5a99384",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-21T21:51:23.966467Z",
+      "diff_fingerprint": "sha256:3fed2b0198cf2b7ea90d8028ec29d21f14f3fb511619c62803062464f5a99384",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 2,

--- a/.workflow/records/2079-guided-2079-learning-center-auto-open.json
+++ b/.workflow/records/2079-guided-2079-learning-center-auto-open.json
@@ -143,9 +143,9 @@
   ],
   "check_na": [],
   "commit": {
-    "sha": "2cea225e",
+    "sha": "ef78052d",
     "shas": [
-      "2cea225e"
+      "ef78052d"
     ],
     "trailers": []
   },
@@ -891,6 +891,94 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:44:40.144428Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:44:40.159471Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:44:40.174335Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:44:40.189195Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:44:40.205276Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:44:40.221170Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:44:40.238537Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:44:40.253973Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:44:40.279087Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:44:40.295293Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:44:40.314380Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -912,9 +1000,9 @@
       "frontend/src/components/__tests__/WorkImportOffer.test.tsx",
       "frontend/src/components/__tests__/tutorialProjectOpens.test.tsx"
     ],
-    "diff_fingerprint": "sha256:80b3d87ab75177e5025d435adadb7b8512539b3bb49fa77b1820761c5afc90ee",
+    "diff_fingerprint": "sha256:432170b71f35e62bbef160f09085d8e9d0b32f7005b5ba2215f478ec6779d87d",
     "head": "HEAD",
-    "head_sha": "2cea225e",
+    "head_sha": "ef78052d",
     "surfaces": {
       "docs": 0,
       "frontend": 3,
@@ -1003,6 +1091,14 @@
     {
       "at": "2026-08-21T20:43:50.739240Z",
       "diff_fingerprint": "sha256:80b3d87ab75177e5025d435adadb7b8512539b3bb49fa77b1820761c5afc90ee",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-21T20:44:40.314415Z",
+      "diff_fingerprint": "sha256:432170b71f35e62bbef160f09085d8e9d0b32f7005b5ba2215f478ec6779d87d",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 2,

--- a/.workflow/records/2079-guided-2079-learning-center-auto-open.json
+++ b/.workflow/records/2079-guided-2079-learning-center-auto-open.json
@@ -1,0 +1,283 @@
+{
+  "branch": "guided/2079-learning-center-auto-open",
+  "check_events": [
+    {
+      "at": "2026-08-21T19:37:23.057122Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:bee0017f30f552d2df2de1173f9ac14b9aee5192ca5e5c1de574bb119512b275",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-21T19:37:32.905042Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:d2016153ffe72f6d9588cf72b647d8f545261ca64eb63f312f104e3c66e7d074",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-21T19:37:32.940765Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e31351abfc33f0b3c0f28bc9f2f3d59ae3bc5d4925dc1159a7f931aa932441ed",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    }
+  ],
+  "check_na": [],
+  "commit": null,
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "frontend/src/components/LearningCenter.tsx",
+      "frontend/src/components/LearningCenter.parts/**",
+      "frontend/src/App.parts/useLearningCenter.ts",
+      "frontend/src/components/__tests__/tutorialProjectOpens.test.tsx",
+      "frontend/src/components/__tests__/WorkImportOffer.test.tsx"
+    ]
+  },
+  "directive_events": [
+    {
+      "at": "2026-08-21T19:37:09.818108Z",
+      "owner_directive": "\u4fee\u590d\uff1a\u542f\u52a8\u65f6\u91c7\u7eb3\u7684\u5df2\u5b8c\u6210 session \u4e0d\u5e94\u89e6\u53d1\u5b8c\u6210\u53cd\u5e94\uff08\u5f00 Learning Center\u3001\u5173\u9879\u76ee\u3001\u95ee work-import offer\uff09\uff1b\u53ea\u6709\u672c app run \u89c1\u8bc1\u8fc7\u7684\u5b8c\u6210\u624d\u53cd\u5e94\uff1b\u4ec5 active session \u53ef\u79fb\u52a8\u7a97\u53e3\u5230 tutorial \u9879\u76ee",
+      "reason": "plan"
+    }
+  ],
+  "docs_events": [
+    {
+      "at": "2026-08-21T19:37:09.818212Z",
+      "class": null,
+      "kind": "path",
+      "path": "CHANGELOG.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-21T19:37:09.818226Z",
+      "class": "spec",
+      "kind": "na",
+      "path": null,
+      "rationale": "No contract change \u2014 the spec never prescribed reacting to a kept ended session; live-completion behavior (FR-079/FR-083) is unchanged",
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-21T19:37:09.818232Z",
+      "class": "adr",
+      "kind": "na",
+      "path": null,
+      "rationale": "Frontend reaction guard inside an existing design, not an architectural decision",
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-21T19:37:09.818235Z",
+      "class": "architecture",
+      "kind": "na",
+      "path": null,
+      "rationale": "Owner-controlled doc; no architecture change",
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-21T19:37:09.818237Z",
+      "class": "ai-developer",
+      "kind": "na",
+      "path": null,
+      "rationale": "No wrapper, hook, gate-record, CI, or AI-runtime behaviour changes",
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": false,
+  "guard_events": [
+    {
+      "at": "2026-08-21T19:37:32.973683Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T19:37:32.988772Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T19:37:33.002730Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T19:37:33.016957Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T19:37:33.030379Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T19:37:33.043837Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T19:37:33.058973Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T19:37:33.072314Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T19:37:33.086216Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T19:37:33.100395Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T19:37:33.114454Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 2079,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": {
+    "base": "origin/main",
+    "base_sha": "bca9e5f2",
+    "changed_files": [],
+    "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "head": "HEAD",
+    "head_sha": "bca9e5f2",
+    "surfaces": {
+      "docs": 0,
+      "frontend": 0,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 0,
+      "packaging": 0,
+      "protected_architecture": 0,
+      "protected_core": 0,
+      "sentrux": 0,
+      "test": 0,
+      "workflow_ci": 0
+    }
+  },
+  "owner_directive": "\u4fee\u590d Learning Center \u7a97\u53e3\u5f00\u542f\u903b\u8f91\uff1a\u6bcf\u6b21\u91cd\u542f scistudio \u90fd\u4f1a\u81ea\u52a8\u5f00\u542f\uff1b\u6b63\u786e\u903b\u8f91\u5e94\u4e3a\u5b58\u5728\u672a\u5b8c\u6210 learning \u65f6\u624d\u5f00\u542f\uff0c\u4e0e\u5c0f\u7ea2\u70b9\u51fa\u73b0\u903b\u8f91\u4e00\u81f4\u3002\u4fee\u597d\u540e\u63a8\u4e00\u4e2a PR\u3002",
+  "persona": "live_implementer",
+  "pull_request": null,
+  "reconcile_events": [
+    {
+      "at": "2026-08-21T19:37:33.114498Z",
+      "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "mode": "local",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    }
+  ],
+  "record_id": "2079-guided-2079-learning-center-auto-open",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [
+      "format_check",
+      "full_audit",
+      "lint_format"
+    ],
+    "docs": [],
+    "guards": [
+      "architecture_doc_guard",
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": []
+  },
+  "runtime": "agents",
+  "schema_version": 2,
+  "scope_events": [
+    {
+      "action": "add-include",
+      "at": "2026-08-21T19:40:47.695804Z",
+      "pattern": "CHANGELOG.md",
+      "reason": "CHANGELOG.md entry is part of the docs obligation for this user-visible fix; adding it to declared scope"
+    }
+  ],
+  "session_id": "9e5d06bd-d717-4496-9945-19d3fdf2f041",
+  "strictness_tier": 2,
+  "task_kind": "guided",
+  "test_events": [
+    {
+      "at": "2026-08-21T19:37:09.818240Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/components/__tests__/tutorialProjectOpens.test.tsx",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-21T19:37:09.818244Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/components/__tests__/WorkImportOffer.test.tsx",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/.workflow/records/2079-guided-2079-learning-center-auto-open.json
+++ b/.workflow/records/2079-guided-2079-learning-center-auto-open.json
@@ -94,6 +94,21 @@
       "status": "unknown",
       "summary": "execution error: TimeoutExpired",
       "tool_versions": {}
+    },
+    {
+      "at": "2026-08-21T20:05:25.261083Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": null,
+      "input_fingerprint": "sha256:4a8652db8f4c7d27e9069455a43fb3deeba62392f6b7d4478fd81ff4e3508ffd",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": null,
+      "status": "unknown",
+      "summary": "execution error: TimeoutExpired",
+      "tool_versions": {}
     }
   ],
   "check_na": [],
@@ -406,6 +421,94 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:05:25.337790Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:05:25.359781Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:05:25.380645Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:05:25.400041Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:05:25.426928Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:05:25.448141Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:05:25.467612Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:05:25.489667Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:05:25.508743Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:05:25.525390Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:05:25.549322Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -427,9 +530,9 @@
       "frontend/src/components/__tests__/WorkImportOffer.test.tsx",
       "frontend/src/components/__tests__/tutorialProjectOpens.test.tsx"
     ],
-    "diff_fingerprint": "sha256:507b838db8e7086919632a8d3c1522a7e3e816c388d63305f6798b7a23059137",
+    "diff_fingerprint": "sha256:b046e344e4a61dec6c4494e8865062df38e22255b81d85c3c5c97004fe9c4108",
     "head": "HEAD",
-    "head_sha": "478662d0",
+    "head_sha": "c81151b1",
     "surfaces": {
       "docs": 0,
       "frontend": 3,
@@ -480,6 +583,14 @@
       "unsatisfied": [
         "checks.semantic_dup"
       ]
+    },
+    {
+      "at": "2026-08-21T20:05:25.549374Z",
+      "diff_fingerprint": "sha256:b046e344e4a61dec6c4494e8865062df38e22255b81d85c3c5c97004fe9c4108",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
     }
   ],
   "record_id": "2079-guided-2079-learning-center-auto-open",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- [#2079] **The Learning Center no longer opens itself on every launch.** The
+  backend keeps a finished tutorial as the active session record, so every
+  start-up adopted a session whose status was already `complete` — and the
+  frontend reacted to that record the way it reacts to a live finish: the
+  Learning Center opened, the project you had open was closed, and the
+  work-import unlock was asked, on every single restart. A completion the
+  running app never watched happen is now treated as history rather than news:
+  the finish reaction fires only for a session this app run first saw in a
+  non-complete state, and only a session that is actually running may move the
+  window into its tutorial project. Finishing a tutorial still lands in the
+  Learning Center exactly as before; what changed is that *having finished one
+  yesterday* no longer does.
+
 - [#2073] **A project registry written by a newer build no longer stops an older
   runtime from starting.** `~/.scistudio/projects.json` outlives the runtime that
   reads it — it survives uninstall and reinstall, and the desktop client's OTA

--- a/frontend/src/App.parts/useLearningCenter.ts
+++ b/frontend/src/App.parts/useLearningCenter.ts
@@ -105,7 +105,17 @@ export function useLearningCenter({
    * a project refreshes the project list and the block catalogue and would
    * otherwise re-trigger this effect before `currentProjectId` has caught up.
    */
-  const tutorialProjectId = useAppStore((state) => state.learningCenterSession?.project_id ?? null);
+  /*
+   * Only a live session moves the window. The backend keeps an ended session
+   * as the active record with status `complete` or `error`, so the session
+   * adopted at start-up can be one that finished long ago (#2079) — opening
+   * its project then would resurrect a workspace the lesson is done with.
+   */
+  const tutorialProjectId = useAppStore((state) =>
+    state.learningCenterSession?.status === "active"
+      ? (state.learningCenterSession.project_id ?? null)
+      : null,
+  );
   const currentProjectId = useAppStore((state) => state.currentProject?.id ?? null);
   const openingTutorialProject = useRef<string | null>(null);
 
@@ -171,23 +181,62 @@ export function useLearningCenter({
    * FR-079 — when a tutorial finishes, ask whether the product should now
    * volunteer the work-import offer.
    *
-   * The ref only stops the same completion asking twice; it is not a record of
-   * whether the offer has been shown. That question has one owner, and it is
-   * the backend: `GET /unlock` answers it, and a second copy here would be the
-   * thing that makes a once-only offer appear twice.
+   * A completion is only news when this app run watched the tutorial run.
+   * The backend keeps an ended session as the active record with status
+   * `complete` rather than erasing it (see `tutorials/session.py`), so every
+   * launch adopts the last finished tutorial as a session that is complete
+   * already. Treating that record as a fresh finish is the #2079 bug: the
+   * Learning Center opened — and the open project closed — on every restart.
+   * The reaction below therefore fires only for a completion this app run
+   * witnessed (the session was seen in a non-complete state first), or for one
+   * that is not the session adopted already-complete at start-up, which keeps
+   * a finish that happened while the frontend was disconnected on the reconnect
+   * path.
+   *
+   * The `lastCompletionAsked` ref only stops the same completion asking twice;
+   * it is not a record of whether the offer has been shown. That question has
+   * one owner, and it is the backend: `GET /unlock` answers it, and a second
+   * copy here would be the thing that makes a once-only offer appear twice.
    */
   const checkWorkImportOffer = useAppStore((state) => state.checkWorkImportOffer);
-  const completedTutorialKey = useAppStore((state) => {
+  const tutorialSessionKey = useAppStore((state) => {
     const active = state.learningCenterSession;
-    if (!active || active.status !== "complete") return null;
+    if (!active) return null;
     return `${active.source_kind}:${active.source_id}:${active.tutorial_id}`;
   });
+  const tutorialSessionComplete = useAppStore(
+    (state) => state.learningCenterSession?.status === "complete",
+  );
+  const seenRunningTutorial = useRef<string | null>(null);
+  const startupCompletedTutorial = useRef<string | null | undefined>(undefined);
   const lastCompletionAsked = useRef<string | null>(null);
 
+  /*
+   * Record the session the first catalogue load arrives with. Declared before
+   * the completion effect so that, when one store update carries both the
+   * catalogue and its already-complete active session, this runs first.
+   */
   useEffect(() => {
-    if (!completedTutorialKey) return;
-    if (lastCompletionAsked.current === completedTutorialKey) return;
-    lastCompletionAsked.current = completedTutorialKey;
+    if (startupCompletedTutorial.current !== undefined) return;
+    if (!learningCenterCatalogue) return;
+    const active = learningCenterCatalogue.active;
+    startupCompletedTutorial.current =
+      active && active.status === "complete"
+        ? `${active.source_kind}:${active.source_id}:${active.tutorial_id}`
+        : null;
+  }, [learningCenterCatalogue]);
+
+  useEffect(() => {
+    if (!tutorialSessionKey) return;
+    if (!tutorialSessionComplete) {
+      seenRunningTutorial.current = tutorialSessionKey;
+      return;
+    }
+    if (lastCompletionAsked.current === tutorialSessionKey) return;
+    const witnessed = seenRunningTutorial.current === tutorialSessionKey;
+    const staleFromStartUp = startupCompletedTutorial.current === tutorialSessionKey;
+    if (!witnessed && staleFromStartUp) return;
+    lastCompletionAsked.current = tutorialSessionKey;
     void checkWorkImportOffer();
     /*
      * Finishing lands in the Learning Center rather than in a card saying so.
@@ -200,7 +249,13 @@ export function useLearningCenter({
     // ...and out of the tutorial's project, before it looks like somewhere to
     // keep working. See `closeProject` above.
     closeProject();
-  }, [completedTutorialKey, checkWorkImportOffer, openLearningCenter, closeProject]);
+  }, [
+    tutorialSessionKey,
+    tutorialSessionComplete,
+    checkWorkImportOffer,
+    openLearningCenter,
+    closeProject,
+  ]);
 
   useEffect(() => {
     if (!tutorialStepKey || !tutorialStepRoute) return;

--- a/frontend/src/App.parts/useLearningCenter.ts
+++ b/frontend/src/App.parts/useLearningCenter.ts
@@ -185,13 +185,17 @@ export function useLearningCenter({
    * The backend keeps an ended session as the active record with status
    * `complete` rather than erasing it (see `tutorials/session.py`), so every
    * launch adopts the last finished tutorial as a session that is complete
-   * already. Treating that record as a fresh finish is the #2079 bug: the
-   * Learning Center opened — and the open project closed — on every restart.
-   * The reaction below therefore fires only for a completion this app run
-   * witnessed (the session was seen in a non-complete state first), or for one
-   * that is not the session adopted already-complete at start-up, which keeps
-   * a finish that happened while the frontend was disconnected on the reconnect
-   * path.
+   * already — through the catalogue fetch or through the active-session fetch,
+   * whichever answers first. Treating that record as a fresh finish is the
+   * #2079 bug: the Learning Center opened — and the open project closed — on
+   * every restart. The reaction below therefore fires only for a session this
+   * app run first saw in a non-complete state. That test is deliberately
+   * indifferent to which start-up request answers first: an earlier version
+   * classified the stale record off the first catalogue load, and a session
+   * adopted by the faster active-session request slipped past the guard before
+   * the catalogue arrived (PR #2092 review). A finish that happened while the
+   * frontend was disconnected still lands here, because the session was seen
+   * running before the disconnect.
    *
    * The `lastCompletionAsked` ref only stops the same completion asking twice;
    * it is not a record of whether the offer has been shown. That question has
@@ -208,23 +212,7 @@ export function useLearningCenter({
     (state) => state.learningCenterSession?.status === "complete",
   );
   const seenRunningTutorial = useRef<string | null>(null);
-  const startupCompletedTutorial = useRef<string | null | undefined>(undefined);
   const lastCompletionAsked = useRef<string | null>(null);
-
-  /*
-   * Record the session the first catalogue load arrives with. Declared before
-   * the completion effect so that, when one store update carries both the
-   * catalogue and its already-complete active session, this runs first.
-   */
-  useEffect(() => {
-    if (startupCompletedTutorial.current !== undefined) return;
-    if (!learningCenterCatalogue) return;
-    const active = learningCenterCatalogue.active;
-    startupCompletedTutorial.current =
-      active && active.status === "complete"
-        ? `${active.source_kind}:${active.source_id}:${active.tutorial_id}`
-        : null;
-  }, [learningCenterCatalogue]);
 
   useEffect(() => {
     if (!tutorialSessionKey) return;
@@ -233,9 +221,7 @@ export function useLearningCenter({
       return;
     }
     if (lastCompletionAsked.current === tutorialSessionKey) return;
-    const witnessed = seenRunningTutorial.current === tutorialSessionKey;
-    const staleFromStartUp = startupCompletedTutorial.current === tutorialSessionKey;
-    if (!witnessed && staleFromStartUp) return;
+    if (seenRunningTutorial.current !== tutorialSessionKey) return;
     lastCompletionAsked.current = tutorialSessionKey;
     void checkWorkImportOffer();
     /*

--- a/frontend/src/components/__tests__/WorkImportOffer.test.tsx
+++ b/frontend/src/components/__tests__/WorkImportOffer.test.tsx
@@ -228,8 +228,16 @@ describe("the offer is triggered by a tutorial completing", () => {
       return <WorkImportOffer />;
     }
 
-    useAppStore.setState({ learningCenterSession: completedSession("welcome") });
     render(<Harness />);
+    // A completion the app run never witnessed is history, not news (#2079):
+    // the session is seen running before it completes, as in a real finish.
+    useAppStore.setState({
+      learningCenterSession: { ...completedSession("welcome"), status: "active" },
+    });
+    await waitFor(() =>
+      expect(useAppStore.getState().learningCenterSession?.status).toBe("active"),
+    );
+    useAppStore.setState({ learningCenterSession: completedSession("welcome") });
 
     expect(await screen.findByTestId("work-import-offer")).toBeInTheDocument();
     expect(learningCenterApi.getTutorialUnlock).toHaveBeenCalledTimes(1);

--- a/frontend/src/components/__tests__/WorkImportOffer.test.tsx
+++ b/frontend/src/components/__tests__/WorkImportOffer.test.tsx
@@ -12,7 +12,7 @@
  * contract rather than the shipped default.
  */
 
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type * as LearningCenterModule from "../../lib/api/learningCenter";
@@ -218,25 +218,33 @@ describe("the offer is triggered by a tutorial completing", () => {
     });
     const { useLearningCenter } = await import("../../App.parts/useLearningCenter");
 
+    const openProject = vi.fn();
+
     function Harness() {
       useLearningCenter({
         closeProject: vi.fn(),
         wsConnected: true,
         setLeftTab: vi.fn(),
-        openProject: vi.fn(),
+        openProject,
       });
       return <WorkImportOffer />;
     }
 
     render(<Harness />);
+    // Let the mount-time session refetch settle first: its answer (no active
+    // session here) must land before the test drives the store, or it would
+    // clobber the session the test is about to adopt.
+    await act(async () => {});
     // A completion the app run never witnessed is history, not news (#2079):
     // the session is seen running before it completes, as in a real finish.
+    // The wait is on the project-opening effect rather than on store state
+    // alone, so the hook's effects have actually flushed for the active
+    // session before the completion lands — store writes are synchronous,
+    // effects are not.
     useAppStore.setState({
       learningCenterSession: { ...completedSession("welcome"), status: "active" },
     });
-    await waitFor(() =>
-      expect(useAppStore.getState().learningCenterSession?.status).toBe("active"),
-    );
+    await waitFor(() => expect(openProject).toHaveBeenCalledWith("p1"));
     useAppStore.setState({ learningCenterSession: completedSession("welcome") });
 
     expect(await screen.findByTestId("work-import-offer")).toBeInTheDocument();

--- a/frontend/src/components/__tests__/tutorialProjectOpens.test.tsx
+++ b/frontend/src/components/__tests__/tutorialProjectOpens.test.tsx
@@ -296,10 +296,17 @@ describe("finishing a tutorial lands in the Learning Center", () => {
      * A tutorial project looks like any other workspace once the card is gone,
      * and restarting the tutorial deletes it (FR-066). Leaving it open invites
      * the reader to keep working somewhere their work will not survive.
+     *
+     * The session is seen running before it completes: a finish the app run
+     * never witnessed is history, not news (#2079), so the transition is what
+     * these tests model.
      */
     const closeProject = vi.fn();
-    await renderHarness(vi.fn(), closeProject);
+    const openProject = vi.fn();
+    await renderHarness(openProject, closeProject);
 
+    useAppStore.setState({ learningCenterSession: activeSession() });
+    await waitFor(() => expect(openProject).toHaveBeenCalled());
     useAppStore.setState({
       learningCenterSession: activeSession({ status: "complete", step: null }),
     });
@@ -311,9 +318,12 @@ describe("finishing a tutorial lands in the Learning Center", () => {
     // The last step used to leave a "Tutorial complete." card in the corner and
     // a workspace with nothing to do next. The catalogue is where the next
     // tutorial is, so that is where finishing one goes.
-    await renderHarness(vi.fn());
+    const openProject = vi.fn();
+    await renderHarness(openProject);
     expect(useAppStore.getState().learningCenterOpen).toBe(false);
 
+    useAppStore.setState({ learningCenterSession: activeSession() });
+    await waitFor(() => expect(openProject).toHaveBeenCalled());
     useAppStore.setState({
       learningCenterSession: activeSession({ status: "complete", step: null }),
     });
@@ -328,5 +338,85 @@ describe("finishing a tutorial lands in the Learning Center", () => {
 
     await waitFor(() => expect(useAppStore.getState().learningCenterSession).not.toBeNull());
     expect(useAppStore.getState().learningCenterOpen).toBe(false);
+  });
+});
+
+describe("a session adopted already-complete at start-up is history, not news (#2079)", () => {
+  const STALE_CATALOGUE = {
+    ...EMPTY_CATALOGUE,
+    active: activeSession({ status: "complete", step: null }),
+  };
+
+  beforeEach(() => {
+    resetAppStore();
+    vi.mocked(learningCenterApi.getTutorialCatalogue).mockResolvedValue(STALE_CATALOGUE as never);
+    // Both start-up reads see the kept record, as the backend answers both.
+    vi.mocked(learningCenterApi.getActiveTutorialSession).mockResolvedValue(
+      STALE_CATALOGUE.active as never,
+    );
+    vi.mocked(learningCenterApi.getTutorialUnlock).mockResolvedValue({
+      work_import_offer_pending: false,
+    });
+    // FR-083's first-run landing is dismissed so what these assert is the
+    // completion reaction, and not that.
+    useAppStore.setState({ learningCenterFirstRunDismissed: true });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("does not open the Learning Center on every restart", async () => {
+    /*
+     * The backend keeps an ended session as the active record with status
+     * `complete`, so every launch adopted the last finished tutorial and the
+     * completion reaction fired again: the catalogue opened, the open project
+     * closed, and the unlock endpoint was asked — every single restart.
+     */
+    const closeProject = vi.fn();
+    const openProject = vi.fn();
+    await renderHarness(openProject, closeProject);
+
+    await waitFor(() =>
+      expect(useAppStore.getState().learningCenterSession?.status).toBe("complete"),
+    );
+    expect(useAppStore.getState().learningCenterOpen).toBe(false);
+    expect(closeProject).not.toHaveBeenCalled();
+    expect(learningCenterApi.getTutorialUnlock).not.toHaveBeenCalled();
+  });
+
+  it("does not resurrect the finished tutorial's project", async () => {
+    // A stale session carries the project the lesson ran in; only a live
+    // session may move the window to it.
+    const openProject = vi.fn();
+    await renderHarness(openProject);
+
+    await waitFor(() =>
+      expect(useAppStore.getState().learningCenterSession?.status).toBe("complete"),
+    );
+    expect(openProject).not.toHaveBeenCalled();
+  });
+
+  it("still lands a genuine re-run of the same tutorial in the catalogue", async () => {
+    /*
+     * The stale record must not suppress a real finish either: the user
+     * restarts the same tutorial (FR-066) and completes it again in this app
+     * run, and that completion is witnessed, so it lands like any other.
+     */
+    const openProject = vi.fn();
+    await renderHarness(openProject);
+    await waitFor(() =>
+      expect(useAppStore.getState().learningCenterSession?.status).toBe("complete"),
+    );
+    expect(useAppStore.getState().learningCenterOpen).toBe(false);
+
+    useAppStore.setState({ learningCenterSession: activeSession() });
+    await waitFor(() => expect(openProject).toHaveBeenCalled());
+    useAppStore.setState({
+      learningCenterSession: activeSession({ status: "complete", step: null }),
+    });
+
+    await waitFor(() => expect(useAppStore.getState().learningCenterOpen).toBe(true));
   });
 });

--- a/frontend/src/components/__tests__/tutorialProjectOpens.test.tsx
+++ b/frontend/src/components/__tests__/tutorialProjectOpens.test.tsx
@@ -386,6 +386,39 @@ describe("a session adopted already-complete at start-up is history, not news (#
     expect(learningCenterApi.getTutorialUnlock).not.toHaveBeenCalled();
   });
 
+  it("stays history when the session request wins the start-up race", async () => {
+    /*
+     * PR #2092 review: at launch the active-session request and the catalogue
+     * request race, and the session answer can land first. The guard must not
+     * depend on the catalogue having arrived — a finished tutorial is history
+     * regardless of which request answered first.
+     */
+    let resolveCatalogue: (value: unknown) => void = () => {};
+    vi.mocked(learningCenterApi.getTutorialCatalogue).mockReturnValue(
+      new Promise((resolve) => {
+        resolveCatalogue = resolve;
+      }) as never,
+    );
+    const closeProject = vi.fn();
+    const openProject = vi.fn();
+    await renderHarness(openProject, closeProject);
+
+    // The session answer lands first, as the kept completed record.
+    await waitFor(() =>
+      expect(useAppStore.getState().learningCenterSession?.status).toBe("complete"),
+    );
+    expect(useAppStore.getState().learningCenterOpen).toBe(false);
+    expect(closeProject).not.toHaveBeenCalled();
+    expect(learningCenterApi.getTutorialUnlock).not.toHaveBeenCalled();
+
+    // The catalogue arriving later changes nothing.
+    resolveCatalogue(STALE_CATALOGUE);
+    await waitFor(() => expect(useAppStore.getState().learningCenterCatalogue).not.toBeNull());
+    expect(useAppStore.getState().learningCenterOpen).toBe(false);
+    expect(closeProject).not.toHaveBeenCalled();
+    expect(learningCenterApi.getTutorialUnlock).not.toHaveBeenCalled();
+  });
+
   it("does not resurrect the finished tutorial's project", async () => {
     // A stale session carries the project the lesson ran in; only a live
     // session may move the window to it.


### PR DESCRIPTION
# fix(#2079): the Learning Center no longer opens itself on every launch

## Symptom

Every restart of SciStudio opened the Learning Center on its own.

## Root cause

The backend keeps an ended tutorial session as the active record with status
`complete` (`src/scistudio/tutorials/session.py`), so every launch adopted the
last finished tutorial as a session that was complete already. The completion
effect in `useLearningCenter` treated that record as a fresh finish and ran the
full finish reaction on every start-up:

- `openLearningCenter()` — the window the owner saw on every restart;
- `closeProject()` — which also closed whatever project was open;
- `checkWorkImportOffer()` — an unlock ask that was not owed.

The same stale record also fed the project-opening effect, resurrecting the
finished tutorial's project at every launch.

## Fix

`frontend/src/App.parts/useLearningCenter.ts`:

- A completion is only news when this app run watched the tutorial run: the
  finish reaction fires only for a session first seen in a non-complete state.
  The test is deliberately indifferent to which start-up request answers first
  — the catalogue fetch and the active-session fetch race at launch, and a
  guard keyed off the catalogue's arrival would still fire when the session
  answer lands first (review finding on this PR). A finish that happened while
  the frontend was disconnected still lands, because the session was seen
  running before the disconnect.
- Only a session with status `active` may move the window into its tutorial
  project.

This aligns start-up behaviour with the unfinished-work dot (FR-086): with the
core group complete there is nothing to point at, and nothing opens. The
first-run landing (FR-083) and the live-completion landing are unchanged.

## Tests

`frontend/src/components/__tests__/tutorialProjectOpens.test.tsx` gains a
describe for #2079: a session adopted already-complete at start-up does not
open the Learning Center, does not close or open any project, and does not ask
the unlock endpoint — including when the active-session request wins the
start-up race against the catalogue request — while a genuine re-run of the
same tutorial still lands in the catalogue. The two existing completion tests
now model the real active → complete transition, and `WorkImportOffer.test.tsx`
does the same for the offer trigger.

Gate record: .workflow/records/2079-guided-2079-learning-center-auto-open.json

Closes #2079
