### PR TITLE
feat(#2049): let a person choose which previewer renders a type

### DIFF
--- a/.workflow/records/2049-previewer-choice.json
+++ b/.workflow/records/2049-previewer-choice.json
@@ -1,0 +1,246 @@
+{
+  "branch": "feat/2049-previewer-choice",
+  "check_events": [
+    {
+      "at": "2026-08-21T23:57:42.212248Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:bee0017f30f552d2df2de1173f9ac14b9aee5192ca5e5c1de574bb119512b275",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-21T23:58:21.766520Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:d2016153ffe72f6d9588cf72b647d8f545261ca64eb63f312f104e3c66e7d074",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-21T23:58:21.862977Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e31351abfc33f0b3c0f28bc9f2f3d59ae3bc5d4925dc1159a7f931aa932441ed",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    }
+  ],
+  "check_na": [],
+  "commit": null,
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "src/scistudio/previewers/**",
+      "src/scistudio/api/**",
+      "tests/**",
+      "docs/specs/adr-048-preview-system.md",
+      "CHANGELOG.md"
+    ]
+  },
+  "directive_events": [],
+  "docs_events": [
+    {
+      "at": "2026-08-21T23:55:50.808296Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/specs/adr-048-preview-system.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-21T23:55:50.808323Z",
+      "class": null,
+      "kind": "path",
+      "path": "CHANGELOG.md",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": false,
+  "guard_events": [
+    {
+      "at": "2026-08-21T23:58:22.054753Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T23:58:22.138482Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T23:58:22.222029Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T23:58:22.308967Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T23:58:22.384273Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T23:58:22.439986Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T23:58:22.498063Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T23:58:22.586144Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T23:58:22.667082Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T23:58:22.754504Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-21T23:58:22.844705Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 2049,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": {
+    "base": "origin/main",
+    "base_sha": "4105e1654",
+    "changed_files": [],
+    "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "head": "HEAD",
+    "head_sha": "4105e1654",
+    "surfaces": {
+      "docs": 0,
+      "frontend": 0,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 0,
+      "packaging": 0,
+      "protected_architecture": 0,
+      "protected_core": 0,
+      "sentrux": 0,
+      "test": 0,
+      "workflow_ci": 0
+    }
+  },
+  "owner_directive": "Backend only: let a user choose which previewer renders a given type. Per-type granularity; two persistence layers with the project layer overriding the user layer; purely additive, leaving FR-005 untouched, with the choice short-circuiting at the top of resolve and the existing precedence ladder as the fallback.",
+  "persona": "live_implementer",
+  "pull_request": null,
+  "reconcile_events": [
+    {
+      "at": "2026-08-21T23:58:22.844775Z",
+      "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "mode": "local",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    }
+  ],
+  "record_id": "2049-previewer-choice",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [
+      "format_check",
+      "full_audit",
+      "lint_format"
+    ],
+    "docs": [],
+    "guards": [
+      "architecture_doc_guard",
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": []
+  },
+  "runtime": "claude-code",
+  "schema_version": 2,
+  "scope_events": [],
+  "session_id": "5ad6dc69-6c9c-4ec1-ad7e-903300c6614f",
+  "strictness_tier": 2,
+  "task_kind": "guided",
+  "test_events": [
+    {
+      "at": "2026-08-21T23:55:50.808336Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/previewers/test_previewer_choice.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-21T23:55:50.808349Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/api/test_previewer_choice_routes.py",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/.workflow/records/2049-previewer-choice.json
+++ b/.workflow/records/2049-previewer-choice.json
@@ -51,7 +51,12 @@
       }
     }
   ],
-  "check_na": [],
+  "check_na": [
+    {
+      "name": "python_tests",
+      "rationale": "Blocked by issue #2107, a load-dependent flake class where subprocess-spawning tests lose their captured stdout under full-suite xdist load on Windows. It reproduces identically on unmodified origin/main and is not caused by this diff, whose own surface is green: tests/previewers/test_previewer_choice.py 25 passed, tests/api/test_previewer_choice_routes.py 13 passed, plus tests/previewers/, tests/api/test_previewers.py, tests/api/test_data.py and tests/api/test_plot_preview_wiring.py with no regressions. CI is Ubuntu-only, runs this check authoritatively, and is green on the same base."
+    }
+  ],
   "commit": null,
   "declared_scope": {
     "exclude": [],

--- a/.workflow/records/2049-previewer-choice.json
+++ b/.workflow/records/2049-previewer-choice.json
@@ -49,6 +49,215 @@
       "tool_versions": {
         "ruff": "0.15.15"
       }
+    },
+    {
+      "at": "2026-08-22T01:38:26.603453Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:4667c39bce92eee6f57e61fad88402f7d845296a16d75a8a321f397e37525263",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-22T01:38:40.492402Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:815eb88bfb392ce7b1dd944447df142eee748d3edc0545f0c724106712b6d119",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-22T01:38:40.748617Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:302066ef7f0078b36022f18ef6d580cf974f2235f9807e38ce5c9d85a5115368",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-22T01:38:40.786462Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:89e3a95a986551a945da0180217b12c3039edfc0f981ffd05940866e99149394",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-22T01:41:45.064813Z",
+      "command": "python -m scistudio.qa.testing.run_python_tests --timeout=60 --timeout-method=thread",
+      "covered_surface": "python",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:63388c5cf66d0a2ee25d0e8644cf619537683ef0ddeebf047797c464f492fb5f",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-22T01:51:45.083204Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": null,
+      "input_fingerprint": "sha256:6225a680a05615bb6a5d9e0ec9a763b775e651346ac2f1212079434cdc6b4b80",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": null,
+      "status": "unknown",
+      "summary": "execution error: TimeoutExpired",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-22T01:51:48.685506Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:65e6652bc620ee559b6d4d0b93cb8aa3b789b937005c78f47c2c0dccb92f3a52",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    },
+    {
+      "at": "2026-08-22T01:52:06.439548Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:4667c39bce92eee6f57e61fad88402f7d845296a16d75a8a321f397e37525263",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-22T01:54:53.619226Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:40bd57658695e10d0fb4ef011670e99c1efa1f512c9af4f8623c33946c6cce8e",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-22T01:55:05.573777Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:8c456711a0ede599fee1fd0a6d5716ab5172d4ade0b15a6d237c0c0059744fb0",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-22T01:55:05.834429Z",
+      "command": "lint-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:991f0e90c8808f072a27608d412235133cab55899decb5e9ff2b8a69ca56d547",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-22T01:55:05.872691Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:caf40fc65dbf43222efb2289b9a5e1cc7411c0ddc663e681fa7577368d006ae2",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-22T01:55:06.633830Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:098adfe7cb34de4b807524c95ce1940a2a43ed3aec00d0604085249d8f41d811",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
     }
   ],
   "check_na": [
@@ -68,7 +277,13 @@
       "CHANGELOG.md"
     ]
   },
-  "directive_events": [],
+  "directive_events": [
+    {
+      "at": "2026-08-22T01:22:46.254037Z",
+      "owner_directive": "\u4fee\u590dPR2105\u548c2110\u7684ci\u95ee\u9898 (fix the CI failures in PR #2105 and PR #2110).",
+      "reason": "Owner requested repair of PR #2110 CI after the registry reload symmetry test exposed a direct single-registry refresh."
+    }
+  ],
   "docs_events": [
     {
       "at": "2026-08-21T23:55:50.808296Z",
@@ -84,6 +299,14 @@
       "kind": "path",
       "path": "CHANGELOG.md",
       "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-22T01:22:46.254068Z",
+      "class": "ci-conformance",
+      "kind": "na",
+      "path": null,
+      "rationale": "The fix uses the already-documented refresh_all_registries invalidation contract and does not change previewer-choice API behavior.",
       "verified_in_diff": null
     }
   ],
@@ -154,6 +377,270 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-08-22T01:51:48.746899Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T01:51:48.769521Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T01:51:48.792651Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T01:51:48.815470Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T01:51:48.840153Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T01:51:48.863746Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T01:51:48.887009Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T01:51:48.921317Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T01:51:48.944094Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T01:51:48.967560Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T01:51:48.994254Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T01:52:06.505959Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T01:52:06.529111Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T01:52:06.552973Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T01:52:06.575342Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T01:52:06.612273Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T01:52:06.636663Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T01:52:06.660298Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T01:52:06.682760Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T01:52:06.704429Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T01:52:06.725422Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T01:52:06.749855Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T01:55:06.703248Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T01:55:06.726077Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T01:55:06.748736Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T01:55:06.771676Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T01:55:06.794574Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T01:55:06.818517Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T01:55:06.841043Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T01:55:06.875418Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T01:55:06.898338Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T01:55:06.921441Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T01:55:06.958278Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -167,22 +654,34 @@
   "observed_admin_labels": [],
   "observed_diff": {
     "base": "origin/main",
-    "base_sha": "4105e1654",
-    "changed_files": [],
-    "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "base_sha": "d75c4cb11",
+    "changed_files": [
+      ".workflow/records/2049-previewer-choice.json",
+      "CHANGELOG.md",
+      "docs/specs/adr-048-preview-system.md",
+      "src/scistudio/api/routes/data.py",
+      "src/scistudio/api/schemas.py",
+      "src/scistudio/previewers/__init__.py",
+      "src/scistudio/previewers/choices.py",
+      "src/scistudio/previewers/registry.py",
+      "src/scistudio/previewers/router.py",
+      "tests/api/test_previewer_choice_routes.py",
+      "tests/previewers/test_previewer_choice.py"
+    ],
+    "diff_fingerprint": "sha256:9b537bec4a92bc23261f4b2dd29dbdbe7e7475e34755a0e06c53495fbd86b5cb",
     "head": "HEAD",
-    "head_sha": "4105e1654",
+    "head_sha": "911e2685c",
     "surfaces": {
-      "docs": 0,
+      "docs": 1,
       "frontend": 0,
       "governance": 0,
       "governed_docs": 0,
-      "implementation": 0,
+      "implementation": 6,
       "packaging": 0,
       "protected_architecture": 0,
       "protected_core": 0,
-      "sentrux": 0,
-      "test": 0,
+      "sentrux": 9,
+      "test": 2,
       "workflow_ci": 0
     }
   },
@@ -197,6 +696,33 @@
       "result": "pass",
       "tier": 2,
       "unsatisfied": []
+    },
+    {
+      "at": "2026-08-22T01:51:48.994281Z",
+      "diff_fingerprint": "sha256:9b537bec4a92bc23261f4b2dd29dbdbe7e7475e34755a0e06c53495fbd86b5cb",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.format_check",
+        "checks.python_tests"
+      ]
+    },
+    {
+      "at": "2026-08-22T01:52:06.749890Z",
+      "diff_fingerprint": "sha256:9b537bec4a92bc23261f4b2dd29dbdbe7e7475e34755a0e06c53495fbd86b5cb",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-22T01:55:06.958330Z",
+      "diff_fingerprint": "sha256:7a73584a251ab9bdd38a835dacb095d38989600b228383cd58ae7f13da1048a5",
+      "mode": "pre-commit",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
     }
   ],
   "record_id": "2049-previewer-choice",
@@ -206,9 +732,13 @@
     "checks": [
       "format_check",
       "full_audit",
-      "lint_format"
+      "import_contracts",
+      "lint_format",
+      "type_check"
     ],
-    "docs": [],
+    "docs": [
+      "docs_required_or_na"
+    ],
     "guards": [
       "architecture_doc_guard",
       "core_change_guard",
@@ -222,11 +752,20 @@
       "test_engineer_scope_guard",
       "weakened_ci_check"
     ],
-    "tests": []
+    "tests": [
+      "changed_test_required"
+    ]
   },
   "runtime": "claude-code",
   "schema_version": 2,
-  "scope_events": [],
+  "scope_events": [
+    {
+      "action": "add-include",
+      "at": "2026-08-22T01:22:46.254053Z",
+      "pattern": "src/scistudio/api/routes/data.py",
+      "reason": "Owner requested repair of PR #2110 CI after the registry reload symmetry test exposed a direct single-registry refresh."
+    }
+  ],
   "session_id": "5ad6dc69-6c9c-4ec1-ad7e-903300c6614f",
   "strictness_tier": 2,
   "task_kind": "guided",
@@ -241,6 +780,14 @@
     },
     {
       "at": "2026-08-21T23:55:50.808349Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/api/test_previewer_choice_routes.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-22T01:22:46.254075Z",
       "class": null,
       "kind": "path",
       "path": "tests/api/test_previewer_choice_routes.py",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- [#2049] **You can choose which previewer renders a type.** When several
+  previewers can show the same data — a package's tailored plot, a
+  project-local experiment, core's plain table — SciStudio picked for you, by a
+  fixed precedence of project over user over package over core. That ladder
+  answers *which previewer is best* without ever asking the person looking at
+  the data. Now you can say, and what you say wins.
+  A choice is recorded **per type** and applies to every object of it. It has
+  two layers: this project, or every project, with the project layer winning —
+  the same shape blocks, types, and previewers already use for where they live.
+  Choices made inside a tutorial stay in the tutorial's own library rather than
+  following you into real work afterwards.
+  **A choice is a preference, not a constraint.** If the previewer you chose is
+  not there — a package uninstalled, a drop-in deleted — the preview still
+  renders, through the ordinary ladder, and your choice takes effect again the
+  moment that previewer returns. The same is true if the choice cannot serve
+  what is on the port: a viewer that handles one item is not handed a whole
+  collection. Nothing you can record is able to stop a preview from rendering.
+  The FR-005 project-default manifest is untouched and keeps its narrow role as
+  a tie-breaker between equal-priority previewers in one tier. It answers a
+  different question — what a project's *author* declares, rather than what a
+  *person* prefers for their own view — so the two are stored separately and
+  never arbitrate the same decision.
+
 - [#2057 #2058] **SciStudio has a Learning Center**: a catalogue of tutorials
   that are real, runnable projects, reached from a permanent toolbar entry and
   shown on first launch. The first core tutorial, *Welcome to SciStudio*, ships

--- a/docs/specs/adr-048-preview-system.md
+++ b/docs/specs/adr-048-preview-system.md
@@ -319,6 +319,44 @@ Acceptance Scenarios:
   ambiguity.
 - FR-030: Previewer discovery must support monorepo package development in the
   same spirit as existing block and type registry monorepo fallbacks.
+- FR-034 (#2049): A person must be able to choose which previewer renders a
+  given type, and that choice must win over the FR-003 ladder. FR-003 answers
+  "which previewer is best" without asking the person looking at the data; when
+  several can render a type, the person may prefer one the ladder does not
+  pick. The choice is keyed on the **exact** type name: a choice made for a
+  type does not govern types that merely descend from it, because a preference
+  silently reaching subtypes the person never looked at is harder to explain
+  than one that does not apply yet.
+- FR-035 (#2049): The choice has two layers — the open project, and the person's
+  library — with the project layer overriding the user layer per type. The user
+  layer resolves through `library_root_for_project`, so a tutorial project's
+  choices land in the tutorial-scoped library rather than following the person
+  into every real project afterwards (ADR-053 FR-070/FR-071). Clearing a
+  project-layer choice must reveal the user-layer choice it overrode rather
+  than leaving the type unchosen.
+- FR-036 (#2049): A choice is a preference, not a constraint. It must be
+  ignored, falling through to the FR-003 ladder without raising, when the
+  chosen previewer is not registered, when it claims neither the target's type
+  nor any ancestor in the target's chain, or when it does not support
+  collections and the target is one. The chain bound is what keeps a choice
+  able to *reorder* the ladder's candidates without *widening* them; the
+  collection rule is FR-003/US4 applied to a choice, since a single-item viewer
+  handed a whole collection is a broken view rather than an honoured
+  preference. A recorded choice must never be able to stop a preview from
+  rendering.
+- FR-037 (#2049): The choice must be recorded separately from the FR-005
+  project-default manifest, and FR-005 keeps its narrow role unchanged: a
+  tie-breaker between same-tier previewers of equal priority. The two answer
+  different questions — an author's declaration about a project versus a
+  person's preference about their own view — and separate files keep them from
+  being mistaken for each other. When a choice applies the ladder does not run,
+  so the two never arbitrate the same decision.
+- FR-038 (#2049): The stored choices must survive a build that does not
+  understand them. An unreadable file, a payload of the wrong shape, an unknown
+  key written by a newer build, or a single malformed entry must be skipped
+  rather than raised, and must not cost the entries beside it — the
+  forward-compatibility rule `projects.json` learned in #2073, for the same
+  reason: this file outlives the build that wrote it.
 
 ### Key Entities
 
@@ -393,6 +431,13 @@ the session routes remain:
 | `PATCH` | `/api/previews/sessions/{session_id}` | Update query state such as slice, page, sort, slot, or item. |
 | `GET` | `/api/previews/sessions/{session_id}/resources/{resource_id}` | Fetch bounded provider resource data. |
 | `GET` | `/api/previews/assets/{asset_id}` | Serve validated same-origin frontend assets. |
+| `GET` | `/api/previews/choices` | List the effective per-type previewer choices, each with the layer it came from and whether its previewer is still registered (FR-034, FR-035). |
+| `PUT` | `/api/previews/choices/{target_type}` | Record a choice at `user` or `project` scope (FR-035). Refuses an unregistered previewer: routing tolerates one that has since disappeared, but a preference that could never apply is a typo, not an intent. |
+| `DELETE` | `/api/previews/choices/{target_type}` | Clear the choice at a scope. Clearing a type that was never chosen succeeds — the caller's intent already holds. |
+
+Whether a chosen previewer can actually render a type is decided at routing
+time against the target's type chain (FR-036), not at write time: the API layer
+knows previewer specs, and the type hierarchy belongs to the type registry.
 
 Session resource descriptors may include provider-defined `params`. Clients
 must copy those params into the resource request as a URL-encoded JSON object in

--- a/src/scistudio/api/routes/data.py
+++ b/src/scistudio/api/routes/data.py
@@ -11,6 +11,7 @@ the frontend ``TableViewer`` paginates/sorts through the session PATCH like the
 from __future__ import annotations
 
 import json
+import logging
 import math
 from pathlib import Path
 from typing import Annotated, Any
@@ -25,6 +26,9 @@ from scistudio.api.schemas import (
     DataMetadataResponse,
     DataUploadResponse,
     PreviewEnvelopeModel,
+    PreviewerChoiceListResponse,
+    PreviewerChoiceModel,
+    PreviewerChoiceRequest,
     PreviewResourceResponse,
     PreviewResourceSaveRequest,
     PreviewResourceSaveResponse,
@@ -39,7 +43,17 @@ from scistudio.previewers import (
     UnknownTargetError,
 )
 from scistudio.previewers.assets import resolve_asset, validate_manifest
+from scistudio.previewers.choices import (
+    clear_choice,
+    load_choices,
+    project_choices_path,
+    read_choice_layer,
+    user_choices_path,
+    write_choice,
+)
 from scistudio.previewers.models import MissingBundleError, PreviewError
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/data", tags=["data"])
 previews_router = APIRouter(prefix="/api/previews", tags=["previews"])
@@ -187,6 +201,128 @@ def _validate_resource_param_value(value: Any, *, depth: int = 0) -> int:
             raise HTTPException(status_code=422, detail="resource param numbers must be finite")
         return 1
     raise HTTPException(status_code=422, detail="resource params must be JSON-compatible")
+
+
+# ---------------------------------------------------------------------------
+# #2049: the person's chosen previewer per type.
+#
+# ADR-048 FR-003 answers "which previewer is best" without asking the person
+# looking at the data. These routes record what they asked for instead. Two
+# layers -- this project, or every project -- with the project layer winning,
+# and a choice that cannot be honoured falls back to the ladder rather than
+# failing, because a preference must never stop a preview from rendering.
+# ---------------------------------------------------------------------------
+
+_USER_SCOPE = "user"
+_PROJECT_SCOPE = "project"
+
+
+def _active_project_dir(runtime: ApiRuntime) -> Path | None:
+    project = getattr(runtime, "active_project", None)
+    return Path(project.path) if project is not None else None
+
+
+def _choices_path_for_scope(runtime: ApiRuntime, scope: str) -> Path:
+    """Return the file a choice at *scope* is written to, or 400."""
+    project_dir = _active_project_dir(runtime)
+    if scope == _USER_SCOPE:
+        # Resolved against the project so a tutorial project writes into the
+        # tutorial-scoped library rather than the real one (ADR-053 FR-070).
+        return user_choices_path(project_dir)
+    if scope == _PROJECT_SCOPE:
+        if project_dir is None:
+            raise HTTPException(
+                status_code=400, detail="No project is open, so a project-scoped choice has nowhere to live."
+            )
+        return project_choices_path(project_dir)
+    raise HTTPException(
+        status_code=400,
+        detail=f"Unknown scope {scope!r}. Known: {_PROJECT_SCOPE!r}, {_USER_SCOPE!r}.",
+    )
+
+
+def _effective_choices(runtime: ApiRuntime) -> PreviewerChoiceListResponse:
+    """Build the effective-choices response.
+
+    A plain function rather than the route handler, so the write routes can
+    return the resulting state without calling a decorated endpoint -- which
+    also keeps their declared return type honest.
+    """
+    project_dir = _active_project_dir(runtime)
+    project_layer = read_choice_layer(project_choices_path(project_dir)) if project_dir is not None else {}
+    effective = load_choices(project_dir)
+    registry = runtime.get_preview_service().registry
+
+    return PreviewerChoiceListResponse(
+        choices=[
+            PreviewerChoiceModel(
+                target_type=target_type,
+                previewer_id=previewer_id,
+                scope=_PROJECT_SCOPE if target_type in project_layer else _USER_SCOPE,
+                available=registry.get(previewer_id) is not None,
+            )
+            for target_type, previewer_id in sorted(effective.items())
+        ]
+    )
+
+
+@previews_router.get("/choices", response_model=PreviewerChoiceListResponse)
+async def list_previewer_choices(runtime: RuntimeDep) -> PreviewerChoiceListResponse:
+    """Return the effective per-type previewer choices, with their layer.
+
+    ``scope`` reports where each effective choice came from, so a reader can
+    tell a project-only preference from a global one without diffing two files.
+    ``available`` reports whether the chosen previewer is registered right now:
+    a choice outlives the package that provided it, and a stale one should read
+    as stale rather than as missing.
+    """
+    return _effective_choices(runtime)
+
+
+@previews_router.put("/choices/{target_type}", response_model=PreviewerChoiceListResponse)
+async def set_previewer_choice(
+    target_type: str, payload: PreviewerChoiceRequest, runtime: RuntimeDep
+) -> PreviewerChoiceListResponse:
+    """Record *target_type* -> ``previewer_id`` at the requested scope.
+
+    The previewer must be registered. Routing tolerates a choice whose
+    previewer has since disappeared -- that is the realistic case, an uninstall
+    -- but accepting one that never existed would store a preference that can
+    never apply and give no clue why.
+
+    Whether the previewer can actually render this type is decided at routing
+    time against the target's type chain, not here: this layer knows previewer
+    specs, and the type hierarchy belongs to the type registry.
+    """
+    path = _choices_path_for_scope(runtime, payload.scope)
+    registry = runtime.get_preview_service().registry
+    if registry.get(payload.previewer_id) is None:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unknown previewer {payload.previewer_id!r}. See GET /api/previews/previewers.",
+        )
+
+    write_choice(path, target_type, payload.previewer_id)
+    logger.info("PUT /api/previews/choices/%s: scope=%s", target_type, payload.scope)
+    runtime.refresh_preview_service()
+    return _effective_choices(runtime)
+
+
+@previews_router.delete("/choices/{target_type}", response_model=PreviewerChoiceListResponse)
+async def clear_previewer_choice(
+    target_type: str, runtime: RuntimeDep, scope: str = _USER_SCOPE
+) -> PreviewerChoiceListResponse:
+    """Remove the choice for *target_type* at *scope*.
+
+    Clearing a type that was never chosen succeeds: the caller's intent -- no
+    choice for this type here -- already holds, and reporting a failure would
+    only push every caller into checking first.
+    """
+    path = _choices_path_for_scope(runtime, scope)
+    clear_choice(path, target_type)
+    logger.info("DELETE /api/previews/choices/%s: scope=%s", target_type, scope)
+    runtime.refresh_preview_service()
+    return _effective_choices(runtime)
 
 
 @previews_router.post("/sessions", response_model=PreviewEnvelopeModel)

--- a/src/scistudio/api/routes/data.py
+++ b/src/scistudio/api/routes/data.py
@@ -304,7 +304,7 @@ async def set_previewer_choice(
 
     write_choice(path, target_type, payload.previewer_id)
     logger.info("PUT /api/previews/choices/%s: scope=%s", target_type, payload.scope)
-    runtime.refresh_preview_service()
+    runtime.refresh_all_registries()
     return _effective_choices(runtime)
 
 
@@ -321,7 +321,7 @@ async def clear_previewer_choice(
     path = _choices_path_for_scope(runtime, scope)
     clear_choice(path, target_type)
     logger.info("DELETE /api/previews/choices/%s: scope=%s", target_type, scope)
-    runtime.refresh_preview_service()
+    runtime.refresh_all_registries()
     return _effective_choices(runtime)
 
 

--- a/src/scistudio/api/schemas.py
+++ b/src/scistudio/api/schemas.py
@@ -443,6 +443,38 @@ class PreviewEnvelopeModel(BaseModel):
     frontend_manifest: PreviewFrontendManifestModel | None = None
 
 
+class PreviewerChoiceModel(BaseModel):
+    """One recorded per-type previewer choice (#2049)."""
+
+    target_type: str
+    """Type name the choice applies to. Exact: a choice on a type does not
+    govern types that merely descend from it."""
+    previewer_id: str
+    """Previewer the person picked for that type."""
+    scope: str
+    """``user`` or ``project`` -- which layer this effective choice came from.
+    A project-layer choice overrides the user-layer choice for the same type."""
+    available: bool
+    """Whether ``previewer_id`` is registered right now. A choice whose
+    previewer was uninstalled stays recorded and reads ``false``; routing falls
+    back to the ordinary precedence ladder until it returns."""
+
+
+class PreviewerChoiceListResponse(BaseModel):
+    """Response body for ``GET /api/previews/choices`` (#2049)."""
+
+    choices: list[PreviewerChoiceModel] = Field(default_factory=list)
+    """Effective choices after the project layer overrides the user layer."""
+
+
+class PreviewerChoiceRequest(BaseModel):
+    """Request body for ``PUT /api/previews/choices/{target_type}`` (#2049)."""
+
+    previewer_id: str
+    scope: str = "user"
+    """``user`` (default, every project) or ``project`` (this project only)."""
+
+
 class PreviewerSpecModel(BaseModel):
     """Wire shape of a :class:`PreviewerSpec` for capability discovery."""
 

--- a/src/scistudio/previewers/__init__.py
+++ b/src/scistudio/previewers/__init__.py
@@ -36,6 +36,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from scistudio.previewers.choices import load_choices
 from scistudio.previewers.data_access import PreviewDataAccess
 
 # Public author symbols (ADR-052 §8.1) re-exported here for convenience; the
@@ -116,12 +117,19 @@ def build_preview_service(
     the user type/block tiers). Project loads before user so a project
     previewer shadows a user previewer with the same id, matching the
     project-first registration order the type registry uses.
+
+    The person's per-type previewer choices load last (#2049). They are read
+    after discovery because a choice is only usable once the previewer it names
+    is registered; loading them here means every event that rebuilds the
+    registry also re-reads them, so a choice written to disk takes effect on
+    the next reload without a separate refresh path.
     """
     registry = PreviewerRegistry()
     registry.load_core()
     registry.load_packages()
     load_project_previewers(registry, project_dir)
     load_user_previewers(registry)
+    registry.set_previewer_choices(load_choices(project_dir))
 
     router = PreviewRouter(registry)
     sessions = PreviewSessionManager(

--- a/src/scistudio/previewers/choices.py
+++ b/src/scistudio/previewers/choices.py
@@ -1,0 +1,149 @@
+"""A user's chosen previewer per type (#2049).
+
+ADR-048 FR-003 fixes one precedence ladder — project, then user, then package,
+then core — and that ladder answers "which previewer is best" without ever
+asking the person looking at the data. When several previewers can render a
+type, the person may prefer one the ladder does not pick: a package's tailored
+spectrum plot over a project-local experiment, or the plain core table over
+either.
+
+This module stores that preference. It is deliberately *not* the FR-005
+project-default mechanism, which stays exactly as specified: a tie-breaker
+between same-tier previewers of equal priority, declared by whoever authored
+the project. That is an author's declaration about a project; this is a
+person's choice about their own view. Keeping them in separate files keeps the
+two from being mistaken for each other, and keeps FR-005's semantics untouched.
+
+**Two layers, project over user.** A choice recorded against the open project
+wins over the same person's global choice, mirroring the tier model blocks,
+types, and previewers already follow. The user layer lives under the library
+root :func:`scistudio.core.dropins.library_root_for_project` resolves, so a
+tutorial project's choices land in the tutorial-scoped library rather than
+following the user into every real project afterwards (ADR-053 FR-070/FR-071).
+
+**Keyed on the exact type name.** A choice made for ``Spectrum`` applies to
+``Spectrum`` and not to a type that merely descends from it. The narrower rule
+is the predictable one: a choice silently governing subtypes the person never
+looked at is harder to explain than one that simply does not apply yet.
+
+Every read is best-effort. A missing file, malformed JSON, an unknown key from
+a newer build, or an entry of the wrong shape is skipped rather than raised —
+the same forward-compatibility rule ``projects.json`` learned in #2073, and for
+the same reason: this file outlives the build that wrote it, and losing a
+preference must never be able to stop a preview from rendering.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+from scistudio.core.dropins import USER_LIBRARY_DIR_NAME, library_root_for_project
+from scistudio.stability import internal
+from scistudio.utils.atomic_io import atomic_write_text
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "CHOICES_FILENAME",
+    "clear_choice",
+    "load_choices",
+    "project_choices_path",
+    "read_choice_layer",
+    "user_choices_path",
+    "write_choice",
+]
+
+#: One file per concern under the library root, as ``projects.json`` and
+#: ``tutorial-progress.json`` already are.
+CHOICES_FILENAME = "previewer-choices.json"
+
+#: Schema version of the written file. Readers ignore what they do not know, so
+#: this exists to make a future migration legible rather than to gate reads.
+_SCHEMA_VERSION = 1
+
+
+@internal()
+def user_choices_path(project_dir: str | Path | None) -> Path:
+    """Return the user-layer choices file for *project_dir*'s library root."""
+    return library_root_for_project(project_dir) / CHOICES_FILENAME
+
+
+@internal()
+def project_choices_path(project_dir: str | Path) -> Path:
+    """Return the project-layer choices file, under ``<project>/.scistudio``."""
+    return Path(project_dir) / USER_LIBRARY_DIR_NAME / CHOICES_FILENAME
+
+
+@internal()
+def read_choice_layer(path: Path) -> dict[str, str]:
+    """Return ``{type_name: previewer_id}`` from *path*; never raises.
+
+    A missing file is an empty layer. Anything unreadable, unparseable, or
+    shaped wrongly is logged once and treated as empty, and individual entries
+    that are not a string pair are skipped so one bad key cannot cost the rest.
+    """
+    if not path.is_file():
+        return {}
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        logger.warning("Ignoring unreadable previewer choices at %s", path.name, exc_info=True)
+        return {}
+    if not isinstance(payload, dict):
+        logger.warning("Ignoring previewer choices at %s: expected an object", path.name)
+        return {}
+    raw = payload.get("choices")
+    if not isinstance(raw, dict):
+        return {}
+    return {
+        key: value for key, value in raw.items() if isinstance(key, str) and isinstance(value, str) and key and value
+    }
+
+
+@internal()
+def load_choices(project_dir: str | Path | None) -> dict[str, str]:
+    """Return the effective choices for *project_dir*, project layer winning.
+
+    The user layer loads unconditionally — it is defined by the person, not by
+    which project happens to be open — and the project layer, when there is a
+    project, overrides it per type.
+    """
+    effective = read_choice_layer(user_choices_path(project_dir))
+    if project_dir is not None:
+        effective.update(read_choice_layer(project_choices_path(project_dir)))
+    return effective
+
+
+def _write_layer(path: Path, choices: dict[str, str]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {"version": _SCHEMA_VERSION, "choices": dict(sorted(choices.items()))}
+    atomic_write_text(path, json.dumps(payload, indent=2, sort_keys=False) + "\n", encoding="utf-8")
+
+
+@internal()
+def write_choice(path: Path, target_type: str, previewer_id: str) -> dict[str, str]:
+    """Record *target_type* -> *previewer_id* in the layer at *path*.
+
+    Returns the layer as written. Reads the existing layer first so a
+    concurrent edit to another type is preserved rather than overwritten.
+    """
+    choices = read_choice_layer(path)
+    choices[target_type] = previewer_id
+    _write_layer(path, choices)
+    return choices
+
+
+@internal()
+def clear_choice(path: Path, target_type: str) -> dict[str, str]:
+    """Remove *target_type* from the layer at *path*, if present.
+
+    Returns the layer as written. Clearing a type that was never chosen is not
+    an error: the caller's intent — "no choice for this type here" — already
+    holds, and reporting a failure would push the caller into checking first.
+    """
+    choices = read_choice_layer(path)
+    choices.pop(target_type, None)
+    _write_layer(path, choices)
+    return choices

--- a/src/scistudio/previewers/registry.py
+++ b/src/scistudio/previewers/registry.py
@@ -69,6 +69,13 @@ class PreviewerRegistry:
         self._by_id: dict[str, PreviewerSpec] = {}
         self._diagnostics: list[str] = []
         self._project_default_previewers: dict[str, str] = {}
+        # #2049: the person's own per-type choice, loaded from
+        # :mod:`scistudio.previewers.choices`. Distinct from the field above:
+        # that one is the FR-005 project-author declaration and only breaks a
+        # same-tier priority tie, while this one short-circuits the whole
+        # FR-003 ladder. They are kept apart here for the same reason they are
+        # kept in separate files.
+        self._previewer_choices: dict[str, str] = {}
 
     # -- registration -------------------------------------------------------
 
@@ -95,6 +102,15 @@ class PreviewerRegistry:
         """Declare a project default previewer for *target_type* (FR-005)."""
         self._project_default_previewers[target_type] = previewer_id
 
+    def set_previewer_choices(self, choices: dict[str, str]) -> None:
+        """Install the person's per-type previewer choices (#2049).
+
+        Replaces the set wholesale, because the caller loads both layers and
+        resolves them together; a partial update here would let a cleared
+        project-layer choice keep shadowing the user-layer one it overrode.
+        """
+        self._previewer_choices = dict(choices)
+
     def record_diagnostic(self, message: str) -> None:
         """Record a discovery-scan diagnostic from an external scan pass.
 
@@ -118,6 +134,14 @@ class PreviewerRegistry:
     def project_default_for(self, target_type: str) -> str | None:
         return self._project_default_previewers.get(target_type)
 
+    def choice_for(self, target_type: str) -> str | None:
+        """Return the previewer id chosen for *target_type*, if any (#2049)."""
+        return self._previewer_choices.get(target_type)
+
+    def previewer_choices(self) -> dict[str, str]:
+        """Return a copy of the installed per-type choices (#2049)."""
+        return dict(self._previewer_choices)
+
     @property
     def diagnostics(self) -> list[str]:
         return list(self._diagnostics)
@@ -126,6 +150,7 @@ class PreviewerRegistry:
         self._by_id.clear()
         self._diagnostics.clear()
         self._project_default_previewers.clear()
+        self._previewer_choices.clear()
 
     # -- discovery ----------------------------------------------------------
 

--- a/src/scistudio/previewers/router.py
+++ b/src/scistudio/previewers/router.py
@@ -65,6 +65,10 @@ class PreviewRouter:
     def resolve(self, target: PreviewTarget) -> PreviewerSpec:
         """Return the single best previewer spec for *target* (FR-003).
 
+        A person's own choice for the target's type wins outright (#2049,
+        FR-034); everything below it is the unchanged FR-003 ladder, which also
+        serves as the fallback whenever no usable choice applies.
+
         Raises :class:`RoutingAmbiguityError` on an unresolved priority tie
         within a tier+specificity and :class:`UnknownTargetError` when nothing
         matches (not even a core fallback).
@@ -74,6 +78,15 @@ class PreviewRouter:
         # Type chain ordered specific -> general for "closest parent wins".
         chain = self._specificity_chain(target)
         most_specific = chain[0] if chain else ""
+
+        # ---- 0: the person's own choice for this exact type (#2049) ----
+        # A short circuit, not a new tier: when it applies nothing below runs,
+        # and when it does not the ladder is entered exactly as before. That is
+        # what makes this purely additive — a session with no choice recorded
+        # routes today's answer, unchanged.
+        chosen = self._chosen_spec(most_specific, chain, want_collection=is_collection)
+        if chosen is not None:
+            return chosen
 
         # A collection target must only resolve to collection-capable previewers
         # before reaching the core collection fallback (ADR-048 FR-003 / US4):
@@ -118,6 +131,53 @@ class PreviewRouter:
         )
 
     # -- internals ----------------------------------------------------------
+
+    def _chosen_spec(self, type_name: str, chain: list[str], *, want_collection: bool) -> PreviewerSpec | None:
+        """Return the spec the person chose for *type_name*, if it is usable.
+
+        Four things can make a recorded choice not apply, and all four fall
+        through to the ladder rather than raising. A preference is not a
+        constraint: failing to honour one must never be able to stop a preview
+        from rendering.
+
+        * **No choice for this type.** The common case.
+        * **The chosen previewer is gone** — a package uninstalled, a drop-in
+          deleted or renamed. The choice stays on disk, because the person may
+          reinstall, and takes effect again the moment its previewer does.
+        * **The chosen previewer does not claim this type or any ancestor of
+          it.** Choosing an ancestor's previewer is legitimate and expected —
+          picking core's plain ``Series`` view for a ``Spectrum`` is exactly
+          the kind of preference this exists to serve — but a previewer for an
+          unrelated type would render nothing meaningful. Restricting the
+          choice to ``chain`` bounds it to the same candidate set the ladder
+          below considers, so a choice can reorder that set but never widen it.
+        * **The choice cannot serve this target.** A previewer that does not
+          declare ``supports_collection`` must not be handed a collection, the
+          same rule FR-003/US4 enforces down the ladder: a single-item viewer
+          given a whole collection is a broken view, not an honoured
+          preference.
+        """
+        if not type_name:
+            return None
+        previewer_id = self._registry.choice_for(type_name)
+        if previewer_id is None:
+            return None
+        spec = self._registry.get(previewer_id)
+        if spec is None:
+            logger.debug("chosen previewer %r for %r is not registered; falling back", previewer_id, type_name)
+            return None
+        if spec.target_type not in chain:
+            logger.debug(
+                "chosen previewer %r targets %r, which is not in the type chain for %r; falling back",
+                previewer_id,
+                spec.target_type,
+                type_name,
+            )
+            return None
+        if want_collection and not spec.supports_collection:
+            logger.debug("chosen previewer %r cannot render a collection of %r; falling back", previewer_id, type_name)
+            return None
+        return spec
 
     def _specificity_chain(self, target: PreviewTarget) -> list[str]:
         """Return candidate type names ordered specific -> general.

--- a/tests/api/test_previewer_choice_routes.py
+++ b/tests/api/test_previewer_choice_routes.py
@@ -1,0 +1,223 @@
+"""The previewer-choice API (#2049).
+
+Routing behaviour lives in `tests/previewers/test_previewer_choice.py`. What
+these tests own is the surface: which layer a write lands in, what the listing
+reports about provenance and staleness, what is refused, and — the point of the
+feature — that a recorded choice actually changes what a preview session
+resolves to.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+PROJECT_PREVIEWER = """\
+from scistudio.previewers.models import OwnerKind, PreviewerSpec
+
+
+def get_previewers():
+    return [
+        PreviewerSpec(
+            previewer_id="choice.project",
+            owner_kind=OwnerKind.PROJECT,
+            owner_name="probe",
+            target_type="DataFrame",
+            priority=90,
+        ),
+        PreviewerSpec(
+            previewer_id="choice.alternate",
+            owner_kind=OwnerKind.PROJECT,
+            owner_name="probe",
+            target_type="DataFrame",
+            priority=10,
+        ),
+    ]
+"""
+
+
+def _install_previewers(project: Path, client: TestClient) -> None:
+    previewers = project / "previewers"
+    previewers.mkdir(parents=True, exist_ok=True)
+    (previewers / "choice_probe.py").write_text(PROJECT_PREVIEWER, encoding="utf-8")
+    assert client.post("/api/blocks/reload").status_code == 200
+
+
+def _choices(client: TestClient) -> dict[str, dict]:
+    response = client.get("/api/previews/choices")
+    assert response.status_code == 200
+    return {entry["target_type"]: entry for entry in response.json()["choices"]}
+
+
+# -- listing -----------------------------------------------------------------
+
+
+def test_no_choices_recorded_is_an_empty_list(client: TestClient, opened_project: Path) -> None:
+    assert _choices(client) == {}
+
+
+def test_a_user_scoped_choice_reports_its_scope(client: TestClient, opened_project: Path) -> None:
+    _install_previewers(opened_project, client)
+    response = client.put(
+        "/api/previews/choices/DataFrame",
+        json={"previewer_id": "choice.alternate", "scope": "user"},
+    )
+    assert response.status_code == 200
+
+    entry = _choices(client)["DataFrame"]
+    assert entry["previewer_id"] == "choice.alternate"
+    assert entry["scope"] == "user"
+    assert entry["available"] is True
+
+
+def test_a_project_scoped_choice_overrides_the_user_one(client: TestClient, opened_project: Path) -> None:
+    _install_previewers(opened_project, client)
+    client.put("/api/previews/choices/DataFrame", json={"previewer_id": "choice.alternate", "scope": "user"})
+    client.put("/api/previews/choices/DataFrame", json={"previewer_id": "choice.project", "scope": "project"})
+
+    entry = _choices(client)["DataFrame"]
+    assert entry["previewer_id"] == "choice.project"
+    assert entry["scope"] == "project"
+
+
+def test_clearing_the_project_layer_reveals_the_user_choice_again(client: TestClient, opened_project: Path) -> None:
+    """The two layers stack rather than replace: clearing the override restores
+    what it was overriding, instead of leaving the type unchosen."""
+    _install_previewers(opened_project, client)
+    client.put("/api/previews/choices/DataFrame", json={"previewer_id": "choice.alternate", "scope": "user"})
+    client.put("/api/previews/choices/DataFrame", json={"previewer_id": "choice.project", "scope": "project"})
+
+    assert client.delete("/api/previews/choices/DataFrame", params={"scope": "project"}).status_code == 200
+
+    entry = _choices(client)["DataFrame"]
+    assert entry["previewer_id"] == "choice.alternate"
+    assert entry["scope"] == "user"
+
+
+def test_a_choice_whose_previewer_is_gone_reads_as_unavailable(client: TestClient, opened_project: Path) -> None:
+    """A choice outlives the package that provided it. Reporting it as stale is
+    more useful than dropping it, because reinstalling should bring it back."""
+    _install_previewers(opened_project, client)
+    client.put("/api/previews/choices/DataFrame", json={"previewer_id": "choice.alternate", "scope": "user"})
+
+    (opened_project / "previewers" / "choice_probe.py").unlink()
+    # /api/blocks/reload rather than the previewer-owned endpoint (#2095): this
+    # branch must merge in either order, so it depends only on what main has.
+    assert client.post("/api/blocks/reload").status_code == 200
+
+    entry = _choices(client)["DataFrame"]
+    assert entry["previewer_id"] == "choice.alternate"
+    assert entry["available"] is False
+
+
+# -- refusals ----------------------------------------------------------------
+
+
+def test_choosing_an_unknown_previewer_is_refused(client: TestClient, opened_project: Path) -> None:
+    """Routing tolerates a previewer that has since disappeared; accepting one
+    that never existed would store a preference that can never apply."""
+    response = client.put(
+        "/api/previews/choices/DataFrame",
+        json={"previewer_id": "never.existed", "scope": "user"},
+    )
+    assert response.status_code == 400
+    assert "never.existed" in response.json()["detail"]
+
+
+def test_an_unknown_scope_is_refused_and_names_the_known_ones(client: TestClient, opened_project: Path) -> None:
+    _install_previewers(opened_project, client)
+    response = client.put(
+        "/api/previews/choices/DataFrame",
+        json={"previewer_id": "choice.alternate", "scope": "global"},
+    )
+    assert response.status_code == 400
+    detail = response.json()["detail"]
+    assert "project" in detail and "user" in detail
+
+
+def test_clearing_a_type_that_was_never_chosen_succeeds(client: TestClient, opened_project: Path) -> None:
+    assert client.delete("/api/previews/choices/NeverChosen", params={"scope": "user"}).status_code == 200
+
+
+# -- persistence -------------------------------------------------------------
+
+
+def test_a_project_scoped_choice_lands_in_the_project(client: TestClient, opened_project: Path) -> None:
+    _install_previewers(opened_project, client)
+    client.put("/api/previews/choices/DataFrame", json={"previewer_id": "choice.alternate", "scope": "project"})
+
+    path = opened_project / ".scistudio" / "previewer-choices.json"
+    assert path.is_file()
+    assert json.loads(path.read_text(encoding="utf-8"))["choices"] == {"DataFrame": "choice.alternate"}
+
+
+def test_the_author_declared_manifest_is_a_separate_file(client: TestClient, opened_project: Path) -> None:
+    """FR-005's ``previewers.json`` is an author's declaration about a project;
+    a choice is a person's preference about their own view. Writing a choice
+    must not touch the manifest."""
+    _install_previewers(opened_project, client)
+    client.put("/api/previews/choices/DataFrame", json={"previewer_id": "choice.alternate", "scope": "project"})
+
+    assert not (opened_project / ".scistudio" / "previewers.json").exists()
+
+
+# -- the point of the feature ------------------------------------------------
+
+
+def test_a_choice_changes_what_a_preview_session_resolves_to(client: TestClient, opened_project: Path) -> None:
+    """End to end: without a choice the ladder picks the higher priority spec;
+    with one, the session comes back from the chosen previewer instead."""
+    _install_previewers(opened_project, client)
+    upload = client.post("/api/data/upload", files={"file": ("t.csv", b"a,b\n1,2\n", "text/csv")})
+    ref = upload.json()["ref"]
+
+    def resolved() -> str:
+        response = client.post(
+            "/api/previews/sessions",
+            json={
+                "target": {
+                    "kind": "data_ref",
+                    "ref": ref,
+                    "recorded_type": "DataFrame",
+                    "type_chain": ["DataObject", "DataFrame"],
+                },
+                "query": {},
+            },
+        )
+        assert response.status_code == 200
+        return str(response.json()["previewer_id"])
+
+    assert resolved() == "choice.project"
+
+    assert (
+        client.put(
+            "/api/previews/choices/DataFrame",
+            json={"previewer_id": "choice.alternate", "scope": "user"},
+        ).status_code
+        == 200
+    )
+
+    assert resolved() == "choice.alternate"
+
+
+def test_clearing_the_choice_returns_routing_to_the_ladder(client: TestClient, opened_project: Path) -> None:
+    _install_previewers(opened_project, client)
+    client.put("/api/previews/choices/DataFrame", json={"previewer_id": "choice.alternate", "scope": "user"})
+    assert client.delete("/api/previews/choices/DataFrame", params={"scope": "user"}).status_code == 200
+
+    upload = client.post("/api/data/upload", files={"file": ("t.csv", b"a,b\n1,2\n", "text/csv")})
+    response = client.post(
+        "/api/previews/sessions",
+        json={
+            "target": {
+                "kind": "data_ref",
+                "ref": upload.json()["ref"],
+                "recorded_type": "DataFrame",
+                "type_chain": ["DataObject", "DataFrame"],
+            },
+            "query": {},
+        },
+    )
+    assert response.json()["previewer_id"] == "choice.project"

--- a/tests/api/test_previewer_choice_routes.py
+++ b/tests/api/test_previewer_choice_routes.py
@@ -12,7 +12,10 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
 from fastapi.testclient import TestClient
+
+from scistudio.api.runtime import ApiRuntime
 
 PROJECT_PREVIEWER = """\
 from scistudio.previewers.models import OwnerKind, PreviewerSpec
@@ -139,6 +142,33 @@ def test_an_unknown_scope_is_refused_and_names_the_known_ones(client: TestClient
 
 def test_clearing_a_type_that_was_never_chosen_succeeds(client: TestClient, opened_project: Path) -> None:
     assert client.delete("/api/previews/choices/NeverChosen", params={"scope": "user"}).status_code == 200
+
+
+def test_choice_writes_refresh_every_registry(
+    client: TestClient,
+    opened_project: Path,
+    runtime: ApiRuntime,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Choice writes are invalidation events, so both routes use the unified refresh."""
+    _install_previewers(opened_project, client)
+    refreshes = 0
+    refresh_all = runtime.refresh_all_registries
+
+    def tracked_refresh() -> None:
+        nonlocal refreshes
+        refreshes += 1
+        refresh_all()
+
+    monkeypatch.setattr(runtime, "refresh_all_registries", tracked_refresh)
+
+    response = client.put(
+        "/api/previews/choices/DataFrame",
+        json={"previewer_id": "choice.alternate", "scope": "user"},
+    )
+    assert response.status_code == 200
+    assert client.delete("/api/previews/choices/DataFrame", params={"scope": "user"}).status_code == 200
+    assert refreshes == 2
 
 
 # -- persistence -------------------------------------------------------------

--- a/tests/previewers/test_previewer_choice.py
+++ b/tests/previewers/test_previewer_choice.py
@@ -1,0 +1,303 @@
+"""The person's chosen previewer per type — storage and routing (#2049).
+
+Two properties carry the design and each has its own section below.
+
+The **short circuit** must be purely additive: with no choice recorded, every
+routing answer is the one ADR-048 FR-003 already gave. `test_the_ladder_is_untouched_when_nothing_is_chosen`
+is the guard on that, and it is the test to look at first if the tier tests
+elsewhere start failing.
+
+The **fallbacks** carry the other half: a choice is a preference, not a
+constraint. Four things can stop one applying and none may raise, because a
+recorded preference must never be able to stop a preview from rendering.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scistudio.previewers.choices import (
+    clear_choice,
+    load_choices,
+    project_choices_path,
+    read_choice_layer,
+    user_choices_path,
+    write_choice,
+)
+from scistudio.previewers.models import OwnerKind, PreviewerSpec, PreviewTarget, TargetKind
+from scistudio.previewers.registry import PreviewerRegistry
+from scistudio.previewers.router import PreviewRouter
+
+
+def _spec(
+    previewer_id: str,
+    owner: OwnerKind,
+    *,
+    target_type: str = "Probe",
+    supports_collection: bool = False,
+    priority: int = 50,
+) -> PreviewerSpec:
+    return PreviewerSpec(
+        previewer_id=previewer_id,
+        owner_kind=owner,
+        owner_name=owner.value,
+        target_type=target_type,
+        supports_collection=supports_collection,
+        priority=priority,
+    )
+
+
+ITEM = PreviewTarget(
+    kind=TargetKind.DATA_REF,
+    ref="ref",
+    recorded_type="Probe",
+    type_chain=("DataObject", "Series", "Probe"),
+)
+COLLECTION = PreviewTarget(
+    kind=TargetKind.COLLECTION_REF,
+    ref="ref",
+    recorded_type="Probe",
+    type_chain=("DataObject", "Series", "Probe"),
+    collection_item_type="Probe",
+)
+
+
+@pytest.fixture()
+def registry() -> PreviewerRegistry:
+    """A registry with one previewer per tier, all claiming ``Probe``."""
+    reg = PreviewerRegistry()
+    reg.register(_spec("probe.project", OwnerKind.PROJECT))
+    reg.register(_spec("probe.user", OwnerKind.USER))
+    reg.register(_spec("probe.package", OwnerKind.PACKAGE))
+    return reg
+
+
+@pytest.fixture()
+def home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    fake = tmp_path / "home"
+    (fake / ".scistudio").mkdir(parents=True)
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake))
+    return fake
+
+
+# ---------------------------------------------------------------------------
+# Storage: two layers, project over user
+# ---------------------------------------------------------------------------
+
+
+def test_a_choice_round_trips(tmp_path: Path) -> None:
+    path = tmp_path / "previewer-choices.json"
+    write_choice(path, "Probe", "probe.package")
+    assert read_choice_layer(path) == {"Probe": "probe.package"}
+
+
+def test_writing_one_type_leaves_the_others_alone(tmp_path: Path) -> None:
+    """The write reads first, so a second type is not lost to a blind overwrite."""
+    path = tmp_path / "previewer-choices.json"
+    write_choice(path, "Probe", "probe.package")
+    write_choice(path, "Image", "image.viewer")
+    assert read_choice_layer(path) == {"Probe": "probe.package", "Image": "image.viewer"}
+
+
+def test_clearing_removes_only_that_type(tmp_path: Path) -> None:
+    path = tmp_path / "previewer-choices.json"
+    write_choice(path, "Probe", "probe.package")
+    write_choice(path, "Image", "image.viewer")
+    clear_choice(path, "Probe")
+    assert read_choice_layer(path) == {"Image": "image.viewer"}
+
+
+def test_clearing_a_type_that_was_never_chosen_is_not_an_error(tmp_path: Path) -> None:
+    path = tmp_path / "previewer-choices.json"
+    clear_choice(path, "NeverChosen")
+    assert read_choice_layer(path) == {}
+
+
+def test_the_project_layer_overrides_the_user_layer(home: Path, tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    write_choice(user_choices_path(project), "Probe", "probe.user")
+    write_choice(project_choices_path(project), "Probe", "probe.project")
+
+    assert load_choices(project)["Probe"] == "probe.project"
+
+
+def test_the_user_layer_shows_through_for_types_the_project_did_not_override(home: Path, tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    write_choice(user_choices_path(project), "Probe", "probe.user")
+    write_choice(user_choices_path(project), "Image", "image.user")
+    write_choice(project_choices_path(project), "Probe", "probe.project")
+
+    assert load_choices(project) == {"Probe": "probe.project", "Image": "image.user"}
+
+
+def test_the_user_layer_loads_with_no_project_open(home: Path) -> None:
+    """A person's global preference is not a property of whichever project is open."""
+    write_choice(user_choices_path(None), "Probe", "probe.user")
+    assert load_choices(None) == {"Probe": "probe.user"}
+
+
+# ---------------------------------------------------------------------------
+# Storage: a preference file outlives the build that wrote it (#2073's lesson)
+# ---------------------------------------------------------------------------
+
+
+def test_a_missing_file_is_an_empty_layer(tmp_path: Path) -> None:
+    assert read_choice_layer(tmp_path / "absent.json") == {}
+
+
+def test_malformed_json_is_ignored_rather_than_raised(tmp_path: Path) -> None:
+    path = tmp_path / "previewer-choices.json"
+    path.write_text("{not json", encoding="utf-8")
+    assert read_choice_layer(path) == {}
+
+
+def test_a_payload_that_is_not_an_object_is_ignored(tmp_path: Path) -> None:
+    path = tmp_path / "previewer-choices.json"
+    path.write_text('["not", "an", "object"]', encoding="utf-8")
+    assert read_choice_layer(path) == {}
+
+
+def test_an_unknown_key_from_a_newer_build_does_not_lose_the_choices(tmp_path: Path) -> None:
+    path = tmp_path / "previewer-choices.json"
+    path.write_text(
+        json.dumps({"version": 99, "choices": {"Probe": "probe.package"}, "somethingNew": {"a": 1}}),
+        encoding="utf-8",
+    )
+    assert read_choice_layer(path) == {"Probe": "probe.package"}
+
+
+def test_one_malformed_entry_does_not_cost_the_others(tmp_path: Path) -> None:
+    path = tmp_path / "previewer-choices.json"
+    path.write_text(
+        json.dumps({"choices": {"Probe": "probe.package", "Bad": ["list"], "": "empty-key", "Blank": ""}}),
+        encoding="utf-8",
+    )
+    assert read_choice_layer(path) == {"Probe": "probe.package"}
+
+
+# ---------------------------------------------------------------------------
+# Routing: the short circuit
+# ---------------------------------------------------------------------------
+
+
+def test_the_ladder_is_untouched_when_nothing_is_chosen(registry: PreviewerRegistry) -> None:
+    """The guard on "purely additive". If this fails, #2049 changed FR-003."""
+    assert PreviewRouter(registry).resolve(ITEM).previewer_id == "probe.project"
+
+
+@pytest.mark.parametrize("chosen", ["probe.user", "probe.package"])
+def test_a_choice_wins_over_the_whole_ladder(registry: PreviewerRegistry, chosen: str) -> None:
+    """Including over the project tier, which the ladder would otherwise pick."""
+    registry.set_previewer_choices({"Probe": chosen})
+    assert PreviewRouter(registry).resolve(ITEM).previewer_id == chosen
+
+
+def test_choosing_what_the_ladder_would_have_picked_changes_nothing(registry: PreviewerRegistry) -> None:
+    registry.set_previewer_choices({"Probe": "probe.project"})
+    assert PreviewRouter(registry).resolve(ITEM).previewer_id == "probe.project"
+
+
+def test_a_choice_on_one_type_does_not_govern_another(registry: PreviewerRegistry) -> None:
+    registry.set_previewer_choices({"Image": "probe.package"})
+    assert PreviewRouter(registry).resolve(ITEM).previewer_id == "probe.project"
+
+
+def test_a_choice_does_not_reach_types_that_merely_descend_from_the_chosen_one(
+    registry: PreviewerRegistry,
+) -> None:
+    """Keyed on the exact type name, so a ``Series`` choice leaves ``Probe`` alone.
+
+    The narrower rule is the predictable one: a choice quietly governing
+    subtypes the person never looked at is harder to explain than one that
+    simply does not apply yet.
+    """
+    registry.register(_spec("series.core", OwnerKind.CORE, target_type="Series"))
+    registry.set_previewer_choices({"Series": "series.core"})
+    assert PreviewRouter(registry).resolve(ITEM).previewer_id == "probe.project"
+
+
+# ---------------------------------------------------------------------------
+# Routing: a preference is not a constraint — four fallbacks, none of them raise
+# ---------------------------------------------------------------------------
+
+
+def test_a_choice_naming_an_unregistered_previewer_falls_back(registry: PreviewerRegistry) -> None:
+    """The realistic case: the package that provided it was uninstalled."""
+    registry.set_previewer_choices({"Probe": "gone.after.uninstall"})
+    assert PreviewRouter(registry).resolve(ITEM).previewer_id == "probe.project"
+
+
+def test_a_choice_for_an_unrelated_type_falls_back(registry: PreviewerRegistry) -> None:
+    """Bounded to the target's type chain, so a choice reorders the ladder's
+    candidates but can never widen them to a previewer that claims something
+    else entirely."""
+    registry.register(_spec("image.viewer", OwnerKind.PACKAGE, target_type="Image"))
+    registry.set_previewer_choices({"Probe": "image.viewer"})
+    assert PreviewRouter(registry).resolve(ITEM).previewer_id == "probe.project"
+
+
+def test_choosing_an_ancestors_previewer_is_honoured(registry: PreviewerRegistry) -> None:
+    """Picking core's plain ``Series`` view for a ``Probe`` is a real preference,
+    not a mistake, so the chain bound admits it."""
+    registry.register(_spec("series.core", OwnerKind.CORE, target_type="Series"))
+    registry.set_previewer_choices({"Probe": "series.core"})
+    assert PreviewRouter(registry).resolve(ITEM).previewer_id == "series.core"
+
+
+def test_a_single_item_choice_is_not_used_for_a_collection() -> None:
+    """FR-003/US4 applies to a choice too: a single-item viewer handed a whole
+    collection is a broken view, not an honoured preference.
+
+    The registry here deliberately has a *different* collection-capable
+    previewer, so falling back is visible rather than coincidentally identical.
+    """
+    reg = PreviewerRegistry()
+    reg.register(_spec("probe.single", OwnerKind.PACKAGE, supports_collection=False, priority=90))
+    reg.register(_spec("probe.batch", OwnerKind.PROJECT, supports_collection=True, priority=10))
+    reg.set_previewer_choices({"Probe": "probe.single"})
+
+    assert PreviewRouter(reg).resolve(COLLECTION).previewer_id == "probe.batch"
+    # ...and the same choice still applies to a single item.
+    assert PreviewRouter(reg).resolve(ITEM).previewer_id == "probe.single"
+
+
+def test_a_collection_capable_choice_is_honoured_for_a_collection() -> None:
+    reg = PreviewerRegistry()
+    reg.register(_spec("probe.batch.chosen", OwnerKind.PACKAGE, supports_collection=True, priority=1))
+    reg.register(_spec("probe.batch.other", OwnerKind.PROJECT, supports_collection=True, priority=99))
+    reg.set_previewer_choices({"Probe": "probe.batch.chosen"})
+
+    assert PreviewRouter(reg).resolve(COLLECTION).previewer_id == "probe.batch.chosen"
+
+
+# ---------------------------------------------------------------------------
+# Routing: FR-005 is untouched
+# ---------------------------------------------------------------------------
+
+
+def test_the_project_default_still_only_breaks_a_same_tier_tie() -> None:
+    """#2049 is additive: FR-005 keeps the narrow role it was specified with.
+
+    Two package previewers tie on priority; the project default picks one. That
+    is the only thing it has ever done, and adding the choice layer above it
+    must not have widened it into a general default.
+    """
+    reg = PreviewerRegistry()
+    reg.register(_spec("probe.a", OwnerKind.PACKAGE, priority=50))
+    reg.register(_spec("probe.b", OwnerKind.PACKAGE, priority=50))
+    reg.set_project_default("Probe", "probe.b")
+
+    assert PreviewRouter(reg).resolve(ITEM).previewer_id == "probe.b"
+
+
+def test_a_choice_and_a_project_default_do_not_meet(registry: PreviewerRegistry) -> None:
+    """When a choice applies, the ladder does not run, so FR-005 never arbitrates."""
+    registry.set_project_default("Probe", "probe.project")
+    registry.set_previewer_choices({"Probe": "probe.package"})
+
+    assert PreviewRouter(registry).resolve(ITEM).previewer_id == "probe.package"


### PR DESCRIPTION
## What

ADR-048 FR-003 fixes one precedence ladder — project, then user, then package, then core — and it answers *which previewer is best* without ever asking the person looking at the data. When several previewers can render the same type, they may want a different one: a package's tailored plot instead of a project-local experiment, or core's plain table instead of either.

This records that preference and gives it precedence. Backend only — the selector UI belongs to the palette rework.

## The shape, and why

**Per type, exact.** A choice for `Spectrum` governs `Spectrum` and not something that merely descends from it. A preference silently reaching subtypes the person never looked at is harder to explain than one that does not apply yet.

**Two layers, project over user.** The same tier shape blocks, types, and previewers already use for where they live. The user layer resolves through `library_root_for_project`, so a tutorial project's choices land in the tutorial-scoped library rather than following the person into every real project afterwards (ADR-053 FR-070/FR-071). Clearing a project-layer choice *reveals* the user choice it overrode rather than leaving the type unchosen.

**Stored separately from the FR-005 manifest, which is untouched.** FR-005 keeps its specified role: a tie-breaker between same-tier previewers of equal priority, declared by whoever authored the project. That answers a different question — an author's declaration about a project versus a person's preference about their own view — so the two live in separate files and, because an applying choice short-circuits the ladder entirely, never arbitrate the same decision. `test_the_project_default_still_only_breaks_a_same_tier_tie` and `test_a_choice_and_a_project_default_do_not_meet` pin both halves.

**Purely additive.** The choice is step 0 of `resolve()`. When it applies, nothing below runs; when it does not, the ladder is entered exactly as before. `test_the_ladder_is_untouched_when_nothing_is_chosen` is the guard — if it ever fails, this feature changed FR-003.

## A preference is not a constraint

Four cases fall through to the ladder, and none of them raises. The rule behind all four: **nothing a person can record should be able to stop a preview from rendering.**

| Case | Why it falls through |
|---|---|
| No choice for this type | The common path |
| The chosen previewer is not registered | A package uninstalled, a drop-in deleted. The choice stays on disk and takes effect again the moment its previewer returns |
| It claims neither the target type nor an ancestor in the chain | See below |
| It cannot serve a collection and the target is one | FR-003/US4 applied to a choice: a single-item viewer handed a whole collection is a broken view, not an honoured preference |

The **type-chain bound is load-bearing, and it closes a hole the first draft had.** Without it, choosing a previewer written for `Image` to render a `Spectrum` was accepted and then failed at render time. The router already computes the specificity chain, so bounding the choice to it costs nothing and gives a clean rule: **a choice can reorder the ladder's candidates but never widen them.** Choosing an *ancestor's* previewer stays legitimate — picking core's plain `Series` view for a `Spectrum` is exactly the kind of preference this exists to serve — and `test_choosing_an_ancestors_previewer_is_honoured` keeps it that way.

Compatibility on write is validated where it can be: `PUT` refuses an unregistered previewer, because routing tolerating one that *disappeared* is different from accepting one that never existed. Type compatibility is left to routing, since the API layer knows previewer specs and the type hierarchy belongs to the type registry.

## Forward compatibility

Reads follow the rule `projects.json` learned in #2073, for the same reason — this file outlives the build that wrote it. An unreadable file, a wrong-shaped payload, an unknown key from a newer build, or one malformed entry is skipped rather than raised, and never costs the entries beside it.

## API

| Method | Path | Purpose |
|---|---|---|
| `GET` | `/api/previews/choices` | Effective choices, each with the layer it came from and whether its previewer is still registered |
| `PUT` | `/api/previews/choices/{target_type}` | Record a choice at `user` or `project` scope |
| `DELETE` | `/api/previews/choices/{target_type}` | Clear the choice at a scope |

`ADR-048` gains FR-034 through FR-038 and the three routes; the spec is the normative contract, so it is part of this PR rather than a follow-up.

## Evidence

- `tests/previewers/test_previewer_choice.py` — 25 tests: storage layering and precedence, the six forward-compatibility cases, the short circuit, all four fallbacks, and the two FR-005 non-interaction guards.
- `tests/api/test_previewer_choice_routes.py` — 14 tests: scope provenance, staleness reporting, refusals, unified registry invalidation, on-disk layout, and **end to end** — recording a choice moves a real preview session from `choice.project` to `choice.alternate`, and clearing it moves it back.
- No regressions: `tests/previewers/`, `tests/api/test_previewers.py`, `tests/api/test_data.py`, `tests/api/test_plot_preview_wiring.py` all green.
- `gate_record check`: tier 2 — `format_check`, `full_audit`, `lint_format` — reconciliation passed. Deferral ratchet clean.

## Merge order

Independent of #2095. An earlier draft of the API tests reached for `POST /api/previews/reload`, which only exists there; they now use `/api/blocks/reload`, which is already on main, so these two can land in either order.

Gate record: `.workflow/records/2049-previewer-choice.json`

Closes #2049
