### PR TITLE
fix(#2093): spawn npm through a shell on Windows so desktop dev starts

### DIFF
--- a/.workflow/records/2093-desktop-dev-spawn.json
+++ b/.workflow/records/2093-desktop-dev-spawn.json
@@ -68,9 +68,9 @@
   ],
   "check_na": [],
   "commit": {
-    "sha": "d869d50b815073c20f100635ffe44dba358a0098",
+    "sha": "22a9bab5f7d47f96e7448c70d3d82988eee20d4e",
     "shas": [
-      "d869d50b815073c20f100635ffe44dba358a0098"
+      "22a9bab5f7d47f96e7448c70d3d82988eee20d4e"
     ],
     "trailers": []
   },
@@ -291,6 +291,138 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:57:27.590852Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:57:27.616059Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:57:27.636888Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:57:27.659946Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:57:27.678740Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:57:27.717720Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:57:27.742471Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:57:27.764817Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:57:27.787212Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:57:27.813672Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:57:27.839033Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:57:59.166887Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:57:59.187246Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:57:59.205056Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:57:59.228603Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:57:59.252896Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:57:59.274137Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:57:59.291667Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:57:59.311904Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:57:59.348015Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:57:59.373535Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:57:59.393656Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -303,7 +435,7 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "origin/main",
+    "base": "4105e165451215ec842d731f8fb6691b45d1d0ea",
     "base_sha": "4105e165",
     "changed_files": [
       ".workflow/records/2093-desktop-dev-spawn.json",
@@ -312,9 +444,9 @@
       "desktop/scripts/start-dev.js",
       "desktop/test/npm-spawn.test.js"
     ],
-    "diff_fingerprint": "sha256:5effed0c2f034b6fc51b69397c7565d1a02fd61c34c131dc400873ab9f9c9340",
+    "diff_fingerprint": "sha256:7773cdeedbbffc409470efff4ecda48d98387511c316760d5c2239519af4bde1",
     "head": "HEAD",
-    "head_sha": "d869d50b",
+    "head_sha": "22a9bab5",
     "surfaces": {
       "docs": 0,
       "frontend": 0,
@@ -336,7 +468,7 @@
     "closes": [
       2093
     ],
-    "number": null,
+    "number": 2094,
     "url": null
   },
   "reconcile_events": [
@@ -359,6 +491,22 @@
     {
       "at": "2026-08-21T20:57:00.274804Z",
       "diff_fingerprint": "sha256:5effed0c2f034b6fc51b69397c7565d1a02fd61c34c131dc400873ab9f9c9340",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-21T20:57:27.839105Z",
+      "diff_fingerprint": "sha256:7773cdeedbbffc409470efff4ecda48d98387511c316760d5c2239519af4bde1",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-21T20:57:59.393696Z",
+      "diff_fingerprint": "sha256:7773cdeedbbffc409470efff4ecda48d98387511c316760d5c2239519af4bde1",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 2,

--- a/.workflow/records/2093-desktop-dev-spawn.json
+++ b/.workflow/records/2093-desktop-dev-spawn.json
@@ -1,0 +1,248 @@
+{
+  "branch": "fix/2093-desktop-dev-spawn-einval",
+  "check_events": [
+    {
+      "at": "2026-08-21T20:54:48.182109Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:bee0017f30f552d2df2de1173f9ac14b9aee5192ca5e5c1de574bb119512b275",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-21T20:55:10.222528Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:d2016153ffe72f6d9588cf72b647d8f545261ca64eb63f312f104e3c66e7d074",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-21T20:55:10.394994Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e31351abfc33f0b3c0f28bc9f2f3d59ae3bc5d4925dc1159a7f931aa932441ed",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    }
+  ],
+  "check_na": [],
+  "commit": null,
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "desktop/scripts/start-dev.js",
+      "desktop/test/**"
+    ]
+  },
+  "directive_events": [],
+  "docs_events": [
+    {
+      "at": "2026-08-21T20:53:52.600038Z",
+      "class": null,
+      "kind": "path",
+      "path": "CHANGELOG.md",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": false,
+  "guard_events": [
+    {
+      "at": "2026-08-21T20:55:10.505928Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:55:10.557220Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:55:10.595563Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:55:10.633749Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:55:10.677561Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:55:10.724720Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:55:10.774544Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:55:10.819784Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:55:10.860570Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:55:10.912617Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:55:10.951643Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 2093,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": {
+    "base": "origin/main",
+    "base_sha": "4105e165",
+    "changed_files": [],
+    "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "head": "HEAD",
+    "head_sha": "4105e165",
+    "surfaces": {
+      "docs": 0,
+      "frontend": 0,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 0,
+      "packaging": 0,
+      "protected_architecture": 0,
+      "protected_core": 0,
+      "sentrux": 0,
+      "test": 0,
+      "workflow_ci": 0
+    }
+  },
+  "owner_directive": "Fix the desktop dev launcher so npm run dev works on Windows under Node 20.12+, where spawning npm.cmd without a shell raises EINVAL.",
+  "persona": "live_implementer",
+  "pull_request": null,
+  "reconcile_events": [
+    {
+      "at": "2026-08-21T20:55:10.951764Z",
+      "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "mode": "local",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    }
+  ],
+  "record_id": "2093-desktop-dev-spawn",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [
+      "format_check",
+      "full_audit",
+      "lint_format"
+    ],
+    "docs": [],
+    "guards": [
+      "architecture_doc_guard",
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": []
+  },
+  "runtime": "claude-code",
+  "schema_version": 2,
+  "scope_events": [
+    {
+      "action": "add-include",
+      "at": "2026-08-21T20:47:22.687278Z",
+      "pattern": "desktop/scripts/**",
+      "reason": "Following the repository precedent from issue 1986: extract the pure platform decision into a requireable module so it can be unit tested without launching Electron."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-21T20:47:22.687305Z",
+      "pattern": "CHANGELOG.md",
+      "reason": "Following the repository precedent from issue 1986: extract the pure platform decision into a requireable module so it can be unit tested without launching Electron."
+    }
+  ],
+  "session_id": "4e54e002-c0a6-45b1-abb2-cd22f96d67a7",
+  "strictness_tier": 2,
+  "task_kind": "guided",
+  "test_events": [
+    {
+      "at": "2026-08-21T20:47:22.687316Z",
+      "class": null,
+      "kind": "path",
+      "path": "desktop/test/npm-spawn.test.js",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-21T20:53:52.600066Z",
+      "class": null,
+      "kind": "path",
+      "path": "desktop/test/npm-spawn.test.js",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/.workflow/records/2093-desktop-dev-spawn.json
+++ b/.workflow/records/2093-desktop-dev-spawn.json
@@ -49,10 +49,31 @@
       "tool_versions": {
         "ruff": "0.15.15"
       }
+    },
+    {
+      "at": "2026-08-21T20:56:53.698111Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:f0d30e84dcafd9d4ed3b986cee6a182fc2159dfd12111cd92e2c4e11874c1c20",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
     }
   ],
   "check_na": [],
-  "commit": null,
+  "commit": {
+    "sha": "d869d50b815073c20f100635ffe44dba358a0098",
+    "shas": [
+      "d869d50b815073c20f100635ffe44dba358a0098"
+    ],
+    "trailers": []
+  },
   "declared_scope": {
     "exclude": [],
     "include": [
@@ -138,6 +159,138 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:56:53.746359Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:56:53.768531Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:56:53.786357Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:56:53.803669Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:56:53.826961Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:56:53.854656Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:56:53.873942Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:56:53.892824Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:56:53.912663Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:56:53.931348Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:56:53.949447Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:57:00.057181Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:57:00.080066Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:57:00.101040Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:57:00.117097Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:57:00.133980Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:57:00.151698Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:57:00.172893Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:57:00.191664Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:57:00.223598Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:57:00.250384Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:57:00.274751Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -152,10 +305,16 @@
   "observed_diff": {
     "base": "origin/main",
     "base_sha": "4105e165",
-    "changed_files": [],
-    "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "changed_files": [
+      ".workflow/records/2093-desktop-dev-spawn.json",
+      "CHANGELOG.md",
+      "desktop/scripts/npm-spawn.js",
+      "desktop/scripts/start-dev.js",
+      "desktop/test/npm-spawn.test.js"
+    ],
+    "diff_fingerprint": "sha256:5effed0c2f034b6fc51b69397c7565d1a02fd61c34c131dc400873ab9f9c9340",
     "head": "HEAD",
-    "head_sha": "4105e165",
+    "head_sha": "d869d50b",
     "surfaces": {
       "docs": 0,
       "frontend": 0,
@@ -166,18 +325,41 @@
       "protected_architecture": 0,
       "protected_core": 0,
       "sentrux": 0,
-      "test": 0,
+      "test": 1,
       "workflow_ci": 0
     }
   },
   "owner_directive": "Fix the desktop dev launcher so npm run dev works on Windows under Node 20.12+, where spawning npm.cmd without a shell raises EINVAL.",
   "persona": "live_implementer",
-  "pull_request": null,
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [
+      2093
+    ],
+    "number": null,
+    "url": null
+  },
   "reconcile_events": [
     {
       "at": "2026-08-21T20:55:10.951764Z",
       "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
       "mode": "local",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-21T20:56:53.949489Z",
+      "diff_fingerprint": "sha256:5effed0c2f034b6fc51b69397c7565d1a02fd61c34c131dc400873ab9f9c9340",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-21T20:57:00.274804Z",
+      "diff_fingerprint": "sha256:5effed0c2f034b6fc51b69397c7565d1a02fd61c34c131dc400873ab9f9c9340",
+      "mode": "pre-pr",
       "result": "pass",
       "tier": 2,
       "unsatisfied": []

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- [#2093] **`npm run dev` in `desktop/` starts again on Windows.** The desktop
+  dev launcher spawns npm twice — once for Vite, once for Electron — and on
+  Windows the `npm` it reaches is `npm.cmd`, a batch shim. Node hardened
+  `child_process.spawn` against Windows batch-file argument injection
+  (CVE-2024-27980, in 18.20.1 / 20.12.1 / 21.7.2): spawning a `.cmd` without a
+  shell now raises `EINVAL` rather than running it. The launcher asked for no
+  shell, so it died on its very first spawn and never reached either child; the
+  only way to run the desktop app in development was to start Vite and Electron
+  by hand.
+  The platform decision now lives in `desktop/scripts/npm-spawn.js` as a pure,
+  unit-tested function, mirroring `desktop/runtime-port.js`. Windows gets the
+  shell it needs, and because passing an argument *array* alongside `shell: true`
+  is deprecated (DEP0190 — those arguments are concatenated rather than escaped),
+  the shell is handed one finished command line instead. Building that line is
+  only sound while no argument needs quoting, so arguments outside a
+  conservative safe set are refused with an explicit error rather than
+  concatenated: cmd.exe quoting is subtle enough that a half-correct escaper
+  would fail silently, at launch, on someone else's machine. POSIX is unchanged
+  — no shell, argument array passed straight through.
+
 - [#2073] **A project registry written by a newer build no longer stops an older
   runtime from starting.** `~/.scistudio/projects.json` outlives the runtime that
   reads it — it survives uninstall and reinstall, and the desktop client's OTA

--- a/desktop/scripts/npm-spawn.js
+++ b/desktop/scripts/npm-spawn.js
@@ -1,0 +1,88 @@
+"use strict";
+
+// How to spawn npm as a child process, per platform (issue #2093).
+//
+// Two Node behaviours collide on Windows, and a launcher has to satisfy both:
+//
+//   1. The `npm` on PATH is `npm.cmd`, a batch shim. Node hardened
+//      `child_process.spawn` against Windows batch-file argument injection
+//      (CVE-2024-27980, shipped in 18.20.1 / 20.12.1 / 21.7.2): spawning a
+//      `.cmd` without `shell: true` now fails with `EINVAL` instead of running
+//      it. So Windows needs the shell.
+//   2. Passing an *args array* together with `shell: true` is deprecated
+//      (DEP0190) precisely because the runtime concatenates those arguments
+//      instead of escaping them. So the shell must be handed one finished
+//      command line, not a command plus an array.
+//
+// Joining tokens into a command line is only safe when no token needs quoting,
+// and correct cmd.exe quoting is genuinely hard to get right: cmd.exe's own
+// parsing and CommandLineToArgvW disagree about backslash-before-quote runs.
+// Rather than ship a quoting routine that is subtly wrong, this module refuses
+// to build a command line out of anything outside a conservative safe set.
+// Every token the launcher actually passes -- `--prefix`, `frontend`, `run`,
+// `dev`, `--`, `--host`, `127.0.0.1`, `--port`, `5173`, `desktop`, `start` --
+// is inside that set, so a future edit that introduces, say, a path with a
+// space fails loudly here instead of mis-quoting silently at launch time.
+//
+// Kept as pure functions in their own module -- no side effects on require --
+// so the decision is unit-testable without starting Vite or Electron. Same
+// shape as `desktop/runtime-port.js` (#1986).
+
+// Letters, digits, and the punctuation that shows up in flags, versions,
+// hosts, ports, and path separators. Deliberately excludes whitespace, quotes,
+// and every cmd.exe metacharacter.
+const SHELL_SAFE_TOKEN = /^[A-Za-z0-9._:/\\@=+-]+$/;
+
+/**
+ * Return the command name and shell flag to spawn npm with.
+ *
+ * @param {string} platform A `process.platform` value.
+ * @returns {{command: string, shell: boolean}}
+ */
+function npmSpawnSpec(platform) {
+  if (platform === "win32") {
+    return { command: "npm.cmd", shell: true };
+  }
+  return { command: "npm", shell: false };
+}
+
+/**
+ * Report whether *token* can be concatenated into a shell command line as-is.
+ *
+ * @param {string} token
+ * @returns {boolean}
+ */
+function isShellSafeToken(token) {
+  return SHELL_SAFE_TOKEN.test(String(token));
+}
+
+/**
+ * Return spawn arguments for running npm with *args* on *platform*.
+ *
+ * On Windows this collapses the command and its arguments into a single shell
+ * command line (see DEP0190 above); elsewhere it returns the command and the
+ * argument array unchanged, with the shell off.
+ *
+ * @param {string} platform A `process.platform` value.
+ * @param {string[]} args Arguments to pass to npm.
+ * @returns {{command: string, args: string[], shell: boolean}}
+ * @throws {Error} On the shell path, when a token would need quoting.
+ */
+function npmSpawnArgs(platform, args) {
+  const spec = npmSpawnSpec(platform);
+  const argv = Array.isArray(args) ? args.map(String) : [];
+  if (!spec.shell) {
+    return { command: spec.command, args: argv, shell: false };
+  }
+  const unsafe = argv.filter((token) => !isShellSafeToken(token));
+  if (unsafe.length > 0) {
+    throw new Error(
+      `npm launch argument needs shell quoting, which this launcher does not do: ${JSON.stringify(unsafe)}. ` +
+        "Windows requires shell:true to reach npm.cmd, and DEP0190 forbids an args array there, " +
+        "so every token must be shell-safe. Pass the value through the environment instead.",
+    );
+  }
+  return { command: [spec.command, ...argv].join(" "), args: [], shell: true };
+}
+
+module.exports = { npmSpawnSpec, npmSpawnArgs, isShellSafeToken };

--- a/desktop/scripts/start-dev.js
+++ b/desktop/scripts/start-dev.js
@@ -1,5 +1,6 @@
 const { spawn } = require("node:child_process");
 const path = require("node:path");
+const { npmSpawnArgs } = require("./npm-spawn");
 
 delete process.env.ELECTRON_RUN_AS_NODE;
 
@@ -7,7 +8,6 @@ const repoRoot = path.resolve(__dirname, "..", "..");
 const frontendUrl = process.env.SCISTUDIO_DESKTOP_FRONTEND_URL || "http://127.0.0.1:5173";
 const runtimePort = process.env.SCISTUDIO_DESKTOP_RUNTIME_PORT || "8000";
 const apiProxyTarget = process.env.SCISTUDIO_API_PROXY || `http://127.0.0.1:${runtimePort}`;
-const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
 
 function spawnChild(command, args, options = {}) {
   const child = spawn(command, args, {
@@ -23,7 +23,9 @@ function spawnChild(command, args, options = {}) {
   return child;
 }
 
-const vite = spawnChild(npmCommand, [
+// #2093: npmSpawnArgs decides command/args/shell per platform so the Windows
+// npm.cmd shim is reachable without tripping EINVAL or DEP0190.
+const viteSpawn = npmSpawnArgs(process.platform, [
   "--prefix",
   "frontend",
   "run",
@@ -33,17 +35,21 @@ const vite = spawnChild(npmCommand, [
   "127.0.0.1",
   "--port",
   "5173",
-], {
+]);
+const vite = spawnChild(viteSpawn.command, viteSpawn.args, {
+  shell: viteSpawn.shell,
   env: {
     ...process.env,
     SCISTUDIO_API_PROXY: apiProxyTarget,
   },
 });
 
+const electronSpawn = npmSpawnArgs(process.platform, ["--prefix", "desktop", "run", "start"]);
 const electron = spawnChild(
-  npmCommand,
-  ["--prefix", "desktop", "run", "start"],
+  electronSpawn.command,
+  electronSpawn.args,
   {
+    shell: electronSpawn.shell,
     env: {
       ...process.env,
       SCISTUDIO_DESKTOP_FRONTEND_URL: frontendUrl,

--- a/desktop/test/npm-spawn.test.js
+++ b/desktop/test/npm-spawn.test.js
@@ -1,0 +1,100 @@
+"use strict";
+
+// Unit tests for the pure npm spawn decision (desktop/scripts/npm-spawn.js,
+// issue #2093). Run with: npm --prefix desktop test   (Node built-in runner).
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { npmSpawnSpec, npmSpawnArgs, isShellSafeToken } = require("../scripts/npm-spawn");
+
+test("npmSpawnSpec: Windows asks for a shell, because npm is a .cmd shim", () => {
+  // The regression this guards: Node >=18.20.1/20.12.1/21.7.2 raises EINVAL
+  // when spawning a .cmd without a shell (CVE-2024-27980), which killed
+  // `npm --prefix desktop run dev` outright.
+  assert.deepEqual(npmSpawnSpec("win32"), { command: "npm.cmd", shell: true });
+});
+
+test("npmSpawnSpec: POSIX platforms spawn npm directly, no shell", () => {
+  assert.deepEqual(npmSpawnSpec("darwin"), { command: "npm", shell: false });
+  assert.deepEqual(npmSpawnSpec("linux"), { command: "npm", shell: false });
+});
+
+test("npmSpawnSpec: an unknown platform falls back to the POSIX form", () => {
+  assert.deepEqual(npmSpawnSpec("freebsd"), { command: "npm", shell: false });
+  assert.deepEqual(npmSpawnSpec(undefined), { command: "npm", shell: false });
+});
+
+test("npmSpawnArgs: POSIX passes the argument array through untouched", () => {
+  assert.deepEqual(npmSpawnArgs("linux", ["--prefix", "frontend", "run", "dev"]), {
+    command: "npm",
+    args: ["--prefix", "frontend", "run", "dev"],
+    shell: false,
+  });
+});
+
+test("npmSpawnArgs: Windows hands the shell one command line and no array", () => {
+  // DEP0190: an args array combined with shell:true is concatenated rather
+  // than escaped, so the array must be empty on the shell path.
+  const spawned = npmSpawnArgs("win32", [
+    "--prefix",
+    "frontend",
+    "run",
+    "dev",
+    "--",
+    "--host",
+    "127.0.0.1",
+    "--port",
+    "5173",
+  ]);
+  assert.equal(spawned.shell, true);
+  assert.deepEqual(spawned.args, []);
+  assert.equal(spawned.command, "npm.cmd --prefix frontend run dev -- --host 127.0.0.1 --port 5173");
+});
+
+test("npmSpawnArgs: both real launch argument vectors survive the round trip", () => {
+  // Spelled out so an edit to either call site in start-dev.js has to come
+  // past this test.
+  assert.equal(
+    npmSpawnArgs("win32", ["--prefix", "desktop", "run", "start"]).command,
+    "npm.cmd --prefix desktop run start",
+  );
+  assert.deepEqual(npmSpawnArgs("darwin", ["--prefix", "desktop", "run", "start"]).args, [
+    "--prefix",
+    "desktop",
+    "run",
+    "start",
+  ]);
+});
+
+test("npmSpawnArgs: tolerates a missing or non-array argument list", () => {
+  assert.equal(npmSpawnArgs("win32", undefined).command, "npm.cmd");
+  assert.deepEqual(npmSpawnArgs("linux", undefined).args, []);
+});
+
+test("npmSpawnArgs: refuses to concatenate a token that would need quoting", () => {
+  // The launcher does not quote. Failing loudly here is the contract: silent
+  // mis-quoting would produce a command line that runs the wrong thing.
+  assert.throws(
+    () => npmSpawnArgs("win32", ["--prefix", "C:/Program Files/app"]),
+    /needs shell quoting/,
+  );
+  assert.throws(() => npmSpawnArgs("win32", ["a&b"]), /needs shell quoting/);
+  assert.throws(() => npmSpawnArgs("win32", ['say "hi"']), /needs shell quoting/);
+});
+
+test("npmSpawnArgs: an unquotable token is fine on POSIX, which keeps the array", () => {
+  // No shell there, so no concatenation and nothing to refuse.
+  assert.deepEqual(npmSpawnArgs("linux", ["C:/Program Files/app"]).args, ["C:/Program Files/app"]);
+});
+
+test("isShellSafeToken: accepts the punctuation real launch arguments carry", () => {
+  for (const token of ["--prefix", "frontend", "127.0.0.1", "5173", "--", "a/b", "a\\b", "x=1"]) {
+    assert.equal(isShellSafeToken(token), true, token);
+  }
+});
+
+test("isShellSafeToken: rejects whitespace, quotes, and cmd.exe metacharacters", () => {
+  for (const token of ["a b", 'a"b', "a&b", "a|b", "a>b", "a<b", "a^b", "a(b", ""]) {
+    assert.equal(isShellSafeToken(token), false, JSON.stringify(token));
+  }
+});


### PR DESCRIPTION
## What

`npm --prefix desktop run dev` died immediately on Windows with `spawn EINVAL`, so the desktop dev entry point was unusable — Vite and Electron had to be started by hand.

## Why it broke

The launcher spawns npm twice, and on Windows the `npm` on PATH is `npm.cmd`, a batch shim. Node hardened `child_process.spawn` against Windows batch-file argument injection (CVE-2024-27980, shipped in 18.20.1 / 20.12.1 / 21.7.2): spawning a `.cmd` without `shell: true` now raises `EINVAL` instead of running it. `desktop/scripts/start-dev.js` asked for no shell, so it failed on its very first spawn.

`desktop/scripts/start-electron.js` was never affected — it spawns the `electron` binary, an `.exe`.

## What changed

- New `desktop/scripts/npm-spawn.js`: pure, side-effect-free functions that answer "how do I spawn npm on this platform". Follows the `desktop/runtime-port.js` precedent (#1986) so the decision is unit-testable without launching Electron.
- `desktop/scripts/start-dev.js` routes both npm launches through it.
- Windows gets `shell: true`. Since passing an argument *array* alongside `shell: true` is deprecated (DEP0190 — arguments are concatenated rather than escaped), the shell is handed one finished command line and an empty array.
- Joining tokens into a command line is only sound while no token needs quoting. Rather than ship a cmd.exe escaper — cmd.exe's own parsing and `CommandLineToArgvW` disagree about backslash-before-quote runs, so a half-correct one fails silently at launch on someone else's machine — tokens outside a conservative safe set are **refused with an explicit error**. Every argument the launcher actually passes is inside that set.
- POSIX behaviour is unchanged: no shell, argument array passed straight through.

## Evidence

Node v24.14.0, Windows 11.

Before / after, same interpreter:

```
BEFORE (npm.cmd, no shell): EINVAL
AFTER  (npmSpawnSpec):      ok 11.9.0
```

Running the fixed launcher: both npm children start (npm prints its own script banners for `scistudio-frontend dev` and `scistudio-desktop start`), with **zero** `EINVAL` and **zero** `DEP0190` in the output. The run then stops on missing `node_modules` in the fresh worktree, which is unrelated to the spawn path.

`npm --prefix desktop test`: 73 pass, 0 fail (11 new tests, including a case asserting the shell path refuses an argument that would need quoting).

`gate_record check`: tier 2, `format_check` / `full_audit` / `lint_format` — reconciliation passed.

Gate record: `.workflow/records/2093-desktop-dev-spawn.json`

Closes #2093
