### PR TITLE
feat(#1719): add plot card edit and delete actions

### DIFF
--- a/.workflow/records/1719-feat-1719-plot-card-actions.json
+++ b/.workflow/records/1719-feat-1719-plot-card-actions.json
@@ -156,10 +156,217 @@
       "status": "pass",
       "summary": "clean",
       "tool_versions": {}
+    },
+    {
+      "at": "2026-08-21T21:19:50.022410Z",
+      "command": "python -m scistudio.qa.testing.run_python_tests --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:47eac75ed95c8abfde2e5868831e97df5202e82116cf9c4a1b1122e549884f6c",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-21T21:29:23.218006Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": null,
+      "input_fingerprint": "sha256:5ac7578af148e57a4742501901771a4c319b77ff7347e618e434955b34cad860",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": null,
+      "status": "unknown",
+      "summary": "execution error: TimeoutExpired",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-21T21:31:05.032463Z",
+      "command": "python -m scistudio.qa.testing.run_python_tests --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:47eac75ed95c8abfde2e5868831e97df5202e82116cf9c4a1b1122e549884f6c",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-21T21:40:37.621258Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": null,
+      "input_fingerprint": "sha256:5ac7578af148e57a4742501901771a4c319b77ff7347e618e434955b34cad860",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": null,
+      "status": "unknown",
+      "summary": "execution error: TimeoutExpired",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-21T21:44:08.770846Z",
+      "command": "python -m scistudio.qa.testing.run_python_tests --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:6773f03cd6241ac5c07c30f43e9c8ac0b01753d0eaa68508f4d4e6d5234783df",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-21T21:45:06.709404Z",
+      "command": "pytest tests/architecture/ -v --no-cov",
+      "covered_surface": "architecture",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:91e97270a88d8578a16582cac0041a71d15b6d5fb8351e73cfc686889494c852",
+      "name": "architecture_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/architecture_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-21T21:45:07.850727Z",
+      "command": "python scripts/deferral_scan.py --check docs/audit/baselines/deferral-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:ea705d29de6f81e4d6878d2e2203a3c087cab99930c050debc49bd809ec7dc2f",
+      "name": "deferral_discipline",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/deferral_discipline.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-21T21:45:07.970321Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e80cd57adf244b57b2ed7b0f3bcbc70c7417654359cdc81202e51af8802f834f",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-21T21:45:14.418886Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:c4472bf6f5987c4daf21cb0391efb13d202e752224328893b032e012bc3d279a",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-21T21:45:14.618541Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:d45b3a11a6d6377c54595e2cbc94a3873274c249e80fae1888e21efa1b2bc695",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-21T21:45:14.658802Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:58b063be94147407f25157a39a3c47f8db3b3e5b674a6c7fa7a48d70e1459aae",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-21T21:54:46.181919Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": null,
+      "input_fingerprint": "sha256:0d5cdf1f4418c4186369c026ccbbb5607e9d0581d56df41f58ba434d624ae036",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": null,
+      "status": "unknown",
+      "summary": "execution error: TimeoutExpired",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-21T21:54:54.848695Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:33939cd0101b3886734c2e0f5b13fd1dce7a370efa3a59f53aa97c1d91145edd",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
     }
   ],
   "check_na": [],
-  "commit": null,
+  "commit": {
+    "sha": "b3f303455528ec0b8717605ef9e9137004e6664a",
+    "shas": [
+      "b3f303455528ec0b8717605ef9e9137004e6664a"
+    ],
+    "trailers": []
+  },
   "declared_scope": {
     "exclude": [],
     "include": [
@@ -178,6 +385,11 @@
       "at": "2026-08-21T20:22:14.556833Z",
       "owner_directive": "Implement a path-safe DELETE /api/plots/{plot_id}; add client wiring and top-right Edit/Delete icon buttons; use native confirmation; refresh plots and ProjectTree after deletion; add backend/frontend tests. SpecKit, spec, and ADR are N/A because this is a local UI/API affordance using existing plot storage and file-tab contracts.",
       "reason": "plan"
+    },
+    {
+      "at": "2026-08-21T22:22:32.701479Z",
+      "owner_directive": "Skip preflight and open the PR; CI remains authoritative.",
+      "reason": "Owner explicitly authorized skipping preflight after semantic_dup exceeded the fixed 600-second local timeout."
     }
   ],
   "docs_events": [
@@ -443,6 +655,490 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:29:23.223371Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:29:23.224383Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:29:23.225276Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:29:23.226183Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:29:23.227357Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:29:23.228193Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:29:23.229315Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:29:23.230104Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:29:23.230986Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:29:23.231814Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:29:23.232783Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:40:37.624595Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:40:37.625025Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:40:37.625448Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:40:37.625866Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:40:37.626328Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:40:37.626697Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:40:37.627343Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:40:37.627633Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:40:37.627966Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:40:37.628322Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:40:37.628894Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:44:08.777424Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:44:08.778513Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:44:08.779550Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:44:08.780726Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:44:08.782241Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:44:08.784188Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:44:08.785434Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:44:08.786445Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:44:08.787928Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:44:08.789066Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:44:08.793234Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:44:41.741712Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:44:41.742564Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:44:41.743705Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:44:41.744569Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:44:41.745474Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:44:41.746671Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:44:41.747885Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:44:41.748683Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:44:41.749545Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:44:41.750365Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:44:41.753178Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:54:54.853381Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:54:54.854358Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:54:54.855350Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:54:54.856227Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:54:54.857113Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:54:54.857956Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:54:54.858940Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:54:54.859757Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:54:54.860615Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:54:54.861449Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:54:54.864406Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:55:09.526539Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:55:09.528330Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:55:09.529513Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:55:09.530595Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:55:09.531718Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:55:09.532753Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:55:09.534021Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:55:09.534883Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:55:09.535993Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:55:09.536909Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:55:09.539737Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -457,27 +1153,44 @@
   "observed_diff": {
     "base": "origin/main",
     "base_sha": "4105e165",
-    "changed_files": [],
-    "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "changed_files": [
+      ".workflow/records/1719-feat-1719-plot-card-actions.json",
+      "frontend/src/components/BottomPanel.parts/PlotsTab.test.tsx",
+      "frontend/src/components/BottomPanel.parts/PlotsTab.tsx",
+      "frontend/src/lib/api/__tests__/api-surface.test.ts",
+      "frontend/src/lib/api/__tests__/plotPreview.test.ts",
+      "frontend/src/lib/api/data.ts",
+      "src/scistudio/_user_guide/writing-plots.md",
+      "src/scistudio/api/routes/plots.py",
+      "tests/api/test_plot_preview_wiring.py"
+    ],
+    "diff_fingerprint": "sha256:ee263eacb9f67fd69c972b03010068b223907207685bef17b004e9df9d75dfb8",
     "head": "HEAD",
-    "head_sha": "4105e165",
+    "head_sha": "b3f30345",
     "surfaces": {
       "docs": 0,
-      "frontend": 0,
+      "frontend": 5,
       "governance": 0,
       "governed_docs": 0,
-      "implementation": 0,
+      "implementation": 7,
       "packaging": 0,
       "protected_architecture": 0,
       "protected_core": 0,
-      "sentrux": 0,
-      "test": 0,
+      "sentrux": 8,
+      "test": 4,
       "workflow_ci": 0
     }
   },
   "owner_directive": "Add top-right Edit and Delete buttons to every plot card; Edit opens the plot render code in an editor tab and Delete removes the plot code after confirmation; push a PR.",
   "persona": "implementer",
-  "pull_request": null,
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [
+      1719
+    ],
+    "number": null,
+    "url": null
+  },
   "reconcile_events": [
     {
       "at": "2026-08-21T20:42:51.987421Z",
@@ -504,10 +1217,80 @@
       "result": "pass",
       "tier": 1,
       "unsatisfied": []
+    },
+    {
+      "at": "2026-08-21T21:29:23.232878Z",
+      "diff_fingerprint": null,
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.python_tests"
+      ]
+    },
+    {
+      "at": "2026-08-21T21:40:37.629067Z",
+      "diff_fingerprint": null,
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.python_tests"
+      ]
+    },
+    {
+      "at": "2026-08-21T21:44:08.793386Z",
+      "diff_fingerprint": "sha256:ee263eacb9f67fd69c972b03010068b223907207685bef17b004e9df9d75dfb8",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-21T21:44:41.753197Z",
+      "diff_fingerprint": "sha256:ee263eacb9f67fd69c972b03010068b223907207685bef17b004e9df9d75dfb8",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.architecture_tests",
+        "checks.deferral_discipline",
+        "checks.format_check",
+        "checks.full_audit",
+        "checks.import_contracts",
+        "checks.lint_format",
+        "checks.semantic_dup",
+        "checks.type_check"
+      ]
+    },
+    {
+      "at": "2026-08-21T21:54:54.864431Z",
+      "diff_fingerprint": "sha256:ee263eacb9f67fd69c972b03010068b223907207685bef17b004e9df9d75dfb8",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-21T21:55:09.539758Z",
+      "diff_fingerprint": "sha256:ee263eacb9f67fd69c972b03010068b223907207685bef17b004e9df9d75dfb8",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.semantic_dup"
+      ]
     }
   ],
   "record_id": "1719-feat-1719-plot-card-actions",
-  "requested_admin_labels": [],
+  "requested_admin_labels": [
+    {
+      "actor_permission": null,
+      "applied_at": null,
+      "applied_by": null,
+      "name": "admin-approved:bypass"
+    }
+  ],
   "required_obligations": {
     "admin_labels": [],
     "checks": [
@@ -518,6 +1301,8 @@
       "full_audit",
       "import_contracts",
       "lint_format",
+      "python_tests",
+      "semantic_dup",
       "type_check"
     ],
     "docs": [

--- a/.workflow/records/1719-feat-1719-plot-card-actions.json
+++ b/.workflow/records/1719-feat-1719-plot-card-actions.json
@@ -1,0 +1,583 @@
+{
+  "branch": "feat/1719-plot-card-actions",
+  "check_events": [
+    {
+      "at": "2026-08-21T20:27:05.605518Z",
+      "command": "pytest tests/architecture/ -v --no-cov",
+      "covered_surface": "architecture",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:0deac04405434cdca6d65dc3c51f5b5938ddb201f6adf484ce98451ad607e155",
+      "name": "architecture_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/architecture_tests.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-21T20:27:07.122782Z",
+      "command": "python scripts/deferral_scan.py --check docs/audit/baselines/deferral-baseline.json",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:102f4fec721ebfc465e7a0ebf36ba896c75f73ca64a3d872407303e84c235e40",
+      "name": "deferral_discipline",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/deferral_discipline.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-21T20:27:07.217870Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:bee0017f30f552d2df2de1173f9ac14b9aee5192ca5e5c1de574bb119512b275",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-21T20:27:23.222638Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:d2016153ffe72f6d9588cf72b647d8f545261ca64eb63f312f104e3c66e7d074",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-21T20:27:23.799516Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:179b1cba851dd153ae0ab07e4f5ff8b2a735cc2c3d6d4494d3c0100847360442",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-21T20:27:23.877873Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e31351abfc33f0b3c0f28bc9f2f3d59ae3bc5d4925dc1159a7f931aa932441ed",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-21T20:32:17.136038Z",
+      "command": "python -m scistudio.qa.testing.run_python_tests --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:47eac75ed95c8abfde2e5868831e97df5202e82116cf9c4a1b1122e549884f6c",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-21T20:42:17.169635Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": null,
+      "input_fingerprint": "sha256:5ac7578af148e57a4742501901771a4c319b77ff7347e618e434955b34cad860",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": null,
+      "status": "unknown",
+      "summary": "execution error: TimeoutExpired",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-21T20:42:51.178331Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e94394e48009cd8fbd5108426e57662cdd3e4d99e817a3b4494b7e53776b5c37",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    },
+    {
+      "at": "2026-08-21T20:48:30.998979Z",
+      "command": "(cd frontend && npm run check:ci)",
+      "covered_surface": "frontend",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:86d79110c681ad351f4b3894b284b3c86d99818612186a179e814e635941c144",
+      "name": "frontend",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/frontend.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    }
+  ],
+  "check_na": [],
+  "commit": null,
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "frontend/src/components/BottomPanel.parts/PlotsTab.tsx",
+      "frontend/src/components/BottomPanel.parts/PlotsTab.test.tsx",
+      "frontend/src/lib/api/data.ts",
+      "frontend/src/lib/api/__tests__/plotPreview.test.ts",
+      "frontend/src/lib/api/__tests__/api-surface.test.ts",
+      "src/scistudio/api/routes/plots.py",
+      "tests/api/test_plot_preview_wiring.py",
+      "src/scistudio/_user_guide/writing-plots.md"
+    ]
+  },
+  "directive_events": [
+    {
+      "at": "2026-08-21T20:22:14.556833Z",
+      "owner_directive": "Implement a path-safe DELETE /api/plots/{plot_id}; add client wiring and top-right Edit/Delete icon buttons; use native confirmation; refresh plots and ProjectTree after deletion; add backend/frontend tests. SpecKit, spec, and ADR are N/A because this is a local UI/API affordance using existing plot storage and file-tab contracts.",
+      "reason": "plan"
+    }
+  ],
+  "docs_events": [
+    {
+      "at": "2026-08-21T20:22:14.556856Z",
+      "class": null,
+      "kind": "path",
+      "path": "src/scistudio/_user_guide/writing-plots.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-21T20:22:14.556872Z",
+      "class": "SpecKit",
+      "kind": "na",
+      "path": null,
+      "rationale": "No new subsystem or significant design choice.",
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-21T20:22:14.556878Z",
+      "class": "spec",
+      "kind": "na",
+      "path": null,
+      "rationale": "No plot storage, runtime, or editor contract changes.",
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-21T20:22:14.556882Z",
+      "class": "ADR",
+      "kind": "na",
+      "path": null,
+      "rationale": "Local reversible UI and REST action; no architectural decision.",
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-21T20:22:14.556884Z",
+      "class": "changelog",
+      "kind": "na",
+      "path": null,
+      "rationale": "User guide documents the visible behavior; no release changelog is maintained for this local feature.",
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": false,
+  "guard_events": [
+    {
+      "at": "2026-08-21T20:42:51.340654Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:42:51.407385Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:42:51.464968Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:42:51.534506Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:42:51.595956Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:42:51.655506Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:42:51.715179Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:42:51.808472Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:42:51.879656Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:42:51.933681Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:42:51.987353Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:45:26.420228Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:45:26.444509Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:45:26.469780Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:45:26.494163Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:45:26.518584Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:45:26.542989Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:45:26.585499Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:45:26.612298Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:45:26.642703Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:45:26.668205Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:45:26.692091Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:48:31.073346Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:48:31.097092Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:48:31.121395Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:48:31.145336Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:48:31.169131Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:48:31.193300Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:48:31.217846Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:48:31.243864Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:48:31.282520Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:48:31.319119Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:48:31.348922Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1719,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": {
+    "base": "origin/main",
+    "base_sha": "4105e165",
+    "changed_files": [],
+    "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "head": "HEAD",
+    "head_sha": "4105e165",
+    "surfaces": {
+      "docs": 0,
+      "frontend": 0,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 0,
+      "packaging": 0,
+      "protected_architecture": 0,
+      "protected_core": 0,
+      "sentrux": 0,
+      "test": 0,
+      "workflow_ci": 0
+    }
+  },
+  "owner_directive": "Add top-right Edit and Delete buttons to every plot card; Edit opens the plot render code in an editor tab and Delete removes the plot code after confirmation; push a PR.",
+  "persona": "implementer",
+  "pull_request": null,
+  "reconcile_events": [
+    {
+      "at": "2026-08-21T20:42:51.987421Z",
+      "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "mode": "local",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.python_tests"
+      ]
+    },
+    {
+      "at": "2026-08-21T20:45:26.692146Z",
+      "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "mode": "local",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-21T20:48:31.348964Z",
+      "diff_fingerprint": "sha256:3a0df94e8713b0a372e1f97385d45df1c25f2e8efa2822b30403f5b9ab2fe568",
+      "mode": "pre-commit",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    }
+  ],
+  "record_id": "1719-feat-1719-plot-card-actions",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [
+      "architecture_tests",
+      "deferral_discipline",
+      "format_check",
+      "frontend",
+      "full_audit",
+      "import_contracts",
+      "lint_format",
+      "type_check"
+    ],
+    "docs": [
+      "docs_required_or_na"
+    ],
+    "guards": [
+      "architecture_doc_guard",
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": [
+      "changed_test_required"
+    ]
+  },
+  "runtime": "codex",
+  "schema_version": 2,
+  "scope_events": [],
+  "session_id": "4304846e-2835-4af7-8320-4b5e80465207",
+  "strictness_tier": 1,
+  "task_kind": "feature",
+  "test_events": [
+    {
+      "at": "2026-08-21T20:22:14.556889Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/components/BottomPanel.parts/PlotsTab.test.tsx",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-21T20:22:14.556894Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/lib/api/__tests__/plotPreview.test.ts",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-21T20:22:14.556896Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/lib/api/__tests__/api-surface.test.ts",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-21T20:22:14.556898Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/api/test_plot_preview_wiring.py",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/.workflow/records/1719-feat-1719-plot-card-actions.json
+++ b/.workflow/records/1719-feat-1719-plot-card-actions.json
@@ -361,9 +361,9 @@
   ],
   "check_na": [],
   "commit": {
-    "sha": "b3f303455528ec0b8717605ef9e9137004e6664a",
+    "sha": "8b8528f97a54f1503f39116689472679c40accc6",
     "shas": [
-      "b3f303455528ec0b8717605ef9e9137004e6664a"
+      "8b8528f97a54f1503f39116689472679c40accc6"
     ],
     "trailers": []
   },
@@ -390,6 +390,11 @@
       "at": "2026-08-21T22:22:32.701479Z",
       "owner_directive": "Skip preflight and open the PR; CI remains authoritative.",
       "reason": "Owner explicitly authorized skipping preflight after semantic_dup exceeded the fixed 600-second local timeout."
+    },
+    {
+      "at": "2026-08-21T22:24:31.631908Z",
+      "owner_directive": "Owner explicitly authorized skipping preflight and opening PR #2101; GitHub CI is authoritative.",
+      "reason": "finalize"
     }
   ],
   "docs_events": [
@@ -1139,6 +1144,94 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:24:32.570617Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:24:32.599461Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:24:32.626502Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:24:32.652206Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:24:32.685544Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:24:32.731094Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:24:32.757459Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:24:32.788094Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:24:32.836699Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:24:32.863301Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:24:32.895942Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -1152,7 +1245,7 @@
   "observed_admin_labels": [],
   "observed_diff": {
     "base": "origin/main",
-    "base_sha": "4105e165",
+    "base_sha": "4105e1654",
     "changed_files": [
       ".workflow/records/1719-feat-1719-plot-card-actions.json",
       "frontend/src/components/BottomPanel.parts/PlotsTab.test.tsx",
@@ -1164,9 +1257,9 @@
       "src/scistudio/api/routes/plots.py",
       "tests/api/test_plot_preview_wiring.py"
     ],
-    "diff_fingerprint": "sha256:ee263eacb9f67fd69c972b03010068b223907207685bef17b004e9df9d75dfb8",
+    "diff_fingerprint": "sha256:15f8369906f08f4fbc4dcf5509fa7ea4580f77a0fcfce15b66df6e8240052635",
     "head": "HEAD",
-    "head_sha": "b3f30345",
+    "head_sha": "8b8528f97",
     "surfaces": {
       "docs": 0,
       "frontend": 5,
@@ -1188,8 +1281,8 @@
     "closes": [
       1719
     ],
-    "number": null,
-    "url": null
+    "number": 2101,
+    "url": "https://github.com/jiazhenz026/SciStudio/pull/2101"
   },
   "reconcile_events": [
     {
@@ -1279,6 +1372,25 @@
       "tier": 1,
       "unsatisfied": [
         "checks.semantic_dup"
+      ]
+    },
+    {
+      "at": "2026-08-21T22:24:32.895975Z",
+      "diff_fingerprint": "sha256:15f8369906f08f4fbc4dcf5509fa7ea4580f77a0fcfce15b66df6e8240052635",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.architecture_tests",
+        "checks.deferral_discipline",
+        "checks.format_check",
+        "checks.frontend",
+        "checks.full_audit",
+        "checks.import_contracts",
+        "checks.lint_format",
+        "checks.python_tests",
+        "checks.semantic_dup",
+        "checks.type_check"
       ]
     }
   ],

--- a/frontend/src/components/BottomPanel.parts/PlotsTab.test.tsx
+++ b/frontend/src/components/BottomPanel.parts/PlotsTab.test.tsx
@@ -11,6 +11,9 @@ const runPlotJob = vi.fn();
 const listPlotTargets = vi.fn();
 const relinkPlot = vi.fn();
 const createPlot = vi.fn();
+const deletePlot = vi.fn();
+const openFileTab = vi.fn();
+const bumpProjectTreeRefresh = vi.fn();
 vi.mock("../../lib/api", async (importOriginal) => {
   const actual = await importOriginal<Record<string, unknown>>();
   const actualApi = (actual.api ?? {}) as Record<string, unknown>;
@@ -23,6 +26,7 @@ vi.mock("../../lib/api", async (importOriginal) => {
       listPlotTargets: (...a: unknown[]) => listPlotTargets(...a),
       relinkPlot: (...a: unknown[]) => relinkPlot(...a),
       createPlot: (...a: unknown[]) => createPlot(...a),
+      deletePlot: (...a: unknown[]) => deletePlot(...a),
     },
   };
 });
@@ -68,19 +72,27 @@ beforeEach(() => {
   listPlotTargets.mockReset();
   relinkPlot.mockReset();
   createPlot.mockReset();
+  deletePlot.mockReset();
+  openFileTab.mockReset();
+  bumpProjectTreeRefresh.mockReset();
   listPlots.mockResolvedValue({ plots: [], count: 0, warnings: [] });
   listPlotTargets.mockResolvedValue({ targets: [] });
+  deletePlot.mockResolvedValue(undefined);
   useAppStore.setState({
     workflowId: "main",
     selectedNodeId: null,
     highlightedNodeId: null,
     plotPicker: null,
+    tabs: [],
+    openFileTab,
+    bumpProjectTreeRefresh,
   });
   useAppStore.getState().setPlotPreviewTarget(null);
 });
 
 afterEach(() => {
   cleanup();
+  vi.restoreAllMocks();
 });
 
 describe("PlotsTab", () => {
@@ -96,6 +108,39 @@ describe("PlotsTab", () => {
     expect(screen.getByText("→ Process Block / output")).toBeInTheDocument();
     // #1713 — language badge.
     expect(screen.getByText("python")).toBeInTheDocument();
+  });
+
+  it("opens the plot render script in an editor tab", async () => {
+    listPlots.mockResolvedValue({ plots: [makePlot()], count: 1, warnings: [] });
+    render(<PlotsTab />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Edit plot My Plot" }));
+
+    expect(openFileTab).toHaveBeenCalledWith("plots/p1/render.py");
+  });
+
+  it("confirms deletion, deletes the plot, and refreshes project files", async () => {
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+    listPlots.mockResolvedValue({ plots: [makePlot()], count: 1, warnings: [] });
+    render(<PlotsTab />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Delete plot My Plot" }));
+
+    await waitFor(() => expect(deletePlot).toHaveBeenCalledWith("p1"));
+    await waitFor(() => expect(screen.queryByTestId("plot-card-p1")).not.toBeInTheDocument());
+    expect(bumpProjectTreeRefresh).toHaveBeenCalledOnce();
+  });
+
+  it("keeps the plot card and shows an error when deletion fails", async () => {
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+    listPlots.mockResolvedValue({ plots: [makePlot()], count: 1, warnings: [] });
+    deletePlot.mockRejectedValue(new Error("delete failed"));
+    render(<PlotsTab />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Delete plot My Plot" }));
+
+    expect(await screen.findByText("delete failed")).toBeInTheDocument();
+    expect(screen.getByTestId("plot-card-p1")).toBeInTheDocument();
   });
 
   it("appends the bound port type to the auto label when there is no display_label (#1721)", async () => {

--- a/frontend/src/components/BottomPanel.parts/PlotsTab.tsx
+++ b/frontend/src/components/BottomPanel.parts/PlotsTab.tsx
@@ -1,4 +1,4 @@
-import { AlertTriangle, Plus, XCircle } from "lucide-react";
+import { AlertTriangle, Pencil, Plus, Trash2, XCircle } from "lucide-react";
 import { useEffect, useState } from "react";
 
 import { api } from "../../lib/api";
@@ -44,10 +44,10 @@ export function PlotsTab() {
   const [plots, setPlots] = useState<PlotListItem[]>([]);
   const [loading, setLoading] = useState(false);
   const [listError, setListError] = useState<string | null>(null);
-  // #1713 — run errors are shown inline on the failing plot's card banner, so
-  // the error is tied to a specific plot_id rather than a single global string.
-  const [runError, setRunError] = useState<{ plotId: string; message: string } | null>(null);
+  // Run, relink, and delete failures stay on the plot card that produced them.
+  const [cardError, setCardError] = useState<{ plotId: string; message: string } | null>(null);
   const [runningId, setRunningId] = useState<string | null>(null);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
   // Bumped after relink / create so the list re-fetches. Also re-runs whenever
   // the tab is (re)mounted — BottomPanel unmounts inactive tabs, so switching
   // to Plots refreshes the list.
@@ -75,12 +75,12 @@ export function PlotsTab() {
 
   async function handleRun(plot: PlotListItem) {
     setRunningId(plot.plot_id);
-    setRunError(null);
+    setCardError(null);
     try {
       const result = await api.runPlotJob({ plot_id: plot.plot_id });
       const nextTarget = plotTargetFromRunResponse(result);
       if (!nextTarget) {
-        setRunError({
+        setCardError({
           plotId: plot.plot_id,
           message: result.errors[0] ?? `Plot run ${result.status}.`,
         });
@@ -101,12 +101,40 @@ export function PlotsTab() {
         setSelectedNodeId(plot.node_id);
       }
     } catch (error) {
-      setRunError({
+      setCardError({
         plotId: plot.plot_id,
         message: error instanceof Error ? error.message : String(error),
       });
     } finally {
       setRunningId(null);
+    }
+  }
+
+  async function handleDelete(plot: PlotListItem, name: string) {
+    const confirmed = window.confirm(
+      `Delete plot '${name}'? This removes its manifest and render script and cannot be undone.`,
+    );
+    if (!confirmed) return;
+
+    const state = useAppStore.getState();
+    const scriptTab = state.tabs.find(
+      (tab) => tab.kind === "file" && tab.filePath === plot.script_path,
+    );
+    if (scriptTab && !state.closeTab(scriptTab.id)) return;
+
+    setDeletingId(plot.plot_id);
+    setCardError(null);
+    try {
+      await api.deletePlot(plot.plot_id);
+      setPlots((current) => current.filter((item) => item.plot_id !== plot.plot_id));
+      bumpProjectTreeRefresh();
+    } catch (error) {
+      setCardError({
+        plotId: plot.plot_id,
+        message: error instanceof Error ? error.message : String(error),
+      });
+    } finally {
+      setDeletingId(null);
     }
   }
 
@@ -142,12 +170,12 @@ export function PlotsTab() {
         }}
         onRelinked={(result) => {
           if (!result.valid && relinkPlot) {
-            setRunError({
+            setCardError({
               plotId: relinkPlot.plot_id,
               message: result.errors[0] ?? "Relinked plot did not validate.",
             });
           } else {
-            setRunError(null);
+            setCardError(null);
           }
           setRefreshToken((token) => token + 1);
         }}
@@ -209,7 +237,7 @@ export function PlotsTab() {
             !plot.broken && (plot.node_id === selectedNodeId || plot.node_id === highlightedNodeId);
           return (
             <div
-              className={`flex min-h-[9rem] flex-col gap-1.5 rounded-2xl border p-3 shadow-sm ${
+              className={`relative flex min-h-[9rem] flex-col gap-1.5 rounded-2xl border p-3 shadow-sm ${
                 plot.broken
                   ? "border-amber-400 bg-amber-50/50"
                   : linked
@@ -223,7 +251,30 @@ export function PlotsTab() {
               data-tutorial-target-key={plot.plot_id}
               key={plot.plot_id}
             >
-              <div className="flex min-w-0 items-start gap-1.5">
+              <div className="absolute right-3 top-3 flex items-center gap-1">
+                <button
+                  aria-label={`Edit plot ${name}`}
+                  className="rounded-md p-1 text-stone-400 hover:bg-stone-100 hover:text-ink disabled:opacity-50"
+                  disabled={deletingId !== null}
+                  onClick={() => openFileTab(plot.script_path)}
+                  title="Edit plot code"
+                  type="button"
+                >
+                  <Pencil className="h-3.5 w-3.5" aria-hidden="true" />
+                </button>
+                <button
+                  aria-label={`Delete plot ${name}`}
+                  className="rounded-md p-1 text-stone-400 hover:bg-red-50 hover:text-red-600 disabled:opacity-50"
+                  disabled={runningId !== null || deletingId !== null}
+                  onClick={() => void handleDelete(plot, name)}
+                  title="Delete plot"
+                  type="button"
+                >
+                  <Trash2 className="h-3.5 w-3.5" aria-hidden="true" />
+                </button>
+              </div>
+
+              <div className="flex min-w-0 items-start gap-1.5 pr-14">
                 {plot.broken ? (
                   <AlertTriangle
                     aria-label="Broken target — needs relink"
@@ -250,7 +301,7 @@ export function PlotsTab() {
                   <button
                     aria-label={`Run plot ${name}`}
                     className="shrink-0 rounded-full bg-ink px-2.5 py-1 text-xs text-white disabled:opacity-50"
-                    disabled={runningId !== null}
+                    disabled={runningId !== null || deletingId !== null}
                     onClick={() => void handleRun(plot)}
                     type="button"
                   >
@@ -259,7 +310,7 @@ export function PlotsTab() {
                   <button
                     aria-label={`Relink data source for plot ${name}`}
                     className="shrink-0 rounded-full border border-stone-300 px-2.5 py-1 text-xs text-stone-600 hover:text-ink disabled:opacity-50"
-                    disabled={runningId !== null}
+                    disabled={runningId !== null || deletingId !== null}
                     onClick={() => openRelinkPlotPicker(plot.plot_id)}
                     title="Relink data source"
                     type="button"
@@ -277,13 +328,13 @@ export function PlotsTab() {
                   <span>Needs relink — reconnect the data source</span>
                 </div>
               ) : null}
-              {runError?.plotId === plot.plot_id ? (
+              {cardError?.plotId === plot.plot_id ? (
                 <div
                   className="flex items-start gap-1 rounded-md bg-red-100 px-2 py-1 text-[0.65rem] text-red-700"
                   role="alert"
                 >
                   <XCircle className="mt-px h-3 w-3 shrink-0" aria-hidden="true" />
-                  <span className="break-words">{runError.message}</span>
+                  <span className="break-words">{cardError.message}</span>
                 </div>
               ) : null}
             </div>

--- a/frontend/src/lib/api/__tests__/api-surface.test.ts
+++ b/frontend/src/lib/api/__tests__/api-surface.test.ts
@@ -47,6 +47,7 @@ const EXPECTED_API_KEYS = [
   // is previewed exclusively through the routed previewer session API.
   "listPlotTargets",
   "createPlot",
+  "deletePlot",
   "runPlotJob",
   "listPlots",
   // filesystem

--- a/frontend/src/lib/api/__tests__/plotPreview.test.ts
+++ b/frontend/src/lib/api/__tests__/plotPreview.test.ts
@@ -176,6 +176,21 @@ describe("dataApi plot list + preview resource save", () => {
     vi.unstubAllGlobals();
   });
 
+  it("DELETEs a plot by its encoded id", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 204,
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await dataApi.deletePlot("plot one");
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("/api/plots/plot%20one");
+    expect(init.method).toBe("DELETE");
+    vi.unstubAllGlobals();
+  });
+
   it("GETs /api/plots with block filters", async () => {
     const body = {
       plots: [

--- a/frontend/src/lib/api/data.ts
+++ b/frontend/src/lib/api/data.ts
@@ -152,6 +152,12 @@ export const dataApi = {
       body: JSON.stringify(request),
     }),
 
+  /** Delete a plot's manifest and render script directory. */
+  deletePlot: (plotId: string) =>
+    apiFetch<void>(`/api/plots/${encodeURIComponent(plotId)}`, {
+      method: "DELETE",
+    }),
+
   /** Re-point an existing plot at a new workflow output target (bug#7).
    *  `POST /api/plots/{plot_id}/relink` rewrites only the manifest target block
    *  (strict 1:1) and re-validates, so a previously broken target becomes valid

--- a/src/scistudio/_user_guide/writing-plots.md
+++ b/src/scistudio/_user_guide/writing-plots.md
@@ -27,6 +27,13 @@ def render(collection):
 Bind the plot to a block's output port and it draws every time you look. That is
 the whole contract.
 
+## Edit or delete a plot
+
+Every card in the **Plots** tab has two actions in its top-right corner. **Edit**
+opens that plot's render script in a code-editor tab. **Delete** asks for
+confirmation, then removes the plot's manifest and render script from the
+project. Deleting a plot cannot be undone.
+
 ## What `collection` gives you
 
 The `collection` is the batch of items on the port you chose. You read it with a

--- a/src/scistudio/api/routes/plots.py
+++ b/src/scistudio/api/routes/plots.py
@@ -30,6 +30,7 @@ and writes under ``.scistudio/previews/``.
 from __future__ import annotations
 
 import logging
+import shutil
 from functools import partial
 from pathlib import Path
 from typing import Annotated, Any
@@ -238,6 +239,33 @@ async def create_plot(payload: PlotCreateRequest, runtime: RuntimeDep) -> PlotCr
         warnings=warnings,
         target=_target_item(target),
     )
+
+
+@router.delete("/{plot_id}", status_code=204)
+async def delete_plot(plot_id: str, runtime: RuntimeDep) -> None:
+    """Delete one project-local plot directory after confined path resolution."""
+    from scistudio.plot.validation import PlotNotFoundError, resolve_manifest_path
+
+    try:
+        runtime.require_active_project()
+        manifest_path = resolve_manifest_path(runtime, plot_id=plot_id, path=None)
+    except RuntimeError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except (PermissionError, ValueError) as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except PlotNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+    if not manifest_path.is_file():
+        raise HTTPException(status_code=404, detail=f"Plot {plot_id!r} does not exist.")
+
+    try:
+        shutil.rmtree(manifest_path.parent)
+    except OSError as exc:
+        raise HTTPException(
+            status_code=500,
+            detail=f"Failed to delete plot {plot_id!r}: {exc}",
+        ) from exc
 
 
 @router.post("/{plot_id}/relink", response_model=PlotRelinkResponse)

--- a/tests/api/test_plot_preview_wiring.py
+++ b/tests/api/test_plot_preview_wiring.py
@@ -326,6 +326,40 @@ def test_plot_create_route_scaffolds_manifest_and_render_script(
     assert "context" not in script_text
 
 
+def test_plot_delete_route_removes_manifest_and_render_script(
+    client: TestClient,
+    opened_project: Path,
+) -> None:
+    """DELETE removes the confined plot directory and the plot disappears from the list."""
+    _write_workflow_and_plot(client, opened_project)
+    plot_dir = opened_project / "plots" / "p1"
+    assert (plot_dir / "plot.yaml").is_file()
+    assert (plot_dir / "render.py").is_file()
+
+    deleted = client.delete("/api/plots/p1")
+
+    assert deleted.status_code == 204, deleted.text
+    assert not plot_dir.exists()
+    listed = client.get("/api/plots", params={"workflow_id": "main"})
+    assert listed.status_code == 200, listed.text
+    assert listed.json()["plots"] == []
+
+
+def test_plot_delete_route_rejects_invalid_or_unknown_ids(
+    client: TestClient,
+    opened_project: Path,
+) -> None:
+    """Invalid ids cannot escape plots/, and unknown valid ids return 404."""
+    _write_workflow_and_plot(client, opened_project)
+
+    invalid = client.delete("/api/plots/bad!id")
+    unknown = client.delete("/api/plots/does-not-exist")
+
+    assert invalid.status_code == 400, invalid.text
+    assert unknown.status_code == 404, unknown.text
+    assert (opened_project / "plots" / "p1" / "render.py").is_file()
+
+
 def test_plot_relink_route_rebinds_manifest_target(
     client: TestClient,
     runtime: ApiRuntime,


### PR DESCRIPTION
## Summary

- add top-right Edit and Delete actions to every plot card
- open the existing plot render script in a Monaco file-editor tab
- delete the confined project-local plot directory after confirmation and refresh the plot list and ProjectTree
- add backend/frontend coverage and document the actions in the plot user guide

## Validation

- frontend gate: pass (`npm run check:ci`)
- Linux full Python gate: pass (bulk and serial phases; 87.89% coverage)
- pre-commit, ruff, format, mypy, commit-message, architecture, import-contract, deferral-discipline, and full-audit checks: pass
- local semantic-duplication scan exceeded its fixed 600-second timeout; the owner authorized skipping preflight, so GitHub CI is authoritative (`admin-approved:bypass`)

Gate record: `.workflow/records/1719-feat-1719-plot-card-actions.json`

Closes #1719
