### PR TITLE
guided(#2090): VS Code-style activity bar + Workflows/Data left-panel sections

### DIFF
--- a/.workflow/records/2090-guided-2090-activity-bar-layout.json
+++ b/.workflow/records/2090-guided-2090-activity-bar-layout.json
@@ -245,6 +245,11 @@
       "at": "2026-08-21T23:00:09.314161Z",
       "owner_directive": "\u522b\u8dd1\u4e86\uff0c\u76f4\u63a5\u5f00PR\u7b49CI\u5c31\u884c\u4e86 (skip the stuck semantic_dup local preflight; rely on CI)",
       "reason": "Owner directed: open the PR and rely on CI for semantic_dup \u2014 the check times out only inside the per-worktree gate venv (environmental); standalone scan passes in 108s. One-off bypass for this session's local preflight; CI remains authoritative."
+    },
+    {
+      "at": "2026-08-22T00:40:13.475774Z",
+      "owner_directive": "Fix the 3 Codex P2 comments and the P1 about tracking the deferred preview work in a follow-up issue; ignore the rest, then push one commit.",
+      "reason": "Owner directed fixing the 3 Codex P2s (drag-collapse desync, stale workflow list on project switch, no structural-event refresh) and the P1 deferral tracking (follow-up issue #2112 created for click-to-preview); the other P1 (final reconciliation fail) is the known semantic_dup environment issue, explicitly ignored per owner."
     }
   ],
   "docs_events": [
@@ -1739,6 +1744,12 @@
       "close_in_pr": true,
       "followup_rationale": null,
       "number": 2090,
+      "url": null
+    },
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 2112,
       "url": null
     }
   ],

--- a/.workflow/records/2090-guided-2090-activity-bar-layout.json
+++ b/.workflow/records/2090-guided-2090-activity-bar-layout.json
@@ -139,6 +139,51 @@
       "status": "unknown",
       "summary": "execution error: TimeoutExpired",
       "tool_versions": {}
+    },
+    {
+      "at": "2026-08-21T22:37:55.913130Z",
+      "command": "(cd frontend && npm run check:ci)",
+      "covered_surface": "frontend",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:c54de51055fafc8cbce8cdbeaa1fd9d4c78f76f1359fbbe3acdff7d22b9f490e",
+      "name": "frontend",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/frontend.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-21T22:38:14.368132Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:175f7f09ca0220974e17e80afd20ab3f3b9ffd7c6d2cc47ce261e127300849ad",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-21T22:48:14.392657Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": null,
+      "input_fingerprint": "sha256:7d8b8b3644cb5aabcde1bde8a0e65d0723dd19141b9bda1bd1394822a0085eff",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": null,
+      "status": "unknown",
+      "summary": "execution error: TimeoutExpired",
+      "tool_versions": {}
     }
   ],
   "check_na": [
@@ -148,9 +193,9 @@
     }
   ],
   "commit": {
-    "sha": "0ab74232541aef121c3b56698e134e008976e222",
+    "sha": "ee7731dc7df08bf21e837a0a512b96f3d729d0df",
     "shas": [
-      "0ab74232541aef121c3b56698e134e008976e222"
+      "ee7731dc7df08bf21e837a0a512b96f3d729d0df"
     ],
     "trailers": []
   },
@@ -195,6 +240,11 @@
       "at": "2026-08-21T22:22:16.383720Z",
       "owner_directive": "Skip the semantic_dup preflight for this guided session; it is an environment issue in the worktree gate venv.",
       "reason": "Owner: the semantic_dup preflight repeatedly times out in the per-worktree gate venv while the same scan passes standalone in the main venv (108s, all ratchets within limits) \u2014 an environment issue; owner authorized skipping the preflight. CI still runs the semantic-dup ratchet on the PR."
+    },
+    {
+      "at": "2026-08-21T23:00:09.314161Z",
+      "owner_directive": "\u522b\u8dd1\u4e86\uff0c\u76f4\u63a5\u5f00PR\u7b49CI\u5c31\u884c\u4e86 (skip the stuck semantic_dup local preflight; rely on CI)",
+      "reason": "Owner directed: open the PR and rely on CI for semantic_dup \u2014 the check times out only inside the per-worktree gate venv (environmental); standalone scan passes in 108s. One-off bypass for this session's local preflight; CI remains authoritative."
     }
   ],
   "docs_events": [
@@ -1066,6 +1116,622 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:33:59.455479Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:33:59.480554Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:33:59.510179Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:33:59.534177Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:33:59.560380Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:33:59.586127Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:33:59.612528Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:33:59.637864Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:33:59.671530Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:33:59.698331Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:33:59.734276Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:48:14.442586Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:48:14.458964Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:48:14.473959Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:48:14.492008Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:48:14.511750Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:48:14.527855Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:48:14.543706Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:48:14.559692Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:48:14.574963Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:48:14.595392Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:48:14.616121Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:48:31.102636Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:48:31.122586Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:48:31.138056Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:48:31.153455Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:48:31.167280Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:48:31.181303Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:48:31.197765Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:48:31.213528Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:48:31.234692Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:48:31.250059Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:48:31.273743Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:59:22.638923Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:59:22.668900Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:59:22.689440Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:59:22.705927Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:59:22.725585Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:59:22.743197Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:59:22.761919Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:59:22.780038Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:59:22.795940Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:59:22.811308Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:59:22.835201Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T23:00:25.561055Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T23:00:25.582420Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T23:00:25.603303Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T23:00:25.627065Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T23:00:25.649136Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T23:00:25.673242Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T23:00:25.695783Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T23:00:25.718827Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T23:00:25.742201Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T23:00:25.778291Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T23:00:25.838198Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T23:26:17.544106Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T23:26:17.577015Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T23:26:17.626453Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T23:26:17.652445Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T23:26:17.676358Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T23:26:17.703040Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T23:26:17.721417Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T23:26:17.739362Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T23:26:17.758931Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T23:26:17.780873Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T23:26:17.814234Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T23:26:36.801928Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T23:26:36.819218Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T23:26:36.836358Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T23:26:36.857930Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T23:26:36.875208Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T23:26:36.892187Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T23:26:36.922958Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T23:26:36.952856Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T23:26:36.971600Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T23:26:36.990543Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T23:26:37.022940Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -1078,7 +1744,7 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "origin/main",
+    "base": "4105e165451215ec842d731f8fb6691b45d1d0ea",
     "base_sha": "4105e1654",
     "changed_files": [
       ".workflow/records/2090-guided-2090-activity-bar-layout.json",
@@ -1096,9 +1762,9 @@
       "frontend/src/components/__tests__/ProjectTree.test.tsx",
       "frontend/src/store/types.ts"
     ],
-    "diff_fingerprint": "sha256:177dca9395ed93a521976349b5af46bd808c203d64e70aa0616e93552264a528",
+    "diff_fingerprint": "sha256:e100220054ee4fb3cecfbff0f588fe9d0adc400f6889ebce19749d16f11e1e0b",
     "head": "HEAD",
-    "head_sha": "0ab742325",
+    "head_sha": "ee7731dc7",
     "surfaces": {
       "docs": 1,
       "frontend": 12,
@@ -1120,8 +1786,8 @@
     "closes": [
       2090
     ],
-    "number": null,
-    "url": null
+    "number": 2106,
+    "url": "https://github.com/jiazhenz026/SciStudio/pull/2106"
   },
   "reconcile_events": [
     {
@@ -1215,10 +1881,87 @@
         "checks.full_audit",
         "checks.semantic_dup"
       ]
+    },
+    {
+      "at": "2026-08-21T22:33:59.734310Z",
+      "diff_fingerprint": "sha256:e100220054ee4fb3cecfbff0f588fe9d0adc400f6889ebce19749d16f11e1e0b",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.frontend",
+        "checks.full_audit",
+        "checks.semantic_dup"
+      ]
+    },
+    {
+      "at": "2026-08-21T22:48:14.616168Z",
+      "diff_fingerprint": "sha256:e100220054ee4fb3cecfbff0f588fe9d0adc400f6889ebce19749d16f11e1e0b",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-21T22:48:31.273780Z",
+      "diff_fingerprint": "sha256:e100220054ee4fb3cecfbff0f588fe9d0adc400f6889ebce19749d16f11e1e0b",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.semantic_dup"
+      ]
+    },
+    {
+      "at": "2026-08-21T22:59:22.835234Z",
+      "diff_fingerprint": "sha256:e100220054ee4fb3cecfbff0f588fe9d0adc400f6889ebce19749d16f11e1e0b",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.semantic_dup"
+      ]
+    },
+    {
+      "at": "2026-08-21T23:00:25.838232Z",
+      "diff_fingerprint": "sha256:e100220054ee4fb3cecfbff0f588fe9d0adc400f6889ebce19749d16f11e1e0b",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.semantic_dup"
+      ]
+    },
+    {
+      "at": "2026-08-21T23:26:17.814261Z",
+      "diff_fingerprint": "sha256:e100220054ee4fb3cecfbff0f588fe9d0adc400f6889ebce19749d16f11e1e0b",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.semantic_dup"
+      ]
+    },
+    {
+      "at": "2026-08-21T23:26:37.022972Z",
+      "diff_fingerprint": "sha256:e100220054ee4fb3cecfbff0f588fe9d0adc400f6889ebce19749d16f11e1e0b",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.semantic_dup"
+      ]
     }
   ],
   "record_id": "2090-guided-2090-activity-bar-layout",
-  "requested_admin_labels": [],
+  "requested_admin_labels": [
+    {
+      "actor_permission": null,
+      "applied_at": null,
+      "applied_by": null,
+      "name": "admin-approved:bypass"
+    }
+  ],
   "required_obligations": {
     "admin_labels": [],
     "checks": [

--- a/.workflow/records/2090-guided-2090-activity-bar-layout.json
+++ b/.workflow/records/2090-guided-2090-activity-bar-layout.json
@@ -1,0 +1,293 @@
+{
+  "branch": "guided/2090-activity-bar-layout",
+  "check_events": [
+    {
+      "at": "2026-08-21T20:37:09.394671Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:bee0017f30f552d2df2de1173f9ac14b9aee5192ca5e5c1de574bb119512b275",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-21T20:37:25.054202Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:d2016153ffe72f6d9588cf72b647d8f545261ca64eb63f312f104e3c66e7d074",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-21T20:37:25.106828Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e31351abfc33f0b3c0f28bc9f2f3d59ae3bc5d4925dc1159a7f931aa932441ed",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    }
+  ],
+  "check_na": [],
+  "commit": null,
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "frontend/src/**"
+    ]
+  },
+  "directive_events": [
+    {
+      "at": "2026-08-21T20:36:59.975029Z",
+      "owner_directive": "Modernize the frontend left sidebar into a VS Code-style layout: vertical icon activity bar with hover tooltips, click-to-open section, click-active-icon-to-collapse; new Workflows panel listing project workflows with YAML descriptions.",
+      "reason": "plan"
+    },
+    {
+      "at": "2026-08-21T20:50:49.238816Z",
+      "owner_directive": "Change the bottom-panel History tab icon to rotate-ccw-clock so it no longer duplicates the new Workflows activity-bar icon.",
+      "reason": "Owner redirected icon choices during live preview: Blocks=Puzzle, Workflows=Waypoints in the activity bar; the bottom-panel History tab also used Waypoints, so it must change to RotateCcwClock to stay distinct."
+    },
+    {
+      "at": "2026-08-21T20:54:16.501163Z",
+      "owner_directive": "Add a color-filled selection highlight to the activity-bar icons.",
+      "reason": "Owner asked during live preview for a color-filled active highlight on the activity-bar icons, not just the edge accent bar."
+    }
+  ],
+  "docs_events": [
+    {
+      "at": "2026-08-21T20:36:59.975159Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/specs/frontend-block-palette.md",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": false,
+  "guard_events": [
+    {
+      "at": "2026-08-21T20:37:25.162424Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:37:25.209806Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:37:25.225565Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:37:25.243389Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:37:25.281167Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:37:25.299533Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:37:25.315503Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:37:25.333663Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:37:25.349210Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:37:25.364461Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T20:37:25.380135Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 2090,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": {
+    "base": "origin/main",
+    "base_sha": "4105e165",
+    "changed_files": [],
+    "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "head": "HEAD",
+    "head_sha": "4105e165",
+    "surfaces": {
+      "docs": 0,
+      "frontend": 0,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 0,
+      "packaging": 0,
+      "protected_architecture": 0,
+      "protected_core": 0,
+      "sentrux": 0,
+      "test": 0,
+      "workflow_ci": 0
+    }
+  },
+  "owner_directive": "Modernize the frontend left sidebar into a VS Code-style layout: a vertical icon activity bar (Blocks / Data types / Workflows / Project) with hover tooltips, click-to-open panel, click-active-icon-to-collapse; add a new Workflows panel listing all project workflows with their YAML descriptions.",
+  "persona": "live_implementer",
+  "pull_request": null,
+  "reconcile_events": [
+    {
+      "at": "2026-08-21T20:37:25.380190Z",
+      "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "mode": "local",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    }
+  ],
+  "record_id": "2090-guided-2090-activity-bar-layout",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [
+      "format_check",
+      "full_audit",
+      "lint_format"
+    ],
+    "docs": [],
+    "guards": [
+      "architecture_doc_guard",
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": []
+  },
+  "runtime": "agents:kimi-code",
+  "schema_version": 2,
+  "scope_events": [
+    {
+      "action": "add-include",
+      "at": "2026-08-21T20:36:59.975049Z",
+      "pattern": "frontend/src/components/ActivityBar.tsx",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-21T20:36:59.975057Z",
+      "pattern": "frontend/src/components/WorkflowPanel.tsx",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-21T20:36:59.975060Z",
+      "pattern": "frontend/src/App.parts/ProjectWorkspace.tsx",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-21T20:36:59.975062Z",
+      "pattern": "frontend/src/App.tsx",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-21T20:36:59.975064Z",
+      "pattern": "docs/specs/frontend-block-palette.md",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-21T20:50:49.238841Z",
+      "pattern": "frontend/src/components/BottomPanel.parts/TabBar.tsx",
+      "reason": "Owner redirected icon choices during live preview: Blocks=Puzzle, Workflows=Waypoints in the activity bar; the bottom-panel History tab also used Waypoints, so it must change to RotateCcwClock to stay distinct."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-21T20:54:16.501182Z",
+      "pattern": "frontend/src/components/ActivityBar.tsx",
+      "reason": "Owner asked during live preview for a color-filled active highlight on the activity-bar icons, not just the edge accent bar."
+    }
+  ],
+  "session_id": "1b557fc7-0aa8-4122-9265-3a7e4dc9b69c",
+  "strictness_tier": 2,
+  "task_kind": "guided",
+  "test_events": [
+    {
+      "at": "2026-08-21T20:36:59.975167Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/components/ActivityBar.test.tsx",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-21T20:36:59.975171Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/components/WorkflowPanel.test.tsx",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/.workflow/records/2090-guided-2090-activity-bar-layout.json
+++ b/.workflow/records/2090-guided-2090-activity-bar-layout.json
@@ -250,6 +250,11 @@
       "at": "2026-08-22T00:40:13.475774Z",
       "owner_directive": "Fix the 3 Codex P2 comments and the P1 about tracking the deferred preview work in a follow-up issue; ignore the rest, then push one commit.",
       "reason": "Owner directed fixing the 3 Codex P2s (drag-collapse desync, stale workflow list on project switch, no structural-event refresh) and the P1 deferral tracking (follow-up issue #2112 created for click-to-preview); the other P1 (final reconciliation fail) is the known semantic_dup environment issue, explicitly ignored per owner."
+    },
+    {
+      "at": "2026-08-22T01:03:14.773671Z",
+      "owner_directive": "Fix the 3 Codex P2s and the deferral-tracking P1; ignore the rest.",
+      "reason": "Correction: #2112 is the follow-up for the DEFERRED click-to-preview work, not delivered by this PR; linking it as a delivered issue broke the issue_link guard in CI (PR body must close every delivered issue). The TODO in ProjectWorkspace.tsx cites #2112, which satisfies the deferral-tracking requirement."
     }
   ],
   "docs_events": [
@@ -1744,12 +1749,6 @@
       "close_in_pr": true,
       "followup_rationale": null,
       "number": 2090,
-      "url": null
-    },
-    {
-      "close_in_pr": true,
-      "followup_rationale": null,
-      "number": 2112,
       "url": null
     }
   ],

--- a/.workflow/records/2090-guided-2090-activity-bar-layout.json
+++ b/.workflow/records/2090-guided-2090-activity-bar-layout.json
@@ -74,6 +74,11 @@
       "at": "2026-08-21T20:54:16.501163Z",
       "owner_directive": "Add a color-filled selection highlight to the activity-bar icons.",
       "reason": "Owner asked during live preview for a color-filled active highlight on the activity-bar icons, not just the edge accent bar."
+    },
+    {
+      "at": "2026-08-21T21:00:13.873184Z",
+      "owner_directive": "Rename the Workflows panel Refresh button to Reload for semantic consistency with the block palette.",
+      "reason": "Owner asked during live preview to rename the WorkflowPanel Refresh button to Reload so the wording matches the Blocks palette's Reload affordance."
     }
   ],
   "docs_events": [

--- a/.workflow/records/2090-guided-2090-activity-bar-layout.json
+++ b/.workflow/records/2090-guided-2090-activity-bar-layout.json
@@ -49,10 +49,76 @@
       "tool_versions": {
         "ruff": "0.15.15"
       }
+    },
+    {
+      "at": "2026-08-21T21:42:20.878236Z",
+      "command": "(cd frontend && npm run check:ci)",
+      "covered_surface": "frontend",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:608f2f33a2fd0379eb1d22db9427419bc79c3198325a33b1249d5cf1d83517ec",
+      "name": "frontend",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/frontend.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-21T21:42:46.674728Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:6f023df036be298210fb708864f2a66573b1118bd9d0791c77b327a8311e13e5",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-21T21:52:46.708294Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": null,
+      "input_fingerprint": "sha256:9867a875ad1ebee88d879470cfa2812035982d0015ac2cbac03c11f59092f333",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": null,
+      "status": "unknown",
+      "summary": "execution error: TimeoutExpired",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-21T22:03:17.456430Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": null,
+      "input_fingerprint": "sha256:9867a875ad1ebee88d879470cfa2812035982d0015ac2cbac03c11f59092f333",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": null,
+      "status": "unknown",
+      "summary": "execution error: TimeoutExpired",
+      "tool_versions": {}
     }
   ],
   "check_na": [],
-  "commit": null,
+  "commit": {
+    "sha": "4fcea09cfb0b9da70ec09cb13691ab52e3b462a1",
+    "shas": [
+      "4fcea09cfb0b9da70ec09cb13691ab52e3b462a1"
+    ],
+    "trailers": []
+  },
   "declared_scope": {
     "exclude": [],
     "include": [
@@ -168,6 +234,358 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:52:46.793409Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:52:46.823142Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:52:46.865576Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:52:46.889246Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:52:46.917117Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:52:46.944878Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:52:46.979409Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:52:47.010500Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:52:47.038927Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:52:47.061834Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:52:47.102323Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:53:05.590836Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:53:05.606020Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:53:05.620827Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:53:05.635389Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:53:05.650547Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:53:05.686231Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:53:05.711600Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:53:05.728005Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:53:05.742715Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:53:05.757629Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T21:53:05.776530Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:03:17.511954Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:03:17.531116Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:03:17.550778Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:03:17.566277Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:03:17.581263Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:03:17.596436Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:03:17.612856Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:03:17.628188Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:03:17.643605Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:03:17.658582Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:03:17.683043Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:03:31.999275Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:03:32.015998Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:03:32.031638Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:03:32.047411Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:03:32.063001Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:03:32.079725Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:03:32.095059Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:03:32.110957Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:03:32.126428Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:03:32.142671Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:03:32.164486Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -182,27 +600,49 @@
   "observed_diff": {
     "base": "origin/main",
     "base_sha": "4105e165",
-    "changed_files": [],
-    "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "changed_files": [
+      ".workflow/records/2090-guided-2090-activity-bar-layout.json",
+      "docs/specs/frontend-block-palette.md",
+      "frontend/src/App.parts/ProjectWorkspace.tsx",
+      "frontend/src/App.tsx",
+      "frontend/src/components/ActivityBar.test.tsx",
+      "frontend/src/components/ActivityBar.tsx",
+      "frontend/src/components/BottomPanel.parts/TabBar.tsx",
+      "frontend/src/components/LearningCenter.parts/targets.ts",
+      "frontend/src/components/ProjectTree.parts/useTreeNodes.ts",
+      "frontend/src/components/ProjectTree.tsx",
+      "frontend/src/components/WorkflowPanel.test.tsx",
+      "frontend/src/components/WorkflowPanel.tsx",
+      "frontend/src/components/__tests__/ProjectTree.test.tsx",
+      "frontend/src/store/types.ts"
+    ],
+    "diff_fingerprint": "sha256:ced9b85920b51fec10ec016ecbc82805ff034c82ba7c6dc49dfcf89c17f81d8f",
     "head": "HEAD",
-    "head_sha": "4105e165",
+    "head_sha": "4fcea09c",
     "surfaces": {
-      "docs": 0,
-      "frontend": 0,
+      "docs": 1,
+      "frontend": 12,
       "governance": 0,
       "governed_docs": 0,
-      "implementation": 0,
+      "implementation": 12,
       "packaging": 0,
       "protected_architecture": 0,
       "protected_core": 0,
-      "sentrux": 0,
-      "test": 0,
+      "sentrux": 13,
+      "test": 3,
       "workflow_ci": 0
     }
   },
   "owner_directive": "Modernize the frontend left sidebar into a VS Code-style layout: a vertical icon activity bar (Blocks / Data types / Workflows / Project) with hover tooltips, click-to-open panel, click-active-icon-to-collapse; add a new Workflows panel listing all project workflows with their YAML descriptions.",
   "persona": "live_implementer",
-  "pull_request": null,
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [
+      2090
+    ],
+    "number": null,
+    "url": null
+  },
   "reconcile_events": [
     {
       "at": "2026-08-21T20:37:25.380190Z",
@@ -211,6 +651,42 @@
       "result": "pass",
       "tier": 2,
       "unsatisfied": []
+    },
+    {
+      "at": "2026-08-21T21:52:47.102388Z",
+      "diff_fingerprint": "sha256:ced9b85920b51fec10ec016ecbc82805ff034c82ba7c6dc49dfcf89c17f81d8f",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-21T21:53:05.776557Z",
+      "diff_fingerprint": "sha256:ced9b85920b51fec10ec016ecbc82805ff034c82ba7c6dc49dfcf89c17f81d8f",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.semantic_dup"
+      ]
+    },
+    {
+      "at": "2026-08-21T22:03:17.683077Z",
+      "diff_fingerprint": "sha256:ced9b85920b51fec10ec016ecbc82805ff034c82ba7c6dc49dfcf89c17f81d8f",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-21T22:03:32.164511Z",
+      "diff_fingerprint": "sha256:ced9b85920b51fec10ec016ecbc82805ff034c82ba7c6dc49dfcf89c17f81d8f",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.semantic_dup"
+      ]
     }
   ],
   "record_id": "2090-guided-2090-activity-bar-layout",
@@ -219,10 +695,14 @@
     "admin_labels": [],
     "checks": [
       "format_check",
+      "frontend",
       "full_audit",
-      "lint_format"
+      "lint_format",
+      "semantic_dup"
     ],
-    "docs": [],
+    "docs": [
+      "docs_required_or_na"
+    ],
     "guards": [
       "architecture_doc_guard",
       "core_change_guard",
@@ -236,7 +716,9 @@
       "test_engineer_scope_guard",
       "weakened_ci_check"
     ],
-    "tests": []
+    "tests": [
+      "changed_test_required"
+    ]
   },
   "runtime": "agents:kimi-code",
   "schema_version": 2,

--- a/.workflow/records/2090-guided-2090-activity-bar-layout.json
+++ b/.workflow/records/2090-guided-2090-activity-bar-layout.json
@@ -84,6 +84,11 @@
       "at": "2026-08-21T21:04:30.412142Z",
       "owner_directive": "Rename the ProjectTree Refresh button to Reload for consistency.",
       "reason": "Owner asked during live preview to also rename the project tree's Refresh button to Reload so all left-panel reload affordances share one wording."
+    },
+    {
+      "at": "2026-08-21T21:30:36.758365Z",
+      "owner_directive": "Add a Data tab to the activity bar: a ProjectTree-style view rooted at the project's data/ folder showing all subdirectories. Defer the click-to-preview variant (option C) to a follow-up.",
+      "reason": "Owner directed a new Data activity-bar section during the live session: a project tree rooted at data/ showing all its subdirectories (option A from the design discussion; click-to-preview deferred). Icon Database, order Blocks/Data types/Workflows/Data/Project."
     }
   ],
   "docs_events": [
@@ -283,6 +288,18 @@
       "at": "2026-08-21T21:04:30.412163Z",
       "pattern": "frontend/src/components/ProjectTree.tsx",
       "reason": "Owner asked during live preview to also rename the project tree's Refresh button to Reload so all left-panel reload affordances share one wording."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-21T21:30:36.758385Z",
+      "pattern": "frontend/src/components/ProjectTree.parts/useTreeNodes.ts",
+      "reason": "Owner directed a new Data activity-bar section during the live session: a project tree rooted at data/ showing all its subdirectories (option A from the design discussion; click-to-preview deferred). Icon Database, order Blocks/Data types/Workflows/Data/Project."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-21T21:30:36.758391Z",
+      "pattern": "frontend/src/components/ActivityBar.tsx",
+      "reason": "Owner directed a new Data activity-bar section during the live session: a project tree rooted at data/ showing all its subdirectories (option A from the design discussion; click-to-preview deferred). Icon Database, order Blocks/Data types/Workflows/Data/Project."
     }
   ],
   "session_id": "1b557fc7-0aa8-4122-9265-3a7e4dc9b69c",

--- a/.workflow/records/2090-guided-2090-activity-bar-layout.json
+++ b/.workflow/records/2090-guided-2090-activity-bar-layout.json
@@ -109,13 +109,48 @@
       "status": "unknown",
       "summary": "execution error: TimeoutExpired",
       "tool_versions": {}
+    },
+    {
+      "at": "2026-08-21T22:17:39.665216Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": null,
+      "input_fingerprint": "sha256:9867a875ad1ebee88d879470cfa2812035982d0015ac2cbac03c11f59092f333",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": null,
+      "status": "unknown",
+      "summary": "execution error: TimeoutExpired",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-21T22:32:30.148326Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": null,
+      "input_fingerprint": "sha256:9867a875ad1ebee88d879470cfa2812035982d0015ac2cbac03c11f59092f333",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": null,
+      "status": "unknown",
+      "summary": "execution error: TimeoutExpired",
+      "tool_versions": {}
     }
   ],
-  "check_na": [],
+  "check_na": [
+    {
+      "name": "semantic_dup",
+      "rationale": "Owner-authorized skip: gate venv run times out (>600s) while the identical standalone scan passes in 108s with all ratchets within limits; the semantic-dup CI job still runs on the PR."
+    }
+  ],
   "commit": {
-    "sha": "4fcea09cfb0b9da70ec09cb13691ab52e3b462a1",
+    "sha": "0ab74232541aef121c3b56698e134e008976e222",
     "shas": [
-      "4fcea09cfb0b9da70ec09cb13691ab52e3b462a1"
+      "0ab74232541aef121c3b56698e134e008976e222"
     ],
     "trailers": []
   },
@@ -155,6 +190,11 @@
       "at": "2026-08-21T21:30:36.758365Z",
       "owner_directive": "Add a Data tab to the activity bar: a ProjectTree-style view rooted at the project's data/ folder showing all subdirectories. Defer the click-to-preview variant (option C) to a follow-up.",
       "reason": "Owner directed a new Data activity-bar section during the live session: a project tree rooted at data/ showing all its subdirectories (option A from the design discussion; click-to-preview deferred). Icon Database, order Blocks/Data types/Workflows/Data/Project."
+    },
+    {
+      "at": "2026-08-21T22:22:16.383720Z",
+      "owner_directive": "Skip the semantic_dup preflight for this guided session; it is an environment issue in the worktree gate venv.",
+      "reason": "Owner: the semantic_dup preflight repeatedly times out in the per-worktree gate venv while the same scan passes standalone in the main venv (108s, all ratchets within limits) \u2014 an environment issue; owner authorized skipping the preflight. CI still runs the semantic-dup ratchet on the PR."
     }
   ],
   "docs_events": [
@@ -586,6 +626,446 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:04:06.447204Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:04:06.474121Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:04:06.499348Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:04:06.525335Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:04:06.544983Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:04:06.561763Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:04:06.578886Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:04:06.594232Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:04:06.610085Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:04:06.628677Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:04:06.649439Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:17:39.732436Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:17:39.758072Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:17:39.774063Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:17:39.797482Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:17:39.815007Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:17:39.830524Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:17:39.846361Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:17:39.862859Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:17:39.887182Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:17:39.904776Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:17:39.927716Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:18:14.648967Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:18:14.667797Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:18:14.691297Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:18:14.707696Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:18:14.723146Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:18:14.738838Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:18:14.754968Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:18:14.776449Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:18:14.794295Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:18:14.810452Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:18:14.832004Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:32:30.198796Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:32:30.214974Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:32:30.230441Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:32:30.246441Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:32:30.263249Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:32:30.281086Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:32:30.302111Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:32:30.318462Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:32:30.334931Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:32:30.351220Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:32:30.373353Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:32:46.893972Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:32:46.909439Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:32:46.925570Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:32:46.943495Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:32:46.959640Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:32:46.977574Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:32:46.994613Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:32:47.015766Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:32:47.097315Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:32:47.114361Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T22:32:47.134072Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -599,7 +1079,7 @@
   "observed_admin_labels": [],
   "observed_diff": {
     "base": "origin/main",
-    "base_sha": "4105e165",
+    "base_sha": "4105e1654",
     "changed_files": [
       ".workflow/records/2090-guided-2090-activity-bar-layout.json",
       "docs/specs/frontend-block-palette.md",
@@ -616,9 +1096,9 @@
       "frontend/src/components/__tests__/ProjectTree.test.tsx",
       "frontend/src/store/types.ts"
     ],
-    "diff_fingerprint": "sha256:ced9b85920b51fec10ec016ecbc82805ff034c82ba7c6dc49dfcf89c17f81d8f",
+    "diff_fingerprint": "sha256:177dca9395ed93a521976349b5af46bd808c203d64e70aa0616e93552264a528",
     "head": "HEAD",
-    "head_sha": "4fcea09c",
+    "head_sha": "0ab742325",
     "surfaces": {
       "docs": 1,
       "frontend": 12,
@@ -685,6 +1165,54 @@
       "result": "fail",
       "tier": 2,
       "unsatisfied": [
+        "checks.semantic_dup"
+      ]
+    },
+    {
+      "at": "2026-08-21T22:04:06.649466Z",
+      "diff_fingerprint": "sha256:8906c5ab8460ff19ecabaf8ebb0cfd8ab192d348902cadb69277714e07c38a20",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.semantic_dup"
+      ]
+    },
+    {
+      "at": "2026-08-21T22:17:39.927781Z",
+      "diff_fingerprint": "sha256:8906c5ab8460ff19ecabaf8ebb0cfd8ab192d348902cadb69277714e07c38a20",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-21T22:18:14.832028Z",
+      "diff_fingerprint": "sha256:8906c5ab8460ff19ecabaf8ebb0cfd8ab192d348902cadb69277714e07c38a20",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.semantic_dup"
+      ]
+    },
+    {
+      "at": "2026-08-21T22:32:30.373385Z",
+      "diff_fingerprint": "sha256:8906c5ab8460ff19ecabaf8ebb0cfd8ab192d348902cadb69277714e07c38a20",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-21T22:32:47.134100Z",
+      "diff_fingerprint": "sha256:177dca9395ed93a521976349b5af46bd808c203d64e70aa0616e93552264a528",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.frontend",
+        "checks.full_audit",
         "checks.semantic_dup"
       ]
     }

--- a/.workflow/records/2090-guided-2090-activity-bar-layout.json
+++ b/.workflow/records/2090-guided-2090-activity-bar-layout.json
@@ -79,6 +79,11 @@
       "at": "2026-08-21T21:00:13.873184Z",
       "owner_directive": "Rename the Workflows panel Refresh button to Reload for semantic consistency with the block palette.",
       "reason": "Owner asked during live preview to rename the WorkflowPanel Refresh button to Reload so the wording matches the Blocks palette's Reload affordance."
+    },
+    {
+      "at": "2026-08-21T21:04:30.412142Z",
+      "owner_directive": "Rename the ProjectTree Refresh button to Reload for consistency.",
+      "reason": "Owner asked during live preview to also rename the project tree's Refresh button to Reload so all left-panel reload affordances share one wording."
     }
   ],
   "docs_events": [
@@ -272,6 +277,12 @@
       "at": "2026-08-21T20:54:16.501182Z",
       "pattern": "frontend/src/components/ActivityBar.tsx",
       "reason": "Owner asked during live preview for a color-filled active highlight on the activity-bar icons, not just the edge accent bar."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-21T21:04:30.412163Z",
+      "pattern": "frontend/src/components/ProjectTree.tsx",
+      "reason": "Owner asked during live preview to also rename the project tree's Refresh button to Reload so all left-panel reload affordances share one wording."
     }
   ],
   "session_id": "1b557fc7-0aa8-4122-9265-3a7e4dc9b69c",
@@ -291,6 +302,14 @@
       "class": null,
       "kind": "path",
       "path": "frontend/src/components/WorkflowPanel.test.tsx",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-21T21:10:56.911112Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/components/__tests__/ProjectTree.test.tsx",
       "rationale": null,
       "verified_in_diff": null
     }

--- a/docs/specs/frontend-block-palette.md
+++ b/docs/specs/frontend-block-palette.md
@@ -23,7 +23,7 @@ scope:
     - A hover detail popover anchored to the right of a tile showing icon, name, full description, and typed port signature; interactive in the palette so it can hold an action row (ADR-053 §9.3).
     - A shared section/filter/tile/chip/popover helper set the Data types tab reuses (ADR-053 §10.1).
     - The category sub-grouping layer, the always-on description line, and the "X in / Y out" text line are removed from the tile.
-    - A one-shot opacity blink confirming a completed Reload, via a shared `useReloadFlash` hook also wired to the project tree Refresh.
+    - A one-shot opacity blink confirming a completed Reload, via a shared `useReloadFlash` hook also wired to the project tree Reload.
     - A tip overlay pinned to the bottom of the shared left panel, rotating one curated tip at a time across all left-panel sections (§12, #1997; the panel gained the §13 activity-bar form in #2090).
   out:
     - Backend or schema changes (none — base_category, subcategory, ports, direction already exist on BlockSummary).
@@ -345,7 +345,7 @@ background catalog syncs, or on a failed reload. It uses the Web Animations API
 so the subtree is not remounted (section-collapse state is preserved), guarded
 for environments without `Element.animate`.
 
-The same hook is wired to the project tree Refresh control (watching the tree
+The same hook is wired to the project tree Reload control (watching the tree
 nodes), so both side panels share one consistent reload feedback.
 
 The hook is covered by `frontend/src/hooks/__tests__/useReloadFlash.test.ts`;

--- a/docs/specs/frontend-block-palette.md
+++ b/docs/specs/frontend-block-palette.md
@@ -691,11 +691,13 @@ collapsed — which is what makes the collapsed state discoverable.
 
 ### 13.1 Sections, Not Tabs
 
-`leftTab` widens from `"blocks" | "types" | "project"` to include `"workflows"`.
-The rail's icon order is Blocks, Data types, Workflows, Project; hovering an
+`leftTab` widens from `"blocks" | "types" | "project"` to include
+`"workflows"` and `"data"`. The rail's icon order is Blocks, Data types,
+Workflows, Data, Project; hovering an
 icon shows the section name in a tooltip (the shared `ui/tooltip`). The active
-section carries a short accent bar on the rail's left edge; a collapsed panel
-shows no active marker at all, same as VS Code.
+section carries an ember-filled highlight plus a short accent bar on the
+rail's left edge; a collapsed panel shows no active marker at all, same as
+VS Code.
 
 Clicking an icon opens that section. Clicking the *active* section's icon
 collapses the whole panel; clicking it again (or pressing Ctrl+B) reopens it.
@@ -718,10 +720,24 @@ the section needed no backend change. A workflow whose detail fetch fails
 currently on the canvas is highlighted (`aria-current`), and a Reload button
 matches the project tree's affordance.
 
-### 13.3 Test Plan
+### 13.3 The Data Section
+
+The Data section is the project tree rooted at `data/` rather than the project
+root: `ProjectTree` grew optional `rootPath` / `title` props, and
+`useTreeNodes(projectId, basePath)` loads its root listing from the
+subdirectory while every path below stays project-relative (so the context
+menu, reload flash, and watcher auto-refresh behave exactly as they do on the
+Project section). All of `data/` shows — `raw`, `processed`, `zarr`,
+`parquet`, `artifacts`, `exchange` — per the owner's call in the live session.
+Single-click file preview in the right-hand DataPreview panel was discussed
+and explicitly deferred (tracked TODO in `ProjectWorkspace.tsx`).
+
+### 13.4 Test Plan
 
 `frontend/src/components/ActivityBar.test.tsx` covers the rail: one icon per
 section, click reporting, the active marker appearing only while the panel is
 open, and the hover tooltip. `frontend/src/components/WorkflowPanel.test.tsx`
-covers the list: ids plus descriptions, click-to-open, the active highlight,
-the failed-detail fallback, the empty state, and Reload.
+covers the workflow list: ids plus descriptions, click-to-open, the active
+highlight, the failed-detail fallback, the empty state, and Reload.
+`frontend/src/components/__tests__/ProjectTree.test.tsx` covers the Reload
+wording on the project tree and the Data section's `rootPath="data"` rooting.

--- a/docs/specs/frontend-block-palette.md
+++ b/docs/specs/frontend-block-palette.md
@@ -24,7 +24,7 @@ scope:
     - A shared section/filter/tile/chip/popover helper set the Data types tab reuses (ADR-053 §10.1).
     - The category sub-grouping layer, the always-on description line, and the "X in / Y out" text line are removed from the tile.
     - A one-shot opacity blink confirming a completed Reload, via a shared `useReloadFlash` hook also wired to the project tree Refresh.
-    - A tip overlay pinned to the bottom of the shared left panel, rotating one curated tip at a time across all three tabs (§12, #1997).
+    - A tip overlay pinned to the bottom of the shared left panel, rotating one curated tip at a time across all left-panel sections (§12, #1997; the panel gained the §13 activity-bar form in #2090).
   out:
     - Backend or schema changes (none — base_category, subcategory, ports, direction already exist on BlockSummary).
     - Per-block custom icons (still tracked as the categoryVisuals follow-up; palette keeps the category-icon fallback).
@@ -46,6 +46,8 @@ governs:
     - frontend/src/hooks/useReloadFlash.ts
     - frontend/src/components/ProjectTree.tsx
     - frontend/src/App.parts/ProjectWorkspace.tsx
+    - frontend/src/components/ActivityBar.tsx
+    - frontend/src/components/WorkflowPanel.tsx
   excludes:
     - frontend/src/components/nodes/BlockNode.parts/categoryVisuals.ts
 tests:
@@ -57,6 +59,8 @@ tests:
   - frontend/src/components/palette/tips/__tests__/tipPool.test.ts
   - frontend/src/components/palette/tips/__tests__/useTipRotation.test.ts
   - frontend/src/components/palette/tips/__tests__/PaletteTipCard.test.tsx
+  - frontend/src/components/ActivityBar.test.tsx
+  - frontend/src/components/WorkflowPanel.test.tsx
 acceptance_source: issue
 language_source: en
 ---
@@ -391,6 +395,9 @@ abstract standing alone next to `Blocks`; the internal `leftTab` key stays
 `types`. `frontend/src/components/TypePalette.tsx` is the pane, with its
 `TypePalette.parts/` model, row, and popover siblings.
 
+(#2090 later replaced the tab strip itself with the §13 activity bar; the
+`types` section, its label, and everything else in §11 still stand.)
+
 ### 11.1 It Mirrors The Blocks Tab, Reusing Its Machinery
 
 The tab reuses §4.3's shared skeleton rather than restating it: `filterItems`
@@ -541,20 +548,23 @@ hints are built on that assumption.
 
 ### 12.1 It Belongs To The Panel, Not To A Tab
 
-The overlay is mounted in `App.parts/ProjectWorkspace.tsx` on the pane body that
-holds all three left tabs (`Blocks`, `Data types`, `Project`), as a sibling of
-the active tab's content rather than inside any one of them.
+The overlay is mounted in `App.parts/ProjectWorkspace.tsx` on the pane body
+that holds the left-panel sections, as a sibling of the active section's
+content rather than inside any one of them. (The panel held three text tabs —
+`Blocks`, `Data types`, `Project` — when this section was written; #2090
+replaced the tab strip with the §13 activity bar and added a fourth section,
+`Workflows`.)
 
-That placement is what makes one card and one clock serve three tabs. Switching
-tabs neither remounts the card nor restarts the rotation, so a user moving
-between Blocks and Data types sees one continuous schedule instead of a card
-that flickers on every switch. It also keeps all three panes unmodified: the
-overlay is positioned against the pane body, so the block grid, the type list,
-and the project tree each keep their full height.
+That placement is what makes one card and one clock serve every section.
+Switching sections neither remounts the card nor restarts the rotation, so a
+user moving between Blocks and Data types sees one continuous schedule instead
+of a card that flickers on every switch. It also keeps all panes unmodified:
+the overlay is positioned against the pane body, so the block grid, the type
+list, the workflow list, and the project tree each keep their full height.
 
 The card is anchored to the **bottom** of the pane body, above the pane's own
-content and below the tab strip. The tab strip stays reachable while a tip is
-up.
+content. (Before #2090 it sat below the tab strip; with the strip gone there
+is nothing above the pane content to collide with.)
 
 ### 12.2 Rotation, And The Two-Step Way Out
 
@@ -669,3 +679,49 @@ the hidden state carrying both `opacity-0` and `pointer-events-none`, dismissal
 and return after the snooze, the card disappearing entirely after the second
 dismissal, the expand control appearing only when something overflows, and a
 long title wrapping to two lines and being released along with the body.
+
+## 13. Activity Bar And Workflows Panel (#2090)
+
+The left panel's text tab strip (`Blocks` / `Data types` / `Project` along the
+panel's top edge) is replaced by a VS Code-style **activity bar**: a 48px
+vertical icon rail at the far left of the workspace,
+`frontend/src/components/ActivityBar.tsx`. The rail sits *outside* the
+`ResizablePanelGroup`, so it never resizes and stays visible while the panel is
+collapsed — which is what makes the collapsed state discoverable.
+
+### 13.1 Sections, Not Tabs
+
+`leftTab` widens from `"blocks" | "types" | "project"` to include `"workflows"`.
+The rail's icon order is Blocks, Data types, Workflows, Project; hovering an
+icon shows the section name in a tooltip (the shared `ui/tooltip`). The active
+section carries a short accent bar on the rail's left edge; a collapsed panel
+shows no active marker at all, same as VS Code.
+
+Clicking an icon opens that section. Clicking the *active* section's icon
+collapses the whole panel; clicking it again (or pressing Ctrl+B) reopens it.
+This wires up the store's `paletteCollapsed` state, which the Ctrl+B shortcut
+and ADR-053 FR-020's library reveal had been writing since the live hotfix
+batch without anything reading it: `ProjectWorkspace` now drives the left
+`ResizablePanel`'s imperative handle from it. Programmatic section switches —
+the FR-020 library reveal and Learning Center step routing — always expand the
+panel, because a section switch that lands behind a collapsed panel is
+invisible.
+
+### 13.2 The Workflows Section
+
+`frontend/src/components/WorkflowPanel.tsx` lists every workflow in the open
+project with the `description` from its YAML, single-click to open it on the
+canvas. It reads the existing endpoints — `GET /api/workflows/list` for the
+ids, then one `GET /api/workflows/{id}` per workflow for the description — so
+the section needed no backend change. A workflow whose detail fetch fails
+(e.g. a mid-write YAML) still appears, without a description. The workflow
+currently on the canvas is highlighted (`aria-current`), and a Refresh button
+matches the project tree's affordance.
+
+### 13.3 Test Plan
+
+`frontend/src/components/ActivityBar.test.tsx` covers the rail: one icon per
+section, click reporting, the active marker appearing only while the panel is
+open, and the hover tooltip. `frontend/src/components/WorkflowPanel.test.tsx`
+covers the list: ids plus descriptions, click-to-open, the active highlight,
+the failed-detail fallback, the empty state, and Refresh.

--- a/docs/specs/frontend-block-palette.md
+++ b/docs/specs/frontend-block-palette.md
@@ -715,7 +715,7 @@ canvas. It reads the existing endpoints — `GET /api/workflows/list` for the
 ids, then one `GET /api/workflows/{id}` per workflow for the description — so
 the section needed no backend change. A workflow whose detail fetch fails
 (e.g. a mid-write YAML) still appears, without a description. The workflow
-currently on the canvas is highlighted (`aria-current`), and a Refresh button
+currently on the canvas is highlighted (`aria-current`), and a Reload button
 matches the project tree's affordance.
 
 ### 13.3 Test Plan
@@ -724,4 +724,4 @@ matches the project tree's affordance.
 section, click reporting, the active marker appearing only while the panel is
 open, and the hover tooltip. `frontend/src/components/WorkflowPanel.test.tsx`
 covers the list: ids plus descriptions, click-to-open, the active highlight,
-the failed-detail fallback, the empty state, and Refresh.
+the failed-detail fallback, the empty state, and Reload.

--- a/docs/specs/frontend-block-palette.md
+++ b/docs/specs/frontend-block-palette.md
@@ -707,7 +707,10 @@ batch without anything reading it: `ProjectWorkspace` now drives the left
 `ResizablePanel`'s imperative handle from it. Programmatic section switches —
 the FR-020 library reveal and Learning Center step routing — always expand the
 panel, because a section switch that lands behind a collapsed panel is
-invisible.
+invisible. Dragging the separator below `minSize` collapses the panel from
+the resizable side, so the panel's `onResize` mirrors that back into
+`paletteCollapsed` — the activity bar's click decision never reads a stale
+value (Codex P2 on #2106).
 
 ### 13.2 The Workflows Section
 
@@ -718,7 +721,11 @@ ids, then one `GET /api/workflows/{id}` per workflow for the description — so
 the section needed no backend change. A workflow whose detail fetch fails
 (e.g. a mid-write YAML) still appears, without a description. The workflow
 currently on the canvas is highlighted (`aria-current`), and a Reload button
-matches the project tree's affordance.
+matches the Blocks palette's affordance. The list refetches when the
+filesystem-watcher's structural-change counter bumps (the same one the
+project tree subscribes to), and in-flight refreshes carry a sequence token
+so a response from a previous project can never overwrite the current list
+(Codex P2s on #2106).
 
 ### 13.3 The Data Section
 
@@ -730,7 +737,8 @@ menu, reload flash, and watcher auto-refresh behave exactly as they do on the
 Project section). All of `data/` shows — `raw`, `processed`, `zarr`,
 `parquet`, `artifacts`, `exchange` — per the owner's call in the live session.
 Single-click file preview in the right-hand DataPreview panel was discussed
-and explicitly deferred (tracked TODO in `ProjectWorkspace.tsx`).
+and explicitly deferred — tracked as issue #2112 (TODO in
+`ProjectWorkspace.tsx`).
 
 ### 13.4 Test Plan
 

--- a/frontend/src/App.parts/ProjectWorkspace.tsx
+++ b/frontend/src/App.parts/ProjectWorkspace.tsx
@@ -10,7 +10,7 @@
 import type { PanelImperativeHandle } from "react-resizable-panels";
 import { useEffect, useRef, type RefObject } from "react";
 
-import type { useAppStore } from "../store";
+import { useAppStore } from "../store";
 import type { AnyTab, FileTab } from "../store/types";
 import type {
   BlockSchemaResponse,
@@ -203,10 +203,10 @@ function PaletteOrProjectPane(props: ProjectWorkspaceProps) {
         // data/ so the panel shows only the project's data folders
         // (raw / processed / zarr / parquet / artifacts / exchange).
         //
-        // TODO(#2090): click-to-preview (option C from the live design
+        // TODO(#2112): click-to-preview (option C from the live design
         // discussion) — single-click a data file to show its content in the
         // right DataPreview panel. Deferred per owner decision in the guided
-        // session; follow-up issue to be filed when picked up.
+        // session. Followup: https://github.com/jiazhenz026/SciStudio/issues/2112
         <ProjectTree
           projectId={currentProject.id}
           projectPath={currentProject.path}
@@ -446,6 +446,17 @@ export function ProjectWorkspace(props: ProjectWorkspaceProps) {
           maxSize="28%"
           collapsible
           collapsedSize="0%"
+          onResize={(size) => {
+            // Codex P2 on #2106 — dragging the separator below `minSize`
+            // collapses the panel internally without touching the store,
+            // leaving the activity bar's click decision stale. Mirror the
+            // panel's collapsed state back into `paletteCollapsed` (the
+            // reverse direction — store → panel — is the effect above).
+            const collapsed = size.asPercentage <= 0.5;
+            if (collapsed !== useAppStore.getState().paletteCollapsed) {
+              useAppStore.setState({ paletteCollapsed: collapsed });
+            }
+          }}
         >
           <PaletteOrProjectPane {...props} />
         </ResizablePanel>

--- a/frontend/src/App.parts/ProjectWorkspace.tsx
+++ b/frontend/src/App.parts/ProjectWorkspace.tsx
@@ -56,10 +56,11 @@ export interface CanvasReadabilityWiring {
  * `blocks` is the renamed first section. `types` is the `Data types` section
  * that sits between `Blocks` and `Workflows`. #2090 replaced the text tab
  * strip with the VS Code-style `ActivityBar` icon rail and added the
- * `workflows` section; the union is widened here ahead of the pane so all
- * section surfaces read one union.
+ * `workflows` and `data` sections (`data` is the project tree rooted at
+ * `data/`); the union is widened here ahead of the pane so all section
+ * surfaces read one union.
  */
-export type LeftTab = "blocks" | "types" | "workflows" | "project";
+export type LeftTab = "blocks" | "types" | "workflows" | "data" | "project";
 
 export interface ProjectWorkspaceProps {
   // Project / workflow context
@@ -196,6 +197,23 @@ function PaletteOrProjectPane(props: ProjectWorkspaceProps) {
           projectId={currentProject.id}
           activeWorkflowId={props.workflowId}
           onOpenWorkflow={(workflowId, displayName) => onLoadWorkflowById(workflowId, displayName)}
+        />
+      ) : leftTab === "data" ? (
+        // #2090 — the Data section: the same tree as Project, rooted at
+        // data/ so the panel shows only the project's data folders
+        // (raw / processed / zarr / parquet / artifacts / exchange).
+        //
+        // TODO(#2090): click-to-preview (option C from the live design
+        // discussion) — single-click a data file to show its content in the
+        // right DataPreview panel. Deferred per owner decision in the guided
+        // session; follow-up issue to be filed when picked up.
+        <ProjectTree
+          projectId={currentProject.id}
+          projectPath={currentProject.path}
+          title="Data"
+          rootPath="data"
+          onLoadWorkflow={(workflowId, displayName) => onLoadWorkflowById(workflowId, displayName)}
+          onReloadBlocks={onReloadBlocks}
         />
       ) : (
         <ProjectTree

--- a/frontend/src/App.parts/ProjectWorkspace.tsx
+++ b/frontend/src/App.parts/ProjectWorkspace.tsx
@@ -8,7 +8,7 @@
 // state wiring.
 
 import type { PanelImperativeHandle } from "react-resizable-panels";
-import { useEffect, type RefObject } from "react";
+import { useEffect, useRef, type RefObject } from "react";
 
 import type { useAppStore } from "../store";
 import type { AnyTab, FileTab } from "../store/types";
@@ -20,6 +20,7 @@ import type {
   WorkflowNode,
 } from "../types/api";
 
+import { ActivityBar } from "../components/ActivityBar";
 import { BlockPalette } from "../components/BlockPalette";
 import { BottomPanel } from "../components/BottomPanel";
 import { CodeEditor } from "../components/CodeEditor";
@@ -29,6 +30,7 @@ import { ProjectTree } from "../components/ProjectTree";
 import { useLibraryReveal } from "../components/promotion/revealInLibrary";
 import { TabBar } from "../components/TabBar";
 import { TypePalette } from "../components/TypePalette";
+import { WorkflowPanel } from "../components/WorkflowPanel";
 import { WorkflowCanvas } from "../components/WorkflowCanvas";
 import { resolveVariadicPorts } from "../components/WorkflowCanvas.parts/flowNodeBuilder";
 import { buildScopedBlockOutputs } from "../components/WorkflowCanvas.parts/subworkflowRunView";
@@ -49,20 +51,31 @@ export interface CanvasReadabilityWiring {
 }
 
 /**
- * Left-panel tabs (ADR-053 §9, FR-034 / FR-039).
+ * Left-panel sections (ADR-053 §9, FR-034 / FR-039; #2090).
  *
- * `blocks` is the renamed first tab. `types` is the `Data types` tab that sits
- * between `Blocks` and `Project`; the key is widened here ahead of the pane so
- * both tab surfaces read one union.
+ * `blocks` is the renamed first section. `types` is the `Data types` section
+ * that sits between `Blocks` and `Workflows`. #2090 replaced the text tab
+ * strip with the VS Code-style `ActivityBar` icon rail and added the
+ * `workflows` section; the union is widened here ahead of the pane so all
+ * section surfaces read one union.
  */
-export type LeftTab = "blocks" | "types" | "project";
+export type LeftTab = "blocks" | "types" | "workflows" | "project";
 
 export interface ProjectWorkspaceProps {
   // Project / workflow context
   currentProject: ProjectResponse;
+  /** The workflow currently on the canvas (WorkflowPanel highlight). */
+  workflowId: string | null;
   // Left panel
   leftTab: LeftTab;
+  /** Programmatic section switch (library reveal, tutorial routing): always
+   * expands the panel, never collapses it. */
   onLeftTabChange: (tab: LeftTab) => void;
+  /** Activity-bar icon click: clicking the active section collapses the
+   * panel, anything else opens that section. */
+  onActivitySelect: (tab: LeftTab) => void;
+  /** Store-backed left-panel collapse state (#2090 wires it to the panel). */
+  paletteCollapsed: boolean;
   blocks: BlockSummary[];
   paletteSearch: string;
   setPaletteSearch: (search: string) => void;
@@ -146,9 +159,10 @@ function PaletteOrProjectPane(props: ProjectWorkspaceProps) {
   } = props;
 
   // ADR-053 FR-020 — a promotion has to leave the user looking at the item in
-  // `My Library`, and the item's section lives on its own tab. The rest of the
-  // reveal (expanding the panel, refreshing the catalogue, narrowing to the
-  // item) is store-side; only the tab switch needs the component that owns it.
+  // `My Library`, and the item's section lives on its own surface. The rest of
+  // the reveal (expanding the panel, refreshing the catalogue, narrowing to
+  // the item) is store-side; only the section switch needs the component that
+  // owns it.
   const revealed = useLibraryReveal();
   useEffect(() => {
     if (revealed) {
@@ -156,67 +170,45 @@ function PaletteOrProjectPane(props: ProjectWorkspaceProps) {
     }
   }, [revealed, onLeftTabChange]);
 
+  // #2090 — the text tab strip is gone; the `ActivityBar` rail outside the
+  // resizable group picks the section, and each pane identifies itself
+  // (search + chips for Blocks / Data types, titles for Workflows / Project).
   return (
-    <div className="flex h-full flex-col overflow-hidden">
-      <div className="flex shrink-0 border-b border-stone-200 bg-[linear-gradient(180deg,_rgba(255,255,255,0.95),_rgba(245,241,232,0.98))]">
-        <button
-          className={`flex-1 px-3 py-2 text-xs font-medium transition ${leftTab === "blocks" ? "border-b-2 border-ember text-ink" : "text-stone-400 hover:text-stone-600"}`}
-          onClick={() => onLeftTabChange("blocks")}
-          type="button"
-        >
-          Blocks
-        </button>
-        {/* ADR-053 FR-039 — the third tab sits between `Blocks` and `Project`.
-            The user-facing label is `Data types`; `Types` is too abstract
-            standing alone next to `Blocks`. The internal key stays `types`. */}
-        <button
-          className={`flex-1 px-3 py-2 text-xs font-medium transition ${leftTab === "types" ? "border-b-2 border-ember text-ink" : "text-stone-400 hover:text-stone-600"}`}
-          onClick={() => onLeftTabChange("types")}
-          type="button"
-        >
-          Data types
-        </button>
-        <button
-          className={`flex-1 px-3 py-2 text-xs font-medium transition ${leftTab === "project" ? "border-b-2 border-ember text-ink" : "text-stone-400 hover:text-stone-600"}`}
-          onClick={() => onLeftTabChange("project")}
-          type="button"
-        >
-          Project
-        </button>
-      </div>
-      {/* `relative` anchors the tip overlay (#1997) to the pane body, so the
-          card floats over the bottom of whichever tab is open and never
-          covers the tab strip. */}
-      <div className="relative min-h-0 flex-1">
-        {/* FR-027 — the Data types pane takes no props: it reads the type
-            catalogue directly, so opening it neither waits for nor
-            re-triggers a blocks fetch. */}
-        {leftTab === "types" ? (
-          <TypePalette />
-        ) : leftTab === "blocks" ? (
-          <BlockPalette
-            blocks={blocks}
-            collapsed={false}
-            onAddBlock={onAddBlockFromPalette}
-            onReload={onReloadBlocks}
-            onSearch={setPaletteSearch}
-            search={paletteSearch}
-          />
-        ) : (
-          <ProjectTree
-            projectId={currentProject.id}
-            projectPath={currentProject.path}
-            onLoadWorkflow={(workflowId, displayName) =>
-              onLoadWorkflowById(workflowId, displayName)
-            }
-            onReloadBlocks={onReloadBlocks}
-          />
-        )}
-        {/* #1997 — one card and one clock for all three tabs: mounted here
-            rather than inside a tab so switching tabs neither restarts the
-            rotation nor makes the card flicker. */}
-        <PaletteTipCard />
-      </div>
+    /* `relative` anchors the tip overlay (#1997) to the pane body, so the
+       card floats over the bottom of whichever section is open. */
+    <div className="relative h-full overflow-hidden">
+      {/* FR-027 — the Data types pane takes no props: it reads the type
+          catalogue directly, so opening it neither waits for nor
+          re-triggers a blocks fetch. */}
+      {leftTab === "types" ? (
+        <TypePalette />
+      ) : leftTab === "blocks" ? (
+        <BlockPalette
+          blocks={blocks}
+          collapsed={false}
+          onAddBlock={onAddBlockFromPalette}
+          onReload={onReloadBlocks}
+          onSearch={setPaletteSearch}
+          search={paletteSearch}
+        />
+      ) : leftTab === "workflows" ? (
+        <WorkflowPanel
+          projectId={currentProject.id}
+          activeWorkflowId={props.workflowId}
+          onOpenWorkflow={(workflowId, displayName) => onLoadWorkflowById(workflowId, displayName)}
+        />
+      ) : (
+        <ProjectTree
+          projectId={currentProject.id}
+          projectPath={currentProject.path}
+          onLoadWorkflow={(workflowId, displayName) => onLoadWorkflowById(workflowId, displayName)}
+          onReloadBlocks={onReloadBlocks}
+        />
+      )}
+      {/* #1997 — one card and one clock for all sections: mounted here rather
+          than inside a pane so switching sections neither restarts the
+          rotation nor makes the card flicker. */}
+      <PaletteTipCard />
     </div>
   );
 }
@@ -345,6 +337,9 @@ export function ProjectWorkspace(props: ProjectWorkspaceProps) {
     switchTab,
     closeTab,
     onNewWorkflowTab,
+    leftTab,
+    onActivitySelect,
+    paletteCollapsed,
     bottomPanelRef,
     bottomPanelPinned,
     toggleBottomPanelPinned,
@@ -360,6 +355,20 @@ export function ProjectWorkspace(props: ProjectWorkspaceProps) {
     workflowEdges,
     selectedNodeLabel,
   } = props;
+
+  // #2090 — the store's `paletteCollapsed` (toggled by the activity bar and
+  // Ctrl+B) was disconnected from the actual panel before; this handle is
+  // what makes the collapse real.
+  const leftPanelRef = useRef<PanelImperativeHandle>(null);
+  useEffect(() => {
+    const panel = leftPanelRef.current;
+    if (!panel) return;
+    if (paletteCollapsed) {
+      panel.collapse();
+    } else {
+      panel.expand();
+    }
+  }, [paletteCollapsed]);
 
   // ADR-044 — preview panels read the same run-scoped, exposed-mapped outputs as
   // the canvas, so selecting a subworkflow node (or a node in an expanded child
@@ -383,157 +392,177 @@ export function ProjectWorkspace(props: ProjectWorkspaceProps) {
       : undefined;
 
   return (
-    <ResizablePanelGroup
-      orientation="horizontal"
-      className="min-h-0 flex-1"
-      onLayoutChanged={(layout) => {
-        const sizes = Object.values(layout);
-        const palette = sizes[0];
-        const preview = sizes[2];
-        if (palette !== null && palette !== undefined && palette >= 4) {
-          setPanelSize("palette", palette);
-        }
-        if (preview !== null && preview !== undefined && preview >= 4) {
-          setPanelSize("preview", preview);
-        }
-      }}
-    >
-      {/* Left Sidebar — tab switcher + content.
-          `minSize` is 10% rather than 4%: below roughly that the pane is
-          narrower than a single 80px tile plus the pane's own padding, so the
-          block grid clipped its tiles and the tip card had no room for a
-          title. The pane is still `collapsible` to 0%, so the narrow end of
-          the range is a real collapse instead of an unusable sliver. */}
-      <ResizablePanel defaultSize="15%" minSize="10%" maxSize="28%" collapsible collapsedSize="0%">
-        <PaletteOrProjectPane {...props} />
-      </ResizablePanel>
-      <ResizableHandle withHandle />
+    <div className="flex min-h-0 flex-1">
+      {/* #2090 — the VS Code-style icon rail sits OUTSIDE the resizable
+          group: it never resizes and stays visible when the panel is
+          collapsed, which is what makes the collapsed state discoverable. */}
+      <ActivityBar activeTab={leftTab} panelOpen={!paletteCollapsed} onSelect={onActivitySelect} />
+      <ResizablePanelGroup
+        orientation="horizontal"
+        className="min-h-0 flex-1"
+        onLayoutChanged={(layout) => {
+          const sizes = Object.values(layout);
+          const palette = sizes[0];
+          const preview = sizes[2];
+          if (palette !== null && palette !== undefined && palette >= 4) {
+            setPanelSize("palette", palette);
+          }
+          if (preview !== null && preview !== undefined && preview >= 4) {
+            setPanelSize("preview", preview);
+          }
+        }}
+      >
+        {/* Left Sidebar — section content picked by the activity bar.
+            `minSize` is 10% rather than 4%: below roughly that the pane is
+            narrower than a single 80px tile plus the pane's own padding, so
+            the block grid clipped its tiles and the tip card had no room for
+            a title. The pane is still `collapsible` to 0%, so the narrow end
+            of the range is a real collapse instead of an unusable sliver. */}
+        <ResizablePanel
+          panelRef={leftPanelRef}
+          // Start collapsed when the persisted store says so, so reopening
+          // the app does not flash an open panel before the effect above
+          // can collapse it.
+          defaultSize={paletteCollapsed ? "0%" : "15%"}
+          minSize="10%"
+          maxSize="28%"
+          collapsible
+          collapsedSize="0%"
+        >
+          <PaletteOrProjectPane {...props} />
+        </ResizablePanel>
+        <ResizableHandle withHandle />
 
-      {/* Center: Tab Bar + Canvas + Bottom Panel vertical split */}
-      <ResizablePanel defaultSize="63%">
-        <div className="flex h-full flex-col">
-          <TabBar
-            tabs={tabs}
-            activeTabId={activeTabId}
-            onSwitchTab={switchTab}
-            onCloseTab={closeTab}
-            onNewTab={onNewWorkflowTab}
-          />
-          <ResizablePanelGroup
-            orientation="vertical"
-            className="min-h-0 flex-1"
-            onLayoutChanged={(layout) => {
-              const sizes = Object.values(layout);
-              const bottom = sizes[1];
-              if (bottom !== null && bottom !== undefined && bottom >= 10) {
-                setPanelSize("bottom", bottom);
-              }
-            }}
-          >
-            <ResizablePanel defaultSize="70%" minSize="20%">
-              <CanvasOrEditor {...props} />
-            </ResizablePanel>
-            <ResizableHandle withHandle />
-            <ResizablePanel
-              panelRef={bottomPanelRef}
-              // collapsedSize is in % of the canvas-column height. 8% on a
-              // typical 800–1000px column ≈ 64–80px, which accommodates the
-              // ~60px tab strip without clipping it. The previous 3%
-              // (~24–30px) cut off the bottom half of the tab buttons.
-              collapsedSize="8%"
-              collapsible
-              // 45% gives Git / Lineage / Logs tabs enough vertical room
-              // for their list + detail content out-of-the-box. 30% (prior
-              // default) made the Git history list unreadable on a 1080p
-              // canvas column.
-              defaultSize="45%"
-              minSize="10%"
+        {/* Center: Tab Bar + Canvas + Bottom Panel vertical split */}
+        <ResizablePanel defaultSize="63%">
+          <div className="flex h-full flex-col">
+            <TabBar
+              tabs={tabs}
+              activeTabId={activeTabId}
+              onSwitchTab={switchTab}
+              onCloseTab={closeTab}
+              onNewTab={onNewWorkflowTab}
+            />
+            <ResizablePanelGroup
+              orientation="vertical"
+              className="min-h-0 flex-1"
+              onLayoutChanged={(layout) => {
+                const sizes = Object.values(layout);
+                const bottom = sizes[1];
+                if (bottom !== null && bottom !== undefined && bottom >= 10) {
+                  setPanelSize("bottom", bottom);
+                }
+              }}
             >
-              <BottomPanel
-                activeTab={activeBottomTab}
-                blockOutputs={scopedBlockOutputs}
-                edges={workflowEdges}
-                logEntries={logEntries}
-                onTabChange={onBottomTabChange}
-                onTogglePin={toggleBottomPanelPinned}
-                onUpdateConfig={(patch) => {
-                  if (selectedNodeId) {
-                    onUpdateNodeConfig(selectedNodeId, patch);
-                  }
-                }}
-                pinned={bottomPanelPinned}
-                selectedNode={selectedNode}
-                selectedSchema={selectedSchema}
-                unreadLogsCount={unreadLogsCount}
-              />
-            </ResizablePanel>
-          </ResizablePanelGroup>
-        </div>
-      </ResizablePanel>
-      <ResizableHandle withHandle />
+              <ResizablePanel defaultSize="70%" minSize="20%">
+                <CanvasOrEditor {...props} />
+              </ResizablePanel>
+              <ResizableHandle withHandle />
+              <ResizablePanel
+                panelRef={bottomPanelRef}
+                // collapsedSize is in % of the canvas-column height. 8% on a
+                // typical 800–1000px column ≈ 64–80px, which accommodates the
+                // ~60px tab strip without clipping it. The previous 3%
+                // (~24–30px) cut off the bottom half of the tab buttons.
+                collapsedSize="8%"
+                collapsible
+                // 45% gives Git / Lineage / Logs tabs enough vertical room
+                // for their list + detail content out-of-the-box. 30% (prior
+                // default) made the Git history list unreadable on a 1080p
+                // canvas column.
+                defaultSize="45%"
+                minSize="10%"
+              >
+                <BottomPanel
+                  activeTab={activeBottomTab}
+                  blockOutputs={scopedBlockOutputs}
+                  edges={workflowEdges}
+                  logEntries={logEntries}
+                  onTabChange={onBottomTabChange}
+                  onTogglePin={toggleBottomPanelPinned}
+                  onUpdateConfig={(patch) => {
+                    if (selectedNodeId) {
+                      onUpdateNodeConfig(selectedNodeId, patch);
+                    }
+                  }}
+                  pinned={bottomPanelPinned}
+                  selectedNode={selectedNode}
+                  selectedSchema={selectedSchema}
+                  unreadLogsCount={unreadLogsCount}
+                />
+              </ResizablePanel>
+            </ResizablePanelGroup>
+          </div>
+        </ResizablePanel>
+        <ResizableHandle withHandle />
 
-      {/* Data Preview — full height right column */}
-      <ResizablePanel defaultSize="22%" minSize="15%" maxSize="42%" collapsible collapsedSize="0%">
-        <DataPreview
-          blockOutputs={scopedBlockOutputs}
-          subworkflowPorts={subworkflowPorts}
-          selectedNodeId={selectedNodeId}
-          selectedNodeLabel={selectedNodeLabel}
-          // #1326 port-info panel: resolve effective per-instance ports for
-          // the selected node.
-          //
-          // Hotfix 2026-05-23: ``node.config`` is a two-tier envelope where
-          // user-editable params live under ``node.config.params`` (see
-          // ``mergeNodeConfig``). The canvas-side BlockNode reads
-          // ``paramsOf(node) = node.config.params``; we mirror that here so
-          // both ``resolveVariadicPorts`` (variadic ports stored at
-          // ``params.{input,output}_ports``) AND ``computeEffectivePorts``
-          // (dynamic-port driving key at ``params.core_type``) see the
-          // same config the canvas sees. Reading ``node.config`` directly
-          // was a pre-existing bug that hid newly-added variadic ports
-          // from the panel and froze dynamic-port types at their
-          // schema-static fallback ``DataObject``.
-          selectedInputPorts={
-            selectedNode && selectedSchema
-              ? computeEffectivePorts(
-                  selectedSchema.dynamic_ports ?? null,
-                  selectedSchema.dynamic_ports?.source_config_key
-                    ? (((selectedNode.config.params as Record<string, unknown> | undefined) ?? {})[
-                        selectedSchema.dynamic_ports.source_config_key
-                      ] as string | undefined)
-                    : undefined,
-                  resolveVariadicPorts(
-                    selectedSchema.input_ports,
-                    (selectedNode.config.params as Record<string, unknown> | undefined) ?? {},
+        {/* Data Preview — full height right column */}
+        <ResizablePanel
+          defaultSize="22%"
+          minSize="15%"
+          maxSize="42%"
+          collapsible
+          collapsedSize="0%"
+        >
+          <DataPreview
+            blockOutputs={scopedBlockOutputs}
+            subworkflowPorts={subworkflowPorts}
+            selectedNodeId={selectedNodeId}
+            selectedNodeLabel={selectedNodeLabel}
+            // #1326 port-info panel: resolve effective per-instance ports for
+            // the selected node.
+            //
+            // Hotfix 2026-05-23: ``node.config`` is a two-tier envelope where
+            // user-editable params live under ``node.config.params`` (see
+            // ``mergeNodeConfig``). The canvas-side BlockNode reads
+            // ``paramsOf(node) = node.config.params``; we mirror that here so
+            // both ``resolveVariadicPorts`` (variadic ports stored at
+            // ``params.{input,output}_ports``) AND ``computeEffectivePorts``
+            // (dynamic-port driving key at ``params.core_type``) see the
+            // same config the canvas sees. Reading ``node.config`` directly
+            // was a pre-existing bug that hid newly-added variadic ports
+            // from the panel and froze dynamic-port types at their
+            // schema-static fallback ``DataObject``.
+            selectedInputPorts={
+              selectedNode && selectedSchema
+                ? computeEffectivePorts(
+                    selectedSchema.dynamic_ports ?? null,
+                    selectedSchema.dynamic_ports?.source_config_key
+                      ? (((selectedNode.config.params as Record<string, unknown> | undefined) ??
+                          {})[selectedSchema.dynamic_ports.source_config_key] as string | undefined)
+                      : undefined,
+                    resolveVariadicPorts(
+                      selectedSchema.input_ports,
+                      (selectedNode.config.params as Record<string, unknown> | undefined) ?? {},
+                      "input",
+                      selectedSchema,
+                    ),
                     "input",
-                    selectedSchema,
-                  ),
-                  "input",
-                )
-              : undefined
-          }
-          selectedOutputPorts={
-            selectedNode && selectedSchema
-              ? computeEffectivePorts(
-                  selectedSchema.dynamic_ports ?? null,
-                  selectedSchema.dynamic_ports?.source_config_key
-                    ? (((selectedNode.config.params as Record<string, unknown> | undefined) ?? {})[
-                        selectedSchema.dynamic_ports.source_config_key
-                      ] as string | undefined)
-                    : undefined,
-                  resolveVariadicPorts(
-                    selectedSchema.output_ports,
-                    (selectedNode.config.params as Record<string, unknown> | undefined) ?? {},
+                  )
+                : undefined
+            }
+            selectedOutputPorts={
+              selectedNode && selectedSchema
+                ? computeEffectivePorts(
+                    selectedSchema.dynamic_ports ?? null,
+                    selectedSchema.dynamic_ports?.source_config_key
+                      ? (((selectedNode.config.params as Record<string, unknown> | undefined) ??
+                          {})[selectedSchema.dynamic_ports.source_config_key] as string | undefined)
+                      : undefined,
+                    resolveVariadicPorts(
+                      selectedSchema.output_ports,
+                      (selectedNode.config.params as Record<string, unknown> | undefined) ?? {},
+                      "output",
+                      selectedSchema,
+                    ),
                     "output",
-                    selectedSchema,
-                  ),
-                  "output",
-                )
-              : undefined
-          }
-          selectedSchema={selectedSchema}
-        />
-      </ResizablePanel>
-    </ResizablePanelGroup>
+                  )
+                : undefined
+            }
+            selectedSchema={selectedSchema}
+          />
+        </ResizablePanel>
+      </ResizablePanelGroup>
+    </div>
   );
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -22,7 +22,7 @@
 //     BlockNode split; useAppKeyboardShortcuts here).
 
 import { ReactFlowProvider } from "@xyflow/react";
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 
 import { useLogStream } from "./hooks/useSSE";
 import { useWorkflowWebSocket } from "./hooks/useWebSocket";
@@ -243,6 +243,38 @@ export default function App() {
   const { activeFileTab, activeTabKind } = useActiveTab(tabs as AnyTab[], activeTabId);
   const [busy, setBusy] = useState(false);
   const [leftTab, setLeftTab] = useState<LeftTab>("blocks");
+  const paletteCollapsed = useAppStore((state) => state.paletteCollapsed);
+  /*
+   * #2090 — left-panel section routing.
+   *
+   * `selectLeftTab` is the programmatic switch (library reveal, tutorial
+   * routing): it always expands the panel, because a section switch that
+   * lands behind a collapsed panel is invisible. `handleActivitySelect` is
+   * the activity-bar icon click: clicking the active section while the panel
+   * is open collapses it (VS Code behavior), anything else opens that
+   * section.
+   *
+   * Both read collapse state through `getState()` so neither needs
+   * `paletteCollapsed` / `togglePalette` in its dependency array.
+   */
+  const selectLeftTab = useCallback((tab: LeftTab) => {
+    setLeftTab(tab);
+    if (useAppStore.getState().paletteCollapsed) {
+      useAppStore.getState().togglePalette();
+    }
+  }, []);
+  const handleActivitySelect = useCallback(
+    (tab: LeftTab) => {
+      const { paletteCollapsed: collapsed, togglePalette: toggle } = useAppStore.getState();
+      if (tab === leftTab && !collapsed) {
+        toggle();
+      } else {
+        setLeftTab(tab);
+        if (collapsed) toggle();
+      }
+    },
+    [leftTab],
+  );
   const openNewPlotPicker = useAppStore((state) => state.openNewPlotPicker);
   const { promptRequest, promptInput, clearPrompt } = usePromptInput();
   const {
@@ -381,7 +413,7 @@ export default function App() {
    */
   useLearningCenter({
     wsConnected,
-    setLeftTab,
+    setLeftTab: selectLeftTab,
     openProject,
     closeProject: () => closeCurrentProject({ setCurrentProject, setWorkflow, resetExecution }),
   });
@@ -475,8 +507,11 @@ export default function App() {
             <>
               <ProjectWorkspace
                 currentProject={currentProject}
+                workflowId={workflowId}
                 leftTab={leftTab}
-                onLeftTabChange={setLeftTab}
+                onLeftTabChange={selectLeftTab}
+                onActivitySelect={handleActivitySelect}
+                paletteCollapsed={paletteCollapsed}
                 blocks={blocks}
                 paletteSearch={paletteSearch}
                 setPaletteSearch={setPaletteSearch}

--- a/frontend/src/components/ActivityBar.test.tsx
+++ b/frontend/src/components/ActivityBar.test.tsx
@@ -23,7 +23,7 @@ describe("ActivityBar", () => {
   it("renders one icon button per left-panel section", () => {
     renderBar();
     expect(screen.getByTestId("activity-bar")).toBeInTheDocument();
-    for (const label of ["Blocks", "Data types", "Workflows", "Project"]) {
+    for (const label of ["Blocks", "Data types", "Workflows", "Data", "Project"]) {
       expect(screen.getByRole("button", { name: label })).toBeInTheDocument();
     }
   });

--- a/frontend/src/components/ActivityBar.test.tsx
+++ b/frontend/src/components/ActivityBar.test.tsx
@@ -1,0 +1,61 @@
+// #2090 — the VS Code-style activity bar: icon rail, hover tooltips, and the
+// active-section marker (hidden while the panel is collapsed).
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { ActivityBar, type ActivityBarProps } from "./ActivityBar";
+import { TooltipProvider } from "./ui/tooltip";
+
+afterEach(cleanup);
+
+function renderBar(overrides: Partial<ActivityBarProps> = {}) {
+  const onSelect = vi.fn();
+  render(
+    <TooltipProvider delayDuration={0}>
+      <ActivityBar activeTab="blocks" panelOpen onSelect={onSelect} {...overrides} />
+    </TooltipProvider>,
+  );
+  return onSelect;
+}
+
+describe("ActivityBar", () => {
+  it("renders one icon button per left-panel section", () => {
+    renderBar();
+    expect(screen.getByTestId("activity-bar")).toBeInTheDocument();
+    for (const label of ["Blocks", "Data types", "Workflows", "Project"]) {
+      expect(screen.getByRole("button", { name: label })).toBeInTheDocument();
+    }
+  });
+
+  it("reports the clicked section", () => {
+    const onSelect = renderBar();
+    fireEvent.click(screen.getByRole("button", { name: "Workflows" }));
+    expect(onSelect).toHaveBeenCalledWith("workflows");
+    fireEvent.click(screen.getByRole("button", { name: "Project" }));
+    expect(onSelect).toHaveBeenCalledWith("project");
+  });
+
+  it("marks the active section only while the panel is open", () => {
+    renderBar({ activeTab: "types", panelOpen: true });
+    expect(screen.getByRole("button", { name: "Data types" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(screen.getByRole("button", { name: "Blocks" })).toHaveAttribute("aria-pressed", "false");
+
+    cleanup();
+    renderBar({ activeTab: "types", panelOpen: false });
+    // VS Code behavior: a collapsed panel shows no active marker at all.
+    expect(screen.getByRole("button", { name: "Data types" })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+  });
+
+  it("shows the section name in a tooltip on hover/focus", async () => {
+    renderBar();
+    fireEvent.focus(screen.getByRole("button", { name: "Workflows" }));
+    expect(await screen.findByRole("tooltip")).toHaveTextContent("Workflows");
+  });
+});

--- a/frontend/src/components/ActivityBar.tsx
+++ b/frontend/src/components/ActivityBar.tsx
@@ -8,7 +8,7 @@
 // resizes and stays visible when the panel is collapsed, which is what makes
 // the collapsed state discoverable.
 
-import { FolderTree, Puzzle, Shapes, Waypoints, type LucideIcon } from "lucide-react";
+import { Database, FolderTree, Puzzle, Shapes, Waypoints, type LucideIcon } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 
@@ -22,11 +22,13 @@ interface ActivityBarEntry {
 }
 
 // Top-to-bottom visual order. `workflows` sits between the library sections
-// (blocks / types) and the raw project tree.
+// (blocks / types) and the data/project trees; `data` (#2090) is the project
+// tree rooted at data/.
 const ACTIVITY_BAR_ENTRIES: readonly ActivityBarEntry[] = [
   { key: "blocks", label: "Blocks", icon: Puzzle },
   { key: "types", label: "Data types", icon: Shapes },
   { key: "workflows", label: "Workflows", icon: Waypoints },
+  { key: "data", label: "Data", icon: Database },
   { key: "project", label: "Project", icon: FolderTree },
 ];
 

--- a/frontend/src/components/ActivityBar.tsx
+++ b/frontend/src/components/ActivityBar.tsx
@@ -1,0 +1,91 @@
+// The workspace activity bar (#2090): the narrow vertical icon rail at the far
+// left of the window, VS Code-style. Each icon opens its section of the left
+// panel; clicking the active section's icon collapses the panel instead
+// (click again — or press Ctrl+B — to reopen). Hovering an icon shows the
+// section name in a tooltip.
+//
+// The rail is intentionally outside the `ResizablePanelGroup`: it never
+// resizes and stays visible when the panel is collapsed, which is what makes
+// the collapsed state discoverable.
+
+import { FolderTree, Puzzle, Shapes, Waypoints, type LucideIcon } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+import type { LeftTab } from "../App.parts/ProjectWorkspace";
+import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/tooltip";
+
+interface ActivityBarEntry {
+  key: LeftTab;
+  label: string;
+  icon: LucideIcon;
+}
+
+// Top-to-bottom visual order. `workflows` sits between the library sections
+// (blocks / types) and the raw project tree.
+const ACTIVITY_BAR_ENTRIES: readonly ActivityBarEntry[] = [
+  { key: "blocks", label: "Blocks", icon: Puzzle },
+  { key: "types", label: "Data types", icon: Shapes },
+  { key: "workflows", label: "Workflows", icon: Waypoints },
+  { key: "project", label: "Project", icon: FolderTree },
+];
+
+export interface ActivityBarProps {
+  /** The section the left panel shows (or would show when reopened). */
+  activeTab: LeftTab;
+  /** Whether the left panel is currently expanded. */
+  panelOpen: boolean;
+  /**
+   * Icon click. The owner (App) decides between "switch section", "expand",
+   * and "collapse": clicking the active section while the panel is open
+   * collapses it, everything else opens that section.
+   */
+  onSelect: (tab: LeftTab) => void;
+}
+
+export function ActivityBar({ activeTab, panelOpen, onSelect }: ActivityBarProps) {
+  return (
+    <nav
+      aria-label="Workspace sections"
+      className="flex w-12 shrink-0 flex-col items-center gap-1 border-r border-stone-200 bg-[linear-gradient(180deg,_rgba(255,255,255,0.95),_rgba(245,241,232,0.98))] py-2"
+      data-testid="activity-bar"
+    >
+      {ACTIVITY_BAR_ENTRIES.map(({ key, label, icon: Icon }) => {
+        // A collapsed panel shows no active marker at all — same as VS Code.
+        const active = panelOpen && activeTab === key;
+        return (
+          <Tooltip key={key}>
+            <TooltipTrigger asChild>
+              <button
+                aria-label={label}
+                aria-pressed={active}
+                className={cn(
+                  "relative flex h-10 w-10 items-center justify-center rounded-md transition",
+                  // #2090 — active section: soft ember fill + ember icon, on
+                  // top of the edge accent bar (owner-requested color fill,
+                  // same `bg-ember/15` treatment as the bottom-panel pin).
+                  active
+                    ? "bg-ember/15 text-ember"
+                    : "text-stone-400 hover:bg-white/70 hover:text-stone-600",
+                )}
+                data-testid={`activity-bar-${key}`}
+                onClick={() => onSelect(key)}
+                type="button"
+              >
+                {/* VS Code-style active marker: a short accent bar on the
+                    rail's left edge rather than a background fill. The button
+                    is centered in the 48px rail, so -left-1 lands the bar on
+                    the rail edge. */}
+                {active ? (
+                  <span className="absolute -left-1 top-1/2 h-5 w-0.5 -translate-y-1/2 rounded-full bg-ember" />
+                ) : null}
+                <Icon className="h-5 w-5" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="right">{label}</TooltipContent>
+          </Tooltip>
+        );
+      })}
+    </nav>
+  );
+}

--- a/frontend/src/components/BottomPanel.parts/TabBar.tsx
+++ b/frontend/src/components/BottomPanel.parts/TabBar.tsx
@@ -1,5 +1,6 @@
 import {
   GitBranch,
+  History,
   LineChart,
   MessageSquare,
   Pin,
@@ -7,7 +8,6 @@ import {
   ScrollText,
   SlidersHorizontal,
   Terminal,
-  Waypoints,
 } from "lucide-react";
 import { type ReactNode } from "react";
 
@@ -36,7 +36,11 @@ const TAB_LABELS: Record<BottomTab, ReactNode> = {
   // the prior Jobs placeholder which is removed entirely.
   // #1713 follow-up — display label only is "History" (the BottomTab key and
   // all code stay "lineage"); owner-requested UI rename.
-  lineage: tabLabel(Waypoints, "History"),
+  // #2090 — the icon changed from Waypoints to History (the same glyph newer
+  // lucide releases call rotate-ccw-clock; this lucide version still names it
+  // History): Waypoints now belongs to the activity bar's Workflows section,
+  // and duplicated glyphs across the two rails read as the same destination.
+  lineage: tabLabel(History, "History"),
   // ADR-039 §3.5 (#972) — Git versioning surface moved out of the top
   // Toolbar into a dedicated bottom-panel tab so the commit history /
   // branch graph / merge flows are reachable without overflowing the

--- a/frontend/src/components/LearningCenter.parts/targets.ts
+++ b/frontend/src/components/LearningCenter.parts/targets.ts
@@ -21,8 +21,9 @@
  *
  *   - `history` → the `BottomTab` key `lineage`. The tab was renamed to
  *     "History" in the UI by owner request (#1713 follow-up) while the key and
- *     all the code behind it stayed `lineage`. `TabBar.tsx` still reads
- *     `lineage: tabLabel(Waypoints, "History")`.
+ *     all the code behind it stayed `lineage`. `TabBar.tsx` now reads
+ *     `lineage: tabLabel(History, "History")` (#2090 moved `Waypoints`
+ *     to the activity bar's Workflows section).
  *   - `ai_chat` → the `BottomTab` key `ai`.
  *
  * The other five bottom-panel names match their keys exactly. Do not "fix"

--- a/frontend/src/components/ProjectTree.parts/useTreeNodes.ts
+++ b/frontend/src/components/ProjectTree.parts/useTreeNodes.ts
@@ -1,6 +1,10 @@
 /**
  * Tree-state hook for ProjectTree (lazy-loaded children, expand/collapse,
  * refresh wiring). Extracted in #1413 so the parent function stays small.
+ *
+ * `basePath` roots the tree at a project subdirectory instead of the project
+ * root — the #2090 Data section passes "data" so the panel shows only the
+ * project's data folders while every path below stays project-relative.
  */
 import { useCallback, useEffect, useRef, useState } from "react";
 
@@ -48,7 +52,7 @@ export interface UseTreeNodesResult {
   handleToggle: (node: TreeNodeData) => Promise<void>;
 }
 
-export function useTreeNodes(projectId: string): UseTreeNodesResult {
+export function useTreeNodes(projectId: string, basePath = ""): UseTreeNodesResult {
   const [rootNodes, setRootNodes] = useState<TreeNodeData[]>([]);
   const [loading, setLoading] = useState(false);
   // Mirror the latest tree so `refresh()` (a stable callback) can read the
@@ -81,7 +85,7 @@ export function useTreeNodes(projectId: string): UseTreeNodesResult {
       // loaded before a descendant is merged into them; folders that vanished
       // since the last load are skipped and simply stay collapsed.
       const expandedPaths = collectExpandedPaths(rootNodesRef.current);
-      let tree = await loadChildren("");
+      let tree = await loadChildren(basePath);
       for (const path of expandedPaths) {
         try {
           const children = await loadChildren(path);
@@ -96,7 +100,7 @@ export function useTreeNodes(projectId: string): UseTreeNodesResult {
     } finally {
       setLoading(false);
     }
-  }, [loadChildren]);
+  }, [loadChildren, basePath]);
 
   useEffect(() => {
     void refresh();

--- a/frontend/src/components/ProjectTree.tsx
+++ b/frontend/src/components/ProjectTree.tsx
@@ -120,7 +120,7 @@ export function ProjectTree({
 }: ProjectTreeProps) {
   const { rootNodes, loading, refresh, handleToggle } = useTreeNodes(projectId);
   const [contextMenu, setContextMenu] = useState<ContextMenuState | null>(null);
-  // Blink the tree once a Refresh actually lands (same feedback as the palette).
+  // Blink the tree once a Reload actually lands (same feedback as the palette).
   const { ref: treeRef, trigger: triggerFlash } = useReloadFlash<HTMLDivElement, TreeNodeData[]>(
     rootNodes,
   );
@@ -176,7 +176,9 @@ export function ProjectTree({
       <div className="flex items-center justify-between gap-2">
         <p className="font-display text-xl text-ink">Project</p>
         <button className="toolbar-button" disabled={loading} onClick={handleRefresh} type="button">
-          {loading ? "..." : "Refresh"}
+          {/* #2090 — "Reload" wording shared with the Blocks palette and the
+              Workflows section; one verb for every left-panel reload. */}
+          {loading ? "..." : "Reload"}
         </button>
       </div>
 

--- a/frontend/src/components/ProjectTree.tsx
+++ b/frontend/src/components/ProjectTree.tsx
@@ -18,6 +18,13 @@ interface ProjectTreeProps {
    */
   onLoadWorkflow: (filePath: string, displayName: string) => void;
   onReloadBlocks: () => void;
+  /**
+   * #2090 — root the tree at a project subdirectory (the Data section passes
+   * "data") instead of the project root. Paths below stay project-relative.
+   */
+  rootPath?: string;
+  /** Panel title; defaults to "Project". The Data section passes "Data". */
+  title?: string;
 }
 
 function fileIcon(entry: TreeEntry): string {
@@ -117,8 +124,10 @@ export function ProjectTree({
   projectPath,
   onLoadWorkflow,
   onReloadBlocks,
+  rootPath = "",
+  title = "Project",
 }: ProjectTreeProps) {
-  const { rootNodes, loading, refresh, handleToggle } = useTreeNodes(projectId);
+  const { rootNodes, loading, refresh, handleToggle } = useTreeNodes(projectId, rootPath);
   const [contextMenu, setContextMenu] = useState<ContextMenuState | null>(null);
   // Blink the tree once a Reload actually lands (same feedback as the palette).
   const { ref: treeRef, trigger: triggerFlash } = useReloadFlash<HTMLDivElement, TreeNodeData[]>(
@@ -174,7 +183,7 @@ export function ProjectTree({
   return (
     <aside className="flex h-full flex-col overflow-hidden border-r border-stone-200 bg-[linear-gradient(180deg,_rgba(255,255,255,0.95),_rgba(245,241,232,0.98))] p-4">
       <div className="flex items-center justify-between gap-2">
-        <p className="font-display text-xl text-ink">Project</p>
+        <p className="font-display text-xl text-ink">{title}</p>
         <button className="toolbar-button" disabled={loading} onClick={handleRefresh} type="button">
           {/* #2090 — "Reload" wording shared with the Blocks palette and the
               Workflows section; one verb for every left-panel reload. */}

--- a/frontend/src/components/WorkflowPanel.test.tsx
+++ b/frontend/src/components/WorkflowPanel.test.tsx
@@ -1,0 +1,110 @@
+// #2090 — the Workflows left-panel section: lists every workflow in the open
+// project with its YAML description, highlights the one on the canvas, and
+// opens one on click.
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { api } from "../lib/api";
+import { WorkflowPanel } from "./WorkflowPanel";
+
+vi.mock("../lib/api", () => ({
+  api: {
+    listWorkflows: vi.fn(),
+    getWorkflow: vi.fn(),
+  },
+}));
+
+const listWorkflows = vi.mocked(api.listWorkflows);
+const getWorkflow = vi.mocked(api.getWorkflow);
+
+function workflowResponse(id: string, description: string) {
+  return {
+    id,
+    version: "1.0.0",
+    description,
+    nodes: [],
+    edges: [],
+    metadata: {},
+  };
+}
+
+afterEach(cleanup);
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+describe("WorkflowPanel", () => {
+  it("lists every workflow with its YAML description", async () => {
+    listWorkflows.mockResolvedValue(["main", "qc"]);
+    getWorkflow.mockImplementation(async (id) =>
+      workflowResponse(id, id === "main" ? "Primary pipeline" : "Quality control"),
+    );
+
+    render(<WorkflowPanel projectId="p1" activeWorkflowId={null} onOpenWorkflow={vi.fn()} />);
+
+    expect(await screen.findByText("main")).toBeInTheDocument();
+    expect(screen.getByText("Primary pipeline")).toBeInTheDocument();
+    expect(screen.getByText("qc")).toBeInTheDocument();
+    expect(screen.getByText("Quality control")).toBeInTheDocument();
+  });
+
+  it("opens a workflow on click", async () => {
+    listWorkflows.mockResolvedValue(["main"]);
+    getWorkflow.mockResolvedValue(workflowResponse("main", ""));
+    const onOpenWorkflow = vi.fn();
+
+    render(
+      <WorkflowPanel projectId="p1" activeWorkflowId={null} onOpenWorkflow={onOpenWorkflow} />,
+    );
+
+    fireEvent.click(await screen.findByText("main"));
+    expect(onOpenWorkflow).toHaveBeenCalledWith("main", "main");
+  });
+
+  it("highlights the workflow on the canvas", async () => {
+    listWorkflows.mockResolvedValue(["main", "qc"]);
+    getWorkflow.mockImplementation(async (id) => workflowResponse(id, ""));
+
+    render(<WorkflowPanel projectId="p1" activeWorkflowId="qc" onOpenWorkflow={vi.fn()} />);
+
+    const activeRow = await screen.findByText("qc");
+    expect(activeRow.closest("button")).toHaveAttribute("aria-current", "true");
+    expect(screen.getByText("main").closest("button")).toHaveAttribute("aria-current", "false");
+  });
+
+  it("still lists a workflow whose detail fetch fails, without a description", async () => {
+    listWorkflows.mockResolvedValue(["broken", "main"]);
+    getWorkflow.mockImplementation(async (id) => {
+      if (id === "broken") throw new Error("mid-write YAML");
+      return workflowResponse(id, "Primary pipeline");
+    });
+
+    render(<WorkflowPanel projectId="p1" activeWorkflowId={null} onOpenWorkflow={vi.fn()} />);
+
+    expect(await screen.findByText("broken")).toBeInTheDocument();
+    expect(screen.getByText("main")).toBeInTheDocument();
+    expect(screen.getAllByText("Primary pipeline")).toHaveLength(1);
+  });
+
+  it("shows the empty state when the project has no workflows", async () => {
+    listWorkflows.mockResolvedValue([]);
+
+    render(<WorkflowPanel projectId="p1" activeWorkflowId={null} onOpenWorkflow={vi.fn()} />);
+
+    expect(await screen.findByText("No workflows found")).toBeInTheDocument();
+  });
+
+  it("refetches on Refresh", async () => {
+    listWorkflows.mockResolvedValue(["main"]);
+    getWorkflow.mockImplementation(async (id) => workflowResponse(id, ""));
+
+    render(<WorkflowPanel projectId="p1" activeWorkflowId={null} onOpenWorkflow={vi.fn()} />);
+
+    await screen.findByText("main");
+    fireEvent.click(screen.getByRole("button", { name: "Refresh" }));
+    await screen.findByText("main");
+    expect(listWorkflows).toHaveBeenCalledTimes(2);
+  });
+});

--- a/frontend/src/components/WorkflowPanel.test.tsx
+++ b/frontend/src/components/WorkflowPanel.test.tsx
@@ -96,14 +96,14 @@ describe("WorkflowPanel", () => {
     expect(await screen.findByText("No workflows found")).toBeInTheDocument();
   });
 
-  it("refetches on Refresh", async () => {
+  it("refetches on Reload", async () => {
     listWorkflows.mockResolvedValue(["main"]);
     getWorkflow.mockImplementation(async (id) => workflowResponse(id, ""));
 
     render(<WorkflowPanel projectId="p1" activeWorkflowId={null} onOpenWorkflow={vi.fn()} />);
 
     await screen.findByText("main");
-    fireEvent.click(screen.getByRole("button", { name: "Refresh" }));
+    fireEvent.click(screen.getByRole("button", { name: "Reload" }));
     await screen.findByText("main");
     expect(listWorkflows).toHaveBeenCalledTimes(2);
   });

--- a/frontend/src/components/WorkflowPanel.test.tsx
+++ b/frontend/src/components/WorkflowPanel.test.tsx
@@ -2,18 +2,28 @@
 // project with its YAML description, highlights the one on the canvas, and
 // opens one on click.
 
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import type * as ApiModule from "../lib/api";
 import { api } from "../lib/api";
+import { useAppStore } from "../store";
 import { WorkflowPanel } from "./WorkflowPanel";
 
-vi.mock("../lib/api", () => ({
-  api: {
-    listWorkflows: vi.fn(),
-    getWorkflow: vi.fn(),
-  },
-}));
+vi.mock("../lib/api", async () => {
+  // Partial mock: the real store (imported for the watcher-counter test)
+  // pulls in the full api surface, so only the two endpoints the panel
+  // calls are replaced.
+  const actual = await vi.importActual<typeof ApiModule>("../lib/api");
+  return {
+    ...actual,
+    api: {
+      ...actual.api,
+      listWorkflows: vi.fn(),
+      getWorkflow: vi.fn(),
+    },
+  };
+});
 
 const listWorkflows = vi.mocked(api.listWorkflows);
 const getWorkflow = vi.mocked(api.getWorkflow);
@@ -33,6 +43,9 @@ afterEach(cleanup);
 
 beforeEach(() => {
   vi.resetAllMocks();
+  // The panel subscribes to this watcher counter (Codex P2 on #2106); keep
+  // every test starting from the no-bump baseline.
+  useAppStore.setState({ projectTreeRefreshCounter: 0 });
 });
 
 describe("WorkflowPanel", () => {
@@ -105,6 +118,42 @@ describe("WorkflowPanel", () => {
     await screen.findByText("main");
     fireEvent.click(screen.getByRole("button", { name: "Reload" }));
     await screen.findByText("main");
+    expect(listWorkflows).toHaveBeenCalledTimes(2);
+  });
+
+  // Codex P2 on #2106.
+  it("ignores a stale refresh that resolves after a project switch", async () => {
+    let resolveOld!: (ids: string[]) => void;
+    listWorkflows
+      .mockImplementationOnce(() => new Promise<string[]>((resolve) => (resolveOld = resolve)))
+      .mockResolvedValue(["wf-new"]);
+    getWorkflow.mockImplementation(async (id) => workflowResponse(id, `desc of ${id}`));
+
+    const { rerender } = render(
+      <WorkflowPanel projectId="p1" activeWorkflowId={null} onOpenWorkflow={vi.fn()} />,
+    );
+    // Switch projects while p1's list request is still outstanding.
+    rerender(<WorkflowPanel projectId="p2" activeWorkflowId={null} onOpenWorkflow={vi.fn()} />);
+    expect(await screen.findByText("wf-new")).toBeInTheDocument();
+
+    // The old project's request finishes last — it must not overwrite p2's list.
+    await act(async () => resolveOld(["wf-old"]));
+    expect(screen.queryByText("wf-old")).not.toBeInTheDocument();
+    expect(screen.getByText("wf-new")).toBeInTheDocument();
+  });
+
+  // Codex P2 on #2106 — same watcher counter the project tree subscribes to.
+  it("refreshes when the structural workflow counter bumps", async () => {
+    listWorkflows.mockResolvedValue(["main"]);
+    getWorkflow.mockImplementation(async (id) => workflowResponse(id, ""));
+
+    render(<WorkflowPanel projectId="p1" activeWorkflowId={null} onOpenWorkflow={vi.fn()} />);
+    await screen.findByText("main");
+    expect(listWorkflows).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      useAppStore.setState({ projectTreeRefreshCounter: 1 });
+    });
     expect(listWorkflows).toHaveBeenCalledTimes(2);
   });
 });

--- a/frontend/src/components/WorkflowPanel.tsx
+++ b/frontend/src/components/WorkflowPanel.tsx
@@ -1,0 +1,104 @@
+// The Workflows left-panel section (#2090): every workflow in the current
+// project with the `description` from its YAML, single-click to open it on
+// the canvas.
+//
+// Data comes from the existing endpoints — `GET /api/workflows/list` for the
+// ids, then one `GET /api/workflows/{id}` per workflow for the description —
+// so the panel needed no backend change. Layout and the Refresh affordance
+// mirror `ProjectTree` so the left panel reads as one surface.
+
+import { useCallback, useEffect, useState } from "react";
+
+import { api } from "../lib/api";
+import { cn } from "@/lib/utils";
+
+interface WorkflowListItem {
+  id: string;
+  description: string;
+}
+
+export interface WorkflowPanelProps {
+  /** Refetch trigger: the list belongs to the open project. */
+  projectId: string;
+  /** The workflow currently on the canvas, highlighted in the list. */
+  activeWorkflowId: string | null;
+  onOpenWorkflow: (workflowId: string, displayName: string) => void;
+}
+
+export function WorkflowPanel({ projectId, activeWorkflowId, onOpenWorkflow }: WorkflowPanelProps) {
+  const [items, setItems] = useState<WorkflowListItem[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    try {
+      const ids = await api.listWorkflows();
+      const summaries = await Promise.all(
+        ids.map(async (id): Promise<WorkflowListItem> => {
+          try {
+            const workflow = await api.getWorkflow(id);
+            return { id, description: workflow.description ?? "" };
+          } catch {
+            // A workflow that fails to load (e.g. a mid-write YAML) still
+            // belongs in the list — just without a description.
+            return { id, description: "" };
+          }
+        }),
+      );
+      setItems(summaries);
+    } catch {
+      setItems([]);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    setItems([]);
+    void refresh();
+  }, [projectId, refresh]);
+
+  return (
+    <aside
+      className="flex h-full flex-col overflow-hidden border-r border-stone-200 bg-[linear-gradient(180deg,_rgba(255,255,255,0.95),_rgba(245,241,232,0.98))] p-4"
+      data-testid="workflow-panel"
+    >
+      <div className="flex items-center justify-between gap-2">
+        <p className="font-display text-xl text-ink">Workflows</p>
+        <button
+          className="toolbar-button"
+          disabled={loading}
+          onClick={() => void refresh()}
+          type="button"
+        >
+          {loading ? "..." : "Refresh"}
+        </button>
+      </div>
+
+      <div className="mt-4 min-h-0 flex-1 overflow-y-auto pb-6 scrollbar-thin">
+        {!loading && items.length === 0 ? (
+          <p className="text-xs text-stone-400">No workflows found</p>
+        ) : null}
+        <div className="flex flex-col gap-1">
+          {items.map((item) => (
+            <button
+              aria-current={item.id === activeWorkflowId}
+              className={cn(
+                "flex w-full flex-col gap-0.5 rounded px-2 py-1.5 text-left transition",
+                item.id === activeWorkflowId ? "bg-white shadow-sm" : "hover:bg-stone-100",
+              )}
+              key={item.id}
+              onClick={() => onOpenWorkflow(item.id, item.id)}
+              type="button"
+            >
+              <span className="truncate text-sm font-medium text-stone-700">{item.id}</span>
+              {item.description ? (
+                <span className="line-clamp-2 text-xs text-stone-400">{item.description}</span>
+              ) : null}
+            </button>
+          ))}
+        </div>
+      </div>
+    </aside>
+  );
+}

--- a/frontend/src/components/WorkflowPanel.tsx
+++ b/frontend/src/components/WorkflowPanel.tsx
@@ -66,7 +66,7 @@ export function WorkflowPanel({ projectId, activeWorkflowId, onOpenWorkflow }: W
       <div className="flex items-center justify-between gap-2">
         <p className="font-display text-xl text-ink">Workflows</p>
         {/* "Reload" matches the Blocks palette's affordance (#2090 owner
-            note); the project tree keeps its own "Refresh" wording. */}
+            note); the project tree uses the same wording. */}
         <button
           className="toolbar-button"
           disabled={loading}

--- a/frontend/src/components/WorkflowPanel.tsx
+++ b/frontend/src/components/WorkflowPanel.tsx
@@ -7,9 +7,10 @@
 // so the panel needed no backend change. Layout and the Reload affordance
 // mirror the Blocks palette so the left panel reads as one surface.
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import { api } from "../lib/api";
+import { useAppStore } from "../store";
 import { cn } from "@/lib/utils";
 
 interface WorkflowListItem {
@@ -28,8 +29,15 @@ export interface WorkflowPanelProps {
 export function WorkflowPanel({ projectId, activeWorkflowId, onOpenWorkflow }: WorkflowPanelProps) {
   const [items, setItems] = useState<WorkflowListItem[]>([]);
   const [loading, setLoading] = useState(false);
+  // Codex P2 on #2106 — `listWorkflows`/`getWorkflow` resolve against the
+  // backend's *active* project, so when the user switches projects with a
+  // refresh still in flight, the older request can finish last and overwrite
+  // the new project's list. A monotonic sequence token discards stale
+  // completions.
+  const requestSeq = useRef(0);
 
   const refresh = useCallback(async () => {
+    const seq = ++requestSeq.current;
     setLoading(true);
     try {
       const ids = await api.listWorkflows();
@@ -45,11 +53,11 @@ export function WorkflowPanel({ projectId, activeWorkflowId, onOpenWorkflow }: W
           }
         }),
       );
-      setItems(summaries);
+      if (seq === requestSeq.current) setItems(summaries);
     } catch {
-      setItems([]);
+      if (seq === requestSeq.current) setItems([]);
     } finally {
-      setLoading(false);
+      if (seq === requestSeq.current) setLoading(false);
     }
   }, []);
 
@@ -57,6 +65,16 @@ export function WorkflowPanel({ projectId, activeWorkflowId, onOpenWorkflow }: W
     setItems([]);
     void refresh();
   }, [projectId, refresh]);
+
+  // Codex P2 on #2106 — structural workflow changes (create/delete/rename by
+  // the embedded agent or another tab) bump the same watcher counter the
+  // project tree subscribes to; without it the list goes stale until the user
+  // clicks Reload.
+  const refreshCounter = useAppStore((s) => s.projectTreeRefreshCounter);
+  useEffect(() => {
+    if (refreshCounter === 0) return;
+    void refresh();
+  }, [refreshCounter, refresh]);
 
   return (
     <aside

--- a/frontend/src/components/WorkflowPanel.tsx
+++ b/frontend/src/components/WorkflowPanel.tsx
@@ -4,8 +4,8 @@
 //
 // Data comes from the existing endpoints — `GET /api/workflows/list` for the
 // ids, then one `GET /api/workflows/{id}` per workflow for the description —
-// so the panel needed no backend change. Layout and the Refresh affordance
-// mirror `ProjectTree` so the left panel reads as one surface.
+// so the panel needed no backend change. Layout and the Reload affordance
+// mirror the Blocks palette so the left panel reads as one surface.
 
 import { useCallback, useEffect, useState } from "react";
 
@@ -65,13 +65,15 @@ export function WorkflowPanel({ projectId, activeWorkflowId, onOpenWorkflow }: W
     >
       <div className="flex items-center justify-between gap-2">
         <p className="font-display text-xl text-ink">Workflows</p>
+        {/* "Reload" matches the Blocks palette's affordance (#2090 owner
+            note); the project tree keeps its own "Refresh" wording. */}
         <button
           className="toolbar-button"
           disabled={loading}
           onClick={() => void refresh()}
           type="button"
         >
-          {loading ? "..." : "Refresh"}
+          {loading ? "..." : "Reload"}
         </button>
       </div>
 

--- a/frontend/src/components/__tests__/ProjectTree.test.tsx
+++ b/frontend/src/components/__tests__/ProjectTree.test.tsx
@@ -132,6 +132,27 @@ describe("ProjectTree — Reload button (#2090)", () => {
   });
 });
 
+describe("ProjectTree — Data section rooting (#2090)", () => {
+  it("rootPath='data' loads the tree from the data/ subdirectory", async () => {
+    getProjectTreeMock.mockResolvedValue({
+      entries: [{ name: "raw", type: "directory" }],
+    } as any);
+    render(
+      <ProjectTree
+        projectId="proj-1"
+        projectPath="/tmp/proj-1"
+        title="Data"
+        rootPath="data"
+        onLoadWorkflow={vi.fn()}
+        onReloadBlocks={vi.fn()}
+      />,
+    );
+    await screen.findByText("raw");
+    expect(getProjectTreeMock).toHaveBeenCalledWith("proj-1", "data");
+    expect(screen.getByText("Data")).toBeInTheDocument();
+  });
+});
+
 describe("ProjectTree — expansion persists across a watcher refresh (#1751)", () => {
   it("keeps an expanded folder open when projectTreeRefreshCounter bumps", async () => {
     // Root lists one directory; expanding it lists one child file. Any other

--- a/frontend/src/components/__tests__/ProjectTree.test.tsx
+++ b/frontend/src/components/__tests__/ProjectTree.test.tsx
@@ -123,6 +123,15 @@ describe("ProjectTree — ADR-036 §3.5 double-click wiring (I36c)", () => {
   });
 });
 
+describe("ProjectTree — Reload button (#2090)", () => {
+  it("labels the reload affordance 'Reload' and refetches on click", async () => {
+    await renderTreeWith([{ name: "workflows", type: "directory" }]);
+    expect(getProjectTreeMock).toHaveBeenCalledTimes(1);
+    fireEvent.click(screen.getByRole("button", { name: "Reload" }));
+    await waitFor(() => expect(getProjectTreeMock).toHaveBeenCalledTimes(2));
+  });
+});
+
 describe("ProjectTree — expansion persists across a watcher refresh (#1751)", () => {
   it("keeps an expanded folder open when projectTreeRefreshCounter bumps", async () => {
     // Root lists one directory; expanding it lists one child file. Any other

--- a/frontend/src/store/types.ts
+++ b/frontend/src/store/types.ts
@@ -338,7 +338,7 @@ export interface UISlice {
    * reports a project-tree-relevant change. ``ProjectTree`` subscribes to
    * this counter so external edits (e.g. ``write_workflow`` from the
    * embedded agent) trigger an auto-refresh without the user clicking
-   * the Refresh button.
+   * the Reload button.
    */
   projectTreeRefreshCounter: number;
   /**


### PR DESCRIPTION
# Modernize the left sidebar: VS Code-style activity bar + Workflows panel

Closes #2090

## What changed

- **Activity bar** (`frontend/src/components/ActivityBar.tsx`): the left
  sidebar's text tab strip (Blocks / Data types / Project) is replaced by a
  48px vertical icon rail, VS Code-style. The rail sits outside the
  `ResizablePanelGroup`, so it never resizes and stays visible while the panel
  is collapsed. Each icon carries a hover tooltip; the active section gets an
  ember-filled highlight plus an edge accent bar.
- **Collapse wiring**: clicking the active section's icon collapses the panel,
  clicking again (or Ctrl+B) reopens it. This finally connects the store's
  `paletteCollapsed` state — previously written by Ctrl+B and the ADR-053
  FR-020 library reveal but never read — to the left `ResizablePanel`'s
  imperative handle. Programmatic section switches (library reveal, Learning
  Center step routing) always expand the panel.
- **Workflows section** (`frontend/src/components/WorkflowPanel.tsx`): a new
  fourth section lists every workflow in the open project with the
  `description` from its YAML, single-click to open on the canvas, the
  on-canvas workflow highlighted (`aria-current`), and a Reload affordance.
  Data comes from existing endpoints (`GET /api/workflows/list` +
  `GET /api/workflows/{id}`); a workflow whose detail fetch fails still
  appears, without a description. No backend change.
- **History tab icon** (`frontend/src/components/BottomPanel.parts/TabBar.tsx`):
  the bottom-panel History tab switches from `Waypoints` to the `History`
  (rotate-ccw-clock) glyph so it no longer duplicates the activity bar's
  Workflows icon.
- **Data section**: a fifth activity-bar entry (`Database` icon, between
  Workflows and Project) shows the project tree rooted at `data/` — `raw`,
  `processed`, `zarr`, `parquet`, `artifacts`, `exchange` — reusing
  `ProjectTree` via new optional `rootPath` / `title` props and a `basePath`
  parameter on `useTreeNodes`. Single-click file preview in the DataPreview
  panel was discussed and explicitly deferred (tracked TODO).
- **Reload wording**: the project tree and Workflows section reload buttons
  now read "Reload", matching the Blocks palette.

## Icons

Blocks → `Puzzle`, Data types → `Shapes` (unchanged), Workflows → `Waypoints`,
Project → `FolderTree` (unchanged); owner-selected during the live session.

## Tests

- New: `frontend/src/components/ActivityBar.test.tsx` (icon per section, click
  reporting, active marker only while open, hover tooltip).
- New: `frontend/src/components/WorkflowPanel.test.tsx` (ids + descriptions,
  click-to-open, active highlight, failed-detail fallback, empty state,
  Reload).
- Full frontend suite: 158 files / 1745 tests passing; typecheck clean.

## Docs

- `docs/specs/frontend-block-palette.md` — new §13 (activity bar, sections-not-
  tabs, Workflows section, test plan), plus corrections to the now-stale
  tab-strip wording in §11/§12 and the `governs` file/test lists.

Gate record: `.workflow/records/2090-guided-2090-activity-bar-layout.json`
