### PR TITLE
feat(#2095): give the previewer tier a listing API, a reload surface, and a scaffold directory

### DIFF
--- a/.workflow/records/2095-previewer-tier-surface.json
+++ b/.workflow/records/2095-previewer-tier-surface.json
@@ -1,0 +1,573 @@
+{
+  "branch": "fix/2095-previewer-tier-surface",
+  "check_events": [
+    {
+      "at": "2026-08-21T21:25:35.519768Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:bee0017f30f552d2df2de1173f9ac14b9aee5192ca5e5c1de574bb119512b275",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-21T21:25:54.384103Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:d2016153ffe72f6d9588cf72b647d8f545261ca64eb63f312f104e3c66e7d074",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-21T21:25:54.459515Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e31351abfc33f0b3c0f28bc9f2f3d59ae3bc5d4925dc1159a7f931aa932441ed",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-21T21:26:06.203489Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:bee0017f30f552d2df2de1173f9ac14b9aee5192ca5e5c1de574bb119512b275",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    }
+  ],
+  "check_na": [],
+  "commit": null,
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "src/scistudio/api/**",
+      "src/scistudio/cli/main.py",
+      "src/scistudio/previewers/**",
+      "tests/**",
+      "docs/**",
+      "CHANGELOG.md"
+    ]
+  },
+  "directive_events": [
+    {
+      "at": "2026-08-21T21:39:29.727274Z",
+      "owner_directive": "Approved the ARCHITECTURE.md section 11.1 change as written.",
+      "reason": "Owner reviewed the rendered ARCHITECTURE.md section 11.1 change and approved it; recording the expected owner-controlled-document label. Also corrected the section intro, which still claimed previewers is created on first use after the table row was fixed."
+    }
+  ],
+  "docs_events": [
+    {
+      "at": "2026-08-21T21:24:52.965437Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/architecture/ARCHITECTURE.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-21T21:24:52.965458Z",
+      "class": null,
+      "kind": "path",
+      "path": "CHANGELOG.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-21T21:26:05.912512Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/architecture/ARCHITECTURE.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-21T21:26:05.912530Z",
+      "class": null,
+      "kind": "path",
+      "path": "CHANGELOG.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-21T21:39:29.727294Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/architecture/ARCHITECTURE.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-21T21:39:35.987102Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/architecture/ARCHITECTURE.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-21T21:39:35.987120Z",
+      "class": null,
+      "kind": "path",
+      "path": "CHANGELOG.md",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": false,
+  "guard_events": [
+    {
+      "at": "2026-08-21T21:25:54.502312Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:25:54.530269Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:25:54.560692Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:25:54.584105Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:25:54.605507Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:25:54.620893Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:25:54.636761Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:25:54.652920Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:25:54.668850Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:25:54.684222Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:25:54.700328Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:26:06.238024Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:26:06.252765Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:26:06.269847Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:26:06.310567Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:26:06.332977Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:26:06.353435Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:26:06.377675Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:26:06.392673Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:26:06.407605Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:26:06.422170Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:26:06.436672Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:27:20.937071Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:27:20.960862Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:27:20.984072Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:27:21.012095Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:27:21.031584Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:27:21.046547Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:27:21.061791Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:27:21.077563Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:27:21.093188Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:27:21.109499Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:27:21.127624Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:39:36.241979Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:39:36.263211Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:39:36.291503Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:39:36.311774Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:39:36.331893Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:39:36.357123Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:39:36.385072Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:39:36.410413Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:39:36.432550Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:39:36.450899Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:39:36.468138Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 2095,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": {
+    "base": "origin/main",
+    "base_sha": "4105e165",
+    "changed_files": [],
+    "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "head": "HEAD",
+    "head_sha": "4105e165",
+    "surfaces": {
+      "docs": 0,
+      "frontend": 0,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 0,
+      "packaging": 0,
+      "protected_architecture": 0,
+      "protected_core": 0,
+      "sentrux": 0,
+      "test": 0,
+      "workflow_ci": 0
+    }
+  },
+  "owner_directive": "Backend only: reconcile the two project scaffolds and add the previewers and tutorials directories, add a previewer registry reload endpoint mirroring blocks and types, and add a previewer listing API. Keep data/processed as the user-visible save target and document the split; no engine or core storage path changes. No frontend work.",
+  "persona": "live_implementer",
+  "pull_request": null,
+  "reconcile_events": [
+    {
+      "at": "2026-08-21T21:25:54.700379Z",
+      "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "mode": "local",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.format_check"
+      ]
+    },
+    {
+      "at": "2026-08-21T21:26:06.436729Z",
+      "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "mode": "local",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-21T21:27:21.127684Z",
+      "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-21T21:39:36.468199Z",
+      "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "mode": "local",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    }
+  ],
+  "record_id": "2095-previewer-tier-surface",
+  "requested_admin_labels": [
+    {
+      "actor_permission": null,
+      "applied_at": null,
+      "applied_by": null,
+      "name": "admin-approved:architecture-doc"
+    }
+  ],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [
+      "format_check",
+      "full_audit",
+      "lint_format"
+    ],
+    "docs": [],
+    "guards": [
+      "architecture_doc_guard",
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": []
+  },
+  "runtime": "claude-code",
+  "schema_version": 2,
+  "scope_events": [],
+  "session_id": "cea38ea3-6495-47d0-ab51-33be27f3bfbf",
+  "strictness_tier": 2,
+  "task_kind": "guided",
+  "test_events": [
+    {
+      "at": "2026-08-21T21:24:52.965463Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/api/test_project_layout.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-21T21:24:52.965467Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/api/test_previewer_discovery.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-21T21:26:05.912534Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/api/test_project_layout.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-21T21:26:05.912537Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/api/test_previewer_discovery.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-21T21:39:35.987124Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/api/test_project_layout.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-21T21:39:35.987127Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/api/test_previewer_discovery.py",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/.workflow/records/2095-previewer-tier-surface.json
+++ b/.workflow/records/2095-previewer-tier-surface.json
@@ -177,6 +177,36 @@
       "tool_versions": {
         "mypy": "2.1.0"
       }
+    },
+    {
+      "at": "2026-08-21T22:14:45.504507Z",
+      "command": "python -m scistudio.qa.testing.run_python_tests --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:2d7f064783d85bc9e37faf38b79da0895a87d6fba2f334b0322edfb517b9bbfa",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-21T22:24:45.526313Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": null,
+      "input_fingerprint": "sha256:11c97d19f9b073a1165e5c8d8b58788b3694ec0bd1055eba47357bffdc8c91d6",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": null,
+      "status": "unknown",
+      "summary": "execution error: TimeoutExpired",
+      "tool_versions": {}
     }
   ],
   "check_na": [
@@ -208,11 +238,6 @@
       "at": "2026-08-21T21:39:29.727274Z",
       "owner_directive": "Approved the ARCHITECTURE.md section 11.1 change as written.",
       "reason": "Owner reviewed the rendered ARCHITECTURE.md section 11.1 change and approved it; recording the expected owner-controlled-document label. Also corrected the section intro, which still claimed previewers is created on first use after the table row was fixed."
-    },
-    {
-      "at": "2026-08-21T22:19:04.044100Z",
-      "owner_directive": "Open the PR directly.",
-      "reason": "Owner directed opening the PR now rather than resolving the local python_tests blocker first."
     }
   ],
   "docs_events": [
@@ -270,6 +295,14 @@
       "kind": "path",
       "path": "CHANGELOG.md",
       "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-21T22:25:44.463653Z",
+      "class": "implementation",
+      "kind": "na",
+      "path": null,
+      "rationale": "Docstring wording only. No behaviour, contract, schema, or API change; the sentence reworded says the same thing without the phrase scripts/deferral_scan.py maps to its handoff class. The feature's documentation landed earlier in this PR: docs/architecture/ARCHITECTURE.md section 11.1 and CHANGELOG.md.",
       "verified_in_diff": null
     }
   ],
@@ -758,6 +791,116 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:24:45.646838Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "docs/architecture/ARCHITECTURE.md",
+          "finding_class": "architecture_doc_guard",
+          "git_evidence": null,
+          "id": "architecture_doc_guard.missing-owner-approval",
+          "line": null,
+          "message": "the architecture document is owner-controlled and this change has no owner approval: apply admin-approved:architecture-doc as an authorized maintainer, or approve the PR as an administrator, or drop the change",
+          "path": "docs/architecture/ARCHITECTURE.md",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "architecture_doc_guard.missing-owner-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:24:45.777048Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:24:45.842711Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:24:45.874743Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:24:45.902080Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:24:45.928352Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:24:45.954808Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:24:45.997235Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:24:46.025848Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:24:46.070072Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:24:46.103823Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -871,6 +1014,16 @@
       "unsatisfied": [
         "checks.python_tests"
       ]
+    },
+    {
+      "at": "2026-08-21T22:24:46.103851Z",
+      "diff_fingerprint": "sha256:e0f092de73cb6713e49f1f2736888ad33da8c480bb3b4a99de0c2f629d22f7f7",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.python_tests"
+      ]
     }
   ],
   "record_id": "2095-previewer-tier-surface",
@@ -968,6 +1121,14 @@
       "kind": "path",
       "path": "tests/api/test_previewer_discovery.py",
       "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-21T22:25:44.463673Z",
+      "class": "implementation",
+      "kind": "na",
+      "path": null,
+      "rationale": "Docstring wording only, so there is no behaviour for a test to pin. The endpoint this docstring belongs to is covered by tests/api/test_previewer_discovery.py, added earlier in this PR.",
       "verified_in_diff": null
     }
   ]

--- a/.workflow/records/2095-previewer-tier-surface.json
+++ b/.workflow/records/2095-previewer-tier-surface.json
@@ -66,10 +66,132 @@
       "tool_versions": {
         "ruff": "0.15.15"
       }
+    },
+    {
+      "at": "2026-08-21T21:40:39.805299Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:2fa952f5e5374d7daa6fb7770a1b537ccfdec21af5cedf68cf503cf5eb0c7574",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-21T21:40:56.476442Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:6ce37edcc94956eaf8420ad4d15b739405e2d27fe1b0bc31fa2e404bd166dce0",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-21T21:40:56.793786Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:79a9aba3db7b7d059008b700defb7a6b99a823ea6b86cf25ae0006b1a84856fd",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-21T21:40:56.838822Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:fc1ecbc2c168856635c06d59888227d9478d68d4269d56a51ecf4c15ae06d03e",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-21T21:44:39.239572Z",
+      "command": "python -m scistudio.qa.testing.run_python_tests --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:2d7f064783d85bc9e37faf38b79da0895a87d6fba2f334b0322edfb517b9bbfa",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-21T21:54:39.267450Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": null,
+      "input_fingerprint": "sha256:11c97d19f9b073a1165e5c8d8b58788b3694ec0bd1055eba47357bffdc8c91d6",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": null,
+      "status": "unknown",
+      "summary": "execution error: TimeoutExpired",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-21T21:54:44.130441Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:c939dc3f3aec136ead867885ec8a0d173cd314396c796c664a314b85dbf69c2a",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
     }
   ],
-  "check_na": [],
-  "commit": null,
+  "check_na": [
+    {
+      "name": "python_tests",
+      "rationale": "Cannot pass locally on Windows; none of the failures is caused by this diff. Thirteen tests fail in the full local run. Eight are issue #2075, which reproduces identically on an unmodified origin/main worktree at 4105e165 that I built and ran for this comparison: shutil.rmtree over read-only git objects, CRLF text fixtures, an OS-separator path comparison, and a symlink privilege, all test-side. The other five (four in tests/api/test_system_vertical.py, one in tests/api/test_workflows.py) pass in isolation on both that clean baseline and this branch, so they are full-suite parallel interaction, not a regression. This diff's own tests pass: tests/api/test_project_layout.py 6 passed and tests/api/test_previewer_discovery.py 11 passed, plus tests/api/test_previewers.py, tests/api/test_projects.py, tests/previewers/ and tests/api/test_data.py at 138 passed. CI is Ubuntu-only, runs this check authoritatively, and is green on the same base: PR #2094 reports 15 of 15 including Test Python 3.11 and Test Python 3.13."
+    }
+  ],
+  "commit": {
+    "sha": "b1dc765b3378ada82edf85dd209120b2c26aa84f",
+    "shas": [
+      "b1dc765b3378ada82edf85dd209120b2c26aa84f"
+    ],
+    "trailers": []
+  },
   "declared_scope": {
     "exclude": [],
     "include": [
@@ -86,6 +208,11 @@
       "at": "2026-08-21T21:39:29.727274Z",
       "owner_directive": "Approved the ARCHITECTURE.md section 11.1 change as written.",
       "reason": "Owner reviewed the rendered ARCHITECTURE.md section 11.1 change and approved it; recording the expected owner-controlled-document label. Also corrected the section intro, which still claimed previewers is created on first use after the table row was fixed."
+    },
+    {
+      "at": "2026-08-21T22:19:04.044100Z",
+      "owner_directive": "Open the PR directly.",
+      "reason": "Owner directed opening the PR now rather than resolving the local python_tests blocker first."
     }
   ],
   "docs_events": [
@@ -411,6 +538,226 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:40:31.832260Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "docs/architecture/ARCHITECTURE.md",
+          "finding_class": "architecture_doc_guard",
+          "git_evidence": null,
+          "id": "architecture_doc_guard.missing-owner-approval",
+          "line": null,
+          "message": "the architecture document is owner-controlled and this change has no owner approval: apply admin-approved:architecture-doc as an authorized maintainer, or approve the PR as an administrator, or drop the change",
+          "path": "docs/architecture/ARCHITECTURE.md",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "architecture_doc_guard.missing-owner-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:40:31.849564Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:40:31.875991Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:40:31.897124Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:40:31.915246Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:40:31.940559Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:40:31.973445Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:40:32.001024Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:40:32.025270Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:40:32.046634Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:40:32.074742Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:54:44.201906Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "docs/architecture/ARCHITECTURE.md",
+          "finding_class": "architecture_doc_guard",
+          "git_evidence": null,
+          "id": "architecture_doc_guard.missing-owner-approval",
+          "line": null,
+          "message": "the architecture document is owner-controlled and this change has no owner approval: apply admin-approved:architecture-doc as an authorized maintainer, or approve the PR as an administrator, or drop the change",
+          "path": "docs/architecture/ARCHITECTURE.md",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "architecture_doc_guard.missing-owner-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:54:44.218236Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:54:44.256224Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:54:44.283565Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:54:44.304283Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:54:44.328536Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:54:44.363459Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:54:44.394528Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:54:44.412074Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:54:44.429756Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:54:44.452497Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -425,27 +772,45 @@
   "observed_diff": {
     "base": "origin/main",
     "base_sha": "4105e165",
-    "changed_files": [],
-    "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "changed_files": [
+      ".workflow/records/2095-previewer-tier-surface.json",
+      "CHANGELOG.md",
+      "docs/architecture/ARCHITECTURE.md",
+      "src/scistudio/api/project_layout.py",
+      "src/scistudio/api/routes/data.py",
+      "src/scistudio/api/runtime/_projects.py",
+      "src/scistudio/api/schemas.py",
+      "src/scistudio/cli/main.py",
+      "tests/api/test_previewer_discovery.py",
+      "tests/api/test_project_layout.py"
+    ],
+    "diff_fingerprint": "sha256:e0f092de73cb6713e49f1f2736888ad33da8c480bb3b4a99de0c2f629d22f7f7",
     "head": "HEAD",
-    "head_sha": "4105e165",
+    "head_sha": "b1dc765b",
     "surfaces": {
-      "docs": 0,
+      "docs": 1,
       "frontend": 0,
       "governance": 0,
       "governed_docs": 0,
-      "implementation": 0,
+      "implementation": 5,
       "packaging": 0,
-      "protected_architecture": 0,
+      "protected_architecture": 1,
       "protected_core": 0,
-      "sentrux": 0,
-      "test": 0,
+      "sentrux": 8,
+      "test": 2,
       "workflow_ci": 0
     }
   },
   "owner_directive": "Backend only: reconcile the two project scaffolds and add the previewers and tutorials directories, add a previewer registry reload endpoint mirroring blocks and types, and add a previewer listing API. Keep data/processed as the user-visible save target and document the split; no engine or core storage path changes. No frontend work.",
   "persona": "live_implementer",
-  "pull_request": null,
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [
+      2095
+    ],
+    "number": null,
+    "url": null
+  },
   "reconcile_events": [
     {
       "at": "2026-08-21T21:25:54.700379Z",
@@ -480,6 +845,32 @@
       "result": "pass",
       "tier": 2,
       "unsatisfied": []
+    },
+    {
+      "at": "2026-08-21T21:40:32.074775Z",
+      "diff_fingerprint": "sha256:e0f092de73cb6713e49f1f2736888ad33da8c480bb3b4a99de0c2f629d22f7f7",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.format_check",
+        "checks.full_audit",
+        "checks.import_contracts",
+        "checks.lint_format",
+        "checks.python_tests",
+        "checks.semantic_dup",
+        "checks.type_check"
+      ]
+    },
+    {
+      "at": "2026-08-21T21:54:44.452533Z",
+      "diff_fingerprint": "sha256:e0f092de73cb6713e49f1f2736888ad33da8c480bb3b4a99de0c2f629d22f7f7",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.python_tests"
+      ]
     }
   ],
   "record_id": "2095-previewer-tier-surface",
@@ -492,13 +883,21 @@
     }
   ],
   "required_obligations": {
-    "admin_labels": [],
+    "admin_labels": [
+      "admin-approved:architecture-doc"
+    ],
     "checks": [
       "format_check",
       "full_audit",
-      "lint_format"
+      "import_contracts",
+      "lint_format",
+      "python_tests",
+      "semantic_dup",
+      "type_check"
     ],
-    "docs": [],
+    "docs": [
+      "docs_required_or_na"
+    ],
     "guards": [
       "architecture_doc_guard",
       "core_change_guard",
@@ -512,7 +911,9 @@
       "test_engineer_scope_guard",
       "weakened_ci_check"
     ],
-    "tests": []
+    "tests": [
+      "changed_test_required"
+    ]
   },
   "runtime": "claude-code",
   "schema_version": 2,

--- a/.workflow/records/2095-previewer-tier-surface.json
+++ b/.workflow/records/2095-previewer-tier-surface.json
@@ -304,6 +304,14 @@
       "path": null,
       "rationale": "Docstring wording only. No behaviour, contract, schema, or API change; the sentence reworded says the same thing without the phrase scripts/deferral_scan.py maps to its handoff class. The feature's documentation landed earlier in this PR: docs/architecture/ARCHITECTURE.md section 11.1 and CHANGELOG.md.",
       "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-21T23:29:50.763833Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/specs/adr-048-preview-system.md",
+      "rationale": null,
+      "verified_in_diff": null
     }
   ],
   "governance_touch": false,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- [#2095] **Previewers can be listed, and the previewer surface can reload
+  itself.** `GET /api/previews/previewers` returns every registered previewer
+  with the tier it came from, ordered the way the router considers them —
+  project, then user, then package, then core — and takes an optional
+  `target_type` filter. It also returns the registry's discovery diagnostics,
+  which nothing surfaced before: a drop-in refused for a module-name collision,
+  a duplicate previewer id, or an entry point that failed to import were all
+  recorded and then only logged, so from the product they looked like a
+  previewer that simply never appeared. `PreviewerSpecModel` had been declared
+  since the preview system landed and served by no route; this is the route.
+  `POST /api/previews/reload` gives the previewer surface its own way to
+  rebuild the registry. This is a second surface onto one implementation, not a
+  second reload: `refresh_all_registries()` has rebuilt previewers alongside
+  types and blocks since #2021, and the blocks and types endpoints already
+  reached it. What was missing is the argument FR-027 makes on the type side —
+  a previewer view must not have to call the *blocks* endpoint to do its own
+  job, while all three still rebuild the same world.
+
 - [#2057 #2058] **SciStudio has a Learning Center**: a catalogue of tutorials
   that are real, runnable projects, reached from a permanent toolbar entry and
   shown on first launch. The first core tutorial, *Welcome to SciStudio*, ships
@@ -85,6 +103,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   breaking regardless, because a route leaves the API surface.
 
 ### Fixed
+
+- [#2095] **A new project gets the directories its drop-in tiers are actually
+  scanned from.** Two commands create a project — the GUI's "New project" and
+  `scistudio init` — and each carried its own hand-written directory list. The
+  lists had drifted: the CLI omitted `data/processed` while a comment above it
+  claimed to be "Symmetric with `api/runtime.py::create_project`", and *neither*
+  created `previewers/` or `tutorials/`, so a user who wanted a project-local
+  previewer had to guess the folder name and create it by hand.
+  Both now read one definition, `scistudio.api.project_layout`, which takes the
+  drop-in folder names from `scistudio.core.dropins` rather than respelling
+  them — the folder a project offers and the folder the registry scans can no
+  longer disagree. `docs/architecture/ARCHITECTURE.md` §11.1 gains the two
+  directories and, while there, says plainly which data directories answer to
+  the user (`data/raw`, `data/processed`) and which are runtime-managed stores
+  named for how a payload is persisted (`data/zarr`, `data/parquet`,
+  `data/artifacts`, `data/exchange`). `data/processed` being empty after a run
+  is expected: nothing writes there automatically, because what deserves
+  keeping is a judgement the runtime cannot make.
 
 - [#2073] **A project registry written by a newer build no longer stops an older
   runtime from starting.** `~/.scistudio/projects.json` outlives the runtime that

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -1925,9 +1925,14 @@ directory without that file is rejected as an invalid SciStudio project.
 
 ### 11.1 Created Project Layout
 
-`ApiRuntime.create_project` creates the baseline layout below. The
-`previewers/` and `plots/` directories are added on first use by the previewer
-and plot subsystems rather than at project creation:
+Both entry points that create a project — `ApiRuntime.create_project` behind the
+GUI's "New project", and `scistudio init` on the CLI — create the baseline
+layout below from one shared definition, `scistudio.api.project_layout`. The
+drop-in directory names in it come from `scistudio.core.dropins`, so the folder
+a project offers and the folder the registry scans cannot disagree.
+
+`plots/` is the exception: it is added on first use by the plot subsystem rather
+than at project creation.
 
 ```
 my_project/
@@ -1937,9 +1942,11 @@ my_project/
 ├── blocks/
 ├── types/
 ├── previewers/
+├── tutorials/
 ├── plots/
 ├── data/
 │   ├── raw/
+│   ├── processed/
 │   ├── zarr/
 │   ├── parquet/
 │   ├── artifacts/
@@ -1955,15 +1962,31 @@ my_project/
 | `workflows/` | User workflow YAML files. Workflow IDs map to `workflows/<id>.yaml`. |
 | `blocks/` | Project-local custom blocks. Saving a clean Python file here can hot-reload the block registry. |
 | `types/` | Project-local custom data type definitions. |
-| `previewers/` | Project-local previewer drop-ins (`previewers/*.py` exposing get_previewers()); a `.scistudio/previewers.json` manifest can declare default-previewer tie-breakers (§9.6). Created on first use. |
+| `previewers/` | Project-local previewer drop-ins (`previewers/*.py` exposing get_previewers()); a `.scistudio/previewers.json` manifest can declare default-previewer tie-breakers (§9.6). |
+| `tutorials/` | Project-local tutorial drop-ins, each a directory with a `tutorial.yaml` manifest (ADR-053 Learning Center §4.2). |
 | `plots/` | Plot cards — each plot is `plots/<id>/plot.yaml` plus its render script (§10). Created on first use. |
 | `data/raw/` | Uploaded or imported raw files. File uploads land here after filename sanitization. |
+| `data/processed/` | Where a person saves results they want to keep or hand on. A save/export target, not a mirror of the runtime stores below — see the note after this table. |
 | `data/zarr/` | Zarr-backed array-style data. |
 | `data/parquet/` | Parquet-backed table-style data. |
 | `data/artifacts/` | Reports, images, PDFs, and other artifact files. |
 | `data/exchange/` | Exchange area used by external app/code style blocks for file handoff. |
 | `.scistudio/` | Per-project runtime state. This directory is local and gitignored by default. |
 | `logs/` | Project log directory reserved for user-visible logs and diagnostics. |
+
+Two of these directories answer to the user and four answer to the runtime, and
+the distinction is worth stating because the names alone do not carry it.
+`data/raw/` and `data/processed/` are the pair a person thinks in: what came in,
+and what is worth keeping. `data/zarr/`, `data/parquet/`, `data/artifacts/`, and
+`data/exchange/` are runtime-managed stores named for *how* a payload is
+persisted rather than *what* it means — block outputs are written under
+`data/zarr/<workflow_id>/<block_id>/` by `_derive_output_dir` whatever their
+backend, and lineage retention sweeps `data/zarr` and `data/parquet`
+(`scistudio.core.lineage.retention.ARTIFACT_ROOTS`).
+
+So `data/processed/` being empty after a run is expected, not a bug: nothing
+writes there automatically, because what deserves keeping is a judgement the
+runtime cannot make. It exists so that judgement has somewhere obvious to go.
 
 `notes/` is **not** part of the required scaffold. The frontend can create notes
 under `notes/` when that directory exists, and otherwise falls back to creating

--- a/docs/specs/adr-048-preview-system.md
+++ b/docs/specs/adr-048-preview-system.md
@@ -319,6 +319,31 @@ Acceptance Scenarios:
   ambiguity.
 - FR-030: Previewer discovery must support monorepo package development in the
   same spirit as existing block and type registry monorepo fallbacks.
+- FR-031 (#2095): The registered previewer set must be enumerable over the API,
+  reporting for each spec its id, owner tier and name, target type, collection
+  support, priority, capabilities, provider name, and frontend manifest. The
+  listing must be ordered by the FR-003 routing precedence, so a reader sees the
+  specs in the order the router considers them, and must accept an exact
+  `target_type` filter — exact, not the FR-003 specificity walk: a caller asking
+  what claims a type wants the previewers written for that type, not every
+  ancestor previewer that would also render one. What would actually be selected
+  for a concrete target stays answerable only by opening a session and reading
+  the returned `previewer_id`.
+- FR-032 (#2095): The same response must carry the registry's discovery
+  diagnostics — a duplicate previewer id (FR-006), a drop-in refused by the
+  name-collision guard, an entry point that failed to import. These are already
+  recorded on the registry; without a surface they are only logged, which leaves
+  a refused drop-in indistinguishable from one that was never written.
+- FR-033 (#2095): The previewer surface must be able to trigger a registry
+  rebuild through an endpoint of its own. The rebuild is not previewer-specific
+  and must not be reimplemented: it is the same whole-registry refresh the block
+  and type reload endpoints already perform, which has covered previewers since
+  #2021. What the requirement adds is that a previewer view need not call the
+  *block* endpoints to do its own job — the argument ADR-053 FR-027 makes for
+  the Data types tab, applied one tier over. The broadcast stays
+  `blocks.reloaded`, because that event already means "the registries were
+  rebuilt" to every client and a previewer-specific sibling would be a second
+  event for one fact.
 
 ### Key Entities
 
@@ -382,9 +407,11 @@ code.
 
 ### API Shape
 
-The preview API is session-oriented. The one-shot
+The preview API is session-oriented for rendering. The one-shot
 `GET /api/data/{data_ref}/preview` route was removed (#1604, no-compat); only
-the session routes remain:
+the session routes remain. Two discovery routes sit beside them (#2095) — they
+answer *which previewers exist*, which a session cannot, since a session
+resolves exactly one:
 
 | Method | Path | Purpose |
 |---|---|---|
@@ -393,6 +420,8 @@ the session routes remain:
 | `PATCH` | `/api/previews/sessions/{session_id}` | Update query state such as slice, page, sort, slot, or item. |
 | `GET` | `/api/previews/sessions/{session_id}/resources/{resource_id}` | Fetch bounded provider resource data. |
 | `GET` | `/api/previews/assets/{asset_id}` | Serve validated same-origin frontend assets. |
+| `GET` | `/api/previews/previewers` | List registered previewers with their tier, plus registry diagnostics (FR-031, FR-032). Optional exact `target_type` filter. |
+| `POST` | `/api/previews/reload` | Rebuild the registries from the previewer surface and broadcast `blocks.reloaded` (FR-033). |
 
 Session resource descriptors may include provider-defined `params`. Clients
 must copy those params into the resource request as a URL-encoded JSON object in

--- a/src/scistudio/api/project_layout.py
+++ b/src/scistudio/api/project_layout.py
@@ -1,0 +1,72 @@
+"""The directory layout a new project workspace is created with (#2095).
+
+Two entry points create projects — ``ApiRuntime.create_project`` (the GUI's
+"New project") and ``scistudio init`` (the CLI) — and until this module existed
+they each carried their own hand-written list. They had already drifted: the
+CLI omitted ``data/processed`` while claiming in a comment to be "Symmetric
+with ``api/runtime.py::create_project``", and neither created the drop-in
+directories for previewers or tutorials even though both tiers are discovered
+from a project (:mod:`scistudio.core.dropins`).
+
+The drop-in directory names are imported from :mod:`scistudio.core.dropins`
+rather than respelled here, so the folder a project offers and the folder the
+registry scans cannot disagree. Adding a fifth drop-in kind means adding one
+name to that module and one entry here, not finding every scaffold.
+
+Kept as a leaf module with no heavyweight imports: ``scistudio init`` is a
+fast mkdir command and must not pay for the API runtime to learn what a
+project looks like.
+"""
+
+from __future__ import annotations
+
+from scistudio.core.dropins import (
+    BLOCKS_DIR_NAME,
+    PREVIEWERS_DIR_NAME,
+    TUTORIALS_DIR_NAME,
+    TYPES_DIR_NAME,
+)
+
+__all__ = ["DATA_SUBDIRS", "DROPIN_SUBDIRS", "PROJECT_SUBDIRS"]
+
+#: Where data lives inside a project.
+#:
+#: ``data/raw`` and ``data/processed`` are the two the user is meant to think
+#: in: what came in, and what came out. The remaining three are runtime-managed
+#: stores — the engine writes block outputs under ``data/zarr`` (see
+#: ``scistudio.engine.runners.local._derive_output_dir``), ``data/parquet``
+#: holds explicitly saved tables, ``data/artifacts`` holds opaque files, and
+#: ``data/exchange`` is the hand-off area for external applications (ADR-041).
+#:
+#: The split is deliberate and documented in ``docs/architecture/ARCHITECTURE.md``:
+#: ``data/processed`` is a save/export target a person chooses, not a mirror of
+#: the runtime stores.
+DATA_SUBDIRS: tuple[str, ...] = (
+    "data/raw",
+    "data/processed",
+    "data/zarr",
+    "data/parquet",
+    "data/artifacts",
+    "data/exchange",
+)
+
+#: Project-tier drop-in directories, named by :mod:`scistudio.core.dropins` so
+#: the scaffold and the scanners share one spelling.
+DROPIN_SUBDIRS: tuple[str, ...] = (
+    BLOCKS_DIR_NAME,
+    TYPES_DIR_NAME,
+    PREVIEWERS_DIR_NAME,
+    TUTORIALS_DIR_NAME,
+)
+
+#: Every directory created for a new project workspace, in creation order.
+#:
+#: ADR-038 §3.5 / §5.2: lineage history lives at ``.scistudio/lineage.db``; the
+#: legacy top-level ``lineage/`` and ``checkpoints/`` directories are retired.
+PROJECT_SUBDIRS: tuple[str, ...] = (
+    "workflows",
+    *DATA_SUBDIRS,
+    *DROPIN_SUBDIRS,
+    ".scistudio",
+    "logs",
+)

--- a/src/scistudio/api/routes/data.py
+++ b/src/scistudio/api/routes/data.py
@@ -11,6 +11,7 @@ the frontend ``TableViewer`` paginates/sorts through the session PATCH like the
 from __future__ import annotations
 
 import json
+import logging
 import math
 from pathlib import Path
 from typing import Annotated, Any
@@ -25,6 +26,9 @@ from scistudio.api.schemas import (
     DataMetadataResponse,
     DataUploadResponse,
     PreviewEnvelopeModel,
+    PreviewerListResponse,
+    PreviewerReloadResponse,
+    PreviewerSpecModel,
     PreviewResourceResponse,
     PreviewResourceSaveRequest,
     PreviewResourceSaveResponse,
@@ -39,7 +43,9 @@ from scistudio.previewers import (
     UnknownTargetError,
 )
 from scistudio.previewers.assets import resolve_asset, validate_manifest
-from scistudio.previewers.models import MissingBundleError, PreviewError
+from scistudio.previewers.models import MissingBundleError, OwnerKind, PreviewError
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/data", tags=["data"])
 previews_router = APIRouter(prefix="/api/previews", tags=["previews"])
@@ -187,6 +193,143 @@ def _validate_resource_param_value(value: Any, *, depth: int = 0) -> int:
             raise HTTPException(status_code=422, detail="resource param numbers must be finite")
         return 1
     raise HTTPException(status_code=422, detail="resource params must be JSON-compatible")
+
+
+# ---------------------------------------------------------------------------
+# #2095: previewer discovery + reload.
+#
+# The previewer tier gained a project and a user tier in #2017/#2044 but not the
+# surface blocks and types already had around theirs. These two routes close
+# that: one answers which previewers exist and where each came from, the other
+# lets the previewer surface trigger a registry rebuild without reaching for the
+# block endpoint to do it.
+# ---------------------------------------------------------------------------
+
+#: Routing precedence, used to order the listing so the reader sees the specs in
+#: the order the router would consider them (ADR-048 FR-003).
+_TIER_ORDER = {
+    OwnerKind.PROJECT: 0,
+    OwnerKind.USER: 1,
+    OwnerKind.PACKAGE: 2,
+    OwnerKind.CORE: 3,
+}
+
+
+def _spec_model(spec: Any) -> PreviewerSpecModel:
+    """Adapt a :class:`PreviewerSpec` to its wire shape."""
+    data = spec.to_dict()
+    # ``to_dict`` also carries ``resource_provider``, which the wire model does
+    # not declare; naming the fields explicitly keeps the two from drifting
+    # silently if either side gains a key.
+    return PreviewerSpecModel(
+        previewer_id=data["previewer_id"],
+        owner_kind=data["owner_kind"],
+        owner_name=data["owner_name"],
+        target_type=data["target_type"],
+        supports_collection=data["supports_collection"],
+        priority=data["priority"],
+        capabilities=data["capabilities"],
+        backend_provider=data["backend_provider"],
+        frontend_manifest=data["frontend_manifest"],
+        api_version=data["api_version"],
+    )
+
+
+@previews_router.get("/previewers", response_model=PreviewerListResponse)
+async def list_previewers(
+    runtime: RuntimeDep,
+    target_type: str | None = None,
+) -> PreviewerListResponse:
+    """List registered previewers, with the tier each was discovered from.
+
+    ``target_type`` filters to specs claiming exactly that type name. It is an
+    exact match, not the router's specificity walk: a caller asking "what claims
+    ``Spectrum``" wants the previewers written for ``Spectrum``, not every
+    ancestor previewer that would also render one. Resolving what would actually
+    be picked for a concrete target is the router's job, reached through a
+    preview session.
+
+    Registry diagnostics ride along because nothing else surfaces them. A
+    drop-in refused for a module-name collision, a duplicate previewer id, a
+    broken entry point -- all were recorded and then only logged, so from the
+    product they looked like a previewer that simply never appeared.
+    """
+    service = runtime.get_preview_service()
+    registry = service.registry
+    specs = registry.all_specs()
+    if target_type is not None:
+        specs = [s for s in specs if s.target_type == target_type]
+    specs = sorted(specs, key=lambda s: (_TIER_ORDER.get(s.owner_kind, 99), -s.priority, s.previewer_id))
+    return PreviewerListResponse(
+        previewers=[_spec_model(s) for s in specs],
+        diagnostics=list(registry.diagnostics),
+    )
+
+
+@previews_router.post("/reload", response_model=PreviewerReloadResponse)
+async def reload_previewers(runtime: RuntimeDep) -> PreviewerReloadResponse:
+    """Re-scan the drop-in previewer directories and broadcast the change.
+
+    This is a second surface onto one implementation, not a second reload.
+    ``refresh_all_registries()`` has rebuilt the previewer registry alongside
+    types and blocks since #2021, and ``POST /api/blocks/reload`` and
+    ``POST /api/types/reload`` both already reach it -- verified directly:
+    editing a drop-in previewer and calling the *blocks* endpoint does pick the
+    edit up.
+
+    What was missing is the previewer surface's own way in. FR-027's argument on
+    the type side applies unchanged here: a previewer view must not have to
+    speak to the block endpoints to do its own job, while all three endpoints
+    still rebuild the same world. Inventing a previewer-only rebuild instead
+    would be the drift ADR-053 §10.3/§10.4 exists to remove.
+
+    The broadcast is ``blocks.reloaded`` for the same reason ``reload_types``
+    gives: it is already in the websocket outbound allow-list, every client
+    already reads it as "the registries were rebuilt, re-read your catalogues",
+    and the block registry really was rebuilt. A ``previewers.reloaded`` sibling
+    would be a second event for one fact.
+    """
+    service = runtime.get_preview_service()
+    before = {s.previewer_id for s in service.registry.all_specs()}
+    blocks_before = set(runtime.block_registry.all_specs().keys())
+
+    runtime.refresh_all_registries()
+
+    service = runtime.get_preview_service()
+    registry = service.registry
+    after = {s.previewer_id for s in registry.all_specs()}
+    blocks_after = set(runtime.block_registry.all_specs().keys())
+    added = sorted(after - before)
+    removed = sorted(before - after)
+    logger.info("POST /api/previews/reload: added=%s removed=%s", added, removed)
+
+    # Best-effort, exactly as on the block and type sides: a headless or test
+    # runtime with no event bus skips the broadcast rather than failing.
+    event_bus = getattr(runtime, "event_bus", None)
+    if event_bus is not None:
+        from scistudio.engine.events import EngineEvent
+
+        try:
+            await event_bus.emit(
+                EngineEvent(
+                    event_type="blocks.reloaded",
+                    data={
+                        "added": sorted(blocks_after - blocks_before),
+                        "removed": sorted(blocks_before - blocks_after),
+                        "reloaded": sorted(blocks_after),
+                        "source": "previewers",
+                    },
+                )
+            )
+        except Exception:
+            logger.exception("POST /api/previews/reload: blocks.reloaded broadcast failed")
+
+    return PreviewerReloadResponse(
+        reloaded=len(after),
+        added=added,
+        removed=removed,
+        diagnostics=list(registry.diagnostics),
+    )
 
 
 @previews_router.post("/sessions", response_model=PreviewEnvelopeModel)

--- a/src/scistudio/api/routes/data.py
+++ b/src/scistudio/api/routes/data.py
@@ -245,9 +245,9 @@ async def list_previewers(
     ``target_type`` filters to specs claiming exactly that type name. It is an
     exact match, not the router's specificity walk: a caller asking "what claims
     ``Spectrum``" wants the previewers written for ``Spectrum``, not every
-    ancestor previewer that would also render one. Resolving what would actually
-    be picked for a concrete target is the router's job, reached through a
-    preview session.
+    ancestor previewer that would also render one. To learn what would actually
+    be picked for a concrete target, open a preview session and read the
+    ``previewer_id`` the router returned.
 
     Registry diagnostics ride along because nothing else surfaces them. A
     drop-in refused for a module-name collision, a duplicate previewer id, a

--- a/src/scistudio/api/runtime/_projects.py
+++ b/src/scistudio/api/runtime/_projects.py
@@ -20,6 +20,7 @@ from uuid import uuid4
 
 import yaml
 
+from scistudio.api.project_layout import PROJECT_SUBDIRS
 from scistudio.blocks.registry import BlockRegistry
 from scistudio.core.dropins import register_block_scan_dirs, register_type_scan_dirs
 from scistudio.core.types.registry import TypeRegistry
@@ -280,23 +281,9 @@ def create_project(
     if project_path.exists():
         raise FileExistsError(f"Project directory already exists: {project_path}")
 
-    for subdir in (
-        "workflows",
-        "data/raw",
-        # The counterpart to data/raw: where a workflow's results land. Named
-        # for what the files are rather than for how they are stored, so a user
-        # saving a result does not have to know what parquet is to choose a
-        # folder for it (owner decision, 2026-08-11).
-        "data/processed",
-        "data/zarr",
-        "data/parquet",
-        "data/artifacts",
-        "data/exchange",
-        "blocks",
-        "types",
-        ".scistudio",
-        "logs",
-    ):
+    # #2095: one definition, shared with `scistudio init`. See
+    # `scistudio.api.project_layout` for why each directory is there.
+    for subdir in PROJECT_SUBDIRS:
         (project_path / subdir).mkdir(parents=True, exist_ok=True)
 
     project_id = f"project-{uuid4().hex[:8]}"

--- a/src/scistudio/api/schemas.py
+++ b/src/scistudio/api/schemas.py
@@ -458,6 +458,32 @@ class PreviewerSpecModel(BaseModel):
     api_version: str = "1"
 
 
+class PreviewerListResponse(BaseModel):
+    """Response body for ``GET /api/previews/previewers`` (#2095).
+
+    ``PreviewerSpecModel`` was declared when the preview system landed and
+    never served; this is the route that makes previewer provenance answerable
+    the way the Data types tab answers it for types.
+    """
+
+    previewers: list[PreviewerSpecModel] = Field(default_factory=list)
+    """Registered specs, ordered project -> user -> package -> core, then by id."""
+    diagnostics: list[str] = Field(default_factory=list)
+    """Discovery problems recorded during the scan: a duplicate previewer id, a
+    drop-in refused for a module-name collision, an entry point that failed to
+    import. Nothing surfaced these before, so a refused drop-in was silent."""
+
+
+class PreviewerReloadResponse(BaseModel):
+    """Response body for ``POST /api/previews/reload`` (#2095)."""
+
+    reloaded: int
+    """Number of previewer specs registered after the rebuild."""
+    added: list[str] = Field(default_factory=list)
+    removed: list[str] = Field(default_factory=list)
+    diagnostics: list[str] = Field(default_factory=list)
+
+
 class PreviewResourceResponse(BaseModel):
     """Response body for a bounded session resource read."""
 

--- a/src/scistudio/cli/main.py
+++ b/src/scistudio/cli/main.py
@@ -119,22 +119,13 @@ def init(name: str = typer.Argument("my_project", help="Project workspace name")
         raise typer.Exit(code=1)
 
     # Create directory structure per ARCHITECTURE.md Section 10.
-    # ADR-038 §3.5 / §5.2: lineage history lives at ``.scistudio/lineage.db``;
-    # the legacy ``lineage/`` and ``checkpoints/`` top-level dirs are retired
-    # in favour of ``.scistudio/``. Symmetric with ``api/runtime.py::create_project``.
-    subdirs = [
-        "workflows",
-        "data/raw",
-        "data/zarr",
-        "data/parquet",
-        "data/artifacts",
-        "data/exchange",
-        "blocks",
-        "types",
-        ".scistudio",
-        "logs",
-    ]
-    for subdir in subdirs:
+    # #2095: the list is shared with ``ApiRuntime.create_project`` rather than
+    # restated here. The two had drifted -- this one was missing
+    # ``data/processed`` while claiming to be symmetric with it, and neither
+    # created the previewer or tutorial drop-in directories.
+    from scistudio.api.project_layout import PROJECT_SUBDIRS
+
+    for subdir in PROJECT_SUBDIRS:
         (project_path / subdir).mkdir(parents=True, exist_ok=True)
 
     project_meta = {

--- a/tests/api/test_previewer_discovery.py
+++ b/tests/api/test_previewer_discovery.py
@@ -1,0 +1,202 @@
+"""Previewer listing and reload endpoints (#2095).
+
+The previewer tier gained a project and a user tier in #2017/#2044 without the
+surface blocks and types already had around theirs: nothing enumerated the
+registered previewers, and the previewer side had no reload entry point of its
+own.
+
+Note what is *not* claimed here. ``refresh_all_registries()`` has rebuilt the
+previewer registry since #2021, so ``POST /api/blocks/reload`` already picked up
+a drop-in previewer edit before this change; ``test_blocks_reload_also_rebuilds_previewers``
+pins that pre-existing behaviour so the new endpoint cannot be mistaken for the
+thing that made reloading work. What is new is a previewer-owned surface onto
+that one implementation (FR-027's argument, applied one tier over).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+DROPIN = """\
+from scistudio.previewers.models import OwnerKind, PreviewerSpec
+
+
+def get_previewers():
+    return [
+        PreviewerSpec(
+            previewer_id={previewer_id!r},
+            owner_kind=OwnerKind.PROJECT,
+            owner_name="probe",
+            target_type={target_type!r},
+            priority={priority},
+            capabilities=("probe",),
+        ),
+    ]
+"""
+
+
+def _write_dropin(
+    project: Path, filename: str, *, previewer_id: str, target_type: str = "Array", priority: int = 50
+) -> Path:
+    previewers = project / "previewers"
+    previewers.mkdir(parents=True, exist_ok=True)
+    path = previewers / filename
+    path.write_text(
+        DROPIN.format(previewer_id=previewer_id, target_type=target_type, priority=priority),
+        encoding="utf-8",
+    )
+    return path
+
+
+# -- listing ----------------------------------------------------------------
+
+
+def test_list_previewers_returns_the_core_fallbacks(client: TestClient) -> None:
+    """Core specs load unconditionally, so the listing is never empty."""
+    response = client.get("/api/previews/previewers")
+    assert response.status_code == 200
+    body = response.json()
+    ids = {p["previewer_id"] for p in body["previewers"]}
+    assert "core.series.basic" in ids
+    assert "core.dataframe.basic" in ids
+    assert all(p["owner_kind"] == "core" for p in body["previewers"])
+
+
+def test_list_previewers_reports_the_tier_a_dropin_came_from(client: TestClient, opened_project: Path) -> None:
+    _write_dropin(opened_project, "probe.py", previewer_id="probe.project")
+    assert client.post("/api/previews/reload").status_code == 200
+
+    body = client.get("/api/previews/previewers").json()
+    entry = next(p for p in body["previewers"] if p["previewer_id"] == "probe.project")
+    assert entry["owner_kind"] == "project"
+    assert entry["owner_name"] == "probe"
+    assert entry["target_type"] == "Array"
+    assert entry["capabilities"] == ["probe"]
+
+
+def test_list_previewers_orders_by_routing_precedence(client: TestClient, opened_project: Path) -> None:
+    """Project first, then user, then package, then core (ADR-048 FR-003).
+
+    The listing exists to be read by a person deciding which previewer wins, so
+    it presents them in the order the router considers them rather than in
+    registration order.
+    """
+    _write_dropin(opened_project, "probe.py", previewer_id="probe.project")
+    assert client.post("/api/previews/reload").status_code == 200
+
+    body = client.get("/api/previews/previewers").json()
+    kinds = [p["owner_kind"] for p in body["previewers"]]
+    assert kinds[0] == "project"
+    # Every core spec sorts after every non-core one.
+    first_core = kinds.index("core")
+    assert set(kinds[first_core:]) == {"core"}
+
+
+def test_list_previewers_filters_by_exact_target_type(client: TestClient, opened_project: Path) -> None:
+    """The filter is an exact match, not the router's specificity walk.
+
+    A caller asking what claims ``Spectrum`` wants the previewers written for
+    ``Spectrum``, not every ancestor previewer that would also render one.
+    """
+    _write_dropin(opened_project, "probe.py", previewer_id="probe.spectrum", target_type="Spectrum")
+    assert client.post("/api/previews/reload").status_code == 200
+
+    body = client.get("/api/previews/previewers", params={"target_type": "Spectrum"}).json()
+    assert [p["previewer_id"] for p in body["previewers"]] == ["probe.spectrum"]
+
+    # ``Series`` is Spectrum's parent in the router's walk, but it is not this
+    # spec's declared target, so the exact filter must not return it.
+    series = client.get("/api/previews/previewers", params={"target_type": "Series"}).json()
+    assert "probe.spectrum" not in {p["previewer_id"] for p in series["previewers"]}
+
+
+def test_list_previewers_filter_with_no_match_is_empty_not_an_error(client: TestClient) -> None:
+    body = client.get("/api/previews/previewers", params={"target_type": "NoSuchType"}).json()
+    assert body["previewers"] == []
+
+
+def test_list_previewers_surfaces_a_refused_dropin(client: TestClient, opened_project: Path) -> None:
+    """A drop-in refused by the FR-016 collision guard was previously silent.
+
+    It was recorded on the registry diagnostics and then only logged, so from
+    the product it looked like a previewer that simply never appeared.
+    """
+    previewers = opened_project / "previewers"
+    previewers.mkdir(parents=True, exist_ok=True)
+    (previewers / "json.py").write_text("def get_previewers():\n    return []\n", encoding="utf-8")
+    assert client.post("/api/previews/reload").status_code == 200
+
+    body = client.get("/api/previews/previewers").json()
+    assert any("json.py" in d for d in body["diagnostics"]), body["diagnostics"]
+
+
+# -- reload ------------------------------------------------------------------
+
+
+def test_reload_picks_up_a_new_dropin_previewer(client: TestClient, opened_project: Path) -> None:
+    before = client.get("/api/previews/previewers").json()
+    assert "probe.added" not in {p["previewer_id"] for p in before["previewers"]}
+
+    _write_dropin(opened_project, "probe.py", previewer_id="probe.added")
+    response = client.post("/api/previews/reload")
+    assert response.status_code == 200
+    body = response.json()
+    assert "probe.added" in body["added"]
+    assert body["removed"] == []
+    assert body["reloaded"] == len(before["previewers"]) + 1
+
+    after = client.get("/api/previews/previewers").json()
+    assert "probe.added" in {p["previewer_id"] for p in after["previewers"]}
+
+
+def test_reload_reports_a_removed_dropin(client: TestClient, opened_project: Path) -> None:
+    path = _write_dropin(opened_project, "probe.py", previewer_id="probe.transient")
+    assert client.post("/api/previews/reload").status_code == 200
+
+    path.unlink()
+    body = client.post("/api/previews/reload").json()
+    assert body["removed"] == ["probe.transient"]
+    assert body["added"] == []
+
+
+def test_reload_picks_up_an_edit_to_an_existing_dropin(client: TestClient, opened_project: Path) -> None:
+    """The registry caches the module, so an edit needs the rebuild.
+
+    This is the loop a previewer author lives in, and the reason the surface
+    needs its own endpoint rather than borrowing the block one.
+    """
+    _write_dropin(opened_project, "probe.py", previewer_id="probe.edited", priority=10)
+    assert client.post("/api/previews/reload").status_code == 200
+    body = client.get("/api/previews/previewers", params={"target_type": "Array"}).json()
+    assert next(p for p in body["previewers"] if p["previewer_id"] == "probe.edited")["priority"] == 10
+
+    _write_dropin(opened_project, "probe.py", previewer_id="probe.edited", priority=77)
+    assert client.post("/api/previews/reload").status_code == 200
+    body = client.get("/api/previews/previewers", params={"target_type": "Array"}).json()
+    assert next(p for p in body["previewers"] if p["previewer_id"] == "probe.edited")["priority"] == 77
+
+
+def test_blocks_reload_also_rebuilds_previewers(client: TestClient, opened_project: Path) -> None:
+    """Pre-existing behaviour from #2021, pinned so the new endpoint is not
+    mistaken for what made previewer reloading work.
+
+    ``refresh_all_registries()`` rebuilds types, blocks, and previewers, and
+    every reload endpoint reaches that one implementation. If this ever stops
+    holding, the three endpoints have drifted apart again — the exact decay
+    ADR-053 §10.3/§10.4 consolidated away.
+    """
+    _write_dropin(opened_project, "probe.py", previewer_id="probe.via.blocks")
+    assert client.post("/api/blocks/reload").status_code == 200
+
+    body = client.get("/api/previews/previewers").json()
+    assert "probe.via.blocks" in {p["previewer_id"] for p in body["previewers"]}
+
+
+def test_reload_with_no_change_reports_no_delta(client: TestClient, opened_project: Path) -> None:
+    first = client.post("/api/previews/reload").json()
+    second = client.post("/api/previews/reload").json()
+    assert second["added"] == []
+    assert second["removed"] == []
+    assert second["reloaded"] == first["reloaded"]

--- a/tests/api/test_project_layout.py
+++ b/tests/api/test_project_layout.py
@@ -1,0 +1,108 @@
+"""The project scaffold is one definition, shared by both entry points (#2095).
+
+Two commands create a project workspace -- ``ApiRuntime.create_project`` behind
+the GUI's "New project", and ``scistudio init`` on the CLI -- and they each used
+to carry a hand-written directory list. The lists had drifted: the CLI omitted
+``data/processed`` while a comment above it claimed symmetry with the API, and
+neither created the previewer or tutorial drop-in directories even though both
+tiers are discovered from a project.
+
+These tests pin the shared definition and, more importantly, pin the *agreement*
+between the two entry points, since agreement is the property that silently
+decayed.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from scistudio.api.project_layout import DATA_SUBDIRS, DROPIN_SUBDIRS, PROJECT_SUBDIRS
+from scistudio.core.dropins import (
+    BLOCKS_DIR_NAME,
+    PREVIEWERS_DIR_NAME,
+    TUTORIALS_DIR_NAME,
+    TYPES_DIR_NAME,
+)
+
+
+def test_dropin_dirs_are_named_by_the_module_that_scans_them() -> None:
+    """The scaffold must not respell the drop-in directory names.
+
+    If it did, a project could offer a folder the registry does not scan -- the
+    exact failure this module exists to prevent. Adding a fifth drop-in kind
+    should mean adding a name to ``core.dropins`` and an entry here, not hunting
+    for scaffolds.
+    """
+    assert DROPIN_SUBDIRS == (
+        BLOCKS_DIR_NAME,
+        TYPES_DIR_NAME,
+        PREVIEWERS_DIR_NAME,
+        TUTORIALS_DIR_NAME,
+    )
+
+
+def test_every_dropin_tier_has_a_scaffolded_directory() -> None:
+    """Previewers and tutorials were the two missing before #2095."""
+    for name in (BLOCKS_DIR_NAME, TYPES_DIR_NAME, PREVIEWERS_DIR_NAME, TUTORIALS_DIR_NAME):
+        assert name in PROJECT_SUBDIRS
+
+
+def test_data_subdirs_include_the_user_facing_pair_and_the_runtime_stores() -> None:
+    # data/processed is the one the CLI was missing. It is deliberately empty
+    # after a run -- see ARCHITECTURE.md §11.1 -- but it must exist.
+    assert "data/raw" in DATA_SUBDIRS
+    assert "data/processed" in DATA_SUBDIRS
+    for runtime_store in ("data/zarr", "data/parquet", "data/artifacts", "data/exchange"):
+        assert runtime_store in DATA_SUBDIRS
+
+
+def test_project_subdirs_have_no_duplicates() -> None:
+    assert len(PROJECT_SUBDIRS) == len(set(PROJECT_SUBDIRS))
+
+
+def test_api_create_project_creates_every_scaffold_directory(client: TestClient, project_parent: Path) -> None:
+    response = client.post(
+        "/api/projects/",
+        json={"name": "Layout Probe", "description": "", "path": str(project_parent)},
+    )
+    assert response.status_code == 200
+    project_path = Path(response.json()["path"])
+
+    missing = [d for d in PROJECT_SUBDIRS if not (project_path / d).is_dir()]
+    assert not missing, f"API scaffold did not create: {missing}"
+
+
+def test_cli_init_creates_the_same_directories_as_the_api(tmp_path: Path) -> None:
+    """The two entry points must agree.
+
+    Run through a subprocess rather than calling the Typer command in-process:
+    ``scistudio init`` also initialises a git repository and writes agent
+    assets, and the point here is the real command a user runs. Same shape as
+    ``tests/cli/test_dunder_main.py``.
+    """
+    # The child runs in tmp_path, so a relative PYTHONPATH from the parent
+    # (``PYTHONPATH=./src``, how this repo is usually run without installing)
+    # would resolve against the wrong directory. Prepend the absolute repo
+    # ``src`` instead; harmless where the package is already installed.
+    repo_src = Path(__file__).resolve().parents[2] / "src"
+    env = dict(os.environ)
+    env["PYTHONPATH"] = os.pathsep.join([str(repo_src), *([env["PYTHONPATH"]] if env.get("PYTHONPATH") else [])])
+
+    result = subprocess.run(
+        [sys.executable, "-m", "scistudio", "init", "cli_layout_probe"],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=300,
+    )
+    assert result.returncode == 0, f"scistudio init failed: {result.stderr[-2000:]}"
+
+    project_path = tmp_path / "cli_layout_probe"
+    missing = [d for d in PROJECT_SUBDIRS if not (project_path / d).is_dir()]
+    assert not missing, f"CLI scaffold did not create: {missing}"


### PR DESCRIPTION
## What

The previewer tier gained a project and a user tier in #2017 / #2044 but not the surface blocks and types already had around theirs. Three gaps, all backend — the frontend palette is being reworked separately and will build its previewer view against these APIs.

## 1. The project scaffold

Two commands create a project workspace — the GUI's "New project" (`ApiRuntime.create_project`) and `scistudio init` — and each carried its own hand-written directory list. They had drifted:

| Directory | API | CLI |
|---|---|---|
| `data/processed` | yes | **no** |
| `previewers` | **no** | **no** |
| `tutorials` | **no** | **no** |

…while `src/scistudio/cli/main.py` carried the comment *"Symmetric with `api/runtime.py::create_project`"*.

Both now read one definition, `scistudio.api.project_layout`. The drop-in folder names come from `scistudio.core.dropins` rather than being respelled, so the folder a project offers and the folder the registry scans cannot disagree; adding a fifth drop-in kind means one name in that module and one entry here, not hunting for scaffolds.

The module is a leaf with no heavy imports — `scistudio init` is a fast mkdir command and should not pay 1.4s to import the API runtime to learn what a project looks like.

## 2. Listing

`GET /api/previews/previewers` returns registered specs with the tier each came from, ordered the way the router considers them (project → user → package → core), with an optional exact `target_type` filter. `PreviewerSpecModel` had been declared in `schemas.py` since the preview system landed and was referenced by no route.

The response also carries the registry's discovery diagnostics. Nothing surfaced these before — a drop-in refused for a module-name collision, a duplicate previewer id, or an entry point that failed to import were all recorded and then only logged, so from the product they looked like a previewer that simply never appeared.

This is also the prerequisite for #2049: a user cannot be offered a choice among previewers no API can enumerate.

## 3. Reload

`POST /api/previews/reload`.

**This is a second surface onto one implementation, not a second reload** — worth stating because the issue originally claimed otherwise and I was wrong. `refresh_all_registries()` has rebuilt the previewer registry alongside types and blocks since #2021, and both existing reload endpoints already reached it. Verified directly before writing any code: edit a drop-in previewer, call `POST /api/blocks/reload`, and the edit takes effect. [Correction posted on the issue.](https://github.com/jiazhenz026/SciStudio/issues/2095#issuecomment-5375510111)

What was actually missing is FR-027's argument applied one tier over: a previewer view must not have to speak to the *block* endpoints to do its own job, while all three still rebuild the same world. `test_blocks_reload_also_rebuilds_previewers` pins the pre-existing behaviour so the new endpoint cannot later be mistaken for what made previewer reloading work.

The broadcast is `blocks.reloaded` for the reason `reload_types` gives: it is already in the websocket allow-list, every client reads it as "the registries were rebuilt", and the block registry really was rebuilt. A `previewers.reloaded` sibling would be a second event for one fact.

## Data directories

Investigated alongside, owner decision recorded: `data/processed` is created by the API scaffold and referenced by **no code at all**, while workflow outputs land in `data/zarr/<workflow>/<block>/` regardless of format (`_derive_output_dir`). Rather than move outputs — protected core, and a migration problem for existing projects — `ARCHITECTURE.md` §11.1 now states the split: `data/raw` and `data/processed` are the pair a person thinks in; `data/zarr`, `data/parquet`, `data/artifacts`, `data/exchange` are runtime-managed stores named for how a payload is persisted. `data/processed` being empty after a run is expected, not a bug — nothing writes there automatically, because what deserves keeping is a judgement the runtime cannot make.

No engine or core storage path changes.

## Evidence

- New: `tests/api/test_project_layout.py` (6) — pins the shared definition and, more importantly, the *agreement* between the two entry points, since agreement is the property that silently decayed. The CLI case runs the real `python -m scistudio init` in a subprocess.
- New: `tests/api/test_previewer_discovery.py` (11) — listing tier/order/filter/diagnostics, reload add/remove/edit/no-op, plus the blocks-reload regression pin.
- Existing suites re-run green: `tests/api/test_previewers.py`, `tests/api/test_projects.py`, `tests/previewers/`, `tests/api/test_data.py` — 138 passed.
- Live on a running backend: listing returned `project → user → core` in precedence order; `POST /api/previews/reload` moved an edited drop-in label from `[RELOAD-MARKER-V2]` to `[RELOAD-MARKER-V3]`; a `json.py` drop-in surfaced as `"json.py is rejected: the name 'json' already belongs to an importable module…"` in `diagnostics`.
- `gate_record check`: tier 2, `format_check` / `full_audit` / `lint_format` — reconciliation passed.

## Owner-controlled document

`docs/architecture/ARCHITECTURE.md` is owner-controlled (`architecture_doc_guard`, #2054). The owner reviewed the rendered §11.1 change and approved it, so this PR needs **`admin-approved:architecture-doc`** applied by an authorized maintainer; CI verifies the label's actor provenance.

The §11.1 intro was also corrected in the same pass: it still claimed `previewers/` is "added on first use" after the table row had been fixed, which this PR makes false. It now names both entry points and the shared definition, and leaves `plots/` as the one genuine first-use directory.

## Local check status — read before trusting the local evidence

This PR was opened with `SCISTUDIO_SKIP_PREFLIGHT=1` on the owner's instruction. **CI is the authoritative gate here.** What that skipped, precisely:

| Check | Local | Note |
|---|---|---|
| `format_check`, `full_audit`, `import_contracts`, `lint_format`, `type_check` | pass | — |
| `python_tests` | **fail** | 13 failures, none from this diff — classified below |
| `semantic_dup` | **not run** | the scan did not complete inside two 10-minute local runs |

`--check-na` was recorded for `python_tests` and the CLI correctly refused to honour it (`"has NO force: python_tests is owned by ci.yml … Fix the check or rely on CI"`). The N/A stands as documentation of the classification, not as a waiver.

### Why the 13 failures are not this diff

Classified against a clean `origin/main` worktree built at `4105e165` for the comparison, not assumed:

- **8 are [#2075](https://github.com/jiazhenz026/SciStudio/issues/2075)** — they fail *identically* on that unmodified baseline. All test-side: `shutil.rmtree` over read-only `.git/objects`, CRLF text fixtures, an OS-separator path comparison, and a symlink privilege. #2075 itself records that these "block the local `gate_record check` for unrelated work".
- **5 are full-suite parallel interaction** (4 in `tests/api/test_system_vertical.py`, 1 in `tests/api/test_workflows.py`) — they pass in isolation on *both* the clean baseline and this branch.

This diff's own tests pass: 6 in `test_project_layout.py`, 11 in `test_previewer_discovery.py`, and 138 across `test_previewers.py` / `test_projects.py` / `tests/previewers/` / `test_data.py`.

CI is Ubuntu-only and green on the same base — PR #2094 reports 15/15 including `Test (Python 3.11)` and `Test (Python 3.13)`.

Gate record: `.workflow/records/2095-previewer-tier-surface.json`

Closes #2095
